### PR TITLE
Remove unneeded alternative view that broke mkdoc builds

### DIFF
--- a/docs/state-machine.diagram.md
+++ b/docs/state-machine.diagram.md
@@ -16,10 +16,3 @@ stateDiagram-v2
     RUNNING --> CATCHINGBLOCKS: CATCHUPBLOCKS
     RUNNING --> IDLE: STOP
 ```
-
-## Alternative Views
-
-If the diagram above doesn't render properly, you can view it using these alternatives:
-
-- **[View in Mermaid.live](https://mermaid.live/edit#pako:eNqNUUtvgkAQ_itkjg0QoTzn0MSuxpoSNEUPtvSwKSuaCJh1adoS_7vL0paoadI5zTffYyaZBt6qjAHCQVDBRluac1oY73ZaarJebl41w7jTpqNo3E3IcEEepvHkPpqRx0SRT8s4lhNsmz9FbQJqyWI27yQtVkQ0ngzJKlnFRGX08EJ3veXM-W_N5SHfHsWd340dXs47eC3vo0CHnG8zQMFrpkPBeEFbCE3rSkFsWMFSQNlmbE3rnUghLY_Stqflc1UVP05e1fkGcE13B4nqfdY_5VfCyoxxUtWlALQsFQHYwAegH9jmret6VhjYwcDyHR0-AT3HDGV5nms5oWcH4VGHL7VzYAa-ezwBKDKO3w)** - Edit and customize the diagram interactively
-- **Static image**: ![State Machine Diagram](https://mermaid.ink/svg/pako:eNqNUUtvgkAQ_itkjg0QoTzn0MSuxpoSNEUPtvSwKSuaCJh1adoS_7vL0paoadI5zTffYyaZBt6qjAHCQVDBRluac1oY73ZaarJebl41w7jTpqNo3E3IcEEepvHkPpqRx0SRT8s4lhNsmz9FbQJqyWI27yQtVkQ0ngzJKlnFRGX08EJ3veXM-W_N5SHfHsWd340dXs47eC3vo0CHnG8zQMFrpkPBeEFbCE3rSkFsWMFSQNlmbE3rnUghLY_Stqflc1UVP05e1fkGcE13B4nqfdY_5VfCyoxxUtWlALQsFQHYwAegH9jmret6VhjYwcDyHR0-AT3HDGV5nms5oWcH4VGHL7VzYAa-ezwBKDKO3w)


### PR DESCRIPTION
The Privacy Plugin (mkdocs.yml:211) downloads and caches external resources locally for performance/privacy
It uses the URL path as the filename, which works fine for normal URLs but breaks when URLs contain long encoded data
Linux has a 255-character filename limit, but the pako-encoded mermaid.ink URL is ~400 characters