### PR TITLE
test(utxo/aerospike): wait for StoreTransactionExternally goroutine to exit

### DIFF
--- a/stores/utxo/aerospike/create_test.go
+++ b/stores/utxo/aerospike/create_test.go
@@ -202,7 +202,16 @@ func TestStore_StoreTransactionExternally(t *testing.T) {
 		tx := readTransaction(t, "testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
 		bItem, binsToStore := prepareBatchStoreItem(t, s, tx, 0, []uint32{}, []uint32{}, []int{})
 
-		go s.StoreTransactionExternally(ctx, bItem, binsToStore)
+		// bItem.RecvDone() returns as soon as StoreTransactionExternally signals
+		// done, but the goroutine still has deferred cleanup to run (releaseLock
+		// issues an Aerospike Delete). Wait for the goroutine itself so that
+		// work finishes before the outer t.Cleanup closes the client — otherwise
+		// Client.Close races with the in-flight Delete on the partition map.
+		storeDone := make(chan struct{})
+		go func() {
+			defer close(storeDone)
+			s.StoreTransactionExternally(ctx, bItem, binsToStore)
+		}()
 
 		err := bItem.RecvDone()
 		require.NoError(t, err)
@@ -222,6 +231,8 @@ func TestStore_StoreTransactionExternally(t *testing.T) {
 		assert.True(t, exists)
 
 		// DAH is now managed centrally by pruner service, not by blob stores
+
+		<-storeDone
 	})
 
 	t.Run("TestStore_StoreTransactionExternally - no utxos", func(t *testing.T) {
@@ -237,7 +248,11 @@ func TestStore_StoreTransactionExternally(t *testing.T) {
 		_ = tx.AddOpReturnOutput([]byte("test"))
 		bItem, binsToStore := prepareBatchStoreItem(t, s, tx, 0, []uint32{}, []uint32{}, []int{})
 
-		go s.StoreTransactionExternally(ctx, bItem, binsToStore)
+		storeDone := make(chan struct{})
+		go func() {
+			defer close(storeDone)
+			s.StoreTransactionExternally(ctx, bItem, binsToStore)
+		}()
 
 		err := bItem.RecvDone()
 		require.NoError(t, err)
@@ -257,6 +272,8 @@ func TestStore_StoreTransactionExternally(t *testing.T) {
 		assert.True(t, exists)
 
 		// DAH is now managed centrally by pruner service, not by blob stores
+
+		<-storeDone
 	})
 }
 
@@ -281,7 +298,11 @@ func TestStore_StorePartialTransactionExternally(t *testing.T) {
 		tx := readTransaction(t, "testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
 		bItem, binsToStore := prepareBatchStoreItem(t, s, tx, 0, []uint32{}, []uint32{}, []int{})
 
-		go s.StorePartialTransactionExternally(ctx, bItem, binsToStore)
+		storeDone := make(chan struct{})
+		go func() {
+			defer close(storeDone)
+			s.StorePartialTransactionExternally(ctx, bItem, binsToStore)
+		}()
 
 		err := bItem.RecvDone()
 		require.NoError(t, err)
@@ -299,6 +320,8 @@ func TestStore_StorePartialTransactionExternally(t *testing.T) {
 		exists, err := s.GetExternalStore().Exists(ctx, bItem.GetTxHash().CloneBytes(), fileformat.FileTypeOutputs)
 		require.NoError(t, err)
 		assert.True(t, exists)
+
+		<-storeDone
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing data race in \`TestStore_StoreTransactionExternally\` and \`TestStore_StorePartialTransactionExternally\`.

## Root cause

Each test spawns a goroutine to run \`Store{,Partial}TransactionExternally\` and synchronises via \`bItem.RecvDone()\`. \`RecvDone()\` returns **as soon as the implementation signals completion** — but the goroutine still has deferred cleanup to run. Specifically, \`storeExternallyWithLock\` has:

\`\`\`go
defer func() {
    if releaseErr := s.releaseLock(lockKey); releaseErr != nil {
        ...
    }
}()
\`\`\`

where \`releaseLock()\` issues an Aerospike \`Delete\`.

Because the outer test registers a \`t.Cleanup\` that calls \`client.Close()\`, the cleanup can fire before the spawned goroutine finishes its deferred work. \`Close()\` clears the cluster's partition map while the in-flight \`Delete\` concurrently reads it.

The race is what the detector surfaces on CI (https://github.com/bsv-blockchain/teranode/actions/runs/24837720493/job/72702577153):

\`\`\`
WARNING: DATA RACE
Read at 0x00c011b74800 by goroutine 14704:
  aerospike-client-go/v8.(*Partition).getSequenceNode   ← inside releaseLock's Delete
Previous write at 0x00c011b74800 by goroutine 14336:
  aerospike-client-go/v8.partitionMap.cleanup
  aerospike-client-go/v8.(*Cluster).Close               ← inside t.Cleanup
\`\`\`

## Fix

Wrap each goroutine in a \`done\` channel and block on it before the subtest returns, so the goroutine's deferred \`releaseLock()\` always completes before \`t.Cleanup\` closes the client.

## Test plan

- [x] \`go build -tags aerospike ./stores/utxo/aerospike/\` passes
- [x] \`go vet -tags aerospike ./stores/utxo/aerospike/...\` passes
- [ ] Reviewer runs the aerospike suite on CI with race detector — race should no longer fire

## Notes

This race is independent of any in-flight feature work. It surfaced on #717 because CI happened to produce the right interleaving, but the racing code is in test infrastructure that hasn't been touched in many PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)