### PR TITLE
perf: add height bounds to recursive CTE queries and tune PostgreSQL config

### DIFF
--- a/deploy/docker/base/docker-services.yml
+++ b/deploy/docker/base/docker-services.yml
@@ -42,7 +42,11 @@ services:
       chmod +x /refresh-collation.sh
       # Run collation refresh in background after postgres starts
       /refresh-collation.sh &
-      exec /usr/local/bin/docker-entrypoint.sh postgres
+      exec /usr/local/bin/docker-entrypoint.sh postgres \
+        -c random_page_cost=1.1 \
+        -c work_mem=16MB \
+        -c shared_preload_libraries=pg_stat_statements \
+        -c pg_stat_statements.track=all
       "
     restart: on-failure
     healthcheck:

--- a/stores/blockchain/sql/FindBlocksContainingSubtree.go
+++ b/stores/blockchain/sql/FindBlocksContainingSubtree.go
@@ -36,6 +36,24 @@ func (s *SQL) FindBlocksContainingSubtree(ctx context.Context, subtreeHash *chai
 	}
 
 	q := `
+		WITH RECURSIVE ChainBlocks AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE invalid = false
+			AND hash = (
+				SELECT b.hash
+				FROM blocks b
+				WHERE b.invalid = false
+				ORDER BY chain_work DESC, peer_id ASC, id ASC
+				LIMIT 1
+			)
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			WHERE bb.id != cb.id
+			  AND bb.invalid = false
+		)
 		SELECT
 		 b.ID
 		,b.version
@@ -51,35 +69,10 @@ func (s *SQL) FindBlocksContainingSubtree(ctx context.Context, subtreeHash *chai
 		,b.subtrees
 		,b.height
 		FROM blocks b
+		JOIN ChainBlocks cb ON b.id = cb.id
 		WHERE ` + subtreeSearchClause + `
-		AND id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE invalid = false
-					AND hash = (
-						SELECT b.hash
-						FROM blocks b
-						WHERE b.invalid = false
-						ORDER BY chain_work DESC, peer_id ASC, id ASC
-						LIMIT 1
-					)
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-					  AND bb.invalid = false
-				)
-				SELECT id FROM ChainBlocks
-				WHERE invalid = FALSE
-				ORDER BY height DESC
-				` + limitClause + `
-			)
-		)
-		ORDER BY height ASC
+		ORDER BY b.height ASC
+		` + limitClause + `
 	`
 
 	rows, err := s.db.QueryContext(ctx, q, args...)

