### PR TITLE
fix(asset): skip nil tx entries in GetSubtreeTransactions

### DIFF
--- a/services/asset/httpimpl/GetSubtreeTxs.go
+++ b/services/asset/httpimpl/GetSubtreeTxs.go
@@ -179,7 +179,7 @@ func (h *HTTP) GetSubtreeTxs(mode ReadMode) func(c echo.Context) error {
 					}
 					txMeta.Tx.SetTxHash(subtreepkg.CoinbasePlaceholderHash)
 				} else {
-					if subtreeData != nil {
+					if subtreeData != nil && subtreeData.Txs[i] != nil {
 						// Use subtreeData to get the transaction metadata
 						txMeta, err = util.TxMetaDataFromTx(subtreeData.Txs[i])
 						if err != nil {

--- a/services/asset/repository/repository.go
+++ b/services/asset/repository/repository.go
@@ -778,6 +778,10 @@ func (repo *Repository) GetSubtreeTransactions(ctx context.Context, hash *chainh
 	transactionMap := make(map[chainhash.Hash]*bt.Tx, len(subtreeData.Txs))
 
 	for _, tx := range subtreeData.Txs {
+		if tx == nil {
+			continue
+		}
+
 		transactionMap[*tx.TxIDChainHash()] = tx
 	}
 


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference in `GetSubtreeTransactions` (`services/asset/repository/repository.go:780`) that panics when iterating over `subtreeData.Txs` containing nil entries (coinbase placeholder at index 0)
- The panic caused HTTP 500 responses on `POST /api/v1/subtree/{hash}/txs`, preventing peer nodes from fetching missing transactions during subtree validation
- This led to cascading block validation failures and node divergence in multi-node deployments

## Root cause

`go-subtree`'s `NewSubtreeDataFromReader` pre-allocates `Txs` as `make([]*bt.Tx, subtree.Length())`. For subtrees with a coinbase placeholder at index 0, `Txs[0]` remains nil after deserialization. The loop in `GetSubtreeTransactions` called `tx.TxIDChainHash()` on this nil entry, causing a panic.

## Test plan

- [ ] Verify `go build ./services/asset/...` compiles cleanly
- [ ] Run `go test ./services/asset/...` 
- [ ] Run 3-node docker-compose deployment and confirm nodes stay in sync