### PR TITLE
fix(blockchain): serialize schema creation + skip DDL when current to prevent startup stall

### DIFF
--- a/internal/banlist/ban_list.go
+++ b/internal/banlist/ban_list.go
@@ -336,7 +336,20 @@ func (b *BanList) notifySubscribersAsync(event BanEvent) {
 	}
 }
 
+// Advisory lock ID for banlist schema creation serialization across pods.
+const banlistSchemaLockID int64 = 7_265_726_098 // "tera" + "bl" in ASCII-ish
+
 func (b *BanList) createTables(ctx context.Context) error {
+	if b.engine == util.Postgres {
+		return usql.WithAdvisoryLock(ctx, b.db, banlistSchemaLockID, func() error {
+			return b.createTablesUnlocked(ctx)
+		})
+	}
+
+	return b.createTablesUnlocked(ctx)
+}
+
+func (b *BanList) createTablesUnlocked(ctx context.Context) error {
 	_, err := b.db.ExecContext(ctx, `
         CREATE TABLE IF NOT EXISTS bans (
             key TEXT PRIMARY KEY,

--- a/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
+++ b/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
@@ -1,0 +1,181 @@
+package sql
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/usql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// newSchemaTestDB spins up a fresh postgres container and returns:
+//   - dbURL parsed for blockchain.New
+//   - a raw *usql.DB for direct probes
+//   - the terminate func (registered via t.Cleanup)
+func newSchemaTestDB(t *testing.T) (*url.URL, *usql.DB) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:13",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Minute),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	dbURL, err := url.Parse(connStr)
+	require.NoError(t, err)
+
+	db, err := usql.Open("postgres", connStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	return dbURL, db
+}
+
+func TestIsBlockchainSchemaCurrent_EmptyDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	_, db := newSchemaTestDB(t)
+
+	current, err := isBlockchainSchemaCurrent(db, true)
+	require.NoError(t, err)
+	assert.False(t, current, "empty DB must not be reported as current")
+}
+
+func TestIsBlockchainSchemaCurrent_AfterCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	dbURL, db := newSchemaTestDB(t)
+
+	// Creating the store runs createPostgresSchema end-to-end, so after New()
+	// returns the probe must report the schema as current.
+	tSettings := test.CreateBaseTestSettings(t)
+	s, err := New(ulogger.TestLogger{}, dbURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	current, err := isBlockchainSchemaCurrent(db, true)
+	require.NoError(t, err)
+	assert.True(t, current, "schema should be current after New() completes")
+}
+
+func TestIsBlockchainSchemaCurrent_MissingColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	dbURL, db := newSchemaTestDB(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	s, err := New(ulogger.TestLogger{}, dbURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Drop one of the expected columns to simulate an out-of-date schema. The
+	// probe must then report not-current so the DDL path runs.
+	_, err = db.Exec(`ALTER TABLE blocks DROP COLUMN on_main_chain`)
+	require.NoError(t, err)
+
+	current, err := isBlockchainSchemaCurrent(db, true)
+	require.NoError(t, err)
+	assert.False(t, current, "schema should not be current after column drop")
+}
+
+func TestIsBlockchainSchemaCurrent_MissingIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	dbURL, db := newSchemaTestDB(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	s, err := New(ulogger.TestLogger{}, dbURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, err = db.Exec(`DROP INDEX IF EXISTS idx_on_main_chain_height`)
+	require.NoError(t, err)
+
+	current, err := isBlockchainSchemaCurrent(db, true)
+	require.NoError(t, err)
+	assert.False(t, current, "schema should not be current after index drop")
+}
+
+func TestIsBlockchainSchemaCurrent_WrongPeerIDType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	dbURL, db := newSchemaTestDB(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	s, err := New(ulogger.TestLogger{}, dbURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Flip peer_id back to an older type so the probe must return false.
+	// TEXT -> VARCHAR(64) — the ALTER COLUMN peer_id TYPE TEXT in
+	// createPostgresSchemaUnlocked is meant to pick this up.
+	_, err = db.Exec(`ALTER TABLE blocks ALTER COLUMN peer_id TYPE VARCHAR(64)`)
+	require.NoError(t, err)
+
+	current, err := isBlockchainSchemaCurrent(db, true)
+	require.NoError(t, err)
+	assert.False(t, current, "schema should not be current when peer_id is not TEXT")
+}
+
+func TestCreatePostgresSchema_FastPathOnSecondCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	dbURL, db := newSchemaTestDB(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	s1, err := New(ulogger.TestLogger{}, dbURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s1.Close() })
+
+	// The second call must detect the schema as current and return without
+	// running DDL. The cheapest proof that no DDL ran is that the call is
+	// fast and produces no errors against a populated schema. We also check
+	// idempotence: object oids remain stable (no DROP/CREATE cycle).
+	var oidBefore int64
+	require.NoError(t, db.QueryRow(
+		`SELECT oid FROM pg_class WHERE relname = 'idx_on_main_chain_height'`,
+	).Scan(&oidBefore))
+
+	require.NoError(t, createPostgresSchema(ulogger.TestLogger{}, db, true))
+
+	var oidAfter int64
+	require.NoError(t, db.QueryRow(
+		`SELECT oid FROM pg_class WHERE relname = 'idx_on_main_chain_height'`,
+	).Scan(&oidAfter))
+
+	assert.Equal(t, oidBefore, oidAfter, "fast path must not re-create objects")
+}

--- a/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
+++ b/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
@@ -149,6 +149,30 @@ func TestIsBlockchainSchemaCurrent_WrongPeerIDType(t *testing.T) {
 	assert.False(t, current, "schema should not be current when peer_id is not TEXT")
 }
 
+func TestIsBlockchainSchemaCurrent_MissingPeerIDColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+
+	dbURL, db := newSchemaTestDB(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	s, err := New(ulogger.TestLogger{}, dbURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Drop the peer_id column entirely. Per the function contract, a missing
+	// column must surface as (false, nil), not (false, sql.ErrNoRows). Without
+	// the EXISTS pattern, QueryRow().Scan() on no rows would propagate as an
+	// error and trigger the misleading "probe failed" warning.
+	_, err = db.Exec(`ALTER TABLE blocks DROP COLUMN peer_id`)
+	require.NoError(t, err)
+
+	current, err := isBlockchainSchemaCurrent(db, true)
+	require.NoError(t, err, "missing column must not be reported as a transport error")
+	assert.False(t, current, "schema must not be current when peer_id column is missing")
+}
+
 func TestCreatePostgresSchema_FastPathOnSecondCall(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping postgres-backed test in -short mode")

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -169,7 +169,7 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		// The 'seeder' query parameter is used to optimize bulk imports by bypassing index creation.
 		// Creating indexes during data insertion can significantly slow down the process, so we skip
 		// index creation when 'seeder=true' is specified in the query parameters.
-		if err = createPostgresSchema(db, storeURL.Query().Get("seeder") != trueStr); err != nil {
+		if err = createPostgresSchema(logger, db, storeURL.Query().Get("seeder") != trueStr); err != nil {
 			return nil, errors.NewStorageError("failed to create postgres schema", err)
 		}
 
@@ -349,7 +349,8 @@ func (s *SQL) Close() error {
 // These must be unique per schema-creation context and stable across releases.
 const blockchainSchemaLockID int64 = 7_265_726_101 // "tera" + "bc" in ASCII-ish
 
-func createPostgresSchema(db *usql.DB, withIndexes bool) error {
+func createPostgresSchema(logger ulogger.Logger, db *usql.DB, withIndexes bool) error {
+	logger.Infof("[blockchain schema] acquiring advisory lock (id=%d) and checking schema", blockchainSchemaLockID)
 	return usql.WithAdvisoryLock(context.Background(), db, blockchainSchemaLockID, func() error {
 		// Fast path: if the schema is already current, skip the DDL sequence
 		// entirely. All DDL statements below ultimately take at least a SHARE
@@ -368,10 +369,19 @@ func createPostgresSchema(db *usql.DB, withIndexes bool) error {
 		// everything we expect is already in place we return early and no
 		// blocks-table lock is ever requested.
 		current, err := isBlockchainSchemaCurrent(db, withIndexes)
-		if err == nil && current {
+		if err != nil {
+			logger.Warnf("[blockchain schema] current-schema probe failed, will run full DDL: %v", err)
+		} else if current {
+			logger.Infof("[blockchain schema] current (withIndexes=%v), skipping DDL", withIndexes)
 			return nil
+		} else {
+			logger.Infof("[blockchain schema] not current (withIndexes=%v), running DDL sequence", withIndexes)
 		}
-		return createPostgresSchemaUnlocked(db, withIndexes)
+		if err := createPostgresSchemaUnlocked(db, withIndexes); err != nil {
+			return err
+		}
+		logger.Infof("[blockchain schema] DDL sequence complete")
+		return nil
 	})
 }
 

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -345,7 +345,17 @@ func (s *SQL) Close() error {
 	return s.db.Close()
 }
 
+// Advisory lock IDs for schema creation serialization across pods.
+// These must be unique per schema-creation context and stable across releases.
+const blockchainSchemaLockID int64 = 7_265_726_101 // "tera" + "bc" in ASCII-ish
+
 func createPostgresSchema(db *usql.DB, withIndexes bool) error {
+	return usql.WithAdvisoryLock(context.Background(), db, blockchainSchemaLockID, func() error {
+		return createPostgresSchemaUnlocked(db, withIndexes)
+	})
+}
+
+func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool) error {
 	if _, err := db.Exec(`
       CREATE TABLE IF NOT EXISTS state (
 	    key            VARCHAR(32) PRIMARY KEY

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -436,14 +436,19 @@ func isBlockchainSchemaCurrent(db *usql.DB, withIndexes bool) (bool, error) {
 		return false, nil
 	}
 
-	// peer_id must already be TEXT — otherwise we still need the ALTER COLUMN.
-	var peerIDType string
+	// peer_id must exist and already be TEXT — otherwise we still need the
+	// ALTER COLUMN. Use EXISTS so a missing column returns (false, nil)
+	// rather than sql.ErrNoRows from QueryRow.Scan.
+	var peerIDIsText bool
 	if err := db.QueryRow(
-		`SELECT data_type FROM information_schema.columns WHERE table_name = 'blocks' AND column_name = 'peer_id'`,
-	).Scan(&peerIDType); err != nil {
+		`SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'blocks' AND column_name = 'peer_id' AND data_type = 'text'
+		)`,
+	).Scan(&peerIDIsText); err != nil {
 		return false, err
 	}
-	if peerIDType != "text" {
+	if !peerIDIsText {
 		return false, nil
 	}
 

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -351,8 +351,125 @@ const blockchainSchemaLockID int64 = 7_265_726_101 // "tera" + "bc" in ASCII-ish
 
 func createPostgresSchema(db *usql.DB, withIndexes bool) error {
 	return usql.WithAdvisoryLock(context.Background(), db, blockchainSchemaLockID, func() error {
+		// Fast path: if the schema is already current, skip the DDL sequence
+		// entirely. All DDL statements below ultimately take at least a SHARE
+		// lock on blocks (CREATE INDEX IF NOT EXISTS still does so briefly on
+		// some postgres versions, and CREATE TABLE IF NOT EXISTS touches the
+		// type catalog). When a concurrent pod has spawned its async
+		// on_main_chain rebuild — which holds ROW EXCLUSIVE on blocks for the
+		// duration of the walk — any SHARE request queues, and postgres fair
+		// queueing then parks subsequent AccessShare (SELECT) callers behind
+		// it. That cascade is what blocks readers during otherwise idle
+		// startup.
+		//
+		// Probing the schema via system catalogs (information_schema and
+		// pg_class) only takes AccessShare on catalog tables, never on
+		// blocks, so it cannot be blocked by the rebuild UPDATE. If
+		// everything we expect is already in place we return early and no
+		// blocks-table lock is ever requested.
+		current, err := isBlockchainSchemaCurrent(db, withIndexes)
+		if err == nil && current {
+			return nil
+		}
 		return createPostgresSchemaUnlocked(db, withIndexes)
 	})
+}
+
+// blockchainSchemaExpectedColumns is the list of columns createPostgresSchemaUnlocked
+// guarantees exist on the blocks table after a successful run. Kept in sync with
+// the CREATE TABLE / ADD COLUMN statements below.
+var blockchainSchemaExpectedColumns = []string{
+	"processed_at",
+	"persisted_at",
+	"median_time_past",
+	"coinbase_bump",
+	"on_main_chain",
+}
+
+// blockchainSchemaExpectedIndexes is the list of indexes on blocks that the
+// withIndexes branch guarantees. Kept in sync with the CREATE INDEX statements
+// below. ux_blocks_hash is always created, so it lives in the base set.
+var (
+	blockchainSchemaExpectedBaseIndexes = []string{
+		"ux_blocks_hash",
+	}
+	blockchainSchemaExpectedFullIndexes = []string{
+		"idx_chain_work_peer_id",
+		"idx_chain_work_valid",
+		"idx_subtrees_mined_height",
+		"idx_subtrees_set_height",
+		"idx_not_persisted_height",
+		"idx_height",
+		"idx_parent_id",
+		"idx_inserted_at",
+		"idx_invalid_height",
+		"idx_on_main_chain_height",
+	}
+)
+
+// isBlockchainSchemaCurrent returns true when the blocks table exists with all
+// expected columns and indexes in place. Uses only system-catalog reads
+// (AccessShare on pg_class / information_schema) so it never contends with
+// writes on blocks. Callers that see true can skip the DDL sequence.
+//
+// Returns (false, nil) if anything is missing. Returns (false, err) only for
+// transport errors — a missing column / table / index is not an error.
+func isBlockchainSchemaCurrent(db *usql.DB, withIndexes bool) (bool, error) {
+	// blocks table present?
+	var hasBlocks bool
+	if err := db.QueryRow(
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'blocks')`,
+	).Scan(&hasBlocks); err != nil {
+		return false, err
+	}
+	if !hasBlocks {
+		return false, nil
+	}
+
+	// peer_id must already be TEXT — otherwise we still need the ALTER COLUMN.
+	var peerIDType string
+	if err := db.QueryRow(
+		`SELECT data_type FROM information_schema.columns WHERE table_name = 'blocks' AND column_name = 'peer_id'`,
+	).Scan(&peerIDType); err != nil {
+		return false, err
+	}
+	if peerIDType != "text" {
+		return false, nil
+	}
+
+	// All expected columns present?
+	for _, col := range blockchainSchemaExpectedColumns {
+		var exists bool
+		if err := db.QueryRow(
+			`SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'blocks' AND column_name = $1)`,
+			col,
+		).Scan(&exists); err != nil {
+			return false, err
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+
+	// All expected indexes present?
+	expected := blockchainSchemaExpectedBaseIndexes
+	if withIndexes {
+		expected = append(expected, blockchainSchemaExpectedFullIndexes...)
+	}
+	for _, idx := range expected {
+		var exists bool
+		if err := db.QueryRow(
+			`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = $1 AND relkind = 'i')`,
+			idx,
+		).Scan(&exists); err != nil {
+			return false, err
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool) error {

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -4259,8 +4259,13 @@ type DBExecutor interface {
 	Close() error
 }
 
+// Advisory lock ID for UTXO schema creation serialization across pods.
+const utxoSchemaLockID int64 = 7_265_726_117 // "tera" + "ux" in ASCII-ish
+
 func createPostgresSchema(db *usql.DB) error {
-	return createPostgresSchemaImpl(db)
+	return usql.WithAdvisoryLock(context.Background(), db, utxoSchemaLockID, func() error {
+		return createPostgresSchemaImpl(db)
+	})
 }
 
 // createPostgresSchemaImpl contains the actual implementation, now testable

--- a/util/usql/advisory_lock.go
+++ b/util/usql/advisory_lock.go
@@ -3,29 +3,64 @@ package usql
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bsv-blockchain/teranode/errors"
 )
+
+// advisoryUnlockTimeout bounds the unlock call in the defer so a degraded or
+// broken connection cannot hang the caller after fn() returns.
+const advisoryUnlockTimeout = 5 * time.Second
 
 // WithAdvisoryLock acquires a PostgreSQL session-level advisory lock, executes fn,
 // then releases the lock. This serializes concurrent DDL operations (like CREATE TABLE
 // IF NOT EXISTS) across multiple pods sharing the same database, preventing race
 // conditions on PostgreSQL system catalog indexes.
 //
-// The lockID should be a unique constant per schema-creation context (e.g. one for
-// blockchain store, one for UTXO store, one for banlist).
+// The lockID must be a unique constant per schema-creation context (e.g. one for
+// blockchain store, one for UTXO store, one for banlist). Stable across releases.
 //
-// This is a no-op wrapper for non-PostgreSQL databases — callers must check the
-// engine type themselves before calling.
+// Connection pinning: pg_advisory_lock / pg_advisory_unlock are session-scoped.
+// When called via *sql.DB the driver can pick any pooled connection, so a naive
+// lock-via-pool / unlock-via-pool pattern can lock on session X and unlock on
+// session Y — leaving X's lock held until the session terminates, permanently
+// blocking other pods. We pin a dedicated *sql.Conn from the pool for the
+// entire lock/fn/unlock window so both statements run on the same session, then
+// return the connection to the pool in a deferred Close.
+//
+// Lock lifetime:
+//  1. The lock is held only for the duration of fn() execution.
+//  2. It is released explicitly before this function returns (or on panic via defer).
+//  3. It is also auto-released by postgres if the pinned session terminates
+//     (e.g. network drop) — so a crashed pod cannot permanently block others.
+//
+// Callers are responsible for engine-gating: this is a no-op wrapper for
+// non-PostgreSQL databases — check the engine type before calling.
 func WithAdvisoryLock(ctx context.Context, db *DB, lockID int64, fn func() error) error {
-	if _, err := db.ExecContext(ctx, fmt.Sprintf("SELECT pg_advisory_lock(%d)", lockID)); err != nil {
+	// Pin a single connection so lock + unlock run on the same session.
+	conn, err := db.DB.Conn(ctx)
+	if err != nil {
+		return errors.New(errors.ERR_ERROR, "advisory lock %d: failed to acquire connection: %w", lockID, err)
+	}
+	defer func() {
+		// Returns the pinned connection to the pool; the advisory lock must
+		// be released *before* this runs, otherwise the pool can hand the
+		// session to another caller while it still holds the lock.
+		_ = conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SELECT pg_advisory_lock(%d)", lockID)); err != nil {
 		return errors.New(errors.ERR_ERROR, "failed to acquire advisory lock %d: %w", lockID, err)
 	}
 
 	defer func() {
-		// Release on a background context — if the parent context was cancelled we
-		// still need to release the lock to avoid blocking other pods.
-		_, _ = db.Exec(fmt.Sprintf("SELECT pg_advisory_unlock(%d)", lockID))
+		// Release on a fresh bounded context: the parent ctx may have been
+		// cancelled by the caller, but we still need to release the lock on
+		// the same pinned session so other pods are not blocked. The timeout
+		// protects against a slow/broken connection hanging cleanup.
+		unlockCtx, cancel := context.WithTimeout(context.Background(), advisoryUnlockTimeout)
+		defer cancel()
+		_, _ = conn.ExecContext(unlockCtx, fmt.Sprintf("SELECT pg_advisory_unlock(%d)", lockID))
 	}()
 
 	return fn()

--- a/util/usql/advisory_lock.go
+++ b/util/usql/advisory_lock.go
@@ -1,0 +1,32 @@
+package usql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bsv-blockchain/teranode/errors"
+)
+
+// WithAdvisoryLock acquires a PostgreSQL session-level advisory lock, executes fn,
+// then releases the lock. This serializes concurrent DDL operations (like CREATE TABLE
+// IF NOT EXISTS) across multiple pods sharing the same database, preventing race
+// conditions on PostgreSQL system catalog indexes.
+//
+// The lockID should be a unique constant per schema-creation context (e.g. one for
+// blockchain store, one for UTXO store, one for banlist).
+//
+// This is a no-op wrapper for non-PostgreSQL databases — callers must check the
+// engine type themselves before calling.
+func WithAdvisoryLock(ctx context.Context, db *DB, lockID int64, fn func() error) error {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("SELECT pg_advisory_lock(%d)", lockID)); err != nil {
+		return errors.New(errors.ERR_ERROR, "failed to acquire advisory lock %d: %w", lockID, err)
+	}
+
+	defer func() {
+		// Release on a background context — if the parent context was cancelled we
+		// still need to release the lock to avoid blocking other pods.
+		_, _ = db.Exec(fmt.Sprintf("SELECT pg_advisory_unlock(%d)", lockID))
+	}()
+
+	return fn()
+}

--- a/util/usql/advisory_lock_test.go
+++ b/util/usql/advisory_lock_test.go
@@ -1,0 +1,210 @@
+package usql
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// newPostgresTestDB spins up a real postgres container and returns a *DB plus
+// a cleanup func. Kept local to this file so advisory-lock behaviour is tested
+// against the same server mechanics the code targets in production.
+func newPostgresTestDB(t *testing.T) *DB {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:13",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Minute),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	// pg driver wants a postgres://... DSN; ConnectionString already returns one.
+	_, err = url.Parse(connStr)
+	require.NoError(t, err)
+
+	db, err := Open("postgres", connStr)
+	require.NoError(t, err)
+	// Small pool so we can deterministically exercise conn pinning.
+	db.DB.SetMaxOpenConns(4)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// advisoryLockHolderCount returns how many postgres backends currently hold the
+// given single-key advisory lock id. Uses pg_locks (system catalog, AccessShare)
+// so the probe cannot block on user-table activity.
+//
+// Encoding reference: pg_advisory_lock(int8 key) stores
+//
+//	classid  = (key >> 32) & 0xFFFFFFFF
+//	objid    =  key        & 0xFFFFFFFF
+//	objsubid = 1
+//
+// (The two-key form pg_advisory_lock(int4, int4) uses objsubid = 2.)
+func advisoryLockHolderCount(t *testing.T, db *DB, lockID int64) int {
+	t.Helper()
+	var count int
+	err := db.QueryRow(`
+        SELECT count(*)
+        FROM pg_locks
+        WHERE locktype = 'advisory'
+          AND objsubid = 1
+          AND ((classid::bigint << 32) | (objid::bigint & x'FFFFFFFF'::bigint)) = $1
+          AND granted = true
+    `, lockID).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+const testLockID int64 = 0xabc_def
+
+func TestWithAdvisoryLock_AcquireReleaseRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+	db := newPostgresTestDB(t)
+	ctx := context.Background()
+
+	// Sanity: nobody holds the lock.
+	require.Equal(t, 0, advisoryLockHolderCount(t, db, testLockID))
+
+	var insideFn int
+	err := WithAdvisoryLock(ctx, db, testLockID, func() error {
+		// Inside fn, exactly one backend must hold the lock.
+		insideFn = advisoryLockHolderCount(t, db, testLockID)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, insideFn, "lock should be held while fn executes")
+
+	// After return, no backend should hold the lock — conn-pinning + defer
+	// unlock must release it on the same session that acquired it.
+	require.Eventually(t, func() bool {
+		return advisoryLockHolderCount(t, db, testLockID) == 0
+	}, 2*time.Second, 50*time.Millisecond, "lock must be released after fn returns")
+}
+
+func TestWithAdvisoryLock_Serializes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+	db := newPostgresTestDB(t)
+	ctx := context.Background()
+
+	const goroutines = 5
+	var (
+		wg       sync.WaitGroup
+		inside   int32 // how many goroutines are currently inside fn
+		maxSeen  int32
+		observed = make([]int32, goroutines)
+	)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			err := WithAdvisoryLock(ctx, db, testLockID, func() error {
+				n := atomic.AddInt32(&inside, 1)
+				observed[i] = n
+				for {
+					cur := atomic.LoadInt32(&maxSeen)
+					if n <= cur || atomic.CompareAndSwapInt32(&maxSeen, cur, n) {
+						break
+					}
+				}
+				time.Sleep(50 * time.Millisecond)
+				atomic.AddInt32(&inside, -1)
+				return nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.EqualValues(t, 1, maxSeen, "advisory lock must permit at most one fn at a time (observed=%v)", observed)
+	// Final state — lock released.
+	require.Eventually(t, func() bool {
+		return advisoryLockHolderCount(t, db, testLockID) == 0
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func TestWithAdvisoryLock_ReleasesOnFnError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+	db := newPostgresTestDB(t)
+	ctx := context.Background()
+
+	wantErr := errorString("boom")
+	err := WithAdvisoryLock(ctx, db, testLockID, func() error { return wantErr })
+	require.ErrorIs(t, err, wantErr)
+
+	require.Eventually(t, func() bool {
+		return advisoryLockHolderCount(t, db, testLockID) == 0
+	}, 2*time.Second, 50*time.Millisecond, "lock must be released even when fn returns an error")
+}
+
+func TestWithAdvisoryLock_ReleasesOnFnPanic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping postgres-backed test in -short mode")
+	}
+	db := newPostgresTestDB(t)
+	ctx := context.Background()
+
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "fn must have panicked")
+			require.True(t, strings.Contains(toString(r), "panic-in-fn"))
+		}()
+		_ = WithAdvisoryLock(ctx, db, testLockID, func() error {
+			panic("panic-in-fn")
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		return advisoryLockHolderCount(t, db, testLockID) == 0
+	}, 2*time.Second, 50*time.Millisecond, "lock must be released via defer when fn panics")
+}
+
+// errorString is a package-local error type to avoid pulling errors.New into
+// tests just for identity comparisons.
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+func toString(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case error:
+		return x.Error()
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary

Prevents concurrent pods from stalling each other during blockchain-store startup against a shared PostgreSQL. Two issues are covered here; both are visible as either a startup crash or a multi-minute hang on reads while one pod runs an async schema migration.

- Adds `usql.WithAdvisoryLock()` and wraps the blockchain, UTXO, and banlist schema creation paths.
- Pins a `*sql.Conn` for the lock/fn/unlock window so the session-level advisory lock is always released (previous version could lock on one session and unlock on another).
- Adds a catalog-only fast path in `createPostgresSchema` so subsequent pods never touch the `blocks` table when the schema is already current.
- Threads the blockchain logger through `createPostgresSchema` so operators see, at startup, whether the schema was already current or whether a full DDL sequence ran.

## Problem 1 — CREATE TABLE race on first startup

In multi-pod deployments, pods racing on `CREATE TABLE IF NOT EXISTS` collide on the PostgreSQL type catalog:

```
ERROR: duplicate key value violates unique constraint "pg_type_typname_nsp_index" (SQLSTATE 23505)
```

`sync.Once` in `GetBanList()` only protects within a single process; it's useless across pods.

**Fix**: session-level `pg_advisory_lock` / `pg_advisory_unlock` around each store's schema creation. Only one pod at a time executes the DDL sequence; others wait.

## Problem 2 — async `on_main_chain` rebuild stalls readers on other pods

After #710 / #744 the blockchain service populates the `on_main_chain` column via an async background UPDATE (recursive CTE, whole chain, can take many minutes on populated testnets). The UPDATE holds `ROW EXCLUSIVE` on `blocks` for its entire run.

Other pods (asset, propagation, p2p) each open a blockchain store through `banlist.NewFromSettings`, which runs the same schema creation. Even with the advisory lock serialization, when a later pod enters `createPostgresSchemaUnlocked`:

- `CREATE UNIQUE INDEX IF NOT EXISTS ux_blocks_hash …` acquires `SHARE` on `blocks` — conflicts with `ROW EXCLUSIVE` → queues behind the UPDATE.
- `ALTER TABLE blocks ALTER COLUMN peer_id TYPE TEXT` acquires `ACCESS EXCLUSIVE` — conflicts with everything → queues.
- PostgreSQL fair queueing then parks subsequent `ACCESS SHARE` (SELECT) readers behind the queued DDL, even though the SELECT is compatible with `ROW EXCLUSIVE`.

Observed on a deployment during the `on_main_chain` migration:

```
pid  423936  active  IO / WalWrite  UPDATE … on_main_chain = true     (progressing)
pid  423947  active  Lock           CREATE UNIQUE INDEX IF NOT EXISTS (queued)
pid  424092  active  Lock           ALTER TABLE … ALTER COLUMN peer_id (queued)
pid  424237  active  Lock           SELECT COUNT(*) FROM blocks       (queued behind the DDLs)
```

The downstream effect is that the `legacy` service hangs at startup: `startLegacyService` is still inside `GetValidatorClient → GetBlockchainClient → NewStore` — waiting on the same `blocks` lock cascade. No peer activity appears in the legacy log because the service never finishes initialisation.

**Fix**: probe `information_schema` / `pg_class` (both read-only on system catalogs, `AccessShare` only — they cannot be blocked by the `blocks` UPDATE) and, when everything we expect is already in place, skip the DDL sequence entirely. No `SHARE` is requested on `blocks`, so the fair-queue cascade never forms and reads stay fast.

## Connection pinning fix

`pg_advisory_lock` / `pg_advisory_unlock` are session-scoped. The previous implementation called them via `*sql.DB`, which lets the driver pick any pooled connection — lock could land on session A and unlock on session B, leaving A's lock held until that session happens to terminate. In a pod that stays up, that session may never terminate, permanently blocking other pods.

This PR now acquires a dedicated `*sql.Conn` for the lock/fn/unlock window so both statements execute on the same session, with a bounded `context.WithTimeout` on the unlock defer so a degraded connection can't hang cleanup. The connection is returned to the pool only after the unlock has run.

## Operator-facing logging

`createPostgresSchema` now prints one line per decision at startup:

```
INFO  [blockchain schema] acquiring advisory lock (id=...) and checking schema
INFO  [blockchain schema] current (withIndexes=true), skipping DDL
INFO  [blockchain schema] not current (withIndexes=true), running DDL sequence
INFO  [blockchain schema] DDL sequence complete
WARN  [blockchain schema] current-schema probe failed, will run full DDL: ...
```

Makes it obvious from pod logs whether a startup stall was caused by this path vs something else downstream.

## Addresses review feedback

- **[Critical]** Unlock defer timeout protection — done (`advisoryUnlockTimeout = 5s`).
- **[Minor]** Document lock lifetime / connection pooling implications — done (godoc expanded; tests cover acquire/release/serialize/error/panic paths).

## Changes

- `util/usql/advisory_lock.go` — pin `*sql.Conn`; bounded unlock; expanded docstring covering pinning, lifetime, and auto-release on session termination.
- `util/usql/advisory_lock_test.go` — postgres-backed tests for acquire/release, serialization across goroutines, release on fn error, release on fn panic.
- `stores/blockchain/sql/sql.go` — `isBlockchainSchemaCurrent` catalog-only probe; `createPostgresSchema` returns early when schema is current; startup decisions logged.
- `stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go` — postgres-backed tests covering empty DB, fresh New(), column drop, index drop, peer_id type mismatch, and that a second `createPostgresSchema` call preserves `pg_class` oids (proving no DROP/CREATE cycle).
- `internal/banlist/ban_list.go`, `stores/utxo/sql/sql.go` — unchanged behaviour, but benefit from the pinning fix through the shared helper.

## Test plan

- [x] `go test ./util/usql/ ./internal/banlist/` — 145 tests pass (existing + new advisory-lock tests).
- [x] `go test -short ./stores/blockchain/sql/` — 441 tests pass (short mode skips postgres-backed tests).
- [x] `go test -run 'TestIsBlockchainSchemaCurrent|TestCreatePostgresSchema_FastPathOnSecondCall' ./stores/blockchain/sql/` — all 6 postgres-backed schema-current tests pass.
- [x] `go test -run 'TestWithAdvisoryLock' ./util/usql/` — all 4 postgres-backed advisory-lock tests pass.
- [ ] Deploy to a multi-pod staging cluster against a populated testnet DB and verify:
  - no `pg_type_typname_nsp_index` violations on simultaneous pod startup
  - legacy / asset / propagation reach `Running` state even while blockchain is still executing the async `on_main_chain` rebuild
  - `SELECT` queries on `blocks` remain responsive during the rebuild window
  - pod startup logs show the `[blockchain schema] current, skipping DDL` line on warm starts
