### PR TITLE
test(blockassembly): fix TestHandleReorgWithInvalidBlock_Integration on main

### DIFF
--- a/services/blockassembly/blockassembly_system_test.go
+++ b/services/blockassembly/blockassembly_system_test.go
@@ -1003,8 +1003,18 @@ func TestHandleReorgWithInvalidBlock_Integration(t *testing.T) {
 	// Invalidate chain A block 2 (A2). This makes A2 and A3 invalid.
 	// Blockchain should reorg to A1 (the last valid block on chain A).
 	t.Log("Invalidating chain A block 2...")
-	_, err = ba.blockchainClient.InvalidateBlock(ctx, chainAHeaders[1].Hash())
+	invalidatedHashes, err := ba.blockchainClient.InvalidateBlock(ctx, chainAHeaders[1].Hash())
 	require.NoError(t, err, "failed to invalidate chain A block 2")
+
+	// Simulate BlockValidation's async reaction to InvalidateBlock: it would
+	// process the BlockMinedUnset notification and re-set mined_set=true after
+	// unsetting tx mined status. BlockValidation isn't running in this test,
+	// so call SetBlockMinedSet directly — otherwise BA's reset() blocks in
+	// waitForBlockMinedSet until its retry budget exhausts.
+	for i := range invalidatedHashes {
+		require.NoError(t, ba.blockchainClient.SetBlockMinedSet(ctx, &invalidatedHashes[i]),
+			"failed to re-set mined_set on invalidated block %s", invalidatedHashes[i].String())
+	}
 
 	// Build chain B: genesis → B1 → B2 → B3 (higher difficulty, from genesis)
 	chainBBits, err := model.NewNBitFromString("1d00ffff")


### PR DESCRIPTION
## Summary

Follow-up to #545. `TestHandleReorgWithInvalidBlock_Integration` has been failing on `main` consistently since the merge (see runs 24533201543, 24532254759, 24529039544).

## Root cause

The test uses `nodehelpers.NewBlockchainDaemon`, which spins up the blockchain service but **not** BlockValidation. `InvalidateBlock` sets `mined_set=false` on the affected blocks and emits a `BlockMinedUnset` notification that BlockValidation normally consumes to re-set `mined_set=true`. With no BlockValidation running, nothing replies to the notification.

The `reset()` path added in #691 then blocks in `waitForBlockMinedSet` until its retry budget is exhausted — far longer than the test's 15s `Eventually` window — so the test times out before BA can settle on chain B.

Error from CI:
```
[Reset] context cancelled while waiting for invalid block mined_set -> UNKNOWN (0): context canceled
```

## Fix

Capture the hashes returned by `InvalidateBlock` and call `SetBlockMinedSet` on each, simulating BlockValidation's async reaction. This is a test-only change — no production code touched.

## Test plan

- [x] `go test -count=1 -run '^TestHandleReorgWithInvalidBlock_Integration$' ./services/blockassembly/` passes 3/3 runs locally
- [x] `go vet ./services/blockassembly/...` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)