### PR TITLE
Improve markdown validation configuration and formatting

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -13,6 +13,9 @@ MD004:
 MD007:
   indent: 4  # 4 spaces for nested list items (exactly what we fixed!)
 
+MD029:
+  style: "ordered"  # Enforce sequential numbering (1/2/3, not 1/1/1)
+
 MD030:
   ul_single: 1  # 1 space after list marker for single-line items
   ol_single: 1  # 1 space after list marker for single-line items


### PR DESCRIPTION
- Enhance .markdownlint.yml with Material for MkDocs best practices
- Add organized rule sections with detailed comments
- Disable MD024 (duplicate headings) and MD046 (code block style)
- Fix ordered list numbering from 1/1/1 to sequential 1/2/3 format
- Auto-fix Material-critical formatting issues:
  - Remove multiple consecutive blank lines (MD012)
  - Fix inconsistent list markers (MD004)
  - Add blank lines around code blocks (MD031)
  - Add blank lines around lists (MD032)

Reduces total markdown errors from 500 to 208 while ensuring Material for MkDocs rendering compatibility.