### PR TITLE
perf(sql): add unlock batcher for SetLocked(false) calls

### DIFF
--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -3592,6 +3592,7 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 		case err := <-done:
 			return err
 		case <-ctx.Done():
+			s.logger.Warnf("[setLockedBatched] context cancelled while waiting for batcher result — unlock may or may not be applied")
 			return ctx.Err()
 		}
 	}

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -101,6 +101,13 @@ type Store struct {
 	spendBatcher    *batcher.Batcher[batchSpend]
 	getBatcher      *batcher.Batcher[batchGetItem]
 	createBatcher   *batcher.Batcher[batchCreateItem]
+	unlockBatcher   *batcher.Batcher[batchUnlockItem]
+}
+
+// batchUnlockItem represents a single SetLocked(false) request.
+type batchUnlockItem struct {
+	hash chainhash.Hash
+	done chan error
 }
 
 // batchGetItemData holds the result of a batch get operation.
@@ -216,6 +223,16 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 		s.createBatcher = batcher.New(storeBatchSize, storeBatchDuration, s.sendCreateBatch, true)
 		if tSettings.BatcherDrainMode {
 			s.createBatcher.SetDrainMode(true)
+		}
+	}
+
+	// Initialize unlock batcher for Postgres — batches single-hash SetLocked(false) calls.
+	if storeURL.Scheme == "postgres" && tSettings.UtxoStore.LockedBatcherSize > 1 {
+		unlockBatchSize := tSettings.UtxoStore.LockedBatcherSize
+		unlockBatchDuration := time.Duration(tSettings.UtxoStore.LockedBatcherDurationMillis) * time.Millisecond
+		s.unlockBatcher = batcher.New(unlockBatchSize, unlockBatchDuration, s.sendUnlockBatch, true)
+		if tSettings.BatcherDrainMode {
+			s.unlockBatcher.SetDrainMode(true)
 		}
 	}
 
@@ -3564,6 +3581,21 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 		return nil
 	}
 
+	// Postgres: single-hash unlock → use batcher.
+	if s.unlockBatcher != nil && len(txHashes) == 1 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		done := make(chan error, 1)
+		s.unlockBatcher.Put(&batchUnlockItem{hash: txHashes[0], done: done})
+		select {
+		case err := <-done:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	// Postgres: bulk unlock + DAH in chunked UPDATE statements
 	if s.engine == "postgres" {
 		return s.setUnlockedBulk(ctx, txHashes)
@@ -4547,4 +4579,26 @@ func isLockError(err error) bool {
 	return strings.Contains(errStr, "database is locked") ||
 		strings.Contains(errStr, "deadlock") ||
 		strings.Contains(errStr, "lock timeout")
+}
+
+// sendUnlockBatch processes a batch of SetLocked(false) calls via setUnlockedBulk,
+// which chunks large batches into multiple UPDATE statements (maxINClauseSize=400).
+func (s *Store) sendUnlockBatch(batch []*batchUnlockItem) {
+	ctx := s.ctx
+
+	if len(batch) == 1 {
+		hashes := []chainhash.Hash{batch[0].hash}
+		batch[0].done <- s.setUnlockedBulk(ctx, hashes)
+		return
+	}
+
+	hashes := make([]chainhash.Hash, len(batch))
+	for i, item := range batch {
+		hashes[i] = item.hash
+	}
+
+	err := s.setUnlockedBulk(ctx, hashes)
+	for _, item := range batch {
+		item.done <- err
+	}
 }

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -37,7 +38,7 @@ func setupPostgresStore(t *testing.T) (*Store, context.Context) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, pgContainer.Terminate(ctx))
+		assert.NoError(t, pgContainer.Terminate(ctx))
 	})
 
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
@@ -100,7 +101,8 @@ func TestUnlockBatcher_Postgres_SingleHash(t *testing.T) {
 }
 
 // TestUnlockBatcher_Postgres_DAH verifies that the batched unlock path
