### PR TITLE
fix: pruner OOM — skip input fetching, fix slice race

### DIFF
--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -944,6 +944,9 @@ func (s *Service) processRecordChunk(ctx context.Context, blockHeight uint32, ch
 		}
 
 		// Accumulate external files
+		// NOTE: When skipParentUpdates=true, inputs are not fetched, so all external
+		// files are classified as FileTypeOutputs. This is acceptable because
+		// skipParentUpdates is only used when external file support is not needed.
 		external, isExternal := rec.Record.Bins[s.fieldExternal].(bool)
 		if isExternal && external {
 			fileType := fileformat.FileTypeOutputs


### PR DESCRIPTION
## Summary

- **Skip inputs bin + parsing when `skipParentUpdates=true`**: The existing `skipParentUpdates` setting already skipped the final flush of parent updates, but the pruner was still fetching the `inputs` bin from Aerospike, parsing every input into `bt.Input` objects, and accumulating them into `allParentUpdates` — only to discard everything. For billion-record prune cycles at 1.3M records/sec, this means billions of wasted allocations and significant network I/O for the largest per-record bin. Now the setting also skips the upstream fetch/parse/accumulate, eliminating the allocation pressure at its source.

- **Fix slice reuse data race in `partitionWorker`**: `chunk = chunk[:0]` resets the slice length but keeps the same backing array, which the main loop then overwrites via `append` while goroutines are still reading from it. Replaced with `chunk = make([]*aerospike.Result, 0, s.chunkSize)` to allocate a fresh backing array per chunk.

## Test plan

- [x] `make build-teranode` compiles cleanly
- [x] `make lint` passes with 0 issues
- [x] `go test -v -race ./services/pruner/...` passes
- [ ] Deploy to staging and monitor pruner memory during billion-record prune cycle — should stay within 2Gi
- [ ] Verify `-race` flag in CI catches no data races in pruner path