### PR TITLE
Revert "fix: add DoS protection for UTXO deserialization"

### DIFF
--- a/cmd/filereader/file_reader.go
+++ b/cmd/filereader/file_reader.go
@@ -164,10 +164,10 @@ func readFile(ctx context.Context, filename string, ext fileformat.FileType, log
 
 	switch ext {
 	case fileformat.FileTypeUtxoSet:
-		return handleUtxoSet(ctx, br, settings)
+		return handleUtxoSet(ctx, br)
 
 	case fileformat.FileTypeUtxoAdditions:
-		return handleUtxoAdditions(ctx, br, settings)
+		return handleUtxoAdditions(ctx, br)
 
 	case fileformat.FileTypeUtxoHeaders:
 		return handleUtxoHeaders(br)
@@ -333,7 +333,7 @@ func handleBlock(br *bufio.Reader, logger ulogger.Logger, settings *settings.Set
 }
 
 // handleUtxoSet processes FileTypeUtxoSet files.
-func handleUtxoSet(ctx context.Context, br *bufio.Reader, settings *settings.Settings) error {
+func handleUtxoSet(ctx context.Context, br *bufio.Reader) error {
 	// Read the previous block hash
 	b := make([]byte, 32)
 
@@ -375,8 +375,7 @@ func handleUtxoSet(ctx context.Context, br *bufio.Reader, settings *settings.Set
 		for {
 			var ud *utxopersister.UTXOWrapper
 
-			maxScriptSize := utxopersister.CalculateMaxScriptSize(settings.Policy.MaxScriptSizePolicy)
-			ud, err = utxopersister.NewUTXOWrapperFromReader(ctx, br, maxScriptSize)
+			ud, err = utxopersister.NewUTXOWrapperFromReader(ctx, br)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					break
@@ -397,7 +396,7 @@ func handleUtxoSet(ctx context.Context, br *bufio.Reader, settings *settings.Set
 }
 
 // handleUtxoAdditions processes FileTypeUtxoAdditions files.
-func handleUtxoAdditions(ctx context.Context, br *bufio.Reader, settings *settings.Settings) error {
+func handleUtxoAdditions(ctx context.Context, br *bufio.Reader) error {
 	b := make([]byte, 32)
 	if _, err := io.ReadFull(br, b); err != nil {
 		return errors.NewProcessingError("error reading block hash", err)
@@ -423,8 +422,7 @@ func handleUtxoAdditions(ctx context.Context, br *bufio.Reader, settings *settin
 		for {
 			var ud *utxopersister.UTXOWrapper
 
-			maxScriptSize := utxopersister.CalculateMaxScriptSize(settings.Policy.MaxScriptSizePolicy)
-			ud, err = utxopersister.NewUTXOWrapperFromReader(ctx, br, maxScriptSize)
+			ud, err = utxopersister.NewUTXOWrapperFromReader(ctx, br)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					break

--- a/cmd/seeder/seeder.go
+++ b/cmd/seeder/seeder.go
@@ -431,8 +431,7 @@ func processUTXOs(ctx context.Context, logger ulogger.Logger, appSettings *setti
 			default:
 				var utxoWrapper *utxopersister.UTXOWrapper
 
-				maxScriptSize := utxopersister.CalculateMaxScriptSize(appSettings.Policy.MaxScriptSizePolicy)
-				utxoWrapper, err = utxopersister.NewUTXOWrapperFromReader(gCtx, reader, maxScriptSize)
+				utxoWrapper, err = utxopersister.NewUTXOWrapperFromReader(gCtx, reader)
 				if err != nil {
 					if errors.Is(err, io.EOF) {
 						break OUTER

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -569,8 +569,7 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 				return ctx.Err()
 			default:
 				// Read the next 36 bytes...
-				maxScriptSize := CalculateMaxScriptSize(us.settings.Policy.MaxScriptSizePolicy)
-				utxoWrapper, err := NewUTXOWrapperFromReader(ctx, previousUTXOSetReader, maxScriptSize)
+				utxoWrapper, err := NewUTXOWrapperFromReader(ctx, previousUTXOSetReader)
 				if err != nil {
 					if err == io.EOF {
 						break OUTER

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -4,7 +4,6 @@ package utxopersister
 import (
 	"context"
 	"io"
-	"math"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -106,7 +105,7 @@ func checkAdditions(t *testing.T, ud *UTXOSet) {
 	defer r.Close()
 
 	for {
-		utxoWrapper, err := NewUTXOWrapperFromReader(context.Background(), r, math.MaxUint32)
+		utxoWrapper, err := NewUTXOWrapperFromReader(context.Background(), r)
 		if err != nil {
 			assert.ErrorIs(t, err, io.EOF)
 			break

--- a/services/utxopersister/UTXO_test.go
+++ b/services/utxopersister/UTXO_test.go
@@ -2,10 +2,7 @@
 package utxopersister
 
 import (
-	"bytes"
-	"math"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -52,7 +49,7 @@ func TestBytesNormalTX(t *testing.T) {
 
 	assert.Len(t, b, 32+4+4+4+8+4+5)
 
-	uw2, err := NewUTXOWrapperFromBytes(b, math.MaxUint32)
+	uw2, err := NewUTXOWrapperFromBytes(b)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uw.TxID, uw2.TxID)
@@ -84,7 +81,7 @@ func TestBytesCoinbaseTX(t *testing.T) {
 
 	assert.Len(t, b, 32+4+4+4+8+4+5)
 
-	u2, err := NewUTXOWrapperFromBytes(b, math.MaxUint32)
+	u2, err := NewUTXOWrapperFromBytes(b)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uw.TxID, u2.TxID)
@@ -99,7 +96,7 @@ func TestTxWithOnlyOutputs(t *testing.T) {
 	txBytes, err := os.ReadFile("testdata/4827ad32852fd9ca3979a8e507e38c6e557e58bc453184ef19cc7a5f86e7d59b.outputs")
 	require.NoError(t, err)
 
-	uw, err := NewUTXOWrapperFromBytes(txBytes, math.MaxUint32)
+	uw, err := NewUTXOWrapperFromBytes(txBytes)
 	require.NoError(t, err)
 
 	assert.Equal(t, 476, len(uw.UTXOs))
@@ -118,188 +115,4 @@ func TestTxWithOnlyOutputs(t *testing.T) {
 	}
 
 	assert.Equal(t, 476, count)
-}
-
-func TestNewUTXOFromReader_DoSProtection(t *testing.T) {
-	t.Run("reject script length exceeding MaxUTXOScriptSize", func(t *testing.T) {
-		testMaxScriptSize := uint32(500000)
-		maliciousScriptLength := testMaxScriptSize + 1
-
-		maliciousBytes := make([]byte, 16)
-		maliciousBytes[0] = 0x01
-
-		maliciousBytes[4] = 0x01
-
-		maliciousBytes[12] = byte(maliciousScriptLength)
-		maliciousBytes[13] = byte(maliciousScriptLength >> 8)
-		maliciousBytes[14] = byte(maliciousScriptLength >> 16)
-		maliciousBytes[15] = byte(maliciousScriptLength >> 24)
-
-		reader := bytes.NewReader(maliciousBytes)
-		uw := &UTXOWrapper{maxScriptSize: testMaxScriptSize}
-		utxo := &UTXO{}
-
-		err := uw.NewUTXOFromReader(reader, utxo)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "script length")
-		assert.Contains(t, err.Error(), "exceeds maximum allowed size")
-	})
-
-	t.Run("reject maximum uint32 script length", func(t *testing.T) {
-		maliciousScriptLength := uint32(0xFFFFFFFF)
-		testMaxScriptSize := uint32(500000)
-
-		maliciousBytes := make([]byte, 16)
-		maliciousBytes[0] = 0x01
-
-		maliciousBytes[4] = 0x01
-
-		maliciousBytes[12] = byte(maliciousScriptLength)
-		maliciousBytes[13] = byte(maliciousScriptLength >> 8)
-		maliciousBytes[14] = byte(maliciousScriptLength >> 16)
-		maliciousBytes[15] = byte(maliciousScriptLength >> 24)
-
-		reader := bytes.NewReader(maliciousBytes)
-		uw := &UTXOWrapper{maxScriptSize: testMaxScriptSize}
-		utxo := &UTXO{}
-
-		err := uw.NewUTXOFromReader(reader, utxo)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "script length")
-		assert.Contains(t, err.Error(), "exceeds maximum allowed size")
-	})
-
-	t.Run("accept script length at MaxUTXOScriptSize", func(t *testing.T) {
-		validScriptLength := uint32(500000)
-
-		validBytes := make([]byte, 16+validScriptLength)
-		validBytes[0] = 0x01
-
-		validBytes[4] = 0x01
-
-		validBytes[12] = byte(validScriptLength)
-		validBytes[13] = byte(validScriptLength >> 8)
-		validBytes[14] = byte(validScriptLength >> 16)
-		validBytes[15] = byte(validScriptLength >> 24)
-
-		reader := bytes.NewReader(validBytes)
-		uw := &UTXOWrapper{maxScriptSize: validScriptLength}
-		utxo := &UTXO{}
-
-		err := uw.NewUTXOFromReader(reader, utxo)
-
-		require.NoError(t, err)
-		assert.Equal(t, int(validScriptLength), len(utxo.Script))
-	})
-}
-
-func TestNewUTXOValueFromReader_DoSProtection(t *testing.T) {
-	t.Run("reject script length exceeding MaxUTXOScriptSize", func(t *testing.T) {
-		testMaxScriptSize := uint32(500000)
-		maliciousScriptLength := testMaxScriptSize + 1
-
-		maliciousBytes := make([]byte, 16)
-		maliciousBytes[0] = 0x01
-
-		maliciousBytes[4] = 0x01
-
-		maliciousBytes[12] = byte(maliciousScriptLength)
-		maliciousBytes[13] = byte(maliciousScriptLength >> 8)
-		maliciousBytes[14] = byte(maliciousScriptLength >> 16)
-		maliciousBytes[15] = byte(maliciousScriptLength >> 24)
-
-		reader := bytes.NewReader(maliciousBytes)
-		uw := &UTXOWrapper{maxScriptSize: testMaxScriptSize}
-
-		value, err := uw.NewUTXOValueFromReader(reader)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "script length")
-		assert.Contains(t, err.Error(), "exceeds maximum allowed size")
-		assert.Equal(t, uint64(0), value)
-	})
-
-	t.Run("reject maximum uint32 script length", func(t *testing.T) {
-		maliciousScriptLength := uint32(0xFFFFFFFF)
-		testMaxScriptSize := uint32(500000)
-
-		maliciousBytes := make([]byte, 16)
-		maliciousBytes[0] = 0x01
-
-		maliciousBytes[4] = 0x01
-
-		maliciousBytes[12] = byte(maliciousScriptLength)
-		maliciousBytes[13] = byte(maliciousScriptLength >> 8)
-		maliciousBytes[14] = byte(maliciousScriptLength >> 16)
-		maliciousBytes[15] = byte(maliciousScriptLength >> 24)
-
-		reader := bytes.NewReader(maliciousBytes)
-		uw := &UTXOWrapper{maxScriptSize: testMaxScriptSize}
-
-		value, err := uw.NewUTXOValueFromReader(reader)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "script length")
-		assert.Contains(t, err.Error(), "exceeds maximum allowed size")
-		assert.Equal(t, uint64(0), value)
-	})
-}
-
-func TestNewUTXOFromReader_ConcurrentAttack(t *testing.T) {
-	numGoroutines := 20
-	maliciousScriptLength := uint32(0xFFFFFFFF)
-	testMaxScriptSize := uint32(500000)
-
-	t.Logf("Starting %d goroutines, each attempting %.2f GB allocation = %.2f GB total!",
-		numGoroutines, float64(maliciousScriptLength)/(1024*1024*1024),
-		float64(numGoroutines)*float64(maliciousScriptLength)/(1024*1024*1024))
-
-	maliciousBytes := make([]byte, 16)
-	maliciousBytes[0] = 0x01
-
-	maliciousBytes[4] = 0x01
-
-	maliciousBytes[12] = byte(maliciousScriptLength)
-	maliciousBytes[13] = byte(maliciousScriptLength >> 8)
-	maliciousBytes[14] = byte(maliciousScriptLength >> 16)
-	maliciousBytes[15] = byte(maliciousScriptLength >> 24)
-
-	results := make(chan error, numGoroutines)
-	var wg sync.WaitGroup
-
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-
-		go func(goroutineID int) {
-			defer wg.Done()
-
-			reader := bytes.NewReader(maliciousBytes)
-			uw := &UTXOWrapper{maxScriptSize: testMaxScriptSize}
-			utxo := &UTXO{}
-
-			err := uw.NewUTXOFromReader(reader, utxo)
-
-			t.Logf("Goroutine %d: %v", goroutineID, err)
-			results <- err
-		}(i)
-	}
-
-	wg.Wait()
-	close(results)
-
-	errorCount := 0
-
-	for err := range results {
-		if err != nil {
-			errorCount++
-		}
-	}
-
-	require.Equal(t, numGoroutines, errorCount, "All goroutines should fail with validation error")
-
-	t.Logf("✓ DoS protection successful: all %d concurrent allocation attempts were blocked", numGoroutines)
-	t.Logf("✓ System prevented %.2f GB of malicious memory allocation",
-		float64(numGoroutines)*float64(maliciousScriptLength)/(1024*1024*1024))
 }

--- a/services/utxopersister/consolidator.go
+++ b/services/utxopersister/consolidator.go
@@ -279,8 +279,7 @@ func (c *consolidator) processAdditionsFromReader(ctx context.Context, r io.Read
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			maxScriptSize := CalculateMaxScriptSize(c.settings.Policy.MaxScriptSizePolicy)
-			wrapper, err := NewUTXOWrapperFromReader(ctx, r, maxScriptSize)
+			wrapper, err := NewUTXOWrapperFromReader(ctx, r)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return nil

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -1346,8 +1346,7 @@ func (s *Store) getExternalTransaction(ctx context.Context, previousTxHash chain
 	} else {
 		bufferedReader := bufio.NewReader(bytes.NewReader(txBytes))
 
-		maxScriptSize := utxopersister.CalculateMaxScriptSize(s.settings.Policy.MaxScriptSizePolicy)
-		uw, err := utxopersister.NewUTXOWrapperFromReader(ctx, bufferedReader, maxScriptSize)
+		uw, err := utxopersister.NewUTXOWrapperFromReader(ctx, bufferedReader)
 		if err != nil {
 			return nil, errors.NewTxInvalidError("[GetTxFromExternalStore][%s] could not read outputs from reader", previousTxHash.String(), err)
 		}


### PR DESCRIPTION
Reverts bsv-blockchain/teranode#94

Fixes #148 

We should not be checking scriptsize for files that we wrote to disk or get provided as seed. All actual maxscriptsize checks will be handled during TX Validation. Incoming transactions use our policy setting of 500k, but when a tx is included in a block we need to follow the consensus which is "unlimited", but in practice to set 4GB in SVNode

See https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/consensus/consensus.h#L59