--- a/stores/blockchain/sql/GetBlockByHeight.go
+++ b/stores/blockchain/sql/GetBlockByHeight.go
@@ -99,6 +99,25 @@ func (s *SQL) GetBlockByHeight(ctx context.Context, height uint32) (*model.Block
 	defer cancel()
 
 	q := `
+		WITH RECURSIVE ChainBlocks AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE invalid = false
+			AND hash = (
+				SELECT b.hash
+				FROM blocks b
+				WHERE b.invalid = false
+				ORDER BY chain_work DESC, peer_id ASC, id ASC
+				LIMIT 1
+			)
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			WHERE bb.id != cb.id
+			  AND bb.invalid = false
+			  AND bb.height >= $1
+		)
 		SELECT
 		 b.ID
 	    ,b.version
@@ -114,32 +133,9 @@ func (s *SQL) GetBlockByHeight(ctx context.Context, height uint32) (*model.Block
 		,b.subtrees
 		,b.height
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE invalid = false
-					AND hash = (
-						SELECT b.hash
-						FROM blocks b
-						WHERE b.invalid = false
-						ORDER BY chain_work DESC, peer_id ASC, id ASC
-						LIMIT 1
-					)
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-					  AND bb.invalid = false
-				)
-				SELECT id FROM ChainBlocks
-				WHERE height = $1
-				LIMIT 1
-			)
-		)
+		JOIN ChainBlocks cb ON b.id = cb.id
+		WHERE cb.height = $1
+		LIMIT 1
 	`
 
 	rows, err := s.db.QueryContext(ctx, q, height)

--- a/stores/blockchain/sql/GetBlockGraphData.go
+++ b/stores/blockchain/sql/GetBlockGraphData.go
@@ -77,6 +77,7 @@ func (s *SQL) GetBlockGraphData(ctx context.Context, periodMillis uint64) (*mode
 			FROM blocks b
 			INNER JOIN ChainBlocks cb ON b.id = cb.parent_id
 			WHERE b.parent_id != 0
+			  AND b.block_time >= $1
 		)
 		SELECT block_time, tx_count FROM ChainBlocks
 		WHERE block_time >= $1

--- a/stores/blockchain/sql/GetBlockHeadersFromOldest.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromOldest.go
@@ -93,6 +93,23 @@ func (s *SQL) GetBlockHeadersFromOldest(ctx context.Context, chainTipHash, targe
 	defer cancel()
 
 	const q = `
+		WITH RECURSIVE target_block AS (
+			SELECT id, height
+			FROM blocks
+			WHERE hash = $2
+		),
+		ChainBlocks AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE hash = $1
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			CROSS JOIN target_block tb
+			WHERE bb.id != cb.id
+			  AND bb.height >= tb.height
+		)
 		SELECT
 			 b.version
 			,b.block_time
@@ -114,24 +131,10 @@ func (s *SQL) GetBlockHeadersFromOldest(ctx context.Context, chainTipHash, targe
 			,b.processed_at
 			,b.coinbase_tx
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE hash = $1
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-				)
-				SELECT id FROM ChainBlocks
-			)
-		)				        
-		  AND id >= (SELECT id from blocks WHERE hash = $2)
-		ORDER BY height ASC
+		JOIN ChainBlocks cb ON b.id = cb.id
+		CROSS JOIN target_block tb
+		WHERE cb.height >= tb.height
+		ORDER BY b.height ASC
 		LIMIT $3
 	`
 

--- a/stores/blockchain/sql/GetBlockHeadersFromTill.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromTill.go
@@ -104,6 +104,21 @@ func (s *SQL) GetBlockHeadersFromTill(ctx context.Context, blockHashFrom *chainh
 	blockHeaderMetas := make([]*model.BlockHeaderMeta, 0, numberOfHeaders)
 
 	q := `
+		WITH RECURSIVE start_block AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE hash = $1
+		),
+		ChainBlocks AS (
+			SELECT id, parent_id, height FROM start_block
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			CROSS JOIN start_block sb
+			WHERE bb.id != cb.id
+			  AND bb.height >= sb.height - $2
+		)
 		SELECT
 			 b.version
 			,b.block_time
@@ -119,24 +134,9 @@ func (s *SQL) GetBlockHeadersFromTill(ctx context.Context, blockHashFrom *chainh
 			,b.block_time
 			,b.inserted_at
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE hash = $1
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-				)
-				SELECT id FROM ChainBlocks
-				LIMIT $2
-			)
-		)
-		ORDER BY height DESC
+		JOIN ChainBlocks cb ON b.id = cb.id
+		ORDER BY b.height DESC
+		LIMIT $2
 	`
 
 	rows, err := s.db.QueryContext(ctx, q, blockHashTill[:], numberOfHeaders)

--- a/stores/blockchain/sql/GetBlockInChainByHeight.go
+++ b/stores/blockchain/sql/GetBlockInChainByHeight.go
@@ -81,6 +81,7 @@ func (s *SQL) GetBlockInChainByHeightHash(ctx context.Context, height uint32, st
 			FROM blocks bb
 			JOIN ChainBlocks cb ON bb.id = cb.parent_id
 			WHERE bb.id != cb.id
+			  AND bb.height >= $1
 		)
 		SELECT
 		 b.ID
@@ -97,11 +98,9 @@ func (s *SQL) GetBlockInChainByHeightHash(ctx context.Context, height uint32, st
 		,b.subtrees
 		,b.invalid
 		FROM blocks b
-		WHERE b.id IN (
-			SELECT id FROM ChainBlocks
-			WHERE height = $1
-			LIMIT 1
-		)
+		JOIN ChainBlocks cb ON b.id = cb.id
+		WHERE cb.height = $1
+		LIMIT 1
 	`
 
 	block = &model.Block{

--- a/stores/blockchain/sql/GetBlocks.go
+++ b/stores/blockchain/sql/GetBlocks.go
@@ -66,6 +66,21 @@ func (s *SQL) GetBlocks(ctx context.Context, blockHashFrom *chainhash.Hash, numb
 	blocks := make([]*model.Block, 0, numberOfHeaders)
 
 	q := `
+		WITH RECURSIVE start_block AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE hash = $1
+		),
+		ChainBlocks AS (
+			SELECT id, parent_id, height FROM start_block
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			CROSS JOIN start_block sb
+			WHERE bb.id != cb.id
+			  AND bb.height >= sb.height - $2
+		)
 		SELECT
 		 b.ID
 	  ,b.version
@@ -81,24 +96,9 @@ func (s *SQL) GetBlocks(ctx context.Context, blockHashFrom *chainhash.Hash, numb
 		,b.subtrees
 		,b.height
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE hash = $1
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-				)
-				SELECT id FROM ChainBlocks
-				LIMIT $2
-			)
-		)
-		ORDER BY height DESC
+		JOIN ChainBlocks cb ON b.id = cb.id
+		ORDER BY b.height DESC
+		LIMIT $2
 	`
 
 	rows, err := s.db.QueryContext(ctx, q, blockHashFrom[:], numberOfHeaders)

--- a/stores/blockchain/sql/GetBlocksByHeight.go
+++ b/stores/blockchain/sql/GetBlocksByHeight.go
@@ -82,6 +82,25 @@ func (s *SQL) GetBlocksByHeight(ctx context.Context, startHeight, endHeight uint
 	blocks := make([]*model.Block, 0, capacity)
 
 	q := `
+		WITH RECURSIVE ChainBlocks AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE invalid = false
+			AND hash = (
+				SELECT b.hash
+				FROM blocks b
+				WHERE b.invalid = false
+				ORDER BY chain_work DESC, peer_id ASC, id ASC
+				LIMIT 1
+			)
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			WHERE bb.id != cb.id
+			  AND bb.invalid = false
+			  AND bb.height >= $1
+		)
 		SELECT
 		 b.ID
 		,b.version
