### PR TITLE
feat(pruner): add metrics for pruner operations

### DIFF
--- a/services/pruner/metrics.go
+++ b/services/pruner/metrics.go
@@ -8,15 +8,14 @@ import (
 )
 
 var (
-	prunerDuration  *prometheus.HistogramVec
-	prunerSkipped   *prometheus.CounterVec
-	prunerProcessed prometheus.Counter
-	prunerErrors    *prometheus.CounterVec
+	prunerDuration *prometheus.HistogramVec
+	prunerSkipped  *prometheus.CounterVec
+	prunerErrors   *prometheus.CounterVec
 
 	// Pruner operation metrics
 	prunerUpdatingParents  prometheus.Counter
 	prunerDeletingChildren prometheus.Counter
-	prunerCurrentHeight prometheus.Gauge
+	prunerCurrentHeight    prometheus.Gauge
 	prunerActive           prometheus.Gauge
 
 	// Blob deletion metrics
@@ -59,13 +58,6 @@ func _initPrometheusMetrics() {
 			Help: "Number of pruner operations skipped",
 		},
 		[]string{"reason"}, // "not_running", "no_new_height", "already_in_progress"
-	)
-
-	prunerProcessed = promauto.NewCounter(
-		prometheus.CounterOpts{
-			Name: "pruner_processed_total",
-			Help: "Total number of successful pruner operations",
-		},
 	)
 
 	prunerErrors = promauto.NewCounterVec(

--- a/services/pruner/worker.go
+++ b/services/pruner/worker.go
@@ -206,7 +206,6 @@ func (s *Server) prunerProcessor(ctx context.Context) {
 				} else {
 					s.logger.Infof("Phase 2: Pruned %d records at height %d", recordsProcessed, latestHeight)
 					prunerDuration.WithLabelValues("dah_pruner").Observe(time.Since(startTime).Seconds())
-					prunerProcessed.Inc()
 					prunerDeletingChildren.Add(float64(recordsProcessed))
 				}
 			}

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 // Ensure Store implements the Pruner Service interface
@@ -568,12 +570,16 @@ func (s *Service) PruneWithPartitions(ctx context.Context, blockHeight uint32, n
 		tpsStr = fmt.Sprintf("%.2f records/sec", tps)
 	}
 
+	p := message.NewPrinter(language.English)
+	formattedTotal := p.Sprintf("%d", totalProcessed)
+	formattedSkipped := p.Sprintf("%d", totalSkipped)
+
 	if s.defensiveEnabled {
-		s.logger.Infof("Completed parallel pruning for block height %d in %v: pruned %d records, skipped %d records (%s, defensive logic)",
-			blockHeight, elapsed, totalProcessed, totalSkipped, tpsStr)
+		s.logger.Infof("Completed parallel pruning for block height %d in %v: pruned %s records, skipped %s records (%s, defensive logic)",
+			blockHeight, elapsed, formattedTotal, formattedSkipped, tpsStr)
 	} else {
-		s.logger.Infof("Completed parallel pruning for block height %d in %v: pruned %d records (%s)",
-			blockHeight, elapsed, totalProcessed, tpsStr)
+		s.logger.Infof("Completed parallel pruning for block height %d in %v: pruned %s records, skipped %s records (%s)",
+			blockHeight, elapsed, formattedTotal, formattedSkipped, tpsStr)
 	}
 
 	prometheusUtxoCleanupBatch.Observe(float64(elapsed.Microseconds()) / 1_000_000)


### PR DESCRIPTION
## Summary
- Add `pruner_updating_parents_total` counter for parent preservation operations
- Add `pruner_deleting_children_total` counter for DAH pruner deletions
- Add `pruner_item_count` gauge for items processed per cycle
- Add `pruner_current_height` gauge for current pruner block height
- Add duration timing for the preserve_parents phase

Closes #4471