### PR TITLE
feat(pruner): add incremental Prometheus metrics for real-time monitoring

### DIFF
--- a/services/pruner/blob_deletion_worker.go
+++ b/services/pruner/blob_deletion_worker.go
@@ -130,6 +130,7 @@ func (s *Server) processBlobDeletionsAtHeight(height uint32, blockHash *chainhas
 		} else {
 			completedIDs = append(completedIDs, deletion.Id)
 			successCount++
+			blobDeletionProcessedTotal.Inc()
 		}
 	}
 
@@ -148,7 +149,6 @@ func (s *Server) processBlobDeletionsAtHeight(height uint32, blockHash *chainhas
 	duration := time.Since(batchStartTime).Round(time.Second)
 	s.logger.Infof("[pruner][%s:%d] blob deletion: batch complete - %s succeeded, %s failed (took %s)",
 		hashStr, height, humanize.Comma(successCount), humanize.Comma(failCount), duration)
-	blobDeletionProcessedTotal.Add(float64(successCount))
 
 	// Notify observer if registered (for testing)
 	if s.blobDeletionObserver != nil {


### PR DESCRIPTION
## Summary

Adds incremental Prometheus metric updates to pruner operations, enabling real-time throughput monitoring in Grafana during multi-minute pruning operations.

## Changes

**New Metrics (stores/utxo/aerospike/pruner):**
- `utxo_pruner_records_deleted_total` - updated after each chunk processes
- `utxo_pruner_parents_updated_total` - updated after each batch of parent updates
- `utxo_pruner_external_files_deleted_total` - updated after each batch of file deletions

**Updated Metrics (services/pruner):**
- `pruner_blob_deletion_processed_total` - now updated per blob instead of per batch

## Benefits

Previously, counters only updated at the end of pruning operations (which can take several minutes). Now they update incrementally as work completes, allowing Grafana queries like:

```promql
rate(utxo_pruner_records_deleted_total[1m])
rate(utxo_pruner_parents_updated_total[1m])
rate(utxo_pruner_external_files_deleted_total[1m])
rate(pruner_blob_deletion_processed_total[1m])
```

These show **records/sec in real-time** throughout the pruning cycle.

## Implementation

Follows the existing pattern of package-level Prometheus metrics (KISS principle). No callbacks, no interfaces, no complexity - just standard counters that increment as work completes.

## Test Plan

- [x] Linter passes
- [ ] Deploy to test environment
- [ ] Verify metrics update incrementally in Prometheus
- [ ] Create Grafana dashboard showing real-time rates
- [ ] Observe during multi-minute pruning operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)