### PR TITLE
chore: Update import of fsmDiagram.svg so image size can be controlled

### DIFF
--- a/docs/topics/architecture/stateManagement.md
+++ b/docs/topics/architecture/stateManagement.md
@@ -53,7 +53,7 @@ The FSM responds to the following **events**:
 
 The diagram below represents the relationships between the states and events in the FSM (as defined in `services/blockchain/fsm.go`):
 
-<img src="img/fsmDiagram.svg" width="500" />
+![Finite state machine diagram](img/fsmDiagram.svg){ width="500" }
 
 The FSM handles the following state **transitions**:
 


### PR DESCRIPTION
Currently the diagram is oversized even when zooming out
<img width="5462" height="3004" alt="image" src="https://github.com/user-attachments/assets/7fe7f952-519f-4dfd-bb16-bb9eee150e96" />

This change should ensure that the diagram size can be controlled via the `width` parameter