### PR TITLE
fix(blockvalidation): remove unsafe concurrent access to block.SubtreeSlices in logging

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -791,18 +791,14 @@ func (u *BlockValidation) setTxMinedStatus(ctx context.Context, blockHash *chain
 	if blockWasAlreadyCached && cachedBlock != nil {
 		// Verify the cached block has subtrees loaded
 		if u.hasValidSubtrees(cachedBlock) {
-			u.logger.Debugf("[setTxMined][%s] using cached block with %d subtrees", blockHash.String(), len(cachedBlock.SubtreeSlices))
+			u.logger.Debugf("[setTxMined][%s] using cached block with subtrees", blockHash.String())
 			block = cachedBlock
 
 			// Remove from cache immediately - we're about to use it and don't need it cached anymore
 			// This frees memory sooner than waiting for cache expiry or the delete at line 894
 			u.lastValidatedBlocks.Delete(*blockHash)
 		} else {
-			if len(cachedBlock.SubtreeSlices) != len(cachedBlock.Subtrees) || len(cachedBlock.SubtreeSlices) == 0 {
-				u.logger.Warnf("[setTxMined][%s] cached block missing subtrees, fetching from blockchain", blockHash.String())
-			} else {
-				u.logger.Warnf("[setTxMined][%s] cached block has invalid subtrees, fetching from blockchain", blockHash.String())
-			}
+			u.logger.Warnf("[setTxMined][%s] cached block has invalid subtrees, fetching from blockchain", blockHash.String())
 			blockWasAlreadyCached = false
 		}
 	}
@@ -1318,7 +1314,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 				}
 
 				// Block validation succeeded - now cache it with subtrees loaded
-				u.logger.Debugf("[ValidateBlock][%s] background validation complete, caching block with subtrees", block.Hash().String(), len(block.SubtreeSlices))
+				u.logger.Debugf("[ValidateBlock][%s] background validation complete, caching block", block.Hash().String())
 				u.lastValidatedBlocks.Set(*block.Hash(), block)
 			}()
 		} else {


### PR DESCRIPTION
## Summary
Fix data race in BlockValidation where multiple goroutines concurrently access `block.SubtreeSlices` without synchronization.

## Problem
The race occurs between two goroutines accessing the same block instance:

**Write (goroutine 1):** `setTxMinedStatus()` at line 894
```go
block.SubtreeSlices = nil  // Clear subtrees to free memory
```

**Read (goroutine 2):** `ValidateBlockWithOptions` background goroutine at line 1321
```go
u.logger.Debugf("... %d subtrees", len(block.SubtreeSlices))  // Diagnostic logging
```

### Race Scenario
1. Background validation goroutine finishes and caches the validated block
2. `setTxMinedStatus` retrieves the same cached block instance
3. Both goroutines have references to the **same block object**
4. Background goroutine reads `len(block.SubtreeSlices)` for logging
5. `setTxMinedStatus` writes `block.SubtreeSlices = nil` simultaneously
6. **Data race detected** by Go's race detector

## Root Cause
Block instances are cached in `lastValidatedBlocks` and shared between goroutines without synchronization. The cached block is retrieved by reference, not copied, so modifications are visible to all holders.

## Solution
Remove `len(block.SubtreeSlices)` from diagnostic log statements:

- **Line 794:** Removed subtree count from "using cached block" log
- **Line 801:** Removed detailed subtree diagnostics  
- **Line 1321:** Removed subtree count from "background validation complete" log

The length information was only used for debugging and is not critical. Removing these reads eliminates the race without requiring:
- Deep copying of blocks (expensive)
- Synchronization primitives (complex)
- Architectural changes (risky)

## Testing
This fix resolves the data race detected in:
```
TestLongestChainAerospike/invalid_block
```

The race was consistently reported at:
```
Write at 0x00c0031d5898 by goroutine 2017:
  BlockValidation.setTxMinedStatus() line 894
  
Previous read at 0x00c0031d5898 by goroutine 2537:
  BlockValidation.ValidateBlockWithOptions.func1.1() line 1321
```

## Impact
- **No functional changes** - Only affects diagnostic logging
- **No performance impact** - Removes a slice length read
- **Thread-safe** - Eliminates concurrent access to shared field

🤖 Generated with [Claude Code](https://claude.com/claude-code)