### PR TITLE
fix: wait for BlockValidation to process invalid moveBack blocks before loading unmined txs

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -455,10 +455,12 @@ func (b *BlockAssembler) reset(ctx context.Context, fullScan bool, validateInput
 		moveBackTxs := make([]chainhash.Hash, 0, len(moveBackBlocksWithMeta)*100)
 
 		for _, blockWithMeta := range moveBackBlocksWithMeta {
-			if blockWithMeta.meta.Invalid {
-				// Skip invalid blocks - BlockValidation already handled them via unsetMined=true
-				continue
-			}
+			// Do NOT skip invalid blocks here. BlockValidation handles them via
+			// setTxMinedStatus(unsetMined=true), but that runs asynchronously via
+			// a BlockMinedUnset notification and may not have completed yet. If we
+			// skip, loadUnminedTransactions() won't find these txs (unmined_since
+			// still NULL) and they'll be silently lost from block assembly.
+			// MarkTransactionsOnLongestChain is idempotent, so double-marking is safe.
 
 			block := blockWithMeta.block
 			blockSubtrees, err := block.GetSubtrees(ctx, b.logger, b.subtreeStore, b.settings.Block.GetAndValidateSubtreesConcurrency)

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
+	"github.com/bsv-blockchain/teranode/util/retry"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"github.com/ordishs/gocore"
 )
@@ -404,6 +405,23 @@ func (b *BlockAssembler) reset(ctx context.Context, fullScan bool, validateInput
 		return errors.NewProcessingError("[Reset] error waiting for pending blocks", err)
 	}
 
+	// Wait for BlockValidation to finish processing any invalid moveBack blocks.
+	// InvalidateBlock sets mined_set=false and sends a BlockMinedUnset notification.
+	// BlockValidation's setTxMinedStatus(unsetMined=true) processes that notification
+	// asynchronously — it unsets the mined status for the block's transactions (sets
+	// unmined_since) and then sets mined_set=true. We must wait for that to complete
+	// before loadUnminedTransactions, otherwise those txs still have unmined_since=NULL
+	// and won't be recovered into block assembly.
+	for _, blockWithMeta := range moveBackBlocksWithMeta {
+		if blockWithMeta.meta.Invalid {
+			blockHash := blockWithMeta.block.Hash()
+			b.logger.Infof("[BlockAssembler][Reset] waiting for invalid block %s to be processed by BlockValidation", blockHash.String())
+			if waitErr := b.waitForBlockMinedSet(ctx, blockHash); waitErr != nil {
+				b.logger.Warnf("[BlockAssembler][Reset] timeout waiting for invalid block %s mined_set: %v (proceeding anyway)", blockHash.String(), waitErr)
+			}
+		}
+	}
+
 	// Mark moveBack transactions as unmined (set unmined_since)
 	//
 	// Division of Responsibility During Reorg:
@@ -455,12 +473,11 @@ func (b *BlockAssembler) reset(ctx context.Context, fullScan bool, validateInput
 		moveBackTxs := make([]chainhash.Hash, 0, len(moveBackBlocksWithMeta)*100)
 
 		for _, blockWithMeta := range moveBackBlocksWithMeta {
-			// Do NOT skip invalid blocks here. BlockValidation handles them via
-			// setTxMinedStatus(unsetMined=true), but that runs asynchronously via
-			// a BlockMinedUnset notification and may not have completed yet. If we
-			// skip, loadUnminedTransactions() won't find these txs (unmined_since
-			// still NULL) and they'll be silently lost from block assembly.
-			// MarkTransactionsOnLongestChain is idempotent, so double-marking is safe.
+			if blockWithMeta.meta.Invalid {
+				// Skip invalid blocks — BlockValidation has already handled them via
+				// setTxMinedStatus(unsetMined=true) which we waited for above.
+				continue
+			}
 
 			block := blockWithMeta.block
 			blockSubtrees, err := block.GetSubtrees(ctx, b.logger, b.subtreeStore, b.settings.Block.GetAndValidateSubtreesConcurrency)
@@ -533,6 +550,27 @@ func (b *BlockAssembler) reset(ctx context.Context, fullScan bool, validateInput
 	b.logger.Warnf("[BlockAssembler][Reset] resetting block assembler DONE")
 
 	return nil
+}
+
+// waitForBlockMinedSet polls until the given block has mined_set=true, indicating
+// that BlockValidation's setTxMinedStatus has completed for it.
+func (b *BlockAssembler) waitForBlockMinedSet(ctx context.Context, blockHash *chainhash.Hash) error {
+	_, err := retry.Retry(ctx, b.logger, func() (bool, error) {
+		isMined, err := b.blockchainClient.GetBlockIsMined(ctx, blockHash)
+		if err != nil {
+			return false, err
+		}
+		if !isMined {
+			return false, errors.NewBlockParentNotMinedError(
+				"[waitForBlockMinedSet] block %s mined_set not yet true", blockHash.String())
+		}
+		return true, nil
+	},
+		retry.WithBackoffDurationType(b.settings.BlockValidation.IsParentMinedRetryBackoffDuration),
+		retry.WithBackoffMultiplier(b.settings.BlockValidation.IsParentMinedRetryBackoffMultiplier),
+		retry.WithRetryCount(b.settings.BlockValidation.IsParentMinedRetryMaxRetry),
+	)
+	return err
 }
 
 // processNewBlockAnnouncement updates the best block information.

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -558,10 +558,24 @@ func (b *BlockAssembler) reset(ctx context.Context, fullScan bool, validateInput
 
 // waitForBlockMinedSet polls until the given block has mined_set=true, indicating
 // that BlockValidation's setTxMinedStatus has completed for it.
+// Non-retriable errors (e.g., block not found) cause an immediate return rather
+// than burning the full retry budget.
 func (b *BlockAssembler) waitForBlockMinedSet(ctx context.Context, blockHash *chainhash.Hash) error {
-	_, err := retry.Retry(ctx, b.logger, func() (bool, error) {
-		isMined, err := b.blockchainClient.GetBlockIsMined(ctx, blockHash)
+	retryCtx, retryCancel := context.WithCancel(ctx)
+	defer retryCancel()
+
+	var nonRetriableErr error
+
+	_, err := retry.Retry(retryCtx, b.logger, func() (bool, error) {
+		isMined, err := b.blockchainClient.GetBlockIsMined(retryCtx, blockHash)
 		if err != nil {
+			// Short-circuit on non-retriable errors (block doesn't exist in DB)
+			if errors.Is(err, errors.ErrBlockNotFound) {
+				nonRetriableErr = errors.NewProcessingError(
+					"[waitForBlockMinedSet] block %s not found — cannot wait for mined_set", blockHash.String())
+				retryCancel()
+				return false, nonRetriableErr
+			}
 			return false, err
 		}
 		if !isMined {
@@ -577,6 +591,10 @@ func (b *BlockAssembler) waitForBlockMinedSet(ctx context.Context, blockHash *ch
 		retry.WithBackoffFactor(2.0),
 		retry.WithMaxBackoff(2*time.Second),
 	)
+
+	if nonRetriableErr != nil {
+		return nonRetriableErr
+	}
 	return err
 }
 

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -405,19 +405,23 @@ func (b *BlockAssembler) reset(ctx context.Context, fullScan bool, validateInput
 		return errors.NewProcessingError("[Reset] error waiting for pending blocks", err)
 	}
 
-	// Wait for BlockValidation to finish processing any invalid moveBack blocks.
+	// Best-effort wait for BlockValidation to finish processing any invalid moveBack blocks.
 	// InvalidateBlock sets mined_set=false and sends a BlockMinedUnset notification.
 	// BlockValidation's setTxMinedStatus(unsetMined=true) processes that notification
 	// asynchronously — it unsets the mined status for the block's transactions (sets
-	// unmined_since) and then sets mined_set=true. We must wait for that to complete
-	// before loadUnminedTransactions, otherwise those txs still have unmined_since=NULL
-	// and won't be recovered into block assembly.
+	// unmined_since) and then sets mined_set=true. We wait for that to complete before
+	// loadUnminedTransactions so those txs have unmined_since set and can be recovered.
+	// On failure (except context cancellation), we proceed anyway — some txs may not
+	// be recovered in this reset cycle but will be picked up on subsequent resets.
 	for _, blockWithMeta := range moveBackBlocksWithMeta {
 		if blockWithMeta.meta.Invalid {
 			blockHash := blockWithMeta.block.Hash()
 			b.logger.Infof("[BlockAssembler][Reset] waiting for invalid block %s to be processed by BlockValidation", blockHash.String())
 			if waitErr := b.waitForBlockMinedSet(ctx, blockHash); waitErr != nil {
-				b.logger.Warnf("[BlockAssembler][Reset] timeout waiting for invalid block %s mined_set: %v (proceeding anyway)", blockHash.String(), waitErr)
+				if ctx.Err() != nil {
+					return errors.NewProcessingError("[Reset] context cancelled while waiting for invalid block mined_set", waitErr)
+				}
+				b.logger.Warnf("[BlockAssembler][Reset] gave up waiting for invalid block %s mined_set: %v (proceeding anyway — txs may be recovered on next reset)", blockHash.String(), waitErr)
 			}
 		}
 	}
@@ -566,9 +570,12 @@ func (b *BlockAssembler) waitForBlockMinedSet(ctx context.Context, blockHash *ch
 		}
 		return true, nil
 	},
+		retry.WithMessage("[BlockAssembler][Reset] waitForBlockMinedSet "+blockHash.String()),
 		retry.WithBackoffDurationType(b.settings.BlockValidation.IsParentMinedRetryBackoffDuration),
-		retry.WithBackoffMultiplier(b.settings.BlockValidation.IsParentMinedRetryBackoffMultiplier),
 		retry.WithRetryCount(b.settings.BlockValidation.IsParentMinedRetryMaxRetry),
+		retry.WithExponentialBackoff(),
+		retry.WithBackoffFactor(2.0),
+		retry.WithMaxBackoff(2*time.Second),
 	)
 	return err
 }

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -572,7 +572,7 @@ func (b *BlockAssembler) waitForBlockMinedSet(ctx context.Context, blockHash *ch
 			// Short-circuit on non-retriable errors (block doesn't exist in DB)
 			if errors.Is(err, errors.ErrBlockNotFound) {
 				nonRetriableErr = errors.NewProcessingError(
-					"[waitForBlockMinedSet] block %s not found — cannot wait for mined_set", blockHash.String())
+					"[waitForBlockMinedSet] block %s not found — cannot wait for mined_set", blockHash.String(), err)
 				retryCancel()
 				return false, nonRetriableErr
 			}


### PR DESCRIPTION
## Summary

During a reorg reset, invalid moveBack blocks are handled by BlockValidation's background job (`setTxMinedStatus(unsetMined=true)`), which sets `unmined_since` on their transactions. Previously, `reset()` called `loadUnminedTransactions` without waiting for this background processing to complete, so those txs still had `unmined_since=NULL` and were invisible to the unmined iterator.

**Changes:**
- Add `waitForBlockMinedSet` — polls until BlockValidation has finished processing each invalid moveBack block (exponential backoff, context-cancellable)
- Call it for each invalid moveBack block before `loadUnminedTransactions` runs
- On context cancellation: return error. On retries exhausted: proceed with warning (txs may be recovered on subsequent resets)
- Short-circuit on non-retriable errors (ErrBlockNotFound)

## Test plan

- [x] Existing block assembly tests pass
- [x] `make lint` — 0 issues
- [ ] Deploy to teratestnet and verify reset correctly recovers txs from invalid moveBack blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)