### PR TITLE
docs(utxo): correct BlockAssembly notification flow comment

### DIFF
--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -933,8 +933,8 @@ func (s *Store) storeExternallyWithLock(
 		// failed during Phase 2 (creating flag cleanup).
 		//
 		// This is a key part of the self-healing architecture:
-		// - First attempt: Creates records → Notifies block assembly → Tries to clear flags → Fails
-		// - Retry attempt: Finds all records exist → Skips block assembly → Completes flag cleanup → Success
+		// - First attempt: Creates records → Tries to clear flags → Fails → Returns success → Validator notifies BlockAssembly
+		// - Retry attempt: Finds all records exist → Returns ErrTxExists → Skips BlockAssembly → Completes flag cleanup
 		//
 		// Without this cleanup attempt, creating flags would remain set indefinitely, requiring
 		// manual intervention. This ensures eventual consistency through automatic recovery.


### PR DESCRIPTION
## Summary

Fixes documentation inaccuracy in `stores/utxo/aerospike/create.go` related to issue #4350.

The comment incorrectly stated that BlockAssembly notification happens inside the UTXO store before clearing the `creating` flag. The actual code flow is:

**Actual flow:**
1. Creates records with `creating=true`
2. Tries to clear `creating` flag via `clearCreatingFlag()`
3. Returns **success** even if clearing fails (line 987)
4. Validator receives success and notifies BlockAssembly

**Updated comment to reflect this accurate flow.**

Issue #4350 was already addressed by previous commits that ensure the UTXO store returns success even when flag cleanup fails, allowing the validator to notify BlockAssembly. The `creating` flag only affects UTXO spendability, not BlockAssembly tracking.

## Test plan

- [x] Build successful
- [x] Linting passes (0 issues)
- [x] Existing tests pass (`TestCreatingBinRemoval`)
- [x] Documentation accurately reflects code behavior