### PR TITLE
fix(blockchain): reduce blob deletion log verbosity

### DIFF
--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
 	"github.com/bsv-blockchain/teranode/settings"
-	"github.com/bsv-blockchain/teranode/stores/blob/storetypes"
 	blockchain_store "github.com/bsv-blockchain/teranode/stores/blockchain"
 	blockchainoptions "github.com/bsv-blockchain/teranode/stores/blockchain/options"
 	blockchain_sql "github.com/bsv-blockchain/teranode/stores/blockchain/sql"
@@ -2964,9 +2963,6 @@ func (b *Blockchain) ScheduleBlobDeletion(ctx context.Context, req *blockchain_a
 		return nil, errors.NewStorageError("failed to schedule deletion", err)
 	}
 
-	b.logger.Infof("Scheduled blob deletion: id=%d, key=%x, store=%s, height=%d",
-		id, req.BlobKey, storetypes.BlobStoreType(req.StoreType).String(), req.DeleteAtHeight)
-
 	return &blockchain_api.ScheduleBlobDeletionResponse{
 		DeletionId: id,
 		Scheduled:  true,
@@ -3000,9 +2996,6 @@ func (b *Blockchain) CancelBlobDeletion(ctx context.Context, req *blockchain_api
 		}
 		return nil, err
 	}
-
-	b.logger.Infof("Cancelled blob deletion: key=%x, store=%s, reason=%s",
-		req.BlobKey, storetypes.BlobStoreType(req.StoreType).String(), req.CancelReason)
 
 	return &blockchain_api.CancelBlobDeletionResponse{
 		Cancelled: true,


### PR DESCRIPTION
## Summary
- Remove chatty info-level logs for successful blob deletion operations
- Only errors are now logged, reducing log noise in production
- Remove unused `storetypes` import

## Changes
This PR removes two info-level log statements that were generating excessive log entries:
- "Scheduled blob deletion" - logged on every successful schedule operation
- "Cancelled blob deletion" - logged on every successful cancel operation

Error logging remains intact for failed operations, ensuring visibility into actual problems.

## Test plan
- Existing tests continue to pass
- Error paths still log appropriately
- Info logs for successful operations are no longer emitted