### PR TITLE
fix: legacy sync must wait for previous block mined_set before processing next block

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/blockassemblyutil"
+	"github.com/bsv-blockchain/teranode/util/retry"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"golang.org/x/sync/errgroup"
 )
@@ -115,6 +116,15 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 		return err
 	}
 
+	// Wait for the previous block's setTxMined to complete before validating
+	// this block's transactions. Ensures BIP68 sequence lock validation can
+	// correctly look up parent transaction BlockHeights in the UTXO store.
+	if blockHeight > 1 {
+		if err = sm.waitForPreviousBlockMined(ctx, &block.MsgBlock().Header.PrevBlock, blockHeight); err != nil {
+			return err
+		}
+	}
+
 	// 3. Create a block message with (block hash, coinbase tx and slice if 1 subtree)
 	var headerBytes bytes.Buffer
 	if err = block.MsgBlock().Header.Serialize(&headerBytes); err != nil {
@@ -184,6 +194,34 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	}()
 
 	return nil
+}
+
+// waitForPreviousBlockMined waits for the previous block to have mined_set=true.
+// This ensures setTxMined has completed for the previous block before we validate
+// the next block's transactions, which is critical for BIP68 sequence lock validation
+// that needs correct BlockHeights from parent transactions in the UTXO store.
+func (sm *SyncManager) waitForPreviousBlockMined(ctx context.Context, prevBlockHash *chainhash.Hash, blockHeight uint32) error {
+	_, err := retry.Retry(ctx, sm.logger, func() (bool, error) {
+		isMined, err := sm.blockchainClient.GetBlockIsMined(ctx, prevBlockHash)
+		if err != nil {
+			if errors.Is(err, errors.ErrBlockNotFound) {
+				// Parent not in blockchain store yet — expected for genesis or very early blocks
+				return true, nil
+			}
+			return false, err
+		}
+		if !isMined {
+			return false, errors.NewBlockParentNotMinedError(
+				"[waitForPreviousBlockMined][height:%d] parent %s not mined yet",
+				blockHeight, prevBlockHash.String())
+		}
+		return true, nil
+	},
+		retry.WithBackoffDurationType(sm.settings.BlockValidation.IsParentMinedRetryBackoffDuration),
+		retry.WithBackoffMultiplier(sm.settings.BlockValidation.IsParentMinedRetryBackoffMultiplier),
+		retry.WithRetryCount(sm.settings.BlockValidation.IsParentMinedRetryMaxRetry),
+	)
+	return err
 }
 
 func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Block) (err error) {

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -204,11 +204,9 @@ func (sm *SyncManager) waitForPreviousBlockMined(ctx context.Context, prevBlockH
 	_, err := retry.Retry(ctx, sm.logger, func() (bool, error) {
 		isMined, err := sm.blockchainClient.GetBlockIsMined(ctx, prevBlockHash)
 		if err != nil {
-			if errors.Is(err, errors.ErrBlockNotFound) {
-				// Parent not in blockchain store yet — expected for genesis or very early blocks
-				return true, nil
-			}
-			return false, err
+			return false, errors.NewServiceError(
+				"[waitForPreviousBlockMined][height:%d] parent %s mined status not available yet",
+				blockHeight, prevBlockHash.String(), err)
 		}
 		if !isMined {
 			return false, errors.NewBlockParentNotMinedError(
@@ -220,6 +218,7 @@ func (sm *SyncManager) waitForPreviousBlockMined(ctx context.Context, prevBlockH
 		retry.WithBackoffDurationType(sm.settings.BlockValidation.IsParentMinedRetryBackoffDuration),
 		retry.WithBackoffMultiplier(sm.settings.BlockValidation.IsParentMinedRetryBackoffMultiplier),
 		retry.WithRetryCount(sm.settings.BlockValidation.IsParentMinedRetryMaxRetry),
+		retry.WithMessage("waitForPreviousBlockMined: legacy sync waiting for parent mined_set"),
 	)
 	return err
 }

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -560,6 +560,98 @@ func makeTxMap(t *testing.T, count int) *txmap.SyncedMap[chainhash.Hash, *TxMapW
 	return txMap
 }
 
+func TestWaitForPreviousBlockMined(t *testing.T) {
+	t.Run("returns immediately when parent is mined", func(t *testing.T) {
+		blockchainClient := &blockchain.Mock{}
+		prevHash := chainhash.HashH([]byte("prev-block"))
+		blockchainClient.On("GetBlockIsMined", mock.Anything, &prevHash).Return(true, nil)
+
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.BlockValidation.IsParentMinedRetryMaxRetry = 3
+		tSettings.BlockValidation.IsParentMinedRetryBackoffMultiplier = 1
+		tSettings.BlockValidation.IsParentMinedRetryBackoffDuration = time.Millisecond
+
+		sm := &SyncManager{
+			settings:         tSettings,
+			logger:           ulogger.TestLogger{},
+			blockchainClient: blockchainClient,
+		}
+
+		err := sm.waitForPreviousBlockMined(context.Background(), &prevHash, 100)
+		require.NoError(t, err)
+		blockchainClient.AssertNumberOfCalls(t, "GetBlockIsMined", 1)
+	})
+
+	t.Run("retries when parent is not mined yet then succeeds", func(t *testing.T) {
+		blockchainClient := &blockchain.Mock{}
+		prevHash := chainhash.HashH([]byte("prev-block"))
+
+		// First two calls: not mined. Third call: mined.
+		blockchainClient.On("GetBlockIsMined", mock.Anything, &prevHash).Return(false, nil).Times(2)
+		blockchainClient.On("GetBlockIsMined", mock.Anything, &prevHash).Return(true, nil).Once()
+
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.BlockValidation.IsParentMinedRetryMaxRetry = 5
+		tSettings.BlockValidation.IsParentMinedRetryBackoffMultiplier = 1
+		tSettings.BlockValidation.IsParentMinedRetryBackoffDuration = time.Millisecond
+
+		sm := &SyncManager{
+			settings:         tSettings,
+			logger:           ulogger.TestLogger{},
+			blockchainClient: blockchainClient,
+		}
+
+		err := sm.waitForPreviousBlockMined(context.Background(), &prevHash, 100)
+		require.NoError(t, err)
+		blockchainClient.AssertNumberOfCalls(t, "GetBlockIsMined", 3)
+	})
+
+	t.Run("retries on ErrBlockNotFound then succeeds", func(t *testing.T) {
+		blockchainClient := &blockchain.Mock{}
+		prevHash := chainhash.HashH([]byte("prev-block"))
+
+		// First call: block not found. Second call: mined.
+		blockchainClient.On("GetBlockIsMined", mock.Anything, &prevHash).Return(false, errors.ErrBlockNotFound).Once()
+		blockchainClient.On("GetBlockIsMined", mock.Anything, &prevHash).Return(true, nil).Once()
+
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.BlockValidation.IsParentMinedRetryMaxRetry = 5
+		tSettings.BlockValidation.IsParentMinedRetryBackoffMultiplier = 1
+		tSettings.BlockValidation.IsParentMinedRetryBackoffDuration = time.Millisecond
+
+		sm := &SyncManager{
+			settings:         tSettings,
+			logger:           ulogger.TestLogger{},
+			blockchainClient: blockchainClient,
+		}
+
+		err := sm.waitForPreviousBlockMined(context.Background(), &prevHash, 100)
+		require.NoError(t, err)
+		blockchainClient.AssertNumberOfCalls(t, "GetBlockIsMined", 2)
+	})
+
+	t.Run("fails after max retries exhausted", func(t *testing.T) {
+		blockchainClient := &blockchain.Mock{}
+		prevHash := chainhash.HashH([]byte("prev-block"))
+		blockchainClient.On("GetBlockIsMined", mock.Anything, &prevHash).Return(false, nil)
+
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.BlockValidation.IsParentMinedRetryMaxRetry = 2
+		tSettings.BlockValidation.IsParentMinedRetryBackoffMultiplier = 1
+		tSettings.BlockValidation.IsParentMinedRetryBackoffDuration = time.Millisecond
+
+		sm := &SyncManager{
+			settings:         tSettings,
+			logger:           ulogger.TestLogger{},
+			blockchainClient: blockchainClient,
+		}
+
+		err := sm.waitForPreviousBlockMined(context.Background(), &prevHash, 100)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not mined yet")
+	})
+}
+
 func TestPreValidateTransactions_AllSucceed(t *testing.T) {
 	initPrometheusMetrics()
 


### PR DESCRIPTION
## Summary
- During legacy sync, `setTxMined` (which sets `BlockHeights`/`BlockIDs` in the UTXO store) runs asynchronously after a `BlockSubtreesSet` notification. Normal block validation waits for the parent's `mined_set=true` via `waitForPreviousBlocksToBeProcessed()`, but legacy sync skipped this entirely.
- When block N+1's subtree validation looks up a parent from block N before `setTxMined` completes, `BlockHeights` is empty and the fallback uses `blockState.Height+1` — producing the wrong `coinHeight` for BIP68 sequence lock checks. This causes valid blocks to be rejected with `TX_INVALID: transaction sequence lock height not satisfied` and panics in `handleBlockMsg`.
- Adds `waitForPreviousBlockMined()` to the legacy `HandleBlockDirect` path, using the same `retry.Retry` pattern and `IsParentMinedRetry*` settings as normal block validation.

## Test plan
- [x] `go build ./services/legacy/...` compiles
- [x] `go test -race -tags "testtxmetacache" ./services/legacy/netsync/...` — all 31 tests pass
- [ ] Deploy to teratestnet, reset services, start sync — should process past block 1518114 without panic
- [ ] Monitor for `waitForPreviousBlockMined` log messages to confirm the wait is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)