### PR TITLE
fix(utxo): cascade conflicting flag to spending descendants

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -2407,7 +2407,7 @@ func (b *BlockAssembler) validateUnminedTxInputs(ctx context.Context, txHash cha
 }
 
 func (b *BlockAssembler) markAsConflicting(ctx context.Context, txHash chainhash.Hash) {
-	if _, _, err := b.utxoStore.SetConflicting(ctx, []chainhash.Hash{txHash}, true); err != nil {
+	if _, err := utxo.MarkConflictingRecursively(ctx, b.utxoStore, []chainhash.Hash{txHash}); err != nil {
 		b.logger.Errorf("[validateUnminedTxInputs][%s] failed to mark as conflicting: %v", txHash.String(), err)
 	}
 }

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -1606,7 +1606,7 @@ func (b *BlockAssembler) validateParentChain(
 			// Batch fetch all parent metadata at once
 			// Request only the fields we need for validation
 			err := b.utxoStore.BatchDecorate(ctx, unresolvedParents,
-				fields.BlockIDs, fields.UnminedSince, fields.Locked)
+				fields.BlockIDs, fields.UnminedSince, fields.Locked, fields.Conflicting)
 			if err != nil {
 				// Log the batch error but continue - individual errors are in UnresolvedMetaData
 				b.logger.Warnf("[BlockAssembler][validateParentChain] BatchDecorate error (will check individual results): %v", err)
@@ -1669,6 +1669,13 @@ func (b *BlockAssembler) validateParentChain(
 					// This means BatchDecorate couldn't find it - it doesn't exist
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s not found in UTXO store", parentTxID.String())
+					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					break
+				}
+
+				if parentMeta.Conflicting {
+					allParentsValid = false
+					invalidReason = fmt.Sprintf("parent tx %s is conflicting", parentTxID.String())
 					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
 					break
 				}
@@ -2407,8 +2414,16 @@ func (b *BlockAssembler) validateUnminedTxInputs(ctx context.Context, txHash cha
 }
 
 func (b *BlockAssembler) markAsConflicting(ctx context.Context, txHash chainhash.Hash) {
-	if _, err := utxo.MarkConflictingRecursively(ctx, b.utxoStore, []chainhash.Hash{txHash}); err != nil {
+	_, cascadedHashes, err := utxo.MarkConflictingRecursively(ctx, b.utxoStore, []chainhash.Hash{txHash})
+	if err != nil {
 		b.logger.Errorf("[validateUnminedTxInputs][%s] failed to mark as conflicting: %v", txHash.String(), err)
+		return
+	}
+
+	for _, h := range cascadedHashes {
+		if removeErr := b.subtreeProcessor.Remove(ctx, h); removeErr != nil {
+			b.logger.Warnf("[validateUnminedTxInputs][%s] failed to evict cascaded tx from subtree processor: %v", h.String(), removeErr)
+		}
 	}
 }
 

--- a/services/blockassembly/filter_transactions_test.go
+++ b/services/blockassembly/filter_transactions_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/mock"
@@ -293,4 +294,140 @@ func TestValidateParentChain_BatchingAndOrdering(t *testing.T) {
 
 		mockStore.AssertExpectations(t)
 	})
+}
+
+// TestValidateParentChain_RejectsChildOfConflictingParent is the regression test for the
+// late-cascade hole: if a parent was flipped to Conflicting=true after a child was already
+// admitted to the unmined list, validateParentChain must refuse to re-admit the child.
+// Without this check, block validation later rejects the template with
+// "parent transaction … has no block IDs" (bad-txns-inputs-missingorspent).
+func TestValidateParentChain_RejectsChildOfConflictingParent(t *testing.T) {
+	ctx := context.Background()
+
+	mockStore := new(utxo.MockUtxostore)
+	logger := ulogger.TestLogger{}
+
+	testSettings := &settings.Settings{}
+	testSettings.BlockAssembly.ParentValidationBatchSize = 50
+	testSettings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs = true
+
+	blockAssembler := &BlockAssembler{
+		utxoStore: mockStore,
+		settings:  testSettings,
+		logger:    logger,
+	}
+
+	var parentHash chainhash.Hash
+	for j := range parentHash {
+		parentHash[j] = 0xAA
+	}
+
+	var childHash chainhash.Hash
+	for j := range childHash {
+		childHash[j] = 0xBB
+	}
+
+	// Only the child is in the unmined list. The conflicting parent has already been
+	// filtered out by the server-side unmined-iterator filter, so validateParentChain
+	// never sees it as an unmined tx — only as a fetched parent metadata record.
+	childTx := &utxo.UnminedTransaction{
+		Node: &subtree.Node{
+			Hash:        childHash,
+			Fee:         1000,
+			SizeInBytes: 250,
+		},
+		TxInpoints: &subtree.TxInpoints{
+			ParentTxHashes: []chainhash.Hash{parentHash},
+			Idxs:           [][]uint32{{0}},
+		},
+		CreatedAt: 1,
+	}
+	unminedTxs := []*utxo.UnminedTransaction{childTx}
+
+	mockStore.On("BatchDecorate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			for _, unresolved := range args.Get(1).([]*utxo.UnresolvedMetaData) {
+				if unresolved.Hash.IsEqual(&parentHash) {
+					unresolved.Data = &meta.Data{
+						BlockIDs:     []uint32{},
+						UnminedSince: 1,
+						Conflicting:  true,
+					}
+				}
+			}
+		}).
+		Return(nil)
+
+	bestBlockHeaderIDsMap := map[uint32]bool{1: true}
+
+	validTxs, err := blockAssembler.validateParentChain(ctx, unminedTxs, bestBlockHeaderIDsMap)
+	require.NoError(t, err)
+	require.Empty(t, validTxs,
+		"child of a conflicting parent must be filtered with OnRestartRemoveInvalidParentChainTxs=true")
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestValidateParentChain_BatchDecorateRequestsConflicting verifies that validateParentChain
+// asks the store for the Conflicting field. Without this field in the decorate call, the
+// defence-in-depth check would read a zero value and always accept the child.
+func TestValidateParentChain_BatchDecorateRequestsConflicting(t *testing.T) {
+	ctx := context.Background()
+
+	mockStore := new(utxo.MockUtxostore)
+	logger := ulogger.TestLogger{}
+
+	testSettings := &settings.Settings{}
+	testSettings.BlockAssembly.ParentValidationBatchSize = 50
+
+	blockAssembler := &BlockAssembler{
+		utxoStore: mockStore,
+		settings:  testSettings,
+		logger:    logger,
+	}
+
+	var parentHash chainhash.Hash
+	for j := range parentHash {
+		parentHash[j] = 0xCC
+	}
+
+	var childHash chainhash.Hash
+	for j := range childHash {
+		childHash[j] = 0xDD
+	}
+
+	childTx := &utxo.UnminedTransaction{
+		Node: &subtree.Node{
+			Hash:        childHash,
+			Fee:         1000,
+			SizeInBytes: 250,
+		},
+		TxInpoints: &subtree.TxInpoints{
+			ParentTxHashes: []chainhash.Hash{parentHash},
+			Idxs:           [][]uint32{{0}},
+		},
+	}
+
+	var capturedFields []fields.FieldName
+	mockStore.On("BatchDecorate", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			// MockUtxostore.BatchDecorate forwards the variadic fields as a single slice,
+			// so args.Get(2) is the whole []fields.FieldName.
+			capturedFields = args.Get(2).([]fields.FieldName)
+			for _, unresolved := range args.Get(1).([]*utxo.UnresolvedMetaData) {
+				if unresolved.Hash.IsEqual(&parentHash) {
+					unresolved.Data = &meta.Data{
+						BlockIDs:     []uint32{1},
+						UnminedSince: 0,
+					}
+				}
+			}
+		}).
+		Return(nil)
+
+	_, err := blockAssembler.validateParentChain(ctx, []*utxo.UnminedTransaction{childTx}, map[uint32]bool{1: true})
+	require.NoError(t, err)
+
+	require.Contains(t, capturedFields, fields.Conflicting,
+		"validateParentChain must request fields.Conflicting from the store")
 }

