### PR TITLE
fix(pruner): resolve null block hash in OnBlockPersisted initial pruning

### DIFF
--- a/services/pruner/server.go
+++ b/services/pruner/server.go
@@ -319,17 +319,44 @@ func (s *Server) triggerInitialPruning(ctx context.Context) {
 		// GetBlockHeadersByHeight walks the main chain (highest chainwork), so this
 		// remains fork-safe while avoiding full block reconstruction/transfer when
 		// only the hash is needed for the initial pruning signal.
+		// Retries with backoff to handle transient blockchain-client unavailability
+		// during startup, since in OnBlockPersisted mode there may be no subsequent
+		// notification to trigger pruning if this fails.
 		if currentHeight > 0 {
-			headers, _, err := s.blockchainClient.GetBlockHeadersByHeight(ctx, currentHeight, currentHeight)
-			if err != nil {
-				s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning: %v", currentHeight, err)
-				return
+			const (
+				maxHeaderLookupAttempts = 3
+				headerLookupBackoff     = 500 * time.Millisecond
+			)
+
+			for attempt := 1; attempt <= maxHeaderLookupAttempts; attempt++ {
+				headers, _, err := s.blockchainClient.GetBlockHeadersByHeight(ctx, currentHeight, currentHeight)
+				if err == nil && len(headers) > 0 && headers[0] != nil {
+					blockHash = *headers[0].Hash()
+					break
+				}
+
+				if err != nil {
+					s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning (attempt %d/%d): %v", currentHeight, attempt, maxHeaderLookupAttempts, err)
+				} else if len(headers) == 0 {
+					s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning (attempt %d/%d): header not found", currentHeight, attempt, maxHeaderLookupAttempts)
+				} else {
+					s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning (attempt %d/%d): header was nil", currentHeight, attempt, maxHeaderLookupAttempts)
+				}
+
+				if attempt == maxHeaderLookupAttempts {
+					return
+				}
+
+				timer := time.NewTimer(headerLookupBackoff)
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					if !timer.Stop() {
+						<-timer.C
+					}
+					return
+				}
 			}
-			if len(headers) == 0 || headers[0] == nil {
-				s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning: header was nil", currentHeight)
-				return
-			}
-			blockHash = *headers[0].Hash()
 		}
 	case settings.PrunerBlockTriggerOnBlockMined:
 		tipHeader, tipMeta, err := s.blockchainClient.GetBestBlockHeader(ctx)

--- a/services/pruner/server.go
+++ b/services/pruner/server.go
@@ -315,16 +315,21 @@ func (s *Server) triggerInitialPruning(ctx context.Context) {
 	switch blockTrigger {
 	case settings.PrunerBlockTriggerOnBlockPersisted:
 		currentHeight = s.lastPersistedHeight.Load()
-		// Look up the actual block hash for the persisted height. GetBlockByHeight
-		// walks the main chain (highest chainwork), so this is fork-safe — it will
-		// always return the main-chain block even if competing blocks exist at this height.
+		// Look up the actual block hash for the persisted height using headers only.
+		// GetBlockHeadersByHeight walks the main chain (highest chainwork), so this
+		// remains fork-safe while avoiding full block reconstruction/transfer when
+		// only the hash is needed for the initial pruning signal.
 		if currentHeight > 0 {
-			block, err := s.blockchainClient.GetBlockByHeight(ctx, currentHeight)
-			if err != nil || block == nil {
-				s.logger.Warnf("[pruner] failed to get block at persisted height %d for initial pruning: %v", currentHeight, err)
+			headers, _, err := s.blockchainClient.GetBlockHeadersByHeight(ctx, currentHeight, currentHeight)
+			if err != nil {
+				s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning: %v", currentHeight, err)
 				return
 			}
-			blockHash = *block.Hash()
+			if len(headers) == 0 || headers[0] == nil {
+				s.logger.Warnf("[pruner] failed to get block header at persisted height %d for initial pruning: header was nil", currentHeight)
+				return
+			}
+			blockHash = *headers[0].Hash()
 		}
 	case settings.PrunerBlockTriggerOnBlockMined:
 		tipHeader, tipMeta, err := s.blockchainClient.GetBestBlockHeader(ctx)

--- a/services/pruner/server.go
+++ b/services/pruner/server.go
@@ -315,6 +315,17 @@ func (s *Server) triggerInitialPruning(ctx context.Context) {
 	switch blockTrigger {
 	case settings.PrunerBlockTriggerOnBlockPersisted:
 		currentHeight = s.lastPersistedHeight.Load()
+		// Look up the actual block hash for the persisted height. GetBlockByHeight
+		// walks the main chain (highest chainwork), so this is fork-safe — it will
+		// always return the main-chain block even if competing blocks exist at this height.
+		if currentHeight > 0 {
+			block, err := s.blockchainClient.GetBlockByHeight(ctx, currentHeight)
+			if err != nil || block == nil {
+				s.logger.Warnf("[pruner] failed to get block at persisted height %d for initial pruning: %v", currentHeight, err)
+				return
+			}
+			blockHash = *block.Hash()
+		}
 	case settings.PrunerBlockTriggerOnBlockMined:
 		tipHeader, tipMeta, err := s.blockchainClient.GetBestBlockHeader(ctx)
 		if err != nil || tipHeader == nil || tipMeta == nil {


### PR DESCRIPTION
## Summary
- `triggerInitialPruning` in `OnBlockPersisted` mode set `currentHeight` from `lastPersistedHeight` but left `blockHash` as the zero-value (all zeros), causing the pruner worker to endlessly retry `waitForBlockMinedStatus` on a non-existent block
- Now fetches the actual block hash via `GetBlockHeadersByHeight` (header-only, avoiding full block reconstruction) before sending the pruning signal
- `GetBlockHeadersByHeight` is fork-safe — its SQL query walks the main chain (highest chainwork) so it always returns the correct block even when competing blocks exist at the same height
- Includes 3-attempt retry with 500ms backoff for transient blockchain-client unavailability at startup
- Distinct error messages for transport errors, missing headers, and nil headers

## Test plan
- [x] Pruner unit tests pass (`go test -v -race ./services/pruner/...`)
- [ ] Deploy to teratestnet and verify pruner no longer logs warnings about block `0000...0000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)