### PR TITLE
docs: standardize SETTINGS_CONTEXT placeholder to YOUR_CONTEXT

### DIFF
--- a/docs/howto/locallyRunningServices.md
+++ b/docs/howto/locallyRunningServices.md
@@ -25,7 +25,7 @@ Before running Teranode, ensure the required infrastructure services are started
 
 ### Start Teranode
 
-Execute all services in a single terminal window with the command below. Replace `[YOUR_USERNAME]` with your specific username.
+Execute all services in a single terminal window with the command below. Replace `[YOUR_CONTEXT]` with your specific development context identifier.
 
 ```shell
 SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run .
@@ -52,20 +52,20 @@ Teranode supports multiple database backends for UTXO storage, configured via se
    ./scripts/postgres.sh
 
    # Your settings_local.conf should have a PostgreSQL connection string
-   utxostore.dev.[YOUR_USERNAME] = postgres://teranode:teranode@localhost:5432/teranode?blockHeightRetention=5
+   utxostore.dev.[YOUR_CONTEXT] = postgres://teranode:teranode@localhost:5432/teranode?blockHeightRetention=5
 
    # Run with the PostgreSQL backend
-   SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run .
+   SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run .
    ```
 
 2. **SQLite** (Lightweight option):
 
    ```shell
    # Your settings_local.conf should have an SQLite connection string
-   utxostore.dev.[YOUR_USERNAME] = sqlite:///utxostore?blockHeightRetention=5
+   utxostore.dev.[YOUR_CONTEXT] = sqlite:///utxostore?blockHeightRetention=5
 
    # Run with SQLite backend
-   SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run .
+   SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run .
    ```
 
 3. **Aerospike** (High-performance option):
@@ -99,7 +99,7 @@ To use Aerospike as the UTXO storage backend:
 2. Run Teranode with the aerospike tag:
 
    ```shell
-   rm -rf data && SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike .
+   rm -rf data && SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike .
    ```
 
 ### Transaction Metadata Cache Configurations
@@ -109,19 +109,19 @@ Teranode supports different transaction metadata cache sizes through build tags:
 - **Large Cache (Default)**: Used when no specific tx metadata cache tag is specified
 
   ```shell
-  SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike .
+  SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike .
   ```
 
 - **Small Cache**: Reduces memory usage with a smaller transaction metadata cache
 
   ```shell
-  SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike,smalltxmetacache .
+  SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike,smalltxmetacache .
   ```
 
 - **Test Cache**: Configured specifically for testing scenarios
 
   ```shell
-  SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike,testtxmetacache .
+  SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike,testtxmetacache .
   ```
 
 ### Multiple Tags
@@ -129,7 +129,7 @@ Teranode supports different transaction metadata cache sizes through build tags:
 You can combine multiple tags by separating them with commas:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike,smalltxmetacache .
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike,smalltxmetacache .
 ```
 
 ### Network Configuration
@@ -138,13 +138,13 @@ Teranode supports different Bitcoin networks (mainnet, testnet, etc.). This is p
 
 ```shell
 # Run on testnet
-network=testnet SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run .
+network=testnet SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run .
 
 # Run on testnet with Aerospike
-network=testnet SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike .
+network=testnet SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike .
 ```
 
-> **Note:** The network setting defaults to what's specified in your settings_local.conf under `network.dev.[YOUR_USERNAME]`. The environment variable overrides this setting.
+> **Note:** The network setting defaults to what's specified in your settings_local.conf under `network.dev.[YOUR_CONTEXT]`. The environment variable overrides this setting.
 
 ### Testing Tags
 
@@ -195,7 +195,7 @@ Enable or disable components by setting the corresponding option to `1` or `0`. 
 To start the node with only validation and UTXO storage:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike . -validator=1 -utxopersister=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike . -validator=1 -utxopersister=1
 ```
 
 ### Wait For PostgreSQL
@@ -203,7 +203,7 @@ SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike . -validator=1 -utxo
 If you want Teranode to wait for PostgreSQL to be available before starting:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run . -wait_for_postgres=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run . -wait_for_postgres=1
 ```
 
 This is useful in containerized environments or when PostgreSQL might not be immediately ready.
@@ -220,7 +220,7 @@ Teranode exposes health check endpoints on port 8000 (configurable in settings):
 Teranode respects the `NO_COLOR` environment variable to disable colored output in logs.
 
 ```shell
-NO_COLOR=1 SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run .
+NO_COLOR=1 SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run .
 ```
 
 #### Component Selection Examples
@@ -230,7 +230,7 @@ NO_COLOR=1 SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run .
 To initiate the node with only specific components, such as `Validator`:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike . -validator=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike . -validator=1
 ```
 
 **Disabling all services by default and enabling only specific ones:**
