### PR TITLE
feat(health): add default timeout and ?timeout query param

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -304,20 +304,22 @@ func (d *Daemon) Start(logger ulogger.Logger, args []string, appSettings *settin
 
 	util.RegisterPrometheusMetrics()
 
+	const defaultHealthTimeout = 5 * time.Second
+
 	mux := http.NewServeMux()
 	healthFunc := func(liveness bool) func(http.ResponseWriter, *http.Request) {
 		return func(w http.ResponseWriter, r *http.Request) {
-			var status int
-
-			var details string
-
-			status, details, err = sm.HealthHandler(sm.Ctx, liveness)
-			if err != nil {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(details))
-
-				return
+			timeout := defaultHealthTimeout
+			if v := r.URL.Query().Get("timeout"); v != "" {
+				if parsed, parseErr := time.ParseDuration(v); parseErr == nil && parsed > 0 {
+					timeout = parsed
+				}
 			}
+
+			ctx, cancel := context.WithTimeout(sm.Ctx, timeout)
+			defer cancel()
+
+			status, details, _ := sm.HealthHandler(ctx, liveness)
 
 			w.WriteHeader(status)
 			_, _ = w.Write([]byte(details))


### PR DESCRIPTION
## Summary
- Health check endpoints now use a **5s default context timeout**, replacing the previous no-deadline context that caused Aerospike to fall back to its ~1s client default
- Callers can override with `?timeout=10s` query parameter (accepts any `time.ParseDuration` format)
- Fixes an issue where the Aerospike Put/Get would timeout before the `stop_writes` check could run, returning an unhelpful `TIMEOUT` error instead of the actual root cause

## Test plan
- [ ] Deploy to a test environment and verify `curl http://localhost:8000/health/readiness` returns within 5s
- [ ] Verify `?timeout=10s` overrides the default
- [ ] Verify invalid `?timeout` values (negative, unparseable) are ignored and the 5s default is used
- [ ] Confirm that when Aerospike is in `stop_writes` mode, the health check now reports the stop-write error instead of a timeout