### PR TITLE
fix: add nofile ulimits to aerospike-tn to fix container startup

### DIFF
--- a/deploy/docker/base/docker-services.yml
+++ b/deploy/docker/base/docker-services.yml
@@ -190,6 +190,10 @@ services:
     entrypoint: ["asd", "--foreground", "--config-file", "/etc/aerospike.conf"]
     privileged: true  # Allow the container to access raw devices
     hostname: aerospike
+    ulimits:
+      nofile:
+        soft: 15000
+        hard: 15000
 
   aerospike-exporter:
     image: aerospike/aerospike-prometheus-exporter:latest


### PR DESCRIPTION
Add nofile ulimits (soft/hard: 15000) to aerospike-tn service in docker-services.yml to fix container failing to start