### PR TITLE
fix(blockchain): give startup on_main_chain migration a generous timeout

### DIFF
--- a/stores/blockchain/sql/OnMainChain_test.go
+++ b/stores/blockchain/sql/OnMainChain_test.go
@@ -930,3 +930,18 @@ func TestOnMainChain_ConsistentWithFindBlocksContainingSubtree(t *testing.T) {
 		}
 	}
 }
+
+// TestOnMainChain_MigrationTimeoutExceedsWindowedTimeout guards the invariant
+// that the startup full-migration rebuild gets a more generous deadline than
+// bounded-window rebuilds. The migration walks the entire chain via a recursive
+// CTE and can take minutes on multi-million-block chains (especially on
+// undersized VMs); reducing its timeout to match the windowed one silently
+// leaves on_main_chain unpopulated after startup and breaks
+// CheckBlockIsInCurrentChain's fast path for any block below the windowed
+// rebuild floor.
+func TestOnMainChain_MigrationTimeoutExceedsWindowedTimeout(t *testing.T) {
+	require.Greater(t, migrationFullRebuildTimeout, rebuildOffChainSetTimeout,
+		"full-migration rebuild must have a more generous timeout than windowed rebuilds")
+	require.GreaterOrEqual(t, migrationFullRebuildTimeout, time.Minute,
+		"migration timeout should be minutes-scale to accommodate multi-million-block chains")
+}

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -54,6 +54,19 @@ const chainWalkCacheTTL = 10 * time.Minute
 // context cancellation.
 const rebuildOffChainSetTimeout = 30 * time.Second
 
+// migrationFullRebuildTimeout bounds the one-shot full-chain rebuildOnMainChainFlag
+// that runs at startup the first time the on_main_chain column is populated.
+// Unlike the bounded-window rebuilds (which touch at most 10×CoinbaseMaturity
+// blocks and always fit in rebuildOffChainSetTimeout), the migration walks the
+// full chain via a recursive CTE and its runtime scales with chain length. On a
+// multi-million-block chain on an undersized VM this can take several minutes,
+// so the 30 s window used elsewhere is too short: if the migration times out,
+// the column is left unpopulated and CheckBlockIsInCurrentChain's fast path
+// returns no rows, silently breaking validation for any block below the
+// windowed-rebuild floor. 30 minutes is generous enough for any realistic
+// chain while still providing a safety net against a truly stuck query.
+const migrationFullRebuildTimeout = 30 * time.Minute
+
 // SQL implements the blockchain.Store interface using SQL database backends.
 // It provides a complete implementation of blockchain data storage and retrieval
 // operations with support for different SQL engines, caching mechanisms, and
