### PR TITLE
fix: correct conflict resolution and assembly recovery during reorg reset

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -1172,7 +1172,9 @@ func (b *BlockAssembler) handleReorg(ctx context.Context, header *model.BlockHea
 		b.logger.Warnf("[BlockAssembler] large reorg detected, resetting block assembly, moveBackBlocks: %d, moveForwardBlocks: %d", len(moveBackBlocksWithMeta), len(moveForwardBlocksWithMeta))
 
 		// make sure we wait for the reset to complete
-		if err = b.reset(ctx, false); err != nil {
+		// validateInputs=true: getConflictingNodes() may miss conflicts not stored in subtree
+		// files; validateUnminedTxInputs() independently catches them via SpendingData.
+		if err = b.reset(ctx, false, true); err != nil {
 			b.logger.Errorf("[BlockAssembler] error resetting after large reorg: %v", err)
 		}
 
@@ -1209,7 +1211,9 @@ func (b *BlockAssembler) handleReorg(ctx context.Context, header *model.BlockHea
 		// we have an invalid block in the reorg or reorg failed, we need to reset the block assembly and load the unmined transactions again
 		b.logger.Warnf("[BlockAssembler] reorg contains invalid block, resetting block assembly, moveBackBlocks: %d, moveForwardBlocks: %d", len(moveBackBlocks), len(moveForwardBlocks))
 
-		if err = b.reset(ctx, false); err != nil {
+		// validateInputs=true: getConflictingNodes() may miss conflicts not stored in subtree
+		// files; validateUnminedTxInputs() independently catches them via SpendingData.
+		if err = b.reset(ctx, false, true); err != nil {
 			return errors.NewProcessingError("error resetting block assembly after reorg with invalid block", err)
 		}
 	}

--- a/services/blockassembly/BlockAssembler_test.go
+++ b/services/blockassembly/BlockAssembler_test.go
@@ -2400,3 +2400,142 @@ func TestProcessNewBlockAnnouncementCoverage(t *testing.T) {
 		assert.True(t, true, "processNewBlockAnnouncement should complete successfully")
 	})
 }
+
+// TestReset_ConflictDetectionViaValidateInputs verifies that after a Reset, a transaction
+// whose input is already spent by a different (mined) transaction must NOT be loaded back
+// into block assembly.
+//
+// Root cause of the bug: BlockAssembler.reset() calls loadUnminedTransactions with
+// validateInputs=false, so the input-spend conflict is never checked.
+// The getConflictingNodes step only reads pre-stored conflicting markers from block
+// subtree files — if the conflict was not stored there (e.g. because the moveForward block
+// was validated before the conflicting assembly tx was added), the conflict is silently
+// missed and the tx is incorrectly re-added to block assembly.
+//
+// The fix: BlockAssembler.reset() must always use validateInputs=true so that
+// validateUnminedTxInputs() catches any tx whose input's SpendingData points to a
+// different tx. This test is RED before the fix (txA is wrongly in assembly) and GREEN
+// after it (txA is correctly excluded).
+func TestReset_ConflictDetectionViaValidateInputs(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx := t.Context()
+	items := setupBlockAssemblyTest(t)
+	require.NotNil(t, items)
+
+	// Disable parent-chain validation — we only test input-spend conflict detection here.
+	items.blockAssembler.settings.BlockAssembly.OnRestartValidateParentChain = false
+
+	// --- Build the UTXO store state ---
+
+	// txParent: a regular (non-coinbase) tx with one spendable output.
+	// Its own input references a nonexistent tx (Create() does not validate inputs);
+	// PreviousTxSatoshis is set large enough for the fee check to pass.
+	txParent := bt.NewTx()
+	txParent.LockTime = 0
+	parentIn := &bt.Input{
+		PreviousTxOutIndex: 0,
+		PreviousTxSatoshis: 200000, // > output.Satoshis → positive fee
+		SequenceNumber:     0xFFFFFFFF,
+		UnlockingScript:    bscript.NewFromBytes([]byte{}),
+	}
+	_ = parentIn.PreviousTxIDAdd(&chainhash.Hash{1, 2, 3}) // nonexistent — not validated by Create()
+	txParent.Inputs = []*bt.Input{parentIn}
+	txParent.Outputs = []*bt.Output{
+		{Satoshis: 100000, LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14, 0x00, 0x88, 0xac})},
+	}
+	_, err := items.utxoStore.Create(ctx, txParent, 1)
+	require.NoError(t, err)
+	parentHash := txParent.TxIDChainHash()
+	require.NoError(t, items.utxoStore.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*parentHash}, true))
+
+	// txA: the LOSING tx that spends txParent output[0].
+	// It is in the unmined pool (unmined_since set, conflicting=false) — simulating the state
+	// where getConflictingNodes() missed it because the moveForward block's subtree file had
+	// no conflicting marker for txA.
+	txA := bt.NewTx()
+	_ = txA.From(parentHash.String(), 0, txParent.Outputs[0].LockingScript.String(), txParent.Outputs[0].Satoshis)
+	txA.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
+	txA.Outputs = []*bt.Output{{Satoshis: 90000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
+	const assemblyHeight = uint32(5)
+	require.NoError(t, items.utxoStore.SetBlockHeight(assemblyHeight))
+	_, err = items.utxoStore.Create(ctx, txA, assemblyHeight)
+	require.NoError(t, err)
+	txAHash := txA.TxIDChainHash()
+
+	// Directly write SpendingData for txParent output[0] to point to a "winner tx" (not txA).
+	// This bypasses utxoStore.Spend() to avoid coinbase-maturity / UTXO-hash complications
+	// while still exercising the exact check inside validateUnminedTxInputs:
+	//   spendingData.TxID != txAHash  →  txA is conflicting → NOT loaded.
+	// Format: 32 bytes txID + 4 bytes vin (little-endian, vin=0 → four zero bytes).
+	winnerHash := chainhash.HashH([]byte("mined-winner-tx"))
+	sdBytes := make([]byte, 36)
+	copy(sdBytes[:32], winnerHash.CloneBytes())
+
+	sqlStore, ok := items.utxoStore.(*utxostoresql.Store)
+	require.True(t, ok, "test requires SQLite store")
+	_, err = sqlStore.RawDB().Exec(
+		"UPDATE outputs SET spending_data = ? WHERE transaction_id = (SELECT id FROM transactions WHERE hash = ?) AND idx = 0",
+		sdBytes, parentHash[:],
+	)
+	require.NoError(t, err)
+
+	// Sanity-check the preconditions.
+	txAMeta, err := items.utxoStore.Get(ctx, txAHash, utxofields.UnminedSince, utxofields.Conflicting)
+	require.NoError(t, err)
+	require.NotZero(t, txAMeta.UnminedSince, "txA must be in the unmined pool")
+	require.False(t, txAMeta.Conflicting, "txA must not be pre-marked conflicting")
+
+	// --- Set up blockchain client mock so reset() can run without a real blockchain store ---
+	//
+	// reset() calls: GetBestBlockHeader, IsFSMCurrentState, GetBlockLocator (×2),
+	// GetBlockHeader (common ancestor), GetBlockHeaders (×2), and GetBlockHeaderIDs.
+	// With BA and blockchain both at genesis (height 0), getReorgBlocks() returns
+	// empty moveBack and moveForward → reset runs with no block movement.
+	genesisHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}
+	genesisMeta := &model.BlockHeaderMeta{Height: 0, ID: 1}
+	genesisHash := genesisHeader.Hash()
+	genesisHashSlice := []*chainhash.Hash{genesisHash}
+
+	mockBC := &blockchain.Mock{}
+	mockBC.On("GetBestBlockHeader", mock.Anything).Return(genesisHeader, genesisMeta, nil)
+	mockBC.On("IsFSMCurrentState", mock.Anything, mock.Anything).Return(false, nil)
+	// getReorgBlockHeaders: two GetBlockLocator calls, one GetBlockHeader (common ancestor),
+	// two GetBlockHeaders (moveBack count=1, moveForward count=0).
+	mockBC.On("GetBlockLocator", mock.Anything, mock.Anything, mock.Anything).Return(genesisHashSlice, nil)
+	mockBC.On("GetBlockHeader", mock.Anything, mock.Anything).Return(genesisHeader, genesisMeta, nil)
+	mockBC.On("GetBlockHeaders", mock.Anything, mock.Anything, uint64(1)).
+		Return([]*model.BlockHeader{genesisHeader}, []*model.BlockHeaderMeta{genesisMeta}, nil)
+	mockBC.On("GetBlockHeaders", mock.Anything, mock.Anything, uint64(0)).
+		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil)
+	// loadUnminedTransactions: GetBlockHeaderIDs for best-chain check.
+	mockBC.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{}, nil)
+	// reset() calls SetState to persist the new block assembly tip after reset completes.
+	mockBC.On("SetState", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	items.blockAssembler.blockchainClient = mockBC
+
+	// Initialize the block assembly's best block header so CurrentBlock() is non-nil.
+	items.blockAssembler.setBestBlockHeader(genesisHeader, 0)
+	items.blockAssembler.subtreeProcessor.InitCurrentBlockHeader(genesisHeader)
+
+	// Call reset() — this is the path that currently uses validateInputs=false (the bug).
+	// After the fix, reset() must use validateInputs=true so that validateUnminedTxInputs()
+	// catches that txA's input is already spent by another tx.
+	//
+	// RED before fix:  txA IS in assembly  → require.False fails.
+	// GREEN after fix: txA NOT in assembly → require.False passes.
+	// Mirrors handleReorg's call after the fix: reset(ctx, false, true).
+	err = items.blockAssembler.reset(ctx, false, true)
+	require.NoError(t, err)
+
+	hashes := items.blockAssembler.subtreeProcessor.GetTransactionHashes()
+	require.False(t, containsHash(hashes, *txAHash),
+		"after reset(validateInputs=true), a tx whose input is spent by another tx must NOT be in block assembly")
+}

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1068,6 +1068,47 @@ func (stp *SubtreeProcessor) reset(blockHeader *model.BlockHeader, moveBackBlock
 
 	defer deferFn()
 
+	ctx := context.Background()
+
+	// Mark all currently-in-assembly transactions as NOT on longest chain before clearing state.
+	//
+	// Some assembly transactions may have unmined_since=NULL in the UTXO store if a competing
+	// fork's BlockValidation processed them (it inserts them with UnminedSince=0, i.e. "mined").
+	// Without this step, loadUnminedTransactions() — which uses the unmined_since index
+	// (WHERE unmined_since IS NOT NULL) — will not find them, and they will be silently dropped
+	// from block assembly after the reset.
+	//
+	// This mirrors exactly what reorgBlocks() does at lines 2665-2710 before it finalises a reorg.
+	// The call is idempotent: for transactions that already have unmined_since set, it is a no-op.
+	{
+		currentSubtree := stp.currentSubtree.Load()
+		subtreeNodeCount := len(currentSubtree.Nodes)
+		for _, st := range stp.chainedSubtrees {
+			subtreeNodeCount += len(st.Nodes)
+		}
+
+		assemblyTxHashes := make([]chainhash.Hash, 0, subtreeNodeCount)
+		for _, st := range stp.chainedSubtrees {
+			for _, node := range st.Nodes {
+				if !node.Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
+					assemblyTxHashes = append(assemblyTxHashes, node.Hash)
+				}
+			}
+		}
+		for _, node := range currentSubtree.Nodes {
+			if !node.Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
+				assemblyTxHashes = append(assemblyTxHashes, node.Hash)
+			}
+		}
+
+		if len(assemblyTxHashes) > 0 {
+			stp.logger.Infof("[SubtreeProcessor][reset] marking %d assembly txs as not on longest chain before clearing state", len(assemblyTxHashes))
+			if err := stp.markNotOnLongestChain(ctx, assemblyTxHashes); err != nil {
+				return errors.NewProcessingError("[SubtreeProcessor][reset] error marking assembly txs as not on longest chain before reset", err)
+			}
+		}
+	}
+
 	stp.closeChainedSubtrees()
 
 	itemsPerFile := int(stp.currentItemsPerFile.Load())