--- a/services/blockassembly/mark_as_conflicting_test.go
+++ b/services/blockassembly/mark_as_conflicting_test.go
@@ -1,0 +1,94 @@
+// Package blockassembly provides functionality for assembling Bitcoin blocks in Teranode.
+package blockassembly
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/services/blockassembly/subtreeprocessor"
+	"github.com/bsv-blockchain/teranode/settings"
+	utxoStore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestMarkAsConflicting_EvictsCascadedDescendants verifies that when a parent is
+// marked conflicting via the reload-time validateUnminedTxInputs path, every
+// cascaded descendant is also removed from the in-memory subtree processor.
+//
+// Before the cascade fix (and even with the cascade alone, without eviction),
+// a parallel worker could admit a child to the subtree processor's in-memory
+// template before the cascade flipped its conflicting flag in the store; the
+// stale child would then appear in the next mining candidate even though its
+// parent is now marked conflicting.
+//
+// This test exercises a 3-level chain (parent → child → grandchild) to show that
+// the eviction walks the full cascade, not just the initial hash.
+func TestMarkAsConflicting_EvictsCascadedDescendants(t *testing.T) {
+	ctx := context.Background()
+
+	parentHash := chainhash.HashH([]byte("parent"))
+	childHash := chainhash.HashH([]byte("child"))
+	grandchildHash := chainhash.HashH([]byte("grandchild"))
+
+	mockStore := new(utxoStore.MockUtxostore)
+	// Level 1: parent → child
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
+		Return([]*utxoStore.Spend{{TxID: &parentHash, Vout: 0}}, []chainhash.Hash{childHash}, nil)
+	// Level 2: child → grandchild
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
+		Return([]*utxoStore.Spend{{TxID: &childHash, Vout: 0}}, []chainhash.Hash{grandchildHash}, nil)
+	// Level 3: grandchild has no children — BFS terminates
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true).
+		Return([]*utxoStore.Spend{{TxID: &grandchildHash, Vout: 0}}, []chainhash.Hash{}, nil)
+
+	mockStp := &subtreeprocessor.MockSubtreeProcessor{}
+	mockStp.On("Remove", mock.Anything, parentHash).Return(nil).Once()
+	mockStp.On("Remove", mock.Anything, childHash).Return(nil).Once()
+	mockStp.On("Remove", mock.Anything, grandchildHash).Return(nil).Once()
+
+	ba := &BlockAssembler{
+		utxoStore:        mockStore,
+		subtreeProcessor: mockStp,
+		settings:         &settings.Settings{},
+		logger:           ulogger.TestLogger{},
+	}
+
+	ba.markAsConflicting(ctx, parentHash)
+
+	mockStore.AssertExpectations(t)
+	mockStp.AssertExpectations(t)
+	mockStp.AssertNumberOfCalls(t, "Remove", 3)
+}
+
+// TestMarkAsConflicting_CascadeErrorDoesNotEvict verifies that when the cascade
+// itself fails (underlying SetConflicting returns an error), markAsConflicting
+// does not attempt any evictions. This avoids partial eviction of children that
+// remain non-conflicting in the store — a reload would simply re-admit them.
+func TestMarkAsConflicting_CascadeErrorDoesNotEvict(t *testing.T) {
+	ctx := context.Background()
+
+	parentHash := chainhash.HashH([]byte("parent-fail"))
+
+	mockStore := new(utxoStore.MockUtxostore)
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
+		Return([]*utxoStore.Spend(nil), []chainhash.Hash(nil),
+			errors.NewProcessingError("aerospike unavailable"))
+
+	mockStp := &subtreeprocessor.MockSubtreeProcessor{}
+	// Deliberately no Remove expectations — must not be called.
+
+	ba := &BlockAssembler{
+		utxoStore:        mockStore,
+		subtreeProcessor: mockStp,
+		settings:         &settings.Settings{},
+		logger:           ulogger.TestLogger{},
+	}
+
+	ba.markAsConflicting(ctx, parentHash)
+
+	mockStore.AssertExpectations(t)
+	mockStp.AssertNotCalled(t, "Remove", mock.Anything, mock.Anything)
+}

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -614,9 +614,11 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 							return nil, err
 						}
 
