### PR TITLE
MvP-4434 Add policy check MaxCoinsViewCacheSize

### DIFF
--- a/services/validator/TxValidator_test.go
+++ b/services/validator/TxValidator_test.go
@@ -895,3 +895,62 @@ func TestTx5f37c7a38b5e0bc177a4c353481f30c6de1bc46db534019846d7bc829f58254a(t *t
 	})
 	require.NoError(t, err)
 }
+
+func TestMaxCoinsViewCacheSize(t *testing.T) {
+	// TxID := 9f569c12dfe382504748015791d1994725a7d81d92ab61a6221eadab9f122ece
+	testTxHex := "010000000000000000ef011c044c4db32b3da68aa54e3f30c71300db250e0b48ea740bd3897a8ea1a2cc9a020000006b483045022100c6177fa406ecb95817d3cdd3e951696439b23f8e888ef993295aa73046504029022052e75e7bfd060541be406ec64f4fc55e708e55c3871963e95bf9bd34df747ee041210245c6e32afad67f6177b02cfc2878fce2a28e77ad9ecbc6356960c020c592d867ffffffffd4c7a70c000000001976a914296b03a4dd56b3b0fe5706c845f2edff22e84d7388ac0301000000000000001976a914a4429da7462800dedc7b03a4fc77c363b8de40f588ac000000000000000024006a4c2042535620466175636574207c20707573682d7468652d627574746f6e2e617070d2c7a70c000000001976a914296b03a4dd56b3b0fe5706c845f2edff22e84d7388ac00000000"
+	testTx, errTx := bt.NewTxFromString(testTxHex)
+	require.NoError(t, errTx)
+
+	testBlockHeight := uint32(886413)
+	testUtxoHeights := []uint32{886412}
+
+	// Calculate N: the actual accumulated previous tx script size
+	var accumulatedScriptSize uint64
+	for _, input := range testTx.Inputs {
+		accumulatedScriptSize += uint64(len(*input.PreviousTxScript))
+	}
+
+	t.Run("MaxCoinsViewCacheSize zero - should pass", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.Policy.MaxCoinsViewCacheSize = 0 // disabled
+		tSettings.ChainCfgParams = &chaincfg.MainNetParams
+
+		txValidator := NewTxValidator(ulogger.TestLogger{}, tSettings)
+		err := txValidator.ValidateTransaction(testTx, testBlockHeight, testUtxoHeights, &Options{})
+		require.NoError(t, err)
+	})
+
+	t.Run("MaxCoinsViewCacheSize N - should pass", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.Policy.MaxCoinsViewCacheSize = accumulatedScriptSize // exactly at limit
+		tSettings.ChainCfgParams = &chaincfg.MainNetParams
+
+		txValidator := NewTxValidator(ulogger.TestLogger{}, tSettings)
+		err := txValidator.ValidateTransaction(testTx, testBlockHeight, testUtxoHeights, &Options{})
+		require.NoError(t, err)
+	})
+
+	t.Run("MaxCoinsViewCacheSize N-1 - should fail", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.Policy.MaxCoinsViewCacheSize = accumulatedScriptSize - 1 // below limit
+		tSettings.ChainCfgParams = &chaincfg.MainNetParams
+
+		txValidator := NewTxValidator(ulogger.TestLogger{}, tSettings)
+		err := txValidator.ValidateTransaction(testTx, testBlockHeight, testUtxoHeights, &Options{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad-txns-inputs-too-large")
+	})
+
+	t.Run("SkipPolicyChecks true - should pass even with low limit", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.Policy.MaxCoinsViewCacheSize = 1 // very low limit
+		tSettings.ChainCfgParams = &chaincfg.MainNetParams
+
+		txValidator := NewTxValidator(ulogger.TestLogger{}, tSettings)
+		err := txValidator.ValidateTransaction(testTx, testBlockHeight, testUtxoHeights, &Options{
+			SkipPolicyChecks: true,
+		})
+		require.NoError(t, err)
+	})
+}

--- a/settings/policy.go
+++ b/settings/policy.go
@@ -27,6 +27,7 @@ type PolicySettings struct {
 	MinConfConsolidationInput       int     `json:"minconfconsolidationinput"`
 	MinConsolidationInputMaturity   int     `json:"minconsolidationinputmaturity"`
 	AcceptNonStdConsolidationInput  bool    `json:"acceptnonstdconsolidationinput"`
+	MaxCoinsViewCacheSize           uint64  `json:"maxcoinsviewcachesize"`
 }
 
 func NewPolicySettings() *PolicySettings {
@@ -139,6 +140,10 @@ func (ps *PolicySettings) SetAcceptNonStdConsolidationInput(accept bool) {
 	ps.AcceptNonStdConsolidationInput = accept
 }
 
+func (ps *PolicySettings) SetMaxCoinsViewCacheSize(size uint64) {
+	ps.MaxCoinsViewCacheSize = size
+}
+
 func (ps *PolicySettings) GetExcessiveBlockSize() int {
 	return ps.ExcessiveBlockSize
 }
@@ -241,4 +246,8 @@ func (ps *PolicySettings) GetMinConsolidationInputMaturity() int {
 
 func (ps *PolicySettings) GetAcceptNonStdConsolidationInput() bool {
 	return ps.AcceptNonStdConsolidationInput
+}
+
+func (ps *PolicySettings) GetMaxCoinsViewCacheSize() uint64 {
+	return ps.MaxCoinsViewCacheSize
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -97,6 +97,7 @@ func NewSettings(alternativeContext ...string) *Settings {
 			MinConfConsolidationInput:       getInt("minconfconsolidationinput", 6, alternativeContext...),
 			MinConsolidationInputMaturity:   getInt("minconsolidationinputmaturity", 6, alternativeContext...),
 			AcceptNonStdConsolidationInput:  getBool("acceptnonstdconsolidationinput", false, alternativeContext...),
+			MaxCoinsViewCacheSize:           getUint64("maxcoinsviewcachesize", 0, alternativeContext...),
 		},
 		Kafka: KafkaSettings{
 			Blocks:                getString("KAFKA_BLOCKS", "blocks", alternativeContext...),


### PR DESCRIPTION
This PR add the check of the previous UTXOs size to replicate BSV Node check when receive transactions from a peer

See :
https://github.com/teranode-group/bitcoin-sv-staging/blob/develop/src/coins.cpp#L131

This resolve the issue
https://github.com/bitcoin-sv/teranode/issues/4434