@@ -1090,8 +1131,6 @@ func (stp *SubtreeProcessor) reset(blockHeader *model.BlockHeader, moveBackBlock
 
 	// reset tx count
 	stp.setTxCountFromSubtrees()
-
-	ctx := context.Background()
 
 	// the processed conflicting hashes map keeps track of all the conflicting hashes we've already processed
 	// this is to avoid processing the same conflicting hash multiple times if it appears in multiple blocks

--- a/services/blockassembly/subtreeprocessor/reset_reorg_test.go
+++ b/services/blockassembly/subtreeprocessor/reset_reorg_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	blob_memory "github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -1270,4 +1271,98 @@ func TestSubtreeProcessor_Reorg(t *testing.T) {
 			t.Logf("Reorg failed with error: %v", err)
 		}
 	})
+}
+
+// TestResetMarksAssemblyTxsAsNotOnLongestChainBeforeClearing verifies that SubtreeProcessor.reset()
+// marks all currently-in-assembly transactions as NOT on longest chain in the UTXO store BEFORE
+// clearing its internal state.
+//
+// The bug: when reset() clears chainedSubtrees and currentSubtree (lines 1071-1092), it loses
+// track of which transactions were in assembly. If any of those transactions had unmined_since=NULL
+// (mined) in the UTXO store — e.g., because a competing fork's BlockValidation processed them —
+// they won't appear in the unmined_since index scan used by loadUnminedTransactions(). As a result,
+// those transactions are silently dropped from block assembly after the reset.
+//
+// The fix: call markNotOnLongestChain() on all assembly transactions before clearing state, mirroring
+// what reorgBlocks() does at lines 2665-2710.
+func TestResetMarksAssemblyTxsAsNotOnLongestChainBeforeClearing(t *testing.T) {
+	ctx := context.Background()
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	settings := test.CreateBaseTestSettings(t)
+	utxoStore, err := sql.New(ctx, ulogger.TestLogger{}, settings, utxoStoreURL)
+	require.NoError(t, err)
+
+	blobStore := blob_memory.New()
+	newSubtreeChan := make(chan NewSubtreeRequest, 10)
+	go func() {
+		for req := range newSubtreeChan {
+			if req.ErrChan != nil {
+				req.ErrChan <- nil
+			}
+		}
+	}()
+	t.Cleanup(func() { close(newSubtreeChan) })
+
+	mockBlockchainClient := &blockchain.Mock{}
+	stp, err := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, settings, blobStore, mockBlockchainClient, utxoStore, newSubtreeChan)
+	require.NoError(t, err)
+	stp.Start(ctx)
+	t.Cleanup(func() { stp.Stop(context.Background()) })
+
+	// Insert coinbaseTx into the UTXO store so markNotOnLongestChain can update it.
+	const blockHeight = uint32(100)
+	require.NoError(t, utxoStore.SetBlockHeight(blockHeight))
+	_, err = utxoStore.Create(ctx, coinbaseTx, blockHeight)
+	require.NoError(t, err)
+
+	txHash := coinbaseTx.TxIDChainHash()
+
+	// Mark it as ON longest chain (unmined_since = NULL).
+	// This simulates what BlockValidation does when a competing fork mines this tx —
+	// the tx is "mined" in the UTXO store but hasn't been removed from block assembly yet.
+	require.NoError(t, utxoStore.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*txHash}, true))
+
+	// Verify precondition: UnminedSince == 0 means unmined_since is NULL (mined state).
+	metaBefore, err := utxoStore.Get(ctx, txHash, fields.UnminedSince)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), metaBefore.UnminedSince,
+		"precondition: tx must be marked as mined (unmined_since=NULL) before reset")
+
+	// Add the tx to block assembly so reset() sees it in its state.
+	stp.AddBatch([]subtree.Node{{
+		Hash:        *txHash,
+		Fee:         100,
+		SizeInBytes: 200,
+	}}, []*subtree.TxInpoints{{}})
+
+	// Wait for the async queue to process the add.
+	time.Sleep(100 * time.Millisecond)
+	require.True(t, stp.GetCurrentTxMap().Exists(*txHash), "tx must be in block assembly before reset")
+
+	// Call Reset with no moveBack/moveForward — we are testing the assembly-clearing step only.
+	targetHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      1234567890,
+		Bits:           model.NBit{},
+		Nonce:          9999,
+	}
+	response := stp.Reset(targetHeader, nil, nil, false, nil)
+	require.NoError(t, response.Err)
+
+	// After Reset, the tx must have unmined_since != 0 (i.e., NOT NULL).
+	// Only then will loadUnminedTransactions() find it via the unmined_since index
+	// and add it back to block assembly.
+	//
+	// WITHOUT THE FIX: unmined_since remains NULL → loadUnminedTransactions misses it → tx LOST.
+	// WITH THE FIX:    reset marks it NOT on longest chain → unmined_since is set → tx RECOVERED.
+	metaAfter, err := utxoStore.Get(ctx, txHash, fields.UnminedSince)
+	require.NoError(t, err)
+	require.NotEqual(t, uint32(0), metaAfter.UnminedSince,
+		"after reset, an assembly tx that had unmined_since=NULL must be marked as NOT on longest chain "+
+			"so loadUnminedTransactions can recover it; without the fix this tx is silently lost from block assembly")
 }

