### PR TITLE
errors As() optimisation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: golangci-lint
         name: Run go linter
-        entry: make lint-full-changed-dirs
+        entry: golangci-lint run --new ./...
         language: system
         types: [ go ]
         pass_filenames: false

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -202,7 +202,13 @@ func (e *Error) As(target interface{}) bool {
 	for current != nil {
 		// Handle *Error types manually to avoid re-entering As
 		if errPtr, ok := current.(*Error); ok {
-			// Check if this error's data satisfies target
+			// First check if the *Error itself matches the target type
+			if te, ok := target.(**Error); ok {
+				*te = errPtr
+				return true
+			}
+
+			// Then check if this error's data satisfies target
 			if err, ok := errPtr.data.(error); ok && err != nil {
 				if errors.As(err, target) {
 					return true
@@ -768,12 +774,11 @@ func Join(errs ...error) error {
 	if len(errs) > 0 && errors.As(errs[0], &tErr) {
 		previousErr = tErr
 
-		// Skip the first error (already processed) and chain the rest
-		for _, err := range errs[1:] {
-			if errors.As(err, &tErr2) {
+		for i := 1; i < len(errs); i++ {
+			if errors.As(errs[i], &tErr2) {
 				previousErr.SetWrappedErr(tErr2)
 			} else {
-				tErr2 = NewError(err.Error())
+				tErr2 = NewError(errs[i].Error())
 				previousErr.SetWrappedErr(tErr2)
 			}
 


### PR DESCRIPTION
Running local I found teranode doing this over and over and taking up 100% CPU on all cores
```
1 @ 0x1041a175c 0x1041e270c 0x10458ef05 0x10458f168 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f168 0x10458f168 0x10458f18c 0x10458f168 0x10458f18c 0x10458f18c 0x10458f168 0x10458f18c 0x10458f168 0x10458f18c 0x10458f168 0x10458f168 0x10458f18c 0x10458f168 0x10458f168 0x10458f168 0x10458f168 0x10458f18c 0x10458f18c 0x10458f168 0x10458f168 0x10458f168 0x10458f168 0x10458f168 0x10458f168 0x10458f168 0x10458f168 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x10458f18c 0x1041ea3e0 0x1041ea20c 0x10458b964 0x10459187c 0x104591869 0x1060601cc 0x10605f3c4 0x10606eea8 0x106081848 0x10489d82c 0x1041e1b24
#	0x10458ef04	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x74							github.com/bsv-blockchain/teranode/errors/errors.go:195
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f167	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2d7							github.com/bsv-blockchain/teranode/errors/errors.go:211
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x10458f18b	github.com/bsv-blockchain/teranode/errors.(*Error).As+0x2fb							github.com/bsv-blockchain/teranode/errors/errors.go:204
#	0x1041ea3df	errors.as+0xef													errors/wrap.go:122
#	0x1041ea20b	errors.As+0x18b													errors/wrap.go:113
#	0x10458b963	google.golang.org/grpc/status.FromError+0x183									google.golang.org/grpc@v1.75.0/status/status.go:113
#	0x10459187b	github.com/bsv-blockchain/teranode/errors.isGRPCWrappedError+0x2b						github.com/bsv-blockchain/teranode/errors/errors.go:847
#	0x104591868	github.com/bsv-blockchain/teranode/errors.Is+0x18								github.com/bsv-blockchain/teranode/errors/errors.go:796
#	0x1060601cb	github.com/bsv-blockchain/teranode/services/validator.(*Validator).validateInternal+0x85b			github.com/bsv-blockchain/teranode/services/validator/Validator.go:554
#	0x10605f3c3	github.com/bsv-blockchain/teranode/services/validator.(*Validator).ValidateWithOptions+0x103			github.com/bsv-blockchain/teranode/services/validator/Validator.go:318
#	0x10606eea7	github.com/bsv-blockchain/teranode/services/subtreevalidation.(*Server).blessMissingTransaction+0x167		github.com/bsv-blockchain/teranode/services/subtreevalidation/SubtreeValidation.go:371
#	0x106081847	github.com/bsv-blockchain/teranode/services/subtreevalidation.(*Server).processTransactionsInLevels.func1+0x87	github.com/bsv-blockchain/teranode/services/subtreevalidation/check_block_subtrees.go:758
#	0x10489d82b	golang.org/x/sync/errgroup.(*Group).Go.func1+0x4b								golang.org/x/sync@v0.19.0/errgroup/errgroup.go:93
```

This PR is tweaking As() to be more efficient and not take up all the CPU time.