@@ -238,7 +238,7 @@ SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike . -validator=1
 This is particularly useful for development:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -tags aerospike . -all=0 -validator=1 -rpc=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -tags aerospike . -all=0 -validator=1 -rpc=1
 ```
 
 ## 🔧 Running Individual Services

--- a/docs/topics/services/alert.md
+++ b/docs/topics/services/alert.md
@@ -266,7 +266,7 @@ The Alert Service initializes the necessary components and services to start pro
 To run the Alert Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -Alert=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -Alert=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Alert Service locally.

--- a/docs/topics/services/assetServer.md
+++ b/docs/topics/services/assetServer.md
@@ -344,7 +344,7 @@ Key technologies involved:
 To run the Asset Server locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -Asset=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -Asset=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Asset Server locally.

--- a/docs/topics/services/blockAssembly.md
+++ b/docs/topics/services/blockAssembly.md
@@ -543,7 +543,7 @@ The service integrates comprehensive Prometheus metrics for operational monitori
 To run the Block Assembly Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -BlockAssembly=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -BlockAssembly=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Block Assembly Service locally.

--- a/docs/topics/services/blockPersister.md
+++ b/docs/topics/services/blockPersister.md
@@ -225,7 +225,7 @@ services/blockpersister/
 To run the Block Persister Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -BlockPersister=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -BlockPersister=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Block Persister Service locally.

--- a/docs/topics/services/blockValidation.md
+++ b/docs/topics/services/blockValidation.md
@@ -328,7 +328,7 @@ The Block Validation Service uses gRPC for communication between nodes. The prot
 To run the Block Validation Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -BlockValidation=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -BlockValidation=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Block Validation Service locally.

--- a/docs/topics/services/blockchain.md
+++ b/docs/topics/services/blockchain.md
@@ -467,7 +467,7 @@ stores/blockchain
 To run the Blockchain Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -Blockchain=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -Blockchain=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Blockchain Service locally.

--- a/docs/topics/services/legacy.md
+++ b/docs/topics/services/legacy.md
@@ -352,7 +352,7 @@ Technology highlights:
 To run the Legacy Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -Legacy=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -Legacy=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Legacy Service locally.

--- a/docs/topics/services/p2p.md
+++ b/docs/topics/services/p2p.md
@@ -486,7 +486,7 @@ Within the P2P service, notifications are sent to the Websocket clients using th
 To run the P2P Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -P2P=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -P2P=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the P2P Service locally.

--- a/docs/topics/services/propagation.md
+++ b/docs/topics/services/propagation.md
@@ -180,7 +180,7 @@ Main technologies involved:
 To run the Propagation Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -Propagation=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -Propagation=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Propagation Service locally.

--- a/docs/topics/services/rpc.md
+++ b/docs/topics/services/rpc.md
@@ -1428,7 +1428,7 @@ For comprehensive configuration documentation including all settings, defaults, 
 To run the RPC Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -RPC=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -RPC=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the RPC Service locally.

--- a/docs/topics/services/subtreeValidation.md
+++ b/docs/topics/services/subtreeValidation.md
@@ -251,7 +251,7 @@ The Subtree Validation Service uses gRPC for communication between nodes. The pr
 To run the Subtree Validation Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -SubtreeValidation=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -SubtreeValidation=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Subtree Validation Service locally.

--- a/docs/topics/services/utxoPersister.md
+++ b/docs/topics/services/utxoPersister.md
@@ -266,7 +266,7 @@ The Block Persister service is located in the `services/utxopersister` directory
 To run the UTXO Persister Service locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -UTXOPersister=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -UTXOPersister=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the UTXO Persister Service locally.

--- a/docs/topics/services/validator.md
+++ b/docs/topics/services/validator.md
@@ -690,7 +690,7 @@ The code snippet you've provided utilizes a variety of technologies and librarie
 To run the Validator locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -Validator=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -Validator=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Validator locally.

--- a/docs/topics/stores/utxo.md
+++ b/docs/topics/stores/utxo.md
@@ -551,7 +551,7 @@ UTXO Store Package Structure (stores/utxo)
 To run the UTXO Store locally, you can execute the following command:
 
 ```shell
-SETTINGS_CONTEXT=dev.[YOUR_USERNAME] go run -UtxoStore=1
+SETTINGS_CONTEXT=dev.[YOUR_CONTEXT] go run -UtxoStore=1
 ```
 
 Please refer to the [Locally Running Services Documentation](../../howto/locallyRunningServices.md) document for more information on running the Bootstrap Service locally.


### PR DESCRIPTION
Replace inconsistent use of [YOUR_USERNAME] with [YOUR_CONTEXT] across all documentation for SETTINGS_CONTEXT environment variable usage.

Rationale:
- The identifier after 'dev.' is a generic context name, not necessarily a username (e.g., dev.kafkatool, dev.newenvironment1)
- [YOUR_CONTEXT] more accurately describes what the placeholder represents
- Provides consistency across all documentation

Changes:
- Updated 15 documentation files
- Changed SETTINGS_CONTEXT=dev.[YOUR_USERNAME] to dev.[YOUR_CONTEXT]
- Updated settings file examples (utxostore.dev.*, network.dev.*)
- Improved explanatory text to clarify context identifiers

Note: [YOUR_USERNAME] placeholders in forkAndPullRequestGuidelines.md were intentionally not changed as they correctly refer to GitHub usernames.