@@ -97,33 +116,9 @@ func (s *SQL) GetBlocksByHeight(ctx context.Context, startHeight, endHeight uint
 		,b.subtrees
 		,b.height
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE invalid = false
-					AND hash = (
-						SELECT b.hash
-						FROM blocks b
-						WHERE b.invalid = false
-						ORDER BY chain_work DESC, peer_id ASC, id ASC
-						LIMIT 1
-					)
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-					  AND bb.invalid = false
-				)
-				SELECT id FROM ChainBlocks
-				WHERE height >= $1 AND height <= $2
-				  AND invalid = FALSE
-				ORDER BY height ASC
-			)
-		)
+		JOIN ChainBlocks cb ON b.id = cb.id
+		WHERE cb.height >= $1 AND cb.height <= $2
+		ORDER BY cb.height ASC
 	`
 
 	rows, err := s.db.QueryContext(ctx, q, startHeight, endHeight)

--- a/stores/blockchain/sql/GetLastNBlocks.go
+++ b/stores/blockchain/sql/GetLastNBlocks.go
@@ -71,7 +71,7 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 
 	fromHeightQuery := ""
 	if fromHeight > 0 {
-		fromHeightQuery = fmt.Sprintf("WHERE height <= %d", fromHeight)
+		fromHeightQuery = fmt.Sprintf("WHERE b.height <= %d", fromHeight)
 	}
 
 	var q string
@@ -97,6 +97,24 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 	`
 	} else {
 		q = `
+		WITH RECURSIVE tip_block AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE invalid = false
+			ORDER BY chain_work DESC, peer_id ASC, id ASC
+			LIMIT 1
+		),
+		ChainBlocks AS (
+			SELECT id, parent_id, height FROM tip_block
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			CROSS JOIN tip_block tb
+			WHERE bb.id != cb.id
+			  AND bb.invalid = false
+			  AND bb.height >= tb.height - $1
+		)
 		SELECT
 		 b.version
 		,b.block_time
@@ -110,33 +128,10 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 		,b.height
 		,b.inserted_at
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE invalid = false
-					AND hash = (
-						SELECT b.hash
-						FROM blocks b
-						WHERE b.invalid = false
-						ORDER BY chain_work DESC, peer_id ASC, id ASC
-						LIMIT 1
-					)
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-					  AND bb.invalid = false
-				)
-				SELECT id FROM ChainBlocks
-				` + fromHeightQuery + `
-				LIMIT $1
-			)
-		)
-		ORDER BY height DESC
+		JOIN ChainBlocks cb ON b.id = cb.id
+		` + fromHeightQuery + `
+		ORDER BY b.height DESC
+		LIMIT $1
 	`
 	}
 

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -92,6 +92,16 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 	var args []interface{}
 
 	baseQuery := `
+		WITH RECURSIVE ChainBlocks AS (
+			SELECT id, parent_id, height
+			FROM blocks
+			WHERE hash = $1
+			UNION ALL
+			SELECT bb.id, bb.parent_id, bb.height
+			FROM blocks bb
+			JOIN ChainBlocks cb ON bb.id = cb.parent_id
+			WHERE bb.id != cb.id
+		)
 		SELECT
 	   	 b.version
 		,b.block_time
@@ -106,22 +116,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		,b.tx_count
 		,b.chain_work
 		FROM blocks b
-		WHERE id IN (
-			SELECT id FROM blocks
-			WHERE id IN (
-				WITH RECURSIVE ChainBlocks AS (
-					SELECT id, parent_id, height
-					FROM blocks
-					WHERE hash = $1
-					UNION ALL
-					SELECT bb.id, bb.parent_id, bb.height
-					FROM blocks bb
-					JOIN ChainBlocks cb ON bb.id = cb.parent_id
-					WHERE bb.id != cb.id
-				)
-				SELECT id FROM ChainBlocks
-			)
-		)`
+		JOIN ChainBlocks cb ON b.id = cb.id`
 
 	if s.engine == util.Postgres {
 		// Convert []chainhash.Hash to [][]byte
@@ -132,7 +127,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 
 		q = baseQuery + `
 			AND b.hash = ANY($2)