-						// Tx already exists — ensure it and all its spending descendants are marked conflicting
+						// Tx already exists — ensure it and all its spending descendants are marked conflicting.
+						// NOTE: cascaded descendants may still be in the subtree processor's in-memory template
+						// until the next reset/reload — this path has no subtreeProcessor handle to evict them.
 						if !txMetaData.Conflicting {
-							if _, setErr := utxo.MarkConflictingRecursively(decoupledCtx, v.utxoStore, []chainhash.Hash{*tx.TxIDChainHash()}); setErr != nil {
+							if _, _, setErr := utxo.MarkConflictingRecursively(decoupledCtx, v.utxoStore, []chainhash.Hash{*tx.TxIDChainHash()}); setErr != nil {
 								err = errors.NewProcessingError("[Validate][%s] failed to mark existing tx as conflicting", txID, setErr)
 								span.RecordError(err)
 

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -614,9 +614,9 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 							return nil, err
 						}
 
-						// Tx already exists — ensure it's marked as conflicting in the store
+						// Tx already exists — ensure it and all its spending descendants are marked conflicting
 						if !txMetaData.Conflicting {
-							if _, _, setErr := v.utxoStore.SetConflicting(decoupledCtx, []chainhash.Hash{*tx.TxIDChainHash()}, true); setErr != nil {
+							if _, setErr := utxo.MarkConflictingRecursively(decoupledCtx, v.utxoStore, []chainhash.Hash{*tx.TxIDChainHash()}); setErr != nil {
 								err = errors.NewProcessingError("[Validate][%s] failed to mark existing tx as conflicting", txID, setErr)
 								span.RecordError(err)
 

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -924,17 +924,16 @@ func (t *TxMetaCache) GetConflictingChildren(ctx context.Context, txHash chainha
 // - Array of transaction hashes that were successfully marked
 // - Error if the operation fails
 func (t *TxMetaCache) SetConflicting(ctx context.Context, txHashes []chainhash.Hash, setValue bool) ([]*utxo.Spend, []chainhash.Hash, error) {
-	_, _, err := t.utxoStore.SetConflicting(ctx, txHashes, setValue)
+	affectedSpends, spendingChildren, err := t.utxoStore.SetConflicting(ctx, txHashes, setValue)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// remove from cache to ensure consistency, as conflicting transactions are not cached
 	for _, txHash := range txHashes {
 		_ = t.Delete(ctx, &txHash)
 	}
 
-	return nil, txHashes, nil
+	return affectedSpends, spendingChildren, nil
 }
 
 // SetLocked marks transactions as locked and not spendable.

--- a/stores/txmetacache/txmetacache_conflicting_test.go
+++ b/stores/txmetacache/txmetacache_conflicting_test.go
@@ -237,3 +237,64 @@ func TestSetConflicting_ShouldInvalidateCache(t *testing.T) {
 	// If not found, that's correct — forces a store lookup which
 	// returns the correct value.
 }
+
+// forwardingStore lets a test configure the exact return values of SetConflicting
+// so we can verify that TxMetaCache.SetConflicting forwards them unchanged.
+type forwardingStore struct {
+	*nullstore.NullStore
+	spendsToReturn   []*utxo.Spend
+	childrenToReturn []chainhash.Hash
+	lastInput        []chainhash.Hash
+}
+
+func newForwardingStore(t testing.TB, spends []*utxo.Spend, children []chainhash.Hash) *forwardingStore {
+	t.Helper()
+	ns, err := nullstore.NewNullStore()
+	require.NoError(t, err)
+	require.NoError(t, ns.SetBlockHeight(100))
+	return &forwardingStore{
+		NullStore:        ns,
+		spendsToReturn:   spends,
+		childrenToReturn: children,
+	}
+}
+
+func (s *forwardingStore) SetConflicting(_ context.Context, txHashes []chainhash.Hash, _ bool) ([]*utxo.Spend, []chainhash.Hash, error) {
+	s.lastInput = append([]chainhash.Hash(nil), txHashes...)
+	return s.spendsToReturn, s.childrenToReturn, nil
+}
+
+// TestSetConflicting_ForwardsReturnValues proves that TxMetaCache.SetConflicting
+// does not silently discard the affected-spends slice and the spending-children
+// slice returned by the underlying store. Before the fix, the wrapper returned
+// (nil, txHashes, nil) — echoing the input hashes back as "children" and dropping
+// the spends. A recursive caller like MarkConflictingRecursively would then see
+// its own input fed back, the visited dedup would reject it, and BFS would
+// terminate after one level with no cascade.
+func TestSetConflicting_ForwardsReturnValues(t *testing.T) {
+	ctx := context.Background()
+
+	parentHash := testHash(1)
+	childHash := testHash(2)
+	grandchildHash := testHash(3)
+
+	parentSpendTxID := parentHash
+	expectedSpends := []*utxo.Spend{{TxID: &parentSpendTxID, Vout: 0}}
+	expectedChildren := []chainhash.Hash{childHash, grandchildHash}
+
+	store := newForwardingStore(t, expectedSpends, expectedChildren)
+
+	c, err := NewTxMetaCache(ctx, test.CreateBaseTestSettings(t), ulogger.TestLogger{}, store, Unallocated)
+	require.NoError(t, err)
+	cache := c.(*TxMetaCache)
+
+	spends, children, err := cache.SetConflicting(ctx, []chainhash.Hash{parentHash}, true)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedSpends, spends,
+		"wrapper must forward affected-parent-spends from underlying store")
+	require.Equal(t, expectedChildren, children,
+		"wrapper must forward spending-children from underlying store, not echo the input")
+	require.Equal(t, []chainhash.Hash{parentHash}, store.lastInput,
+		"underlying store should have received exactly the input hashes")
+}

--- a/stores/utxo/aerospike/setconflicting_cascade_test.go
+++ b/stores/utxo/aerospike/setconflicting_cascade_test.go
@@ -55,17 +55,15 @@ func TestSetConflictingCascade_Aerospike(t *testing.T) {
 		_, err = store.Spend(ctx, childTx, store.GetBlockHeight()+1)
 		require.NoError(t, err)
 
-		// Mark parent conflicting with recursive cascade
 		parentHash := *tx.TxIDChainHash()
-		_, err = utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
+		_, markedHashes, err := utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
 		require.NoError(t, err)
+		require.Len(t, markedHashes, 2, "parent + child should both be marked")
 
-		// Parent must be conflicting
 		parentMeta, err := store.Get(ctx, tx.TxIDChainHash(), fields.Conflicting)
 		require.NoError(t, err)
 		require.True(t, parentMeta.Conflicting, "parent must be conflicting")
 
-		// Child must also be conflicting via cascade
 		childMeta, err := store.Get(ctx, childTx.TxIDChainHash(), fields.Conflicting)
 		require.NoError(t, err)
 		require.True(t, childMeta.Conflicting,
@@ -95,10 +93,10 @@ func TestSetConflictingCascade_Aerospike(t *testing.T) {
 		_, err = store.Spend(ctx, grandchildTx, store.GetBlockHeight()+1)
 		require.NoError(t, err)
 
-		// Mark parent conflicting — must cascade entire descendant tree
 		parentHash := *tx.TxIDChainHash()
-		_, err = utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
+		_, markedHashes, err := utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
 		require.NoError(t, err)
+		require.Len(t, markedHashes, 3, "parent + child + grandchild should all be marked")
 
 		parentMeta, err := store.Get(ctx, tx.TxIDChainHash(), fields.Conflicting)
 		require.NoError(t, err)

--- a/stores/utxo/aerospike/setconflicting_cascade_test.go
+++ b/stores/utxo/aerospike/setconflicting_cascade_test.go
@@ -58,7 +58,8 @@ func TestSetConflictingCascade_Aerospike(t *testing.T) {
 		parentHash := *tx.TxIDChainHash()
 		_, markedHashes, err := utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
 		require.NoError(t, err)
-		require.Len(t, markedHashes, 2, "parent + child should both be marked")
+		require.Equal(t, []chainhash.Hash{parentHash, *childTx.TxIDChainHash()}, markedHashes,
+			"marked set must be returned in BFS order: parent first, then cascaded child")
 
 		parentMeta, err := store.Get(ctx, tx.TxIDChainHash(), fields.Conflicting)
 		require.NoError(t, err)
@@ -96,7 +97,10 @@ func TestSetConflictingCascade_Aerospike(t *testing.T) {
 		parentHash := *tx.TxIDChainHash()
 		_, markedHashes, err := utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
 		require.NoError(t, err)
-		require.Len(t, markedHashes, 3, "parent + child + grandchild should all be marked")
+		require.Equal(t,
+			[]chainhash.Hash{parentHash, *childTx.TxIDChainHash(), *grandchildTx.TxIDChainHash()},
+			markedHashes,
+			"marked set must be returned in BFS order: parent, child, grandchild")
 
 		parentMeta, err := store.Get(ctx, tx.TxIDChainHash(), fields.Conflicting)
 		require.NoError(t, err)

--- a/stores/utxo/aerospike/setconflicting_cascade_test.go
+++ b/stores/utxo/aerospike/setconflicting_cascade_test.go
@@ -1,0 +1,115 @@
+package aerospike_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetConflictingCascade_Aerospike verifies that MarkConflictingRecursively
+// cascades the conflicting flag to all spending descendants against real Aerospike.
+func TestSetConflictingCascade_Aerospike(t *testing.T) {
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+	t.Cleanup(deferFn)
+
+	buildChildTx := func(t *testing.T, parentTx *bt.Tx, vout uint32) *bt.Tx {
+		t.Helper()
+		child := bt.NewTx()
+		require.NoError(t, child.From(
+			parentTx.TxIDChainHash().String(), vout,
+			parentTx.Outputs[vout].LockingScript.String(),
+			parentTx.Outputs[vout].Satoshis,
+		))
+		require.NoError(t, child.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+			parentTx.Outputs[vout].Satoshis/3))
+		return child
+	}
+
+	t.Run("MarkConflictingRecursively cascades to child", func(t *testing.T) {
+		cleanDB(t, client)
+
+		// tests.ParentTx is the grandparent — needed because tx's input references it
+		// and SetConflicting calls updateParentConflictingChildren internally.
+		_, err := store.Create(ctx, tests.ParentTx, 999)
+		require.NoError(t, err)
+
+		_, err = store.Create(ctx, tx, 1000)
+		require.NoError(t, err)
+
+		childTx := buildChildTx(t, tx, 0)
+		_, err = store.Create(ctx, childTx, 1001)
+		require.NoError(t, err)
+
+		// Spend tx's output 0 with childTx — sets spender metadata
+		// that SetConflicting uses to discover children.
+		_, err = store.Spend(ctx, childTx, store.GetBlockHeight()+1)
+		require.NoError(t, err)
+
+		// Mark parent conflicting with recursive cascade
+		parentHash := *tx.TxIDChainHash()
+		_, err = utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
+		require.NoError(t, err)
+
+		// Parent must be conflicting
+		parentMeta, err := store.Get(ctx, tx.TxIDChainHash(), fields.Conflicting)
+		require.NoError(t, err)
+		require.True(t, parentMeta.Conflicting, "parent must be conflicting")
+
+		// Child must also be conflicting via cascade
+		childMeta, err := store.Get(ctx, childTx.TxIDChainHash(), fields.Conflicting)
+		require.NoError(t, err)
+		require.True(t, childMeta.Conflicting,
+			"child must be cascaded to conflicting when parent is marked conflicting")
+	})
+
+	t.Run("three-level chain cascades to all descendants", func(t *testing.T) {
+		cleanDB(t, client)
+
+		_, err := store.Create(ctx, tests.ParentTx, 999)
+		require.NoError(t, err)
+
+		_, err = store.Create(ctx, tx, 1000)
+		require.NoError(t, err)
+
+		childTx := buildChildTx(t, tx, 0)
+		_, err = store.Create(ctx, childTx, 1001)
+		require.NoError(t, err)
+
+		_, err = store.Spend(ctx, childTx, store.GetBlockHeight()+1)
+		require.NoError(t, err)
+
+		grandchildTx := buildChildTx(t, childTx, 0)
+		_, err = store.Create(ctx, grandchildTx, 1002)
+		require.NoError(t, err)
+
+		_, err = store.Spend(ctx, grandchildTx, store.GetBlockHeight()+1)
+		require.NoError(t, err)
+
+		// Mark parent conflicting — must cascade entire descendant tree
+		parentHash := *tx.TxIDChainHash()
+		_, err = utxo.MarkConflictingRecursively(ctx, store, []chainhash.Hash{parentHash})
+		require.NoError(t, err)
+
+		parentMeta, err := store.Get(ctx, tx.TxIDChainHash(), fields.Conflicting)
+		require.NoError(t, err)
+		require.True(t, parentMeta.Conflicting)
+
+		childMeta, err := store.Get(ctx, childTx.TxIDChainHash(), fields.Conflicting)
+		require.NoError(t, err)
+		require.True(t, childMeta.Conflicting, "child must be cascaded to conflicting")
+
+		gcMeta, err := store.Get(ctx, grandchildTx.TxIDChainHash(), fields.Conflicting)
+		require.NoError(t, err)
+		require.True(t, gcMeta.Conflicting, "grandchild must be cascaded to conflicting via BFS")
+	})
+}

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -119,7 +119,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 	losingTxHashes := losingTxHashesMap.Keys()
 
 	// - 1: mark all losingTxHashesPerConflictingTx as conflicting + all its spending transactions recursively
-	affectedParentSpends, err := markConflictingRecursively(ctx, s, losingTxHashes)
+	affectedParentSpends, err := MarkConflictingRecursively(ctx, s, losingTxHashes)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 	return losingTxHashesMap, nil
 }
 
-// markConflictingRecursively marks the given transactions as conflicting, and iteratively marks all their spending
+// MarkConflictingRecursively marks the given transactions as conflicting, and iteratively marks all their spending
 // children as conflicting too using breadth-first traversal.
 //
 // Parameters:
@@ -186,8 +186,8 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 // Returns:
 //   - A slice of pointers to Spend structs representing the affected parent spends.
 //   - An error if any issues occur during the process.
-func markConflictingRecursively(ctx context.Context, s Store, hashes []chainhash.Hash) ([]*Spend, error) {
-	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "markConflictingRecursively")
+func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash.Hash) ([]*Spend, error) {
+	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "MarkConflictingRecursively")
 
 	defer deferFn()
 

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -119,7 +119,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 	losingTxHashes := losingTxHashesMap.Keys()
 
 	// - 1: mark all losingTxHashesPerConflictingTx as conflicting + all its spending transactions recursively
-	affectedParentSpends, err := MarkConflictingRecursively(ctx, s, losingTxHashes)
+	affectedParentSpends, _, err := MarkConflictingRecursively(ctx, s, losingTxHashes)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,9 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 //
 // Returns:
 //   - A slice of pointers to Spend structs representing the affected parent spends.
+//   - A slice of all transaction hashes that were marked conflicting (initial + cascaded descendants).
 //   - An error if any issues occur during the process.
-func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash.Hash) ([]*Spend, error) {
+func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash.Hash) ([]*Spend, []chainhash.Hash, error) {
 	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "MarkConflictingRecursively")
 
 	defer deferFn()
@@ -202,7 +203,7 @@ func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash
 	for len(toProcess) > 0 {
 		affectedParentSpends, spendingChildTxs, err := s.SetConflicting(ctx, toProcess, true)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		allAffectedSpends = append(allAffectedSpends, affectedParentSpends...)
@@ -218,7 +219,12 @@ func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash
 		toProcess = nextBatch
 	}
 
-	return allAffectedSpends, nil
+	allMarked := make([]chainhash.Hash, 0, len(visited))
+	for h := range visited {
+		allMarked = append(allMarked, h)
+	}
+
+	return allAffectedSpends, allMarked, nil
 }
 
 func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]chainhash.Hash, error) {

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -185,7 +185,10 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 //
 // Returns:
 //   - A slice of pointers to Spend structs representing the affected parent spends.
-//   - A slice of all transaction hashes that were marked conflicting (initial + cascaded descendants).
+//   - A slice of all transaction hashes that were marked conflicting by this call,
+//     including the input hashes and every descendant reached via BFS. Insertion
+//     order is BFS order (input level first, then each descendant level) — callers
+//     can rely on this for deterministic logs, traces, and eviction ordering.
 //   - An error if any issues occur during the process.
 func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash.Hash) ([]*Spend, []chainhash.Hash, error) {
 	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "MarkConflictingRecursively")
@@ -196,8 +199,12 @@ func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash
 	toProcess := hashes
 
 	visited := make(map[chainhash.Hash]struct{}, len(hashes))
+	markedOrder := make([]chainhash.Hash, 0, len(hashes))
 	for _, h := range hashes {
-		visited[h] = struct{}{}
+		if _, ok := visited[h]; !ok {
+			visited[h] = struct{}{}
+			markedOrder = append(markedOrder, h)
+		}
 	}
 
 	for len(toProcess) > 0 {
@@ -213,18 +220,14 @@ func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash
 		for _, child := range spendingChildTxs {
 			if _, ok := visited[child]; !ok {
 				visited[child] = struct{}{}
+				markedOrder = append(markedOrder, child)
 				nextBatch = append(nextBatch, child)
 			}
 		}
 		toProcess = nextBatch
 	}
 
-	allMarked := make([]chainhash.Hash, 0, len(visited))
-	for h := range visited {
-		allMarked = append(allMarked, h)
-	}
-
-	return allAffectedSpends, allMarked, nil
+	return allAffectedSpends, markedOrder, nil
 }
 
 func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]chainhash.Hash, error) {

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -252,11 +252,12 @@ func TestMarkConflictingRecursively_Success(t *testing.T) {
 		Return(childAffectedSpends, []chainhash.Hash{}, nil)
 
 	// Execute test
-	result, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
+	result, markedHashes, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
 
 	// Assertions
 	require.NoError(t, err)
 	assert.Len(t, result, 2) // Should contain both parent and child spends
+	assert.Len(t, markedHashes, 2) // parent + child
 	mockStore.AssertExpectations(t)
 }
 
@@ -271,10 +272,11 @@ func TestMarkConflictingRecursively_SetConflictingError(t *testing.T) {
 		Return([]*Spend{}, []chainhash.Hash{}, errors.NewProcessingError("set conflicting error"))
 
 	// Execute test
-	result, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
+	result, markedHashes, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
 
 	// Assertions
 	assert.Nil(t, result)
+	assert.Nil(t, markedHashes)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "set conflicting error")
 	mockStore.AssertExpectations(t)
@@ -292,12 +294,13 @@ func TestMarkConflictingRecursively_NoChildren(t *testing.T) {
 		Return(affectedSpends, []chainhash.Hash{}, nil)
 
 	// Execute test
-	result, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
+	result, markedHashes, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
 
 	// Assertions
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, txHash, *result[0].TxID)
+	assert.Len(t, markedHashes, 1)
 	mockStore.AssertExpectations(t)
 }
 

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -256,8 +256,9 @@ func TestMarkConflictingRecursively_Success(t *testing.T) {
 
 	// Assertions
 	require.NoError(t, err)
-	assert.Len(t, result, 2)       // Should contain both parent and child spends
-	assert.Len(t, markedHashes, 2) // parent + child
+	assert.Len(t, result, 2) // Should contain both parent and child spends
+	assert.Equal(t, []chainhash.Hash{txHash, childHash}, markedHashes,
+		"marked set must be returned in BFS order: input first, then cascaded child")
 	mockStore.AssertExpectations(t)
 }
 
