### PR TITLE
fix: resolve data race in Block.SubtreeSlices concurrent access (#296)

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -350,12 +350,33 @@ type MinedBlockStore interface {
 }
 
 func (b *Block) String() string {
-	b.subtreeSlicesMu.Lock()
-	defer func() {
-		b.subtreeSlicesMu.Unlock()
-	}()
+	b.subtreeSlicesMu.RLock()
+	txCount := b.TransactionCount
+	sizeInBytes := b.SizeInBytes
+	b.subtreeSlicesMu.RUnlock()
+	return fmt.Sprintf("Block %s (height: %d, id: %d, txCount: %d, size: %d)", b.Hash().String(), b.Height, b.ID, txCount, sizeInBytes)
+}
 
-	return fmt.Sprintf("Block %s (height: %d, id: %d, txCount: %d, size: %d)", b.Hash().String(), b.Height, b.ID, b.TransactionCount, b.SizeInBytes)
+// LockSubtreeSlices acquires a write lock for SubtreeSlices field.
+// Must be followed by UnlockSubtreeSlices() when done.
+func (b *Block) LockSubtreeSlices() {
+	b.subtreeSlicesMu.Lock()
+}
+
+// UnlockSubtreeSlices releases the write lock for SubtreeSlices field.
+func (b *Block) UnlockSubtreeSlices() {
+	b.subtreeSlicesMu.Unlock()
+}
+
+// RLockSubtreeSlices acquires a read lock for SubtreeSlices field.
+// Must be followed by RUnlockSubtreeSlices() when done.
+func (b *Block) RLockSubtreeSlices() {
+	b.subtreeSlicesMu.RLock()
+}
+
+// RUnlockSubtreeSlices releases the read lock for SubtreeSlices field.
+func (b *Block) RUnlockSubtreeSlices() {
+	b.subtreeSlicesMu.RUnlock()
 }
 
 type SubtreeStore interface {
@@ -470,13 +491,21 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 		}
 
 		// Verify that we have at least one subtree and that it has at least one node
-		if len(b.SubtreeSlices) == 0 || len(b.SubtreeSlices[0].Nodes) == 0 {
+		b.RLockSubtreeSlices()
+		hasNodes := len(b.SubtreeSlices) > 0 && len(b.SubtreeSlices[0].Nodes) > 0
+		var firstNodeHash *chainhash.Hash
+		if hasNodes {
+			firstNodeHash = &b.SubtreeSlices[0].Nodes[0].Hash
+		}
+		b.RUnlockSubtreeSlices()
+
+		if !hasNodes {
 			return false, errors.NewBlockInvalidError("[BLOCK][%s] first subtree has no nodes", b.String())
 		}
 
 		// 7. Check that the first transaction in the first subtree is a coinbase placeholder (zeros)
-		if !b.SubtreeSlices[0].Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholder) {
-			return false, errors.NewBlockInvalidError("[BLOCK][%s] first transaction in first subtree is not a coinbase placeholder: %s", b.String(), b.SubtreeSlices[0].Nodes[0].Hash.String())
+		if !firstNodeHash.Equal(subtreepkg.CoinbasePlaceholder) {
+			return false, errors.NewBlockInvalidError("[BLOCK][%s] first transaction in first subtree is not a coinbase placeholder: %s", b.String(), firstNodeHash.String())
 		}
 
 		// 8. Calculate the merkle root of the list of subtrees and check it matches the MR in the block header.
@@ -548,10 +577,12 @@ func (b *Block) checkBlockRewardAndFees(params *chaincfg.Params) error {
 
 	subtreeFees := uint64(0)
 
+	b.RLockSubtreeSlices()
 	for i := 0; i < len(b.SubtreeSlices); i++ {
 		subtree := b.SubtreeSlices[i]
 		subtreeFees += subtree.Fees
 	}
+	b.RUnlockSubtreeSlices()
 
 	coinbaseReward := util.GetBlockSubsidyForHeight(b.Height, params)
 
@@ -589,15 +620,21 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, checkDuplicateTr
 	}
 
 	// set the expected subtree size based on the first subtree in the block
+	b.RLockSubtreeSlices()
 	subtreeSize := 0
 	if len(b.SubtreeSlices) > 0 {
 		subtreeSize = b.SubtreeSlices[0].Size()
 	}
 
+	// Create a copy of subtree references to avoid holding lock during goroutine execution
+	subtreesCopy := make([]*subtreepkg.Subtree, len(b.SubtreeSlices))
+	copy(subtreesCopy, b.SubtreeSlices)
+	b.RUnlockSubtreeSlices()
+
 	b.txMap = txmap.NewSplitSwissMapUint64(transactionCountUint32)
-	for subIdx := 0; subIdx < len(b.SubtreeSlices); subIdx++ {
+	for subIdx := 0; subIdx < len(subtreesCopy); subIdx++ {
 		subIdx := subIdx
-		subtree := b.SubtreeSlices[subIdx]
+		subtree := subtreesCopy[subIdx]
 
 		g.Go(func() (err error) {
 			return b.checkDuplicateTransactionsInSubtree(subtree, subIdx, subtreeSize)
@@ -688,8 +725,14 @@ func (b *Block) validOrderAndBlessed(ctx context.Context, logger ulogger.Logger,
 	g, gCtx := errgroup.WithContext(ctx)
 	util.SafeSetLimit(g, concurrency)
 
-	for sIdx := 0; sIdx < len(b.SubtreeSlices); sIdx++ {
-		subtree := b.SubtreeSlices[sIdx]
+	// Create a copy of subtree references to avoid holding lock during goroutine execution
+	b.RLockSubtreeSlices()
+	subtreesCopy := make([]*subtreepkg.Subtree, len(b.SubtreeSlices))
+	copy(subtreesCopy, b.SubtreeSlices)
+	b.RUnlockSubtreeSlices()
+
+	for sIdx := 0; sIdx < len(subtreesCopy); sIdx++ {
+		subtree := subtreesCopy[sIdx]
 		sIdx := sIdx
 
 		g.Go(func() error {
@@ -1205,9 +1248,11 @@ func (b *Block) GetAndValidateSubtrees(ctx context.Context, logger ulogger.Logge
 		}
 	}
 
+	b.subtreeSlicesMu.Lock()
 	b.TransactionCount = txCount.Load()
 	// header + transaction count + size in bytes + coinbase tx size
 	b.SizeInBytes = sizeInBytes.Load() + 80 + util.VarintSize(b.TransactionCount) + uint64(b.CoinbaseTx.Size()) // nolint: gosec
+	b.subtreeSlicesMu.Unlock()
 
 	// TODO something with conflicts
 
@@ -1235,9 +1280,18 @@ func (b *Block) getSubtreeMetaSlice(ctx context.Context, subtreeStore SubtreeSto
 }
 
 func (b *Block) CheckMerkleRoot(ctx context.Context) (err error) {
-	if len(b.Subtrees) != len(b.SubtreeSlices) {
+	b.RLockSubtreeSlices()
+	subtreesLen := len(b.Subtrees)
+	subtreeSlicesLen := len(b.SubtreeSlices)
+	if subtreesLen != subtreeSlicesLen {
+		b.RUnlockSubtreeSlices()
 		return errors.NewStorageError("[BLOCK][%s] number of subtrees does not match number of subtree slices, have you called block.GetAndValidateSubtrees()?", b.String())
 	}
+
+	// Create a copy of subtree references for processing
+	subtreesCopy := make([]*subtreepkg.Subtree, len(b.SubtreeSlices))
+	copy(subtreesCopy, b.SubtreeSlices)
+	b.RUnlockSubtreeSlices()
 
 	_, _, deferFn := tracing.Tracer("block").Start(ctx, "CheckMerkleRoot",
 		tracing.WithHistogram(prometheusBlockCheckMerkleRoot),
@@ -1246,8 +1300,8 @@ func (b *Block) CheckMerkleRoot(ctx context.Context) (err error) {
 
 	hashes := make([]chainhash.Hash, len(b.Subtrees))
 
-	for sIdx := 0; sIdx < len(b.SubtreeSlices); sIdx++ {
-		subtree := b.SubtreeSlices[sIdx]
+	for sIdx := 0; sIdx < len(subtreesCopy); sIdx++ {
+		subtree := subtreesCopy[sIdx]
 		if subtree == nil {
 			return errors.NewProcessingError("[BLOCK][%s] missing subtree %d of %d", b.String(), sIdx, len(b.Subtrees))
 		}

--- a/model/update-tx-mined.go
+++ b/model/update-tx-mined.go
@@ -179,7 +179,14 @@ func updateTxMinedStatus(ctx context.Context, logger ulogger.Logger, tSettings *
 		setMinedErrorCount  = atomic.Uint64{}
 	)
 
-	for subtreeIdx, subtree := range block.SubtreeSlices {
+	// Acquire read lock to safely access SubtreeSlices
+	// We need to copy the slice references before spawning goroutines
+	block.RLockSubtreeSlices()
+	subtreeSlicesCopy := make([]*subtreepkg.Subtree, len(block.SubtreeSlices))
+	copy(subtreeSlicesCopy, block.SubtreeSlices)
+	block.RUnlockSubtreeSlices()
+
+	for subtreeIdx, subtree := range subtreeSlicesCopy {
 		subtreeIdx := subtreeIdx
 		subtree := subtree
 

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -739,6 +739,9 @@ func (u *BlockValidation) hasValidSubtrees(block *model.Block) bool {
 		return false
 	}
 
+	block.RLockSubtreeSlices()
+	defer block.RUnlockSubtreeSlices()
+
 	// Check if subtrees are loaded and match expected count
 	if len(block.SubtreeSlices) != len(block.Subtrees) || len(block.SubtreeSlices) == 0 {
 		return false
@@ -823,6 +826,7 @@ func (u *BlockValidation) setTxMinedStatus(ctx context.Context, blockHash *chain
 	if len(unsetMined) > 0 && unsetMined[0] {
 		u.logger.Warnf("[setTxMined][%s] block is marked as invalid, will attempt to unset tx mined", block.Hash().String())
 
+		block.LockSubtreeSlices()
 		block.SubtreeSlices = make([]*subtreepkg.Subtree, len(block.Subtrees))
 
 		// when the block is invalid, we might not have all the subtrees
@@ -846,8 +850,10 @@ func (u *BlockValidation) setTxMinedStatus(ctx context.Context, blockHash *chain
 
 			u.logger.Debugf("[setTxMined][%s] loaded subtree %d/%s from store", block.Hash().String(), subtreeIdx, subtreeHash.String())
 		}
+		block.UnlockSubtreeSlices()
 	} else {
 		// All subtrees should already be available for fully processed blocks
+		// GetSubtrees internally handles SubtreeSlices locking
 		_, err = block.GetSubtrees(ctx, u.logger, u.subtreeStore, u.settings.Block.GetAndValidateSubtreesConcurrency)
 		if err != nil {
 			return errors.NewProcessingError("[setTxMined][%s] failed to get subtrees from block", block.Hash().String(), err)
@@ -887,7 +893,9 @@ func (u *BlockValidation) setTxMinedStatus(ctx context.Context, blockHash *chain
 	// Clear subtrees to free memory - they're no longer needed after UpdateTxMinedStatus
 	// This prevents memory retention in the blockchain store cache if block came from there and was mutated
 	// Note: lastValidatedBlocks cache was already cleared at line 799 when we retrieved the block
+	block.LockSubtreeSlices()
 	block.SubtreeSlices = nil
+	block.UnlockSubtreeSlices()
 
 	// update block mined_set to true
 	if err = u.blockchainClient.SetBlockMinedSet(ctx, blockHash); err != nil {
@@ -1433,14 +1441,18 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 
 		// Cache the block only if subtrees are loaded (they should be from Valid() call)
 		if u.hasValidSubtrees(block) {
+			block.RLockSubtreeSlices()
 			u.logger.Debugf("[ValidateBlock][%s] caching block with %d subtrees loaded", block.Hash().String(), len(block.SubtreeSlices))
+			block.RUnlockSubtreeSlices()
 			u.lastValidatedBlocks.Set(*block.Hash(), block)
 		} else {
+			block.RLockSubtreeSlices()
 			if len(block.SubtreeSlices) != len(block.Subtrees) || len(block.SubtreeSlices) == 0 {
 				u.logger.Warnf("[ValidateBlock][%s] not caching block - subtrees not loaded (%d slices, %d hashes)", block.Hash().String(), len(block.SubtreeSlices), len(block.Subtrees))
 			} else {
 				u.logger.Warnf("[ValidateBlock][%s] not caching block - some subtrees are nil", block.Hash().String())
 			}
+			block.RUnlockSubtreeSlices()
 		}
 
 		return nil

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -281,7 +281,9 @@ func (u *BlockValidation) getBlockTransactions(ctx context.Context, block *model
 		return nil, errors.NewProcessingError("[getBlockTransactions][%s] block has no subtrees", block.Hash().String())
 	}
 
+	block.LockSubtreeSlices()
 	block.SubtreeSlices = make([]*subtreepkg.Subtree, len(block.Subtrees))
+	block.UnlockSubtreeSlices()
 	txs := make([]txWrapper, 0, block.TransactionCount)
 	txsIndex := make(map[chainhash.Hash]int, block.TransactionCount)
 	txsPerSubtree := make([][]txWrapper, len(block.Subtrees))
@@ -405,7 +407,9 @@ func (u *BlockValidation) getBlockTransactions(ctx context.Context, block *model
 					}
 				}
 
+				block.LockSubtreeSlices()
 				block.SubtreeSlices[subtreeIdx] = fullSubtree
+				block.UnlockSubtreeSlices()
 
 				fullSubtreeBytes, err := fullSubtree.Serialize()
 				if err != nil {
@@ -433,7 +437,9 @@ func (u *BlockValidation) getBlockTransactions(ctx context.Context, block *model
 					return errors.NewProcessingError("[getBlockTransactions][%s] failed to deserialize full subtree %s", block.Hash().String(), subtreeHash.String(), err)
 				}
 
+				block.LockSubtreeSlices()
 				block.SubtreeSlices[subtreeIdx] = fullSubtree
+				block.UnlockSubtreeSlices()
 
 				// make sure the subtree is not marked for deletion
 				if err = u.subtreeStore.SetDAH(gCtx, subtreeHash[:], fileformat.FileTypeSubtree, 0); err != nil {
@@ -529,15 +535,19 @@ func (u *BlockValidation) getBlockTransactions(ctx context.Context, block *model
 	}
 
 	// check that all the subtrees, except the last are the same size
+	block.RLockSubtreeSlices()
 	for i := 0; i < len(block.SubtreeSlices)-1; i++ {
 		if i == 0 {
 			subtreeSize = block.SubtreeSlices[i].Length()
 		} else if block.SubtreeSlices[i].Length() != subtreeSize && i != len(block.SubtreeSlices)-1 {
+			block.RUnlockSubtreeSlices()
 			return nil, errors.NewProcessingError("[getBlockTransactions][%s] subtree %d size %d does not match previous subtree size %d", block.Hash().String(), i, block.SubtreeSlices[i].Size(), subtreeSize)
 		}
 	}
+	block.RUnlockSubtreeSlices()
 
 	// check the merkle root of the block, this is a quick check to ensure we have the correct transactions
+	// CheckMerkleRoot handles its own locking internally
 	if err := block.CheckMerkleRoot(ctx); err != nil {
 		return nil, errors.NewProcessingError("[getBlockTransactions][%s] merkle root mismatch", block.Hash().String(), err)
 	}


### PR DESCRIPTION
Fixes #296

## Problem

A data race existed where multiple goroutines concurrently accessed Block.SubtreeSlices without proper synchronization:

- **Write**: setTxMinedStatus() sets SubtreeSlices = nil (line 890)
- **Read**: hasValidSubtrees() reads len(SubtreeSlices) (line 743)
- **Write**: getBlockTransactions() writes SubtreeSlices[idx] (lines 408, 436)
- **Read**: UpdateTxMinedStatus() iterates SubtreeSlices (line 182)

The Block struct had an internal subtreeSlicesMu RWMutex but it was not being used consistently across all access points, leading to intermittent race conditions detected by Go's race detector.

## Solution

Implemented proper mutex synchronization using the existing subtreeSlicesMu:

1. **Added exported mutex methods** to Block struct:
   - LockSubtreeSlices() / UnlockSubtreeSlices() for write operations
   - RLockSubtreeSlices() / RUnlockSubtreeSlices() for read operations

2. **Protected all SubtreeSlices access points**:
   - hasValidSubtrees(): Added RLock/RUnlock for reads
   - setTxMinedStatus(): Added Lock/Unlock for writes, careful handling around GetSubtrees() which acquires lock internally
   - UpdateTxMinedStatus(): Copy slice with RLock before goroutine spawn
   - getBlockTransactions(): Lock writes, RLock reads
   - ValidateBlock(): Protected logging access to SubtreeSlices

## Results

- ✅ No compilation errors
- ✅ No data race warnings with -race flag
- ✅ Sequential tests pass
- ✅ All concurrent access properly synchronized
- ✅ RWMutex allows efficient concurrent reads

## Technical Details

The fix uses Go's sync.RWMutex pattern:
- Multiple goroutines can hold read locks concurrently (RLock)
- Write locks are exclusive (Lock)
- Prevents data races while maintaining performance

This is the idiomatic Go solution for protecting shared data structures accessed by multiple goroutines.