### PR TITLE
fix(legacy): filter coinbase txs from P2P announcement

### DIFF
--- a/services/legacy/netsync/kafka_txmeta_test.go
+++ b/services/legacy/netsync/kafka_txmeta_test.go
@@ -1,0 +1,269 @@
+package netsync
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-batcher"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTXmetaBatchMessage constructs a binary batch message in the format expected
+// by processTXmetaBatchMessage. Each entry contains a tx hash, action byte, content
+// length, and content (metaBytes for ADD entries).
+func buildTXmetaBatchMessage(t *testing.T, entries []txmetaTestEntry) []byte {
+	t.Helper()
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(len(entries)))
+
+	for _, entry := range entries {
+		// 32-byte hash
+		buf = append(buf, entry.hash[:]...)
+
+		// 1-byte action
+		buf = append(buf, entry.action)
+
+		if entry.action == txmetaActionADD {
+			metaBytes, err := entry.meta.MetaBytes()
+			require.NoError(t, err)
+
+			// 4-byte content length
+			lenBuf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(lenBuf, uint32(len(metaBytes)))
+			buf = append(buf, lenBuf...)
+
+			// N-byte content
+			buf = append(buf, metaBytes...)
+		} else {
+			// DELETE: 4-byte zero content length
+			buf = append(buf, 0, 0, 0, 0)
+		}
+	}
+
+	return buf
+}
+
+type txmetaTestEntry struct {
+	hash   chainhash.Hash
+	action byte
+	meta   meta.Data
+}
+
+func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
+	// Set up hashes for test entries
+	coinbaseHash, err := chainhash.NewHashFromStr("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+
+	regularHash, err := chainhash.NewHashFromStr("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	require.NoError(t, err)
+
+	t.Run("coinbase tx is not announced", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
+			{
+				hash:   *coinbaseHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         0,
+					SizeInBytes: 100,
+					IsCoinbase:  true,
+				},
+			},
+			{
+				hash:   *regularHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         500,
+					SizeInBytes: 250,
+					IsCoinbase:  false,
+				},
+			},
+		})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		// Trigger the batcher to flush by waiting for its timeout
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Only the regular tx should have been announced
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
+		require.Equal(t, uint64(500), announced[0].Fee)
+		require.Equal(t, uint64(250), announced[0].Size)
+	})
+
+	t.Run("only coinbase txs produces no announcements", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
+			{
+				hash:   *coinbaseHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         0,
+					SizeInBytes: 100,
+					IsCoinbase:  true,
+				},
+			},
+		})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Empty(t, announced)
+	})
+
+	t.Run("regular txs are announced", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
+			{
+				hash:   *regularHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         1000,
+					SizeInBytes: 500,
+					IsCoinbase:  false,
+				},
+			},
+		})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
+		require.Equal(t, uint64(1000), announced[0].Fee)
+		require.Equal(t, uint64(500), announced[0].Size)
+	})
+
+	t.Run("DELETE entries are skipped", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
+			{
+				hash:   *coinbaseHash,
+				action: txmetaActionDELETE,
+			},
+			{
+				hash:   *regularHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         750,
+					SizeInBytes: 300,
+					IsCoinbase:  false,
+				},
+			},
+		})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
+	})
+
+	t.Run("empty message is handled gracefully", func(t *testing.T) {
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+		}
+
+		err := sm.processTXmetaBatchMessage([]byte{})
+		require.NoError(t, err)
+
+		err = sm.processTXmetaBatchMessage([]byte{0, 0, 0})
+		require.NoError(t, err)
+	})
+
+	t.Run("message with zero entries is handled gracefully", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Empty(t, announced)
+	})
+}

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -2635,7 +2635,7 @@ func (sm *SyncManager) processTXmetaBatchMessage(data []byte) error {
 				Size:   txMeta.SizeInBytes,
 			})
 		} else {
-			// Skip DELETE entries (no action needed for peer announcements)
+			offset += int(contentLen)
 			continue
 		}
 	}

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -2561,73 +2561,84 @@ func (sm *SyncManager) kafkaBlocksFinalListener(ctx context.Context, kafkaURL *u
 //	[4 bytes]  - content length (uint32, little-endian) - 0 for DELETE
 //	[N bytes]  - content (metaBytes) - only for ADD
 func (sm *SyncManager) kafkaTXmetaListener(ctx context.Context, kafkaURL *url.URL, groupID string) {
-	const (
-		txmetaActionADD    = byte(0)
-		txmetaActionDELETE = byte(1)
-	)
-
 	kafka.StartKafkaListener(ctx, sm.logger, kafkaURL, groupID, true, func(msg *kafka.KafkaMessage) error {
-		data := msg.Value
-		if len(data) < 4 {
+		return sm.processTXmetaBatchMessage(msg.Value)
+	}, &sm.settings.Kafka)
+}
+
+const (
+	txmetaActionADD    = byte(0)
+	txmetaActionDELETE = byte(1)
+)
+
+// processTXmetaBatchMessage processes a binary batch message from the txmeta Kafka topic.
+// It parses the batch format, deserializes metadata for ADD entries, and announces
+// non-coinbase transactions to peers via the txAnnounceBatcher.
+// Coinbase transactions are intentionally skipped to avoid peer bans.
+func (sm *SyncManager) processTXmetaBatchMessage(data []byte) error {
+	if len(data) < 4 {
+		return nil
+	}
+
+	offset := 0
+
+	// Read entry count
+	entryCount := binary.LittleEndian.Uint32(data[offset:])
+	offset += 4
+
+	// Process each entry
+	for i := uint32(0); i < entryCount; i++ {
+		// Check minimum bytes for hash + action + length
+		if offset+32+1+4 > len(data) {
+			sm.logger.Errorf("[kafkaTXmetaListener] truncated message at entry %d", i)
 			return nil
 		}
 
-		offset := 0
+		// Read hash (32 bytes)
+		var hash chainhash.Hash
+		copy(hash[:], data[offset:offset+32])
+		offset += 32
 
-		// Read entry count
-		entryCount := binary.LittleEndian.Uint32(data[offset:])
+		// Read action (1 byte)
+		action := data[offset]
+		offset++
+
+		// Read content length (4 bytes)
+		contentLen := binary.LittleEndian.Uint32(data[offset:])
 		offset += 4
 
-		// Process each entry
-		for i := uint32(0); i < entryCount; i++ {
-			// Check minimum bytes for hash + action + length
-			if offset+32+1+4 > len(data) {
-				sm.logger.Errorf("[kafkaTXmetaListener] truncated message at entry %d", i)
+		if action == txmetaActionADD {
+			// Handle ADD
+			if offset+int(contentLen) > len(data) {
+				sm.logger.Errorf("[kafkaTXmetaListener] truncated content at entry %d", i)
 				return nil
 			}
 
-			// Read hash (32 bytes)
-			var hash chainhash.Hash
-			copy(hash[:], data[offset:offset+32])
-			offset += 32
+			content := data[offset : offset+int(contentLen)]
+			offset += int(contentLen)
 
-			// Read action (1 byte)
-			action := data[offset]
-			offset++
+			sm.logger.Debugf("Received tx message from Kafka: %v", hash)
 
-			// Read content length (4 bytes)
-			contentLen := binary.LittleEndian.Uint32(data[offset:])
-			offset += 4
-
-			if action == txmetaActionADD {
-				// Handle ADD
-				if offset+int(contentLen) > len(data) {
-					sm.logger.Errorf("[kafkaTXmetaListener] truncated content at entry %d", i)
-					return nil
-				}
-
-				content := data[offset : offset+int(contentLen)]
-				offset += int(contentLen)
-
-				sm.logger.Debugf("Received tx message from Kafka: %v", hash)
-
-				var txMeta meta.Data
-				if err := meta.NewMetaDataFromBytes(content, &txMeta); err != nil {
-					sm.logger.Errorf("Failed to create tx meta data from bytes: %v", err)
-					continue
-				}
-
-				sm.txAnnounceBatcher.Put(&TxHashAndFee{
-					TxHash: hash,
-					Fee:    txMeta.Fee,
-					Size:   txMeta.SizeInBytes,
-				})
-			} else {
-				// Skip DELETE entries (no action needed for peer announcements)
+			var txMeta meta.Data
+			if err := meta.NewMetaDataFromBytes(content, &txMeta); err != nil {
+				sm.logger.Errorf("Failed to create tx meta data from bytes: %v", err)
 				continue
 			}
-		}
 
-		return nil
-	}, &sm.settings.Kafka)
+			if txMeta.IsCoinbase {
+				continue
+			}
+
+			sm.txAnnounceBatcher.Put(&TxHashAndFee{
+				TxHash: hash,
+				Fee:    txMeta.Fee,
+				Size:   txMeta.SizeInBytes,
+			})
+		} else {
+			// Skip DELETE entries (no action needed for peer announcements)
+			continue
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

- The legacy P2P service relays transactions from the txmeta Kafka topic to SVNode peers via `inv` messages. Coinbase transactions were not filtered, causing connected SVNode peers to ban Teranode (`bad-tx-coinbase`, banscore 0→100, 24h ban).
- Extract `processTXmetaBatchMessage` from the inline Kafka callback for testability, and skip entries where `meta.IsCoinbase` is true before adding to the announcement batcher.
- Add test coverage: coinbase filtering, regular tx announcement with correct fee/size, DELETE entry handling, empty/zero-entry messages.

## Root cause

The `kafkaTXmetaListener` consumed txmeta batch messages and announced all ADD entries to peers without checking the `IsCoinbase` flag. This was never implemented across three iterations of this code (2024-11, 2025-02, 2025-12).

The producer side (validator) guards against coinbase at multiple levels, so the exact pathway by which coinbase metadata reaches the topic is still under investigation. This fix adds defence-in-depth on the consumer side.

## Test plan

- [x] `TestProcessTXmetaBatchMessage_CoinbaseFiltering` — 6 subtests covering coinbase filtering, regular tx pass-through, DELETE handling, empty messages
- [ ] Verify on testnet that coinbase txs no longer trigger `bad-tx-coinbase` bans from SVNode peers