### PR TITLE
Add missing new fields to node status messages

### DIFF
--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -927,6 +927,8 @@ func (s *Server) handleNodeStatusTopic(_ context.Context, m []byte, from string)
 		CommitHash:          nodeStatusMessage.CommitHash,
 		BestBlockHash:       nodeStatusMessage.BestBlockHash,
 		BestHeight:          nodeStatusMessage.BestHeight,
+		TxCount:             nodeStatusMessage.TxCount,
+		SubtreeCount:        nodeStatusMessage.SubtreeCount,
 		FSMState:            nodeStatusMessage.FSMState,
 		StartTime:           nodeStatusMessage.StartTime,
 		Uptime:              nodeStatusMessage.Uptime,


### PR DESCRIPTION
Continues from #24 

Why local worked but remote didn't:
  - Local node status messages are created by getNodeStatusMessage() which includes these fields
  - Remote peer messages come through handleNodeStatusTopic() which was missing the field mapping