--- a/test/sequentialtest/double_spend/11_reorg_reset_recovers_assembly_tx_test.go
+++ b/test/sequentialtest/double_spend/11_reorg_reset_recovers_assembly_tx_test.go
@@ -1,0 +1,107 @@
+package doublespendtest
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/daemon"
+	"github.com/bsv-blockchain/teranode/services/blockassembly/blockassembly_api"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReorgResetRecoversAssemblyTxPostgres verifies that after a SubtreeProcessor reset,
+// a transaction that was in block assembly but had unmined_since=NULL in the UTXO store
+// is recovered back into block assembly (not silently lost).
+//
+// See TestReorgResetRecoversAssemblyTxAerospike for the Aerospike variant.
+func TestReorgResetRecoversAssemblyTxPostgres(t *testing.T) {
+	t.Run("reset_recovers_assembly_tx_with_mined_utxo_state", func(t *testing.T) {
+		testReorgResetRecoversAssemblyTx(t, "postgres")
+	})
+}
+
+// TestReorgResetRecoversAssemblyTxAerospike is the Aerospike variant of TestReorgResetRecoversAssemblyTxPostgres.
+func TestReorgResetRecoversAssemblyTxAerospike(t *testing.T) {
+	t.Run("reset_recovers_assembly_tx_with_mined_utxo_state", func(t *testing.T) {
+		testReorgResetRecoversAssemblyTx(t, "aerospike")
+	})
+}
+
+// testReorgResetRecoversAssemblyTx demonstrates the bug where SubtreeProcessor.reset() fails
+// to recover a block assembly transaction that has unmined_since=NULL in the UTXO store.
+//
+// Root cause: reset() clears assembly state (chainedSubtrees, currentSubtree) without first
+// marking those transactions as NOT on longest chain. The subsequent loadUnminedTransactions()
+// call uses the unmined_since index, so any transaction with unmined_since=NULL (mined) is
+// invisible to the scan and permanently dropped from block assembly.
+//
+// This state (tx in assembly, unmined_since=NULL) can arise when a competing fork's
+// BlockValidation processes a block containing the tx, marking it as "mined" even though
+// the block has not yet become (or will not remain) the longest chain.
+//
+// The fix: call markNotOnLongestChain() on all assembly transactions before clearing state,
+// mirroring what reorgBlocks() already does at lines 2665-2710 of SubtreeProcessor.go.
+//
+// Test flow:
+//  1. Send txX via propagation → txX lands in block assembly with unmined_since set.
+//  2. Manually set unmined_since=NULL for txX in the UTXO store, simulating the competing
+//     fork scenario where BlockValidation marked it as mined.
+//  3. Call ResetBlockAssembly() to force a SubtreeProcessor reset.
+//  4. Assert txX is back in block assembly.
+//     WITHOUT FIX: txX has unmined_since=NULL → loadUnminedTransactions misses it → LOST.
+//     WITH FIX:    reset marks txX NOT on longest chain → loadUnminedTransactions finds it → RECOVERED.
+func testReorgResetRecoversAssemblyTx(t *testing.T, utxoStoreType string) {
+	td := daemon.NewTestDaemon(t, daemon.TestOptions{
+		UTXOStoreType:        utxoStoreType,
+		SettingsOverrideFunc: test.SystemTestSettings(),
+	})
+	defer td.Stop(t)
+
+	require.NoError(t, td.BlockchainClient.Run(td.Ctx, "test"))
+
+	// Generate 101 blocks so we have coinbase UTXOs to spend.
+	require.NoError(t, td.BlockAssemblyClient.GenerateBlocks(td.Ctx, &blockassembly_api.GenerateBlocksRequest{Count: 101}))
+
+	block1, err := td.BlockchainClient.GetBlockByHeight(td.Ctx, 1)
+	require.NoError(t, err)
+
+	// Create a transaction and propagate it into block assembly.
+	txX := td.CreateTransaction(t, block1.CoinbaseTx, 0)
+	require.NoError(t, td.PropagationClient.ProcessTransaction(td.Ctx, txX))
+	require.NoError(t, td.WaitForTransactionInBlockAssembly(txX, blockWait),
+		"txX should be in block assembly after propagation")
+
+	txXHash := txX.TxIDChainHash()
+
+	// Simulate the scenario: a competing fork's BlockValidation marks txX as mined
+	// (unmined_since=NULL) even though txX is still in block assembly waiting to be mined
+	// on the main chain.
+	require.NoError(t, td.UtxoStore.MarkTransactionsOnLongestChain(td.Ctx, []chainhash.Hash{*txXHash}, true),
+		"simulating BlockValidation marking txX as mined on a competing fork")
+
+	// Verify the injected state: txX is mined in the UTXO store (unmined_since=NULL).
+	utxoMeta, err := td.UtxoStore.Get(td.Ctx, txXHash, fields.UnminedSince)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), utxoMeta.UnminedSince,
+		"precondition: txX must have unmined_since=NULL (mined) before the reset")
+
+	// Force a SubtreeProcessor reset via the block assembly API.
+	// This triggers BlockAssembler.reset() → SubtreeProcessor.reset() → loadUnminedTransactions().
+	require.NoError(t, td.BlockAssemblyClient.ResetBlockAssembly(td.Ctx),
+		"ResetBlockAssembly must not fail")
+
+	// After the reset, txX must be back in block assembly.
+	//
+	// WITHOUT THE FIX: txX has unmined_since=NULL in the UTXO store, so the unmined_since
+	// index scan inside loadUnminedTransactions() skips it. txX is never re-added to block
+	// assembly and is permanently lost — even though it was never mined on the actual main chain.
+	//
+	// WITH THE FIX: reset() calls markNotOnLongestChain() for all assembly txs before clearing
+	// state, setting txX's unmined_since to a non-zero value. loadUnminedTransactions() finds
+	// txX in the index and adds it back to block assembly.
+	require.NoError(t, td.WaitForTransactionInBlockAssembly(txX, blockWait),
+		"txX must be recovered into block assembly after reset; "+
+			"without the fix, assembly txs with unmined_since=NULL are silently dropped")
+}


