### PR TITLE
fix(propagation): handle duplicate transactions gracefully (#382)

### DIFF
--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -1103,6 +1103,10 @@ func (ps *PropagationServer) storeTransaction(ctx context.Context, btTx *bt.Tx) 
 
 	if ps.txStore != nil {
 		if err := ps.txStore.Set(ctx, btTx.TxIDChainHash().CloneBytes(), fileformat.FileTypeTx, btTx.SerializeBytes()); err != nil {
+			// Duplicate transactions are acceptable - the transaction already exists
+			if errors.Is(err, errors.ErrBlobAlreadyExists) {
+				return nil
+			}
 			// TODO make this resilient to errors
 			// write it to secondary store (Kafka) and retry?
 			return err


### PR DESCRIPTION
When the transaction store is enabled, resending a previously stored transaction now returns success instead of an HTTP 500 error.

The storeTransaction() function now checks for BlobAlreadyExistsError and treats it as a success case, since duplicate transactions are acceptable - the transaction already exists in the store.