@@ -234,10 +247,11 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 	go func() {
 		defer s.mainChainRebuilding.Add(-1) // release the guard held by New()
 
-		ctx, cancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
-		defer cancel()
-
-		full, err := s.needsFullOnMainChainRebuild(ctx)
+		// Detection is a COUNT comparison — always fast, so the standard bounded
+		// timeout is appropriate.
+		detectCtx, detectCancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
+		full, err := s.needsFullOnMainChainRebuild(detectCtx)
+		detectCancel()
 		if err != nil {
 			// On error we cannot determine whether this is a fresh migration or
 			// a consistent DB. A bounded rebuild would silently leave deep
@@ -251,14 +265,30 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		if full {
 			s.logger.Infof("startup: on_main_chain appears unpopulated — running full-chain rebuild (migration)")
 		}
-		if rebuildErr := s.rebuildOnMainChainFlag(ctx, full); rebuildErr != nil {
+
+		// The rebuild itself has two very different runtime profiles:
+		//   - full=true: one-shot recursive CTE over the entire chain; can take
+		//     minutes on multi-million-block chains, especially on undersized
+		//     VMs. Needs migrationFullRebuildTimeout so the migration can
+		//     actually complete — timing out here leaves on_main_chain
+		//     unpopulated and silently breaks validation for deep blocks.
+		//   - full=false: bounded to a 10×CoinbaseMaturity window above the
+		//     tip; always short, so rebuildOffChainSetTimeout is sufficient
+		//     and protects against runaway queries.
+		rebuildTimeout := rebuildOffChainSetTimeout
+		if full {
+			rebuildTimeout = migrationFullRebuildTimeout
+		}
+		rebuildCtx, rebuildCancel := s.shutdownAwareContext(rebuildTimeout)
+		if rebuildErr := s.rebuildOnMainChainFlag(rebuildCtx, full); rebuildErr != nil {
 			s.logger.Errorf("startup: rebuildOnMainChainFlag: %v", rebuildErr)
 		}
+		rebuildCancel()
 
 		if useInMemory {
-			rebuildCtx, rebuildCancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
-			defer rebuildCancel()
-			if rebuildErr := s.rebuildOffChainSet(rebuildCtx); rebuildErr != nil {
+			offChainCtx, offChainCancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
+			defer offChainCancel()
+			if rebuildErr := s.rebuildOffChainSet(offChainCtx); rebuildErr != nil {
 				s.logger.Errorf("startup: rebuildOffChainSet: %v", rebuildErr)
 			} else {
 				s.lastSuccessfulRebuild.Store(time.Now().Unix())


### PR DESCRIPTION
## Summary

- Startup migration rebuild of `on_main_chain` was sharing the 30 s `rebuildOffChainSetTimeout` with bounded-window rebuilds, which is far too short for a recursive-CTE walk across millions of blocks on an undersized VM.
- Split the timeouts: keep 30 s for detection + windowed rebuilds, give the one-shot full migration 30 minutes.
- Add a regression test that pins `migrationFullRebuildTimeout > rebuildOffChainSetTimeout` and that the migration timeout stays minutes-scale.

## Problem

The startup goroutine in `stores/blockchain/sql/sql.go` calls `needsFullOnMainChainRebuild` to decide between a full-chain rebuild (migration) and a bounded windowed rebuild, then runs the chosen one. Both were wrapped in the same 30 s `shutdownAwareContext`. For the bounded case this is fine — the windowed rebuild only touches `10 × CoinbaseMaturity` blocks. For the migration case it's not: the recursive CTE walks the entire chain and its runtime scales with chain length.

When the migration times out, `on_main_chain` stays `false` for every block outside the windowed floor, the defer still releases `mainChainRebuilding`, and subsequent queries use the fast path against a half-populated column. `CheckBlockIsInCurrentChain` returns no rows for deep parent IDs, `checkOldBlockIDs` rejects any transaction whose parent sits below the floor, and legacy-sync cascade-invalidates every block from the tip downward (`parent blocks are not from current chain` → `parent block is invalid` on each descendant).

## Observed on testnet

- Chain height ~1.52M blocks on a 7.6 GiB VM with heavy swap usage.
- `on_main_chain = true` count: **1** out of 1,523,871.
- Log line repeated indefinitely:
  ```
  startup: on_main_chain appears unpopulated — running full-chain rebuild (migration)
  ERROR startup: rebuildOnMainChainFlag: failed to set on_main_chain flags -> timeout: context deadline exceeded
  ```
- Blocks 1,523,851–1,523,870 marked invalid; legacy-sync stuck in a retry loop.

Mainnet (~415k blocks) and teratestnet (~16k blocks) finished inside 30 s on the same binary, so they never surfaced the bug.

## Fix

`stores/blockchain/sql/sql.go`

- New constant `migrationFullRebuildTimeout = 30 * time.Minute` with a doc-comment explaining why the windowed timeout isn't enough.
- Separate `detectCtx` (30 s) for `needsFullOnMainChainRebuild` (a fast COUNT query).
- `rebuildCtx` now picks its timeout from `full`: `migrationFullRebuildTimeout` when `full == true`, otherwise `rebuildOffChainSetTimeout`.
- Off-chain set rebuild keeps 30 s.
- Every context has an explicit `Cancel` — no `defer` in between the detect and rebuild phases so the old context is released before the long one is created.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 -run TestOnMainChain ./stores/blockchain/sql/...` — 23 tests pass including the new `TestOnMainChain_MigrationTimeoutExceedsWindowedTimeout` regression guard.
- [x] Manual verification on testnet: stopping teranode, backfilling `on_main_chain` with the same recursive-CTE query (no timeout) populates 1,524,052 rows in ~minutes; restarting teranode immediately processes blocks 1,523,851+ at sub-50 ms `ProcessBlock` times.

## Notes

- No migration required — this is purely a timeout fix. Existing healthy databases are unaffected; only databases that repeatedly time out on startup (like testnet did) will now complete the rebuild on the next start.
- 30 minutes is deliberately generous. On healthy hardware the rebuild completes in seconds; the budget exists to accommodate the worst case (multi-million-block chain on a swap-thrashing VM). Shutdown-aware cancellation still bounds it from above if the process is killed.