### PR TITLE
use trim ratio for unallocated mode also

### DIFF
--- a/stores/txmetacache/improved_cache.go
+++ b/stores/txmetacache/improved_cache.go
@@ -282,7 +282,7 @@ func New(maxBytes int, bucketType BucketType) (*ImprovedCache, error) {
 	case Unallocated:
 		for i := 0; i < BucketsCount; i++ {
 			c.buckets[i] = &bucketUnallocated{}
-			if err := c.buckets[i].Init(maxBucketBytes, 0); err != nil {
+			if err := c.buckets[i].Init(maxBucketBytes, trimRatio); err != nil {
 				return nil, errors.NewProcessingError("error creating unallocated cache", err)
 			}
 		}
@@ -298,7 +298,7 @@ func New(maxBytes int, bucketType BucketType) (*ImprovedCache, error) {
 	default: // trimmed cache
 		for i := 0; i < BucketsCount; i++ {
 			c.buckets[i] = &bucketTrimmed{}
-			if err := c.buckets[i].Init(maxBucketBytes, 0); err != nil {
+			if err := c.buckets[i].Init(maxBucketBytes, trimRatio); err != nil {
 				return nil, errors.NewProcessingError("error creating trimmed cache", err)
 			}
 		}
@@ -647,13 +647,15 @@ type bucketTrimmed struct {
 
 	elementsAdded int
 
+	trimRatio int
+
 	// number of items in the bucket.
 	numberOfItems int
 
 	overWriting bool
 }
 
-func (b *bucketTrimmed) Init(maxBytes uint64, _ int) error {
+func (b *bucketTrimmed) Init(maxBytes uint64, trimRatio int) error {
 	if maxBytes == 0 {
 		return errors.NewInvalidArgumentError("maxBytes cannot be zero")
 	}
@@ -676,6 +678,7 @@ func (b *bucketTrimmed) Init(maxBytes uint64, _ int) error {
 	b.chunks = make([][]byte, maxChunksInt)
 	b.m = txmap.NewSplitSwissLockFreeMapUint64(1024)
 	b.overWriting = false
+	b.trimRatio = trimRatio
 	b.Reset()
 
 	return nil
@@ -801,7 +804,7 @@ func (b *bucketTrimmed) Set(k, v []byte, h uint64, skipLocking ...bool) error {
 
 	// calculate the idx of the k-v pair to be added
 	// adjust idxNew, calculate where the new k-v pair will end
-	// the new k-v pair must be in the same chunk.
+	// new k-v pair must be in the same chunk.
 	idx := b.idx
 	idxNew := idx + kvLen
 	chunkIdx := idx / ChunkSize
@@ -809,8 +812,13 @@ func (b *bucketTrimmed) Set(k, v []byte, h uint64, skipLocking ...bool) error {
 
 	// check if we are crossing the chunk boundary, we need to allocate a new chunk
 	if chunkIdxNew > chunkIdx {
-		// if there are no more chunks to allocate, we need to reset the bucket
-		if chunkIdxNew >= uint64(len(chunks)) {
+		// if there are no more chunks to allocate, we need to reset bucket
+		maxChunks := uint64(len(chunks))
+		trimThreshold := uint64(float64(maxChunks) * (100 - float64(b.trimRatio)) / 100)
+		if trimThreshold < 1 {
+			trimThreshold = 1
+		}
+		if chunkIdxNew >= trimThreshold {
 			// writing needs to start over from the beginning.
 			idx = 0
 			idxNew = kvLen
@@ -1355,9 +1363,11 @@ type bucketUnallocated struct {
 	// maxSlabChunks is the per-bucket cap for mmap slab size (in chunks).
 	// It is computed from the configured bucket maxBytes.
 	maxSlabChunks uint64
+
+	trimRatio int
 }
 
-func (b *bucketUnallocated) Init(maxBytes uint64, _ int) error {
+func (b *bucketUnallocated) Init(maxBytes uint64, trimRatio int) error {
 	if maxBytes == 0 {
 		return errors.NewProcessingError("maxBytes cannot be zero")
 	}
@@ -1382,6 +1392,7 @@ func (b *bucketUnallocated) Init(maxBytes uint64, _ int) error {
 
 	b.chunks = make([][]byte, maxChunksInt)
 	b.m = make(map[uint64]uint64)
+	b.trimRatio = trimRatio
 
 	b.Reset()
 
@@ -1500,7 +1511,7 @@ func (b *bucketUnallocated) Set(k, v []byte, h uint64, skipLocking ...bool) erro
 
 	// calculate the idx of the k-v pair to be added
 	// adjust idxNew, calculate where the new k-v pair will end
-	// the new k-v pair must be in the same chunk.
+	// new k-v pair must be in same chunk.
 	idx := b.idx
 	idxNew := idx + kvLen
 	chunkIdx := idx / ChunkSize
@@ -1508,7 +1519,12 @@ func (b *bucketUnallocated) Set(k, v []byte, h uint64, skipLocking ...bool) erro
 	// check if we are crossing the chunk boundary, we need to allocate a new chunk
 	if chunkIdxNew > chunkIdx {
 		// if there are no more chunks to allocate, we need to reset the bucket
-		if chunkIdxNew >= uint64(len(chunks)) {
+		maxChunks := uint64(len(chunks))
+		trimThreshold := uint64(float64(maxChunks) * (100 - float64(b.trimRatio)) / 100)
+		if trimThreshold < 1 {
+			trimThreshold = 1
+		}
+		if chunkIdxNew >= trimThreshold {
 			// writing needs to start over from the beginning.
 			idx = 0
 			idxNew = kvLen

--- a/stores/txmetacache/improved_cache_mmap_test.go
+++ b/stores/txmetacache/improved_cache_mmap_test.go
@@ -60,11 +60,11 @@ func TestTxMetaCache_Unallocated_Memory_1_2_3_GiB(t *testing.T) {
 				maxChunksPerBucket = 1
 			}
 
-			// With key=32 and val=2000: kvLen = 4+32+2000 = 2036 bytes -> 2 entries per 4096B chunk.
+			// With key=32 and val=2000: kvLen = 4+32+2000 = 2036 bytes -> 2 entries per 4KB chunk.
 			entriesPerChunk := uint64(2)
 			entriesToFullyAllocateBucket := maxChunksPerBucket * entriesPerChunk
 
-			// Fill all buckets to their per-bucket chunk capacity.
+			// Fill all buckets to their trim threshold (not full capacity)
 			for bi := 0; bi < BucketsCount; bi++ {
 				ub, ok := cache.buckets[bi].(*bucketUnallocated)
 				require.True(t, ok, "bucket %d is not bucketUnallocated", bi)
@@ -84,7 +84,16 @@ func TestTxMetaCache_Unallocated_Memory_1_2_3_GiB(t *testing.T) {
 					require.NoError(t, ub.Set(key, val, h))
 				}
 
-				require.Equal(t, maxChunksPerBucket, ub.allocatedChunks, "bucket %d should be fully allocated", bi)
+				// Verify each bucket allocated up to trim threshold (with small variance)
+				trimRatio := ub.trimRatio
+				expectedMinAllocatedChunks := uint64(float64(maxChunksPerBucket) * (100 - float64(trimRatio)) / 100)
+				if expectedMinAllocatedChunks < 1 {
+					expectedMinAllocatedChunks = 1
+				}
+				expectedMaxAllocatedChunks := expectedMinAllocatedChunks + (expectedMinAllocatedChunks / 20)
+
+				require.GreaterOrEqual(t, ub.allocatedChunks, expectedMinAllocatedChunks, "bucket %d should allocate at least min threshold (trimRatio=%d, maxChunks=%d)", bi, trimRatio, maxChunksPerBucket)
+				require.LessOrEqual(t, ub.allocatedChunks, expectedMaxAllocatedChunks, "bucket %d should not allocate more than max threshold (trimRatio=%d, maxChunks=%d)", bi, trimRatio, maxChunksPerBucket)
 			}
 
 			// Total off-heap chunk bytes mmapped is tracked by allocatedChunks.
@@ -99,6 +108,11 @@ func TestTxMetaCache_Unallocated_Memory_1_2_3_GiB(t *testing.T) {
 			for bi := 0; bi < BucketsCount; bi++ {
 				ub := cache.buckets[bi].(*bucketUnallocated)
 				allocatedAtFull := ub.allocatedChunks
+
+				// Only overwrite buckets that were actually allocated
+				if allocatedAtFull == 0 {
+					continue
+				}
 
 				// Overwrite enough entries to force wraparounds (exceed capacity in "entries"),
 				// but it must never allocate more chunk buffers once fully allocated.


### PR DESCRIPTION
# Problem

The txmetacache was trimming too aggressively, nearly halving its size (~50% reduction) when it reached capacity. This aggressive trimming caused unnecessary cache evictions, reducing cache hit rates.

The issue was that the `txMetaCacheTrimRatio` configuration setting only applied to the `bucketPreallocated` bucket type. However, production teranode uses the `bucketUnallocated` bucket type, which was hardcoded to wrap at 100% capacity regardless of the trim ratio setting.

# Solution

Made the `trimRatio` configuration apply uniformly to all bucket types:

## Code Changes

1. **stores/txmetacache/improved_cache.go**:
   - Added `trimRatio` field to `bucketUnallocated` and `bucketTrimmed` structs
   - Modified `Init()` for both bucket types to accept and store the `trimRatio` parameter
   - Updated `Set()` methods to wrap at `(100 - trimRatio)`% of capacity instead of 100%
   - Modified `New()` to pass `trimRatio` config to `Unallocated` and `Trimmed` bucket types (previously only passed to `Preallocated`)

2. **stores/txmetacache/improved_cache_mmap_test.go**:
   - Updated memory test to verify buckets allocate only up to trim threshold
   - Added assertions to check allocation stays within expected range

3. **settings.conf**:
   - Changed `txMetaCacheTrimRatio` from 5 to 20 (trims 20%, keeps 80%)

## Behavior

With `txMetaCacheTrimRatio = 20`:
- Cache now keeps ~80% of entries before trimming (instead of wrapping at 100% and clearing everything)
- Less aggressive eviction = better cache hit rates
- Configurable per environment via settings

Previously with 100% wrap (effective behavior):
- Would fill to 100% then start over from the beginning
- Resulted in ~50% effective retention due to ring buffer behavior

## Testing

All existing tests pass, including:
- `TestTxMetaCache_Unallocated_Memory_1_2_3_GiB` - verifies trim threshold allocation
- `TestImprovedCache_*` - all cache operations work correctly with new trim logic