### PR TITLE
fix: remove singleton Quorum pattern from subtree validation Server

### DIFF
--- a/services/subtreevalidation/Server_coverage_test.go
+++ b/services/subtreevalidation/Server_coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"sync"
 	"testing"
 	"time"
 
@@ -187,10 +186,6 @@ func TestServerNew(t *testing.T) {
 	})
 
 	t.Run("successful creation with quorum path", func(t *testing.T) {
-		// Reset the once to allow quorum initialization
-		once = sync.Once{}
-		q = nil
-
 		common := testutil.NewCommonTestSetup(t)
 		tSettings := common.Settings
 		tSettings.SubtreeValidation.QuorumPath = "/tmp/test-quorum"
@@ -226,10 +221,6 @@ func TestServerNew(t *testing.T) {
 	})
 
 	t.Run("with tx meta cache enabled", func(t *testing.T) {
-		// Reset the once to allow quorum initialization
-		once = sync.Once{}
-		q = nil
-
 		common := testutil.NewCommonTestSetup(t)
 		tSettings := common.Settings
 		tSettings.SubtreeValidation.QuorumPath = "/tmp/test-quorum"
@@ -255,10 +246,6 @@ func TestServerNew(t *testing.T) {
 	})
 
 	t.Run("with invalid subtree kafka producer", func(t *testing.T) {
-		// Reset the once to allow quorum initialization
-		once = sync.Once{}
-		q = nil
-
 		common := testutil.NewCommonTestSetup(t)
 		tSettings := common.Settings
 		tSettings.SubtreeValidation.QuorumPath = "/tmp/test-quorum"

--- a/services/subtreevalidation/processor_benchmark_test.go
+++ b/services/subtreevalidation/processor_benchmark_test.go
@@ -254,13 +254,6 @@ func setupRealServerWithIterationID(t *testing.T, iterationID int) (*Server, blo
 	mockBlockchainClient.On("CheckBlockIsInCurrentChain", mock.Anything, mock.Anything).
 		Return(true, nil).Maybe()
 
-	// Create a fresh quorum for this test (bypassing the once guard)
-	tmpDir := t.TempDir()
-	q, err = NewQuorum(logger, subtreeStore, tmpDir)
-	if err != nil {
-		panic(err)
-	}
-
 	// Create server directly without subscription to avoid blockchain errors
 	server := &Server{
 		logger:           logger,
@@ -270,6 +263,13 @@ func setupRealServerWithIterationID(t *testing.T, iterationID int) (*Server, blo
 		utxoStore:        utxoStore,
 		validatorClient:  validatorClient,
 		blockchainClient: mockBlockchainClient,
+	}
+
+	// Create a fresh quorum for this server instance
+	tmpDir := t.TempDir()
+	server.quorum, err = NewQuorum(logger, subtreeStore, tmpDir)
+	if err != nil {
+		panic(err)
 	}
 
 	// Initialize orphanage

--- a/services/subtreevalidation/subtreeHandler.go
+++ b/services/subtreevalidation/subtreeHandler.go
@@ -121,7 +121,7 @@ func (u *Server) subtreesHandler(ctx context.Context, hash *chainhash.Hash, base
 		return errors.NewProcessingError("[subtreesHandler] failed to get best block header meta during subtree validation")
 	}
 
-	gotLock, _, releaseLockFunc, err := q.TryLockIfFileNotExists(ctx, hash, fileformat.FileTypeSubtree)
+	gotLock, _, releaseLockFunc, err := u.quorum.TryLockIfFileNotExists(ctx, hash, fileformat.FileTypeSubtree)
 	if err != nil {
 		return errors.NewProcessingError("[subtreesHandler] error getting lock for Subtree %s", hash.String(), err)
 	}

--- a/services/subtreevalidation/subtreeHandler_test.go
+++ b/services/subtreevalidation/subtreeHandler_test.go
@@ -172,7 +172,7 @@ func TestSubtreesHandler(t *testing.T) {
 			server.Server.currentBlockIDsMap.Store(&blockIDsMap)
 			server.Server.bestBlockHeaderMeta.Store(&model.BlockHeaderMeta{Height: 100})
 
-			q, _ = NewQuorum(
+			server.Server.quorum, _ = NewQuorum(
 				logger,
 				subtreeStore,
 				tSettings.SubtreeValidation.QuorumPath,


### PR DESCRIPTION
The package-level sync.Once + global Quorum variable meant only the first call to New() initialized the Quorum — subsequent calls silently reused it, ignoring different settings. This broke sequential tests and any multi-instance scenario. The Quorum's own lock handling already prevents conflicts, making the singleton guard unnecessary.

Moves the Quorum to a Server instance field so each Server gets its own Quorum initialized with its own settings.