### PR TITLE
refactor(p2p): remove unused baseURL parameter from HandleWebSocket

### DIFF
--- a/services/p2p/HandleWebsocket.go
+++ b/services/p2p/HandleWebsocket.go
@@ -248,7 +248,7 @@ func (s *Server) sendInitialNodeStatuses(clientCh chan []byte) {
 	}
 }
 
-func (s *Server) HandleWebSocket(notificationCh chan *notificationMsg, baseURL string) func(c echo.Context) error {
+func (s *Server) HandleWebSocket(notificationCh chan *notificationMsg) func(c echo.Context) error {
 	clientChannels := newClientChannelMap()
 	newClientCh := make(chan chan []byte, 1_000)
 	deadClientCh := make(chan chan []byte, 1_000)

--- a/services/p2p/HandleWebsocket_test.go
+++ b/services/p2p/HandleWebsocket_test.go
@@ -375,7 +375,7 @@ func TestHandleWebSocket(t *testing.T) {
 	notificationCh := make(chan *notificationMsg, 1)
 
 	// Create handler
-	handler := s.HandleWebSocket(notificationCh, baseURL)
+	handler := s.HandleWebSocket(notificationCh)
 
 	// Create test server
 	serverReady := make(chan struct{}, 1)

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -501,7 +501,7 @@ func (s *Server) setupHTTPServer() *echo.Echo {
 		return c.String(http.StatusOK, "OK")
 	})
 
-	e.GET("/p2p-ws", s.HandleWebSocket(s.notificationCh, s.AssetHTTPAddressURL))
+	e.GET("/p2p-ws", s.HandleWebSocket(s.notificationCh))
 
 	return e
 }

--- a/services/p2p/websocket_integration_test.go
+++ b/services/p2p/websocket_integration_test.go
@@ -44,8 +44,7 @@ func TestP2PWebSocketIntegration(t *testing.T) {
 	notificationCh := make(chan *notificationMsg, 10)
 
 	// Create handler
-	baseURL := "http://test.com"
-	handler := server.HandleWebSocket(notificationCh, baseURL)
+	handler := server.HandleWebSocket(notificationCh)
 
 	// Create test server
 	e := echo.New()


### PR DESCRIPTION
## Summary
Removes the unused `baseURL` parameter from `HandleWebSocket` function, simplifying the API and reducing confusion.

## Changes
- Removed `baseURL` parameter from `HandleWebSocket` function signature
- Updated function call in `Server.setupHTTPServer()`
- Updated test files to match new signature

## Rationale
The `baseURL` parameter was never used in the function body and created confusion since the function already has access to `s.AssetHTTPAddressURL` through the server instance.

## Test Plan
- All existing websocket tests pass
- Package compiles successfully
- No behavioral changes