### PR TITLE
data-race-set-tx-mined-and-valid-order-and-blessed

### DIFF
--- a/test/sequentialtest/longest_chain/longest_chain_test.go
+++ b/test/sequentialtest/longest_chain/longest_chain_test.go
@@ -23,8 +23,6 @@ func TestLongestChainPostgres(t *testing.T) {
 }
 
 func TestLongestChainAerospike(t *testing.T) {
-	t.Skip("Skipping due to known data race in BlockValidation.setTxMinedStatus - see issue #296")
-
 	t.Run("simple", func(t *testing.T) {
 		testLongestChainSimple(t, "aerospike")
 	})


### PR DESCRIPTION
re-enable the test - the data race has actually been fixed already

This data race has been fixed in PR https://github.com/bsv-blockchain/teranode/pull/319 (commit https://github.com/bsv-blockchain/teranode/commit/226f1003d848982797ebfa0dd0a83eb1812b1ed6).