### PR TITLE
fix: allow nil coinbase_tx in StoreBlock for V1 seeder headers

### DIFF
--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -423,7 +423,7 @@ RETURNING id
 		return 0, 0, nil, false, errors.NewStorageError("failed to get subtree bytes", err)
 	}
 
-	var coinbaseBytes []byte
+	coinbaseBytes := []byte{}
 	if block.CoinbaseTx != nil {
 		coinbaseBytes = block.CoinbaseTx.Bytes()
 	}

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -648,6 +648,41 @@ func TestStoreBlock_ValidCoinbaseTransaction(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestStoreBlock_NilCoinbaseTransaction(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// First store a normal block to create a valid parent
+	_, _, err = s.StoreBlock(context.Background(), block1, "test-peer")
+	require.NoError(t, err)
+
+	// Create block with nil CoinbaseTx, simulating V1 utxo-headers from a pruned SV Node
+	blockNilCoinbase := &model.Block{
+		Header: &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  block1.Hash(),
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      uint32(time.Now().Unix()),
+			Bits:           *bits,
+			Nonce:          0,
+		},
+		Height:           2,
+		TransactionCount: 1,
+		SizeInBytes:      100,
+		CoinbaseTx:       nil,
+	}
+
+	blockID, height, err := s.StoreBlock(context.Background(), blockNilCoinbase, "test-peer")
+	require.NoError(t, err, "StoreBlock must accept nil CoinbaseTx (V1 seeder headers)")
+	assert.Greater(t, blockID, uint64(0))
+	assert.Equal(t, uint32(2), height)
+}
+
 func TestStoreBlock_InheritInvalidFromParent(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 	storeURL, err := url.Parse("sqlitememory:///")


### PR DESCRIPTION
## Summary
- V1 utxo-headers exported from pruned SV Nodes don't include coinbase transactions — this is the only bootstrap path from SV Node to Teranode
- `StoreBlock` initialized `coinbaseBytes` as `nil`, which violated the `coinbase_tx BYTEA NOT NULL` constraint in Postgres
- Changed default from `nil` to `[]byte{}` so V1 headers store an empty byte array instead of NULL
- Added `TestStoreBlock_NilCoinbaseTransaction` regression test

## Test plan
- [x] New test `TestStoreBlock_NilCoinbaseTransaction` passes
- [x] All existing `TestStoreBlock*` tests pass
- [x] Seed from a V1 utxo-headers file against Postgres