### PR TITLE
perf(utxo-sql): partial index on unspent outputs to unblock spend-path CTE

### DIFF
--- a/stores/utxo/sql/create_postgres_schema_test.go
+++ b/stores/utxo/sql/create_postgres_schema_test.go
@@ -223,6 +223,20 @@ func TestCreatePostgresSchema_ErrorAtConflictingChildrenTable(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not create conflicting_children table")
 }
 
+func TestCreatePostgresSchema_ErrorAtUnspentByParentIndex(t *testing.T) {
+	mockDB := CreateMockDBForSchema()
+	defer mockDB.AssertExpectations(t)
+
+	// Setup error at step 14 (px_outputs_unspent_by_parent partial index)
+	SetupCreatePostgresSchemaErrorMocks(mockDB, 14)
+
+	udb := &usql.DB{DB: nil}
+	err := createPostgresSchemaWithMockDB(udb, mockDB)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not create px_outputs_unspent_by_parent index")
+}
+
 // The ACTUAL solution to get coverage: Create a testable interface version
 // and temporarily modify the original function to be testable
 

--- a/stores/utxo/sql/mock.go
+++ b/stores/utxo/sql/mock.go
@@ -264,6 +264,11 @@ func SetupCreatePostgresSchemaSuccessMocks(mockDB *MockDB) {
 	mockDB.On("Exec", mock.MatchedBy(func(query string) bool {
 		return strings.Contains(query, "CREATE TABLE IF NOT EXISTS conflicting_children")
 	}), mock.Anything).Return(sqlmock.NewResult(0, 0), nil)
+
+	// Step 14: CREATE INDEX px_outputs_unspent_by_parent
+	mockDB.On("Exec", mock.MatchedBy(func(query string) bool {
+		return strings.Contains(query, "CREATE INDEX IF NOT EXISTS px_outputs_unspent_by_parent")
+	}), mock.Anything).Return(sqlmock.NewResult(0, 0), nil)
 }
 
 // SetupCreatePostgresSchemaErrorMocks configures mock expectations for schema creation error at specific step
@@ -296,6 +301,9 @@ func SetupCreatePostgresSchemaErrorMocks(mockDB *MockDB, errorAtStep int) {
 			return strings.Contains(q, "block_ids_transaction_id_fkey") && strings.Contains(q, "confdeltype")
 		},
 		func(q string) bool { return strings.Contains(q, "CREATE TABLE IF NOT EXISTS conflicting_children") },
+		func(q string) bool {
+			return strings.Contains(q, "CREATE INDEX IF NOT EXISTS px_outputs_unspent_by_parent")
+		},
 	}
 
 	// Setup successful mocks for steps before the error

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -4456,6 +4456,23 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 		return errors.NewStorageError("could not create conflicting_children table - [%+v]", err)
 	}
 
+	// Partial index over unspent outputs, keyed by parent transaction_id.
+	// Used by the spend-path bulk UPDATE's unspent_before CTE stage, which
+	// counts how many outputs of each touched parent are still unspent to
+	// decide whether this batch has drained the parent's last unspent output
+	// (so DAH can be set). Without this index Postgres falls back to the
+	// composite PK's leading column only — scanning every output of every
+	// touched parent and filtering spending_data IS NULL after the read.
+	// For data-carrier / large-fan-out parents that's thousands of rows per
+	// parent per batch and was surfacing as multi-second IO:DataFileRead
+	// waits inside sendSpendBatch on mainnet. With this partial index the
+	// count becomes an index-only scan over just the unspent rows, which on
+	// a healthy chain is a small minority of the outputs table.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS px_outputs_unspent_by_parent ON outputs (transaction_id) WHERE spending_data IS NULL;`); err != nil {
+		_ = db.Close()
+		return errors.NewStorageError("could not create px_outputs_unspent_by_parent index - [%+v]", err)
+	}
+
 	return nil
 }
 
