### PR TITLE
Fix flaky chaos test thresholds

### DIFF
--- a/test/chaos/scenario_04_intermittent_drops_test.go
+++ b/test/chaos/scenario_04_intermittent_drops_test.go
@@ -189,9 +189,9 @@ func TestScenario04_IntermittentDrops(t *testing.T) {
 		t.Logf("PostgreSQL results: %d successes, %d failures out of %d attempts", successCount, failureCount, attempts)
 
 		// With 30% drop rate, we expect some successes (at least 40% should succeed statistically)
-		require.Greater(t, successCount, attempts*4/10, "Expected at least 40%% success rate")
+		require.GreaterOrEqual(t, successCount, attempts*4/10, "Expected at least 40%% success rate")
 		// But also some failures (at least 10% should fail)
-		require.Greater(t, failureCount, attempts/10, "Expected some failures with 30%% drop rate")
+		require.GreaterOrEqual(t, failureCount, attempts/10, "Expected some failures with 30%% drop rate")
 
 		t.Logf("✓ PostgreSQL handling low intermittent drops correctly")
 	})
@@ -236,7 +236,7 @@ func TestScenario04_IntermittentDrops(t *testing.T) {
 
 		// With 30% drop rate, expect similar success/failure distribution
 		// Note: Kafka might have internal retries that improve success rate
-		require.Greater(t, successCount, attempts*4/10, "Expected at least 40%% success rate")
+		require.GreaterOrEqual(t, successCount, attempts*4/10, "Expected at least 40%% success rate")
 		// Kafka may handle drops better than PostgreSQL due to internal buffering
 		if failureCount == 0 {
 			t.Logf("⚠ No failures observed - Kafka may have internal retry mechanisms")
@@ -306,7 +306,7 @@ func TestScenario04_IntermittentDrops(t *testing.T) {
 
 			// With retry logic and 60% drop rate, should get more successes than without retries
 			// At least 40% should eventually succeed (0.4^3 = 6.4% chance of 3 consecutive failures)
-			require.Greater(t, retrySuccessCount, attempts*4/10, "Retry logic should improve success rate")
+			require.GreaterOrEqual(t, retrySuccessCount, attempts*4/10, "Retry logic should improve success rate")
 
 			t.Logf("✓ PostgreSQL retry logic working correctly")
 		})


### PR DESCRIPTION
## Summary
Fixes flaky test failures in scenario_04 chaos tests caused by strict boundary conditions in percentage-based assertions.

## Problem
The tests were failing intermittently when results hit exactly the threshold percentage:
- `PostgreSQL_With_Low_Drops`: Got exactly 4 successes out of 10 (40%), but test required `> 4`
- Similar issues in `Kafka_With_Low_Drops` and retry tests

Example failure:
```
Error: "4" is not greater than "4"
Test: TestScenario04_IntermittentDrops/PostgreSQL_With_Low_Drops
```

## Root Cause
Using `require.Greater(t, value, threshold)` with integer division:
- `10 * 4 / 10 = 4` 
- Test requires strictly `> 4`, but getting exactly 4 is valid behavior

## Solution
Changed `require.Greater` to `require.GreaterOrEqual` for all percentage-based assertions to accept boundary conditions.

## Changes
Fixed in 4 locations:
- Line 192: PostgreSQL success rate check (40% of 10)
- Line 194: PostgreSQL failure rate check (10% of 10)  
- Line 239: Kafka success rate check (40% of 10)
- Line 309: PostgreSQL retry success rate check (40% of 5)

## Testing
The fix allows chaos tests to pass when results are exactly at the statistical threshold, which is valid behavior for randomized connection drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)