### PR DESCRIPTION
## Problem

When `handleReorg` falls back to `reset()` — either because the reorg is too large, contains an invalid block, or `subtreeProcessor.Reorg()` returns an error — two distinct bugs cause the block assembly to end up in an incorrect state after the reset completes.

### Bug 1: Assembly transactions silently lost after reset

`SubtreeProcessor.reset()` clears the in-memory assembly (`chainedSubtrees`, `currentSubtree`, `currentTxMap`) without first marking those transactions as NOT on longest chain in the UTXO store.

The unmined iterator used by `loadUnminedTransactions()` filters by `WHERE unmined_since IS NOT NULL`. Any assembly transaction whose `unmined_since` is NULL in the UTXO store — which happens when a competing fork's `BlockValidation` processed it, inserting it with `UnminedSince=0` — is invisible to this scan. The transaction is silently dropped from the rebuilt assembly and never mined.

The `reorgBlocks()` path already handles this correctly: before finalising the reorg it calls `markNotOnLongestChain()` for all current assembly transactions (lines 2665–2710). The reset path was missing the equivalent step.

### Bug 2: Conflicts not detected after reset

`BlockAssembler.reset()` called `loadUnminedTransactions` with `validateInputs=false`. The `getConflictingNodes()` step that precedes it reads only pre-stored conflicting markers from block subtree files. If a moveForward block was validated *before* the conflicting assembly tx existed (so no marker was written into the subtree file), the conflict goes undetected.

