### PR TITLE
feat(netsync): pre-assign block ID in legacy path to enable skipping setTxMined

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1103,9 +1103,20 @@ func (u *BlockValidation) runOncePerBlock(blockHash *chainhash.Hash, opts *Valid
 // Returns an error if validation fails or nil on success.
 
 // buildAddBlockOpts returns AddBlock options for the block.
-// When block.ID is pre-assigned (by legacy netsync in LEGACYSYNCING mode), it uses that ID
+//
+// When block.ID is pre-assigned (set by legacy netsync in LEGACYSYNCING mode), it uses that ID
 // and sets mined_set=true upfront. This causes the setMinedChan worker to skip setTxMinedStatus
-// via its existing MinedSet guard, eliminating redundant SetMinedMulti calls for every UTXO.
+// via its existing MinedSet guard (BlockValidation.go setMinedChan worker, MinedSet check),
+// eliminating redundant SetMinedMulti calls for every UTXO.
+//
+// Trade-off: skipping setTxMinedStatus also skips its post-storage double-spend cross-check
+// (UpdateTxMinedStatus → SetMinedMulti). This is safe for LEGACYSYNCING because:
+//  1. block.Valid() performs pre-storage double-spend detection via checkParentExistsOnChain
+//     before AddBlock is called.
+//  2. LEGACYSYNCING processes a canonical chain with trusted historical blocks.
+//
+// For any block arriving without a pre-assigned ID (block.ID == 0), this function returns nil
+// and AddBlock behaves exactly as before — setTxMinedStatus runs normally.
 func (u *BlockValidation) buildAddBlockOpts(block *model.Block) []blockchainoptions.StoreBlockOption {
 	if block.ID == 0 {
 		return nil

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1101,6 +1101,21 @@ func (u *BlockValidation) runOncePerBlock(blockHash *chainhash.Hash, opts *Valid
 //   - disableOptimisticMining: Optional flag to force standard validation
 //
 // Returns an error if validation fails or nil on success.
+
+// buildAddBlockOpts returns AddBlock options for the block.
+// When block.ID is pre-assigned (by legacy netsync in LEGACYSYNCING mode), it uses that ID
+// and sets mined_set=true upfront. This causes the setMinedChan worker to skip setTxMinedStatus
+// via its existing MinedSet guard, eliminating redundant SetMinedMulti calls for every UTXO.
+func (u *BlockValidation) buildAddBlockOpts(block *model.Block) []blockchainoptions.StoreBlockOption {
+	if block.ID == 0 {
+		return nil
+	}
+	return []blockchainoptions.StoreBlockOption{
+		blockchainoptions.WithID(uint64(block.ID)),
+		blockchainoptions.WithMinedSet(true),
+	}
+}
+
 func (u *BlockValidation) ValidateBlock(ctx context.Context, block *model.Block, baseURL string, disableOptimisticMining ...bool) error {
 	// Convert legacy parameters to options
 	opts := &ValidateBlockOptions{}
@@ -1363,7 +1378,8 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 				ctxLogger.Warnf("[ValidateBlock][%s] failed to compute coinbase BUMP: %v", block.Hash().String(), err)
 			}
 
-			if err = u.blockchainClient.AddBlock(ctx, block, opts.PeerID); err != nil {
+			addBlockOpts := u.buildAddBlockOpts(block)
+			if err = u.blockchainClient.AddBlock(ctx, block, opts.PeerID, addBlockOpts...); err != nil {
 				return errors.NewServiceError("[ValidateBlock][%s] failed to store block", block.Hash().String(), err)
 			}
 
@@ -1534,7 +1550,8 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 					u.logger.Warnf("[ValidateBlock][%s] failed to compute coinbase BUMP: %v", block.Hash().String(), err)
 				}
 
-				if err = u.blockchainClient.AddBlock(storeCtx, block, opts.PeerID); err != nil {
+				addBlockOpts := u.buildAddBlockOpts(block)
+				if err = u.blockchainClient.AddBlock(storeCtx, block, opts.PeerID, addBlockOpts...); err != nil {
 					return errors.NewServiceError("[ValidateBlock][%s] failed to store block", block.Hash().String(), err)
 				}
 			}

--- a/services/blockvalidation/Client.go
+++ b/services/blockvalidation/Client.go
@@ -150,7 +150,7 @@ func (s *Client) BlockFound(ctx context.Context, blockHash *chainhash.Hash, base
 //   - blockHeight: Expected chain height for the block
 //
 // Returns an error if block processing fails
-func (s *Client) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string) error {
+func (s *Client) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error {
 	blockBytes, err := block.Bytes()
 	if err != nil {
 		return err
@@ -161,6 +161,7 @@ func (s *Client) ProcessBlock(ctx context.Context, block *model.Block, blockHeig
 		Height:  blockHeight,
 		PeerId:  peerID,
 		BaseUrl: baseURL,
+		BlockId: blockID,
 	}
 
 	_, err = s.apiClient.ProcessBlock(ctx, req)

--- a/services/blockvalidation/Client_test.go
+++ b/services/blockvalidation/Client_test.go
@@ -332,7 +332,7 @@ func TestClient_ProcessBlock(t *testing.T) {
 			return req.Height == 100 && len(req.Block) > 0
 		}), mock.Anything).Return(&blockvalidation_api.EmptyMessage{}, nil)
 
-		err := client.ProcessBlock(ctx, block, 100, "", "legacy")
+		err := client.ProcessBlock(ctx, block, 100, "", "legacy", 0)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -342,7 +342,7 @@ func TestClient_ProcessBlock(t *testing.T) {
 		mockClient.On("ProcessBlock", ctx, mock.Anything, mock.Anything).Return(
 			nil, status.Error(codes.Internal, "processing error"))
 
-		err := client.ProcessBlock(ctx, block, 100, "", "legacy")
+		err := client.ProcessBlock(ctx, block, 100, "", "legacy", 0)
 		assert.Error(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -356,7 +356,7 @@ func TestClient_ProcessBlock(t *testing.T) {
 			Header: nil, // This should cause serialization to fail
 		}
 
-		err := client.ProcessBlock(ctx, invalidBlock, 100, "", "legacy")
+		err := client.ProcessBlock(ctx, invalidBlock, 100, "", "legacy", 0)
 		assert.Error(t, err)
 		mockClient.AssertExpectations(t)
 	})

--- a/services/blockvalidation/Interface.go
+++ b/services/blockvalidation/Interface.go
@@ -36,7 +36,8 @@ type Interface interface {
 	BlockFound(ctx context.Context, blockHash *chainhash.Hash, baseURL string, waitToComplete bool) error
 
 	// ProcessBlock validates and processes a complete block at the specified height.
-	ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string) error
+	// blockID is the pre-assigned block ID from the caller (0 = not pre-assigned, blockchain will auto-assign).
+	ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error
 
 	// ValidateBlock validates a block using the provided request, but does not update any state or database tables.
 	// This is useful for validating blocks without committing them to the database.
@@ -63,7 +64,7 @@ func (mv *MockBlockValidation) BlockFound(ctx context.Context, blockHash *chainh
 	return nil
 }
 
-func (mv *MockBlockValidation) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string) error {
+func (mv *MockBlockValidation) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error {
 	return nil
 }
 

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1261,6 +1261,13 @@ func (u *Server) ProcessBlock(ctx context.Context, request *blockvalidation_api.
 
 	block.Height = height
 
+	// If a block ID was pre-assigned by the caller (e.g. legacy netsync in LEGACYSYNCING mode),
+	// apply it so the validation path can use AddBlock(WithID, WithMinedSet(true)) and allow
+	// the setMinedChan worker to skip setTxMinedStatus via the existing MinedSet guard.
+	if request.BlockId != 0 {
+		block.ID = request.BlockId
+	}
+
 	baseURL := request.BaseUrl
 	if baseURL == "" {
 		baseURL = "legacy" // default to legacy if not provided

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -72,8 +72,8 @@ func (m *mockBlockValidationInterface) BlockFound(ctx context.Context, blockHash
 	return args.Error(0)
 }
 
-func (m *mockBlockValidationInterface) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string) error {
-	args := m.Called(ctx, block, blockHeight, peerID, baseURL)
+func (m *mockBlockValidationInterface) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error {
+	args := m.Called(ctx, block, blockHeight, peerID, baseURL, blockID)
 	return args.Error(0)
 }
 

--- a/services/blockvalidation/blockvalidation_api/blockvalidation_api.pb.go
+++ b/services/blockvalidation/blockvalidation_api/blockvalidation_api.pb.go
@@ -195,7 +195,8 @@ type ProcessBlockRequest struct {
 	Block         []byte                 `protobuf:"bytes,1,opt,name=block,proto3" json:"block,omitempty"`
 	Height        uint32                 `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
 	BaseUrl       string                 `protobuf:"bytes,3,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
-	PeerId        string                 `protobuf:"bytes,4,opt,name=peer_id,json=peerId,proto3" json:"peer_id,omitempty"` // P2P peer identifier for peer tracking via P2P service
+	PeerId        string                 `protobuf:"bytes,4,opt,name=peer_id,json=peerId,proto3" json:"peer_id,omitempty"`     // P2P peer identifier for peer tracking via P2P service
+	BlockId       uint32                 `protobuf:"varint,5,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"` // Pre-assigned block ID from legacy netsync (0 = not pre-assigned, blockchain will auto-assign)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -256,6 +257,13 @@ func (x *ProcessBlockRequest) GetPeerId() string {
 		return x.PeerId
 	}
 	return ""
+}
+
+func (x *ProcessBlockRequest) GetBlockId() uint32 {
+	if x != nil {
+		return x.BlockId
+	}
+	return 0
 }
 
 // swagger:model ValidateBlockRequest
@@ -697,12 +705,13 @@ const file_services_blockvalidation_blockvalidation_api_blockvalidation_api_prot
 	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x19\n" +
 	"\bbase_url\x18\x02 \x01(\tR\abaseUrl\x12(\n" +
 	"\x10wait_to_complete\x18\x03 \x01(\bR\x0ewaitToComplete\x12\x17\n" +
-	"\apeer_id\x18\x04 \x01(\tR\x06peerId\"w\n" +
+	"\apeer_id\x18\x04 \x01(\tR\x06peerId\"\x92\x01\n" +
 	"\x13ProcessBlockRequest\x12\x14\n" +
 	"\x05block\x18\x01 \x01(\fR\x05block\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\rR\x06height\x12\x19\n" +
 	"\bbase_url\x18\x03 \x01(\tR\abaseUrl\x12\x17\n" +
-	"\apeer_id\x18\x04 \x01(\tR\x06peerId\"m\n" +
+	"\apeer_id\x18\x04 \x01(\tR\x06peerId\x12\x19\n" +
+	"\bblock_id\x18\x05 \x01(\rR\ablockId\"m\n" +
 	"\x14ValidateBlockRequest\x12\x14\n" +
 	"\x05block\x18\x01 \x01(\fR\x05block\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\rR\x06height\x12'\n" +

--- a/services/blockvalidation/blockvalidation_api/blockvalidation_api.proto
+++ b/services/blockvalidation/blockvalidation_api/blockvalidation_api.proto
@@ -40,6 +40,7 @@ message ProcessBlockRequest {
   uint32 height = 2;
   string base_url = 3;
   string peer_id = 4; // P2P peer identifier for peer tracking via P2P service
+  uint32 block_id = 5; // Pre-assigned block ID from legacy netsync (0 = not pre-assigned, blockchain will auto-assign)
 }
 
 // swagger:model ValidateBlockRequest

--- a/services/blockvalidation/mock.go
+++ b/services/blockvalidation/mock.go
@@ -41,7 +41,7 @@ func (m *Mock) BlockFound(ctx context.Context, blockHash *chainhash.Hash, baseUR
 
 // ProcessBlock performs a mock block processing.
 func (m *Mock) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error {
-	args := m.Called(ctx, block, blockHeight)
+	args := m.Called(ctx, block, blockHeight, peerID, baseURL, blockID)
 	return args.Error(0)
 }
 

--- a/services/blockvalidation/mock.go
+++ b/services/blockvalidation/mock.go
@@ -40,7 +40,7 @@ func (m *Mock) BlockFound(ctx context.Context, blockHash *chainhash.Hash, baseUR
 }
 
 // ProcessBlock performs a mock block processing.
-func (m *Mock) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string) error {
+func (m *Mock) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error {
 	args := m.Called(ctx, block, blockHeight)
 	return args.Error(0)
 }

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -330,6 +330,12 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 			// mined info from creation. This ID is threaded through to blockvalidation via
 			// ProcessBlock so it can call AddBlock(WithID, WithMinedSet(true)) and cause the
 			// setMinedChan worker to skip setTxMinedStatus (MinedSet guard in BlockValidation.go).
+			//
+			// Note on ID gaps: GetNextBlockID advances the sequence atomically. If anything fails
+			// after this point (createUtxos error, network error, context cancellation), the ID
+			// is consumed and a gap appears in block IDs. This is acceptable — the blockchain
+			// store tolerates non-contiguous IDs; the sequence is used only as a monotonic counter,
+			// not a contiguous index.
 			id, idErr := sm.blockchainClient.GetNextBlockID(ctx)
 			if idErr != nil {
 				return nil, 0, errors.NewProcessingError("[prepareSubtrees] failed to get next block ID", idErr)

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/utxopersister/filestorer"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/blockassemblyutil"
@@ -149,7 +150,7 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 
 	// validate all subtrees and store all subtree data
 	// this also should spend and create all utxos
-	subtrees, err := sm.prepareSubtrees(ctx, block)
+	subtrees, blockID, err := sm.prepareSubtrees(ctx, block)
 	if err != nil {
 		return err
 	}
@@ -162,7 +163,7 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 		return err
 	}
 
-	teranodeBlock, err := model.NewBlock(header, coinbaseTx, subtrees, uint64(len(block.Transactions())), blockSizeUint64, blockHeight, 0)
+	teranodeBlock, err := model.NewBlock(header, coinbaseTx, subtrees, uint64(len(block.Transactions())), blockSizeUint64, blockHeight, blockID)
 	if err != nil {
 		return errors.NewProcessingError("failed to create model.NewBlock", err)
 	}
@@ -174,7 +175,7 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	}
 
 	// call the process block wrapper, which will add tracing and logging
-	err = sm.ProcessBlock(ctx, teranodeBlock)
+	err = sm.ProcessBlock(ctx, teranodeBlock, blockID)
 	if err != nil {
 		return err
 	}
@@ -223,7 +224,7 @@ func (sm *SyncManager) waitForPreviousBlockMined(ctx context.Context, prevBlockH
 	return err
 }
 
-func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Block) (err error) {
+func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Block, blockID uint32) (err error) {
 	ctx, _, deferFn := tracing.Tracer("netsync").Start(ctx, "SyncManager:processBlock",
 		tracing.WithLogMessage(
 			sm.logger,
@@ -239,7 +240,7 @@ func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Bl
 
 	// send the block to the blockValidation for processing and validation
 	// all the block subtrees should have been validated in processSubtrees
-	if err = sm.blockValidation.ProcessBlock(ctx, teranodeBlock, teranodeBlock.Height, "", "legacy"); err != nil {
+	if err = sm.blockValidation.ProcessBlock(ctx, teranodeBlock, teranodeBlock.Height, "", "legacy", blockID); err != nil {
 		if errors.Is(err, errors.ErrBlockExists) {
 			sm.logger.Infof("[SyncManager:processBlock][%s %d] block already exists", teranodeBlock.Hash().String(), teranodeBlock.Height)
 			return nil
@@ -257,7 +258,7 @@ type TxMapWrapper struct {
 	ChildLevelInBlock  uint32
 }
 
-func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block) (subtrees []*chainhash.Hash, err error) {
+func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block) (subtrees []*chainhash.Hash, blockID uint32, err error) {
 	ctx, _, deferFn := tracing.Tracer("netsync").Start(ctx, "prepareSubtrees",
 		tracing.WithLogMessage(
 			sm.logger,
@@ -287,11 +288,11 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 	// then validate the subtree through the subtreeValidation service
 	if len(block.Transactions()) > 1 {
 		if subtree, err = subtreepkg.NewIncompleteTreeByLeafCount(len(block.Transactions())); err != nil {
-			return nil, errors.NewSubtreeError("[prepareSubtrees] failed to create subtree", err)
+			return nil, 0, errors.NewSubtreeError("[prepareSubtrees] failed to create subtree", err)
 		}
 
 		if err = subtree.AddCoinbaseNode(); err != nil {
-			return nil, errors.NewSubtreeError("[prepareSubtrees] failed to add coinbase placeholder", err)
+			return nil, 0, errors.NewSubtreeError("[prepareSubtrees] failed to add coinbase placeholder", err)
 		}
 
 		// subtreeData contains the extended tx bytes of all transactions references in the subtree
@@ -303,17 +304,17 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 		txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](len(block.Transactions()))
 
 		if err = sm.createTxMap(ctx, block, txMap); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		// extend all the transactions in the block
 		if err = sm.extendTransactions(ctx, block, txMap); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		// create the subtree and subtreeData for the block
 		if err = sm.createSubtree(ctx, block, txMap, subtree, subtreeData, subtreeMetaData); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if legacyMode, err = sm.blockchainClient.IsFSMCurrentState(sm.ctx, blockchain_api.FSMStateType_LEGACYSYNCING); err != nil {
@@ -325,30 +326,40 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 		quickValidationMode := legacyMode
 
 		if quickValidationMode {
+			// Only in LEGACYSYNCING (LEGACY_SYNC mode) — fetch block ID upfront so UTXOs carry
+			// mined info from creation. This ID is threaded through to blockvalidation via
+			// ProcessBlock so it can call AddBlock(WithID, WithMinedSet(true)) and cause the
+			// setMinedChan worker to skip setTxMinedStatus (MinedSet guard in BlockValidation.go).
+			id, idErr := sm.blockchainClient.GetNextBlockID(ctx)
+			if idErr != nil {
+				return nil, 0, errors.NewProcessingError("[prepareSubtrees] failed to get next block ID", idErr)
+			}
+			blockID = uint32(id) // nolint:gosec
+
 			// in quickValidationMode, we can process transactions in a block in parallel, but in reverse order
 			// first we create all the utxos, then we spend them
-			if err = sm.ValidateTransactionsLegacyMode(ctx, txMap, block); err != nil {
-				return nil, err
+			if err = sm.ValidateTransactionsLegacyMode(ctx, txMap, block, blockID); err != nil {
+				return nil, 0, err
 			}
 		}
 
 		// write all the subtree data to the subtree store
 		if err = sm.writeSubtree(ctx, block, subtree, subtreeData, subtreeMetaData, quickValidationMode); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		// we don't need to check the subtree in the subtree validation in legacy or catching blocks mode,
 		// since we already validated the transactions and created all the subtree files needed
 		if !quickValidationMode {
 			if err = sm.checkSubtreeFromBlock(ctx, block, subtree); err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 		}
 
 		subtrees = append(subtrees, subtree.RootHash())
 	}
 
-	return subtrees, nil
+	return subtrees, blockID, nil
 }
 
 func (sm *SyncManager) checkSubtreeFromBlock(ctx context.Context, block *bsvutil.Block, subtree *subtreepkg.Subtree) error {
@@ -541,7 +552,7 @@ func (sm *SyncManager) writeSubtree(ctx context.Context, block *bsvutil.Block, s
 }
 
 func (sm *SyncManager) ValidateTransactionsLegacyMode(ctx context.Context, txMap *txmap.SyncedMap[chainhash.Hash, *TxMapWrapper],
-	block *bsvutil.Block) (err error) {
+	block *bsvutil.Block, blockID uint32) (err error) {
 	ctx, _, deferFn := tracing.Tracer("netsync").Start(ctx, "validateTransactionsLegacyMode",
 		tracing.WithHistogram(prometheusLegacyNetsyncValidateTransactionsLegacyMode),
 		tracing.WithLogMessage(sm.logger, "[validateTransactionsLegacyMode] called for block %s, height %d", block.Hash(), block.Height()),
@@ -551,7 +562,7 @@ func (sm *SyncManager) ValidateTransactionsLegacyMode(ctx context.Context, txMap
 		deferFn(err)
 	}()
 
-	if err = sm.createUtxos(ctx, txMap, block); err != nil {
+	if err = sm.createUtxos(ctx, txMap, block, blockID); err != nil {
 		return err
 	}
 
@@ -573,7 +584,7 @@ func (sm *SyncManager) ValidateTransactionsLegacyMode(ctx context.Context, txMap
 // createUtxos creates all the utxos for the transactions in the block in parallel
 // before any spending is done. This only occurs in legacy mode when we assume the
 // block is valid.
-func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[chainhash.Hash, *TxMapWrapper], block *bsvutil.Block) (err error) {
+func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[chainhash.Hash, *TxMapWrapper], block *bsvutil.Block, blockID uint32) (err error) {
 	_, _, deferFn := tracing.Tracer("netsync").Start(ctx, "createUtxos",
 		tracing.WithLogMessage(sm.logger, "[createUtxos] called for block %s / height %d", block.Hash(), block.Height()),
 		tracing.WithHistogram(prometheusLegacyNetsyncCreateUtxos),
@@ -608,7 +619,11 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 				return errors.NewProcessingError("transaction %s not found in txMap", txHash.String())
 			}
 
-			if _, err := sm.utxoStore.Create(gCtx, txWrapper.Tx, blockHeightUint32); err != nil {
+			if _, err := sm.utxoStore.Create(gCtx, txWrapper.Tx, blockHeightUint32, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+				BlockID:     blockID,
+				BlockHeight: blockHeightUint32,
+				SubtreeIdx:  0, // legacy path produces a single subtree at index 0
+			})); err != nil {
 				if errors.Is(err, errors.ErrTxExists) {
 					sm.logger.Debugf("failed to create utxo for tx %s: %s", txHash.String(), err)
 				} else {

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -175,7 +175,7 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	}
 
 	// call the process block wrapper, which will add tracing and logging
-	err = sm.ProcessBlock(ctx, teranodeBlock, blockID)
+	err = sm.ProcessBlock(ctx, teranodeBlock)
 	if err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func (sm *SyncManager) waitForPreviousBlockMined(ctx context.Context, prevBlockH
 	return err
 }
 
-func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Block, blockID uint32) (err error) {
+func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Block) (err error) {
 	ctx, _, deferFn := tracing.Tracer("netsync").Start(ctx, "SyncManager:processBlock",
 		tracing.WithLogMessage(
 			sm.logger,
@@ -240,7 +240,10 @@ func (sm *SyncManager) ProcessBlock(ctx context.Context, teranodeBlock *model.Bl
 
 	// send the block to the blockValidation for processing and validation
 	// all the block subtrees should have been validated in processSubtrees
-	if err = sm.blockValidation.ProcessBlock(ctx, teranodeBlock, teranodeBlock.Height, "", "legacy", blockID); err != nil {
+	// teranodeBlock.ID was set by model.NewBlock from the pre-assigned ID returned by prepareSubtrees.
+	// Read it from the struct here — avoids duplicating it as a parameter. It still has to travel as
+	// a separate proto field in the gRPC request because block.Bytes() does not serialize ID.
+	if err = sm.blockValidation.ProcessBlock(ctx, teranodeBlock, teranodeBlock.Height, "", "legacy", teranodeBlock.ID); err != nil {
 		if errors.Is(err, errors.ErrBlockExists) {
 			sm.logger.Infof("[SyncManager:processBlock][%s %d] block already exists", teranodeBlock.Hash().String(), teranodeBlock.Height)
 			return nil

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -378,7 +378,7 @@ func TestSyncManager_createUtxos(t *testing.T) {
 	block.SetHeight(100)
 
 	// Test createUtxos
-	utxos := sm.createUtxos(context.Background(), txMap, block)
+	utxos := sm.createUtxos(context.Background(), txMap, block, 0)
 	assert.NotNil(t, utxos)
 }
 
@@ -469,9 +469,10 @@ func TestSyncManager_prepareSubtrees(t *testing.T) {
 	}
 
 	// For single transaction blocks, prepareSubtrees returns empty
-	subtrees, err := sm.prepareSubtrees(context.Background(), block)
+	subtrees, blockID, err := sm.prepareSubtrees(context.Background(), block)
 	assert.NoError(t, err)
 	assert.NotNil(t, subtrees)
+	assert.Equal(t, uint32(0), blockID) // single-tx block exits early, IsFSMCurrentState=false → blockID stays 0
 
 	blockchainClient.AssertExpectations(t)
 }

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -4731,7 +4731,7 @@ func (m *mockBlockValidationClient) BlockFound(ctx context.Context, blockHash *c
 	return nil
 }
 
-func (m *mockBlockValidationClient) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string) error {
+func (m *mockBlockValidationClient) ProcessBlock(ctx context.Context, block *model.Block, blockHeight uint32, peerID, baseURL string, blockID uint32) error {
 	if m.processBlockFunc != nil {
 		return m.processBlockFunc(ctx, block, blockHeight)
 	}

--- a/test/e2e/daemon/bsv/bsv_invalidblockrequest_test.go
+++ b/test/e2e/daemon/bsv/bsv_invalidblockrequest_test.go
@@ -179,7 +179,7 @@ func testInvalidCoinbaseAmount(t *testing.T, nodes []*daemon.TestDaemon) {
 	_, validBlock := node0.CreateTestBlock(t, previousBlock, 12345) // Empty block with just coinbase
 
 	// Try to process the valid block first to ensure our setup works
-	err = node0.BlockValidationClient.ProcessBlock(ctx, validBlock, validBlock.Height, "", "legacy")
+	err = node0.BlockValidationClient.ProcessBlock(ctx, validBlock, validBlock.Height, "", "legacy", 0)
 	require.NoError(t, err, "Valid block should be accepted")
 
 	t.Log("✅ Valid block was accepted, now testing invalid scenarios...")
@@ -235,7 +235,7 @@ func testInvalidBlockProcessing(t *testing.T, nodes []*daemon.TestDaemon) {
 	_, testBlock := node0.CreateTestBlock(t, bestBlock, 54321, parentTx, childTx)
 
 	// Try to process the block - this should work if transactions are valid
-	err = node0.BlockValidationClient.ProcessBlock(ctx, testBlock, testBlock.Height, "", "legacy")
+	err = node0.BlockValidationClient.ProcessBlock(ctx, testBlock, testBlock.Height, "", "legacy", 0)
 	if err != nil {
 		t.Logf("Block validation failed as expected: %v", err)
 		t.Log("✅ Block validation correctly rejected invalid block")

--- a/test/e2e/daemon/ready/legacy_sync_test.go
+++ b/test/e2e/daemon/ready/legacy_sync_test.go
@@ -1758,7 +1758,7 @@ func TestFloatingBlock_SubmitToTeranodeFirst(t *testing.T) {
 	require.NoError(t, err, "Should create model block from wire.MsgBlock")
 
 	expectedHeight := fundingBlockHeight + 1
-	err = td.BlockValidationClient.ProcessBlock(ctx, modelBlock, expectedHeight, "test", "")
+	err = td.BlockValidationClient.ProcessBlock(ctx, modelBlock, expectedHeight, "test", "", 0)
 	require.NoError(t, err, "Teranode should accept the floating block")
 	t.Logf("Submitted floating block to Teranode at height %d", expectedHeight)
 

--- a/test/e2e/daemon/ready/pruner_unmined_retention_test.go
+++ b/test/e2e/daemon/ready/pruner_unmined_retention_test.go
@@ -136,7 +136,7 @@ func TestPrunerUnminedParentRetention(t *testing.T) {
 
 	for i := 0; i < 8; i++ {
 		_, newBlock := node.CreateTestBlock(t, prevBlock, uint32(9000+i))
-		err = node.BlockValidationClient.ProcessBlock(ctx, newBlock, newBlock.Height, "", "legacy")
+		err = node.BlockValidationClient.ProcessBlock(ctx, newBlock, newBlock.Height, "", "legacy", 0)
 		require.NoError(t, err)
 		t.Logf("Processed empty block at height %d", newBlock.Height)
 		prevBlock = newBlock
@@ -269,7 +269,7 @@ func TestPrunerMixedChildrenParentPreservation(t *testing.T) {
 
 	// Block 1: includes minedChild (tx1 spending parent output 0)
 	_, block := node.CreateTestBlock(t, prevBlock, 9000, minedChild)
-	err = node.BlockValidationClient.ProcessBlock(ctx, block, block.Height, "", "legacy")
+	err = node.BlockValidationClient.ProcessBlock(ctx, block, block.Height, "", "legacy", 0)
 	require.NoError(t, err)
 	t.Logf("Block %d: mined child (tx1) %s included (spends parent output 0)", block.Height, minedChildHash)
 	prevBlock = block
@@ -277,7 +277,7 @@ func TestPrunerMixedChildrenParentPreservation(t *testing.T) {
 	// Blocks 2-8: empty blocks to exceed parent's DAH
 	for i := 1; i < 8; i++ {
 		_, block = node.CreateTestBlock(t, prevBlock, uint32(9000+i))
-		err = node.BlockValidationClient.ProcessBlock(ctx, block, block.Height, "", "legacy")
+		err = node.BlockValidationClient.ProcessBlock(ctx, block, block.Height, "", "legacy", 0)
 		require.NoError(t, err)
 		prevBlock = block
 	}

--- a/test/e2e/daemon/ready/smoke_test.go
+++ b/test/e2e/daemon/ready/smoke_test.go
@@ -846,7 +846,7 @@ func TestShouldRejectOversizedTx(t *testing.T) {
 
 	// now try add a block with the transaction
 	_, block3 := td.CreateTestBlock(t, block2, 10101, newTx)
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block3, block3.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block3, block3.Height, "", "legacy", 0)
 	// TODO should this be an error?
 	require.NoError(t, err)
 }

--- a/test/e2e/daemon/wip/invalid_block_test.go
+++ b/test/e2e/daemon/wip/invalid_block_test.go
@@ -430,7 +430,7 @@ func TestOrphanTxWithSingleNode(t *testing.T) {
 
 	_, block3 := node1.CreateTestBlock(t, block2, 3, childTx)
 
-	require.Error(t, node1.BlockValidationClient.ProcessBlock(node1.Ctx, block3, block3.Height, "", "legacy"))
+	require.Error(t, node1.BlockValidationClient.ProcessBlock(node1.Ctx, block3, block3.Height, "", "legacy", 0))
 
 	bestHeight, _, err := node1.BlockchainClient.GetBestHeightAndTime(node1.Ctx)
 	require.NoError(t, err)

--- a/test/e2e/daemon/wip/unmined_since_reorg_bug_test.go
+++ b/test/e2e/daemon/wip/unmined_since_reorg_bug_test.go
@@ -166,7 +166,7 @@ func testSideToMain(t *testing.T, td *daemon.TestDaemon, ctx context.Context, te
 	t.Logf("Mining %d blocks on main chain (without test tx)...", testCoinbaseMaturity+1)
 	for i := 0; i < testCoinbaseMaturity+1; i++ {
 		_, mainBlock := createTestBlockWithCorrectSubsidy(t, td, forkPointBlock, uint32(10000+i), nil)
-		require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, mainBlock, mainBlock.Height, "", "legacy"))
+		require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, mainBlock, mainBlock.Height, "", "legacy", 0))
 		forkPointBlock = mainBlock
 	}
 
@@ -183,7 +183,7 @@ func testSideToMain(t *testing.T, td *daemon.TestDaemon, ctx context.Context, te
 	td.WaitForBlockAssemblyToProcessTx(t, testTxHash.String())
 
 	_, sideBlock1 := createTestBlockWithCorrectSubsidy(t, td, forkPointBlock, uint32(20000), []*bt.Tx{testTx})
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, sideBlock1, sideBlock1.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, sideBlock1, sideBlock1.Height, "", "legacy", 0))
 
 	// Wait for mined_set background job to complete
 	td.WaitForBlockBeingMined(t, sideBlock1)
@@ -203,7 +203,7 @@ func testSideToMain(t *testing.T, td *daemon.TestDaemon, ctx context.Context, te
 	prevBlock := sideBlock1
 	for i := 1; i < testCoinbaseMaturity+2; i++ {
 		_, sideBlock := createTestBlockWithCorrectSubsidy(t, td, prevBlock, uint32(20000+i), nil)
-		require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, sideBlock, sideBlock.Height, "", "legacy"))
+		require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, sideBlock, sideBlock.Height, "", "legacy", 0))
 		prevBlock = sideBlock
 	}
 
@@ -277,7 +277,7 @@ func testMainToSideAfterSideToMain(t *testing.T, td *daemon.TestDaemon, ctx cont
 	prevBlock := parentBlock
 	for i := 0; i < testCoinbaseMaturity+1; i++ {
 		_, sideBlock := createTestBlockWithCorrectSubsidy(t, td, prevBlock, uint32(30000+i), nil)
-		require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, sideBlock, sideBlock.Height, "", "legacy"))
+		require.NoError(t, td.BlockValidationClient.ProcessBlock(ctx, sideBlock, sideBlock.Height, "", "legacy", 0))
 		prevBlock = sideBlock
 		t.Logf("Side chain block %d/%d mined at height %d", i+1, testCoinbaseMaturity+1, sideBlock.Height)
 	}

--- a/test/e2e/daemon/wip/unmined_tx_block_assembly_reorg_test.go
+++ b/test/e2e/daemon/wip/unmined_tx_block_assembly_reorg_test.go
@@ -146,7 +146,7 @@ func testUnminedTransactionInBlockAssemblyAfterReorg(t *testing.T, utxoStore str
 
 	// Process and Validate the block manually
 	t.Log("Processing and validating block3A...")
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block3A, block3A.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block3A, block3A.Height, "", "legacy", 0)
 	require.NoError(t, err, "Failed to process block3A")
 
 	err = td.BlockValidationClient.ValidateBlock(td.Ctx, block3A, nil)
@@ -167,7 +167,7 @@ func testUnminedTransactionInBlockAssemblyAfterReorg(t *testing.T, utxoStore str
 	t.Logf("Created fork block3B at height 3: %s", block3B.Header.Hash().String())
 
 	// Process and validate block3B
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block3B, block3B.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block3B, block3B.Height, "", "legacy", 0)
 	require.NoError(t, err, "Failed to process block3B")
 
 	err = td.BlockValidationClient.ValidateBlock(td.Ctx, block3B, nil)
@@ -180,7 +180,7 @@ func testUnminedTransactionInBlockAssemblyAfterReorg(t *testing.T, utxoStore str
 	t.Logf("Created block4B at height 4: %s", block4B.Header.Hash().String())
 
 	// Process and validate block4B
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block4B, block4B.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block4B, block4B.Height, "", "legacy", 0)
 	require.NoError(t, err, "Failed to process block4B")
 
 	err = td.BlockValidationClient.ValidateBlock(td.Ctx, block4B, nil)

--- a/test/e2e/daemon/wip/unmined_tx_cleanup_e2e_test.go
+++ b/test/e2e/daemon/wip/unmined_tx_cleanup_e2e_test.go
@@ -122,7 +122,7 @@ func TestUnminedTransactionCleanup(t *testing.T) {
 	for i := uint32(0); i < blocksToMineBeforePreservation; i++ {
 		nonce++
 		_, prevBlock = td.CreateTestBlock(t, prevBlock, nonce)
-		require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, prevBlock, prevBlock.Height, "", "legacy"),
+		require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, prevBlock, prevBlock.Height, "", "legacy", 0),
 			"Failed to process block")
 	}
 
@@ -213,7 +213,7 @@ func TestUnminedTransactionCleanup(t *testing.T) {
 	// create a test block
 	nonce++
 	_, block4b := td.CreateTestBlock(t, block3, nonce, spendingParentTxB)
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy", 0)
 	require.NoError(t, err)
 	time.Sleep(2 * time.Second)
 	prevBlockB := block4b
@@ -380,7 +380,7 @@ func TestUnminedTransactionCleanupAerospike(t *testing.T) {
 	for i := uint32(0); i < blocksToMineBeforePreservation; i++ {
 		nonce++
 		_, prevBlock = td.CreateTestBlock(t, prevBlock, nonce)
-		require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, prevBlock, prevBlock.Height, "", "legacy"),
+		require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, prevBlock, prevBlock.Height, "", "legacy", 0),
 			"Failed to process block")
 	}
 
@@ -458,7 +458,7 @@ func TestUnminedTransactionCleanupAerospike(t *testing.T) {
 	// Create a test block
 	nonce++
 	_, block4b := td.CreateTestBlock(t, block3, nonce, spendingParentTxB)
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy", 0)
 	require.NoError(t, err)
 	time.Sleep(2 * time.Second)
 

--- a/test/sequentialtest/double_spend/01_single_double_spend_external_tx_test.go
+++ b/test/sequentialtest/double_spend/01_single_double_spend_external_tx_test.go
@@ -55,7 +55,7 @@ func testSingleDoubleSpendExternalTx(t *testing.T, utxoStore string) {
 	// create 103A
 	// 0 -> 1 ... 101 -> 102a -> 103a (*)
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, txA0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	// Create block 102b with a double spend external transaction
@@ -68,7 +68,7 @@ func testSingleDoubleSpendExternalTx(t *testing.T, utxoStore string) {
 	// Create block 103b to make the longest chain...
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block104b, blockWait, true)
@@ -94,11 +94,11 @@ func testSingleDoubleSpendExternalTx(t *testing.T, utxoStore string) {
 
 	// Fork back to the original chain and check that everything is processed properly
 	_, block104a := td.CreateTestBlock(t, block103a, 10401) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	_, block105a := td.CreateTestBlock(t, block104a, 10501) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlock(t, block105a, blockWait)

--- a/test/sequentialtest/double_spend/02_multiple_conflicting_external_tx_test.go
+++ b/test/sequentialtest/double_spend/02_multiple_conflicting_external_tx_test.go
@@ -58,7 +58,7 @@ func testMarkAsConflictingMultipleExternalTx(t *testing.T, utxoStore string) {
 	// create 103A with txA0
 	// 0 -> 1 ... 101 -> 102a -> 103a (*)
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, txA0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	// Create block 103b with a double spend external transaction
@@ -79,7 +79,7 @@ func testMarkAsConflictingMultipleExternalTx(t *testing.T, utxoStore string) {
 
 	// Create block 104b to make chain b the longest
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block104b, blockWait, true)

--- a/test/sequentialtest/double_spend/03_conflicting_chains_external_tx_test.go
+++ b/test/sequentialtest/double_spend/03_conflicting_chains_external_tx_test.go
@@ -53,7 +53,7 @@ func testMarkAsConflictingChainsExternalTx(t *testing.T, utxoStore string) {
 
 	// Create block 103a with txA0
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, txA0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block103a, blockWait, true)
@@ -92,7 +92,7 @@ func testMarkAsConflictingChainsExternalTx(t *testing.T, utxoStore string) {
 	// Create block 104a with chain A transactions
 	subtree104a, block104a := td.CreateTestBlock(t, block103a, 10401, txA1, txA2, txA3, txA4)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	// 0 -> 1 ... 101 -> 102a -> 103a [txA0] -> 104a [txA1, txA2, txA3, txA4]
@@ -151,7 +151,7 @@ func testMarkAsConflictingChainsExternalTx(t *testing.T, utxoStore string) {
 	// Switch forks by mining 105b
 	_, block105b := td.CreateTestBlock(t, block104b, 10502) // Empty block
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	// Wait for block assembly to reach height 105

--- a/test/sequentialtest/double_spend/04_double_spend_fork_external_tx_test.go
+++ b/test/sequentialtest/double_spend/04_double_spend_fork_external_tx_test.go
@@ -59,7 +59,7 @@ func testDoubleSpendForkExternalTx(t *testing.T, utxoStore string) {
 	// First, mine txA0 so its outputs can be spent
 	// 0 -> 1 ... 101 -> 102a [parentTx] -> 103a [txA0]
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, txA0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block103a")
 
 	td.WaitForBlockHeight(t, block103a, blockWait, true)
@@ -95,7 +95,7 @@ func testDoubleSpendForkExternalTx(t *testing.T, utxoStore string) {
 	// Create block 104a with chain A external transactions
 	subtree104a, block104a := td.CreateTestBlock(t, block103a, 10401, txA1, txA2, txA3, txA4)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block104a")
 
 	td.WaitForBlockHeight(t, block104a, blockWait, true)
@@ -131,7 +131,7 @@ func testDoubleSpendForkExternalTx(t *testing.T, utxoStore string) {
 
 	// Create block103b with chain B external transactions (forks from 102a)
 	_, block103b := td.CreateTestBlock(t, block102aRefetch, 10302, txB0, txB1, txB2, txB3)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block103b")
 
 	//                   / 102a -> 103a [txA0] -> 104a [txA1..txA4] (*)
@@ -143,11 +143,11 @@ func testDoubleSpendForkExternalTx(t *testing.T, utxoStore string) {
 
 	// Switch forks by mining 104b and 105b to make chain B longer
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block104b")
 
 	_, block105b := td.CreateTestBlock(t, block104b, 10502) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy", 0),
 		"Failed to process block105b")
 
 	//                   / 102a -> 103a [txA0] -> 104a [txA1..txA4]

--- a/test/sequentialtest/double_spend/05_triple_forked_chain_external_tx_test.go
+++ b/test/sequentialtest/double_spend/05_triple_forked_chain_external_tx_test.go
@@ -62,7 +62,7 @@ func testTripleForkedChainExternalTx(t *testing.T, utxoStore string) {
 	// First, mine txA0 so its outputs can be spent
 	// 0 -> 1 ... 101 -> 102a [parentTx] -> 103a [txA0]
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, txA0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block103a")
 
 	td.WaitForBlockHeight(t, block103a, blockWait, true)
@@ -91,7 +91,7 @@ func testTripleForkedChainExternalTx(t *testing.T, utxoStore string) {
 	// Create block 104a with chain A external transactions
 	subtree104a, block104a := td.CreateTestBlock(t, block103a, 10401, txA1, txA2, txA3)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block104a")
 
 	td.WaitForBlockHeight(t, block104a, blockWait, true)
@@ -142,12 +142,12 @@ func testTripleForkedChainExternalTx(t *testing.T, utxoStore string) {
 
 	// Create block103b with chain B external transactions (forks from 102a)
 	subtree103b, block103b := td.CreateTestBlock(t, block102aRefetch, 10302, txB0, txB1, txB2)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block103b")
 
 	// Create block103c with chain C external transactions (forks from 102a)
 	_, block103c := td.CreateTestBlock(t, block102aRefetch, 10303, txC0, txC1, txC2)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103c, block103c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103c, block103c.Height, "", "legacy", 0),
 		"Failed to process block103c")
 
 	//                   / 102a -> 103a [txA0] -> 104a [txA1..txA3] (*)
@@ -159,11 +159,11 @@ func testTripleForkedChainExternalTx(t *testing.T, utxoStore string) {
 
 	// Make chain B win temporarily by mining 104b and 105b
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block104b")
 
 	_, block105b := td.CreateTestBlock(t, block104b, 10502) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy", 0),
 		"Failed to process block105b")
 
 	//                   / 102a -> 103a [txA0] -> 104a [txA1..txA3]
@@ -175,15 +175,15 @@ func testTripleForkedChainExternalTx(t *testing.T, utxoStore string) {
 
 	// Make chain C the ultimate winner by mining 104c, 105c, and 106c
 	_, block104c := td.CreateTestBlock(t, block103c, 10403) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104c, block104c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104c, block104c.Height, "", "legacy", 0),
 		"Failed to process block104c")
 
 	_, block105c := td.CreateTestBlock(t, block104c, 10503) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105c, block105c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105c, block105c.Height, "", "legacy", 0),
 		"Failed to process block105c")
 
 	_, block106c := td.CreateTestBlock(t, block105c, 10603) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block106c, block106c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block106c, block106c.Height, "", "legacy", 0),
 		"Failed to process block106c")
 
 	//                   / 102a -> 103a [txA0] -> 104a [txA1..txA3]

--- a/test/sequentialtest/double_spend/06_grandparent_child_conflict_test.go
+++ b/test/sequentialtest/double_spend/06_grandparent_child_conflict_test.go
@@ -115,12 +115,12 @@ func testGrandparentChildConflict(t *testing.T, utxoStore string) {
 
 	// Create block3b with grandparent (same as 3a content)
 	_, block3b := td.CreateTestBlock(t, block2, 10302, grandparent)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block3b, block3b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block3b, block3b.Height, "", "legacy", 0),
 		"Failed to process block3b")
 
 	// Create block4b with conflictingChild
 	_, block4b := td.CreateTestBlock(t, block3b, 10402, conflictingChild)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy", 0),
 		"Failed to process block4b")
 
 	//            / 3a [grandparent] -> 4a [parent] (*)
@@ -140,7 +140,7 @@ func testGrandparentChildConflict(t *testing.T, utxoStore string) {
 
 	// Now make chain B longer by mining block5b
 	_, block5b := td.CreateTestBlock(t, block4b, 10502)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy", 0),
 		"Failed to process block5b")
 
 	//            / 3a [grandparent] -> 4a [parent]

--- a/test/sequentialtest/double_spend/07_grandparent_multi_output_conflict_test.go
+++ b/test/sequentialtest/double_spend/07_grandparent_multi_output_conflict_test.go
@@ -138,12 +138,12 @@ func testGrandparentMultiOutputConflict(t *testing.T, utxoStore string) {
 
 	// Create block2b with grandparent (same tx in both chains)
 	_, block3b := td.CreateTestBlock(t, block2, 10202, grandparent)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block3b, block3b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block3b, block3b.Height, "", "legacy", 0),
 		"Failed to process block3b")
 
 	// Create block3b with conflictingChild
 	_, block4b := td.CreateTestBlock(t, block3b, 10302, conflictingChild)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy", 0),
 		"Failed to process block4b")
 
 	//        / 2a [grandparent] -> 3a [parent] (*)
@@ -170,7 +170,7 @@ func testGrandparentMultiOutputConflict(t *testing.T, utxoStore string) {
 
 	// Now make chain B longer by mining block4b
 	_, block5b := td.CreateTestBlock(t, block4b, 10402)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy", 0),
 		"Failed to process block5b")
 
 	//        / 2a [grandparent] -> 3a [parent]
@@ -310,7 +310,7 @@ func testGrandparentChildWithParentDependency(t *testing.T, utxoStore string) {
 
 	// Create block4b with childB (skipping parent entirely)
 	_, block4b := td.CreateTestBlock(t, block3a, 10302, childB)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy", 0),
 		"Failed to process block4b")
 
 	//                  / 3a [parent] -> 4a [childA] (*)
@@ -329,10 +329,10 @@ func testGrandparentChildWithParentDependency(t *testing.T, utxoStore string) {
 
 	// Make fork longer to trigger reorg
 	_, block5b := td.CreateTestBlock(t, block4b, 10402)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy", 0))
 
 	_, block6b := td.CreateTestBlock(t, block5b, 10502)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block6b, block6b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block6b, block6b.Height, "", "legacy", 0))
 
 	//                  / 3a [parent] -> 4a [childA]
 	// 0 -> 1 -> 2 [grandparent]

--- a/test/sequentialtest/double_spend/08_same_chain_grandparent_double_spend_test.go
+++ b/test/sequentialtest/double_spend/08_same_chain_grandparent_double_spend_test.go
@@ -142,7 +142,7 @@ func testSameChainGrandparentDoubleSpend(t *testing.T, utxoStore string) {
 
 	// The block validation should fail because it contains a transaction
 	// that attempts to spend an already-spent UTXO
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block5Invalid, block5Invalid.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block5Invalid, block5Invalid.Height, "", "legacy", 0)
 	require.Error(t, err, "Expected block with invalidChild to be rejected - contains double spend")
 	t.Logf("Block validation correctly rejected block with invalidChild: %v", err)
 

--- a/test/sequentialtest/double_spend/09_forked_chain_grandparent_double_spend_test.go
+++ b/test/sequentialtest/double_spend/09_forked_chain_grandparent_double_spend_test.go
@@ -189,7 +189,7 @@ func testComplexForkGrandparentConflict(t *testing.T, utxoStore string) {
 
 	// Create block 4b with parentB (forking from block 3 [grandparent])
 	_, block4b := td.CreateTestBlock(t, block3gp, 10302, parentB)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4b, block4b.Height, "", "legacy", 0),
 		"Failed to process block4b with parentB")
 
 	//                      / 4a [parent] -> 5a [child1, child2, parentSibling] (*)
@@ -207,10 +207,10 @@ func testComplexForkGrandparentConflict(t *testing.T, utxoStore string) {
 	t.Log("\n=== Extending Chain B to trigger reorg ===")
 
 	_, block5b := td.CreateTestBlock(t, block4b, 10402)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block5b, block5b.Height, "", "legacy", 0))
 
 	_, block6b := td.CreateTestBlock(t, block5b, 10502)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block6b, block6b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block6b, block6b.Height, "", "legacy", 0))
 
 	//                      / 4a [parent] -> 5a [child1, child2, parentSibling]
 	// 0 -> 1 -> 2 -> 3 [GP]

--- a/test/sequentialtest/double_spend/10_large_scale_conflict_resolution_test.go
+++ b/test/sequentialtest/double_spend/10_large_scale_conflict_resolution_test.go
@@ -53,7 +53,7 @@ func testDeepChainConflictResolution(t *testing.T, utxoStore string) {
 
 	// Mine txA0 in block 103a
 	_, block103a := td.CreateTestBlock(t, block102a, 50301, txA0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block103a, blockWait, true)
 
 	// Build a 10-level deep chain from txA0. Each tx spends outputs 0,1 from its parent
@@ -89,12 +89,12 @@ func testDeepChainConflictResolution(t *testing.T, utxoStore string) {
 	// Mine chain A across two blocks
 	// Block 104a: txA1..txA4
 	subtree104a, block104a := td.CreateTestBlock(t, block103a, 50401, chainA[1], chainA[2], chainA[3], chainA[4])
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block104a, blockWait, true)
 
 	// Block 105a: txA5..txA9
 	subtree105a, block105a := td.CreateTestBlock(t, block104a, 50501, chainA[5], chainA[6], chainA[7], chainA[8], chainA[9])
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block105a, blockWait, true)
 
 	// Verify chain A txs are not conflicting
@@ -116,17 +116,17 @@ func testDeepChainConflictResolution(t *testing.T, utxoStore string) {
 
 	// Mine empty blocks on chain B to overtake chain A
 	_, block104b := td.CreateTestBlock(t, block103b, 50402)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0))
 
 	_, block105b := td.CreateTestBlock(t, block104b, 50502)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy", 0))
 
 	// Block 106b makes chain B longer — triggers reorg and conflict resolution
 	// This is the critical section: the old recursive code would hang here
 	reorgStart := time.Now()
 
 	_, block106b := td.CreateTestBlock(t, block105b, 50602)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block106b, block106b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block106b, block106b.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block106b, 30*time.Second, true)
 
 	reorgDuration := time.Since(reorgStart)
@@ -199,7 +199,7 @@ func testWideTreeConflictResolution(t *testing.T, utxoStore string) {
 
 	// Mine txA_root in block 103a
 	_, block103a := td.CreateTestBlock(t, block102a, 51301, txARoot)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block103a, blockWait, true)
 
 	// Build wide tree: 4 children from txA_root, each spending a different output
@@ -263,7 +263,7 @@ func testWideTreeConflictResolution(t *testing.T, utxoStore string) {
 	// Mine all tree txs in block 104a (children first, then grandchildren — dependency order)
 	allTreeTxs := []*bt.Tx{child0, child1, child2, child3, gc0, gc1, gc2, gc3, gc4, gc5, gc6}
 	subtree104a, block104a := td.CreateTestBlock(t, block103a, 51401, allTreeTxs...)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block104a, blockWait, true)
 
 	// Verify tree txs are not conflicting
@@ -283,13 +283,13 @@ func testWideTreeConflictResolution(t *testing.T, utxoStore string) {
 
 	// Mine empty blocks on chain B to overtake
 	_, block104b := td.CreateTestBlock(t, block103b, 51402)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0))
 
 	// Block 105b makes chain B longer — triggers reorg
 	reorgStart := time.Now()
 
 	_, block105b := td.CreateTestBlock(t, block104b, 51502)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy"))
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy", 0))
 	td.WaitForBlockHeight(t, block105b, 30*time.Second, true)
 
 	reorgDuration := time.Since(reorgStart)

--- a/test/sequentialtest/double_spend/16_same_tx_both_forks_test.go
+++ b/test/sequentialtest/double_spend/16_same_tx_both_forks_test.go
@@ -178,7 +178,7 @@ func testSameTxBothForks(t *testing.T, utxoStore string) {
 
 	// Now make chain B longer to trigger reorg
 	_, block6b := td.CreateTestBlock(t, block5b, 60002) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block6b, block6b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block6b, block6b.Height, "", "legacy", 0),
 		"Failed to process block6b")
 
 	//                                              / 5a [tx1Conflicting]

--- a/test/sequentialtest/double_spend/critical_validation_test.go
+++ b/test/sequentialtest/double_spend/critical_validation_test.go
@@ -91,7 +91,7 @@ func testNilSubtreeStoreBypass(t *testing.T, utxoStore string) {
 	// 3. Mock the validation dependencies
 	//
 	// For now, we verify that blocks with duplicates are rejected normally.
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with duplicate transactions should be rejected")
 
 	t.Logf("SECURITY NOTE: This test documents a potential bypass at Block.go:500")
@@ -153,7 +153,7 @@ func testEmptySubtreeSlices(t *testing.T, utxoStore string) {
 	_, block102 := td.CreateTestBlock(t, block101, 10401)
 
 	// Process the block - should handle empty subtrees gracefully
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.NoError(t, err, "Block with minimal/empty subtrees should be accepted")
 
 	t.Logf("✓ Block with minimal subtrees handled correctly")
@@ -217,7 +217,7 @@ func testConcurrencyConfigurationEdgeCases(t *testing.T, utxoStore string) {
 	// Test with concurrency = 0
 	_, block102 := td.CreateTestBlock(t, block101, 10402, duplicateTx, duplicateTx)
 
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with duplicates should be rejected even with concurrency=0")
 }
 
@@ -298,7 +298,7 @@ func testRaceDetectorDuplicateDetection(t *testing.T, utxoStore string) {
 	)
 
 	// Process with high concurrency - race detector will catch issues
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with duplicates should be rejected")
 
 	t.Logf("✓ Race detector test completed")

--- a/test/sequentialtest/double_spend/double_spend_test.go
+++ b/test/sequentialtest/double_spend/double_spend_test.go
@@ -151,7 +151,7 @@ func testSingleDoubleSpend(t *testing.T, utxoStore string) {
 	// Create block 103b to make the longest chain...
 	_, block103b := td.CreateTestBlock(t, block102b, 10302) // Empty block
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block103b, blockWait, true)
@@ -177,11 +177,11 @@ func testSingleDoubleSpend(t *testing.T, utxoStore string) {
 
 	// fork back to the original chain and check that everything is processed properly
 	_, block103a := td.CreateTestBlock(t, block102a, 10301) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	_, block104a := td.CreateTestBlock(t, block103a, 10401) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block104a, blockWait)
@@ -213,7 +213,7 @@ func testDoubleSpendInSubsequentBlock(t *testing.T, utxoStore string) {
 	// Step 1: Create and validate block with double spend transaction
 	_, block103 := td.CreateTestBlock(t, block102, 10301, txB0)
 
-	require.Error(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103, block103.Height, "", "legacy"),
+	require.Error(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103, block103.Height, "", "legacy", 0),
 		"Failed to reject invalid block with double spend transaction")
 }
 
@@ -257,7 +257,7 @@ func testMarkAsConflictingMultiple(t *testing.T, utxoStore string) {
 
 	// Create block 103b to make the longest chain...
 	_, block103b := td.CreateTestBlock(t, block102b, 10302) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block103b, blockWait)
@@ -295,7 +295,7 @@ func testMarkAsConflictingChains(t *testing.T, utxoStore string) {
 	// Create block 103a with the original transactions
 	subtree103a, block103a := td.CreateTestBlock(t, block102a, 10301, txA1, txA2, txA3, txA4)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	// 0 -> 1 ... 101 -> 102a -> 103a
@@ -331,7 +331,7 @@ func testMarkAsConflictingChains(t *testing.T, utxoStore string) {
 	// switch forks by mining 104b
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	// wait for block assembly to reach height 104
@@ -379,7 +379,7 @@ func testDoubleSpendFork(t *testing.T, utxoStore string) {
 	// Create block 103a with chain A transactions
 	subtree103a, block103a := td.CreateTestBlock(t, block102a, 10301, txA1, txA2, txA3, txA4)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block103a")
 
 	// 0 -> 1 ... 101 -> 102a -> 103a
@@ -391,7 +391,7 @@ func testDoubleSpendFork(t *testing.T, utxoStore string) {
 	// Create block102b from block101
 	_, block102b := td.CreateTestBlock(t, block101, 10202) // Empty block
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102b, block102b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102b, block102b.Height, "", "legacy", 0),
 		"Failed to process block102b")
 
 	//                / 102a -> 103a (*)
@@ -405,7 +405,7 @@ func testDoubleSpendFork(t *testing.T, utxoStore string) {
 
 	// Create block103b with chain B transactions
 	_, block103b := td.CreateTestBlock(t, block102b, 10302, txB0, txB1, txB2, txB3)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block103b")
 
 	//                / 102a -> 103a (*)
@@ -417,7 +417,7 @@ func testDoubleSpendFork(t *testing.T, utxoStore string) {
 
 	// switch forks by mining 104b
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block104b")
 
 	//                / 102a -> 103a
@@ -446,13 +446,13 @@ func createConflictingBlock(t *testing.T, td *daemon.TestDaemon, originalBlock *
 	newBlockSubtree, newBlock := td.CreateTestBlock(t, previousBlock, nonce, blockTxs...)
 
 	if len(expectBlockError) > 0 && expectBlockError[0] {
-		require.Error(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy"),
+		require.Error(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy", 0),
 			"Failed to process block with double spend transaction")
 
 		return nil
 	}
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy", 0),
 		"Failed to process block with double spend transaction")
 
 	td.VerifyBlockByHash(t, newBlock, newBlock.Header.Hash())
@@ -509,7 +509,7 @@ func testTripleForkedChain(t *testing.T, utxoStore string) {
 	// Create block 103a with chain A transactions
 	subtree103a, block103a := td.CreateTestBlock(t, block102a, 10301, txA1, txA2, txA3)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block103a")
 
 	//
@@ -524,7 +524,7 @@ func testTripleForkedChain(t *testing.T, utxoStore string) {
 
 	// Create block102b from block101
 	_, block102b := td.CreateTestBlock(t, block101, 10202) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102b, block102b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102b, block102b.Height, "", "legacy", 0),
 		"Failed to process block102b")
 
 	// Create chain B transactions
@@ -533,7 +533,7 @@ func testTripleForkedChain(t *testing.T, utxoStore string) {
 
 	// Create block103b with chain B transactions
 	subtree103b, block103b := td.CreateTestBlock(t, block102b, 10302, txB0, txB1, txB2)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block103b")
 
 	//                         txA1
@@ -556,12 +556,12 @@ func testTripleForkedChain(t *testing.T, utxoStore string) {
 
 	// Create block102c from block101
 	_, block102c := td.CreateTestBlock(t, block101, 10203) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102c, block102c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102c, block102c.Height, "", "legacy", 0),
 		"Failed to process block102c")
 
 	// Create block103c with chain C transactions
 	_, block103c := td.CreateTestBlock(t, block102c, 10303, txC0, txC1, txC2)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103c, block103c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103c, block103c.Height, "", "legacy", 0),
 		"Failed to process block103c")
 
 	//                  102a -> 103a (*)
@@ -575,7 +575,7 @@ func testTripleForkedChain(t *testing.T, utxoStore string) {
 
 	// Make chain B win temporarily by mining 104b
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block104b")
 
 	//                  102a -> 103a
@@ -589,11 +589,11 @@ func testTripleForkedChain(t *testing.T, utxoStore string) {
 
 	// Make chain C the ultimate winner by mining 104c and 105c
 	_, block104c := td.CreateTestBlock(t, block103c, 10403) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104c, block104c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104c, block104c.Height, "", "legacy", 0),
 		"Failed to process block104c")
 
 	_, block105c := td.CreateTestBlock(t, block104c, 10503) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105c, block105c.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105c, block105c.Height, "", "legacy", 0),
 		"Failed to process block105c")
 
 	//                  102a -> 103a
@@ -636,7 +636,7 @@ func testNonConflictingTxReorg(t *testing.T, utxoStore string) {
 	// Create block 103b to make the longest chain...
 	_, block103b := td.CreateTestBlock(t, block102b, 10302, txX0)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block103b, blockWait)
@@ -656,7 +656,7 @@ func testNonConflictingTxReorg(t *testing.T, utxoStore string) {
 
 	// fork back to the original chain and check that everything is processed properly
 	_, block103a := td.CreateTestBlock(t, block102a, 10301) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	//                   / 102a {txA0} -> 103a
@@ -675,7 +675,7 @@ func testNonConflictingTxReorg(t *testing.T, utxoStore string) {
 	td.VerifyConflictingInSubtrees(t, block102b.Subtrees[0], txB0)
 
 	_, block104a := td.CreateTestBlock(t, block103a, 10401) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block104a, blockWait)
@@ -697,7 +697,7 @@ func testNonConflictingTxReorg(t *testing.T, utxoStore string) {
 
 	// create another block 105a with the tx2
 	_, block105a := td.CreateTestBlock(t, block104a, 10501, txX0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.VerifyConflictingInUtxoStore(t, false, txX0)
@@ -725,12 +725,12 @@ func testConflictingTxReorg(t *testing.T, utxoStore string) {
 	// Create block 103a with the conflicting tx
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, tx1Conflicting)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"), "Failed to process block")
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0), "Failed to process block")
 
 	// Create block 103b with the conflicting tx
 	_, block103b := td.CreateTestBlock(t, block102a, 10302, tx1Conflicting)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"), "Failed to process block")
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0), "Failed to process block")
 
 	td.WaitForBlockHeight(t, block103a, blockWait)
 
@@ -749,7 +749,7 @@ func testConflictingTxReorg(t *testing.T, utxoStore string) {
 
 	// fork to the new chain and check that everything is processed properly
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"), "Failed to process block")
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0), "Failed to process block")
 
 	// When we reorg, tx1Conflicting should be processed properly and removed from block assembly
 	//                   / 103a {tx1Conflicting}
@@ -783,7 +783,7 @@ func testNonConflictingTxBlockAssemblyReset(t *testing.T, utxoStore string) {
 	// Create block 103b to make the longest chain...
 	_, block103b := td.CreateTestBlock(t, block102b, 10302, txX0)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block103b, blockWait)
@@ -809,11 +809,11 @@ func testNonConflictingTxBlockAssemblyReset(t *testing.T, utxoStore string) {
 
 	// fork back to the original chain and check that everything is processed properly
 	_, block103a := td.CreateTestBlock(t, block102a, 10301) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	_, block104a := td.CreateTestBlock(t, block103a, 10401) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.WaitForBlockHeight(t, block104a, blockWait)
@@ -837,7 +837,7 @@ func testNonConflictingTxBlockAssemblyReset(t *testing.T, utxoStore string) {
 
 	// create another block 105a with the tx2
 	_, block105a := td.CreateTestBlock(t, block104a, 10501, txX0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy", 0),
 		"Failed to process block")
 
 	td.VerifyConflictingInUtxoStore(t, false, txX0)
@@ -882,7 +882,7 @@ func testDoubleSpendForkWithNestedTXs(t *testing.T, utxoStore string) {
 	// Create block 103a with chain A transactions
 	_, block103a := td.CreateTestBlock(t, block102a, 10301, txA1)
 
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103a, block103a.Height, "", "legacy", 0),
 		"Failed to process block103a")
 
 	//
@@ -901,7 +901,7 @@ func testDoubleSpendForkWithNestedTXs(t *testing.T, utxoStore string) {
 
 	// Create block102b from block101
 	_, block102b := td.CreateTestBlock(t, block101, 10202) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102b, block102b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block102b, block102b.Height, "", "legacy", 0),
 		"Failed to process block102b")
 
 	//
@@ -913,7 +913,7 @@ func testDoubleSpendForkWithNestedTXs(t *testing.T, utxoStore string) {
 
 	// Create block103b with chain B transactions
 	_, block103b := td.CreateTestBlock(t, block102b, 10302, txB0)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block103b, block103b.Height, "", "legacy", 0),
 		"Failed to process block103b")
 
 	//
@@ -937,7 +937,7 @@ func testDoubleSpendForkWithNestedTXs(t *testing.T, utxoStore string) {
 
 	// switch forks by mining 104b
 	_, block104b := td.CreateTestBlock(t, block103b, 10402) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104b, block104b.Height, "", "legacy", 0),
 		"Failed to process block104b")
 
 	//
@@ -965,7 +965,7 @@ func testDoubleSpendForkWithNestedTXs(t *testing.T, utxoStore string) {
 
 	// Add a new block 105b on top of 104b with the new double spends
 	_, block105b := td.CreateTestBlock(t, block104b, 10502, txB1)
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105b, block105b.Height, "", "legacy", 0),
 		"Failed to process block105b")
 
 	td.WaitForBlockHeight(t, block105b, blockWait)
@@ -993,15 +993,15 @@ func testDoubleSpendForkWithNestedTXs(t *testing.T, utxoStore string) {
 
 	// now make the other chain longer
 	_, block104a := td.CreateTestBlock(t, block103a, 10401) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block104a, block104a.Height, "", "legacy", 0),
 		"Failed to process block104a")
 
 	_, block105a := td.CreateTestBlock(t, block104a, 10501) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block105a, block105a.Height, "", "legacy", 0),
 		"Failed to process block105a")
 
 	_, block106a := td.CreateTestBlock(t, block105a, 10601) // Empty block
-	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block106a, block106a.Height, "", "legacy"),
+	require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block106a, block106a.Height, "", "legacy", 0),
 		"Failed to process block106a")
 
 	//

--- a/test/sequentialtest/double_spend/early_duplicate_test.go
+++ b/test/sequentialtest/double_spend/early_duplicate_test.go
@@ -91,7 +91,7 @@ func testEarlyDuplicatePartiallySpentAndPruned(t *testing.T, utxoStore string) {
 	_, block102 := td.CreateTestBlock(t, block101, 10202, duplicateTx, spendingTx, duplicateTx)
 
 	// Process the block - should fail
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with early duplicate transaction should be rejected even when partially spent")
 	require.Contains(t, err.Error(), "duplicate transaction", "Error should mention duplicate transaction")
 
@@ -148,7 +148,7 @@ func testEarlyDuplicateNotSpent(t *testing.T, utxoStore string) {
 	_, block102 := td.CreateTestBlock(t, block101, 10203, duplicateTx, duplicateTx)
 
 	// Process the block - should fail
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with duplicate transaction should be rejected")
 	require.Contains(t, err.Error(), "duplicate transaction", "Error should mention duplicate transaction")
 

--- a/test/sequentialtest/double_spend/edge_case_duplicate_test.go
+++ b/test/sequentialtest/double_spend/edge_case_duplicate_test.go
@@ -78,7 +78,7 @@ func testUnknownDuplicateCoinbaseRejection(t *testing.T, utxoStore string) {
 	// A proper test would require manual block construction
 
 	// Verify the block was created successfully (no duplicate coinbase)
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.NoError(t, err, "Block with unique coinbase should be accepted")
 
 	t.Logf("Note: Full coinbase duplication test requires manual block construction")
@@ -159,7 +159,7 @@ func testDuplicateAcrossSubtreeBoundary(t *testing.T, utxoStore string) {
 	)
 
 	// Process the block - should fail due to duplicate detection (or UTXO error with SQLite)
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with duplicate across subtrees should be rejected")
 
 	// Accept either duplicate detection error or UTXO locking error (both indicate block rejection)
@@ -247,7 +247,7 @@ func testDuplicateInLastIncompleteSubtree(t *testing.T, utxoStore string) {
 	)
 
 	// Process the block - should fail due to duplicate (or UTXO error with SQLite)
-	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy")
+	err = td.BlockValidationClient.ProcessBlock(td.Ctx, block102, block102.Height, "", "legacy", 0)
 	require.Error(t, err, "Block with duplicate in incomplete last subtree should be rejected")
 
 	// Accept either duplicate detection error or UTXO locking error (both indicate block rejection)

--- a/test/sequentialtest/double_spend/external_tx_helpers.go
+++ b/test/sequentialtest/double_spend/external_tx_helpers.go
@@ -202,12 +202,12 @@ func createConflictingBlockUseExternalRecords(t *testing.T, td *daemon.TestDaemo
 	newBlockSubtree, newBlock := td.CreateTestBlock(t, previousBlock, nonce, blockTxs...)
 
 	if len(expectBlockError) > 0 && expectBlockError[0] {
-		require.Error(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy"),
+		require.Error(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy", 0),
 			"Expected block with double spend transaction to be rejected")
 		return nil
 	}
 
-	// require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy"),
+	// require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, newBlock, newBlock.Height, "", "legacy", 0),
 	// 	"Failed to process block with double spend transaction")
 
 	require.NoError(t, td.BlockValidation.ValidateBlock(td.Ctx, newBlock, "legacy"),

--- a/test/sequentialtest/longest_chain/longest_chain_test.go
+++ b/test/sequentialtest/longest_chain/longest_chain_test.go
@@ -133,7 +133,7 @@ func testLongestChainInvalidateBlock(t *testing.T, utxoStore string) {
 	td.VerifyInBlockAssembly(t, tx1)
 
 	_, block4a := td.CreateTestBlock(t, block3, 4001, tx1)
-	// require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4a, block4a.Height, "legacy", ""))
+	// require.NoError(t, td.BlockValidationClient.ProcessBlock(td.Ctx, block4a, block4a.Height, "legacy", "", 0))
 	require.NoError(t, td.BlockValidation.ValidateBlock(td.Ctx, block4a, "legacy", false, true), "Failed to process block")
 	td.WaitForBlock(t, block4a, blockWait)
 	td.WaitForBlockBeingMined(t, block4a)


### PR DESCRIPTION
## Problem

During LEGACYSYNCING, the legacy netsync path (`handle_block.go`) calls `createUtxos` which creates UTXOs **without a block ID**. Later, blockvalidation runs full `ValidateBlockWithOptions`, adds the block to the blockchain (auto-assigning an ID), then `updateSubtreesDAH` triggers the `setMinedChan` background worker. That worker calls `setTxMinedStatus` → `UpdateTxMinedStatus` → `SetMinedMulti` to retroactively write the block ID to **every UTXO in the block**. This is a redundant round-trip for each transaction in every legacy-synced block.

The catchup path (`quickValidateBlock`) already avoids this by:
1. Calling `GetNextBlockID` upfront to get block ID X
2. Creating UTXOs with `WithMinedBlockInfo{BlockID: X}`
3. Calling `AddBlock(WithID(X), WithMinedSet(true))` — block stored with `mined_set = true`
4. The `setMinedChan` worker sees `blockHeaderMeta.MinedSet == true` (guard at `BlockValidation.go:533–536`) and skips `setTxMinedStatus` entirely

This PR replicates the same pattern for the legacy netsync path.

## Solution

Three layers of change:

### 1. Netsync (`handle_block.go`)
- `prepareSubtrees` now calls `blockchainClient.GetNextBlockID` **only when in LEGACYSYNCING mode** (`quickValidationMode = legacyMode`) and returns the assigned block ID
- The block ID is threaded through `ValidateTransactionsLegacyMode` → `createUtxos`, which now passes `WithMinedBlockInfo{BlockID, BlockHeight, SubtreeIdx: 0}` to `utxoStore.Create`
- `ProcessBlock` accepts the block ID and forwards it to blockvalidation

### 2. gRPC interface (`blockvalidation_api.proto`)
- New `block_id uint32` field added to `ProcessBlockRequest` (field 5)
- Allows netsync to pass the pre-assigned block ID across the service boundary without modifying the block wire format

### 3. Blockvalidation (`Server.go` + `BlockValidation.go`)
- `Server.ProcessBlock` sets `block.ID = request.BlockId` when non-zero
- New `buildAddBlockOpts` helper: when `block.ID != 0`, returns `[WithID(block.ID), WithMinedSet(true)]`
- Both `AddBlock` call sites in `ValidateBlockWithOptions` use this helper, so blocks arriving from the legacy netsync path are stored with `mined_set = true` upfront
- The existing `setMinedChan` guard (`blockHeaderMeta.MinedSet == true` → `continue`) then skips `setTxMinedStatus` entirely for those blocks

## Why the gRPC field is necessary

`block.Bytes()` (the wire serialisation used in the gRPC request) does **not** include `block.ID` — it is an internal database field. Without the new proto field, the pre-assigned ID is lost at the service boundary and blockvalidation would auto-assign a different ID, causing UTXOs to be created with ID X but the block stored with ID Y, and `setTxMined` would still run to overwrite X→Y.

## Impact

- **LEGACYSYNCING blocks**: `setTxMinedStatus` is now skipped entirely (via existing guard). UTXOs are written with the correct block ID at creation time.
- **All other blocks** (live, catchup, revalidation): `block.ID == 0` in the gRPC request → `buildAddBlockOpts` returns `nil` → `AddBlock` behaves exactly as before. No behaviour change.
- **Proto**: backward-compatible addition (field 5, default value 0 = "not pre-assigned").

## Testing

- `go build ./...` — clean
- `make lint` — 0 issues
- Unit tests for all modified packages pass:
  - `services/legacy/netsync/...`
  - `services/blockvalidation/...`
  - `services/rpc/...`
  - `services/asset/...`
- All existing `ProcessBlock` call sites in integration/smoke tests updated with `0` (no pre-assigned ID) — no behaviour change for those tests

## Verification in a live environment

With LEGACYSYNCING active, the `setMinedChan` worker will log:

```
[BlockValidation:start][<hash>] block already has mined_set true, skipping setTxMined
```

for every block processed via the legacy path, confirming `setTxMinedStatus` is bypassed.