### PR TITLE
long-test-model-test-data-folder-tweak

### DIFF
--- a/test/longtest/model/BlockBig_test.go
+++ b/test/longtest/model/BlockBig_test.go
@@ -606,7 +606,7 @@ func Test_LoadTxMetaIntoMemory(t *testing.T) {
 	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
 	require.NoError(t, err)
 
-	teranode_model.TestFileDir = "./testdata/"
+	teranode_model.TestFileDir = t.TempDir() + "/"
 	teranode_model.TestTxMetafileNameTemplate = teranode_model.TestFileDir + "txMeta.bin"
 
 	teranode_model.TestCachedTxMetaStore, err = txmetacache.NewTxMetaCache(context.Background(), settings.NewSettings(), ulogger.TestLogger{}, utxoStore, txmetacache.Unallocated)
@@ -627,7 +627,7 @@ func Test_LoadTxMetaIntoMemory(t *testing.T) {
 }
 
 func generateBigBlockTestData(t *testing.T) (*teranode_model.TestLocalSubtreeStore, *teranode_model.Block, error) {
-	teranode_model.TestFileDir = "./test_data/"
+	teranode_model.TestFileDir = t.TempDir() + "/"
 	teranode_model.TestFileNameTemplate = teranode_model.TestFileDir + "subtree-%d.bin"
 	teranode_model.TestFileNameTemplateMerkleHashes = teranode_model.TestFileDir + "subtree-merkle-hashes.bin"
 	teranode_model.TestFileNameTemplateBlock = teranode_model.TestFileDir + "block.bin"


### PR DESCRIPTION
## Summary
Fix test data cleanup in longtest model tests by using Go's built-in `t.TempDir()` for automatic directory management.

## Problem
The `test/longtest/model` tests were generating ~1.4GB of test data files (subtree-*.bin, txMeta.bin) in a local `test_data/` directory that was:
- Never cleaned up after tests completed
- Showing up as untracked files in git status
- Accumulating on disk with each test run

## Changes
- Updated `generateBigBlockTestData()` to use `t.TempDir()` instead of `"./test_data/"`
- Updated `Test_LoadTxMetaIntoMemory()` to use `t.TempDir()` instead of `"./testdata/"`
- Removed existing test_data directory

## Benefits
- **Automatic cleanup**: Test data is removed immediately after each test completes
- **Test isolation**: Each test gets its own unique temporary directory
- **No git clutter**: Temp files are created in system temp location, not in the project
- **Safe parallel execution**: Tests can run concurrently without file conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)