`validateUnminedTxInputs()` independently verifies each unmined tx's inputs against the UTXO store's `SpendingData`. If `SpendingData.TxID` points to a different tx the input is already spent elsewhere and the tx is marked conflicting and excluded. This check has no dependency on subtree file markers, so it catches exactly the gaps left by `getConflictingNodes()`.

## Fix

**`SubtreeProcessor.reset()`** (`services/blockassembly/subtreeprocessor/SubtreeProcessor.go`):

Before clearing the assembly state, collect all transaction hashes from `chainedSubtrees` and `currentSubtree` and call `markNotOnLongestChain()`. This is idempotent — transactions that already have `unmined_since` set are unchanged — and directly mirrors what `reorgBlocks()` does.

**`BlockAssembler.handleReorg()`** (`services/blockassembly/BlockAssembler.go`):

Both `reset()` call sites in `handleReorg` now pass `validateInputs=true`. This enables `validateUnminedTxInputs()` inside `loadUnminedTransactions`, which catches any spending conflicts that `getConflictingNodes()` missed due to absent subtree markers. The existing gRPC-triggered reset path (`resetReq.ValidateInputs`) is unchanged.

## Tests

Three new tests added using TDD — each written as failing (RED) first, then the fix applied to make it pass (GREEN):

### Unit: `TestResetMarksAssemblyTxsAsNotOnLongestChainBeforeClearing`
(`services/blockassembly/subtreeprocessor/reset_reorg_test.go`)

