### PR TITLE
fix(sql): set unmined_since when unsetting mined status for invalidation

### DIFF
--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -2670,29 +2670,45 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 	} else {
 		// Not on longest chain: clear delete_at_height, set locked = false
 		if minedBlockInfo.UnsetMined {
-			// UnsetMined path (block invalidation): set unmined_since for transactions
-			// that no longer have any block_ids after the deletion above.
+			// UnsetMined path (block invalidation): unlock and clear delete_at_height
+			// for all affected transactions, then set unmined_since only for those
+			// with zero remaining block_ids.
 			// This mirrors the aerospike Lua which sets unmined_since = currentBlockHeight
 			// when #blocks == 0 after removing the block_id.
 			// Use the store's current block height (not the invalidated block's height)
 			// to match Aerospike's setMined UDF behavior.
 			currentBlockHeight := s.blockHeight.Load() + 1
-			inClause3, inArgs3 := buildINClause(existingHashBytes, 2)
+
+			// Step 1: Unlock and clear delete_at_height for all affected transactions
+			inClause3, inArgs3 := buildINClause(existingHashBytes, 1)
 			qUpdate := fmt.Sprintf(`
 				UPDATE transactions
 				SET locked = false
 				   ,delete_at_height = NULL
-				   ,unmined_since = CASE
-				        WHEN NOT EXISTS (
-				            SELECT 1 FROM block_ids bi WHERE bi.transaction_id = transactions.id
-				        ) THEN $1
-				        ELSE unmined_since
-				    END
 				WHERE hash IN %s
 			`, inClause3)
-			args := append([]interface{}{currentBlockHeight}, inArgs3...)
-			if _, err = txn.ExecContext(ctx, qUpdate, args...); err != nil {
+			if _, err = txn.ExecContext(ctx, qUpdate, inArgs3...); err != nil {
 				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+			}
+
+			// Step 2: Set unmined_since only for transactions with no remaining block_ids
+			inClause3b, inArgs3b := buildINClause(existingHashBytes, 2)
+			qUpdateUnmined := fmt.Sprintf(`
+				WITH txs_without_blocks AS (
+					SELECT t.id
+					FROM transactions t
+					LEFT JOIN block_ids bi ON bi.transaction_id = t.id
+					WHERE t.hash IN %s
+					GROUP BY t.id
+					HAVING COUNT(bi.transaction_id) = 0
+				)
+				UPDATE transactions
+				SET unmined_since = $1
+				WHERE id IN (SELECT id FROM txs_without_blocks)
+			`, inClause3b)
+			args := append([]interface{}{currentBlockHeight}, inArgs3b...)
+			if _, err = txn.ExecContext(ctx, qUpdateUnmined, args...); err != nil {
+				return nil, errors.NewStorageError("SQL error updating unmined_since: %v", err)
 			}
 		} else {
 			// Normal not-on-longest-chain path: MarkTransactionsOnLongestChain handles unmined_since

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -2674,6 +2674,9 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 			// that no longer have any block_ids after the deletion above.
 			// This mirrors the aerospike Lua which sets unmined_since = currentBlockHeight
 			// when #blocks == 0 after removing the block_id.
+			// Use the store's current block height (not the invalidated block's height)
+			// to match Aerospike's setMined UDF behavior.
+			currentBlockHeight := s.blockHeight.Load() + 1
 			inClause3, inArgs3 := buildINClause(existingHashBytes, 2)
 			qUpdate := fmt.Sprintf(`
 				UPDATE transactions
@@ -2687,7 +2690,7 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 				    END
 				WHERE hash IN %s
 			`, inClause3)
-			args := append([]interface{}{minedBlockInfo.BlockHeight}, inArgs3...)
+			args := append([]interface{}{currentBlockHeight}, inArgs3...)
 			if _, err = txn.ExecContext(ctx, qUpdate, args...); err != nil {
 				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
 			}

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -2669,15 +2669,39 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 		}
 	} else {
 		// Not on longest chain: clear delete_at_height, set locked = false
-		// Do NOT set unmined_since here — that's MarkTransactionsOnLongestChain's job
-		inClause3, inArgs3 := buildINClause(existingHashBytes, 1)
-		qUpdate := fmt.Sprintf(`
-			UPDATE transactions
-			SET locked = false, delete_at_height = NULL
-			WHERE hash IN %s
-		`, inClause3)
-		if _, err = txn.ExecContext(ctx, qUpdate, inArgs3...); err != nil {
-			return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+		if minedBlockInfo.UnsetMined {
+			// UnsetMined path (block invalidation): set unmined_since for transactions
+			// that no longer have any block_ids after the deletion above.
+			// This mirrors the aerospike Lua which sets unmined_since = currentBlockHeight
+			// when #blocks == 0 after removing the block_id.
+			inClause3, inArgs3 := buildINClause(existingHashBytes, 2)
+			qUpdate := fmt.Sprintf(`
+				UPDATE transactions
+				SET locked = false
+				   ,delete_at_height = NULL
+				   ,unmined_since = CASE
+				        WHEN NOT EXISTS (
+				            SELECT 1 FROM block_ids bi WHERE bi.transaction_id = transactions.id
+				        ) THEN $1
+				        ELSE unmined_since
+				    END
+				WHERE hash IN %s
+			`, inClause3)
+			args := append([]interface{}{minedBlockInfo.BlockHeight}, inArgs3...)
+			if _, err = txn.ExecContext(ctx, qUpdate, args...); err != nil {
+				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+			}
+		} else {
+			// Normal not-on-longest-chain path: MarkTransactionsOnLongestChain handles unmined_since
+			inClause3, inArgs3 := buildINClause(existingHashBytes, 1)
+			qUpdate := fmt.Sprintf(`
+				UPDATE transactions
+				SET locked = false, delete_at_height = NULL
+				WHERE hash IN %s
+			`, inClause3)
+			if _, err = txn.ExecContext(ctx, qUpdate, inArgs3...); err != nil {
+				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+			}
 		}
 	}
 

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -398,6 +398,111 @@ func TestSetMinedMulti(t *testing.T) {
 		assert.False(t, txMeta.Locked)
 		assert.Zero(t, txMeta.UnminedSince)
 	})
+
+	t.Run("unset last block_id sets unmined_since to current block height", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		utxoStore, tx := setup(ctx, t)
+
+		// Set the store's current block height to 500
+		err := utxoStore.SetBlockHeight(500)
+		require.NoError(t, err)
+
+		// Create tx as unmined at height 100
+		_, err = utxoStore.Create(ctx, tx, 100)
+		require.NoError(t, err)
+
+		// Mine the tx into block at height 200 (not on longest chain)
+		_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
+			BlockID:        10,
+			BlockHeight:    200,
+			SubtreeIdx:     0,
+			OnLongestChain: false,
+		})
+		require.NoError(t, err)
+
+		// Verify tx has block_id 10
+		txMeta, err := utxoStore.Get(ctx, tx.TxIDChainHash(), append(utxo.MetaFields, fields.UnminedSince)...)
+		require.NoError(t, err)
+		require.Len(t, txMeta.BlockIDs, 1)
+		require.Equal(t, uint32(10), txMeta.BlockIDs[0])
+
+		// Now unset mined (block invalidation) -- this removes the only block_id
+		_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
+			BlockID:        10,
+			BlockHeight:    200,
+			SubtreeIdx:     0,
+			OnLongestChain: false,
+			UnsetMined:     true,
+		})
+		require.NoError(t, err)
+
+		// Verify: tx should have zero block_ids and unmined_since set to current block height (501 = 500+1)
+		txMeta, err = utxoStore.Get(ctx, tx.TxIDChainHash(), append(utxo.MetaFields, fields.UnminedSince)...)
+		require.NoError(t, err)
+		assert.Len(t, txMeta.BlockIDs, 0, "tx should have no block_ids after unsetting the only one")
+		assert.Equal(t, uint32(501), txMeta.UnminedSince,
+			"unmined_since should be set to current block height (store height + 1), not the invalidated block's height")
+		assert.False(t, txMeta.Locked, "tx should be unlocked after unset mined")
+	})
+
+	t.Run("unset one of two block_ids does not set unmined_since", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		utxoStore, tx := setup(ctx, t)
+
+		// Set the store's current block height to 500
+		err := utxoStore.SetBlockHeight(500)
+		require.NoError(t, err)
+
+		// Create tx as unmined at height 100
+		_, err = utxoStore.Create(ctx, tx, 100)
+		require.NoError(t, err)
+
+		// Mine the tx into two blocks (not on longest chain)
+		_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
+			BlockID:        10,
+			BlockHeight:    200,
+			SubtreeIdx:     0,
+			OnLongestChain: false,
+		})
+		require.NoError(t, err)
+
+		_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
+			BlockID:        20,
+			BlockHeight:    201,
+			SubtreeIdx:     0,
+			OnLongestChain: false,
+		})
+		require.NoError(t, err)
+
+		// Verify tx has both block_ids
+		txMeta, err := utxoStore.Get(ctx, tx.TxIDChainHash(), append(utxo.MetaFields, fields.UnminedSince)...)
+		require.NoError(t, err)
+		require.Len(t, txMeta.BlockIDs, 2)
+
+		// Unset one block_id (invalidate block 10)
+		_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
+			BlockID:        10,
+			BlockHeight:    200,
+			SubtreeIdx:     0,
+			OnLongestChain: false,
+			UnsetMined:     true,
+		})
+		require.NoError(t, err)
+
+		// Verify: tx still has one block_id and unmined_since should NOT be updated
+		txMeta, err = utxoStore.Get(ctx, tx.TxIDChainHash(), append(utxo.MetaFields, fields.UnminedSince)...)
+		require.NoError(t, err)
+		assert.Len(t, txMeta.BlockIDs, 1, "tx should have one block_id remaining")
+		assert.Equal(t, uint32(20), txMeta.BlockIDs[0], "remaining block_id should be 20")
+		// unmined_since should retain whatever value it had before (not set to current height)
+		// because the tx still has a block_id
+		assert.NotEqual(t, uint32(501), txMeta.UnminedSince,
+			"unmined_since should NOT be set to current block height when tx still has block_ids")
+	})
 }
 
 func TestBatchDecorate(t *testing.T) {

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -478,10 +478,11 @@ func TestSetMinedMulti(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Verify tx has both block_ids
+		// Verify tx has both block_ids and capture unmined_since before the unset
 		txMeta, err := utxoStore.Get(ctx, tx.TxIDChainHash(), append(utxo.MetaFields, fields.UnminedSince)...)
 		require.NoError(t, err)
 		require.Len(t, txMeta.BlockIDs, 2)
+		unminedSinceBefore := txMeta.UnminedSince
 
 		// Unset one block_id (invalidate block 10)
 		_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
@@ -493,15 +494,14 @@ func TestSetMinedMulti(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Verify: tx still has one block_id and unmined_since should NOT be updated
+		// Verify: tx still has one block_id and unmined_since is unchanged
 		txMeta, err = utxoStore.Get(ctx, tx.TxIDChainHash(), append(utxo.MetaFields, fields.UnminedSince)...)
 		require.NoError(t, err)
 		assert.Len(t, txMeta.BlockIDs, 1, "tx should have one block_id remaining")
 		assert.Equal(t, uint32(20), txMeta.BlockIDs[0], "remaining block_id should be 20")
-		// unmined_since should retain whatever value it had before (not set to current height)
-		// because the tx still has a block_id
-		assert.NotEqual(t, uint32(501), txMeta.UnminedSince,
-			"unmined_since should NOT be set to current block height when tx still has block_ids")
+		// unmined_since should be unchanged because the tx still has a remaining block_id
+		assert.Equal(t, unminedSinceBefore, txMeta.UnminedSince,
+			"unmined_since should be unchanged when tx still has block_ids")
 	})
 }
 


### PR DESCRIPTION
## Summary
- When `UnsetMined=true` (block invalidation path), sets `unmined_since` for transactions that no longer have any `block_ids` after the block_id deletion
- This mirrors the aerospike Lua behavior which sets `unmined_since = currentBlockHeight` when `#blocks == 0` after removing a block_id
- Previously the not-on-longest-chain path never set `unmined_since`, so invalidated transactions would not be picked up by `loadUnminedTransactions` for re-mining
- The normal (non-invalidation) path is unchanged — `MarkTransactionsOnLongestChain` still handles `unmined_since` for regular reorgs

## Test plan
- [ ] Verify `go build ./stores/utxo/sql/` compiles cleanly
- [ ] Run existing sql store unit tests including SetMinedMulti tests
- [ ] Verify invalidated block transactions get `unmined_since` set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)