### PR TITLE
fix(dashboard): align numeric columns with tabular figures

### DIFF
--- a/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
@@ -641,6 +641,7 @@
   }
   :global(.table .td .num) {
     text-align: right;
+    font-variant-numeric: tabular-nums;
     display: block;
     width: 100%;
   }

--- a/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
@@ -405,6 +405,7 @@
   }
   :global(table .num) {
     text-align: right;
+    font-variant-numeric: tabular-nums;
     display: block;
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- Add `font-variant-numeric: tabular-nums` to the `.num` CSS rules in both the standard-table and div-table variants
- Ensures digits in numeric columns (Height, Tx, TPS, Size) align vertically, improving readability

## Test plan
- [ ] Run `npm run dev --prefix ./ui/dashboard` and navigate to the Blocks view
- [ ] Confirm numeric columns have vertically aligned digits
- [ ] Verify no visual regressions in other table views