-// correctly recalculates delete_at_height (DAH) for spent transactions.
+// correctly recalculates delete_at_height (DAH) for a fully-spent, mined,
+// on-longest-chain transaction.
 func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration test in short mode")
@@ -116,16 +118,34 @@ func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = store.Delete(ctx, tests.ParentTx.TxIDChainHash()) }()
 
-	// Create the child tx unlocked so we can spend its outputs.
-	_, err = store.Create(ctx, tests.Tx, 1000)
+	// Create the child tx as mined on the longest chain (block_ids exist,
+	// unmined_since is NULL) so the DAH branch in setUnlockedBulk triggers.
+	_, err = store.Create(ctx, tests.Tx, 1000,
+		utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+			BlockID:        100,
+			BlockHeight:    1000,
+			SubtreeIdx:     0,
+			OnLongestChain: true,
+		}),
+	)
 	require.NoError(t, err)
 	defer func() { _ = store.Delete(ctx, tests.Tx.TxIDChainHash()) }()
+
+	txHash := *tests.Tx.TxIDChainHash()
+
+	// Verify delete_at_height is NULL before spending.
+	var dahBefore *int64
+	err = store.db.QueryRowContext(ctx,
+		"SELECT delete_at_height FROM transactions WHERE hash = $1",
+		txHash[:]).Scan(&dahBefore)
+	require.NoError(t, err)
+	require.Nil(t, dahBefore, "delete_at_height should be NULL before spending")
 
 	// Spend all outputs to make the tx fully spent.
 	for i, out := range tests.Tx.Outputs {
 		spendTx := bt.NewTx()
 		require.NoError(t, spendTx.From(
-			tests.Tx.TxIDChainHash().String(), uint32(i),
+			txHash.String(), uint32(i),
 			out.LockingScript.String(),
 			out.Satoshis,
 		))
@@ -136,7 +156,6 @@ func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
 	}
 
 	// Lock the now-spent tx, then unlock via the batcher path.
-	txHash := *tests.Tx.TxIDChainHash()
 	err = store.SetLocked(ctx, []chainhash.Hash{txHash}, true)
 	require.NoError(t, err)
 
@@ -152,10 +171,22 @@ func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
 	m, err = store.Get(ctx, &txHash)
 	require.NoError(t, err)
 	require.False(t, m.Locked, "tx should be unlocked after batcher unlock")
+
+	// Verify that delete_at_height was set by the DAH recalculation.
+	// For a fully-spent, mined, on-longest-chain tx: DAH = blockHeight + 1 + retention.
+	// blockHeight=1000, retention=GlobalBlockHeightRetention(10), so DAH = 1011.
+	var dahAfter *int64
+	err = store.db.QueryRowContext(ctx,
+		"SELECT delete_at_height FROM transactions WHERE hash = $1",
+		txHash[:]).Scan(&dahAfter)
+	require.NoError(t, err)
+	require.NotNil(t, dahAfter, "delete_at_height should be set after unlock of fully-spent mined tx")
+	require.Equal(t, int64(1011), *dahAfter, "delete_at_height should be blockHeight+1+retention")
 }
 
 // TestUnlockBatcher_Postgres_MultipleConcurrent verifies that multiple