@@ -300,7 +301,7 @@ func TestMarkConflictingRecursively_NoChildren(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, txHash, *result[0].TxID)
-	assert.Len(t, markedHashes, 1)
+	assert.Equal(t, []chainhash.Hash{txHash}, markedHashes)
 	mockStore.AssertExpectations(t)
 }
 

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -256,7 +256,7 @@ func TestMarkConflictingRecursively_Success(t *testing.T) {
 
 	// Assertions
 	require.NoError(t, err)
-	assert.Len(t, result, 2) // Should contain both parent and child spends
+	assert.Len(t, result, 2)       // Should contain both parent and child spends
 	assert.Len(t, markedHashes, 2) // parent + child
 	mockStore.AssertExpectations(t)
 }

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -252,7 +252,7 @@ func TestMarkConflictingRecursively_Success(t *testing.T) {
 		Return(childAffectedSpends, []chainhash.Hash{}, nil)
 
 	// Execute test
-	result, err := markConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
+	result, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
 
 	// Assertions
 	require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestMarkConflictingRecursively_SetConflictingError(t *testing.T) {
 		Return([]*Spend{}, []chainhash.Hash{}, errors.NewProcessingError("set conflicting error"))
 
 	// Execute test
-	result, err := markConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
+	result, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
 
 	// Assertions
 	assert.Nil(t, result)
@@ -292,7 +292,7 @@ func TestMarkConflictingRecursively_NoChildren(t *testing.T) {
 		Return(affectedSpends, []chainhash.Hash{}, nil)
 
 	// Execute test
-	result, err := markConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
+	result, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{txHash})
 
 	// Assertions
 	require.NoError(t, err)

--- a/stores/utxo/setconflicting_cascade_bug_test.go
+++ b/stores/utxo/setconflicting_cascade_bug_test.go
@@ -26,10 +26,11 @@ func TestSetConflicting_MustCascadeToChildren(t *testing.T) {
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
 		Return(childSpends, []chainhash.Hash{}, nil)
 
-	allSpends, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
+	allSpends, markedHashes, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
 	require.NoError(t, err)
 
 	require.Len(t, allSpends, 2, "parent + child spends")
+	require.Len(t, markedHashes, 2, "parent + child marked")
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true)
 	mockStore.AssertExpectations(t)
@@ -50,7 +51,7 @@ func TestSetConflicting_CallerMustCascade(t *testing.T) {
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
 		Return([]*Spend{{TxID: &childHash, Vout: 0}}, []chainhash.Hash{}, nil)
 
-	_, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
+	_, _, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
 	require.NoError(t, err)
 
 	mockStore.AssertNumberOfCalls(t, "SetConflicting", 2)
@@ -75,10 +76,11 @@ func TestMarkConflictingRecursively_DoesCascade(t *testing.T) {
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true).
 		Return([]*Spend{{TxID: &grandchildHash, Vout: 0}}, []chainhash.Hash{}, nil)
 
-	allSpends, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
+	allSpends, markedHashes, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
 	require.NoError(t, err)
 
 	require.Len(t, allSpends, 3)
+	require.Len(t, markedHashes, 3)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true)

--- a/stores/utxo/setconflicting_cascade_bug_test.go
+++ b/stores/utxo/setconflicting_cascade_bug_test.go
@@ -1,0 +1,86 @@
+package utxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetConflicting_MustCascadeToChildren verifies that marking a parent tx
+// conflicting via MarkConflictingRecursively also cascades to all spending children.
+func TestSetConflicting_MustCascadeToChildren(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	parentHash := createTestHash("parent-tx")
+	childHash := createTestHash("child-tx")
+
+	parentSpends := []*Spend{{TxID: &parentHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
+		Return(parentSpends, []chainhash.Hash{childHash}, nil)
+
+	childSpends := []*Spend{{TxID: &childHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
+		Return(childSpends, []chainhash.Hash{}, nil)
+
+	allSpends, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
+	require.NoError(t, err)
+
+	require.Len(t, allSpends, 2, "parent + child spends")
+	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true)
+	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true)
+	mockStore.AssertExpectations(t)
+}
+
+// TestSetConflicting_CallerMustCascade verifies SetConflicting is called for both
+// parent and child when using MarkConflictingRecursively.
+func TestSetConflicting_CallerMustCascade(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	parentHash := createTestHash("parent-tx")
+	childHash := createTestHash("child-tx")
+
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
+		Return([]*Spend{{TxID: &parentHash, Vout: 0}}, []chainhash.Hash{childHash}, nil)
+
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
+		Return([]*Spend{{TxID: &childHash, Vout: 0}}, []chainhash.Hash{}, nil)
+
+	_, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
+	require.NoError(t, err)
+
+	mockStore.AssertNumberOfCalls(t, "SetConflicting", 2)
+}
+
+// TestMarkConflictingRecursively_DoesCascade verifies the BFS cascade works
+// through a 3-level chain: parent → child → grandchild.
+func TestMarkConflictingRecursively_DoesCascade(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	parentHash := createTestHash("parent-tx")
+	childHash := createTestHash("child-tx")
+	grandchildHash := createTestHash("grandchild-tx")
+
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
+		Return([]*Spend{{TxID: &parentHash, Vout: 0}}, []chainhash.Hash{childHash}, nil)
+
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
+		Return([]*Spend{{TxID: &childHash, Vout: 0}}, []chainhash.Hash{grandchildHash}, nil)
+
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true).
+		Return([]*Spend{{TxID: &grandchildHash, Vout: 0}}, []chainhash.Hash{}, nil)
+
+	allSpends, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{parentHash})
+	require.NoError(t, err)
+
+	require.Len(t, allSpends, 3)
+	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true)
+	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true)
+	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true)
+	mockStore.AssertExpectations(t)
+}

