### PR TITLE
fix: handle context cancellation gracefully during service shutdown

### DIFF
--- a/services/asset/Server.go
+++ b/services/asset/Server.go
@@ -275,8 +275,11 @@ func (v *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := v.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			v.logger.Infof("[Asset Service] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		v.logger.Errorf("[Asset Service] Failed to wait for FSM transition from IDLE state: %s", err)
-
 		return err
 	}
 

--- a/services/asset/Server.go
+++ b/services/asset/Server.go
@@ -275,9 +275,9 @@ func (v *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := v.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			v.logger.Infof("[Asset Service] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		v.logger.Errorf("[Asset Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/asset/Server_test.go
+++ b/services/asset/Server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/blob"
@@ -19,6 +20,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -571,4 +573,34 @@ func TestInit_ErrorCases(t *testing.T) {
 		// Should handle invalid address gracefully
 		_ = err
 	})
+}
+
+// TestServerStart_FSMContextCancellation verifies graceful shutdown handling
+// when the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestServerStart_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Asset.HTTPListenAddress = fmt.Sprintf("localhost:%d", getFreePort(t))
+	tSettings.Asset.CentrifugeDisable = true
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	server := NewServer(logger, tSettings, utxoStore, blobMemory.New(), blobMemory.New(), blobMemory.New(), mockBlockchainClient, nil, nil, nil)
+	require.NoError(t, server.Init(ctx))
+
+	readyCh := make(chan struct{})
+	startErr := server.Start(ctx, readyCh)
+
+	require.Error(t, startErr)
+	require.True(t, errors.IsContextError(startErr), "expected context error, got %v", startErr)
+	mockBlockchainClient.AssertExpectations(t)
 }

--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -1760,6 +1760,10 @@ func (c *Client) WaitUntilFSMTransitionFromIdleState(ctx context.Context) error 
 	cancelWait()
 
 	if err != nil {
+		if ctx.Err() != nil {
+			c.logger.Infof("[Blockchain Client] FSM wait interrupted by shutdown")
+			return ctx.Err()
+		}
 		c.logger.Errorf("[Blockchain Client] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err
 	}

--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -1760,9 +1760,9 @@ func (c *Client) WaitUntilFSMTransitionFromIdleState(ctx context.Context) error 
 	cancelWait()
 
 	if err != nil {
-		if ctx.Err() != nil {
-			c.logger.Infof("[Blockchain Client] FSM wait interrupted by shutdown")
-			return ctx.Err()
+		if errors.IsContextError(err) {
+			c.logger.Infof("[Blockchain Client] Shutting down during FSM wait")
+			return err
 		}
 		c.logger.Errorf("[Blockchain Client] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/blockpersister/Server.go
+++ b/services/blockpersister/Server.go
@@ -234,8 +234,11 @@ func (u *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := u.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			u.logger.Infof("[Block Persister Service] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		u.logger.Errorf("[Block Persister Service] Failed to wait for FSM transition from IDLE state: %s", err)
-
 		return err
 	}
 

--- a/services/blockpersister/Server.go
+++ b/services/blockpersister/Server.go
@@ -234,9 +234,9 @@ func (u *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := u.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			u.logger.Infof("[Block Persister Service] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		u.logger.Errorf("[Block Persister Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/blockpersister/Server_test.go
+++ b/services/blockpersister/Server_test.go
@@ -1086,6 +1086,35 @@ func TestStart_FSMTransitionError(t *testing.T) {
 	}
 }
 
+// TestStart_FSMContextCancellation verifies graceful shutdown handling when
+// the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestStart_FSMContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	mockClient := NewMockBlockchainClient()
+	mockClient.SetFSMTransitionFromIdleError(context.Canceled)
+
+	server := New(ctx, logger, tSettings, nil, nil, nil, mockClient)
+	readyCh := make(chan struct{})
+
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+
+	select {
+	case <-readyCh:
+	default:
+		t.Fatal("Ready channel should be closed on shutdown")
+	}
+}
+
 // TestStart_HTTPServerSetup tests HTTP server setup when configured
 func TestStart_HTTPServerSetup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1030,6 +1030,10 @@ func (u *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 		// Blocks until the FSM transitions from the IDLE state
 		err := u.blockchainClient.WaitUntilFSMTransitionFromIdleState(gctx)
 		if err != nil {
+			if gctx.Err() != nil {
+				u.logger.Infof("[Block Validation Service] Shutting down during FSM wait")
+				return gctx.Err()
+			}
 			u.logger.Errorf("[Block Validation Service] Failed to wait for FSM transition from IDLE state: %s", err)
 			return err
 		}

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1030,9 +1030,9 @@ func (u *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 		// Blocks until the FSM transitions from the IDLE state
 		err := u.blockchainClient.WaitUntilFSMTransitionFromIdleState(gctx)
 		if err != nil {
-			if gctx.Err() != nil {
+			if errors.IsContextError(err) {
 				u.logger.Infof("[Block Validation Service] Shutting down during FSM wait")
-				return gctx.Err()
+				return err
 			}
 			u.logger.Errorf("[Block Validation Service] Failed to wait for FSM transition from IDLE state: %s", err)
 			return err

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -1065,6 +1065,35 @@ func Test_Start_FSMTransitionError(t *testing.T) {
 	mockBlockchainClient.AssertExpectations(t)
 }
 
+// Test_Start_FSMContextCancellation verifies graceful shutdown handling when
+// the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func Test_Start_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.GRPCListenAddress = ""
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	tSettings.BlockValidation.GRPCListenAddress = "localhost:0"
+
+	server := &Server{
+		logger:           logger,
+		settings:         tSettings,
+		blockchainClient: mockBlockchainClient,
+	}
+
+	readyCh := make(chan struct{})
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
+}
+
 func Test_Stop(t *testing.T) {
 	ctx := context.Background()
 	logger := ulogger.NewErrorTestLogger(t)

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -605,8 +605,11 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			s.logger.Infof("[Legacy Server] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		s.logger.Errorf("[Legacy Server] Failed to wait for FSM transition from IDLE state: %s", err)
-
 		return err
 	}
 

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -605,9 +605,9 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			s.logger.Infof("[Legacy Server] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		s.logger.Errorf("[Legacy Server] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/legacy/server_start_test.go
+++ b/services/legacy/server_start_test.go
@@ -1,0 +1,37 @@
+package legacy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStart_FSMContextCancellation verifies graceful shutdown handling when
+// the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestStart_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	server := &Server{
+		logger:           ulogger.TestLogger{},
+		settings:         &settings.Settings{},
+		blockchainClient: mockBlockchainClient,
+	}
+
+	readyCh := make(chan struct{})
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
+}

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -553,9 +553,9 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err = s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			s.logger.Infof("[P2P Service] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		s.logger.Errorf("[P2P Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -553,8 +553,11 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err = s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			s.logger.Infof("[P2P Service] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		s.logger.Errorf("[P2P Service] Failed to wait for FSM transition from IDLE state: %s", err)
-
 		return err
 	}
 

--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -319,6 +319,10 @@ func (ps *PropagationServer) Start(ctx context.Context, readyCh chan<- struct{})
 	// Blocks until the FSM transitions from the IDLE state
 	err = ps.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			ps.logger.Infof("[Propagation Service] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		ps.logger.Errorf("[Propagation Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err
 	}

--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -319,9 +319,9 @@ func (ps *PropagationServer) Start(ctx context.Context, readyCh chan<- struct{})
 	// Blocks until the FSM transitions from the IDLE state
 	err = ps.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			ps.logger.Infof("[Propagation Service] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		ps.logger.Errorf("[Propagation Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/propagation/propagation_api"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -1432,4 +1434,29 @@ func TestProcessTransactionBatch_BatchConcurrencyLimit(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Len(t, resp.Errors, 2)
 	})
+}
+
+// TestPropagationServer_Start_FSMContextCancellation verifies graceful shutdown
+// handling when the context is cancelled during the FSM wait. The error must be
+// returned (not swallowed) and must be a context error so the service manager
+// can distinguish it from a real failure.
+func TestPropagationServer_Start_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Propagation.GRPCListenAddress = ""
+	tSettings.Propagation.HTTPListenAddress = ""
+	tSettings.Propagation.IPv6Addresses = ""
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	ps := New(logger, tSettings, nil, nil, mockBlockchainClient, nil, nil)
+
+	readyCh := make(chan struct{})
+	err := ps.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
 }

--- a/services/pruner/server.go
+++ b/services/pruner/server.go
@@ -266,6 +266,10 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Wait for blockchain FSM to be ready
 	err := s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			s.logger.Infof("[Pruner Service] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		return err
 	}
 

--- a/services/pruner/server.go
+++ b/services/pruner/server.go
@@ -266,9 +266,9 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Wait for blockchain FSM to be ready
 	err := s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			s.logger.Infof("[Pruner Service] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		return err
 	}

--- a/services/pruner/server.go
+++ b/services/pruner/server.go
@@ -270,6 +270,7 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 			s.logger.Infof("[Pruner Service] Shutting down during FSM wait")
 			return err
 		}
+		s.logger.Errorf("[Pruner Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err
 	}
 

--- a/services/pruner/worker_test.go
+++ b/services/pruner/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	blockassembly_api "github.com/bsv-blockchain/teranode/services/blockassembly/blockassembly_api"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
@@ -306,4 +307,29 @@ func TestWaitForBlockMinedStatusSkippedWhenNoBAClient(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("pruning should proceed without blockAssemblyClient")
 	}
+}
+
+// TestStart_FSMContextCancellation verifies graceful shutdown handling when
+// the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestStart_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	server := &Server{
+		ctx:              ctx,
+		logger:           ulogger.New("test"),
+		settings:         &settings.Settings{},
+		blockchainClient: mockBlockchainClient,
+	}
+
+	readyCh := make(chan struct{})
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
 }

--- a/services/subtreevalidation/Server.go
+++ b/services/subtreevalidation/Server.go
@@ -501,9 +501,9 @@ func (u *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := u.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			u.logger.Infof("[Subtree Validation Service] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		u.logger.Errorf("[Subtree Validation Service] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/subtreevalidation/Server.go
+++ b/services/subtreevalidation/Server.go
@@ -501,8 +501,11 @@ func (u *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := u.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			u.logger.Infof("[Subtree Validation Service] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		u.logger.Errorf("[Subtree Validation Service] Failed to wait for FSM transition from IDLE state: %s", err)
-
 		return err
 	}
 

--- a/services/subtreevalidation/Server_test.go
+++ b/services/subtreevalidation/Server_test.go
@@ -12,13 +12,17 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -257,4 +261,28 @@ func TestTtlCache(t *testing.T) {
 	assert.Equal(t, 4, cache.Len())
 	time.Sleep(2 * time.Second)
 	assert.Equal(t, 0, cache.Len())
+}
+
+// TestStart_FSMContextCancellation verifies graceful shutdown handling when
+// the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestStart_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	server := &Server{
+		logger:           ulogger.TestLogger{},
+		settings:         settings.NewSettings(),
+		blockchainClient: mockBlockchainClient,
+	}
+
+	readyCh := make(chan struct{})
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
 }

--- a/services/utxopersister/Server.go
+++ b/services/utxopersister/Server.go
@@ -254,8 +254,11 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 		// Blocks until the FSM transitions from the IDLE state
 		err = s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 		if err != nil {
+			if ctx.Err() != nil {
+				s.logger.Infof("[UTXOPersister Service] Shutting down during FSM wait")
+				return ctx.Err()
+			}
 			s.logger.Errorf("[UTXOPersister Service] Failed to wait for FSM transition from IDLE state: %s", err)
-
 			return err
 		}
 

--- a/services/utxopersister/Server.go
+++ b/services/utxopersister/Server.go
@@ -254,9 +254,9 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 		// Blocks until the FSM transitions from the IDLE state
 		err = s.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 		if err != nil {
-			if ctx.Err() != nil {
+			if errors.IsContextError(err) {
 				s.logger.Infof("[UTXOPersister Service] Shutting down during FSM wait")
-				return ctx.Err()
+				return err
 			}
 			s.logger.Errorf("[UTXOPersister Service] Failed to wait for FSM transition from IDLE state: %s", err)
 			return err

--- a/services/utxopersister/Server_test.go
+++ b/services/utxopersister/Server_test.go
@@ -426,3 +426,25 @@ func TestTrigger_AlreadyRunning_Simple(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, server.running) // Should remain true
 }
+
+// TestStart_FSMContextCancellation verifies graceful shutdown handling when
+// the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestStart_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	server := New(ctx, logger, tSettings, memory.New(), mockBlockchainClient)
+
+	readyCh := make(chan struct{})
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, terrors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
+}

--- a/services/validator/Server.go
+++ b/services/validator/Server.go
@@ -325,9 +325,9 @@ func (v *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := v.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.IsContextError(err) {
 			v.logger.Infof("[Validator] Shutting down during FSM wait")
-			return ctx.Err()
+			return err
 		}
 		v.logger.Errorf("[Validator] Failed to wait for FSM transition from IDLE state: %s", err)
 		return err

--- a/services/validator/Server.go
+++ b/services/validator/Server.go
@@ -325,8 +325,11 @@ func (v *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Blocks until the FSM transitions from the IDLE state
 	err := v.blockchainClient.WaitUntilFSMTransitionFromIdleState(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			v.logger.Infof("[Validator] Shutting down during FSM wait")
+			return ctx.Err()
+		}
 		v.logger.Errorf("[Validator] Failed to wait for FSM transition from IDLE state: %s", err)
-
 		return err
 	}
 

--- a/services/validator/Server_test.go
+++ b/services/validator/Server_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -468,4 +470,27 @@ func (m *TestMockValidator) TriggerBatcher() {
 
 func (m *TestMockValidator) EnsureMTPLoaded(_ context.Context, _ uint32) error {
 	return nil
+}
+
+// TestServer_Start_FSMContextCancellation verifies graceful shutdown handling
+// when the context is cancelled during the FSM wait. The error must be returned
+// (not swallowed) and must be a context error so the service manager can
+// distinguish it from a real failure.
+func TestServer_Start_FSMContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStore := &utxo.MockUtxostore{}
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("WaitUntilFSMTransitionFromIdleState", mock.Anything).Return(context.Canceled)
+
+	server := NewServer(logger, tSettings, utxoStore, mockBlockchainClient, nil, nil, nil, nil)
+
+	readyCh := make(chan struct{})
+	err := server.Start(ctx, readyCh)
+
+	require.Error(t, err)
+	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
+	mockBlockchainClient.AssertExpectations(t)
 }

--- a/util/servicemanager/service_manager.go
+++ b/util/servicemanager/service_manager.go
@@ -256,7 +256,11 @@ func (sm *ServiceManager) Wait() error {
 	// Wait for all services to complete or error
 	err := sm.g.Wait()
 	if err != nil {
-		sm.logger.Errorf("Received error: %v", err)
+		if errors.Is(err, context.Canceled) {
+			sm.logger.Infof("Shutdown signal received, stopping services...")
+		} else {
+			sm.logger.Errorf("Received error: %v", err)
+		}
 	}
 
 	for i := len(sm.services) - 1; i >= 0; i-- {


### PR DESCRIPTION
## Summary

- Services that block on `WaitUntilFSMTransitionFromIdleState` during startup now treat context cancellation as a clean shutdown signal instead of a fatal error
- Blockchain Client logs context cancellation at info level, not error
- ServiceManager logs `context.Canceled` as info ("shutdown signal received") instead of error

## Problem

When SIGTERM/SIGINT is received while services are still in their startup FSM wait, every service logs ERROR-level messages like:

```
Failed to wait for FSM transition from IDLE state: rpc error: code = Canceled desc = context canceled
```

This makes a clean shutdown look like a crash in logs and monitoring. The service manager already handles `context.Canceled` correctly (returns nil), but the noisy error logs from 10 services obscure that.

## Affected services (10 of 13)

legacy, blockpersister, utxopersister, pruner, p2p, subtreevalidation, blockvalidation, propagation, validator, asset

The 3 unaffected services (blockassembly, alert, rpc) don't call `WaitUntilFSMTransitionFromIdleState`.

## What changed

Each affected service's `Start()` now checks `ctx.Err()` after a failed FSM wait:
- If context was cancelled: log at **info** level, return `ctx.Err()`
- If real error: log at **error** level, return error (unchanged behavior)

The ServiceManager.Wait() also now logs context.Canceled at info level instead of error.

## Test plan

- [ ] All existing unit tests pass
- [ ] Send SIGTERM to a running multi-service deployment during startup - should see info-level "Shutting down during FSM wait" instead of error-level "Failed to wait for FSM transition"
- [ ] Send SIGTERM during normal operation - behavior unchanged
- [ ] Verify no error-level logs for clean shutdown scenarios