### PR TITLE
fix(ui): replace missed `d` reference with `data` in tx viewer

### DIFF
--- a/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
@@ -81,7 +81,7 @@
         variant={isJson ? 'tertiary' : 'primary'}
         on:click={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
       >
-      {#if (d?.blockHashes && d?.blockHashes.length > 0) || (d?.blockIDs && d?.blockIDs.length > 0)}
+      {#if (data?.blockHashes && data?.blockHashes.length > 0) || (data?.blockIDs && data?.blockIDs.length > 0)}
         <Button
           size="medium"
           hasFocusRect={false}


### PR DESCRIPTION
## Summary
Fixes a regression from PR #15 where a reference to the removed reactive alias `d` was missed during refactoring.

## Problem
When viewing transactions that are already included in a block (have `blockHashes` or `blockIDs`), the viewer would crash with:
```
ReferenceError: d is not defined
```

## Root Cause
PR #15 removed the reactive alias `$: d = data` to fix runaway reactivity issues, but missed updating one reference on line 84 of `tx-details-card/index.svelte`.

## Solution
Changed `d?.blockHashes` and `d?.blockIDs` to `data?.blockHashes` and `data?.blockIDs` in the Merkle Proof tab conditional.

## Why This Wasn't Caught Earlier
The bug only triggered for transactions with merkle proof data (i.e., transactions already in blocks). Mempool transactions bypassed this code path via short-circuit evaluation, so they continued to work fine.

## Testing
- Built dashboard successfully
- TypeScript checks pass
- Fix verified in production URL that was previously failing

Fixes: Transactions with merkle proof data now render correctly without ReferenceError.