### PR TITLE
fix: fix(legacy): remove peer checks from readiness probe

### DIFF
--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -227,47 +226,6 @@ func (s *Server) Health(ctx context.Context, checkLiveness bool) (int, string, e
 	if s.blockAssemblyClient != nil {
 		checks = append(checks, health.Check{Name: "BlockAssembly", Check: s.blockAssemblyClient.Health})
 	}
-
-	// Add custom check for peer connection
-	checks = append(checks, health.Check{
-		Name: "PeerConnection",
-		Check: func(ctx context.Context, checkLiveness bool) (int, string, error) {
-			peersResp, err := s.GetPeers(ctx, &emptypb.Empty{})
-			if err != nil {
-				return http.StatusServiceUnavailable, "Failed to get peers for health check", err
-			}
-			peers := peersResp.GetPeers()
-			if len(peers) == 0 {
-				return http.StatusServiceUnavailable, "No connected peers", nil
-			}
-			return http.StatusOK, fmt.Sprintf("Connected to %d peers", len(peers)), nil
-		},
-	})
-
-	// Add custom check for recent peer activity
-	checks = append(checks, health.Check{
-		Name: "PeerActivity",
-		Check: func(ctx context.Context, checkLiveness bool) (int, string, error) {
-			peersResp, err := s.GetPeers(ctx, &emptypb.Empty{})
-			if err != nil {
-				return http.StatusServiceUnavailable, "Failed to get peers for activity check", err
-			}
-			peers := peersResp.GetPeers()
-			currentTime := time.Now().Unix()
-			recentActivityThreshold := currentTime - 120 // 2 minutes in seconds
-			hasRecentActivity := false
-			for _, p := range peers {
-				if p.GetLastRecv() >= recentActivityThreshold {
-					hasRecentActivity = true
-					break
-				}
-			}
-			if !hasRecentActivity {
-				return http.StatusServiceUnavailable, "No peer activity in the last 2 minutes", nil
-			}
-			return http.StatusOK, "Recent peer activity detected", nil
-		},
-	})
 
 	return health.CheckAll(ctx, checkLiveness, checks)
 }


### PR DESCRIPTION
Peer presence and activity are runtime metrics, not readiness signals. Gating readiness on them created a bootstrap deadlock where a legacy node couldn't report ready until a peer connected — breaking tests that need teranode ready before starting svnode.