### PR TITLE
Handle invalid processeAt time for block headers

### DIFF
--- a/services/asset/httpimpl/block_header_response.go
+++ b/services/asset/httpimpl/block_header_response.go
@@ -76,6 +76,17 @@ func (r *blockHeaderResponse) MarshalJSON() ([]byte, error) {
 		ProcessedAt       *time.Time `json:"processed_at"`
 	}
 
+	// Validate ProcessedAt timestamp before marshaling
+	var processedAt *time.Time
+	if r.ProcessedAt != nil {
+		year := r.ProcessedAt.Year()
+		// Check if the year is within the valid JSON marshaling range [0, 9999]
+		if year >= 0 && year <= 9999 {
+			processedAt = r.ProcessedAt
+		}
+		// If invalid, processedAt remains nil and will be omitted from JSON
+	}
+
 	a := aliasResponse{
 		Hash:              r.Hash,
 		Version:           r.Version,
@@ -89,7 +100,7 @@ func (r *blockHeaderResponse) MarshalJSON() ([]byte, error) {
 		SizeInBytes:       r.SizeInBytes,
 		Miner:             r.Miner,
 		Invalid:           r.Invalid,
-		ProcessedAt:       r.ProcessedAt,
+		ProcessedAt:       processedAt,
 	}
 	return json.Marshal(a)
 }


### PR DESCRIPTION
This pull request improves the handling of the `ProcessedAt` timestamp in the block header response to ensure only valid timestamps are included in the JSON output. It also adds comprehensive tests to verify the correct behavior for both valid and invalid timestamp scenarios.

**Block header response marshaling:**

* Added validation in `blockHeaderResponse.MarshalJSON` to ensure the `ProcessedAt` timestamp is only included in the JSON output if its year is within the valid range [0, 9999]; otherwise, it is omitted or set to null. [[1]](diffhunk://#diff-5adfc2684d60b640bed80e7ab1d0e97d1865336b1685075f92ad09ecd68821dfR79-R89) [[2]](diffhunk://#diff-5adfc2684d60b640bed80e7ab1d0e97d1865336b1685075f92ad09ecd68821dfL92-R103)

**Testing improvements:**

* Added tests in `get_block_header_test.go` to verify:
  - The `processed_at` field is present and correct for valid timestamps.
  - The `processed_at` field is omitted or set to null for timestamps with years outside the valid range (both far past and far future).
* Imported the `time` package to support the new tests.