--- a/stores/utxo/setconflicting_cascade_bug_test.go
+++ b/stores/utxo/setconflicting_cascade_bug_test.go
@@ -30,7 +30,8 @@ func TestSetConflicting_MustCascadeToChildren(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, allSpends, 2, "parent + child spends")
-	require.Len(t, markedHashes, 2, "parent + child marked")
+	require.Equal(t, []chainhash.Hash{parentHash, childHash}, markedHashes,
+		"marked set must be returned in BFS order: parent first, then child")
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true)
 	mockStore.AssertExpectations(t)
@@ -80,7 +81,8 @@ func TestMarkConflictingRecursively_DoesCascade(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, allSpends, 3)
-	require.Len(t, markedHashes, 3)
+	require.Equal(t, []chainhash.Hash{parentHash, childHash, grandchildHash}, markedHashes,
+		"marked set must be returned in BFS order: parent, then child, then grandchild")
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true)
 	mockStore.AssertCalled(t, "SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true)

--- a/stores/utxo/sql/setconflicting_cascade_test.go
+++ b/stores/utxo/sql/setconflicting_cascade_test.go
@@ -1,9 +1,13 @@
 package sql
 
 // Tests for the SetConflicting cascade bug live in:
-//   - stores/utxo/process_conflicting_cascade_test.go (mock-based, proves the interface gap)
+//   - stores/utxo/setconflicting_cascade_bug_test.go (mock-based, proves the cascade)
 //   - stores/utxo/aerospike/setconflicting_cascade_test.go (Aerospike TestContainer)
 //
-// SQLite's single-writer model deadlocks when SetConflicting (which starts a
-// write transaction) internally calls GetSpend (which needs a read connection
-// from the pool). This is a test infrastructure limitation, not a code bug.
+// SQLite cannot be tested here: SetConflicting (sql.go:3537) opens a write
+// transaction via s.db.Begin(), then calls s.Get/s.GetSpend (lines 3548, 3595)
+// on the store's connection pool — not on the open transaction. In SQLite
+// serialized mode with a single-connection test pool, this deadlocks.
+//
+// This is also a potential production-latency concern for the SQL store under
+// high concurrency, not just a test limitation.

--- a/stores/utxo/sql/setconflicting_cascade_test.go
+++ b/stores/utxo/sql/setconflicting_cascade_test.go
@@ -1,0 +1,9 @@
+package sql
+
+// Tests for the SetConflicting cascade bug live in:
+//   - stores/utxo/process_conflicting_cascade_test.go (mock-based, proves the interface gap)
+//   - stores/utxo/aerospike/setconflicting_cascade_test.go (Aerospike TestContainer)
+//
+// SQLite's single-writer model deadlocks when SetConflicting (which starts a
+// write transaction) internally calls GetSpend (which needs a read connection
+// from the pool). This is a test infrastructure limitation, not a code bug.


### PR DESCRIPTION
## Summary

- When a tx is marked conflicting via direct `SetConflicting`, its unmined spending descendants are **not** cascaded — they stay non-conflicting
- Block assembly then includes these children in templates, and block validation rejects because the parent has no `blockIDs`
- The recursive cascade (`MarkConflictingRecursively`, BFS) already existed in `ProcessConflicting` but was never wired to the two direct call sites introduced in #649, #653, #657

## Changes

### Core fix
- **Export `MarkConflictingRecursively`** from `stores/utxo/process_conflicting.go` — returns `([]*Spend, []chainhash.Hash, error)` so callers get the full list of marked hashes
- **Validator.go** (`existing-tx-conflicting` path): replace direct `SetConflicting` with `MarkConflictingRecursively`
- **BlockAssembler.go** (`markAsConflicting` helper): replace direct `SetConflicting` with `MarkConflictingRecursively`, evict cascaded hashes from subtree processor via `Remove()`

### Defense-in-depth
- **txmetacache.SetConflicting**: pass through real `affectedSpends` and `spendingChildren` from underlying store instead of discarding them — prevents silent BFS termination if the cache is ever wrapped around the validator/assembler store
- **validateParentChain**: fetch `fields.Conflicting` alongside existing fields; reject any child whose parent has `Conflicting=true` at reload time — catches pre-fix stale state without cold restart

### Tests
- 3 mock-based regression tests proving cascade through 1-level, 2-level, and 3-level chains
- 2 Aerospike TestContainer tests verifying cascade against real store
- Existing `ProcessConflicting` and `MarkConflictingRecursively` tests updated for new return signature

## Root cause

Three PRs each introduced a direct `SetConflicting` call that discarded the returned child hashes:

| PR | Call site | Pattern |
|----|-----------|---------|
| #649 | `BlockAssembler.validateUnminedTxInputs` | `if _, _, err := SetConflicting(...)` |
| #653 | `BlockAssembler.markAsConflicting` (extracted helper) | same |
| #657 | `Validator.go` existing-tx branch (most likely trigger for observed state) | `if _, _, setErr := SetConflicting(...)` |

`SetConflicting` discovers children but only returns their hashes — it does not recurse. The callers never used those hashes to cascade. Not a regression of working code — these are new code paths that used the wrong primitive from the start.

## Known limitation

The Validator call site (`Validator.go:619`) does not hold a subtree processor handle, so cascaded descendants may remain in the in-memory template until the next block assembly reset/reload. The BlockAssembler path evicts immediately. A Kafka-based notification for cross-service eviction is out of scope for this PR.

## Test plan

- [x] Mock tests: `TestSetConflicting_MustCascadeToChildren`, `TestSetConflicting_CallerMustCascade`, `TestMarkConflictingRecursively_DoesCascade`
- [x] Aerospike TestContainer: `TestSetConflictingCascade_Aerospike` (2-level + 3-level chains)
- [x] Existing `ProcessConflicting` / `MarkConflictingRecursively` tests pass with new signature
- [ ] CI full test suite