### PR TITLE
fix(validator): prevent panic on mtpStore out-of-bounds during BIP68 validation

### DIFF
--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -1169,10 +1169,12 @@ func (v *Validator) EnsureMTPLoaded(ctx context.Context, blockHeight uint32) err
 		return nil
 	}
 
-	// The highest MTP index we ever need is blockHeight:
-	//   - utxoHeights are always < blockHeight (a UTXO must exist before the spending block)
+	// The highest MTP index we guarantee is blockHeight:
 	//   - blockMTPHeight = blockHeight: GetMedianTimePastRange computes stored_mtp(N)
 	//     on the fly for the not-yet-persisted block N from block_time values [N-11, N-1].
+	//   - utxoHeights *may* exceed blockHeight when the chain tip advances during
+	//     validation (unconfirmed parents get blockState.Height+1); validateTransaction
+	//     clamps those lookups to blockMTPHeight.
 	needed := blockHeight
 
 	// Fast path: store already covers the needed height.
@@ -1286,9 +1288,14 @@ func (v *Validator) validateTransaction(ctx context.Context, tx *bt.Tx, blockHei
 		return err
 	}
 
+	storeLen := uint32(len(v.mtpStore))
 	utxoMTPs := make([]uint32, len(utxoHeights))
 	for i, h := range utxoHeights {
-		utxoMTPs[i] = v.mtpStore[h]
+		if h >= storeLen {
+			utxoMTPs[i] = v.mtpStore[blockMTPHeight]
+		} else {
+			utxoMTPs[i] = v.mtpStore[h]
+		}
 	}
 	blockMTP := v.mtpStore[blockMTPHeight]
 


### PR DESCRIPTION
## Summary
- Fixes a panic (`index out of range`) in `validateTransaction` during BIP68 sequence-lock validation when UTXO heights exceed the pre-loaded `mtpStore` bounds
- Root cause: unconfirmed parent transactions are assigned `blockState.Height + 1` as their UTXO height, which can exceed the `blockHeight` used to size `mtpStore` when the chain tip advances during concurrent block validation
- Out-of-range UTXO heights now clamp to the block's own MTP, correctly reflecting zero coin age for just-created UTXOs

## Test plan
- [ ] Run `make test` to verify no regressions
- [ ] Deploy to multi-node regtest environment and run blaster workload to confirm no panics during concurrent block validation
- [ ] Verify BIP68 sequence-lock transactions still validate correctly under normal conditions