### PR TITLE
Add interaction failure tracking for invalid subtree handling

### DIFF
--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -1858,26 +1858,15 @@ func (s *Server) ReportInvalidSubtree(ctx context.Context, subtreeHash string, p
 	s.logger.Infof("[ReportInvalidSubtree] invalid subtree report for peer %s, subtree %s: %s",
 		peerID, subtreeHash, reason)
 
-	// TODO: The penalty system here should be refactored. Currently all reasons
-	// (peer_cannot_provide_transactions, malformed_transaction_data, transaction_count_mismatch)
-	// are more likely network issues than malicious behavior. This will be addressed in a separate PR.
-	// For now, both RecordMaliciousInteraction and AddBanScore are disabled.
-	//
-	// // Record as malicious interaction for reputation tracking
-	// s.peerRegistry.RecordMaliciousInteraction(peer.ID(peerID))
-	//
-	// // Create the request to add ban score
-	// req := &p2p_api.AddBanScoreRequest{
-	// 	PeerId: peerID,
-	// 	Reason: "invalid_subtree",
-	// }
-	//
-	// // Call the AddBanScore method
-	// _, err = s.AddBanScore(ctx, req)
-	// if err != nil {
-	// 	s.logger.Errorf("[ReportInvalidSubtree] error adding ban score to peer %s: %v", peerID, err)
-	// 	return errors.NewServiceError("error adding ban score to peer %s", peerID, err)
-	// }
+	// Record as a failed interaction for reputation tracking
+	// This will not be too harsh on failures of transient behavior
+	// but also track if we are having trouble fetching data from peers
+	decodedPeerID, err := peer.Decode(peerID)
+	if err != nil {
+		s.logger.Warnf("[ReportInvalidSubtree] failed to decode peer ID %s: %v", peerID, err)
+	} else {
+		s.peerRegistry.RecordInteractionFailure(decodedPeerID)
+	}
 
 	// Remove the subtree from the map to avoid memory leaks
 	s.subtreePeerMap.Delete(subtreeHash)


### PR DESCRIPTION
This pull request refactors how invalid subtree reports are handled in the P2P server, shifting from a punitive ban system to a reputation-based tracking of peer failures. It also significantly expands and improves the related test coverage to ensure correct behavior for all failure scenarios and reputation adjustments.

**Refactor of invalid subtree handling:**

* Replaces the previous system of recording malicious interactions and banning peers in `Server.ReportInvalidSubtree` with a new approach that records interaction failures in the peer registry, making the penalty less harsh and more appropriate for transient network issues.

**Expanded and improved test coverage:**

* Updates `TestInvalidSubtreeHandlerHappyPath` to create real peer IDs, use the peer registry, and verify that interaction failures are incremented and subtrees are removed from the map after processing. [[1]](diffhunk://#diff-48a904648c6f53a67f2a118a62b15f18932efccdfadec7e76b291058a9165ac4L2157-R2192) [[2]](diffhunk://#diff-48a904648c6f53a67f2a118a62b15f18932efccdfadec7e76b291058a9165ac4R2208-R2216)
* Refactors and expands tests for `ReportInvalidSubtree` to:
  - Use valid peer IDs and registry entries,
  - Check that failures are recorded and subtrees are removed,
  - Add a new test to cover all possible "reason" codes and verify failure increments,
  - Add a test to verify that repeated failures reduce peer reputation appropriately.

These changes make the system fairer for peers experiencing transient issues and provide more robust, scenario-driven test coverage.