### PR TITLE
docs: fix chown command to use correct group syntax

### DIFF
--- a/docs/howto/miners/docker/minersHowToSyncTheNode.md
+++ b/docs/howto/miners/docker/minersHowToSyncTheNode.md
@@ -167,7 +167,7 @@ bitcoin-cli stop
 ```bash
 # Create export directory
 sudo mkdir -p /mnt/teranode/seed/export
-sudo chown $USER:$USER /mnt/teranode/seed/export
+sudo chown $USER:$(id -gn $USER) /mnt/teranode/seed/export
 ```
 
 #### Step 3: Export UTXO Data

--- a/docs/howto/miners/kubernetes/minersHowToSyncTheNode.md
+++ b/docs/howto/miners/kubernetes/minersHowToSyncTheNode.md
@@ -171,7 +171,7 @@ bitcoin-cli stop
 ```bash
 # Create export directory
 sudo mkdir -p /mnt/teranode/seed/export
-sudo chown $USER:$USER /mnt/teranode/seed/export
+sudo chown $USER:$(id -gn $USER) /mnt/teranode/seed/export
 ```
 
 #### Step 3: Export UTXO Data


### PR DESCRIPTION
Replace `$USER:$USER` with `$USER:$(id -gn $USER)` in directory permission setup commands.

Issue: The original command assumed the group name matches the username, which isn't always true on all systems. This caused permission errors when creating the export directory.

Fix: Use `$(id -gn $USER)` to dynamically get the user's actual primary group name instead of assuming it matches the username.

Files updated:
- docs/howto/miners/docker/minersHowToSyncTheNode.md
- docs/howto/miners/kubernetes/minersHowToSyncTheNode.md

Reported by user who encountered: "Permission denied" errors that were resolved by using the correct group syntax.