### PR TITLE
fix(health): ensure liveness response is valid JSON

### DIFF
--- a/util/servicemanager/service_manager.go
+++ b/util/servicemanager/service_manager.go
@@ -300,6 +300,10 @@ func (sm *ServiceManager) HealthHandler(ctx context.Context, checkLiveness bool)
 			overallStatus = http.StatusServiceUnavailable
 		}
 
+		if !json.Valid([]byte(details)) {
+			details = fmt.Sprintf(`{"message": "%s"}`, details)
+		}
+
 		jsonStr := fmt.Sprintf(`{"service": "%s","status": "%d","dependencies": [%s]}`, service.name, status, details)
 
 		msgs = append(msgs, jsonStr)


### PR DESCRIPTION
## Summary
- Liveness health checks returned invalid JSON: `"dependencies": [OK]` — `OK` was unquoted
- Services return plain strings like `"OK"` for liveness (they skip dependency checks)
- `HealthHandler` interpolated these directly into a JSON array without quoting
- Fix: detect non-JSON details via `json.Valid()` and wrap them in `{"message": "..."}` before interpolation

**Before:** `{"service": "BlockValidation","status": "200","dependencies": [OK]}`
**After:** `{"service": "BlockValidation","status": "200","dependencies": [{"message": "OK"}]}`

## Test plan
- [ ] Hit `/health/liveness` and verify the response is valid JSON
- [ ] Hit `/health/readiness` and verify it still returns correctly structured JSON
- [ ] Pipe response through `jq` to confirm parseability