### PR TITLE
feat(blockchain): add on_main_chain column to eliminate recursive CTEs

### DIFF
--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
@@ -25,7 +25,11 @@ func (s *SQL) CheckBlockIsInCurrentChain(ctx context.Context, blockIDs []uint32)
 		return false, nil
 	}
 
-	if !s.useInMemoryChainCheck {
+	// Fall back to SQL when:
+	//   - in-memory mode is disabled, OR
+	//   - a rebuild is in progress: offChainBlockIDs may be empty (startup) or stale
+	//     (ongoing reorg/invalidation) and the SQL path has its own CTE fallback.
+	if !s.useInMemoryChainCheck || s.mainChainRebuilding.Load() > 0 {
 		return s.checkBlockIsInCurrentChainSQL(ctx, blockIDs)
 	}
 
@@ -56,7 +60,7 @@ func (s *SQL) CheckBlockIsInCurrentChain(ctx context.Context, blockIDs []uint32)
 // useInMemoryChainCheck is false. Uses the on_main_chain column when flags are
 // consistent; falls back to the recursive CTE when a rebuild is in progress.
 func (s *SQL) checkBlockIsInCurrentChainSQL(ctx context.Context, blockIDs []uint32) (bool, error) {
-	if !s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() == 0 {
 		// Fast path: on_main_chain flags are reliable — check them directly.
 		for _, id := range blockIDs {
 			var onMainChain bool

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
@@ -10,6 +10,12 @@ import (
 	"github.com/bsv-blockchain/teranode/util/tracing"
 )
 
+// maxIDsPerCheckBatch caps the number of placeholders per IN() query in the
+// on_main_chain fast path. Postgres has a 32767 bind-parameter limit; 1000 is
+// far below that and keeps plan-cache pressure low while still amortising
+// round-trip cost across many IDs.
+const maxIDsPerCheckBatch = 1000
+
 // CheckBlockIsInCurrentChain determines if any of the specified blocks are on the current
 // main chain. When useInMemoryChainCheck is true, uses a pure in-memory O(1) lookup via
 // the off-chain set. When false, falls back to the original SQL recursive CTE.
@@ -60,20 +66,41 @@ func (s *SQL) CheckBlockIsInCurrentChain(ctx context.Context, blockIDs []uint32)
 // useInMemoryChainCheck is false. Uses the on_main_chain column when flags are
 // consistent; falls back to the recursive CTE when a rebuild is in progress.
 func (s *SQL) checkBlockIsInCurrentChainSQL(ctx context.Context, blockIDs []uint32) (bool, error) {
+	// Defense in depth: the public wrapper already rejects empty input, but
+	// direct callers (tests, benchmarks) may bypass that. The CTE fallback
+	// below indexes blockIDs[0], so an empty slice must not reach it.
+	if len(blockIDs) == 0 {
+		return false, nil
+	}
+
 	if s.mainChainRebuilding.Load() == 0 {
-		// Fast path: on_main_chain flags are reliable — check them directly.
-		for _, id := range blockIDs {
-			var onMainChain bool
-			err := s.db.QueryRowContext(ctx, `SELECT on_main_chain FROM blocks WHERE id = $1`, id).Scan(&onMainChain)
+		// Fast path: on_main_chain flags are reliable. Resolve ANY-of semantics
+		// in a single round-trip per batch, rather than one query per ID. Cap
+		// each batch at maxIDsPerCheckBatch so we never approach Postgres's
+		// parameter limit (32767) even if a future caller passes a huge slice.
+		for start := 0; start < len(blockIDs); start += maxIDsPerCheckBatch {
+			end := start + maxIDsPerCheckBatch
+			if end > len(blockIDs) {
+				end = len(blockIDs)
+			}
+			batch := blockIDs[start:end]
+
+			placeholders := make([]string, len(batch))
+			args := make([]interface{}, len(batch))
+			for i, id := range batch {
+				placeholders[i] = fmt.Sprintf("$%d", i+1)
+				args[i] = id
+			}
+			q := fmt.Sprintf(`SELECT 1 FROM blocks WHERE id IN (%s) AND on_main_chain = true LIMIT 1`, strings.Join(placeholders, ","))
+			var found int // sentinel — we only care whether a row is returned
+			err := s.db.QueryRowContext(ctx, q, args...).Scan(&found)
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
-					continue
+					continue // this batch had no match; try the next
 				}
-				return false, errors.NewStorageError("failed to check on_main_chain for block", err)
+				return false, errors.NewStorageError("failed to check on_main_chain for blocks", err)
 			}
-			if onMainChain {
-				return true, nil
-			}
+			return true, nil // ANY-of short-circuit
 		}
 		return false, nil
 	}

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
@@ -52,9 +52,29 @@ func (s *SQL) CheckBlockIsInCurrentChain(ctx context.Context, blockIDs []uint32)
 	return false, nil
 }
 
-// checkBlockIsInCurrentChainSQL is the original SQL recursive CTE implementation.
-// Used when useInMemoryChainCheck is false.
+// checkBlockIsInCurrentChainSQL is the SQL fallback implementation used when
+// useInMemoryChainCheck is false. Uses the on_main_chain column when flags are
+// consistent; falls back to the recursive CTE when a rebuild is in progress.
 func (s *SQL) checkBlockIsInCurrentChainSQL(ctx context.Context, blockIDs []uint32) (bool, error) {
+	if !s.mainChainRebuilding.Load() {
+		// Fast path: on_main_chain flags are reliable — check them directly.
+		for _, id := range blockIDs {
+			var onMainChain bool
+			err := s.db.QueryRowContext(ctx, `SELECT on_main_chain FROM blocks WHERE id = $1`, id).Scan(&onMainChain)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					continue
+				}
+				return false, errors.NewStorageError("failed to check on_main_chain for block", err)
+			}
+			if onMainChain {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	// CTE fallback when on_main_chain is being rebuilt.
 	_, bestBlockMeta, err := s.GetBestBlockHeader(ctx)
 	if err != nil {
 		return false, errors.NewStorageError("failed to get best block header", err)

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain_bench_test.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain_bench_test.go
@@ -1,0 +1,92 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkCheckBlockIsInCurrentChainSQL measures the per-call latency of the
+// on_main_chain fast path at increasing N (number of block IDs per call) and
+// compares it to the CTE fallback. It documents the single-query win over the
+// previous N-round-trip loop and guards against regressions.
+//
+// Run: go test -bench BenchmarkCheckBlockIsInCurrentChainSQL -run '^$' ./stores/blockchain/sql/...
+func BenchmarkCheckBlockIsInCurrentChainSQL(b *testing.B) {
+	tSettings := test.CreateBaseTestSettings(b)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(b, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(b, err)
+	defer s.Close()
+
+	// Wait for the startup rebuild goroutine to release its guard so the fast
+	// path (mainChainRebuilding == 0) is actually exercised.
+	deadline := time.Now().Add(5 * time.Second)
+	for s.mainChainRebuilding.Load() > 0 {
+		if time.Now().After(deadline) {
+			b.Fatal("startup rebuild did not complete in time")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Seed a 25-block main chain: block1 → block2 → block3 → 22 fork-builder
+	// blocks on top. All are on_main_chain = true by construction.
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(b, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(b, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(b, err)
+
+	chain := []*model.Block{block1, block2, block3}
+	const totalBlocks = 25
+	for len(chain) < totalBlocks {
+		next := createBlock3OnFork(chain[len(chain)-1])
+		_, _, err = s.StoreBlock(context.Background(), next, "peer")
+		require.NoError(b, err)
+		chain = append(chain, next)
+	}
+
+	ids := make([]uint32, len(chain))
+	for i, blk := range chain {
+		var id uint32
+		require.NoError(b, s.db.QueryRow(`SELECT id FROM blocks WHERE hash = $1`, blk.Hash().CloneBytes()).Scan(&id))
+		ids[i] = id
+	}
+
+	for _, n := range []int{1, 5, 20} {
+		input := ids[:n]
+
+		b.Run(fmt.Sprintf("FastPath/N=%d", n), func(b *testing.B) {
+			require.Zero(b, s.mainChainRebuilding.Load(), "fast path requires guard=0")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := s.checkBlockIsInCurrentChainSQL(context.Background(), input); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("CTE/N=%d", n), func(b *testing.B) {
+			s.mainChainRebuilding.Add(1)
+			defer s.mainChainRebuilding.Add(-1)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := s.checkBlockIsInCurrentChainSQL(context.Background(), input); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
@@ -200,6 +200,17 @@ func newStoreWithInMemoryChainCheck(t *testing.T) *SQL {
 	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 	require.NoError(t, err)
 
+	waitForStartupRebuild(t, s)
+	return s
+}
+
+// waitForStartupRebuild blocks until the startup rebuild goroutine has released
+// its guard, or fails the test after 5 seconds. Use this in tests that need
+// deterministic behaviour from the fast-path (guard == 0) or that call Close()
+// and want to avoid noisy "database is closed" logs from the still-running
+// startup goroutine.
+func waitForStartupRebuild(t *testing.T, s *SQL) {
+	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for s.mainChainRebuilding.Load() > 0 {
 		if time.Now().After(deadline) {
@@ -207,7 +218,6 @@ func newStoreWithInMemoryChainCheck(t *testing.T) *SQL {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	return s
 }
 
 func TestCheckBlockIsInCurrentChain_InMemory_SingleBlockInChain(t *testing.T) {

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -185,7 +186,10 @@ func TestCheckBlockIsInCurrentChain_InvalidatedBlock(t *testing.T) {
 	assert.False(t, result, "Invalidated block should be off-chain")
 }
 
-// newStoreWithInMemoryChainCheck creates a SQL store with useInMemoryChainCheck enabled.
+// newStoreWithInMemoryChainCheck creates a SQL store with useInMemoryChainCheck enabled
+// and waits for the startup rebuild goroutine to complete before returning. Tests that
+// rely on the in-memory chain check being authoritative (e.g. DB-independence tests)
+// must run after the startup guard has been released.
 func newStoreWithInMemoryChainCheck(t *testing.T) *SQL {
 	t.Helper()
 	tSettings := test.CreateBaseTestSettings(t)
@@ -195,6 +199,14 @@ func newStoreWithInMemoryChainCheck(t *testing.T) *SQL {
 
 	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 	require.NoError(t, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for s.mainChainRebuilding.Load() > 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("startup rebuild did not complete within 5 seconds")
+		}
+		time.Sleep(time.Millisecond)
+	}
 	return s
 }
 

--- a/stores/blockchain/sql/FindBlocksContainingSubtree.go
+++ b/stores/blockchain/sql/FindBlocksContainingSubtree.go
@@ -35,7 +35,9 @@ func (s *SQL) FindBlocksContainingSubtree(ctx context.Context, subtreeHash *chai
 		subtreeSearchClause = "position($1 in b.subtrees) > 0"
 	}
 
-	q := `
+	var q string
+	if s.mainChainRebuilding.Load() {
+		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -75,6 +77,30 @@ func (s *SQL) FindBlocksContainingSubtree(ctx context.Context, subtreeHash *chai
 		ORDER BY b.height ASC
 		` + limitClause + `
 	`
+	} else {
+		q = `
+		SELECT
+		 b.ID
+		,b.version
+		,b.block_time
+		,b.n_bits
+		,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+		,b.tx_count
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.subtree_count
+		,b.subtrees
+		,b.height
+		,b.coinbase_bump
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		  AND ` + subtreeSearchClause + `
+		ORDER BY b.height ASC
+		` + limitClause + `
+	`
+	}
 
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {

--- a/stores/blockchain/sql/FindBlocksContainingSubtree.go
+++ b/stores/blockchain/sql/FindBlocksContainingSubtree.go
@@ -36,7 +36,7 @@ func (s *SQL) FindBlocksContainingSubtree(ctx context.Context, subtreeHash *chai
 	}
 
 	var q string
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetBlockByHeight.go
+++ b/stores/blockchain/sql/GetBlockByHeight.go
@@ -98,7 +98,9 @@ func (s *SQL) GetBlockByHeight(ctx context.Context, height uint32) (*model.Block
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	q := `
+	var q string
+	if s.mainChainRebuilding.Load() {
+		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -138,6 +140,29 @@ func (s *SQL) GetBlockByHeight(ctx context.Context, height uint32) (*model.Block
 		WHERE cb.height = $1
 		LIMIT 1
 	`
+	} else {
+		q = `
+		SELECT
+		 b.ID
+	    ,b.version
+		,b.block_time
+		,b.n_bits
+	    ,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+	    ,b.tx_count
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.subtree_count
+		,b.subtrees
+		,b.height
+		,b.coinbase_bump
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		  AND b.height = $1
+		LIMIT 1
+	`
+	}
 
 	rows, err := s.db.QueryContext(ctx, q, height)
 	if err != nil {

--- a/stores/blockchain/sql/GetBlockByHeight.go
+++ b/stores/blockchain/sql/GetBlockByHeight.go
@@ -99,7 +99,7 @@ func (s *SQL) GetBlockByHeight(ctx context.Context, height uint32) (*model.Block
 	defer cancel()
 
 	var q string
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetBlockGraphData.go
+++ b/stores/blockchain/sql/GetBlockGraphData.go
@@ -56,7 +56,7 @@ func (s *SQL) GetBlockGraphData(ctx context.Context, periodMillis uint64) (*mode
 	// through parent links. The final WHERE clause filters to only blocks within
 	// the requested time period.
 	var q string
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT

--- a/stores/blockchain/sql/GetBlockGraphData.go
+++ b/stores/blockchain/sql/GetBlockGraphData.go
@@ -85,12 +85,17 @@ func (s *SQL) GetBlockGraphData(ctx context.Context, periodMillis uint64) (*mode
 		WHERE block_time >= $1
 	`
 	} else {
-		// id > 0 excludes genesis (id=0), matching the original CTE behaviour.
+		// Mirror the original CTE exactly. The CTE's anchor is `id IN (0, best)`
+		// so genesis is explicitly included; the recursive step has
+		// `WHERE b.parent_id != 0` (needed because genesis's parent_id
+		// self-references to 0) which inadvertently drops the height-1 block
+		// (whose parent_id equals genesis's id, 0). So: keep genesis, keep
+		// anything with parent_id != 0, drop the height-1 block.
 		q = `
 		SELECT block_time, tx_count
 		FROM blocks
 		WHERE on_main_chain = true
-		  AND id > 0
+		  AND (id = 0 OR parent_id != 0)
 		  AND block_time >= $1
 	`
 	}

--- a/stores/blockchain/sql/GetBlockGraphData.go
+++ b/stores/blockchain/sql/GetBlockGraphData.go
@@ -55,7 +55,9 @@ func (s *SQL) GetBlockGraphData(ctx context.Context, periodMillis uint64) (*mode
 	// The query starts from both genesis (id=0) and the best block, walking back
 	// through parent links. The final WHERE clause filters to only blocks within
 	// the requested time period.
-	q := `
+	var q string
+	if s.mainChainRebuilding.Load() {
+		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT
 			 id
@@ -82,6 +84,16 @@ func (s *SQL) GetBlockGraphData(ctx context.Context, periodMillis uint64) (*mode
 		SELECT block_time, tx_count FROM ChainBlocks
 		WHERE block_time >= $1
 	`
+	} else {
+		// id > 0 excludes genesis (id=0), matching the original CTE behaviour.
+		q = `
+		SELECT block_time, tx_count
+		FROM blocks
+		WHERE on_main_chain = true
+		  AND id > 0
+		  AND block_time >= $1
+	`
+	}
 
 	blockDataPoints := &model.BlockDataPoints{}
 

--- a/stores/blockchain/sql/GetBlockHeadersByHeight.go
+++ b/stores/blockchain/sql/GetBlockHeadersByHeight.go
@@ -86,7 +86,7 @@ func (s *SQL) GetBlockHeadersByHeight(ctx context.Context, startHeight, endHeigh
 	blockMetas := make([]*model.BlockHeaderMeta, 0, capacity)
 
 	var q string
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetBlockHeadersByHeight.go
+++ b/stores/blockchain/sql/GetBlockHeadersByHeight.go
@@ -85,7 +85,9 @@ func (s *SQL) GetBlockHeadersByHeight(ctx context.Context, startHeight, endHeigh
 	blockHeaders := make([]*model.BlockHeader, 0, capacity)
 	blockMetas := make([]*model.BlockHeaderMeta, 0, capacity)
 
-	q := `
+	var q string
+	if s.mainChainRebuilding.Load() {
+		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -125,6 +127,30 @@ func (s *SQL) GetBlockHeadersByHeight(ctx context.Context, startHeight, endHeigh
 		WHERE cb.height >= $1 AND cb.height <= $2
 		ORDER BY cb.height ASC
 	`
+	} else {
+		q = `
+		SELECT
+		 b.version
+		,b.block_time
+		,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+		,b.n_bits
+		,b.id
+		,b.height
+		,b.tx_count
+		,b.size_in_bytes
+		,b.peer_id
+		,b.block_time
+		,b.inserted_at
+		,b.median_time_past
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		  AND b.height >= $1
+		  AND b.height <= $2
+		ORDER BY b.height ASC
+	`
+	}
 	rows, err := s.db.QueryContext(ctx, q, startHeight, endHeight)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/stores/blockchain/sql/GetBlockStats.go
+++ b/stores/blockchain/sql/GetBlockStats.go
@@ -73,7 +73,7 @@ func (s *SQL) GetBlockStats(ctx context.Context) (*model.BlockStats, error) {
 	}
 
 	var q string
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		q = fmt.Sprintf(`
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT

--- a/stores/blockchain/sql/GetBlockStats.go
+++ b/stores/blockchain/sql/GetBlockStats.go
@@ -72,7 +72,9 @@ func (s *SQL) GetBlockStats(ctx context.Context) (*model.BlockStats, error) {
 		tweak = "'\\x00'::bytea"
 	}
 
-	q := fmt.Sprintf(`
+	var q string
+	if s.mainChainRebuilding.Load() {
+		q = fmt.Sprintf(`
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT
 			 id
@@ -95,7 +97,7 @@ func (s *SQL) GetBlockStats(ctx context.Context) (*model.BlockStats, error) {
 			INNER JOIN ChainBlocks cb ON b.id = cb.parent_id
 			WHERE b.parent_id != 0
 		)
-		SELECT 
+		SELECT
 			COALESCE(count(1), 0),
 			COALESCE(sum(tx_count), 0),
 			COALESCE(max(height), 0),
@@ -107,6 +109,28 @@ func (s *SQL) GetBlockStats(ctx context.Context) (*model.BlockStats, error) {
 		FROM ChainBlocks
 		WHERE id > 0
 	`, tweak)
+	} else {
+		// Mirror the original CTE's behaviour exactly:
+		//   - id > 0 excludes genesis (the caller adds 1 for genesis via blockStats.BlockCount += 1)
+		//   - parent_id != 0 excludes the block at height 1 (parent = genesis, parent_id = 0)
+		//     because the original CTE's "WHERE b.parent_id != 0" guard (needed to prevent
+		//     infinite recursion at genesis) also inadvertently skips height-1 blocks.
+		q = fmt.Sprintf(`
+		SELECT
+			COALESCE(count(1), 0),
+			COALESCE(sum(tx_count), 0),
+			COALESCE(max(height), 0),
+			COALESCE(avg(size_in_bytes), 0),
+			COALESCE(avg(tx_count), 0),
+			COALESCE(min(block_time), 0),
+			COALESCE(max(block_time), 0),
+			COALESCE((SELECT chain_work FROM blocks WHERE id > 0 ORDER BY chain_work DESC, id ASC LIMIT 1), %s)
+		FROM blocks
+		WHERE on_main_chain = true
+		  AND id > 0
+		  AND parent_id != 0
+	`, tweak)
+	}
 
 	blockStats := &model.BlockStats{}
 

--- a/stores/blockchain/sql/GetBlocksByHeight.go
+++ b/stores/blockchain/sql/GetBlocksByHeight.go
@@ -82,7 +82,7 @@ func (s *SQL) GetBlocksByHeight(ctx context.Context, startHeight, endHeight uint
 	blocks := make([]*model.Block, 0, capacity)
 
 	var q string
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetBlocksByHeight.go
+++ b/stores/blockchain/sql/GetBlocksByHeight.go
@@ -81,7 +81,9 @@ func (s *SQL) GetBlocksByHeight(ctx context.Context, startHeight, endHeight uint
 	capacity := max(1, endHeight-startHeight+1)
 	blocks := make([]*model.Block, 0, capacity)
 
-	q := `
+	var q string
+	if s.mainChainRebuilding.Load() {
+		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -121,6 +123,30 @@ func (s *SQL) GetBlocksByHeight(ctx context.Context, startHeight, endHeight uint
 		WHERE cb.height >= $1 AND cb.height <= $2
 		ORDER BY cb.height ASC
 	`
+	} else {
+		q = `
+		SELECT
+		 b.ID
+		,b.version
+		,b.block_time
+		,b.n_bits
+		,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+		,b.tx_count
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.subtree_count
+		,b.subtrees
+		,b.height
+		,b.coinbase_bump
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		  AND b.height >= $1
+		  AND b.height <= $2
+		ORDER BY b.height ASC
+	`
+	}
 
 	rows, err := s.db.QueryContext(ctx, q, startHeight, endHeight)
 	if err != nil {

--- a/stores/blockchain/sql/GetLastNBlocks.go
+++ b/stores/blockchain/sql/GetLastNBlocks.go
@@ -93,7 +93,7 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 	`
 		args = []any{n}
 	} else if fromHeight > 0 {
-		if s.mainChainRebuilding.Load() {
+		if s.mainChainRebuilding.Load() > 0 {
 			// When paginating, cap CTE walk depth to the lower of tip height and fromHeight,
 			// so that fromHeight > tip is handled gracefully (behaves like fromHeight = tip).
 			// Uses CASE instead of LEAST/MIN for cross-database compatibility (PostgreSQL + SQLite).
@@ -157,7 +157,7 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 		}
 		args = []any{n, fromHeight}
 	} else {
-		if s.mainChainRebuilding.Load() {
+		if s.mainChainRebuilding.Load() > 0 {
 			q = `
 		WITH RECURSIVE tip_block AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetLastNBlocks.go
+++ b/stores/blockchain/sql/GetLastNBlocks.go
@@ -93,10 +93,11 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 	`
 		args = []any{n}
 	} else if fromHeight > 0 {
-		// When paginating, cap CTE walk depth to the lower of tip height and fromHeight,
-		// so that fromHeight > tip is handled gracefully (behaves like fromHeight = tip).
-		// Uses CASE instead of LEAST/MIN for cross-database compatibility (PostgreSQL + SQLite).
-		q = `
+		if s.mainChainRebuilding.Load() {
+			// When paginating, cap CTE walk depth to the lower of tip height and fromHeight,
+			// so that fromHeight > tip is handled gracefully (behaves like fromHeight = tip).
+			// Uses CASE instead of LEAST/MIN for cross-database compatibility (PostgreSQL + SQLite).
+			q = `
 		WITH RECURSIVE tip_block AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -133,9 +134,31 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 		ORDER BY b.height DESC
 		LIMIT $1
 	`
+		} else {
+			q = `
+		SELECT
+		 b.version
+		,b.block_time
+		,b.n_bits
+	  ,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+	  ,b.tx_count
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.height
+		,b.inserted_at
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		  AND b.height <= $2
+		ORDER BY b.height DESC
+		LIMIT $1
+	`
+		}
 		args = []any{n, fromHeight}
 	} else {
-		q = `
+		if s.mainChainRebuilding.Load() {
+			q = `
 		WITH RECURSIVE tip_block AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -171,6 +194,26 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 		ORDER BY b.height DESC
 		LIMIT $1
 	`
+		} else {
+			q = `
+		SELECT
+		 b.version
+		,b.block_time
+		,b.n_bits
+	  ,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+	  ,b.tx_count
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.height
+		,b.inserted_at
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		ORDER BY b.height DESC
+		LIMIT $1
+	`
+		}
 		args = []any{n}
 	}
 

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -91,7 +91,8 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 	var q string
 	var args []interface{}
 
-	baseQuery := `
+	if s.mainChainRebuilding.Load() {
+		baseQuery := `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -119,33 +120,70 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		FROM blocks b
 		JOIN ChainBlocks cb ON b.id = cb.id`
 
-	if s.engine == util.Postgres {
-		// Convert []chainhash.Hash to pgtype.FlatArray[[]byte] for pgx driver
-		hashBytes := make(pgtype.FlatArray[[]byte], len(blockLocator))
-		for i, hash := range blockLocator {
-			hashBytes[i] = hash[:]
-		}
-
-		q = baseQuery + `
+		if s.engine == util.Postgres {
+			hashBytes := make(pgtype.FlatArray[[]byte], len(blockLocator))
+			for i, hash := range blockLocator {
+				hashBytes[i] = hash[:]
+			}
+			q = baseQuery + `
 			AND b.hash = ANY($2)
 			ORDER BY b.height DESC
 			LIMIT 1`
-		args = []interface{}{bestBlockHash[:], hashBytes}
-	} else {
-		// SQLite: Generate dynamic placeholders for IN clause
-		placeholders := make([]string, len(blockLocator))
-		args = make([]interface{}, len(blockLocator)+1)
-		args[0] = bestBlockHash[:]
-
-		for i, hash := range blockLocator {
-			placeholders[i] = fmt.Sprintf("$%d", i+2)
-			args[i+1] = hash[:]
-		}
-
-		q = baseQuery + fmt.Sprintf(`
+			args = []interface{}{bestBlockHash[:], hashBytes}
+		} else {
+			placeholders := make([]string, len(blockLocator))
+			args = make([]interface{}, len(blockLocator)+1)
+			args[0] = bestBlockHash[:]
+			for i, hash := range blockLocator {
+				placeholders[i] = fmt.Sprintf("$%d", i+2)
+				args[i+1] = hash[:]
+			}
+			q = baseQuery + fmt.Sprintf(`
 			AND b.hash IN (%s)
 			ORDER BY b.height DESC
 			LIMIT 1`, strings.Join(placeholders, ","))
+		}
+	} else {
+		fastBase := `
+		SELECT
+	   	 b.version
+		,b.block_time
+		,b.n_bits
+		,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.peer_id
+		,b.height
+		,b.tx_count
+		,b.chain_work
+		,b.median_time_past
+		FROM blocks b
+		WHERE b.on_main_chain = true`
+
+		if s.engine == util.Postgres {
+			hashBytes := make(pgtype.FlatArray[[]byte], len(blockLocator))
+			for i, hash := range blockLocator {
+				hashBytes[i] = hash[:]
+			}
+			q = fastBase + `
+			AND b.hash = ANY($1)
+			ORDER BY b.height DESC
+			LIMIT 1`
+			args = []interface{}{hashBytes}
+		} else {
+			placeholders := make([]string, len(blockLocator))
+			args = make([]interface{}, len(blockLocator))
+			for i, hash := range blockLocator {
+				placeholders[i] = fmt.Sprintf("$%d", i+1)
+				args[i] = hash[:]
+			}
+			q = fastBase + fmt.Sprintf(`
+			AND b.hash IN (%s)
+			ORDER BY b.height DESC
+			LIMIT 1`, strings.Join(placeholders, ","))
+		}
 	}
 
 	blockHeader := &model.BlockHeader{}

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -91,7 +91,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 	var q string
 	var args []interface{}
 
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		baseQuery := `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -144,6 +144,12 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 			LIMIT 1`, strings.Join(placeholders, ","))
 		}
 	} else {
+		// Fast path: use on_main_chain flag instead of the recursive CTE walk.
+		// We still enforce the bestBlockHash height constraint so that only blocks
+		// that are ancestors-of or equal-to bestBlockHash are considered — matching
+		// the CTE's walk-from-bestBlockHash semantics exactly.
+		// If bestBlockHash is not in the DB the subquery returns NULL and the height
+		// comparison yields no rows, producing the same ErrNoRows as the CTE path.
 		fastBase := `
 		SELECT
 	   	 b.version
@@ -160,7 +166,8 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		,b.chain_work
 		,b.median_time_past
 		FROM blocks b
-		WHERE b.on_main_chain = true`
+		WHERE b.on_main_chain = true
+		  AND b.height <= (SELECT height FROM blocks WHERE hash = $1 LIMIT 1)`
 
 		if s.engine == util.Postgres {
 			hashBytes := make(pgtype.FlatArray[[]byte], len(blockLocator))
@@ -168,16 +175,17 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 				hashBytes[i] = hash[:]
 			}
 			q = fastBase + `
-			AND b.hash = ANY($1)
+			AND b.hash = ANY($2)
 			ORDER BY b.height DESC
 			LIMIT 1`
-			args = []interface{}{hashBytes}
+			args = []interface{}{bestBlockHash[:], hashBytes}
 		} else {
 			placeholders := make([]string, len(blockLocator))
-			args = make([]interface{}, len(blockLocator))
+			args = make([]interface{}, len(blockLocator)+1)
+			args[0] = bestBlockHash[:]
 			for i, hash := range blockLocator {
-				placeholders[i] = fmt.Sprintf("$%d", i+1)
-				args[i] = hash[:]
+				placeholders[i] = fmt.Sprintf("$%d", i+2)
+				args[i+1] = hash[:]
 			}
 			q = fastBase + fmt.Sprintf(`
 			AND b.hash IN (%s)

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -91,7 +91,37 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 	var q string
 	var args []interface{}
 
-	if s.mainChainRebuilding.Load() > 0 {
+	// The fast path filters blocks by on_main_chain = true and height <=
+	// bestBlockHash's height. That matches the CTE's walk-from-bestBlockHash
+	// semantics only when bestBlockHash is itself on the main chain. When it is
+	// a fork tip (a known hash with on_main_chain = false), the two paths
+	// disagree — the CTE follows the fork's ancestors, the fast path would
+	// substitute whichever main-chain block sits at the same heights. Fall
+	// back to the CTE in that case. Treat DB errors or unknown hashes as
+	// "not on main chain" so the CTE (which also surfaces that error) stays
+	// authoritative.
+	//
+	// TOCTOU: the guard check and bestOnMain preflight are non-atomic with the
+	// main query that follows. A concurrent writer can bump the guard after
+	// this check but before the main query runs. In the worst case the caller
+	// sees one call's worth of slightly-stale data; on the next call the
+	// guard is observed > 0 and the CTE path is taken. Acceptable under the
+	// store's single-writer model, where these transient inconsistencies are
+	// bounded and self-healing.
+	rebuilding := s.mainChainRebuilding.Load() > 0
+	bestOnMain := false
+	if !rebuilding {
+		if scanErr := s.db.QueryRowContext(ctx,
+			`SELECT COALESCE((SELECT on_main_chain FROM blocks WHERE hash = $1 LIMIT 1), false)`,
+			bestBlockHash[:],
+		).Scan(&bestOnMain); scanErr != nil {
+			// Error falls through to the CTE path, which will re-run the same
+			// kind of DB access and surface the error to the caller.
+			bestOnMain = false
+		}
+	}
+
+	if rebuilding || !bestOnMain {
 		baseQuery := `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator_test.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator_test.go
@@ -223,10 +223,10 @@ func TestSQLGetLatestBlockHeaderFromBlockLocator(t *testing.T) {
 		s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 		require.NoError(t, err)
 
-		// Use a non-existent hash as best block. With the on_main_chain fast path,
-		// bestBlockHash is not used to constrain the search — instead we find the
-		// highest locator hash on the main chain directly. Genesis is on the main chain
-		// and is in the locator, so it is returned.
+		// Use a non-existent hash as best block. The height constraint
+		// (b.height <= SELECT height FROM blocks WHERE hash = $random) evaluates to
+		// b.height <= NULL, which matches no rows — identical to the CTE path walking
+		// from a non-existent hash.
 		randomHash, err := chainhash.NewHashFromStr("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
 		require.NoError(t, err)
 
@@ -234,9 +234,9 @@ func TestSQLGetLatestBlockHeaderFromBlockLocator(t *testing.T) {
 		blockLocator := []chainhash.Hash{*genesisHash}
 
 		header, meta, err := s.GetLatestBlockHeaderFromBlockLocator(t.Context(), randomHash, blockLocator)
-		require.NoError(t, err)
-		require.NotNil(t, header)
-		require.NotNil(t, meta)
+		require.Error(t, err, "no matching blocks found in locator")
+		require.Nil(t, header)
+		require.Nil(t, meta)
 	})
 
 	t.Run("large locator array", func(t *testing.T) {

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator_test.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator_test.go
@@ -223,7 +223,10 @@ func TestSQLGetLatestBlockHeaderFromBlockLocator(t *testing.T) {
 		s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 		require.NoError(t, err)
 
-		// Use a non-existent hash as best block
+		// Use a non-existent hash as best block. With the on_main_chain fast path,
+		// bestBlockHash is not used to constrain the search — instead we find the
+		// highest locator hash on the main chain directly. Genesis is on the main chain
+		// and is in the locator, so it is returned.
 		randomHash, err := chainhash.NewHashFromStr("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
 		require.NoError(t, err)
 
@@ -231,9 +234,9 @@ func TestSQLGetLatestBlockHeaderFromBlockLocator(t *testing.T) {
 		blockLocator := []chainhash.Hash{*genesisHash}
 
 		header, meta, err := s.GetLatestBlockHeaderFromBlockLocator(t.Context(), randomHash, blockLocator)
-		require.Error(t, err, "no matching blocks found in locator")
-		require.Nil(t, header)
-		require.Nil(t, meta)
+		require.NoError(t, err)
+		require.NotNil(t, header)
+		require.NotNil(t, meta)
 	})
 
 	t.Run("large locator array", func(t *testing.T) {

--- a/stores/blockchain/sql/GetSuitableBlock_test.go
+++ b/stores/blockchain/sql/GetSuitableBlock_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_getMedianBlock(t *testing.T) {
-	var blocks []*model.SuitableBlock
+	blocks := make([]*model.SuitableBlock, 0, 3)
 
 	blocks = append(blocks, &model.SuitableBlock{
 		Time: 1,

--- a/stores/blockchain/sql/InvalidateBlock.go
+++ b/stores/blockchain/sql/InvalidateBlock.go
@@ -100,13 +100,13 @@ func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (i
 		hash      *chainhash.Hash
 	)
 
-	// Set guard before the UPDATE so concurrent queries fall back to the CTE for
-	// the entire window: from when invalid flags change until on_main_chain is
-	// corrected by rebuildOnMainChainFlag (which clears the guard on return).
-	s.mainChainRebuilding.Store(true)
+	// Guard the entire window: from when invalid flags change until on_main_chain
+	// is corrected by rebuildOnMainChainFlag. Balanced by the defer so all exit
+	// paths (including the early error below) decrement.
+	s.mainChainRebuilding.Add(1)
+	defer s.mainChainRebuilding.Add(-1)
 
 	if rows, err = s.db.QueryContext(ctx, q, blockHash.CloneBytes()); err != nil {
-		s.mainChainRebuilding.Store(false)
 		return nil, errors.NewStorageError("error querying blocks to invalidate", err)
 	}
 
@@ -124,7 +124,7 @@ func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (i
 		// Rebuild on_main_chain flags to reflect the new canonical chain after invalidation.
 		rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
 		defer rebuildCancel()
-		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
+		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx, false); rebuildErr != nil {
 			s.logger.Errorf("InvalidateBlock: rebuildOnMainChainFlag: %v", rebuildErr)
 		}
 

--- a/stores/blockchain/sql/InvalidateBlock.go
+++ b/stores/blockchain/sql/InvalidateBlock.go
@@ -100,20 +100,36 @@ func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (i
 		hash      *chainhash.Hash
 	)
 
+	// Set guard immediately: concurrent queries fall back to the CTE while we
+	// invalidate blocks and correct the on_main_chain flags.
+	s.mainChainRebuilding.Store(true)
+
 	if rows, err = s.db.QueryContext(ctx, q, blockHash.CloneBytes()); err != nil {
+		s.mainChainRebuilding.Store(false)
 		return nil, errors.NewStorageError("error querying blocks to invalidate", err)
 	}
 
 	defer func() {
 		err = errors.Join(err, rows.Close())
 
-		// Invalidate caches to ensure cached blocks reflect updated invalid field
+		// Invalidate caches FIRST so that rebuildOnMainChainFlag's getBestBlockID call
+		// does not return a stale best block that included the now-invalid block.
 		s.blockTimestampCache.Clear()
 		s.ResetResponseCache()
 		if s.useInMemoryChainCheck {
 			s.resetChainWalkCache()
-			rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
-			defer rebuildCancel()
+		}
+
+		// Rebuild on_main_chain flags to reflect the new canonical chain after invalidation.
+		rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+		defer rebuildCancel()
+		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
+			s.logger.Errorf("InvalidateBlock: rebuildOnMainChainFlag: %v", rebuildErr)
+		}
+		// Clear guard — on_main_chain is now consistent, queries can use fast path.
+		s.mainChainRebuilding.Store(false)
+
+		if s.useInMemoryChainCheck {
 			if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {
 				s.logger.Errorf("InvalidateBlock: %v", rebuildErr)
 			} else {

--- a/stores/blockchain/sql/InvalidateBlock.go
+++ b/stores/blockchain/sql/InvalidateBlock.go
@@ -100,7 +100,13 @@ func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (i
 		hash      *chainhash.Hash
 	)
 
+	// Set guard before the UPDATE so concurrent queries fall back to the CTE for
+	// the entire window: from when invalid flags change until on_main_chain is
+	// corrected by rebuildOnMainChainFlag (which clears the guard on return).
+	s.mainChainRebuilding.Store(true)
+
 	if rows, err = s.db.QueryContext(ctx, q, blockHash.CloneBytes()); err != nil {
+		s.mainChainRebuilding.Store(false)
 		return nil, errors.NewStorageError("error querying blocks to invalidate", err)
 	}
 

--- a/stores/blockchain/sql/InvalidateBlock.go
+++ b/stores/blockchain/sql/InvalidateBlock.go
@@ -100,20 +100,15 @@ func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (i
 		hash      *chainhash.Hash
 	)
 
-	// Set guard immediately: concurrent queries fall back to the CTE while we
-	// invalidate blocks and correct the on_main_chain flags.
-	s.mainChainRebuilding.Store(true)
-
 	if rows, err = s.db.QueryContext(ctx, q, blockHash.CloneBytes()); err != nil {
-		s.mainChainRebuilding.Store(false)
 		return nil, errors.NewStorageError("error querying blocks to invalidate", err)
 	}
 
 	defer func() {
 		err = errors.Join(err, rows.Close())
 
-		// Invalidate caches FIRST so that rebuildOnMainChainFlag's getBestBlockID call
-		// does not return a stale best block that included the now-invalid block.
+		// Invalidate caches FIRST so that rebuildOnMainChainFlag does not return a
+		// stale best block that included the now-invalid block.
 		s.blockTimestampCache.Clear()
 		s.ResetResponseCache()
 		if s.useInMemoryChainCheck {
@@ -126,8 +121,6 @@ func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (i
 		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
 			s.logger.Errorf("InvalidateBlock: rebuildOnMainChainFlag: %v", rebuildErr)
 		}
-		// Clear guard — on_main_chain is now consistent, queries can use fast path.
-		s.mainChainRebuilding.Store(false)
 
 		if s.useInMemoryChainCheck {
 			if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {

--- a/stores/blockchain/sql/OnMainChain_test.go
+++ b/stores/blockchain/sql/OnMainChain_test.go
@@ -1,0 +1,346 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/stores/blockchain/options"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getOnMainChain reads the on_main_chain flag directly from the database for the block
+// with the given hash. Returns false if the block does not exist.
+func getOnMainChain(t *testing.T, s *SQL, hashBytes []byte) bool {
+	t.Helper()
+	var v bool
+	err := s.db.QueryRow(`SELECT on_main_chain FROM blocks WHERE hash = $1`, hashBytes).Scan(&v)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	require.NoError(t, err)
+	return v
+}
+
+// TestOnMainChain_Genesis verifies that the genesis block is always marked on_main_chain.
+func TestOnMainChain_Genesis(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	genesisHash := tSettings.ChainCfgParams.GenesisHash
+	assert.True(t, getOnMainChain(t, s, genesisHash[:]), "genesis must be on_main_chain")
+}
+
+// TestOnMainChain_NormalExtend verifies that a block extending the main chain gets
+// on_main_chain = true in its INSERT (no separate UPDATE needed).
+func TestOnMainChain_NormalExtend(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 must be on_main_chain")
+	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 must be on_main_chain")
+	assert.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 must be on_main_chain")
+}
+
+// TestOnMainChain_ForkBlock verifies that a fork block (non-best) is NOT on_main_chain.
+func TestOnMainChain_ForkBlock(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+
+	// blockAlternative2 has same parent as block2 but less chain_work (older timestamp) —
+	// it is a fork that doesn't become the best block.
+	_, _, err = s.StoreBlock(context.Background(), blockAlternative2, "peer")
+	require.NoError(t, err)
+
+	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 (best) must be on_main_chain")
+	assert.False(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "fork block must NOT be on_main_chain")
+}
+
+// TestOnMainChain_InvalidBlock verifies that blocks stored with WithInvalid are NOT on_main_chain.
+func TestOnMainChain_InvalidBlock(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer", options.WithInvalid(true))
+	require.NoError(t, err)
+
+	assert.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "invalid block must NOT be on_main_chain")
+}
+
+// TestOnMainChain_InvalidateBlock verifies that InvalidateBlock clears on_main_chain for the
+// invalidated block and that the previous block remains on the main chain.
+func TestOnMainChain_InvalidateBlock(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	_, err = s.InvalidateBlock(context.Background(), block3.Hash())
+	require.NoError(t, err)
+
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 still on main chain after block3 invalidated")
+	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 still on main chain after block3 invalidated")
+	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "invalidated block3 must NOT be on_main_chain")
+}
+
+// TestOnMainChain_RevalidateBlock verifies that RevalidateBlock restores on_main_chain for a
+// block if it becomes the best chain after revalidation.
+func TestOnMainChain_RevalidateBlock(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	// Invalidate then revalidate block3
+	_, err = s.InvalidateBlock(context.Background(), block3.Hash())
+	require.NoError(t, err)
+	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 off-chain after invalidation")
+
+	err = s.RevalidateBlock(context.Background(), block3.Hash())
+	require.NoError(t, err)
+	assert.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 back on main chain after revalidation")
+}
+
+// TestOnMainChain_StartupRebuild verifies that rebuildOnMainChainFlag correctly restores
+// on_main_chain flags from scratch. This simulates crash recovery where flags were left
+// in a partial state (all cleared to false).
+func TestOnMainChain_StartupRebuild(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+
+	// Simulate a crash mid-rebuild: zero out all flags
+	_, err = s.db.Exec(`UPDATE blocks SET on_main_chain = false`)
+	require.NoError(t, err)
+
+	assert.False(t, getOnMainChain(t, s, tSettings.ChainCfgParams.GenesisHash[:]), "pre-condition: flags are cleared")
+	assert.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "pre-condition: flags are cleared")
+	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "pre-condition: flags are cleared")
+
+	// Startup rebuild should restore correct flags
+	s.responseCache.DeleteAll()
+	err = s.rebuildOnMainChainFlag(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, getOnMainChain(t, s, tSettings.ChainCfgParams.GenesisHash[:]), "genesis on_main_chain after rebuild")
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 on_main_chain after rebuild")
+	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 on_main_chain after rebuild")
+}
+
+// TestOnMainChain_ReorgClearsOldChain verifies that when a fork grows longer and becomes
+// the new main chain (reorg), all blocks on the old chain have on_main_chain = false
+// and all blocks on the new chain have on_main_chain = true.
+func TestOnMainChain_ReorgClearsOldChain(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Build main chain: genesis → block1 → block2 → block3
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 initially on main chain")
+	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 initially on main chain")
+	assert.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 initially on main chain")
+
+	// Build a competing fork: genesis → block1 → altBlock2 → forkBlock3 → forkBlock4
+	// The fork must have more chain_work than the main chain to trigger a reorg.
+	_, _, err = s.StoreBlock(context.Background(), blockAlternative2, "peer")
+	require.NoError(t, err)
+
+	forkBlock3 := createBlock3OnFork(blockAlternative2)
+	_, _, err = s.StoreBlock(context.Background(), forkBlock3, "peer")
+	require.NoError(t, err)
+
+	forkBlock4 := createBlock3OnFork(forkBlock3)
+	_, _, err = s.StoreBlock(context.Background(), forkBlock4, "peer")
+	require.NoError(t, err)
+
+	// forkBlock4 should now be the best block (more chain_work due to one extra block).
+	// The old chain (block2, block3) must be off-chain; the new fork must be on-chain.
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 (common ancestor) still on main chain")
+	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 off-chain after reorg")
+	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 off-chain after reorg")
+	assert.True(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "altBlock2 on new main chain")
+	assert.True(t, getOnMainChain(t, s, forkBlock3.Hash().CloneBytes()), "forkBlock3 on new main chain")
+	assert.True(t, getOnMainChain(t, s, forkBlock4.Hash().CloneBytes()), "forkBlock4 (new tip) on main chain")
+}
+
+// TestOnMainChain_LongFork verifies on_main_chain correctness across a multi-block reorg
+// where the fork is 3 blocks deep before surpassing the main chain.
+func TestOnMainChain_LongFork(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Main chain: genesis → block1 → block2
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+
+	// Fork from block1: genesis → block1 → altBlock2 → forkB3 → forkB4 → forkB5
+	// By the time forkB5 is added the fork has more work and causes a reorg.
+	_, _, err = s.StoreBlock(context.Background(), blockAlternative2, "peer")
+	require.NoError(t, err)
+	forkB3 := createBlock3OnFork(blockAlternative2)
+	_, _, err = s.StoreBlock(context.Background(), forkB3, "peer")
+	require.NoError(t, err)
+	forkB4 := createBlock3OnFork(forkB3)
+	_, _, err = s.StoreBlock(context.Background(), forkB4, "peer")
+	require.NoError(t, err)
+	forkB5 := createBlock3OnFork(forkB4)
+	_, _, err = s.StoreBlock(context.Background(), forkB5, "peer")
+	require.NoError(t, err)
+
+	// After the reorg: block2 should be off-chain; the entire 4-block fork should be on-chain.
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 (common ancestor) still on main chain")
+	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 cleared after long fork reorg")
+	assert.True(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "altBlock2 on new chain")
+	assert.True(t, getOnMainChain(t, s, forkB3.Hash().CloneBytes()), "forkB3 on new chain")
+	assert.True(t, getOnMainChain(t, s, forkB4.Hash().CloneBytes()), "forkB4 on new chain")
+	assert.True(t, getOnMainChain(t, s, forkB5.Hash().CloneBytes()), "forkB5 (tip) on new chain")
+}
+
+// TestOnMainChain_InvalidBlockFork verifies that blocks on a fork that gets invalidated
+// have on_main_chain = false and the original main chain is unaffected.
+func TestOnMainChain_InvalidBlockFork(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Main chain: genesis → block1 → block2 → block3
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	// Invalidate block2 — this should cascade to block3 as well
+	_, err = s.InvalidateBlock(context.Background(), block2.Hash())
+	require.NoError(t, err)
+
+	// After invalidating block2: block1 is the new best, block2 and block3 are off-chain
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 is new tip after invalidation")
+	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 invalidated, off-chain")
+	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 invalidated (child of invalid block2), off-chain")
+}
+
+// TestOnMainChain_ConsistentWithGetBlockByHeight verifies that the fast-path query
+// (on_main_chain = true) returns the same block as the CTE fallback.
+func TestOnMainChain_ConsistentWithGetBlockByHeight(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	for _, height := range []uint32{1, 2, 3} {
+		// Fast path (mainChainRebuilding = false by default)
+		fastBlock, err := s.GetBlockByHeight(context.Background(), height)
+		require.NoError(t, err, "height=%d fast path", height)
+
+		// CTE fallback
+		s.mainChainRebuilding.Store(true)
+		cteBlock, err := s.GetBlockByHeight(context.Background(), height)
+		s.mainChainRebuilding.Store(false)
+		require.NoError(t, err, "height=%d CTE path", height)
+
+		assert.Equal(t, fastBlock.Hash().String(), cteBlock.Hash().String(),
+			"fast path and CTE must return the same block at height %d", height)
+	}
+}

--- a/stores/blockchain/sql/OnMainChain_test.go
+++ b/stores/blockchain/sql/OnMainChain_test.go
@@ -187,7 +187,7 @@ func TestOnMainChain_StartupRebuild(t *testing.T) {
 
 	// Startup rebuild should restore correct flags
 	s.responseCache.DeleteAll()
-	err = s.rebuildOnMainChainFlag(context.Background())
+	err = s.rebuildOnMainChainFlag(context.Background(), false)
 	require.NoError(t, err)
 
 	assert.True(t, getOnMainChain(t, s, tSettings.ChainCfgParams.GenesisHash[:]), "genesis on_main_chain after rebuild")
@@ -330,17 +330,91 @@ func TestOnMainChain_ConsistentWithGetBlockByHeight(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, height := range []uint32{1, 2, 3} {
-		// Fast path (mainChainRebuilding = false by default)
+		// Fast path (mainChainRebuilding = 0 by default)
 		fastBlock, err := s.GetBlockByHeight(context.Background(), height)
 		require.NoError(t, err, "height=%d fast path", height)
 
 		// CTE fallback
-		s.mainChainRebuilding.Store(true)
+		s.mainChainRebuilding.Add(1)
 		cteBlock, err := s.GetBlockByHeight(context.Background(), height)
-		s.mainChainRebuilding.Store(false)
+		s.mainChainRebuilding.Add(-1)
 		require.NoError(t, err, "height=%d CTE path", height)
 
 		assert.Equal(t, fastBlock.Hash().String(), cteBlock.Hash().String(),
 			"fast path and CTE must return the same block at height %d", height)
 	}
+}
+
+// TestOnMainChain_BoundedWindowRespected verifies that rebuildOnMainChainFlag with
+// full=false does NOT touch blocks whose height is below the window floor. This is
+// the safety property that makes the optimization valid: blocks deeper than
+// 10×CoinbaseMaturity are never rewritten.
+func TestOnMainChain_BoundedWindowRespected(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	// CoinbaseMaturity=0 → window size 0 → windowBottom == bestHeight.
+	// With bestHeight=3, only the tip (block3) is in the window; block1 and block2
+	// are outside it.
+	tSettings.ChainCfgParams.CoinbaseMaturity = 0
+
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
+	require.NoError(t, err)
+
+	// Corrupt block1's flag via direct SQL — this simulates a deep inconsistency
+	// (e.g., from migration) that bounded rebuild must leave untouched.
+	_, err = s.db.Exec(`UPDATE blocks SET on_main_chain = false WHERE hash = $1`, block1.Hash().CloneBytes())
+	require.NoError(t, err)
+	require.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "pre-condition: block1 flag cleared")
+
+	// Bounded rebuild must NOT fix block1 (it is below windowBottom).
+	err = s.rebuildOnMainChainFlag(context.Background(), false)
+	require.NoError(t, err)
+	assert.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
+		"bounded rebuild must not touch blocks below windowBottom")
+
+	// Full rebuild must fix block1 (walks all the way to genesis).
+	err = s.rebuildOnMainChainFlag(context.Background(), true)
+	require.NoError(t, err)
+	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
+		"full rebuild must correct deep flags")
+}
+
+// TestOnMainChain_MigrationDetection verifies that needsFullOnMainChainRebuild
+// returns true when on_main_chain is unpopulated relative to the canonical chain.
+func TestOnMainChain_MigrationDetection(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
+	require.NoError(t, err)
+
+	// With all flags correct, no full rebuild needed.
+	needsFull, err := s.needsFullOnMainChainRebuild(context.Background())
+	require.NoError(t, err)
+	assert.False(t, needsFull, "consistent state requires no full rebuild")
+
+	// Simulate migration: clear all flags.
+	_, err = s.db.Exec(`UPDATE blocks SET on_main_chain = false`)
+	require.NoError(t, err)
+
+	needsFull, err = s.needsFullOnMainChainRebuild(context.Background())
+	require.NoError(t, err)
+	assert.True(t, needsFull, "unpopulated state requires full rebuild")
 }

--- a/stores/blockchain/sql/OnMainChain_test.go
+++ b/stores/blockchain/sql/OnMainChain_test.go
@@ -4,14 +4,55 @@ import (
 	"context"
 	"database/sql"
 	"net/url"
+	"runtime"
 	"testing"
+	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/blockchain/options"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newOnMainChainTestStore creates a *SQL backed by an sqlitememory DB, waits
+// for the background startup rebuild to complete, and returns the store ready
+// for use. The caller is responsible for s.Close() (via t.Cleanup).
+func newOnMainChainTestStore(t *testing.T) *SQL {
+	t.Helper()
+	return newOnMainChainTestStoreWith(t, nil)
+}
+
+// newOnMainChainTestStoreWith is the same as newOnMainChainTestStore but lets
+// the caller mutate settings before the store is created (e.g. to tweak
+// CoinbaseMaturity or enable UseInMemoryChainCheck).
+func newOnMainChainTestStoreWith(t *testing.T, mutate func(*settings.Settings)) *SQL {
+	t.Helper()
+	tSettings := test.CreateBaseTestSettings(t)
+	if mutate != nil {
+		mutate(tSettings)
+	}
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	waitForStartupRebuild(t, s)
+	return s
+}
+
+// storeBlocks stores a sequence of blocks via StoreBlock, failing the test on
+// any error. Returns the list for convenience.
+func storeBlocks(t *testing.T, s *SQL, blocks ...*model.Block) {
+	t.Helper()
+	for i, b := range blocks {
+		_, _, err := s.StoreBlock(context.Background(), b, "peer")
+		require.NoError(t, err, "store block %d (height %d)", i, b.Height)
+	}
+}
 
 // getOnMainChain reads the on_main_chain flag directly from the database for the block
 // with the given hash. Returns false if the block does not exist.
@@ -28,306 +69,196 @@ func getOnMainChain(t *testing.T, s *SQL, hashBytes []byte) bool {
 
 // TestOnMainChain_Genesis verifies that the genesis block is always marked on_main_chain.
 func TestOnMainChain_Genesis(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	genesisHash := s.chainParams.GenesisHash
+	require.True(t, getOnMainChain(t, s, genesisHash[:]), "genesis must be on_main_chain")
+}
 
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
+// TestOnMainChain_GenesisOverrideWhenPreBestHashIsNil verifies the genesis
+// override path inside storeBlock: when the DB is empty at insert time, the
+// outer StoreBlock computes onMainChain=false (preBestHash is nil), but the
+// override flips it to true for non-invalid genesis. This exercises the
+// explicit storeBlock.go `if genesis { onMainChain = !storeAsInvalid }` branch
+// independently of the automatic New() flow.
+func TestOnMainChain_GenesisOverrideWhenPreBestHashIsNil(t *testing.T) {
+	s := newOnMainChainTestStore(t)
 
-	genesisHash := tSettings.ChainCfgParams.GenesisHash
-	assert.True(t, getOnMainChain(t, s, genesisHash[:]), "genesis must be on_main_chain")
+	// Wipe genesis to simulate a fresh, never-seeded DB.
+	_, err := s.db.Exec(`DELETE FROM blocks`)
+	require.NoError(t, err)
+	require.False(t, getOnMainChain(t, s, s.chainParams.GenesisHash[:]),
+		"pre-condition: genesis row deleted")
+
+	// Re-seed genesis. This goes through StoreBlock → storeBlock, where
+	// preBestHash is nil (empty DB) so the outer logic computes onMainChain=false.
+	// The override inside storeBlock must set it back to true.
+	require.NoError(t, s.insertGenesisTransaction(ulogger.TestLogger{}))
+
+	require.True(t, getOnMainChain(t, s, s.chainParams.GenesisHash[:]),
+		"genesis override must set on_main_chain=true even when preBestHash is nil")
 }
 
 // TestOnMainChain_NormalExtend verifies that a block extending the main chain gets
 // on_main_chain = true in its INSERT (no separate UPDATE needed).
 func TestOnMainChain_NormalExtend(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
 
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
-
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 must be on_main_chain")
-	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 must be on_main_chain")
-	assert.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 must be on_main_chain")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 must be on_main_chain")
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 must be on_main_chain")
+	require.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 must be on_main_chain")
 }
 
 // TestOnMainChain_ForkBlock verifies that a fork block (non-best) is NOT on_main_chain.
 func TestOnMainChain_ForkBlock(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
 
 	// blockAlternative2 has same parent as block2 but less chain_work (older timestamp) —
 	// it is a fork that doesn't become the best block.
-	_, _, err = s.StoreBlock(context.Background(), blockAlternative2, "peer")
-	require.NoError(t, err)
+	storeBlocks(t, s, blockAlternative2)
 
-	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 (best) must be on_main_chain")
-	assert.False(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "fork block must NOT be on_main_chain")
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 (best) must be on_main_chain")
+	require.False(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "fork block must NOT be on_main_chain")
 }
 
 // TestOnMainChain_InvalidBlock verifies that blocks stored with WithInvalid are NOT on_main_chain.
 func TestOnMainChain_InvalidBlock(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
+	s := newOnMainChainTestStore(t)
+
+	_, _, err := s.StoreBlock(context.Background(), block1, "peer", options.WithInvalid(true))
 	require.NoError(t, err)
 
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer", options.WithInvalid(true))
-	require.NoError(t, err)
-
-	assert.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "invalid block must NOT be on_main_chain")
+	require.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "invalid block must NOT be on_main_chain")
 }
 
 // TestOnMainChain_InvalidateBlock verifies that InvalidateBlock clears on_main_chain for the
 // invalidated block and that the previous block remains on the main chain.
 func TestOnMainChain_InvalidateBlock(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
+
+	_, err := s.InvalidateBlock(context.Background(), block3.Hash())
 	require.NoError(t, err)
 
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
-
-	_, err = s.InvalidateBlock(context.Background(), block3.Hash())
-	require.NoError(t, err)
-
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 still on main chain after block3 invalidated")
-	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 still on main chain after block3 invalidated")
-	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "invalidated block3 must NOT be on_main_chain")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 still on main chain after block3 invalidated")
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 still on main chain after block3 invalidated")
+	require.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "invalidated block3 must NOT be on_main_chain")
 }
 
 // TestOnMainChain_RevalidateBlock verifies that RevalidateBlock restores on_main_chain for a
 // block if it becomes the best chain after revalidation.
 func TestOnMainChain_RevalidateBlock(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
 
 	// Invalidate then revalidate block3
-	_, err = s.InvalidateBlock(context.Background(), block3.Hash())
+	_, err := s.InvalidateBlock(context.Background(), block3.Hash())
 	require.NoError(t, err)
-	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 off-chain after invalidation")
+	require.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 off-chain after invalidation")
 
 	err = s.RevalidateBlock(context.Background(), block3.Hash())
 	require.NoError(t, err)
-	assert.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 back on main chain after revalidation")
+	require.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 back on main chain after revalidation")
 }
 
 // TestOnMainChain_StartupRebuild verifies that rebuildOnMainChainFlag correctly restores
 // on_main_chain flags from scratch. This simulates crash recovery where flags were left
 // in a partial state (all cleared to false).
 func TestOnMainChain_StartupRebuild(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
 
 	// Simulate a crash mid-rebuild: zero out all flags
-	_, err = s.db.Exec(`UPDATE blocks SET on_main_chain = false`)
+	_, err := s.db.Exec(`UPDATE blocks SET on_main_chain = false`)
 	require.NoError(t, err)
 
-	assert.False(t, getOnMainChain(t, s, tSettings.ChainCfgParams.GenesisHash[:]), "pre-condition: flags are cleared")
-	assert.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "pre-condition: flags are cleared")
-	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "pre-condition: flags are cleared")
+	require.False(t, getOnMainChain(t, s, s.chainParams.GenesisHash[:]), "pre-condition: flags are cleared")
+	require.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "pre-condition: flags are cleared")
+	require.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "pre-condition: flags are cleared")
 
 	// Startup rebuild should restore correct flags
 	s.responseCache.DeleteAll()
 	err = s.rebuildOnMainChainFlag(context.Background(), false)
 	require.NoError(t, err)
 
-	assert.True(t, getOnMainChain(t, s, tSettings.ChainCfgParams.GenesisHash[:]), "genesis on_main_chain after rebuild")
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 on_main_chain after rebuild")
-	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 on_main_chain after rebuild")
+	require.True(t, getOnMainChain(t, s, s.chainParams.GenesisHash[:]), "genesis on_main_chain after rebuild")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 on_main_chain after rebuild")
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 on_main_chain after rebuild")
 }
 
 // TestOnMainChain_ReorgClearsOldChain verifies that when a fork grows longer and becomes
 // the new main chain (reorg), all blocks on the old chain have on_main_chain = false
 // and all blocks on the new chain have on_main_chain = true.
 func TestOnMainChain_ReorgClearsOldChain(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
+	s := newOnMainChainTestStore(t)
 
 	// Build main chain: genesis → block1 → block2 → block3
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
+	storeBlocks(t, s, block1, block2, block3)
 
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 initially on main chain")
-	assert.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 initially on main chain")
-	assert.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 initially on main chain")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 initially on main chain")
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 initially on main chain")
+	require.True(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 initially on main chain")
 
 	// Build a competing fork: genesis → block1 → altBlock2 → forkBlock3 → forkBlock4
 	// The fork must have more chain_work than the main chain to trigger a reorg.
-	_, _, err = s.StoreBlock(context.Background(), blockAlternative2, "peer")
-	require.NoError(t, err)
-
 	forkBlock3 := createBlock3OnFork(blockAlternative2)
-	_, _, err = s.StoreBlock(context.Background(), forkBlock3, "peer")
-	require.NoError(t, err)
-
 	forkBlock4 := createBlock3OnFork(forkBlock3)
-	_, _, err = s.StoreBlock(context.Background(), forkBlock4, "peer")
-	require.NoError(t, err)
+	storeBlocks(t, s, blockAlternative2, forkBlock3, forkBlock4)
 
 	// forkBlock4 should now be the best block (more chain_work due to one extra block).
 	// The old chain (block2, block3) must be off-chain; the new fork must be on-chain.
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 (common ancestor) still on main chain")
-	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 off-chain after reorg")
-	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 off-chain after reorg")
-	assert.True(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "altBlock2 on new main chain")
-	assert.True(t, getOnMainChain(t, s, forkBlock3.Hash().CloneBytes()), "forkBlock3 on new main chain")
-	assert.True(t, getOnMainChain(t, s, forkBlock4.Hash().CloneBytes()), "forkBlock4 (new tip) on main chain")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 (common ancestor) still on main chain")
+	require.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 off-chain after reorg")
+	require.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 off-chain after reorg")
+	require.True(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "altBlock2 on new main chain")
+	require.True(t, getOnMainChain(t, s, forkBlock3.Hash().CloneBytes()), "forkBlock3 on new main chain")
+	require.True(t, getOnMainChain(t, s, forkBlock4.Hash().CloneBytes()), "forkBlock4 (new tip) on main chain")
 }
 
 // TestOnMainChain_LongFork verifies on_main_chain correctness across a multi-block reorg
 // where the fork is 3 blocks deep before surpassing the main chain.
 func TestOnMainChain_LongFork(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	// Main chain: genesis → block1 → block2
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
 
 	// Fork from block1: genesis → block1 → altBlock2 → forkB3 → forkB4 → forkB5
 	// By the time forkB5 is added the fork has more work and causes a reorg.
-	_, _, err = s.StoreBlock(context.Background(), blockAlternative2, "peer")
-	require.NoError(t, err)
 	forkB3 := createBlock3OnFork(blockAlternative2)
-	_, _, err = s.StoreBlock(context.Background(), forkB3, "peer")
-	require.NoError(t, err)
 	forkB4 := createBlock3OnFork(forkB3)
-	_, _, err = s.StoreBlock(context.Background(), forkB4, "peer")
-	require.NoError(t, err)
 	forkB5 := createBlock3OnFork(forkB4)
-	_, _, err = s.StoreBlock(context.Background(), forkB5, "peer")
-	require.NoError(t, err)
+	storeBlocks(t, s, blockAlternative2, forkB3, forkB4, forkB5)
 
 	// After the reorg: block2 should be off-chain; the entire 4-block fork should be on-chain.
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 (common ancestor) still on main chain")
-	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 cleared after long fork reorg")
-	assert.True(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "altBlock2 on new chain")
-	assert.True(t, getOnMainChain(t, s, forkB3.Hash().CloneBytes()), "forkB3 on new chain")
-	assert.True(t, getOnMainChain(t, s, forkB4.Hash().CloneBytes()), "forkB4 on new chain")
-	assert.True(t, getOnMainChain(t, s, forkB5.Hash().CloneBytes()), "forkB5 (tip) on new chain")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 (common ancestor) still on main chain")
+	require.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 cleared after long fork reorg")
+	require.True(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "altBlock2 on new chain")
+	require.True(t, getOnMainChain(t, s, forkB3.Hash().CloneBytes()), "forkB3 on new chain")
+	require.True(t, getOnMainChain(t, s, forkB4.Hash().CloneBytes()), "forkB4 on new chain")
+	require.True(t, getOnMainChain(t, s, forkB5.Hash().CloneBytes()), "forkB5 (tip) on new chain")
 }
 
 // TestOnMainChain_InvalidBlockFork verifies that blocks on a fork that gets invalidated
 // have on_main_chain = false and the original main chain is unaffected.
 func TestOnMainChain_InvalidBlockFork(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	// Main chain: genesis → block1 → block2 → block3
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
 
 	// Invalidate block2 — this should cascade to block3 as well
-	_, err = s.InvalidateBlock(context.Background(), block2.Hash())
+	_, err := s.InvalidateBlock(context.Background(), block2.Hash())
 	require.NoError(t, err)
 
 	// After invalidating block2: block1 is the new best, block2 and block3 are off-chain
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 is new tip after invalidation")
-	assert.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 invalidated, off-chain")
-	assert.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 invalidated (child of invalid block2), off-chain")
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "block1 is new tip after invalidation")
+	require.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 invalidated, off-chain")
+	require.False(t, getOnMainChain(t, s, block3.Hash().CloneBytes()), "block3 invalidated (child of invalid block2), off-chain")
 }
 
 // TestOnMainChain_ConsistentWithGetBlockByHeight verifies that the fast-path query
 // (on_main_chain = true) returns the same block as the CTE fallback.
 func TestOnMainChain_ConsistentWithGetBlockByHeight(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
 
 	for _, height := range []uint32{1, 2, 3} {
 		// Fast path (mainChainRebuilding = 0 by default)
@@ -340,7 +271,7 @@ func TestOnMainChain_ConsistentWithGetBlockByHeight(t *testing.T) {
 		s.mainChainRebuilding.Add(-1)
 		require.NoError(t, err, "height=%d CTE path", height)
 
-		assert.Equal(t, fastBlock.Hash().String(), cteBlock.Hash().String(),
+		require.Equal(t, fastBlock.Hash().String(), cteBlock.Hash().String(),
 			"fast path and CTE must return the same block at height %d", height)
 	}
 }
@@ -350,65 +281,43 @@ func TestOnMainChain_ConsistentWithGetBlockByHeight(t *testing.T) {
 // the safety property that makes the optimization valid: blocks deeper than
 // 10×CoinbaseMaturity are never rewritten.
 func TestOnMainChain_BoundedWindowRespected(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
 	// CoinbaseMaturity=0 → window size 0 → windowBottom == bestHeight.
 	// With bestHeight=3, only the tip (block3) is in the window; block1 and block2
 	// are outside it.
-	tSettings.ChainCfgParams.CoinbaseMaturity = 0
-
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block3, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStoreWith(t, func(ts *settings.Settings) {
+		ts.ChainCfgParams.CoinbaseMaturity = 0
+	})
+	storeBlocks(t, s, block1, block2, block3)
 
 	// Corrupt block1's flag via direct SQL — this simulates a deep inconsistency
 	// (e.g., from migration) that bounded rebuild must leave untouched.
-	_, err = s.db.Exec(`UPDATE blocks SET on_main_chain = false WHERE hash = $1`, block1.Hash().CloneBytes())
+	_, err := s.db.Exec(`UPDATE blocks SET on_main_chain = false WHERE hash = $1`, block1.Hash().CloneBytes())
 	require.NoError(t, err)
 	require.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()), "pre-condition: block1 flag cleared")
 
 	// Bounded rebuild must NOT fix block1 (it is below windowBottom).
 	err = s.rebuildOnMainChainFlag(context.Background(), false)
 	require.NoError(t, err)
-	assert.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
+	require.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
 		"bounded rebuild must not touch blocks below windowBottom")
 
 	// Full rebuild must fix block1 (walks all the way to genesis).
 	err = s.rebuildOnMainChainFlag(context.Background(), true)
 	require.NoError(t, err)
-	assert.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
 		"full rebuild must correct deep flags")
 }
 
 // TestOnMainChain_MigrationDetection verifies that needsFullOnMainChainRebuild
 // returns true when on_main_chain is unpopulated relative to the canonical chain.
 func TestOnMainChain_MigrationDetection(t *testing.T) {
-	tSettings := test.CreateBaseTestSettings(t)
-	storeURL, err := url.Parse("sqlitememory:///")
-	require.NoError(t, err)
-
-	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
-	require.NoError(t, err)
-	defer s.Close()
-
-	_, _, err = s.StoreBlock(context.Background(), block1, "peer")
-	require.NoError(t, err)
-	_, _, err = s.StoreBlock(context.Background(), block2, "peer")
-	require.NoError(t, err)
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
 
 	// With all flags correct, no full rebuild needed.
 	needsFull, err := s.needsFullOnMainChainRebuild(context.Background())
 	require.NoError(t, err)
-	assert.False(t, needsFull, "consistent state requires no full rebuild")
+	require.False(t, needsFull, "consistent state requires no full rebuild")
 
 	// Simulate migration: clear all flags.
 	_, err = s.db.Exec(`UPDATE blocks SET on_main_chain = false`)
@@ -416,5 +325,608 @@ func TestOnMainChain_MigrationDetection(t *testing.T) {
 
 	needsFull, err = s.needsFullOnMainChainRebuild(context.Background())
 	require.NoError(t, err)
-	assert.True(t, needsFull, "unpopulated state requires full rebuild")
+	require.True(t, needsFull, "unpopulated state requires full rebuild")
+}
+
+// TestStoreBlock_GuardReleasedAfterCall verifies that StoreBlock's defer runs so
+// mainChainRebuilding returns to 0 after every exit path (normal extend, reorg,
+// fork). If the defer leaks, readers are forever stuck on the CTE fallback.
+func TestStoreBlock_GuardReleasedAfterCall(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "baseline: guard is 0")
+
+	// Normal extend.
+	storeBlocks(t, s, block1)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released after extend")
+
+	// Fork branch (non-best).
+	storeBlocks(t, s, block2, blockAlternative2)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released after fork insert")
+
+	// Reorg: build fork deep enough to overtake main chain.
+	forkB3 := createBlock3OnFork(blockAlternative2)
+	forkB4 := createBlock3OnFork(forkB3)
+	storeBlocks(t, s, forkB3, forkB4)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released after reorg")
+}
+
+// TestRevalidateBlock_GuardReleasedAfterCall verifies RevalidateBlock's defer runs.
+func TestRevalidateBlock_GuardReleasedAfterCall(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
+
+	_, err := s.InvalidateBlock(context.Background(), block2.Hash())
+	require.NoError(t, err)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released after InvalidateBlock")
+
+	err = s.RevalidateBlock(context.Background(), block2.Hash())
+	require.NoError(t, err)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released after RevalidateBlock")
+}
+
+// TestRebuildOnMainChainFlag_GuardHeldDuringCall verifies the invariant that
+// the guard is > 0 for the entire duration of rebuildOnMainChainFlag. The test
+// is deterministic (no polling for arbitrary events): we take a long-running
+// write transaction on a separate connection, which blocks rebuild's internal
+// UPDATE until we release. While blocked, the rebuild goroutine has already
+// executed its synchronous `Add(1)` on entry — we can observe guard > 0 and
+// unblock in a controlled sequence. The original polling-based variant of this
+// test was prone to scheduler-dependent flakes.
+//
+// This test covers the mechanism used by StoreBlock, InvalidateBlock, and
+// RevalidateBlock (they all call rebuildOnMainChainFlag through the same
+// code path); the balanced Add(1)/Add(-1) pairs at each call site are
+// covered separately by the *GuardReleasedAfterCall tests above.
+func TestRebuildOnMainChainFlag_GuardHeldDuringCall(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "baseline")
+
+	// Take a write lock on another tx. SQLite acquires the database-level
+	// RESERVED lock on the first write of a transaction, blocking subsequent
+	// writers until commit/rollback. rebuildOnMainChainFlag's first UPDATE
+	// will block inside the goroutine below.
+	blocker, err := s.db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = blocker.Exec(`INSERT INTO state (key, data) VALUES ('guard_held_test_lock', X'00')`)
+	require.NoError(t, err)
+
+	// Launch the rebuild. It will Add(1), begin tx, SELECT best block, then
+	// block on the first UPDATE (waiting for blocker to release).
+	rebuildDone := make(chan error, 1)
+	go func() {
+		rebuildDone <- s.rebuildOnMainChainFlag(context.Background(), false)
+	}()
+
+	// Wait for the goroutine to enter and increment the guard. Because the
+	// rebuild is stuck on the lock, this observation is not racing completion —
+	// the rebuild cannot progress until we release blocker.
+	guardDeadline := time.Now().Add(5 * time.Second)
+	for s.mainChainRebuilding.Load() == 0 {
+		if time.Now().After(guardDeadline) {
+			_ = blocker.Rollback()
+			<-rebuildDone
+			t.Fatal("rebuild goroutine never incremented guard")
+		}
+		runtime.Gosched()
+	}
+
+	// At this point the rebuild is mid-flight with guard > 0. Assert the
+	// documented invariant — a reader calling CheckBlockIsInCurrentChain now
+	// would take the CTE fallback.
+	require.Greater(t, s.mainChainRebuilding.Load(), int32(0),
+		"guard must be > 0 while rebuild is in progress")
+
+	// Release the blocker so the rebuild can finish.
+	require.NoError(t, blocker.Rollback())
+
+	select {
+	case err := <-rebuildDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("rebuild did not complete after blocker released")
+	}
+
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released after rebuild returns")
+}
+
+// TestGetLatestBlockHeaderFromBlockLocator_ForkTipFallback verifies the fix for
+// the semantic divergence: when bestBlockHash is a fork block (on_main_chain=false)
+// the function must fall back to the CTE and return the fork's ancestor, not a
+// same-height main-chain substitute.
+func TestGetLatestBlockHeaderFromBlockLocator_ForkTipFallback(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+
+	// Main chain: genesis → block1 → block2. Fork at height 2: blockAlternative2
+	// (same parent as block2, different hash).
+	storeBlocks(t, s, block1, block2, blockAlternative2)
+
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "block2 on main chain")
+	require.False(t, getOnMainChain(t, s, blockAlternative2.Hash().CloneBytes()), "blockAlternative2 is fork")
+
+	// Query from the fork tip with a locator that contains the fork tip itself.
+	// Expected (CTE): highest locator block that's an ancestor of blockAlternative2
+	// = blockAlternative2. The fast path would instead return block2 (same height,
+	// on main chain, in locator) — semantically wrong.
+	locator := []chainhash.Hash{*blockAlternative2.Hash(), *block1.Hash()}
+	header, meta, err := s.GetLatestBlockHeaderFromBlockLocator(context.Background(), blockAlternative2.Hash(), locator)
+	require.NoError(t, err)
+	require.NotNil(t, header)
+	require.Equal(t, blockAlternative2.Hash().String(), header.Hash().String(),
+		"fork-tip caller must receive the fork block, not a main-chain block at the same height")
+	require.EqualValues(t, 2, meta.Height)
+}
+
+// TestGetLatestBlockHeaderFromBlockLocator_MainChainTipFastPath verifies the fast
+// path still works for the common case (bestBlockHash on main chain).
+func TestGetLatestBlockHeaderFromBlockLocator_MainChainTipFastPath(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
+
+	locator := []chainhash.Hash{*block3.Hash(), *block2.Hash(), *block1.Hash()}
+	header, meta, err := s.GetLatestBlockHeaderFromBlockLocator(context.Background(), block3.Hash(), locator)
+	require.NoError(t, err)
+	require.NotNil(t, header)
+	require.Equal(t, block3.Hash().String(), header.Hash().String(), "highest locator match must be returned")
+	require.EqualValues(t, 3, meta.Height)
+}
+
+// TestCheckBlockIsInCurrentChainSQL_SingleQueryMultipleIDs verifies the new
+// single-query IN() fast path returns correct ANY-of semantics across multiple
+// IDs in one round-trip.
+func TestCheckBlockIsInCurrentChainSQL_SingleQueryMultipleIDs(t *testing.T) {
+	// Keep useInMemoryChainCheck default (typically false in test settings) so
+	// CheckBlockIsInCurrentChain routes through the SQL fallback.
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, blockAlternative2)
+
+	mainID := getBlockID(t, s, block2.Hash().CloneBytes())
+	forkID := getBlockID(t, s, blockAlternative2.Hash().CloneBytes())
+	require.NotEqualValues(t, 0, mainID)
+	require.NotEqualValues(t, 0, forkID)
+
+	// All on-chain: true.
+	result, err := s.checkBlockIsInCurrentChainSQL(context.Background(), []uint32{mainID})
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// Any-of semantics: one on-chain plus one off-chain must return true.
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), []uint32{forkID, mainID})
+	require.NoError(t, err)
+	require.True(t, result, "ANY-of: one on-chain ID is enough")
+
+	// All off-chain: false.
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), []uint32{forkID})
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// Non-existent IDs must be ignored silently, not return an error.
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), []uint32{9_999_999, mainID})
+	require.NoError(t, err)
+	require.True(t, result, "ANY-of including unknown ID plus on-chain ID must succeed")
+
+	// Unknown-only returns false without error.
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), []uint32{9_999_998, 9_999_997})
+	require.NoError(t, err)
+	require.False(t, result)
+}
+
+// TestCheckBlockIsInCurrentChainSQL_FastAndCTEAgree verifies that the fast path
+// and CTE fallback return the same answer on identical input, across multiple IDs.
+func TestCheckBlockIsInCurrentChainSQL_FastAndCTEAgree(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, blockAlternative2)
+
+	mainID := getBlockID(t, s, block2.Hash().CloneBytes())
+	forkID := getBlockID(t, s, blockAlternative2.Hash().CloneBytes())
+
+	cases := [][]uint32{
+		{mainID},
+		{forkID},
+		{mainID, forkID},
+		{forkID, mainID},
+		{9_999_999, mainID},
+		{9_999_999},
+	}
+	for _, ids := range cases {
+		fast, err := s.checkBlockIsInCurrentChainSQL(context.Background(), ids)
+		require.NoError(t, err, "fast path: %v", ids)
+
+		s.mainChainRebuilding.Add(1)
+		cte, err := s.checkBlockIsInCurrentChainSQL(context.Background(), ids)
+		s.mainChainRebuilding.Add(-1)
+		require.NoError(t, err, "CTE path: %v", ids)
+
+		require.Equal(t, fast, cte, "fast and CTE must agree for IDs=%v", ids)
+	}
+}
+
+// TestGetBlockGraphData_GenesisIncludedBlock1Excluded verifies the exact
+// semantics of the fast path match the original CTE: genesis is included via
+// the CTE's anchor clause, and block at height 1 is excluded because its
+// parent_id equals genesis's id (0), which the CTE's `parent_id != 0` guard
+// drops.
+func TestGetBlockGraphData_GenesisIncludedBlock1Excluded(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3)
+
+	// period 0 — include everything with block_time >= 0.
+	data, err := s.GetBlockGraphData(context.Background(), 0)
+	require.NoError(t, err)
+
+	// Fast path and CTE must agree on shape; verify both call sites.
+	fastCount := len(data.DataPoints)
+
+	s.mainChainRebuilding.Add(1)
+	data, err = s.GetBlockGraphData(context.Background(), 0)
+	s.mainChainRebuilding.Add(-1)
+	require.NoError(t, err)
+	cteCount := len(data.DataPoints)
+
+	require.Equal(t, cteCount, fastCount, "fast and CTE must yield the same count")
+}
+
+// TestNeedsFullOnMainChainRebuild_CanceledContextReturnsError verifies the
+// error surface of needsFullOnMainChainRebuild when the context is canceled.
+// The companion test TestStartupFallback_DbErrorTriggersFullRebuild covers
+// the downstream "on error, opt into full rebuild" startup behaviour.
+func TestNeedsFullOnMainChainRebuild_CanceledContextReturnsError(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.needsFullOnMainChainRebuild(canceledCtx)
+	require.Error(t, err, "canceled context must surface an error")
+}
+
+// TestStartupFallback_DbErrorTriggersFullRebuild verifies the startup goroutine's
+// behaviour when needsFullOnMainChainRebuild fails: it must fall back to a full
+// rebuild (not a bounded one). The previous test only checked the error surface.
+// This test exercises the fallback end-to-end by:
+//  1. Creating a store, letting the startup rebuild run
+//  2. Storing several blocks
+//  3. Corrupting a block deeper than the bounded window
+//  4. Calling the same function the startup goroutine calls (full=true when
+//     needsFull returns an error or true) and verifying the deep block is fixed
+//
+// We can't directly trigger a DB error mid-startup, but we can verify the
+// semantic equivalence: when full=true is chosen, rebuildOnMainChainFlag
+// corrects blocks outside the bounded window.
+func TestStartupFallback_DbErrorTriggersFullRebuild(t *testing.T) {
+	// CoinbaseMaturity=0 → bounded window is just the tip. A corruption below
+	// the window can only be corrected by a full rebuild.
+	s := newOnMainChainTestStoreWith(t, func(ts *settings.Settings) {
+		ts.ChainCfgParams.CoinbaseMaturity = 0
+	})
+	storeBlocks(t, s, block1, block2, block3)
+
+	// Corrupt block1 outside the bounded window.
+	_, err := s.db.Exec(`UPDATE blocks SET on_main_chain = false WHERE hash = $1`, block1.Hash().CloneBytes())
+	require.NoError(t, err)
+	require.False(t, getOnMainChain(t, s, block1.Hash().CloneBytes()))
+
+	// Simulate the startup goroutine's error-path choice: full=true.
+	err = s.rebuildOnMainChainFlag(context.Background(), true)
+	require.NoError(t, err)
+	require.True(t, getOnMainChain(t, s, block1.Hash().CloneBytes()),
+		"full rebuild (chosen on needsFull error) must correct blocks outside the bounded window")
+}
+
+// getBlockID is a test helper that reads the blocks.id for a block hash.
+func getBlockID(t *testing.T, s *SQL, hashBytes []byte) uint32 {
+	t.Helper()
+	var id uint32
+	err := s.db.QueryRow(`SELECT id FROM blocks WHERE hash = $1`, hashBytes).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+// TestRevalidateBlock_NonExistentBlock verifies RevalidateBlock returns an error
+// for a block that does not exist, without touching the on_main_chain flag.
+func TestRevalidateBlock_NonExistentBlock(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+
+	bogus, err := chainhash.NewHashFromStr("1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+
+	err = s.RevalidateBlock(context.Background(), bogus)
+	require.Error(t, err, "revalidating a non-existent block must return an error")
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard not taken when block does not exist")
+}
+
+// TestRevalidateBlock_WithInMemoryChainCheck exercises the useInMemoryChainCheck
+// branch inside RevalidateBlock (resetChainWalkCache + triggerRebuildOffChainSet).
+func TestRevalidateBlock_WithInMemoryChainCheck(t *testing.T) {
+	s := newOnMainChainTestStoreWith(t, func(ts *settings.Settings) {
+		ts.BlockChain.UseInMemoryChainCheck = true
+	})
+	storeBlocks(t, s, block1, block2)
+
+	_, err := s.InvalidateBlock(context.Background(), block2.Hash())
+	require.NoError(t, err)
+	require.False(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "post-invalidate: off chain")
+
+	err = s.RevalidateBlock(context.Background(), block2.Hash())
+	require.NoError(t, err)
+	require.True(t, getOnMainChain(t, s, block2.Hash().CloneBytes()), "post-revalidate: back on main chain")
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard released")
+}
+
+// TestInvalidateBlock_GuardBalancedOnError verifies that InvalidateBlock
+// balances its mainChainRebuilding Add(1)/Add(-1) regardless of which path
+// returns an error. The two escape paths after the guard is taken are:
+//  1. GetBlockExists / exists-check fails — guard never taken (covered by
+//     TestRevalidateBlock_NonExistentBlock for the mirror function).
+//  2. QueryContext fails AFTER guard is taken — guard must still be released
+//     via the defer.
+//
+// We cannot deterministically trigger path (2) via a canceled context because
+// the pre-check also uses the same context, so we instead verify the invariant
+// holistically: under a variety of early-cancellation scenarios, the guard
+// counter must return to 0.
+func TestInvalidateBlock_GuardBalancedOnError(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
+
+	// Pre-canceled context: whichever DB call fails first (GetBlockExists or
+	// the main QueryContext), the defer must leave the counter balanced.
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := 0; i < 5; i++ {
+		_, _ = s.InvalidateBlock(canceledCtx, block2.Hash())
+		require.EqualValues(t, 0, s.mainChainRebuilding.Load(),
+			"guard must be balanced after error path #%d", i)
+	}
+
+	// Non-existent block: exits before the guard is taken.
+	bogus, err := chainhash.NewHashFromStr("1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+	_, _ = s.InvalidateBlock(context.Background(), bogus)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard balanced after non-existent path")
+
+	// Successful invalidation: must also end at 0.
+	_, err = s.InvalidateBlock(context.Background(), block2.Hash())
+	require.NoError(t, err)
+	require.EqualValues(t, 0, s.mainChainRebuilding.Load(), "guard balanced after success")
+}
+
+// TestCheckBlockIsInCurrentChainSQL_EmptyInput verifies defense-in-depth: the
+// direct-caller entry point must not panic on an empty input slice (the public
+// wrapper checks this, but callers like benchmarks may reach the SQL path
+// directly).
+func TestCheckBlockIsInCurrentChainSQL_EmptyInput(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+
+	// Fast path.
+	result, err := s.checkBlockIsInCurrentChainSQL(context.Background(), nil)
+	require.NoError(t, err)
+	require.False(t, result, "empty input is not on main chain")
+
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), []uint32{})
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// CTE fallback branch.
+	s.mainChainRebuilding.Add(1)
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), nil)
+	s.mainChainRebuilding.Add(-1)
+	require.NoError(t, err)
+	require.False(t, result)
+}
+
+// TestCheckBlockIsInCurrentChainSQL_MultiBatch exercises the batching loop when
+// len(blockIDs) exceeds maxIDsPerCheckBatch, ensuring the continue-on-no-match
+// branch is covered and a real match in a later batch is found.
+func TestCheckBlockIsInCurrentChainSQL_MultiBatch(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2)
+
+	mainID := getBlockID(t, s, block2.Hash().CloneBytes())
+
+	// Build a slice that spans two batches: batch 1 is all misses, batch 2
+	// contains the real on-chain ID as the last element. Forces the loop to
+	// iterate past the first batch.
+	ids := make([]uint32, 0, maxIDsPerCheckBatch+1)
+	for i := uint32(1); i <= maxIDsPerCheckBatch; i++ {
+		ids = append(ids, 900_000_000+i) // guaranteed non-existent
+	}
+	ids = append(ids, mainID)
+
+	result, err := s.checkBlockIsInCurrentChainSQL(context.Background(), ids)
+	require.NoError(t, err)
+	require.True(t, result, "match in the second batch must be found")
+
+	// All-miss across multiple batches returns false.
+	onlyMisses := make([]uint32, 0, maxIDsPerCheckBatch+10)
+	for i := uint32(1); i <= maxIDsPerCheckBatch+10; i++ {
+		onlyMisses = append(onlyMisses, 800_000_000+i)
+	}
+	result, err = s.checkBlockIsInCurrentChainSQL(context.Background(), onlyMisses)
+	require.NoError(t, err)
+	require.False(t, result, "all-miss across multiple batches must return false")
+}
+
+// TestGetLatestBlockHeaderFromBlockLocator_PreflightErrorFallsBackToCTE cancels
+// the context before calling to force the preflight query (and the CTE query)
+// to fail. The preflight's error is swallowed; the CTE path then surfaces the
+// cancellation. Verifies the swallow-and-fall-through branch runs.
+func TestGetLatestBlockHeaderFromBlockLocator_PreflightErrorFallsBackToCTE(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := s.GetLatestBlockHeaderFromBlockLocator(canceledCtx, block1.Hash(), []chainhash.Hash{*block1.Hash()})
+	require.Error(t, err, "canceled context must surface as an error via the CTE path")
+}
+
+// withCTEFallback runs f with mainChainRebuilding temporarily bumped so that
+// the CTE fallback is used by any `on_main_chain`-aware query. Used by the
+// fast-vs-CTE consistency tests to compare the two query paths on identical
+// DB state without needing to actually trigger a rebuild.
+func withCTEFallback(s *SQL, f func()) {
+	s.mainChainRebuilding.Add(1)
+	defer s.mainChainRebuilding.Add(-1)
+	s.responseCache.DeleteAll() // ensure the fast-path result is not returned from cache
+	f()
+}
+
+// runConsistency runs the same query once on the fast path and once on the
+// CTE fallback and returns both results for comparison.
+func runConsistency[T any](t *testing.T, s *SQL, run func() (T, error)) (fast, cte T) {
+	t.Helper()
+	// Fast path (mainChainRebuilding == 0 by default).
+	s.responseCache.DeleteAll()
+	fast, err := run()
+	require.NoError(t, err, "fast path")
+
+	// CTE fallback.
+	withCTEFallback(s, func() {
+		var cteErr error
+		cte, cteErr = run()
+		require.NoError(t, cteErr, "CTE path")
+	})
+	return fast, cte
+}
+
+// TestOnMainChain_ConsistentWithGetBlocksByHeight verifies GetBlocksByHeight
+// fast path and CTE fallback return identical blocks across several ranges,
+// including main chain + fork scenarios.
+func TestOnMainChain_ConsistentWithGetBlocksByHeight(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3, blockAlternative2)
+
+	ranges := []struct{ start, end uint32 }{
+		{1, 3}, {0, 3}, {2, 2}, {1, 1}, {3, 3}, {0, 0}, {0, 100},
+	}
+	for _, r := range ranges {
+		fast, cte := runConsistency(t, s, func() ([]*model.Block, error) {
+			return s.GetBlocksByHeight(context.Background(), r.start, r.end)
+		})
+		require.Equal(t, len(cte), len(fast), "len disagree range=[%d,%d]", r.start, r.end)
+		for i := range fast {
+			require.Equal(t, cte[i].Hash().String(), fast[i].Hash().String(),
+				"block %d disagrees at range=[%d,%d]", i, r.start, r.end)
+			require.Equal(t, cte[i].Height, fast[i].Height)
+		}
+	}
+}
+
+// TestOnMainChain_ConsistentWithGetBlockHeadersByHeight verifies
+// GetBlockHeadersByHeight fast path and CTE fallback return identical headers.
+func TestOnMainChain_ConsistentWithGetBlockHeadersByHeight(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3, blockAlternative2)
+
+	ranges := []struct{ start, end uint32 }{
+		{1, 3}, {0, 3}, {2, 2}, {0, 0}, {0, 100},
+	}
+	for _, r := range ranges {
+		type result struct {
+			headers []*model.BlockHeader
+			metas   []*model.BlockHeaderMeta
+		}
+		fast, cte := runConsistency(t, s, func() (result, error) {
+			h, m, err := s.GetBlockHeadersByHeight(context.Background(), r.start, r.end)
+			return result{headers: h, metas: m}, err
+		})
+		require.Equal(t, len(cte.headers), len(fast.headers), "len disagree range=[%d,%d]", r.start, r.end)
+		for i := range fast.headers {
+			require.Equal(t, cte.headers[i].Hash().String(), fast.headers[i].Hash().String(),
+				"header %d disagrees at range=[%d,%d]", i, r.start, r.end)
+			require.Equal(t, cte.metas[i].Height, fast.metas[i].Height)
+			require.Equal(t, cte.metas[i].TxCount, fast.metas[i].TxCount)
+		}
+	}
+}
+
+// TestOnMainChain_ConsistentWithGetLastNBlocks verifies the three branches of
+// GetLastNBlocks (includeOrphans, fromHeight>0, fromHeight==0) agree between
+// fast and CTE paths.
+func TestOnMainChain_ConsistentWithGetLastNBlocks(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	// Build a main chain with a fork so the fast-path on_main_chain filter
+	// meaningfully differs from the full-table scan.
+	storeBlocks(t, s, block1, block2, block3, blockAlternative2)
+
+	// fromHeight > 0 branch.
+	t.Run("fromHeight>0", func(t *testing.T) {
+		fast, cte := runConsistency(t, s, func() ([]*model.BlockInfo, error) {
+			return s.GetLastNBlocks(context.Background(), 5, false, 3)
+		})
+		require.Equal(t, len(cte), len(fast))
+		for i := range fast {
+			require.Equal(t, cte[i].Height, fast[i].Height, "index %d", i)
+			require.Equal(t, cte[i].BlockHeader, fast[i].BlockHeader, "index %d", i)
+		}
+	})
+
+	// fromHeight == 0 branch (default tip-anchored).
+	t.Run("fromHeight=0", func(t *testing.T) {
+		fast, cte := runConsistency(t, s, func() ([]*model.BlockInfo, error) {
+			return s.GetLastNBlocks(context.Background(), 5, false, 0)
+		})
+		require.Equal(t, len(cte), len(fast))
+		for i := range fast {
+			require.Equal(t, cte[i].Height, fast[i].Height)
+			require.Equal(t, cte[i].BlockHeader, fast[i].BlockHeader)
+		}
+	})
+
+	// includeOrphans branch — no CTE/fast-path split, but exercise anyway.
+	t.Run("includeOrphans", func(t *testing.T) {
+		fast, cte := runConsistency(t, s, func() ([]*model.BlockInfo, error) {
+			return s.GetLastNBlocks(context.Background(), 10, true, 0)
+		})
+		require.Equal(t, len(cte), len(fast))
+	})
+}
+
+// TestOnMainChain_ConsistentWithGetBlockStats verifies GetBlockStats fast path
+// and CTE fallback return identical stats.
+func TestOnMainChain_ConsistentWithGetBlockStats(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3, blockAlternative2)
+
+	fast, cte := runConsistency(t, s, func() (*model.BlockStats, error) {
+		return s.GetBlockStats(context.Background())
+	})
+
+	require.Equal(t, cte.BlockCount, fast.BlockCount, "BlockCount")
+	require.Equal(t, cte.TxCount, fast.TxCount, "TxCount")
+	require.Equal(t, cte.MaxHeight, fast.MaxHeight, "MaxHeight")
+	require.Equal(t, cte.AvgBlockSize, fast.AvgBlockSize, "AvgBlockSize")
+	require.Equal(t, cte.AvgTxCountPerBlock, fast.AvgTxCountPerBlock, "AvgTxCountPerBlock")
+	require.Equal(t, cte.FirstBlockTime, fast.FirstBlockTime, "FirstBlockTime")
+	require.Equal(t, cte.LastBlockTime, fast.LastBlockTime, "LastBlockTime")
+	require.Equal(t, cte.ChainWork, fast.ChainWork, "ChainWork")
+}
+
+// TestOnMainChain_ConsistentWithFindBlocksContainingSubtree verifies
+// FindBlocksContainingSubtree fast path and CTE fallback return identical
+// block sets. The test fixture's blocks all reference the same subtree hash,
+// so both paths must find all main-chain blocks that contain it and skip the
+// fork block (not on main chain).
+func TestOnMainChain_ConsistentWithFindBlocksContainingSubtree(t *testing.T) {
+	s := newOnMainChainTestStore(t)
+	storeBlocks(t, s, block1, block2, block3, blockAlternative2)
+
+	// All test blocks share this subtree hash (see sql_test.go test fixtures).
+	subtreeHash, err := chainhash.NewHashFromStr("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098")
+	require.NoError(t, err)
+
+	for _, maxBlocks := range []uint32{0, 1, 5, 100} {
+		fast, cte := runConsistency(t, s, func() ([]*model.Block, error) {
+			return s.FindBlocksContainingSubtree(context.Background(), subtreeHash, maxBlocks)
+		})
+		require.Equal(t, len(cte), len(fast), "len disagree maxBlocks=%d", maxBlocks)
+		for i := range fast {
+			require.Equal(t, cte[i].Hash().String(), fast[i].Hash().String(),
+				"block %d disagrees at maxBlocks=%d", i, maxBlocks)
+		}
+	}
 }

--- a/stores/blockchain/sql/RevalidateBlock.go
+++ b/stores/blockchain/sql/RevalidateBlock.go
@@ -30,9 +30,6 @@ func (s *SQL) RevalidateBlock(ctx context.Context, blockHash *chainhash.Hash) er
 		return errors.NewStorageError("error updating block to valid", err)
 	}
 
-	// Set guard: concurrent queries fall back to the CTE while we fix on_main_chain flags.
-	s.mainChainRebuilding.Store(true)
-
 	rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
 	defer rebuildCancel()
 
@@ -48,8 +45,6 @@ func (s *SQL) RevalidateBlock(ctx context.Context, blockHash *chainhash.Hash) er
 	if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
 		s.logger.Errorf("RevalidateBlock: rebuildOnMainChainFlag: %v", rebuildErr)
 	}
-	// Clear guard — on_main_chain is now consistent, queries can use fast path.
-	s.mainChainRebuilding.Store(false)
 
 	if s.useInMemoryChainCheck {
 		if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {

--- a/stores/blockchain/sql/RevalidateBlock.go
+++ b/stores/blockchain/sql/RevalidateBlock.go
@@ -20,6 +20,12 @@ func (s *SQL) RevalidateBlock(ctx context.Context, blockHash *chainhash.Hash) er
 		return errors.NewStorageError("block %s does not exist", blockHash.String())
 	}
 
+	// Hold the rebuild guard from the UPDATE through the rebuild so concurrent
+	// readers fall back to the authoritative CTE path during the inconsistent
+	// window. Mirrors InvalidateBlock's pattern.
+	s.mainChainRebuilding.Add(1)
+	defer s.mainChainRebuilding.Add(-1)
+
 	// Update the block to valid (not invalid) and clear the mined_set flag.
 	q := `
 		UPDATE blocks

--- a/stores/blockchain/sql/RevalidateBlock.go
+++ b/stores/blockchain/sql/RevalidateBlock.go
@@ -30,12 +30,28 @@ func (s *SQL) RevalidateBlock(ctx context.Context, blockHash *chainhash.Hash) er
 		return errors.NewStorageError("error updating block to valid", err)
 	}
 
+	// Set guard: concurrent queries fall back to the CTE while we fix on_main_chain flags.
+	s.mainChainRebuilding.Store(true)
+
+	rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+	defer rebuildCancel()
+
+	// Invalidate caches FIRST so that rebuildOnMainChainFlag's getBestBlockID call
+	// sees the freshly revalidated state rather than the pre-revalidation cached value.
 	s.blockTimestampCache.Clear()
 	s.ResetResponseCache()
 	if s.useInMemoryChainCheck {
 		s.resetChainWalkCache()
-		rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
-		defer rebuildCancel()
+	}
+
+	// Rebuild on_main_chain flags to reflect the potentially new canonical chain.
+	if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
+		s.logger.Errorf("RevalidateBlock: rebuildOnMainChainFlag: %v", rebuildErr)
+	}
+	// Clear guard — on_main_chain is now consistent, queries can use fast path.
+	s.mainChainRebuilding.Store(false)
+
+	if s.useInMemoryChainCheck {
 		if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {
 			s.logger.Errorf("RevalidateBlock: %v", rebuildErr)
 		} else {

--- a/stores/blockchain/sql/RevalidateBlock.go
+++ b/stores/blockchain/sql/RevalidateBlock.go
@@ -42,7 +42,7 @@ func (s *SQL) RevalidateBlock(ctx context.Context, blockHash *chainhash.Hash) er
 	}
 
 	// Rebuild on_main_chain flags to reflect the potentially new canonical chain.
-	if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
+	if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx, false); rebuildErr != nil {
 		s.logger.Errorf("RevalidateBlock: rebuildOnMainChainFlag: %v", rebuildErr)
 	}
 

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -106,6 +106,16 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 		opt(&storeBlockOptions)
 	}
 
+	// Hold the rebuild guard for the full StoreBlock window. Between the INSERT
+	// commit and the post-insert rebuild (reorg case), readers that take the
+	// fast path would otherwise see a newly-inserted best block with
+	// on_main_chain=false while the old tip still has on_main_chain=true.
+	// Holding the guard forces those readers onto the CTE fallback, which
+	// walks from the authoritative best block and is consistent immediately
+	// after the INSERT commits. Mirrors InvalidateBlock's pattern.
+	s.mainChainRebuilding.Add(1)
+	defer s.mainChainRebuilding.Add(-1)
+
 	// Capture the best block hash before insert. Used both for:
 	//   1. Reorg detection after insert (existing logic, gated on useInMemoryChainCheck)
 	//   2. Determining whether to set on_main_chain = true directly in the INSERT

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -170,7 +170,7 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 			s.updateMaxBlockID(newBlockID)
 			s.resetChainWalkCache()
 		}
-		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
+		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx, false); rebuildErr != nil {
 			s.logger.Errorf("StoreBlock: rebuildOnMainChainFlag: %v", rebuildErr)
 		}
 		if s.useInMemoryChainCheck {

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -106,10 +106,13 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 		opt(&storeBlockOptions)
 	}
 
+	// Capture the best block hash before insert. Used both for:
+	//   1. Reorg detection after insert (existing logic, gated on useInMemoryChainCheck)
+	//   2. Determining whether to set on_main_chain = true directly in the INSERT
+	//      (avoids a post-insert UPDATE for the common extend-chain case)
+	// getBestBlockID is cached, so this is essentially free.
 	var preBestHash *chainhash.Hash
-	if s.useInMemoryChainCheck {
-		// Capture the current best block hash before insert for reorg detection.
-		// getBestBlockID is cached, so this is essentially free.
+	{
 		var preBestErr error
 		_, preBestHash, preBestErr = s.getBestBlockID(ctx)
 		if preBestErr != nil {
@@ -117,7 +120,16 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 		}
 	}
 
-	newBlockID, height, _, _, err := s.storeBlock(ctx, block, peerID, storeBlockOptions)
+	// A block is on the main chain at insert time if it extends the current best block.
+	// If preBestHash is nil (empty DB, or getBestBlockID failed) we insert as false and
+	// let rebuildOnMainChainFlag correct it (genesis case, or startup recovery).
+	// Invalid blocks are never on the main chain.
+	onMainChain := !storeBlockOptions.Invalid &&
+		preBestHash != nil &&
+		block.Header.HashPrevBlock != nil &&
+		*block.Header.HashPrevBlock == *preBestHash
+
+	newBlockID, height, _, _, err := s.storeBlock(ctx, block, peerID, storeBlockOptions, onMainChain)
 	if err != nil {
 		return 0, height, err
 	}
@@ -125,31 +137,20 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 	// Reset response cache to invalidate cached best block ID and headers
 	s.ResetResponseCache()
 
-	if s.useInMemoryChainCheck {
-		// Track the highest block ID for the maxBlockID upper-bound check.
-		s.updateMaxBlockID(newBlockID)
-
-		// Detect forks and reorgs by comparing the newly inserted block against
-		// the post-insert best block.
-		postBestCtx, postBestCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
-		defer postBestCancel()
-		postBestID, _, bestErr := s.getBestBlockID(postBestCtx)
-		if bestErr != nil {
-			s.logger.Errorf("StoreBlock: failed to get best block ID: %v", bestErr)
-		} else if uint64(postBestID) != newBlockID {
+	// Detect forks and reorgs by comparing the newly inserted block against
+	// the post-insert best block. This drives both on_main_chain flag maintenance
+	// and the in-memory off-chain set (when useInMemoryChainCheck is enabled).
+	postBestCtx, postBestCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+	defer postBestCancel()
+	postBestID, _, bestErr := s.getBestBlockID(postBestCtx)
+	if bestErr != nil {
+		s.logger.Errorf("StoreBlock: failed to get best block ID: %v", bestErr)
+	} else if uint64(postBestID) != newBlockID {
+		// Case 1: fork — new block is not the best. on_main_chain is already false
+		// from the INSERT, so no DB update needed. Just update the in-memory set.
+		if s.useInMemoryChainCheck {
 			s.blockTimestampCache.Clear()
-			rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
-			defer rebuildCancel()
-			if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {
-				s.logger.Errorf("StoreBlock: %v", rebuildErr)
-			} else {
-				s.lastSuccessfulRebuild.Store(time.Now().Unix())
-			}
-		} else if preBestHash == nil || *block.Header.HashPrevBlock != *preBestHash {
-			// Case 2: new block is the best but doesn't extend the old best (reorg),
-			// or preBestHash was unavailable — take the conservative path and rebuild.
-			s.blockTimestampCache.Clear()
-			s.resetChainWalkCache()
+			s.updateMaxBlockID(newBlockID)
 			rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
 			defer rebuildCancel()
 			if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {
@@ -158,6 +159,33 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 				s.lastSuccessfulRebuild.Store(time.Now().Unix())
 			}
 		}
+	} else if preBestHash == nil || *block.Header.HashPrevBlock != *preBestHash {
+		// Case 2: new block is the best but doesn't extend the old best (reorg),
+		// or preBestHash was unavailable — rebuild on_main_chain flags in the DB
+		// and the in-memory off-chain set.
+		rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+		defer rebuildCancel()
+		if s.useInMemoryChainCheck {
+			s.blockTimestampCache.Clear()
+			s.updateMaxBlockID(newBlockID)
+			s.resetChainWalkCache()
+		}
+		// Set guard: concurrent queries fall back to CTE while flags are being corrected.
+		s.mainChainRebuilding.Store(true)
+		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
+			s.logger.Errorf("StoreBlock: rebuildOnMainChainFlag: %v", rebuildErr)
+		}
+		s.mainChainRebuilding.Store(false)
+		if s.useInMemoryChainCheck {
+			if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {
+				s.logger.Errorf("StoreBlock: %v", rebuildErr)
+			} else {
+				s.lastSuccessfulRebuild.Store(time.Now().Unix())
+			}
+		}
+	} else if s.useInMemoryChainCheck {
+		// Case 3: normal extend — update maxBlockID for the in-memory upper-bound check.
+		s.updateMaxBlockID(newBlockID)
 	}
 
 	return newBlockID, height, nil
@@ -257,7 +285,7 @@ func (s *SQL) getPreviousBlockInfo(ctx context.Context, prevBlockHash chainhash.
 //   - uint32: The height of the block in the blockchain
 //   - []byte: The calculated cumulative chain work for this block as a byte array
 //   - error: Any error encountered during the operation, including validation failures
-func (s *SQL) storeBlock(ctx context.Context, block *model.Block, peerID string, storeBlockOptions options.StoreBlockOptions) (uint64, uint32, []byte, bool, error) {
+func (s *SQL) storeBlock(ctx context.Context, block *model.Block, peerID string, storeBlockOptions options.StoreBlockOptions, onMainChain bool) (uint64, uint32, []byte, bool, error) {
 	var (
 		coinbaseTxID string
 		q            string
@@ -274,6 +302,12 @@ func (s *SQL) storeBlock(ctx context.Context, block *model.Block, peerID string,
 	}
 
 	storeAsInvalid := previousBlockInvalid || storeBlockOptions.Invalid
+
+	// Genesis is always on the main chain (it IS the chain). Override the caller's
+	// value, which may be false when the DB was empty and getBestBlockID returned nothing.
+	if genesis {
+		onMainChain = !storeAsInvalid
+	}
 
 	// Determine if we should use a custom ID or auto-increment
 	// ID=0 is special: it means "not set" for regular blocks, but "use ID=0" for genesis
@@ -314,7 +348,8 @@ INSERT INTO blocks (
 	,subtrees_set
 	,persisted_at
 	,coinbase_bump
-) VALUES ($1, $2, $3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
+	,on_main_chain
+) VALUES ($1, $2, $3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
 RETURNING id
 			`
 		} else {
@@ -343,7 +378,8 @@ INSERT INTO blocks (
 	,subtrees_set
 	,persisted_at
 	,coinbase_bump
-) VALUES ($1, $2 ,$3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22)
+	,on_main_chain
+) VALUES ($1, $2 ,$3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
 RETURNING id
 			`
 		}
@@ -375,7 +411,8 @@ INSERT INTO blocks (
 	,subtrees_set
 	,persisted_at
 	,coinbase_bump
-) VALUES ($1, $2, $3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
+	,on_main_chain
+) VALUES ($1, $2, $3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
 RETURNING id
 			`
 		} else {
@@ -404,7 +441,8 @@ INSERT INTO blocks (
 	,subtrees_set
 	,persisted_at
 	,coinbase_bump
-) VALUES ($1, $2 ,$3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22)
+	,on_main_chain
+) VALUES ($1, $2 ,$3 ,$4 ,$5 ,$6 ,$7 ,$8 ,$9 ,$10 ,$11 ,$12 ,$13 ,$14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
 RETURNING id
 			`
 		}
@@ -479,6 +517,7 @@ RETURNING id
 			storeBlockOptions.SubtreesSet,
 			persistedAt,
 			coinbaseBump,
+			onMainChain,
 		)
 	} else {
 		// When using auto-increment, no ID parameter is needed
@@ -505,6 +544,7 @@ RETURNING id
 			storeBlockOptions.SubtreesSet,
 			persistedAt,
 			coinbaseBump,
+			onMainChain,
 		)
 	}
 

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -170,12 +170,9 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 			s.updateMaxBlockID(newBlockID)
 			s.resetChainWalkCache()
 		}
-		// Set guard: concurrent queries fall back to CTE while flags are being corrected.
-		s.mainChainRebuilding.Store(true)
 		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx); rebuildErr != nil {
 			s.logger.Errorf("StoreBlock: rebuildOnMainChainFlag: %v", rebuildErr)
 		}
-		s.mainChainRebuilding.Store(false)
 		if s.useInMemoryChainCheck {
 			if rebuildErr := s.triggerRebuildOffChainSet(rebuildCtx); rebuildErr != nil {
 				s.logger.Errorf("StoreBlock: %v", rebuildErr)

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -239,8 +239,14 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 
 		full, err := s.needsFullOnMainChainRebuild(ctx)
 		if err != nil {
-			s.logger.Errorf("startup: needsFullOnMainChainRebuild: %v", err)
-			// Fall through with full=false; bounded rebuild still covers recent blocks.
+			// On error we cannot determine whether this is a fresh migration or
+			// a consistent DB. A bounded rebuild would silently leave deep
+			// blocks with on_main_chain=false and fast-path reads for those
+			// blocks would return no rows. Err on the side of a full rebuild —
+			// it is a one-time cost at startup, bounded rebuilds take over on
+			// subsequent startups once flags are consistent.
+			s.logger.Errorf("startup: needsFullOnMainChainRebuild: %v — assuming full rebuild needed", err)
+			full = true
 		}
 		if full {
 			s.logger.Infof("startup: on_main_chain appears unpopulated — running full-chain rebuild (migration)")
@@ -951,6 +957,12 @@ func (s *SQL) triggerRebuildOffChainSet(ctx context.Context) error {
 // shutdownAwareContext returns a context that is cancelled either when the timeout
 // expires or when Close() is called (s.backgroundDone is closed). Callers must call
 // the returned cancel function to release resources.
+//
+// One goroutine is spawned per call. This is intentionally unbounded because
+// shutdownAwareContext is only called from startup and Close paths — total
+// lifetime calls are O(1) per store. The spawned goroutine is always bounded
+// by ctx.Done (via timeout or caller cancel) or backgroundDone close, so it
+// cannot leak past Close().
 func (s *SQL) shutdownAwareContext(timeout time.Duration) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	go func() {
@@ -968,6 +980,13 @@ func (s *SQL) shutdownAwareContext(timeout time.Duration) (context.Context, cont
 // bestHeight+1 blocks (genesis through tip), so count(on_main_chain=true) must
 // equal that. Any other value indicates either a fresh migration (count << expected)
 // or a corrupt state — both require a full-chain rebuild.
+//
+// The two SELECTs run outside a transaction. This is safe because the function
+// is only invoked from the startup goroutine (see New), before blockchain
+// services come up and begin calling StoreBlock / InvalidateBlock. Under the
+// single-writer model assumed by the store, no concurrent mutations can race
+// the two reads. A false-positive "needs rebuild" from an interleaved write
+// would only cost an extra full rebuild, not corrupt state.
 func (s *SQL) needsFullOnMainChainRebuild(ctx context.Context) (bool, error) {
 	var bestHeight int64
 	err := s.db.QueryRowContext(ctx,
@@ -1009,11 +1028,12 @@ func (s *SQL) needsFullOnMainChainRebuild(ctx context.Context) (bool, error) {
 // mainChainRebuilding is incremented for the duration of the call so concurrent
 // queries fall back to the authoritative CTE rather than reading partially-updated
 // flags. The counter-based guard is safe under reentrant/overlapping callers.
-func (s *SQL) rebuildOnMainChainFlag(ctx context.Context, full bool) error {
+func (s *SQL) rebuildOnMainChainFlag(ctx context.Context, full bool) (err error) {
 	s.mainChainRebuilding.Add(1)
 	defer s.mainChainRebuilding.Add(-1)
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	var tx *sql.Tx
+	tx, err = s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.NewStorageError("rebuildOnMainChainFlag: failed to begin transaction", err)
 	}

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -218,33 +218,30 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		return nil, errors.NewStorageError("failed to insert genesis transaction", err)
 	}
 
-	// Rebuild the on_main_chain column from authoritative chain_work ordering.
-	// This is always done at startup (regardless of useInMemoryChainCheck) to:
-	//   - Set the flag correctly for a brand-new DB (genesis block)
-	//   - Recover from a crash that occurred mid-rebuild leaving flags inconsistent
-	// No mainChainRebuilding guard is needed here: New() is synchronous and no
-	// external queries are possible until it returns.
-	startupRebuildCtx, startupRebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
-	defer startupRebuildCancel()
-	if rebuildErr := s.rebuildOnMainChainFlag(startupRebuildCtx); rebuildErr != nil {
-		s.Close()
-		return nil, errors.NewStorageError("failed to rebuild on_main_chain flags during startup", rebuildErr)
-	}
+	// Rebuild the on_main_chain column and (if applicable) the in-memory off-chain set
+	// asynchronously so startup is not blocked. Concurrent queries fall back to the
+	// authoritative CTE via mainChainRebuilding for the duration of the rebuild.
+	// The rebuild covers only the last 10×CoinbaseMaturity blocks (fast), so the
+	// fallback window is brief.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+		defer cancel()
+		if rebuildErr := s.rebuildOnMainChainFlag(ctx); rebuildErr != nil {
+			s.logger.Errorf("startup: rebuildOnMainChainFlag: %v", rebuildErr)
+		}
+
+		if useInMemory {
+			rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+			defer rebuildCancel()
+			if rebuildErr := s.rebuildOffChainSet(rebuildCtx); rebuildErr != nil {
+				s.logger.Errorf("startup: rebuildOffChainSet: %v", rebuildErr)
+			} else {
+				s.lastSuccessfulRebuild.Store(time.Now().Unix())
+			}
+		}
+	}()
 
 	if useInMemory {
-		// Rebuild the off-chain set so that CheckBlockIsInCurrentChain works correctly
-		// after a process restart. Now that on_main_chain is up-to-date, this uses
-		// the fast flat scan rather than the CTE walk.
-		// This is fatal because the in-memory lookup has no DB fallback — if the
-		// off-chain set is empty, fork/orphan blocks would incorrectly return true.
-		rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
-		defer rebuildCancel()
-		if rebuildErr := s.rebuildOffChainSet(rebuildCtx); rebuildErr != nil {
-			s.Close()
-			return nil, errors.NewStorageError("failed to seed off-chain set during startup", rebuildErr)
-		}
-		s.lastSuccessfulRebuild.Store(time.Now().Unix())
-
 		// Start periodic background refresh of the off-chain set as a safety net.
 		// This catches any missed rebuilds (e.g. due to transient DB errors during
 		// event-driven rebuilds) without requiring a process restart.
@@ -942,9 +939,12 @@ func (s *SQL) triggerRebuildOffChainSet(ctx context.Context) error {
 //   - Step 1: clear on_main_chain for blocks in the window no longer on the chain
 //   - Step 2: set on_main_chain for blocks in the window not yet marked
 //
-// Callers must set mainChainRebuilding = true before calling this and reset it to false
-// after it returns, so that concurrent queries fall back to the CTE during the rebuild.
+// mainChainRebuilding is set for the duration of the call so concurrent queries fall
+// back to the authoritative CTE rather than reading partially-updated flags.
 func (s *SQL) rebuildOnMainChainFlag(ctx context.Context) error {
+	s.mainChainRebuilding.Store(true)
+	defer s.mainChainRebuilding.Store(false)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.NewStorageError("rebuildOnMainChainFlag: failed to begin transaction", err)

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -511,7 +511,9 @@ func createPostgresSchema(db *usql.DB, withIndexes bool) error {
 
 		// === MAIN CHAIN INDEX ===
 		// Partial index for fast main-chain height lookups (replaces recursive CTEs).
-		// Only indexes the small fraction of blocks on the canonical chain.
+		// Scoped to on_main_chain = true blocks; on mainnet where forks are rare this
+		// covers nearly all blocks, but still provides fast B-tree height lookups
+		// without including fork/orphan blocks.
 		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_on_main_chain_height ON blocks (height ASC) WHERE on_main_chain = true;`); err != nil {
 			_ = db.Close()
 			return errors.NewStorageError("could not create idx_on_main_chain_height index", err)
@@ -792,7 +794,9 @@ func createSqliteSchema(db *usql.DB) error {
 
 	// === MAIN CHAIN INDEX ===
 	// Partial index for fast main-chain height lookups (replaces recursive CTEs).
-	// Only indexes the small fraction of blocks on the canonical chain.
+	// Scoped to on_main_chain = true blocks; on mainnet where forks are rare this
+	// covers nearly all blocks, but still provides fast B-tree height lookups
+	// without including fork/orphan blocks.
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_on_main_chain_height ON blocks (height ASC) WHERE on_main_chain = true;`); err != nil {
 		_ = db.Close()
 		return errors.NewStorageError("could not create idx_on_main_chain_height index", err)
@@ -929,23 +933,18 @@ func (s *SQL) triggerRebuildOffChainSet(ctx context.Context) error {
 }
 
 // rebuildOnMainChainFlag updates the on_main_chain column to accurately reflect the
-// current canonical chain. It walks the main chain from the best block backward via
-// parent_id (using the same recursive CTE as rebuildOffChainSet), then:
-//   - Clears on_main_chain for any block that was marked true but is no longer on the chain
-//   - Sets on_main_chain for any block that should be true but isn't yet
+// current canonical chain. It walks the main chain backward from the best block via
+// parent_id, limited to a window of 10×CoinbaseMaturity blocks above the tip.
 //
-// Both UPDATEs run inside a single transaction so readers never see a partial state.
-// On typical block extensions only 0-1 rows change (Step 1: 0 rows, Step 2: 0 rows because
-// on_main_chain was already set in the INSERT). On a reorg only the diverging blocks change.
+// The window bound is safe because a reorg deeper than CoinbaseMaturity is
+// consensus-invalid — blocks beyond that depth have immutable on_main_chain status.
+// Two UPDATEs run inside a single transaction so readers never see a partial state:
+//   - Step 1: clear on_main_chain for blocks in the window no longer on the chain
+//   - Step 2: set on_main_chain for blocks in the window not yet marked
 //
 // Callers must set mainChainRebuilding = true before calling this and reset it to false
 // after it returns, so that concurrent queries fall back to the CTE during the rebuild.
 func (s *SQL) rebuildOnMainChainFlag(ctx context.Context) error {
-	bestBlockID, _, err := s.getBestBlockID(ctx)
-	if err != nil {
-		return errors.NewStorageError("rebuildOnMainChainFlag: failed to get best block ID", err)
-	}
-
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.NewStorageError("rebuildOnMainChainFlag: failed to begin transaction", err)
@@ -956,39 +955,58 @@ func (s *SQL) rebuildOnMainChainFlag(ctx context.Context) error {
 		}
 	}()
 
-	// Step 1: clear on_main_chain for blocks that are no longer on the main chain.
+	// Fetch best block ID and height inside the transaction for a consistent snapshot.
+	var bestBlockID uint32
+	var bestHeight int64
+	bestQ := `SELECT id, height FROM blocks WHERE invalid = false ORDER BY chain_work DESC, peer_id ASC, id ASC LIMIT 1`
+	if err = tx.QueryRowContext(ctx, bestQ).Scan(&bestBlockID, &bestHeight); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil // empty DB — nothing to rebuild
+		}
+		return errors.NewStorageError("rebuildOnMainChainFlag: failed to get best block", err)
+	}
+
+	// Walk only the last 10×CoinbaseMaturity blocks. Reorgs deeper than CoinbaseMaturity
+	// are consensus-invalid; blocks outside this window already have correct flags.
+	windowSize := int64(10) * int64(s.chainParams.CoinbaseMaturity)
+	windowBottom := bestHeight - windowSize
+	if windowBottom < 0 {
+		windowBottom = 0
+	}
+
+	// Step 1: clear on_main_chain for blocks in the window no longer on the main chain.
 	// These are blocks that were previously on_main_chain = true but whose path from
 	// the best block does not reach them anymore (e.g. after a reorg).
 	q1 := `
 		WITH RECURSIVE main_chain AS (
-			SELECT id, parent_id FROM blocks WHERE id = $1
+			SELECT id, parent_id, height FROM blocks WHERE id = $1
 			UNION ALL
-			SELECT b.id, b.parent_id FROM blocks b
+			SELECT b.id, b.parent_id, b.height FROM blocks b
 			INNER JOIN main_chain m ON b.id = m.parent_id
-			WHERE b.id != m.id
+			WHERE b.id != m.id AND b.height >= $2
 		)
 		UPDATE blocks SET on_main_chain = false
-		WHERE on_main_chain = true AND id NOT IN (SELECT id FROM main_chain)
+		WHERE on_main_chain = true AND height >= $2 AND id NOT IN (SELECT id FROM main_chain)
 	`
-	if _, err = tx.ExecContext(ctx, q1, bestBlockID); err != nil {
+	if _, err = tx.ExecContext(ctx, q1, bestBlockID, windowBottom); err != nil {
 		return errors.NewStorageError("rebuildOnMainChainFlag: failed to clear stale on_main_chain flags", err)
 	}
 
-	// Step 2: set on_main_chain for blocks now on the main chain that aren't marked yet.
+	// Step 2: set on_main_chain for blocks in the window now on the main chain.
 	// In the normal extend case this updates the newly inserted block (1 row).
 	// In the reorg case this updates the blocks on the new winning branch.
 	q2 := `
 		WITH RECURSIVE main_chain AS (
-			SELECT id, parent_id FROM blocks WHERE id = $1
+			SELECT id, parent_id, height FROM blocks WHERE id = $1
 			UNION ALL
-			SELECT b.id, b.parent_id FROM blocks b
+			SELECT b.id, b.parent_id, b.height FROM blocks b
 			INNER JOIN main_chain m ON b.id = m.parent_id
-			WHERE b.id != m.id
+			WHERE b.id != m.id AND b.height >= $2
 		)
 		UPDATE blocks SET on_main_chain = true
-		WHERE on_main_chain = false AND id IN (SELECT id FROM main_chain)
+		WHERE on_main_chain = false AND height >= $2 AND id IN (SELECT id FROM main_chain)
 	`
-	if _, err = tx.ExecContext(ctx, q2, bestBlockID); err != nil {
+	if _, err = tx.ExecContext(ctx, q2, bestBlockID, windowBottom); err != nil {
 		return errors.NewStorageError("rebuildOnMainChainFlag: failed to set on_main_chain flags", err)
 	}
 

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -105,6 +105,11 @@ type SQL struct {
 	// in-memory off-chain set (true) or the original SQL recursive CTE (false).
 	// Read once at construction from settings; not changed at runtime.
 	useInMemoryChainCheck bool
+	// mainChainRebuilding is set to true while the on_main_chain column is being
+	// updated (during reorgs, invalidations, revalidations). While true, all queries
+	// that use on_main_chain fall back to the original recursive CTE to ensure they
+	// never read a partially-updated flag. Cleared to false once the rebuild is done.
+	mainChainRebuilding atomic.Bool
 	// blockTimestampCache is a sliding-window cache of recent block timestamps,
 	// eliminating per-block SQL queries in calculateMedianTimePastForHeight during
 	// sequential block processing (seeder, catchup). Cleared on fork detection/invalidation.
@@ -213,9 +218,23 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		return nil, errors.NewStorageError("failed to insert genesis transaction", err)
 	}
 
+	// Rebuild the on_main_chain column from authoritative chain_work ordering.
+	// This is always done at startup (regardless of useInMemoryChainCheck) to:
+	//   - Set the flag correctly for a brand-new DB (genesis block)
+	//   - Recover from a crash that occurred mid-rebuild leaving flags inconsistent
+	// No mainChainRebuilding guard is needed here: New() is synchronous and no
+	// external queries are possible until it returns.
+	startupRebuildCtx, startupRebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+	defer startupRebuildCancel()
+	if rebuildErr := s.rebuildOnMainChainFlag(startupRebuildCtx); rebuildErr != nil {
+		s.Close()
+		return nil, errors.NewStorageError("failed to rebuild on_main_chain flags during startup", rebuildErr)
+	}
+
 	if useInMemory {
-		// Rebuild the off-chain set using a CTE walk of the main chain so that
-		// CheckBlockIsInCurrentChain works correctly after a process restart.
+		// Rebuild the off-chain set so that CheckBlockIsInCurrentChain works correctly
+		// after a process restart. Now that on_main_chain is up-to-date, this uses
+		// the fast flat scan rather than the CTE walk.
 		// This is fatal because the in-memory lookup has no DB fallback — if the
 		// off-chain set is empty, fork/orphan blocks would incorrectly return true.
 		rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
@@ -310,6 +329,7 @@ func createPostgresSchema(db *usql.DB, withIndexes bool) error {
 		,persisted_at   TIMESTAMPTZ NULL
 		,median_time_past BIGINT NOT NULL DEFAULT 0
 		,coinbase_bump  BYTEA NULL
+		,on_main_chain  BOOLEAN NOT NULL DEFAULT FALSE
 	  );
 	`); err != nil {
 		_ = db.Close()
@@ -373,6 +393,21 @@ func createPostgresSchema(db *usql.DB, withIndexes bool) error {
 		} else {
 			_ = db.Close()
 			return errors.NewStorageError("could not check for coinbase_bump column in blocks table", err)
+		}
+	}
+
+	// add the on_main_chain column to the blocks table if it does not exist
+	err = db.QueryRow("SELECT column_name FROM information_schema.columns WHERE table_name='blocks' AND column_name='on_main_chain'").Scan(new(string))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			_, err := db.Exec(`ALTER TABLE blocks ADD COLUMN on_main_chain BOOLEAN NOT NULL DEFAULT FALSE;`)
+			if err != nil {
+				_ = db.Close()
+				return errors.NewStorageError("could not add on_main_chain column to blocks table", err)
+			}
+		} else {
+			_ = db.Close()
+			return errors.NewStorageError("could not check for on_main_chain column in blocks table", err)
 		}
 	}
 
@@ -473,6 +508,14 @@ func createPostgresSchema(db *usql.DB, withIndexes bool) error {
 			_ = db.Close()
 			return errors.NewStorageError("could not create idx_invalid_height index", err)
 		}
+
+		// === MAIN CHAIN INDEX ===
+		// Partial index for fast main-chain height lookups (replaces recursive CTEs).
+		// Only indexes the small fraction of blocks on the canonical chain.
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_on_main_chain_height ON blocks (height ASC) WHERE on_main_chain = true;`); err != nil {
+			_ = db.Close()
+			return errors.NewStorageError("could not create idx_on_main_chain_height index", err)
+		}
 	}
 
 	if _, err := db.Exec(`
@@ -571,6 +614,7 @@ func createSqliteSchema(db *usql.DB) error {
 		,persisted_at   TEXT NULL
 		,median_time_past BIGINT NOT NULL DEFAULT 0
 		,coinbase_bump  BLOB NULL
+		,on_main_chain  BOOLEAN NOT NULL DEFAULT FALSE
 	  );
 	`); err != nil {
 		_ = db.Close()
@@ -631,6 +675,21 @@ func createSqliteSchema(db *usql.DB) error {
 		} else {
 			_ = db.Close()
 			return errors.NewStorageError("could not check for coinbase_bump column in blocks table", err)
+		}
+	}
+
+	// add the on_main_chain column to the blocks table if it does not exist
+	err = db.QueryRow("SELECT name FROM pragma_table_info('blocks') WHERE name='on_main_chain'").Scan(new(string))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			_, err := db.Exec(`ALTER TABLE blocks ADD COLUMN on_main_chain BOOLEAN NOT NULL DEFAULT FALSE;`)
+			if err != nil {
+				_ = db.Close()
+				return errors.NewStorageError("could not add on_main_chain column to blocks table", err)
+			}
+		} else {
+			_ = db.Close()
+			return errors.NewStorageError("could not check for on_main_chain column in blocks table", err)
 		}
 	}
 
@@ -729,6 +788,14 @@ func createSqliteSchema(db *usql.DB) error {
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_invalid_height ON blocks (height DESC) WHERE invalid = true;`); err != nil {
 		_ = db.Close()
 		return errors.NewStorageError("could not create idx_invalid_height index", err)
+	}
+
+	// === MAIN CHAIN INDEX ===
+	// Partial index for fast main-chain height lookups (replaces recursive CTEs).
+	// Only indexes the small fraction of blocks on the canonical chain.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_on_main_chain_height ON blocks (height ASC) WHERE on_main_chain = true;`); err != nil {
+		_ = db.Close()
+		return errors.NewStorageError("could not create idx_on_main_chain_height index", err)
 	}
 
 	if _, err := db.Exec(`
@@ -861,6 +928,77 @@ func (s *SQL) triggerRebuildOffChainSet(ctx context.Context) error {
 	return err
 }
 
+// rebuildOnMainChainFlag updates the on_main_chain column to accurately reflect the
+// current canonical chain. It walks the main chain from the best block backward via
+// parent_id (using the same recursive CTE as rebuildOffChainSet), then:
+//   - Clears on_main_chain for any block that was marked true but is no longer on the chain
+//   - Sets on_main_chain for any block that should be true but isn't yet
+//
+// Both UPDATEs run inside a single transaction so readers never see a partial state.
+// On typical block extensions only 0-1 rows change (Step 1: 0 rows, Step 2: 0 rows because
+// on_main_chain was already set in the INSERT). On a reorg only the diverging blocks change.
+//
+// Callers must set mainChainRebuilding = true before calling this and reset it to false
+// after it returns, so that concurrent queries fall back to the CTE during the rebuild.
+func (s *SQL) rebuildOnMainChainFlag(ctx context.Context) error {
+	bestBlockID, _, err := s.getBestBlockID(ctx)
+	if err != nil {
+		return errors.NewStorageError("rebuildOnMainChainFlag: failed to get best block ID", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.NewStorageError("rebuildOnMainChainFlag: failed to begin transaction", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Step 1: clear on_main_chain for blocks that are no longer on the main chain.
+	// These are blocks that were previously on_main_chain = true but whose path from
+	// the best block does not reach them anymore (e.g. after a reorg).
+	q1 := `
+		WITH RECURSIVE main_chain AS (
+			SELECT id, parent_id FROM blocks WHERE id = $1
+			UNION ALL
+			SELECT b.id, b.parent_id FROM blocks b
+			INNER JOIN main_chain m ON b.id = m.parent_id
+			WHERE b.id != m.id
+		)
+		UPDATE blocks SET on_main_chain = false
+		WHERE on_main_chain = true AND id NOT IN (SELECT id FROM main_chain)
+	`
+	if _, err = tx.ExecContext(ctx, q1, bestBlockID); err != nil {
+		return errors.NewStorageError("rebuildOnMainChainFlag: failed to clear stale on_main_chain flags", err)
+	}
+
+	// Step 2: set on_main_chain for blocks now on the main chain that aren't marked yet.
+	// In the normal extend case this updates the newly inserted block (1 row).
+	// In the reorg case this updates the blocks on the new winning branch.
+	q2 := `
+		WITH RECURSIVE main_chain AS (
+			SELECT id, parent_id FROM blocks WHERE id = $1
+			UNION ALL
+			SELECT b.id, b.parent_id FROM blocks b
+			INNER JOIN main_chain m ON b.id = m.parent_id
+			WHERE b.id != m.id
+		)
+		UPDATE blocks SET on_main_chain = true
+		WHERE on_main_chain = false AND id IN (SELECT id FROM main_chain)
+	`
+	if _, err = tx.ExecContext(ctx, q2, bestBlockID); err != nil {
+		return errors.NewStorageError("rebuildOnMainChainFlag: failed to set on_main_chain flags", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return errors.NewStorageError("rebuildOnMainChainFlag: failed to commit transaction", err)
+	}
+
+	return nil
+}
+
 // rebuildOffChainSet rebuilds the set of block IDs that are NOT on the main chain.
 // It uses a recursive CTE to walk the main chain from the best block backward via
 // parent_id, then finds all block IDs NOT on that path. This correctly handles all
@@ -877,26 +1015,36 @@ func (s *SQL) triggerRebuildOffChainSet(ctx context.Context) error {
 // so this operation is fast even when it runs. The CTE walks the full main chain once
 // (O(chain_depth)), which is acceptable since rebuilds are infrequent.
 func (s *SQL) rebuildOffChainSet(ctx context.Context) error {
-	bestBlockID, _, bestErr := s.getBestBlockID(ctx)
-	if bestErr != nil {
-		return errors.NewStorageError("rebuildOffChainSet: failed to get best block ID", bestErr)
-	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
 
-	// Walk the main chain from bestBlockID backward to genesis via parent_id,
-	// then find all block IDs NOT on that path. This is provably correct for all
-	// chain topologies (including nested forks) because any block not reachable
-	// from the best block via parent_id links is by definition off-chain.
-	// The "b.id != m.id" condition prevents infinite recursion at the genesis
-	// block which has parent_id = id (self-referencing).
-	q := `
-		WITH RECURSIVE main_chain AS (
-			SELECT id, parent_id FROM blocks WHERE id = $1
-			UNION ALL
-			SELECT b.id, b.parent_id FROM blocks b INNER JOIN main_chain m ON b.id = m.parent_id WHERE b.id != m.id
-		)
-		SELECT b.id FROM blocks b LEFT JOIN main_chain m ON b.id = m.id WHERE m.id IS NULL
-	`
-	rows, err := s.db.QueryContext(ctx, q, bestBlockID)
+	if s.mainChainRebuilding.Load() {
+		// on_main_chain flags may be mid-update — fall back to the authoritative CTE walk.
+		// Walk the main chain from bestBlockID backward to genesis via parent_id,
+		// then find all block IDs NOT on that path. This is provably correct for all
+		// chain topologies (including nested forks) because any block not reachable
+		// from the best block via parent_id links is by definition off-chain.
+		// The "b.id != m.id" condition prevents infinite recursion at the genesis
+		// block which has parent_id = id (self-referencing).
+		bestBlockID, _, bestErr := s.getBestBlockID(ctx)
+		if bestErr != nil {
+			return errors.NewStorageError("rebuildOffChainSet: failed to get best block ID", bestErr)
+		}
+		q := `
+			WITH RECURSIVE main_chain AS (
+				SELECT id, parent_id FROM blocks WHERE id = $1
+				UNION ALL
+				SELECT b.id, b.parent_id FROM blocks b INNER JOIN main_chain m ON b.id = m.parent_id WHERE b.id != m.id
+			)
+			SELECT b.id FROM blocks b LEFT JOIN main_chain m ON b.id = m.id WHERE m.id IS NULL
+		`
+		rows, err = s.db.QueryContext(ctx, q, bestBlockID)
+	} else {
+		// on_main_chain flags are up-to-date — use the fast flat scan instead of the CTE.
+		rows, err = s.db.QueryContext(ctx, `SELECT id FROM blocks WHERE on_main_chain = false`)
+	}
 	if err != nil {
 		return errors.NewStorageError("rebuildOffChainSet: failed to query off-chain blocks", err)
 	}

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -105,11 +105,14 @@ type SQL struct {
 	// in-memory off-chain set (true) or the original SQL recursive CTE (false).
 	// Read once at construction from settings; not changed at runtime.
 	useInMemoryChainCheck bool
-	// mainChainRebuilding is set to true while the on_main_chain column is being
-	// updated (during reorgs, invalidations, revalidations). While true, all queries
-	// that use on_main_chain fall back to the original recursive CTE to ensure they
-	// never read a partially-updated flag. Cleared to false once the rebuild is done.
-	mainChainRebuilding atomic.Bool
+	// mainChainRebuilding is a reference counter: each caller that is about to (or
+	// currently is) mutating the on_main_chain column Adds 1 on entry and Adds -1 on
+	// exit. While the counter is > 0, all queries that use on_main_chain fall back to
+	// the authoritative CTE so they never read a partially-updated flag. A counter
+	// rather than a bool is required because multiple callers (reorg + invalidation,
+	// startup + concurrent RPC) may overlap: a bool would be cleared by the first to
+	// finish, exposing readers while later callers are still mid-update.
+	mainChainRebuilding atomic.Int32
 	// blockTimestampCache is a sliding-window cache of recent block timestamps,
 	// eliminating per-block SQL queries in calculateMedianTimePastForHeight during
 	// sequential block processing (seeder, catchup). Cleared on fork detection/invalidation.
@@ -207,10 +210,10 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		blockTimestampCache:   newBlockTimestampCache(),
 	}
 
+	s.backgroundDone = make(chan struct{})
 	if useInMemory {
 		s.chainWalkCache = NewGenerationalCache()
 		s.offChainBlockIDs = make(map[uint32]struct{})
-		s.backgroundDone = make(chan struct{})
 	}
 
 	err = s.insertGenesisTransaction(logger)
@@ -218,20 +221,36 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		return nil, errors.NewStorageError("failed to insert genesis transaction", err)
 	}
 
+	// Hold the rebuild guard synchronously until the background goroutine has started
+	// and incremented it itself. This ensures concurrent queries fall back to the CTE
+	// from the moment New() returns, even before the goroutine is scheduled — without
+	// this, there is a narrow window where maps/flags are unpopulated but the guard is 0.
+	s.mainChainRebuilding.Add(1)
+
 	// Rebuild the on_main_chain column and (if applicable) the in-memory off-chain set
-	// asynchronously so startup is not blocked. Concurrent queries fall back to the
-	// authoritative CTE via mainChainRebuilding for the duration of the rebuild.
-	// The rebuild covers only the last 10×CoinbaseMaturity blocks (fast), so the
-	// fallback window is brief.
+	// asynchronously so startup is not blocked. The first rebuild after the column is
+	// added (migration) walks the whole chain; subsequent starts walk only the last
+	// 10×CoinbaseMaturity blocks.
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+		defer s.mainChainRebuilding.Add(-1) // release the guard held by New()
+
+		ctx, cancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
 		defer cancel()
-		if rebuildErr := s.rebuildOnMainChainFlag(ctx); rebuildErr != nil {
+
+		full, err := s.needsFullOnMainChainRebuild(ctx)
+		if err != nil {
+			s.logger.Errorf("startup: needsFullOnMainChainRebuild: %v", err)
+			// Fall through with full=false; bounded rebuild still covers recent blocks.
+		}
+		if full {
+			s.logger.Infof("startup: on_main_chain appears unpopulated — running full-chain rebuild (migration)")
+		}
+		if rebuildErr := s.rebuildOnMainChainFlag(ctx, full); rebuildErr != nil {
 			s.logger.Errorf("startup: rebuildOnMainChainFlag: %v", rebuildErr)
 		}
 
 		if useInMemory {
-			rebuildCtx, rebuildCancel := context.WithTimeout(context.Background(), rebuildOffChainSetTimeout)
+			rebuildCtx, rebuildCancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
 			defer rebuildCancel()
 			if rebuildErr := s.rebuildOffChainSet(rebuildCtx); rebuildErr != nil {
 				s.logger.Errorf("startup: rebuildOffChainSet: %v", rebuildErr)
@@ -929,21 +948,70 @@ func (s *SQL) triggerRebuildOffChainSet(ctx context.Context) error {
 	return err
 }
 
+// shutdownAwareContext returns a context that is cancelled either when the timeout
+// expires or when Close() is called (s.backgroundDone is closed). Callers must call
+// the returned cancel function to release resources.
+func (s *SQL) shutdownAwareContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	go func() {
+		select {
+		case <-s.backgroundDone:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
+// needsFullOnMainChainRebuild returns true when the on_main_chain column looks
+// unpopulated relative to the canonical chain. The canonical chain has exactly
+// bestHeight+1 blocks (genesis through tip), so count(on_main_chain=true) must
+// equal that. Any other value indicates either a fresh migration (count << expected)
+// or a corrupt state — both require a full-chain rebuild.
+func (s *SQL) needsFullOnMainChainRebuild(ctx context.Context) (bool, error) {
+	var bestHeight int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(height), -1) FROM blocks WHERE invalid = false`,
+	).Scan(&bestHeight)
+	if err != nil {
+		return false, errors.NewStorageError("needsFullOnMainChainRebuild: failed to get best height", err)
+	}
+	if bestHeight < 0 {
+		return false, nil // empty DB
+	}
+
+	var onMainChainCount int64
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM blocks WHERE on_main_chain = true`,
+	).Scan(&onMainChainCount)
+	if err != nil {
+		return false, errors.NewStorageError("needsFullOnMainChainRebuild: failed to count on_main_chain", err)
+	}
+
+	return onMainChainCount != bestHeight+1, nil
+}
+
 // rebuildOnMainChainFlag updates the on_main_chain column to accurately reflect the
 // current canonical chain. It walks the main chain backward from the best block via
-// parent_id, limited to a window of 10×CoinbaseMaturity blocks above the tip.
+// parent_id.
 //
-// The window bound is safe because a reorg deeper than CoinbaseMaturity is
+// When full is false, the walk is bounded to the last 10×CoinbaseMaturity blocks above
+// the tip. The bound is safe because a reorg deeper than CoinbaseMaturity is
 // consensus-invalid — blocks beyond that depth have immutable on_main_chain status.
+// When full is true, the walk covers the entire chain back to genesis. Full rebuild
+// is required once after the on_main_chain column is first added to an existing DB
+// (migration), since default values need to be corrected chain-wide.
+//
 // Two UPDATEs run inside a single transaction so readers never see a partial state:
 //   - Step 1: clear on_main_chain for blocks in the window no longer on the chain
 //   - Step 2: set on_main_chain for blocks in the window not yet marked
 //
-// mainChainRebuilding is set for the duration of the call so concurrent queries fall
-// back to the authoritative CTE rather than reading partially-updated flags.
-func (s *SQL) rebuildOnMainChainFlag(ctx context.Context) error {
-	s.mainChainRebuilding.Store(true)
-	defer s.mainChainRebuilding.Store(false)
+// mainChainRebuilding is incremented for the duration of the call so concurrent
+// queries fall back to the authoritative CTE rather than reading partially-updated
+// flags. The counter-based guard is safe under reentrant/overlapping callers.
+func (s *SQL) rebuildOnMainChainFlag(ctx context.Context, full bool) error {
+	s.mainChainRebuilding.Add(1)
+	defer s.mainChainRebuilding.Add(-1)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -966,12 +1034,15 @@ func (s *SQL) rebuildOnMainChainFlag(ctx context.Context) error {
 		return errors.NewStorageError("rebuildOnMainChainFlag: failed to get best block", err)
 	}
 
-	// Walk only the last 10×CoinbaseMaturity blocks. Reorgs deeper than CoinbaseMaturity
-	// are consensus-invalid; blocks outside this window already have correct flags.
-	windowSize := int64(10) * int64(s.chainParams.CoinbaseMaturity)
-	windowBottom := bestHeight - windowSize
-	if windowBottom < 0 {
-		windowBottom = 0
+	// Compute the walk bound. full=true walks to genesis (windowBottom=0); otherwise
+	// limit to 10×CoinbaseMaturity blocks above the tip.
+	var windowBottom int64
+	if !full {
+		windowSize := int64(10) * int64(s.chainParams.CoinbaseMaturity)
+		windowBottom = bestHeight - windowSize
+		if windowBottom < 0 {
+			windowBottom = 0
+		}
 	}
 
 	// Step 1: clear on_main_chain for blocks in the window no longer on the main chain.
@@ -1038,7 +1109,7 @@ func (s *SQL) rebuildOffChainSet(ctx context.Context) error {
 		err  error
 	)
 
-	if s.mainChainRebuilding.Load() {
+	if s.mainChainRebuilding.Load() > 0 {
 		// on_main_chain flags may be mid-update — fall back to the authoritative CTE walk.
 		// Walk the main chain from bestBlockID backward to genesis via parent_id,
 		// then find all block IDs NOT on that path. This is provably correct for all


### PR DESCRIPTION
## Summary

- Adds `on_main_chain BOOLEAN` column to the `blocks` table (with schema migration for existing DBs) so the canonical chain membership is materialised on every write rather than re-derived on every read
- Replaces ~10 `WITH RECURSIVE` chain-walks in hot query paths with simple `WHERE on_main_chain = true` index scans backed by a new partial index (`idx_on_main_chain_height`)
- Introduces a `mainChainRebuilding atomic.Bool` concurrency guard: while the flag is being updated (reorg, invalidation, revalidation), all affected queries transparently fall back to the proven recursive CTE — zero window of incorrect reads

## How the flag is maintained

| Event | Action |
|-------|--------|
| Block extends main chain | `on_main_chain = true` set directly in the INSERT (zero extra queries) |
| Fork block | Default `false` — nothing extra |
| Reorg detected in `StoreBlock` | `rebuildOnMainChainFlag()` — two-phase transactional UPDATE, only touches diverging blocks |
| `InvalidateBlock` / `RevalidateBlock` | Same rebuild after cache is flushed |
| Startup | `rebuildOnMainChainFlag()` always runs for crash recovery |

## `rebuildOffChainSet` simplified

Now uses `SELECT id FROM blocks WHERE on_main_chain = false` (flat index scan) instead of a recursive CTE walk — except when `mainChainRebuilding` is true, where it falls back to the CTE.

## Queries simplified

`GetBlockByHeight`, `GetBlockStats`, `GetBlockGraphData`, `GetBlocksByHeight`, `GetBlockHeadersByHeight`, `GetLastNBlocks`, `FindBlocksContainingSubtree`, `GetLatestHeaderFromBlockLocator`, `CheckBlockIsInCurrentChain` (SQL fallback), `rebuildOffChainSet`

## Queries unchanged (walk from arbitrary hash, not main chain tip)

`GetBlockHeaders`, `GetBlockHeaderIDs`, `GetHashOfAncestorBlock`, `GetBlockInChainByHeightHash`, `CheckBlockIsAncestorOfBlock`, `InvalidateBlock` (forward walk to descendants), `GetSuitableBlock`, `GetForkedBlockHeaders`, `GetBlockHeadersFromOldest`, `GetBlockHeadersFromTill`

## Test plan

- [ ] `make test` passes — all existing tests green including the full `stores/blockchain/sql` suite
- [ ] New `OnMainChain_test.go` (11 tests): genesis, normal extend, fork, invalid block, `InvalidateBlock`, `RevalidateBlock`, startup rebuild, reorg (single and multi-block), long fork, invalid-block cascade to descendants, fast-path vs CTE consistency
- [ ] Verify schema migration applies cleanly to an existing DB without downtime