### PR TITLE
Fix bootstrap servers

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -668,7 +668,7 @@ p2p_block_topic = block
 
 # list of peers provided by BSVA to speed up peer discovery and message propagation
 # used for relaying when behind firewalls and also as bootstrap servers
-p2p_bootstrap_peers = /dns4/teranode-eks-mainnet-us-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWMx6FbUK8g9zH9z3fvoD7fnXp3wsKJmJuJ3vTA3HyKuCZ|/dns4/teranode-eks-mainnet-eu-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWSpAKYLZqiq8SyG67U4qRGFnEw66eyE2kfo4ZMjUM3YdZ|/dns4/teranode-eks-testnet-us-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWKHfBrniPSRUG7JbBp3mxK1dGkb3uKk4TbVC3Ew4vmcQk|/dns4/teranode-eks-testnet-eu-2-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWR9DMm622shDLAe5hQZk4phNERF84S77JocXfLyZU9NsF|/dns4/teranode-eks-ttn-us-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWFj5nh1m3iAooxnfp5VvDtufYajTpBSopUt7anj4XLqJp|/dns4/teranode-eks-ttn-eu-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWDnQoDerA2KC8xD5hDqiSp21zf9zS5ezM32wuXgLUaden
+p2p_bootstrap_peers = /dns4/teranode-eks-mainnet-us-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWH5JVqGdaw7JEizmysCfRRcPGTFfvRJF7Hkure7oQWYnb|/dns4/teranode-eks-mainnet-eu-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooW9z2JRV37TqsmU8sDQcSQDZGSgtPpvWUmVegYxYvXfW9H|/dns4/teranode-eks-testnet-us-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWK7tQiJHKp4TmS632XTXy7nScvVvyL7Qx5YiU65EYnRub|/dns4/teranode-eks-testnet-eu-2-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWR9DMm622shDLAe5hQZk4phNERF84S77JocXfLyZU9NsF|/dns4/teranode-eks-ttn-us-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWFj5nh1m3iAooxnfp5VvDtufYajTpBSopUt7anj4XLqJp|/dns4/teranode-eks-ttn-eu-1-p2p.bsvb.tech/tcp/9905/p2p/12D3KooWDnQoDerA2KC8xD5hDqiSp21zf9zS5ezM32wuXgLUaden
 
 # NAT Traversal Settings
 # These settings help nodes behind NAT/firewall establish connections


### PR DESCRIPTION
Some peer ids of the bootstrap servers weren't persistent and got changed on the last data reset.

This PR updates to those new values, which have also been made persistent so it doesn't happen again