### PR TITLE
fix(utxo/sql): cap per-tx concurrency feeding spend batcher

### DIFF
--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -1639,6 +1639,16 @@ func (s *Store) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignore
 		g               errgroup.Group
 	)
 
+	// Cap per-tx concurrency into the spend batcher. Without this, a single tx
+	// with tens of thousands of inputs (e.g. a consolidation) can flood the
+	// batcher queue faster than its serialised callback can drain it, producing
+	// a single bulk SELECT whose parameter count exceeds PostgreSQL's 65535
+	// extended-protocol limit. Using SpendBatcherSize*SpendBatcherConcurrency
+	// matches the pattern used in services/legacy/netsync/handle_block.go.
+	if limit := s.settings.UtxoStore.SpendBatcherSize * s.settings.UtxoStore.SpendBatcherConcurrency; limit > 0 {
+		g.SetLimit(limit)
+	}
+
 	for idx, spend := range spends {
 		if spend == nil {
 			return nil, errors.NewProcessingError("spend should not be nil")


### PR DESCRIPTION
## Summary

`stores/utxo/sql/sql.go` `Spend()` launches one goroutine per input with an unlimited `errgroup`. For a transaction with tens of thousands of inputs (a consolidation), all N goroutines call `s.spendBatcher.Put()` before the batcher's serialised callback can drain the queue. The resulting batch is fed to `trySendSpendBatchBulk`, which binds **three parameters per item** in the bulk SELECT. At ~21,845+ items the statement exceeds PostgreSQL's extended-protocol **65535-parameter limit** and every spend in the batch fails.

This cannot be worked around via `utxostore_spendBatcherSize` — that value is the batcher's flush threshold, not a hard cap on how much can queue up between flushes.

## Fix

Cap the per-tx errgroup at `SpendBatcherSize * SpendBatcherConcurrency`, matching the existing pattern used in `services/legacy/netsync/handle_block.go:672`:

```go
if limit := s.settings.UtxoStore.SpendBatcherSize * s.settings.UtxoStore.SpendBatcherConcurrency; limit > 0 {
    g.SetLimit(limit)
}
```

This keeps at most that many Puts in flight from a single tx, so the batcher drains at its configured cadence regardless of tx size. With defaults (SpendBatcherSize=100, SpendBatcherConcurrency=4) the cap is 400, far below the 65535/3 = 21,845 param ceiling.

## Reproduction

Deterministically reproducible on **BSV testnet** with a PostgreSQL UTXO store using default `utxostore_spendBatcherSize=100`:

- **Block:** 1,730,302
- **Offending tx:** ` + "`325d4e44e1cee1504c7f9a6f0f31f78b376db6a5a2a7c3e7f6b277f9c3a280ae`" + `

The block has only 2 txs, but that tx has enough inputs to blow the parameter limit. Any node syncing testnet through this height will fail with:

\`\`\`
validator: UTXO Store spend failed for 325d4e44e1cee1504c7f9a6f0f31f78b376db6a5a2a7c3e7f6b277f9c3a280ae
-> UTXO_ERROR (79): error in sql spend (batched mode) - errors
-> STORAGE_ERROR (69): [Spend] failed: bulk SELECT outputs
-> UNKNOWN (0): extended protocol limited to 65535 parameters
\`\`\`

…and will refuse to advance past 1,730,301 indefinitely.

Reviewers can inspect the tx themselves via any testnet block explorer or by syncing a node and observing the failure before applying this patch.

## Test plan

- [x] \`go build ./stores/utxo/sql/\` passes
- [x] \`go test -count=1 -timeout 180s ./stores/utxo/sql/\` — 154 tests pass
- [ ] Reviewer syncs BSV testnet past 1,730,302 on a PostgreSQL-backed node with and without the patch to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)