### PR TITLE
docs: fix minor issues in protobuf documentation

### DIFF
--- a/docs/references/protobuf_docs/alertProto.md
+++ b/docs/references/protobuf_docs/alertProto.md
@@ -17,8 +17,6 @@
 
 ## alert_api.proto
 
-#this is for testing the commit message only
-
 > Package alert_api defines the gRPC service interface for the Bitcoin SV Alert System.
 
 <a name="HealthResponse"></a>

--- a/docs/references/protobuf_docs/blockchainProto.md
+++ b/docs/references/protobuf_docs/blockchainProto.md
@@ -29,7 +29,6 @@
     - [GetBlockHeadersRequest](#GetBlockHeadersRequest)
     - [GetBlockHeadersResponse](#GetBlockHeadersResponse)
     - [GetBlockHeadersToCommonAncestorRequest](#GetBlockHeadersToCommonAncestorRequest)
-    - [GetBlockHeadersFromCommonAncestorRequest](#GetBlockHeadersFromCommonAncestorRequest)
     - [GetBlockInChainByHeightHashRequest](#GetBlockInChainByHeightHashRequest)
     - [GetBlockIsMinedRequest](#GetBlockIsMinedRequest)
     - [GetBlockIsMinedResponse](#GetBlockIsMinedResponse)


### PR DESCRIPTION
Fixed documentation issues identified in protobuf documentation audit:
- alertProto.md: Removed test comment that was accidentally left in documentation
- blockchainProto.md: Removed duplicate TOC entry for GetBlockHeadersFromCommonAncestorRequest

Note: The audit also identified 3 undocumented API services that need documentation:
- services/legacy/peer_api/peer_api.proto (PeerService with 7 RPC methods)
- services/p2p/p2p_api/p2p_api.proto (PeerService with 9 RPC methods)
- services/asset/asset_api/asset_api.proto (appears incomplete, needs investigation)