### PR TITLE
fix: prevent legacy block processing fallthrough on error

### DIFF
--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -1236,6 +1236,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 		if (legacySyncMode || catchingBlocks) && errors.Is(err, errors.ErrBlockNotFound) {
 			// previous block not found? Probably a new block message from our syncPeer while we are still syncing
 			sm.logger.Errorf("Failed to process new block in legacy mode %v: %v", bmsg.blockHash, err)
+			return nil
 		} else if errors.Is(err, errors.ErrBlockNotFound) {
 			// We don't have the parent of this block/header, so we'll request it.
 			sm.logger.Infof("Block %v has missing parent %v, requesting missing blocks",

--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -30,7 +29,7 @@ import (
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/go-wire"
-	tnerrors "github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation"
@@ -938,7 +937,7 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 			// Only disconnect on block validation failures, not on local
 			// infrastructure issues (database, Kafka, etc.) which would
 			// just cause unnecessary sync peer rotation.
-			if !tnerrors.Is(err, tnerrors.ErrServiceError) && !tnerrors.Is(err, tnerrors.ErrStorageError) {
+			if !errors.Is(err, errors.ErrServiceError) && !errors.Is(err, errors.ErrStorageError) {
 				sp.DisconnectWithWarning(fmt.Sprintf("block %s processing failed, disconnecting to trigger sync peer rotation", block.Hash()))
 				return
 			}
@@ -2220,16 +2219,16 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		// TODO: duplicate oneshots?
 		// Limit max number of total peers.
 		if state.Count() >= cfg.MaxPeers {
-			msg.reply <- errors.New("max peers reached")
+			msg.reply <- errors.NewProcessingError("max peers reached")
 			return
 		}
 
 		for _, persistentPeer := range state.persistentPeers.Range() {
 			if persistentPeer.Addr() == msg.addr {
 				if msg.permanent {
-					msg.reply <- errors.New("peer already connected")
+					msg.reply <- errors.NewProcessingError("peer already connected")
 				} else {
-					msg.reply <- errors.New("peer exists as a permanent peer")
+					msg.reply <- errors.NewProcessingError("peer exists as a permanent peer")
 				}
 
 				return
@@ -2262,7 +2261,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		if found {
 			msg.reply <- nil
 		} else {
-			msg.reply <- errors.New("peer not found")
+			msg.reply <- errors.NewProcessingError("peer not found")
 		}
 	case getOutboundGroup:
 		count, ok := state.outboundGroups.Get(msg.key)
@@ -2310,7 +2309,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 			return
 		}
 
-		msg.reply <- errors.New("peer not found")
+		msg.reply <- errors.NewProcessingError("peer not found")
 	}
 }
 
@@ -3049,13 +3048,13 @@ func newServer(ctx context.Context, logger ulogger.Logger, tSettings *settings.S
 		}
 
 		if len(listeners) == 0 {
-			return nil, errors.New("no valid listen address")
+			return nil, errors.NewProcessingError("no valid listen address")
 		}
 	}
 
 	banList, banChan, err := p2p.GetBanList(ctx, logger, tSettings)
 	if err != nil {
-		return nil, errors.New("can't get banList")
+		return nil, errors.NewProcessingError("can't get banList")
 	}
 
 	s := server{
@@ -3176,7 +3175,7 @@ func newServer(ctx context.Context, logger ulogger.Logger, tSettings *settings.S
 				return addrStringToNetAddr(addrString)
 			}
 
-			return nil, errors.New("no valid connect address")
+			return nil, errors.NewProcessingError("no valid connect address")
 		}
 	}
 

--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -30,6 +30,7 @@ import (
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/go-wire"
+	tnerrors "github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation"
@@ -933,8 +934,14 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 		err = <-sp.blockProcessed
 		if err != nil {
 			sp.server.logger.Errorf("block processing failed: %v", err)
-			sp.DisconnectWithWarning(fmt.Sprintf("block %s processing failed, disconnecting to trigger sync peer rotation", block.Hash()))
-			return
+
+			// Only disconnect on block validation failures, not on local
+			// infrastructure issues (database, Kafka, etc.) which would
+			// just cause unnecessary sync peer rotation.
+			if !tnerrors.Is(err, tnerrors.ErrServiceError) && !tnerrors.Is(err, tnerrors.ErrStorageError) {
+				sp.DisconnectWithWarning(fmt.Sprintf("block %s processing failed, disconnecting to trigger sync peer rotation", block.Hash()))
+				return
+			}
 		}
 	}
 }

--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -933,6 +933,8 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 		err = <-sp.blockProcessed
 		if err != nil {
 			sp.server.logger.Errorf("block processing failed: %v", err)
+			sp.DisconnectWithWarning(fmt.Sprintf("block %s processing failed, disconnecting to trigger sync peer rotation", block.Hash()))
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add missing `return nil` in the legacySyncMode + `ErrBlockNotFound` branch of `handleBlockMsg`. Without this, blocks whose parent failed processing fell through to the "accepted block" code path, logging false acceptance at height -1 and corrupting peer height state.
- Disconnect from the peer when block processing returns a serious error (e.g. `SUBTREE_ERROR`), stopping the cascade of doomed child blocks and triggering sync peer rotation.

## Context
Commit `a8d48926f` replaced `panic(err)` with `return err` in the block processing error handler. This was correct (panicking is too aggressive), but it exposed a pre-existing missing `return nil` in the legacySyncMode branch. The result was that after a block validation failure:
1. The failed block returned an error to `peer_server`, which just logged it
2. Every subsequent block (whose parent was the failed block) hit `BLOCK_NOT_FOUND`, entered the legacySyncMode branch, logged an error, but **fell through** to the "accepted block" code
3. These blocks were falsely logged as "accepted block ... at height -1", rejected txns were cleared, and peer heights were updated with garbage

## Test plan
- [ ] Verify legacy sync handles block validation failures without false "accepted block at height -1" logs
- [ ] Verify peer disconnection occurs on serious block processing errors
- [ ] Verify sync peer rotation picks up a new peer after disconnection
- [ ] Verify normal legacy sync (no errors) is unaffected