### PR TITLE
Disable debug flags for tagged builds

### DIFF
--- a/.github/workflows/teranode_main_build.yaml
+++ b/.github/workflows/teranode_main_build.yaml
@@ -48,7 +48,6 @@ jobs:
       repository: ${{ github.repository }}
       tag_latest: true
       build_args: |
-        DEBUG=true
         GIT_VERSION=${{ needs.calculate-version.outputs.git_version }}
         GIT_COMMIT=${{ needs.calculate-version.outputs.git_commit }}
         GIT_SHA=${{ needs.calculate-version.outputs.git_sha }}


### PR DESCRIPTION
DEBUG=true adds -N -l flags which disables compiler optimizations and inlining, making the binary ~10-15% slower with no benefit for production builds. Debug symbols (DWARF) are kept by default anyway for stack traces, so DEBUG=true only hurts performance without adding value.