### PR TITLE
feat(infra): improve Kafka setup and add data cleanup script

### DIFF
--- a/deploy/docker/base/docker-services.yml
+++ b/deploy/docker/base/docker-services.yml
@@ -87,7 +87,7 @@ services:
       - ../../../services/propagation/propagation_api/propagation_api.proto:/etc/protos/propagation_api.proto:ro
       - ../base/kafka-console-config.yml:/etc/console/config.yml:ro
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8082:8080"
     depends_on:
       - kafka-shared
 

--- a/scripts/clean_datadir.sh
+++ b/scripts/clean_datadir.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+# Parse arguments
+FORCE=false
+if [ "$1" == "--force" ] || [ "$1" == "-f" ]; then
+    FORCE=true
+fi
+
+# Check if DATADIR is set
+if [ -z "$DATADIR" ]; then
+    echo "Error: DATADIR environment variable is not set"
+    exit 1
+fi
+
+# Check if DATADIR exists
+if [ ! -d "$DATADIR" ]; then
+    echo "Error: DATADIR '$DATADIR' does not exist"
+    exit 1
+fi
+
+echo "Cleaning folders in: $DATADIR"
+echo "This will delete all subdirectories but preserve p2p.key in the root"
+
+if [ "$FORCE" = false ]; then
+    read -p "Are you sure you want to continue? (yes/no): " confirm
+    if [ "$confirm" != "yes" ]; then
+        echo "Operation cancelled"
+        exit 0
+    fi
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+echo "Creating temporary directory: $TEMP_DIR"
+
+# Use rsync to delete everything and sync with temp directory
+echo "Running rsync to clean directories..."
+rsync -a --delete --exclude='p2p.key' "$TEMP_DIR/" "$DATADIR/"
+
+echo "✅ Cleanup complete!"
+echo "Contents of $DATADIR:"
+ls -la "$DATADIR/"

--- a/scripts/kafka.sh
+++ b/scripts/kafka.sh
@@ -8,17 +8,25 @@ source "${SCRIPT_DIR}/docker-service-helper.sh"
 # Initialize (DATA_PATH needed to suppress warnings from base docker-services.yml)
 docker_service_init
 
+# Check if /etc/hosts entry exists
+if ! grep -q "kafka-shared" /etc/hosts 2>/dev/null; then
+    echo ""
+    echo "❌ ERROR: Missing required /etc/hosts entry!"
+    echo ""
+    echo "IMPORTANT: Add this to /etc/hosts (required for all developers):"
+    echo "127.0.0.1	kafka-shared"
+    echo ""
+    echo "Run this command to add it:"
+    echo "sudo sh -c 'echo \"127.0.0.1\tkafka-shared\" >> /etc/hosts'"
+    echo ""
+    echo "Why: Kafka advertises itself as 'kafka-shared:9092'. Docker containers can"
+    echo "resolve this via internal DNS, but your host machine needs this /etc/hosts"
+    echo "entry to connect. Without it, Kafka clients will fail to connect."
+    echo ""
+    exit 1
+fi
+
 # Run docker compose with service-specific info
 docker_service_run "${1:-up}" "deploy/docker/kafka" "Kafka and Kafka Console (ephemeral - no persistent data)" \
-    "Kafka broker: localhost:9092" \
-    "Kafka Console UI: http://localhost:8080" \
-    "" \
-    "IMPORTANT: Add this to /etc/hosts (required for all developers):" \
-    "127.0.0.1	kafka-shared" \
-    "" \
-    "Run this command to add it:" \
-    "sudo sh -c 'echo \"127.0.0.1\tkafka-shared\" >> /etc/hosts'" \
-    "" \
-    "Why: Kafka advertises itself as 'kafka-shared:9092'. Docker containers can" \
-    "resolve this via internal DNS, but your host machine needs this /etc/hosts" \
-    "entry to connect. Without it, Kafka clients will fail to connect."
+    "Kafka broker: kafka-shared:9092" \
+    "Kafka Console UI: http://localhost:8082"


### PR DESCRIPTION
## Summary
- Add pre-flight check to kafka.sh to verify /etc/hosts entry before starting Kafka
- Change Kafka Console UI port from 8080 to 8082 to avoid conflicts
- Add clean_datadir.sh script to safely clean data directories while preserving p2p.key

## Changes
1. **scripts/kafka.sh**: Moved /etc/hosts validation to pre-flight check that exits early with clear error message if missing
2. **deploy/docker/base/docker-services.yml**: Updated Kafka Console port mapping from 8080 to 8082
3. **scripts/clean_datadir.sh**: New utility script for cleaning DATADIR with safety checks and confirmation prompt

## Test Plan
- [ ] Verify kafka.sh fails gracefully when /etc/hosts entry is missing
- [ ] Verify kafka.sh starts successfully when /etc/hosts entry is present
- [ ] Verify Kafka Console UI is accessible at http://localhost:8082
- [ ] Test clean_datadir.sh with --force flag
- [ ] Verify clean_datadir.sh preserves p2p.key file