### PR TITLE
fix(sql): close SendBatch before signalling callers in create batcher

### DIFF
--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -973,7 +973,17 @@ func (s *Store) sendCreateBatch(batch []*batchCreateItem) {
 
 		br := pgxConn.SendBatch(s.ctx, pgxBatch)
 
-		// Read results and route to callers
+		// Read results — collect but don't send to callers yet.
+		// We must call br.Close() before signalling callers, because
+		// pipelined auto-committed statements may not be fully visible
+		// to other connections until the batch reader is closed.
+		type batchResult struct {
+			idx      int
+			result   batchCreateResult
+			logError bool
+		}
+		results := make([]batchResult, 0, len(validIndices))
+
 		for _, idx := range validIndices {
 			p := &prepared[idx]
 			rows, queryErr := br.Query()
@@ -986,24 +996,44 @@ func (s *Store) sendCreateBatch(batch []*batchCreateItem) {
 				rows.Close()
 			}
 			if queryErr != nil {
-				s.logger.Errorf("[sendCreateBatch] CTE failed for tx %x: %v", p.txHash[:], queryErr)
-				batch[idx].done <- batchCreateResult{
+				results = append(results, batchResult{idx: idx, result: batchCreateResult{
 					Err: errors.NewStorageError("Failed to create UTXO", queryErr),
-				}
+				}, logError: true})
 			} else if !inserted {
 				// ON CONFLICT (hash) DO NOTHING — new_tx returned 0 rows, tx already exists
-				batch[idx].done <- batchCreateResult{
-					Err: errors.NewTxExistsError("Transaction already exists in postgres store (coinbase=%v):", p.isCoinbase),
-				}
+				results = append(results, batchResult{idx: idx, result: batchCreateResult{
+					Err: errors.NewTxExistsError("Transaction already exists in postgres store (coinbase=%v)", p.isCoinbase),
+				}})
 			} else {
-				batch[idx].done <- batchCreateResult{Data: p.txMeta}
+				results = append(results, batchResult{idx: idx, result: batchCreateResult{Data: p.txMeta}})
 			}
 		}
 
-		if closeErr := br.Close(); closeErr != nil {
-			s.logger.Warnf("[sendCreateBatch] error closing batch results: %v", closeErr)
+		// Close the batch reader — ensures all pipelined commits are finalized
+		// and visible to other connections before callers proceed.
+		closeErr := br.Close()
+		if closeErr != nil {
+			s.logger.Errorf("[sendCreateBatch] error closing batch results: %v", closeErr)
 		}
-		return nil
+
+		// Now signal callers — if Close() failed, override successes with errors
+		// since the connection may be in an error state and data visibility is uncertain.
+		for _, r := range results {
+			if closeErr != nil && r.result.Err == nil {
+				batch[r.idx].done <- batchCreateResult{
+					Err: errors.NewStorageError("batch close failed, results may not be visible", closeErr),
+				}
+				continue
+			}
+			if r.logError {
+				s.logger.Errorf("[sendCreateBatch] CTE failed for tx %x: %v", prepared[r.idx].txHash[:], r.result.Err)
+			}
+			batch[r.idx].done <- r.result
+		}
+
+		// Propagate close error so the connection is not returned to the pool
+		// and Phase 3 (conflicting children) does not run on an uncertain state.
+		return closeErr
 	})
 	if connErr != nil {
 		// Raw callback error — send to any items that haven't received a result yet

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -44,6 +44,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -1002,7 +1003,7 @@ func (s *Store) sendCreateBatch(batch []*batchCreateItem) {
 			} else if !inserted {
 				// ON CONFLICT (hash) DO NOTHING — new_tx returned 0 rows, tx already exists
 				results = append(results, batchResult{idx: idx, result: batchCreateResult{
-					Err: errors.NewTxExistsError("Transaction already exists in postgres store (coinbase=%v)", p.isCoinbase),
+					Err: errors.NewTxExistsError("Transaction already exists in postgres store (coinbase=%v):", p.isCoinbase),
 				}})
 			} else {
 				results = append(results, batchResult{idx: idx, result: batchCreateResult{Data: p.txMeta}})
@@ -1026,14 +1027,19 @@ func (s *Store) sendCreateBatch(batch []*batchCreateItem) {
 				continue
 			}
 			if r.logError {
-				s.logger.Errorf("[sendCreateBatch] CTE failed for tx %x: %v", prepared[r.idx].txHash[:], r.result.Err)
+				s.logger.Errorf("[sendCreateBatch] CTE failed for tx %x: %+v", prepared[r.idx].txHash[:], r.result.Err)
 			}
 			batch[r.idx].done <- r.result
 		}
 
-		// Propagate close error so the connection is not returned to the pool
-		// and Phase 3 (conflicting children) does not run on an uncertain state.
-		return closeErr
+		// Return driver.ErrBadConn so database/sql discards the connection
+		// from the pool rather than reusing it, and Phase 3 (conflicting
+		// children) does not run on an uncertain state. The actual closeErr
+		// is already logged above.
+		if closeErr != nil {
+			return driver.ErrBadConn
+		}
+		return nil
 	})
 	if connErr != nil {
 		// Raw callback error — send to any items that haven't received a result yet


### PR DESCRIPTION
## Summary
- Rewrites `sendCreateBatch` to collect results into a slice and call `br.Close()` BEFORE signalling callers via their done channels
- Pipelined auto-committed statements may not be fully visible to other connections until the batch reader is closed — this ensures data visibility before callers proceed
- If `Close()` fails, overrides successful results with errors since connection state is uncertain
- Returns `driver.ErrBadConn` on close failure so `database/sql` discards the connection from the pool, and Phase 3 (conflicting children) does not run on an uncertain state
- Uses `%+v` format for wrapped error logging to preserve full error context
- Maintains consistent trailing colon format in TxExistsError message across all call sites

## Test plan
- [x] Verify `go build ./stores/utxo/sql/` compiles cleanly
- [ ] Run existing sql store unit tests
- [ ] Smoke test with postgres to verify create batcher still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)