@@ -4529,6 +4546,13 @@ func createSqliteSchema(db *usql.DB) error {
 	`); err != nil {
 		_ = db.Close()
 		return errors.NewStorageError("could not create outputs table - [%+v]", err)
+	}
+
+	// Partial index over unspent outputs — see Postgres schema for rationale.
+	// SQLite supports partial indexes via the WHERE clause.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS px_outputs_unspent_by_parent ON outputs (transaction_id) WHERE spending_data IS NULL;`); err != nil {
+		_ = db.Close()
+		return errors.NewStorageError("could not create px_outputs_unspent_by_parent index - [%+v]", err)
 	}
 
 	if _, err := db.Exec(`


### PR DESCRIPTION
## Summary

- Add `CREATE INDEX IF NOT EXISTS px_outputs_unspent_by_parent ON outputs (transaction_id) WHERE spending_data IS NULL;` to both the Postgres and SQLite schema creators in `stores/utxo/sql/sql.go`.
- Targets a specific CTE stage inside `trySendSpendBatchBulk` that EXPLAIN + pg_stat_activity traced to multi-second `IO:DataFileRead` waits on mainnet.
- Tests: mock success list + stepMatchers gain one trailing entry; one new error-path test. 185/185 passing. `go vet` clean.

## Problem

With the query-plan fix in #722 merged, `extend_transactions` fell from 33.5 s → 4.05 s per block on mainnet (8.3×). The residual bottleneck is the spend path. A re-profile attributed it to one specific sibling CTE inside `trySendSpendBatchBulk`:

```sql
unspent_before AS (
    SELECT o.transaction_id, count(*) AS n_unspent
    FROM outputs o
    JOIN parents p ON p.transaction_id = o.transaction_id
    WHERE o.spending_data IS NULL
    GROUP BY o.transaction_id
)
```

This is the drain check that decides whether this batch has just spent the parent's last unspent output (so `delete_at_height` can be set). Postgres plans it on `outputs_pkey (transaction_id, idx)` using only the leading column and pushes `spending_data IS NULL` down as a post-read Filter:

```
Index Scan using outputs_pkey on outputs o
   Index Cond: (transaction_id = p.transaction_id)
   Filter: (spending_data IS NULL)
```

For every touched parent it reads every output of that parent, then discards the already-spent rows. On data-carrier / large-fan-out parents that is thousands of heap reads per parent per batch.

**Observed on mainnet (height ~416k, 2-core VPS, postgres co-located, post-autovacuum steady state):** `sendSpendBatch` backends stalled **0.62-8.20 s on `IO:DataFileRead`** while running exactly this CTE — evidence from `pg_stat_activity` snapshots during a 90-s rate window. `validate_transactions_legacy_mode` sat at ~16.8 s/block even though block-level wall time had halved elsewhere — IO on this stage was the new gating factor.

## Fix

One partial index, added at the end of schema init:

```sql
CREATE INDEX IF NOT EXISTS px_outputs_unspent_by_parent
    ON outputs (transaction_id)
    WHERE spending_data IS NULL;
```

- **Partial** keeps it tiny — typical outputs are spent shortly after creation, so only a small minority of the `outputs` table carries `spending_data IS NULL`.
- **Index-only scan** over just the unspent rows makes the drain count bounded by `unspent_count_per_parent`, not `total_outputs_per_parent`.
- **Write cost** is one index entry removed per spend UPDATE — cheap, dominated by the UPDATE itself.
- **No behaviour change**: same query returns the same rows. The planner simply has a better path to pick.

Added to both the Postgres and SQLite schema creators so `sqlitememory`-backed tests get the same shape.

## Placement / test-shape note

The new `CREATE INDEX` is appended at the end of `createPostgresSchemaImpl` (after `conflicting_children` creation) rather than adjacent to the `outputs` table DDL. That's deliberate: the mock-driven schema tests at `stores/utxo/sql/create_postgres_schema_test.go` hard-code error-at-step numbers 0-13 against the `stepMatchers` array in `stores/utxo/sql/mock.go`. Inserting mid-array would shift every subsequent step number and require touching 6 existing tests. Appending adds one new step (14), one new success matcher, one new `stepMatchers` entry, and one new error-path test — no churn on existing tests.

## Migration notes

- `CREATE INDEX IF NOT EXISTS` (non-CONCURRENT) is consistent with every other index in the same schema init. On a large live `outputs` table Postgres takes `SHARE` lock (not `ACCESS EXCLUSIVE`) for a regular `CREATE INDEX`, so reads proceed but concurrent writes to the indexed rows queue. On a typical co-located 2-core deployment the build is seconds to a couple of minutes — acceptable for a one-shot startup migration.
- If any deployment wants zero write-block during the build, the operator can pre-create the index manually with `CREATE INDEX CONCURRENTLY` (same name) before rolling this binary — the `IF NOT EXISTS` makes the startup call a no-op.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./stores/utxo/sql/...` clean
- [x] `go test ./stores/utxo/sql/...` — 185/185 passing, including the new `TestCreatePostgresSchema_ErrorAtUnspentByParentIndex` error-path coverage.
- [x] EXPLAIN verified on live mainnet: with the index in place, the `unspent_before` CTE plans as an `Index Only Scan` on `px_outputs_unspent_by_parent` rather than a full-output-per-parent scan.
- [ ] Post-deploy steady-state re-profile to quantify the `validate_transactions_legacy_mode` reduction (to be done after merge + deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)