-// concurrent single-hash unlock calls are correctly batched together.
+// concurrent single-hash unlock calls complete correctly with the unlock
+// batcher-enabled path.
 func TestUnlockBatcher_Postgres_MultipleConcurrent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration test in short mode")

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -1,0 +1,205 @@
+package sql
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupPostgresStore starts a Postgres testcontainer and returns a *Store with
+// the unlock batcher enabled (LockedBatcherSize > 1).
+func setupPostgresStore(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:13",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Minute),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, pgContainer.Terminate(ctx))
+	})
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	dbURL, err := url.Parse(connStr)
+	require.NoError(t, err)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.UtxoStore.DBTimeout = 30 * time.Second
+	tSettings.BatcherDrainMode = true // batcher fires immediately in tests
+	tSettings.UtxoStore.LockedBatcherSize = 64
+	tSettings.UtxoStore.LockedBatcherDurationMillis = 5
+
+	store, err := New(ctx, ulogger.TestLogger{}, tSettings, dbURL)
+	require.NoError(t, err)
+
+	require.NotNil(t, store.unlockBatcher, "unlockBatcher should be initialised for Postgres with LockedBatcherSize > 1")
+
+	return store, ctx
+}
+
+// TestUnlockBatcher_Postgres_SingleHash verifies that a single-hash
+// SetLocked(false) call goes through the unlock batcher on Postgres and
+// correctly clears the locked flag.
+func TestUnlockBatcher_Postgres_SingleHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Postgres integration test in short mode")
+	}
+
+	store, ctx := setupPostgresStore(t)
+
+	err := store.SetBlockHeight(1000)
+	require.NoError(t, err)
+
+	// Create parent tx (needed because tests.Tx references it as input).
+	_, err = store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.ParentTx.TxIDChainHash()) }()
+
+	// Create the test transaction as locked.
+	_, err = store.Create(ctx, tests.Tx, 1000, utxo.WithLocked(true))
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.Tx.TxIDChainHash()) }()
+
+	// Verify it is locked.
+	txHash := *tests.Tx.TxIDChainHash()
+	m, err := store.Get(ctx, &txHash)
+	require.NoError(t, err)
+	require.True(t, m.Locked, "tx should be locked after Create with WithLocked")
+
+	// Unlock via single-hash path (this exercises the batcher).
+	err = store.SetLocked(ctx, []chainhash.Hash{txHash}, false)
+	require.NoError(t, err)
+
+	// Verify it is unlocked.
+	m, err = store.Get(ctx, &txHash)
+	require.NoError(t, err)
+	require.False(t, m.Locked, "tx should be unlocked after SetLocked(false) through batcher")
+}
+
+// TestUnlockBatcher_Postgres_DAH verifies that the batched unlock path
+// correctly recalculates delete_at_height (DAH) for spent transactions.
+func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Postgres integration test in short mode")
+	}
+
+	store, ctx := setupPostgresStore(t)
+
+	err := store.SetBlockHeight(1000)
+	require.NoError(t, err)
+
+	// Create parent tx for the spend chain.
+	_, err = store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.ParentTx.TxIDChainHash()) }()
+
+	// Create the child tx as locked.
+	_, err = store.Create(ctx, tests.Tx, 1000, utxo.WithLocked(true))
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.Tx.TxIDChainHash()) }()
+
+	// Spend all outputs to make the tx fully spent.
+	for i, out := range tests.Tx.Outputs {
+		spendTx := bt.NewTx()
+		require.NoError(t, spendTx.From(
+			tests.Tx.TxIDChainHash().String(), uint32(i),
+			out.LockingScript.String(),
+			out.Satoshis,
+		))
+		require.NoError(t, spendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
+
+		_, spendErr := store.Spend(ctx, spendTx, 1001)
+		require.NoError(t, spendErr)
+	}
+
+	// Unlock via single-hash batcher path.
+	txHash := *tests.Tx.TxIDChainHash()
+	err = store.SetLocked(ctx, []chainhash.Hash{txHash}, false)
+	require.NoError(t, err)
+
+	// Verify unlock.
+	m, err := store.Get(ctx, &txHash)
+	require.NoError(t, err)
+	require.False(t, m.Locked, "tx should be unlocked")
+}
+
+// TestUnlockBatcher_Postgres_MultipleConcurrent verifies that multiple
+// concurrent single-hash unlock calls are correctly batched together.
+func TestUnlockBatcher_Postgres_MultipleConcurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Postgres integration test in short mode")
+	}
+
+	store, ctx := setupPostgresStore(t)
+
+	err := store.SetBlockHeight(1000)
+	require.NoError(t, err)
+
+	// Create a base tx so we can derive children from it.
+	_, err = store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.ParentTx.TxIDChainHash()) }()
+
+	// Create and lock N transactions.
+	const n = 10
+	txs := make([]*bt.Tx, n)
+	for i := 0; i < n; i++ {
+		tx := bt.NewTx()
+		require.NoError(t, tx.FromUTXOs(&bt.UTXO{
+			TxIDHash:      tests.Tx.TxIDChainHash(),
+			Vout:          0,
+			LockingScript: tests.Tx.Inputs[0].PreviousTxScript,
+			Satoshis:      tests.Tx.Inputs[0].PreviousTxSatoshis,
+		}))
+		tx.Inputs[0].UnlockingScript = tests.Tx.Inputs[0].UnlockingScript
+		require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint64(1000+i)))
+		txs[i] = tx
+
+		_, createErr := store.Create(ctx, tx, 1000, utxo.WithLocked(true))
+		require.NoError(t, createErr)
+		defer func(tx *bt.Tx) { _ = store.Delete(ctx, tx.TxIDChainHash()) }(tx)
+	}
+
+	// Unlock all concurrently.
+	errCh := make(chan error, n)
+	for _, tx := range txs {
+		go func(txHash chainhash.Hash) {
+			errCh <- store.SetLocked(ctx, []chainhash.Hash{txHash}, false)
+		}(*tx.TxIDChainHash())
+	}
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, <-errCh)
+	}
+
+	// Verify all are unlocked.
+	for _, tx := range txs {
+		txHash := tx.TxIDChainHash()
+		m, getErr := store.Get(ctx, txHash)
+		require.NoError(t, getErr)
+		require.False(t, m.Locked, "tx %s should be unlocked", txHash)
+	}
+}

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -116,8 +116,8 @@ func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = store.Delete(ctx, tests.ParentTx.TxIDChainHash()) }()
 
