### PR TITLE
MvP-4443 Cleanup checkOutputs

### DIFF
--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -223,17 +223,6 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 	// 	return err
 	// }
 
-	// SAO - https://bitcoin.stackexchange.com/questions/83805/did-the-introduction-of-verifyscript-cause-a-backwards-incompatible-change-to-co
-	// SAO - The rule enforcing that unlocking scripts must be "push only" became more relevant and started being enforced with the
-	//       introduction of Segregated Witness (SegWit) which activated at height 481824.  BCH Forked before this at height 478559
-	//       and therefore let's not enforce this check until then.
-	if tv.interpreter.Interpreter() != TxInterpreterGoBDK && blockHeight > tv.settings.ChainCfgParams.UahfForkHeight {
-		// 9) The unlocking script (scriptSig) can only push numbers on the stack
-		if err := tv.pushDataCheck(tx); err != nil {
-			return err
-		}
-	}
-
 	// 10) Reject if the sum of input values is less than sum of output values
 	// 11) Reject if transaction fee would be too low (minRelayTxFee) to get into an empty block.
 	if !validationOptions.SkipPolicyChecks {
@@ -299,11 +288,9 @@ func isStandardInputScript(script *bscript.Script, blockHeight uint32, uahfHeigh
 	}
 
 	if script == nil {
-		// Nil scripts are not standard (matches pushDataCheck behavior)
 		return false
 	}
 
-	// Use the same parser as pushDataCheck for consistency
 	parser := interpreter.DefaultOpcodeParser{}
 	parsedScript, err := parser.Parse(script)
 	if err != nil {
@@ -319,30 +306,11 @@ func isStandardInputScript(script *bscript.Script, blockHeight uint32, uahfHeigh
 func (tv *TxValidator) checkOutputs(tx *bt.Tx, blockHeight uint32, validationOptions *Options) error {
 	total := uint64(0)
 
-	// Note: We use > instead of >= to exclude the Genesis activation block itself
-	// because transactions in block 620538 were created before Genesis rules existed
-	isGenesisActivated := blockHeight > tv.settings.ChainCfgParams.GenesisActivationHeight
-
 	for index, output := range tx.Outputs {
-		// Check P2SH output after genesis activation
-		if !validationOptions.SkipPolicyChecks && isGenesisActivated && output.LockingScript.IsP2SH() {
-			// See https://github.com/bitcoin-sv/teranode/issues/4333
-			return errors.NewTxInvalidError("transaction output %d is p2sh after genesis activation", index)
-		}
 
 		if output.Satoshis > MaxSatoshis {
 			return errors.NewTxInvalidError("transaction output %d satoshis is invalid", index)
 		}
-
-		// Check dust limit after genesis activation
-		// Dust checks are policy rules, not consensus rules - they only apply to mempool/relay
-		if !validationOptions.SkipPolicyChecks && isGenesisActivated {
-			// Only enforce dust limit for spendable outputs when RequireStandard is true
-			if tv.settings.ChainCfgParams.RequireStandard && output.Satoshis < DustLimit && !isUnspendableOutput(output.LockingScript) {
-				return errors.NewTxInvalidError("zero-satoshi outputs require 'OP_FALSE OP_RETURN' prefix")
-			}
-		}
-
 		total += output.Satoshis
 	}
 
@@ -645,28 +613,6 @@ func (tv *TxValidator) sigOpsCheck(tx *bt.Tx, validationOptions *Options) error 
 					return errors.NewTxInvalidError("transaction unlocking scripts have too many sigops (%d)", numSigOps)
 				}
 			}
-		}
-	}
-
-	return nil
-}
-
-// pushDataCheck validates that transaction input scripts contain only data pushes.
-func (tv *TxValidator) pushDataCheck(tx *bt.Tx) error {
-	for index, input := range tx.Inputs {
-		if input.UnlockingScript == nil {
-			return errors.NewTxInvalidError("transaction input %d unlocking script is empty", index)
-		}
-
-		parser := interpreter.DefaultOpcodeParser{}
-		parsedUnlockingScript, err := parser.Parse(input.UnlockingScript)
-
-		if err != nil {
-			return err
-		}
-
-		if !parsedUnlockingScript.IsPushOnly() {
-			return errors.NewTxInvalidError("transaction input %d unlocking script is not push only", index)
 		}
 	}
 


### PR DESCRIPTION
TxValidator.go:328 output.LockingScript.IsP2SH() is done inside [VerifyScript](https://github.com/teranode-group/bitcoin-sv-staging/blob/develop/src/script/interpreter.cpp#L2367)

TxValidator.go:341 check spendable and dust
- isUnspendableOutput is done in bsv [Solver](https://github.com/teranode-group/bitcoin-sv-staging/blob/develop/src/script/standard.cpp#L88), which is called inside bdk for standardness check
- check dust limit is done in [IsStandardTx](https://github.com/teranode-group/bitcoin-sv-staging/blob/develop/src/script/standard.cpp#L472), which is called inside bdk for standardness check

TxValidator.go:232 pushDataCheck is done inside [VerifyScript](https://github.com/teranode-group/bitcoin-sv-staging/blob/develop/src/script/interpreter.cpp#L2372)