### PR TITLE
fix: use build-injected version in legacy P2P service

### DIFF
--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -83,10 +83,6 @@ var (
 	// userAgentName is the user agent name and is used to help identify
 	// ourselves to other bitcoin peers.
 	userAgentName = "/teranode-legacy-p2p"
-
-	// userAgentVersion is the user agent version and is used to help
-	// identify ourselves to other bitcoin peers.
-	userAgentVersion = fmt.Sprintf("%d.%d.%d", version.AppMajor, version.AppMinor, version.AppPatch)
 )
 
 // addrMe specifies the server address to send peers.
@@ -2371,7 +2367,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		HostToNetAddress:   sp.server.addrManager.HostToNetAddress,
 		Proxy:              cfg.Proxy,
 		UserAgentName:      userAgentName,
-		UserAgentVersion:   userAgentVersion,
+		UserAgentVersion:   version.String(),
 		UserAgentComments:  cfg.UserAgentComments,
 		ChainParams:        sp.server.settings.ChainCfgParams,
 		Services:           sp.server.services,

--- a/services/legacy/version/version.go
+++ b/services/legacy/version/version.go
@@ -2,77 +2,21 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+// Package version provides the application version for the legacy service.
+// The version is sourced from the build-injected value set via gocore.SetInfo()
+// during daemon startup, ensuring consistency with the main Teranode binary.
 package version
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
+
+	"github.com/ordishs/gocore"
 )
 
-// semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
-
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
-const (
-	AppMajor uint = 0
-	AppMinor uint = 13
-	AppPatch uint = 0
-
-	// AppPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
-	AppPreRelease = "beta"
-)
-
-// appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X main.appBuild foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
-var appBuild string
-
-// String returns the application version as a properly formed string per the
-// semantic versioning 2.0.0 spec (http://semver.org/).
+// String returns the application version as set by the build process.
+// It retrieves the version from gocore, which is populated at startup
+// via ldflags (e.g. "v1.2.3" from a git tag or "v0.0.0-20260407-abc1234").
+// The leading "v" prefix is stripped if present.
 func String() string {
-	// Start with the major, minor, and patch versions.
-	version := fmt.Sprintf("%d.%d.%d", AppMajor, AppMinor, AppPatch)
-
-	// Append pre-release version if there is one.  The hyphen called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the pre-release string.  The pre-release version
-	// is not appended if it contains invalid characters.
-	if AppPreRelease != "" {
-		preRelease := normalizeVerString(AppPreRelease)
-		if preRelease == AppPreRelease {
-			version = fmt.Sprintf("%s-%s", version, preRelease)
-		}
-	}
-
-	// Append build metadata if there is any.  The plus called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the build metadata string.  The build metadata
-	// string is not appended if it contains invalid characters.
-	if appBuild != "" {
-		build := normalizeVerString(appBuild)
-		if build == appBuild {
-			version = fmt.Sprintf("%s+%s", version, build)
-		}
-	}
-
-	return version
-}
-
-// normalizeVerString returns the passed string stripped of all characters which
-// are not valid according to the semantic versioning guidelines for pre-release
-// version and build metadata strings.  In particular they MUST only contain
-// characters in semanticAlphabet.
-func normalizeVerString(str string) string {
-	var result bytes.Buffer
-
-	for _, r := range str {
-		if strings.ContainsRune(semanticAlphabet, r) {
-			result.WriteRune(r)
-		}
-	}
-
-	return result.String()
+	return strings.TrimPrefix(gocore.GetVersion(), "v")
 }

--- a/services/legacy/version/version_test.go
+++ b/services/legacy/version/version_test.go
@@ -1,39 +1,45 @@
 package version
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/ordishs/gocore"
 )
 
 func TestString(t *testing.T) {
-	base := fmt.Sprintf("%d.%d.%d-%s", AppMajor, AppMinor, AppPatch, AppPreRelease)
-
 	testCases := []struct {
 		name     string
-		build    string
+		version  string
 		expected string
 	}{
 		{
-			name:     "standard-release",
-			build:    "",
-			expected: base,
-		}, {
-			name:     "with-build",
-			build:    "012-abc",
-			expected: base + "+012-abc",
-		}, {
-			name:     "with-out-of-spec-build",
-			build:    "012_abc",
-			expected: base,
+			name:     "git tag version",
+			version:  "v1.2.3",
+			expected: "1.2.3",
+		},
+		{
+			name:     "dev version with timestamp",
+			version:  "v0.0.0-20260407-abc1234",
+			expected: "0.0.0-20260407-abc1234",
+		},
+		{
+			name:     "no v prefix",
+			version:  "1.0.0",
+			expected: "1.0.0",
+		},
+		{
+			name:     "empty version",
+			version:  "",
+			expected: "",
 		},
 	}
 
 	for _, tc := range testCases {
-		appBuild = tc.build
+		gocore.SetInfo("test", tc.version, "deadbeef")
 
 		v := String()
 		if v != tc.expected {
-			t.Fatalf("%s: expected %s, got %s", tc.name, tc.expected, v)
+			t.Fatalf("%s: expected %q, got %q", tc.name, tc.expected, v)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded version constants (`0.13.0-beta`, inherited from btcsuite circa 2013) in the legacy service with the build-injected version already available via `gocore.GetVersion()`
- The legacy P2P user agent now reports the actual build version (from git tags/ldflags) instead of a stale hardcoded string
- Net reduction of ~50 lines — removes unused `normalizeVerString`, `appBuild`, `semanticAlphabet`, and the hardcoded `AppMajor`/`AppMinor`/`AppPatch`/`AppPreRelease` constants

## Context

The main Teranode binary already derives its version from git tags at build time (`-ldflags "-X main.version=${GIT_VERSION}"`), and stores it via `gocore.SetInfo()` during daemon startup. The legacy service had a completely separate, hardcoded version that was never updated — every build identified itself as `0.13.0-beta` on the P2P network regardless of the actual release.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test -race ./services/legacy/version/` — all tests pass
- [x] `make lint` — 0 issues
- [ ] Verify P2P user agent string shows correct version in a running node