-	// Create the child tx as locked.
-	_, err = store.Create(ctx, tests.Tx, 1000, utxo.WithLocked(true))
+	// Create the child tx unlocked so we can spend its outputs.
+	_, err = store.Create(ctx, tests.Tx, 1000)
 	require.NoError(t, err)
 	defer func() { _ = store.Delete(ctx, tests.Tx.TxIDChainHash()) }()
 
@@ -135,15 +135,23 @@ func TestUnlockBatcher_Postgres_DAH(t *testing.T) {
 		require.NoError(t, spendErr)
 	}
 
-	// Unlock via single-hash batcher path.
+	// Lock the now-spent tx, then unlock via the batcher path.
 	txHash := *tests.Tx.TxIDChainHash()
+	err = store.SetLocked(ctx, []chainhash.Hash{txHash}, true)
+	require.NoError(t, err)
+
+	m, err := store.Get(ctx, &txHash)
+	require.NoError(t, err)
+	require.True(t, m.Locked, "tx should be locked before batcher unlock")
+
+	// Unlock via single-hash batcher path — this exercises DAH recalculation.
 	err = store.SetLocked(ctx, []chainhash.Hash{txHash}, false)
 	require.NoError(t, err)
 
 	// Verify unlock.
-	m, err := store.Get(ctx, &txHash)
+	m, err = store.Get(ctx, &txHash)
 	require.NoError(t, err)
-	require.False(t, m.Locked, "tx should be unlocked")
+	require.False(t, m.Locked, "tx should be unlocked after batcher unlock")
 }
 
 // TestUnlockBatcher_Postgres_MultipleConcurrent verifies that multiple


### PR DESCRIPTION
## Summary
- Adds an unlock batcher that batches individual `SetLocked(false)` calls (single-hash) into bulk `setUnlockedBulk` operations
- Uses existing `LockedBatcherSize` and `LockedBatcherDurationMillis` settings (already used by aerospike store)
- Only activates for Postgres when `LockedBatcherSize > 1`, and only for single-hash unlock calls — multi-hash calls go directly to `setUnlockedBulk`
- Reduces N network round-trips to 1 for validator unlock operations during high throughput

## Test plan
- [ ] Verify `go build ./stores/utxo/sql/` compiles cleanly
- [ ] Run existing sql store unit tests
- [ ] Load test with postgres to verify unlock batching reduces latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)