### PR TITLE
chore: improve Aerospike configuration and dev-stack validation

### DIFF
--- a/scripts/aerospike.conf
+++ b/scripts/aerospike.conf
@@ -20,7 +20,9 @@ network {
 	}
 
 	heartbeat {
+		# mesh is used for environments that do not support multicast
 		mode mesh
+		# Use address any instead of local to allow external connections
 		address any
 		port 3002
 		interval 150
@@ -28,24 +30,24 @@ network {
 	}
 
 	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# Use address any instead of local to allow external connections
 		address any
 		port 3001
 	}
 }
 
 namespace utxo-store {
-    default-ttl 0                        # Records do not expire by default
-    evict-indexes-memory-pct 100         # Never evict indexes - rely on TTL
+    stop-writes-sys-memory-pct 90
 
-    nsup-period 10                       # Run NSUP every 10 seconds
-    nsup-threads 8                       # Allocate threads for expiration processing
-    truncate-threads 8
+    default-ttl           0
+    nsup-period           10
+    nsup-threads          1
+    truncate-threads 1
     transaction-pending-limit 0
 
     replication-factor 1
     partition-tree-sprigs 1024
-
-    stop-writes-sys-memory-pct 100       # docker SERVER_MEM_ERROR fix: Stop writes if more than 100% of system memory is used
 
     storage-engine device {
         # for full IBD, direct disk access is preferred
@@ -71,5 +73,10 @@ namespace utxo-store {
         read-page-cache true
         # Maximum flush delay in milliseconds
         flush-max-ms 1000
+
+        # high number to allow slow storage to keep up in case of traffic peaks
+        # can be dangerous if the instance crashes or the storage can't keep up at all
+        # monitor the queue with `asadm -e "show statistics like write_q"`
+        max-write-cache 1024M
     }
 }

--- a/scripts/dev-stack-macos.sh
+++ b/scripts/dev-stack-macos.sh
@@ -393,6 +393,13 @@ if [ -z "$ACTION" ]; then
     usage
 fi
 
+# Only allow a single sub-command
+if [ $# -gt 1 ]; then
+    echo "Error: Only one command allowed at a time. Got: $*" >&2
+    echo "" >&2
+    usage
+fi
+
 case "$ACTION" in
     up|start)
         start_all

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -556,7 +556,7 @@ func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaD
 
 	err = s.client.BatchOperate(batchPolicy, batchRecords)
 	if err != nil {
-		s.logger.Errorf("error in aerospike map store batch records:\n%#v\n%v", batchRecords, err)
+		s.logger.Errorf("error in aerospike map store batch records:\n%v\n%v", batchRecords, err)
 		return errors.NewStorageError("error in aerospike map store batch records", err)
 	}
 


### PR DESCRIPTION
## Summary
- Add documentation comments to Aerospike network and storage configuration
- Tune Aerospike memory limits and write cache settings for better performance
- Add validation to dev-stack script to prevent multiple commands being passed
- Improve logging format in UTXO batch operations (use %v instead of %#v)

## Changes
1. **scripts/aerospike.conf**:
   - Add comments explaining mesh mode, address configuration, and fabric settings
   - Adjust memory limits (stop-writes-sys-memory-pct: 90)
   - Reduce nsup-threads and truncate-threads to 1
   - Add max-write-cache (1024M) to handle traffic peaks

2. **scripts/dev-stack-macos.sh**:
   - Add validation to ensure only a single sub-command is provided
   - Prevents confusing behavior when multiple commands are passed

3. **stores/utxo/aerospike/get.go**:
   - Change log format from %#v to %v for cleaner batch records output

## Test plan
- [ ] Verify Aerospike starts correctly with new configuration
- [ ] Test dev-stack script rejects multiple commands
- [ ] Confirm UTXO batch operations log correctly