-			ORDER BY height DESC
+			ORDER BY b.height DESC
 			LIMIT 1`
 		args = []interface{}{bestBlockHash[:], pq.Array(hashBytes)}
 	} else {
@@ -148,7 +143,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 
 		q = baseQuery + fmt.Sprintf(`
 			AND b.hash IN (%s)
-			ORDER BY height DESC
+			ORDER BY b.height DESC
 			LIMIT 1`, strings.Join(placeholders, ","))
 	}
 


### PR DESCRIPTION
## Summary

- Adds height-based termination conditions to recursive CTEs across 10 blockchain SQL store files to prevent full chain traversal during block lookups
- Restructures deeply nested `WHERE id IN (SELECT ... WHERE id IN (WITH RECURSIVE ...))` subqueries to top-level CTEs with `JOIN` for better query planning
- Tunes PostgreSQL container config for RAM-resident working sets (`random_page_cost=1.1`, `work_mem=16MB`) and enables `pg_stat_statements` for ongoing monitoring

## Context

While syncing teranode with mainnet via the legacy service, we observed PostgreSQL performance progressively degrading as more blocks were validated. Enabling `pg_stat_statements` on the running node (~128k blocks) revealed recursive CTEs as the dominant cost — and the root cause of the slowdown: every recursive CTE walks backward from the chain tip through `parent_id` links, so query time grows linearly with chain height.

For example, `GetBlockByHeight(100)` walked **all 127,744 blocks** from chain tip to genesis (140ms, 383k buffer hits) just to find one block at a known height. The `GetChainTips` query was doing full parallel sequential scans of the entire blocks table (28ms). `CheckBlockIsAncestorOfBlock` accumulated nearly 5 seconds of total execution time across 1,900 calls, with individual calls spiking to 89ms.

The top queries by total execution time were:

| Query | Total ms | Calls | Mean ms | Max ms |
|-------|----------|-------|---------|--------|
| `CheckBlockIsAncestorOfBlock` | 4,957 | 1,900 | 2.6 | 89 |
| `GetBlockHeadersByHeight` / `GetBlockByHeight` (tip-walk CTEs) | 888 + 586 | 2,720 | 0.3–21 | 208 |
| `GetBlockHeaders` / `GetBlocks` (hash-walk CTEs) | 463 | 786 | 0.6 | 5 |

Without height bounds, these queries will continue to get slower as the chain grows — a node synced to 800k+ blocks would see proportionally worse performance.

## Measured Results (217k-block chain, ~18h run)

After deploying the height-bounded CTEs, `pg_stat_statements` on the live node shows:

### After (with height bounds on recursive CTEs)

| Query | Total ms | Calls | Mean ms | Max ms |
|---|---|---|---|---|
| GetBlockHeadersByHeight / GetBlockByHeight (tip-walk CTEs) | 264,542 | 2,640,238 | **0.10** | 563 |
| GetBlockHeaders / GetBlocks (hash-walk CTEs) | 235,331 | 357,956 | **0.66** | 15.4 |
| GetBlockInChainByHeight (with height bound) | 236 | 29 | **8.1** | 91.8 |
| GetBlockInChainByHeight (old plan, no height bound) | 894 | 57 | 15.7 | 208 |

### Mean Latency Comparison

| Query | Before | After | Improvement |
|---|---|---|---|
| Tip-walk CTEs (GetBlockByHeight etc.) | 0.3–21 ms | **0.10 ms** | 3–210x faster |
| Hash-walk CTEs (GetBlockHeaders etc.) | 0.6 ms | **0.66 ms** | ~same (already fast) |
| GetBlockInChainByHeight | 15.7 ms | **8.1 ms** | ~2x faster |

> Note: Total ms and call counts differ because the "after" sample covers ~18h of runtime vs a shorter initial test. The meaningful comparison is mean and max latency. The 563ms max on tip-walk is a single outlier, likely cold-cache or lock contention during the extended run.

## Changes

### Recursive CTE height bounds (tip-to-height pattern)
These queries walk backward from the best chain tip. Added `bb.height >= $target` to stop recursion at the target height:

| File | Bound added |
|------|------------|
| `GetBlockByHeight.go` | `bb.height >= $1` (target height) |
| `GetBlocksByHeight.go` | `bb.height >= $1` (startHeight) |
| `GetLastNBlocks.go` | `bb.height >= tb.height - $1` (tip minus N) |
| `FindBlocksContainingSubtree.go` | Restructured to top-level CTE + JOIN |

### Recursive CTE height bounds (hash-to-ancestors pattern)
These queries walk backward from a specific block hash. Added `start_block`/`target_block` CTEs to reference the starting height:

| File | Bound added |
|------|------------|
| `GetBlocks.go` | `bb.height >= sb.height - $2` |
| `GetBlockHeadersFromTill.go` | `bb.height >= sb.height - $2` |
| `GetBlockHeadersFromOldest.go` | `bb.height >= tb.height` (target block's height) |
| `GetBlockInChainByHeight.go` | `bb.height >= $1` (target height) |
| `GetLatestHeaderFromBlockLocator.go` | Restructured to top-level CTE + JOIN, fixed ambiguous `height` column |

### Time-based recursion bound
| File | Bound added |
|------|------------|
| `GetBlockGraphData.go` | `b.block_time >= $1` in recursion (stop once past requested time period) |

### PostgreSQL config tuning
| File | Change |
|------|--------|
| `deploy/docker/base/docker-services.yml` | `random_page_cost=1.1`, `work_mem=16MB`, `shared_preload_libraries=pg_stat_statements` |

### Not changed (already bounded or full-chain by design)
- `GetSuitableBlock.go` — depth < 3
- `GetHashOfAncestorBlock.go` — depth < $2
- `CheckBlockIsAncestorOfBlock.go` — depth <= $recursionDepth
- `GetBlockStats.go` — needs full chain aggregates
- `GetForkedBlockHeaders.go` — needs full chain for NOT IN set

## Relationship to #550
PR #550 covers `GetBlockHeaderIDs`, `GetBlockHeaders`, and `GetBlockHeadersByHeight`. This PR applies the same pattern to the remaining 10 files with unbounded recursive CTEs.