### PR TITLE
fix(kafka): prevent typed-nil key from bypassing random partitioner

### DIFF
--- a/util/kafka/kafka_producer_async.go
+++ b/util/kafka/kafka_producer_async.go
@@ -317,15 +317,12 @@ func (c *KafkaAsyncProducer) Start(ctx context.Context, ch chan *Message) {
 					break
 				}
 
-				var key sarama.ByteEncoder
-				if msgBytes.Key != nil {
-					key = sarama.ByteEncoder(msgBytes.Key)
-				}
-
 				message := &sarama.ProducerMessage{
 					Topic: c.Config.Topic,
-					Key:   key,
 					Value: sarama.ByteEncoder(msgBytes.Value),
+				}
+				if msgBytes.Key != nil {
+					message.Key = sarama.ByteEncoder(msgBytes.Key)
 				}
 
 				// Check if closed again right before sending to avoid race condition


### PR DESCRIPTION
## Summary

- Fixes a Go typed-nil interface bug in the async Kafka producer that caused all nil-key messages to hash to a single deterministic partition instead of distributing randomly across all partitions

## Problem

When publishing messages without a key (e.g. txmeta), `var key sarama.ByteEncoder` creates a typed-nil value. Assigning this to `ProducerMessage.Key` (a `sarama.Encoder` interface) produces a non-nil interface wrapping a nil value. Sarama's `HashPartitioner` checks `message.Key == nil` to decide whether to use random partition selection — but a typed-nil interface is never `== nil`, so the random path is never taken. Instead, FNV-1a hashes the empty encoded bytes deterministically, routing every message to the same partition.

In production this resulted in all txmeta traffic (277 MB/s, 256 partitions, 3 Redpanda brokers) funnelling through a single partition on a single broker, with p99 produce latency of 324ms on the hot broker versus <1ms on idle brokers.

## Fix

Build the `ProducerMessage` without a key, then conditionally assign `message.Key` only when the source key is non-nil. This keeps the interface truly nil, allowing Sarama's random partitioner to distribute messages across all partitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)