### PR TITLE
feat(utxo): check aerospike stop_writes in health endpoint

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -445,6 +445,32 @@ func (s *Store) Health(ctx context.Context, checkLiveness bool) (int, string, er
 		return http.StatusServiceUnavailable, details, err
 	}
 
+	nodes := s.client.GetNodes()
+	if len(nodes) == 0 {
+		return http.StatusServiceUnavailable, details, fmt.Errorf("no aerospike nodes available")
+	}
+
+	infoPolicy := aerospike.NewInfoPolicy()
+	if timeout > 0 {
+		infoPolicy.Timeout = timeout
+	}
+
+	nsKey := "namespace/" + s.namespace
+	for _, node := range nodes {
+		infoMap, err := node.RequestInfo(infoPolicy, nsKey)
+		if err != nil {
+			return http.StatusServiceUnavailable, details, fmt.Errorf("failed to get namespace info from node %s: %w", node.GetName(), err)
+		}
+
+		if nsStr, ok := infoMap[nsKey]; ok {
+			for pair := range strings.SplitSeq(nsStr, ";") {
+				if pair == "stop_writes=true" || pair == "clock_skew_stop_writes=true" {
+					return http.StatusServiceUnavailable, details, fmt.Errorf("aerospike namespace %s on node %s has %s", s.namespace, node.GetName(), pair)
+				}
+			}
+		}
+	}
+
 	return http.StatusOK, details, nil
 }
 

--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -447,7 +447,7 @@ func (s *Store) Health(ctx context.Context, checkLiveness bool) (int, string, er
 
 	nodes := s.client.GetNodes()
 	if len(nodes) == 0 {
-		return http.StatusServiceUnavailable, details, fmt.Errorf("no aerospike nodes available")
+		return http.StatusServiceUnavailable, details, errors.NewStorageUnavailableError("no aerospike nodes available")
 	}
 
 	infoPolicy := aerospike.NewInfoPolicy()
@@ -459,13 +459,13 @@ func (s *Store) Health(ctx context.Context, checkLiveness bool) (int, string, er
 	for _, node := range nodes {
 		infoMap, err := node.RequestInfo(infoPolicy, nsKey)
 		if err != nil {
-			return http.StatusServiceUnavailable, details, fmt.Errorf("failed to get namespace info from node %s: %w", node.GetName(), err)
+			return http.StatusServiceUnavailable, details, errors.NewStorageError("failed to get namespace info from node %s: %v", node.GetName(), err)
 		}
 
 		if nsStr, ok := infoMap[nsKey]; ok {
 			for pair := range strings.SplitSeq(nsStr, ";") {
 				if pair == "stop_writes=true" || pair == "clock_skew_stop_writes=true" {
-					return http.StatusServiceUnavailable, details, fmt.Errorf("aerospike namespace %s on node %s has %s", s.namespace, node.GetName(), pair)
+					return http.StatusServiceUnavailable, details, errors.NewStorageUnavailableError("aerospike namespace %s on node %s has %s", s.namespace, node.GetName(), pair)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Adds stop_writes and clock_skew_stop_writes detection to the Aerospike UTXO store health check
- Queries **all** cluster nodes (not just one) so a single node in stop_writes mode is caught
- Returns 503 with the affected node name and flag in the error message

## Test plan
- [ ] Deploy to a test environment and verify `/health/readiness` returns 200 normally
- [ ] Simulate stop_writes (fill namespace disk/memory) and verify readiness returns 503
- [ ] Verify the error message includes the node name and which flag triggered it