Adds a tx to the assembly, manually sets its `unmined_since` to NULL in the UTXO store (simulating a competing fork), calls `Reset()`, and asserts the tx now has `unmined_since` set. Without the fix, the tx remains NULL and is lost from the rebuilt assembly.

### Unit: `TestReset_ConflictDetectionViaValidateInputs`
(`services/blockassembly/BlockAssembler_test.go`)

Creates a tx in the unmined pool whose parent output's `SpendingData` points to a different (winning) tx, then calls `reset(ctx, false, true)`. Asserts the conflicting tx is not loaded into block assembly. Without the fix (`validateInputs=false`), the conflict is missed and the tx incorrectly re-enters assembly.

### E2E: `TestReorgResetRecoversAssemblyTxPostgres/Aerospike`
(`test/sequentialtest/double_spend/11_reorg_reset_recovers_assembly_tx_test.go`)

End-to-end sequential test that sets `unmined_since=NULL` on an assembly tx (simulating it being marked mined by a competing fork), forces a block assembly reset, and verifies the tx is recovered back into assembly. Follows the same style as the other numbered tests in `test/sequentialtest/double_spend/`.

## Test plan

- [ ] `go test -race -tags testtxmetacache -run TestResetMarksAssemblyTxsAsNotOnLongestChainBeforeClearing ./services/blockassembly/subtreeprocessor/` — PASS
- [ ] `go test -race -tags testtxmetacache -run TestReset_ConflictDetectionViaValidateInputs ./services/blockassembly/` — PASS
- [ ] `make sequentialtest TEST=TestReorgResetRecoversAssemblyTxPostgres` — PASS
- [ ] `go test -race -tags testtxmetacache ./services/blockassembly/...` — all existing tests PASS