### PR TITLE
Download missing subtree files before block revalidation

### DIFF
--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1165,7 +1165,9 @@ func (u *Server) RevalidateBlock(ctx context.Context, request *blockvalidation_a
 	// This handles the case where pruner has removed subtree data for old invalid blocks.
 	if u.p2pClient != nil {
 		var baseURL string
-		if peer, err := u.p2pClient.GetPeer(ctx, blockHeaderMeta.PeerID); err == nil && peer != nil {
+		if peer, err := u.p2pClient.GetPeer(ctx, blockHeaderMeta.PeerID); err != nil {
+			u.logger.Warnf("[RevalidateBlock][%s] failed to get peer %s for DataHubURL, will use fallback peers: %v", block.String(), blockHeaderMeta.PeerID, err)
+		} else if peer != nil {
 			baseURL = peer.DataHubURL
 		}
 		if err := u.fetchSubtreeDataForBlock(ctx, block, blockHeaderMeta.PeerID, baseURL); err != nil {


### PR DESCRIPTION
## Problem

When revalidating old invalid blocks via the `RevalidateBlock` RPC endpoint, the pruner may have already removed the subtree files (`FileTypeSubtreeToCheck` and `FileTypeSubtreeData`). This causes revalidation to fail because the validation logic cannot access the required data.

## Solution

Call `fetchSubtreeDataForBlock()` at the start of `RevalidateBlock()` to download any missing subtree files before proceeding with validation. This method:

- Checks if each subtree file exists locally
- Downloads missing files from the original peer's DataHubURL
- Falls back to alternative peers via `GetPeersAtMaxHeight()` if the primary peer fails

The fetch is only attempted when `p2pClient` is available, since peer communication is required to download the files.

## Changes

- `services/blockvalidation/Server.go`: Added subtree fetch logic in `RevalidateBlock()` before calling `ValidateBlockWithOptions()`

## Testing

- Build verified: `go build ./services/blockvalidation/...`
- Manual testing: Create an invalid block, let pruner remove subtrees, call RevalidateBlock via gRPC

🤖 Generated with [Claude Code](https://claude.ai/claude-code)