### PR TITLE
fix(validator): disable BIP68 enforcement post-Genesis

### DIFF
--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -351,6 +351,16 @@ func (tv *TxValidator) sequenceLocks(tx *bt.Tx, blockHeight uint32, utxoHeights 
 	// src/validation.cpp::CheckSequenceLocks), which makes CalculateSequenceLocks
 	// a no-op. Mirror that here so blocks containing non-zero-sequence inputs are
 	// accepted post-Genesis.
+	//
+	// Note on >= vs >: This check uses >= to match BSV's IsGenesisEnabled()
+	// semantics (the activation block itself is considered post-Genesis). That
+	// differs from checkOutputs() below, which uses > because mainnet block
+	// 620538's outputs were created before Genesis rules existed and must not be
+	// retroactively rejected. The two predicates are intentionally different:
+	// checkOutputs gates a backward-incompatible output-shape rule (P2SH/dust)
+	// and exempts the activation block for continuity, whereas sequenceLocks
+	// disables a now-obsolete consensus rule and must match the reference
+	// implementation's boundary exactly.
 	if blockHeight >= tv.settings.ChainCfgParams.GenesisActivationHeight {
 		return nil
 	}

--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -344,6 +344,17 @@ func (tv *TxValidator) sequenceLocks(tx *bt.Tx, blockHeight uint32, utxoHeights 
 		return nil
 	}
 
+	// BSV Genesis restored the original Bitcoin semantics for nSequence: it is
+	// used for RBF signalling only, not for relative lock-time enforcement. The
+	// reference implementation drops LOCKTIME_VERIFY_SEQUENCE post-Genesis (see
+	// src/policy/policy.h::StandardNonFinalVerifyFlags and
+	// src/validation.cpp::CheckSequenceLocks), which makes CalculateSequenceLocks
+	// a no-op. Mirror that here so blocks containing non-zero-sequence inputs are
+	// accepted post-Genesis.
+	if blockHeight >= tv.settings.ChainCfgParams.GenesisActivationHeight {
+		return nil
+	}
+
 	// Version 2 transactions are required for BIP68
 	// Transactions with version < 2 bypass relative lock-time enforcement
 	if tx.Version < 2 {

--- a/services/validator/TxValidator_bip68_test.go
+++ b/services/validator/TxValidator_bip68_test.go
@@ -18,6 +18,7 @@ import (
 // helper — they should use test.CreateBaseTestSettings(t) and rely on the
 // regtest Genesis activation height (10000).
 func bip68TestSettings(t testing.TB) *settings.Settings {
+	t.Helper()
 	tSettings := test.CreateBaseTestSettings(t)
 	// int32 max, not uint32 max — ScriptVerifierGoBDK casts this to int32 and
 	// rejects zero/negative values, so MaxUint32 wraps to -1 and panics.

--- a/services/validator/TxValidator_bip68_test.go
+++ b/services/validator/TxValidator_bip68_test.go
@@ -590,7 +590,11 @@ func TestSequenceLocks_AllInputsDisabled(t *testing.T) {
 func TestSequenceLocks_PostGenesis_BypassesBIP68(t *testing.T) {
 	logger := ulogger.TestLogger{}
 	tSettings := test.CreateBaseTestSettings(t)
-	// Regtest Genesis activation is 10000; use a block height well past it.
+	// Pin CSVHeight below GenesisActivationHeight so the only short-circuit
+	// the test can take is the Genesis bypass under test. Without this, a
+	// chain-params change where CSVHeight > GenesisActivationHeight would let
+	// the test pass via the unrelated `blockHeight < CSVHeight` early return.
+	tSettings.ChainCfgParams.CSVHeight = 1
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -612,6 +616,8 @@ func TestSequenceLocks_PostGenesis_BypassesBIP68(t *testing.T) {
 
 	require.Greater(t, blockHeight, tSettings.ChainCfgParams.GenesisActivationHeight,
 		"test precondition: blockHeight must be post-Genesis")
+	require.GreaterOrEqual(t, blockHeight, tSettings.ChainCfgParams.CSVHeight,
+		"test precondition: blockHeight must be at/after CSVHeight (otherwise the CSV early-return would mask the Genesis bypass)")
 
 	err := txValidator.ValidateTransaction(tx, blockHeight, utxoHeights, &Options{SkipPolicyChecks: true})
 	require.NoError(t, err, "BIP68 must not be enforced post-Genesis (height-based)")
@@ -631,6 +637,9 @@ func TestSequenceLocks_PostGenesis_BypassesBIP68(t *testing.T) {
 func TestSequenceLocks_AtGenesisActivationHeight(t *testing.T) {
 	logger := ulogger.TestLogger{}
 	tSettings := test.CreateBaseTestSettings(t)
+	// Pin CSVHeight below GenesisActivationHeight so the CSV early-return
+	// cannot mask the Genesis boundary check we're validating here.
+	tSettings.ChainCfgParams.CSVHeight = 1
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -644,6 +653,9 @@ func TestSequenceLocks_AtGenesisActivationHeight(t *testing.T) {
 	utxoHeights := []uint32{blockHeight - 50}
 	utxoMTPs := []uint32{1000000}
 	blockMTP := uint32(1000100)
+
+	require.GreaterOrEqual(t, blockHeight, tSettings.ChainCfgParams.CSVHeight,
+		"test precondition: blockHeight must be at/after CSVHeight so the CSV early-return does not mask the Genesis boundary check")
 
 	err := txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
 	require.NoError(t, err, "block at exact GenesisActivationHeight must be treated as post-Genesis")

--- a/services/validator/TxValidator_bip68_test.go
+++ b/services/validator/TxValidator_bip68_test.go
@@ -1,18 +1,34 @@
 package validator
 
 import (
+	"math"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/stretchr/testify/require"
 )
 
+// bip68TestSettings returns settings suitable for exercising BIP68 enforcement.
+// It overrides GenesisActivationHeight to the maximum value so the post-Genesis
+// short-circuit in sequenceLocks() does not pre-empt the logic under test.
+// Tests that specifically verify the post-Genesis bypass should NOT use this
+// helper — they should use test.CreateBaseTestSettings(t) and rely on the
+// regtest Genesis activation height (10000).
+func bip68TestSettings(t testing.TB) *settings.Settings {
+	tSettings := test.CreateBaseTestSettings(t)
+	// int32 max, not uint32 max — ScriptVerifierGoBDK casts this to int32 and
+	// rejects zero/negative values, so MaxUint32 wraps to -1 and panics.
+	tSettings.ChainCfgParams.GenesisActivationHeight = math.MaxInt32
+	return tSettings
+}
+
 // TestSequenceLocks_BeforeCSVHeight verifies that BIP68 is not enforced before CSVHeight.
 func TestSequenceLocks_BeforeCSVHeight(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	// Create a transaction with sequence number that would fail BIP68 if it were active
@@ -39,7 +55,7 @@ func TestSequenceLocks_BeforeCSVHeight(t *testing.T) {
 // TestSequenceLocks_Version1Transaction verifies that version 1 transactions bypass BIP68.
 func TestSequenceLocks_Version1Transaction(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -66,7 +82,7 @@ func TestSequenceLocks_Version1Transaction(t *testing.T) {
 // TestSequenceLocks_DisabledFlag verifies that the disable flag bypasses BIP68.
 func TestSequenceLocks_DisabledFlag(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -92,7 +108,7 @@ func TestSequenceLocks_DisabledFlag(t *testing.T) {
 // TestSequenceLocks_HeightBased_Success verifies successful height-based relative lock-time.
 func TestSequenceLocks_HeightBased_Success(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -121,7 +137,7 @@ func TestSequenceLocks_HeightBased_Success(t *testing.T) {
 // TestSequenceLocks_HeightBased_Failure verifies failed height-based relative lock-time.
 func TestSequenceLocks_HeightBased_Failure(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -151,7 +167,7 @@ func TestSequenceLocks_HeightBased_Failure(t *testing.T) {
 // TestSequenceLocks_TimeBased_Success verifies successful time-based relative lock-time.
 func TestSequenceLocks_TimeBased_Success(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -181,7 +197,7 @@ func TestSequenceLocks_TimeBased_Success(t *testing.T) {
 // TestSequenceLocks_TimeBased_Failure verifies failed time-based relative lock-time.
 func TestSequenceLocks_TimeBased_Failure(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -211,7 +227,7 @@ func TestSequenceLocks_TimeBased_Failure(t *testing.T) {
 // TestSequenceLocks_MultipleInputs verifies sequence locks with multiple inputs.
 func TestSequenceLocks_MultipleInputs(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -249,7 +265,7 @@ func TestSequenceLocks_MultipleInputs(t *testing.T) {
 // TestSequenceLocks_MultipleInputs_Failure verifies failure with multiple inputs.
 func TestSequenceLocks_MultipleInputs_Failure(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -281,7 +297,7 @@ func TestSequenceLocks_MultipleInputs_Failure(t *testing.T) {
 // TestSequenceLocks_MaxValue verifies behavior with maximum sequence number.
 func TestSequenceLocks_MaxValue(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -310,7 +326,7 @@ func TestSequenceLocks_MaxValue(t *testing.T) {
 // TestSequenceLocks_NotEnforcedInMempool verifies that BIP68 is only enforced during block validation.
 func TestSequenceLocks_NotEnforcedInMempool(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -334,7 +350,7 @@ func TestSequenceLocks_NotEnforcedInMempool(t *testing.T) {
 // (inclusive), matching BSV C++: if (pindex_->GetHeight() >= consensusParams.CSVHeight).
 func TestSequenceLocks_AtExactCSVHeight(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	blockHeight := tSettings.ChainCfgParams.CSVHeight
@@ -374,7 +390,7 @@ func TestSequenceLocks_AtExactCSVHeight(t *testing.T) {
 // TestSequenceLocks_MixedTypes verifies transaction with mixed sequence lock types.
 func TestSequenceLocks_MixedTypes(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -417,7 +433,7 @@ func TestSequenceLocks_MixedTypes(t *testing.T) {
 // TestSequenceLocks_MixedTypes_Failure verifies failure when any mixed lock type fails.
 func TestSequenceLocks_MixedTypes_Failure(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -447,7 +463,7 @@ func TestSequenceLocks_MixedTypes_Failure(t *testing.T) {
 // TestSequenceLocks_ZeroValue verifies behavior with zero sequence number.
 func TestSequenceLocks_ZeroValue(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -474,7 +490,7 @@ func TestSequenceLocks_ZeroValue(t *testing.T) {
 // TestSequenceLocks_JustBelowDisableFlag verifies sequence number just below disable flag.
 func TestSequenceLocks_JustBelowDisableFlag(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -503,7 +519,7 @@ func TestSequenceLocks_JustBelowDisableFlag(t *testing.T) {
 // TestSequenceLocks_TypeFlagOnly verifies type flag set with zero lock value.
 func TestSequenceLocks_TypeFlagOnly(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -531,7 +547,7 @@ func TestSequenceLocks_TypeFlagOnly(t *testing.T) {
 // TestSequenceLocks_AllInputsDisabled verifies transaction with all inputs disabled.
 func TestSequenceLocks_AllInputsDisabled(t *testing.T) {
 	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
+	tSettings := bip68TestSettings(t)
 	txValidator := NewTxValidator(logger, tSettings)
 
 	tx := bt.NewTx()
@@ -556,4 +572,78 @@ func TestSequenceLocks_AllInputsDisabled(t *testing.T) {
 	require.NoError(t, err, "All inputs disabled should bypass all sequence lock checks")
 	err = txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
 	require.NoError(t, err, "All inputs disabled should bypass all sequence lock checks")
+}
+
+// TestSequenceLocks_PostGenesis_BypassesBIP68 verifies that BSV Genesis disables
+// BIP68 enforcement. Post-Genesis, nSequence reverts to its original meaning
+// (RBF signalling only) and relative lock-time constraints are not enforced.
+//
+// Regression guard for the testnet sync halt observed on block 1,518,114:
+// the block contained a transaction with a non-zero sequence number that
+// would have been rejected by the height-based BIP68 check, but testnet's
+// Genesis activation (1,344,302) was already past, so the reference
+// implementation accepts the block.
+//
+// See bitcoin-sv/bitcoin-sv policy/policy.h::StandardNonFinalVerifyFlags
+// and validation.cpp::CheckSequenceLocks.
+func TestSequenceLocks_PostGenesis_BypassesBIP68(t *testing.T) {
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	// Regtest Genesis activation is 10000; use a block height well past it.
+	txValidator := NewTxValidator(logger, tSettings)
+
+	tx := bt.NewTx()
+	require.NoError(t, tx.From("0000000000000000000000000000000000000000000000000000000000000001", 0, "76a914000000000000000000000000000000000000000088ac", 100))
+	require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 50))
+
+	tx.Version = 2
+	// A large height-based sequence that would clearly fail BIP68 if it were
+	// still enforced: requires utxoHeight + 100 - 1 blocks to pass.
+	tx.Inputs[0].SequenceNumber = 100
+
+	// utxoHeight == blockHeight-50, so the pre-Genesis check would compute
+	// minHeight = blockHeight-50 + 100 - 1 = blockHeight+49, which is
+	// >= blockHeight → rejected. Post-Genesis we must accept.
+	blockHeight := tSettings.ChainCfgParams.GenesisActivationHeight + 100
+	utxoHeights := []uint32{blockHeight - 50}
+	utxoMTPs := []uint32{1000000}
+	blockMTP := uint32(1000100)
+
+	require.Greater(t, blockHeight, tSettings.ChainCfgParams.GenesisActivationHeight,
+		"test precondition: blockHeight must be post-Genesis")
+
+	err := txValidator.ValidateTransaction(tx, blockHeight, utxoHeights, &Options{SkipPolicyChecks: true})
+	require.NoError(t, err, "BIP68 must not be enforced post-Genesis (height-based)")
+	err = txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
+	require.NoError(t, err, "BIP68 must not be enforced post-Genesis (height-based)")
+
+	// Same check, time-based: a large time-based sequence that would fail the
+	// BIP68 time check pre-Genesis must also be accepted post-Genesis.
+	tx.Inputs[0].SequenceNumber = SequenceLockTimeTypeFlag | 100
+	err = txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
+	require.NoError(t, err, "BIP68 must not be enforced post-Genesis (time-based)")
+}
+
+// TestSequenceLocks_AtGenesisActivationHeight verifies that the boundary block
+// (blockHeight == GenesisActivationHeight) is treated as post-Genesis, matching
+// the BSV reference IsGenesisEnabled() which uses >= for the comparison.
+func TestSequenceLocks_AtGenesisActivationHeight(t *testing.T) {
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	txValidator := NewTxValidator(logger, tSettings)
+
+	tx := bt.NewTx()
+	require.NoError(t, tx.From("0000000000000000000000000000000000000000000000000000000000000001", 0, "76a914000000000000000000000000000000000000000088ac", 100))
+	require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 50))
+
+	tx.Version = 2
+	tx.Inputs[0].SequenceNumber = 100 // would fail BIP68 if enforced
+
+	blockHeight := tSettings.ChainCfgParams.GenesisActivationHeight // exact boundary
+	utxoHeights := []uint32{blockHeight - 50}
+	utxoMTPs := []uint32{1000000}
+	blockMTP := uint32(1000100)
+
+	err := txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
+	require.NoError(t, err, "block at exact GenesisActivationHeight must be treated as post-Genesis")
 }


### PR DESCRIPTION
## Summary

BSV Genesis restored the original Bitcoin semantics for `nSequence`: it is used for RBF signalling only, not for relative lock-time enforcement. The reference implementation at `bitcoin-sv/bitcoin-sv` drops `LOCKTIME_VERIFY_SEQUENCE` from the policy flags post-Genesis in [`src/policy/policy.h::StandardNonFinalVerifyFlags`](https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/policy/policy.h#L248-L256):

```cpp
inline uint32_t StandardNonFinalVerifyFlags(ProtocolEra era)
{
    uint32_t flags { LOCKTIME_MEDIAN_TIME_PAST };
    if(! IsProtocolActive(era, ProtocolName::Genesis))
    {
        flags |= LOCKTIME_VERIFY_SEQUENCE;
    }
    return flags;
}
```

…which causes `CalculateSequenceLocks` to short-circuit to `(-1, -1)` and `EvaluateSequenceLocks` to return `true` unconditionally. `CheckSequenceLocks` in `validation.cpp` also has an explicit `if (IsProtocolActive(..., Genesis)) return true;` guard (line 371-375).

Teranode's `sequenceLocks()` only gated enforcement on the lower bound (`blockHeight < CSVHeight`) and continued enforcing BIP68 indefinitely. This caused testnet sync to halt at block **1,518,114** — a post-Genesis block containing a tx with a non-zero sequence number that real BSV nodes accept but teranode was rejecting with:

```
TX_INVALID (31): transaction sequence lock height not satisfied:
required 1518115, current 1518114
```

## Fix

Add the matching upper bound in `sequenceLocks()`:

```go
if blockHeight >= tv.settings.ChainCfgParams.GenesisActivationHeight {
    return nil
}
```

## Boundary convention

The new check uses `>=` to match BSV's `IsGenesisEnabled()` semantics: blocks **at** `GenesisActivationHeight` are considered post-Genesis.

Note that the existing `TxValidator.go:478` uses `>` (strictly greater than) for `isGenesisActivated`. That's inconsistent with BSV reference and is worth reconciling, but I've scoped this PR narrowly to the BIP68 bug. Happy to fix the `>` vs `>=` inconsistency in a separate PR if reviewers prefer.

## Testing

- **New** `TestSequenceLocks_PostGenesis_BypassesBIP68` — regression test covering the testnet 1,518,114 scenario for both height- and time-based locks.
- **New** `TestSequenceLocks_AtGenesisActivationHeight` — verifies the `>=` boundary.
- **Existing BIP68 tests rewired** through a new `bip68TestSettings()` helper that overrides `GenesisActivationHeight` to `math.MaxInt32` so enforcement remains active during the test. Without this, 15+ existing tests would start passing trivially via the Genesis short-circuit rather than exercising BIP68 logic (their blockHeights are all in the 419k-500k range, well past regtest Genesis = 10000).
- `make lint` — 0 issues.
- `go test ./services/validator/...` — all pass (one pre-existing unrelated Docker-dependent test is skipped on my machine).

## Test plan

- [x] Unit tests pass on the validator package
- [x] New regression tests cover both height-based and time-based BIP68 at and past Genesis activation height
- [x] `make lint` clean
- [ ] Deploy to testnet and verify sync past 1,518,114

🤖 Generated with [Claude Code](https://claude.com/claude-code)