### PR TITLE
fix(health): return actual status code from readiness check

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -319,7 +319,7 @@ func (d *Daemon) Start(logger ulogger.Logger, args []string, appSettings *settin
 				return
 			}
 
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(status)
 			_, _ = w.Write([]byte(details))
 		}
 	}


### PR DESCRIPTION
## Summary
- The `/health/readiness` endpoint always returned HTTP 200, even when dependency checks failed
- `CheckAll` correctly sets the status to 503 and includes it in the JSON body, but returns `nil` error
- The handler only wrote 503 when `err != nil`, so it always fell through to the hardcoded `http.StatusOK`
- Fix: use the returned `status` value instead of hardcoding 200

## Test plan
- [ ] Verify `/health/readiness` returns 200 when all dependencies are healthy
- [ ] Stop a dependency (e.g. Kafka, Aerospike) and verify readiness returns 503
- [ ] Verify the JSON body status matches the HTTP status code