### PR TITLE
fix(txscript): prevent scriptNum.Bytes() panic on math.MinInt64

### DIFF
--- a/services/legacy/txscript/scriptnum.go
+++ b/services/legacy/txscript/scriptnum.go
@@ -15,6 +15,12 @@ const (
 	// defaultScriptNumLen is the default number of bytes
 	// data being interpreted as an integer may be.
 	defaultScriptNumLen = 4
+
+	// maxScriptNumLen is the absolute upper bound on the number of bytes
+	// that can be decoded into a scriptNum. Beyond 8 bytes the value cannot
+	// be represented in an int64, and the per-byte shift in makeScriptNum
+	// (uint8(8*i)) would wrap and produce incorrect values.
+	maxScriptNumLen = 8
 )
 
 // scriptNum represents a numeric value used in the scripting engine with
@@ -96,19 +102,23 @@ func (n scriptNum) Bytes() []byte {
 		return nil
 	}
 
-	// Take the absolute value and keep track of whether it was originally
-	// negative.
+	// Compute the absolute value as uint64 so that math.MinInt64 round-trips
+	// safely. Negating math.MinInt64 as int64 overflows back to itself,
+	// leaving the loop below with no iterations and an empty result slice.
 	isNegative := n < 0
+	var absVal uint64
 	if isNegative {
-		n = -n
+		absVal = uint64(-(n + 1)) + 1
+	} else {
+		absVal = uint64(n)
 	}
 
 	// Encode to little endian.  The maximum number of encoded bytes is 9
 	// (8 bytes for max int64 plus a potential byte for sign extension).
 	result := make([]byte, 0, 9)
-	for n > 0 {
-		result = append(result, byte(n&0xff))
-		n >>= 8
+	for absVal > 0 {
+		result = append(result, byte(absVal&0xff))
+		absVal >>= 8
 	}
 
 	// When the most significant byte already has the high bit set, an
@@ -190,6 +200,18 @@ func makeScriptNum(v []byte, requireMinimal bool, scriptNumLen int) (scriptNum, 
 		str := fmt.Sprintf("numeric value encoded as %x is %d bytes "+
 			"which exceeds the max allowed of %d", v, len(v),
 			scriptNumLen)
+
+		return 0, scriptError(ErrNumberTooBig, str)
+	}
+
+	// Even when callers pass a larger scriptNumLen (OP_BIN2NUM / OP_NUM2BIN
+	// pass len(v), bounded only by MaxScriptElementSize), the decoded value
+	// must still fit in int64. Reject anything beyond 8 bytes so that the
+	// per-byte shift below cannot wrap modulo 256.
+	if len(v) > maxScriptNumLen {
+		str := fmt.Sprintf("numeric value encoded as %x is %d bytes "+
+			"which exceeds the int64 limit of %d", v, len(v),
+			maxScriptNumLen)
 
 		return 0, scriptError(ErrNumberTooBig, str)
 	}

--- a/services/legacy/txscript/scriptnum_test.go
+++ b/services/legacy/txscript/scriptnum_test.go
@@ -7,6 +7,7 @@ package txscript
 import (
 	"bytes"
 	"encoding/hex"
+	"math"
 	"testing"
 
 	"github.com/bsv-blockchain/go-wire"
@@ -76,6 +77,10 @@ func TestScriptNumBytes(t *testing.T) {
 		{-72057594037927935, hexToBytes("ffffffffffffff80")},
 		{9223372036854775807, hexToBytes("ffffffffffffff7f")},
 		{-9223372036854775807, hexToBytes("ffffffffffffffff")},
+
+		// math.MinInt64 must not panic and must encode as a 9-byte
+		// little-endian value with an explicit sign byte.
+		{math.MinInt64, hexToBytes("000000000000008080")},
 	}
 
 	for _, test := range tests {
@@ -141,10 +146,19 @@ func TestMakeScriptNum(t *testing.T) {
 		{hexToBytes("ffffffffff"), -549755813887, 5, true, nil},
 		{hexToBytes("ffffffffffffff7f"), 9223372036854775807, 8, true, nil},
 		{hexToBytes("ffffffffffffffff"), -9223372036854775807, 8, true, nil},
-		{hexToBytes("ffffffffffffffff7f"), -1, 9, true, nil},
-		{hexToBytes("ffffffffffffffffff"), 1, 9, true, nil},
-		{hexToBytes("ffffffffffffffffff7f"), -1, 10, true, nil},
-		{hexToBytes("ffffffffffffffffffff"), 1, 10, true, nil},
+		// Inputs longer than 8 bytes are now rejected outright — they
+		// cannot fit in an int64 and previously triggered a uint8 shift
+		// wrap that produced bogus values (and a reachable Bytes() panic).
+		{hexToBytes("ffffffffffffffff7f"), 0, 9, true, errNumTooBig},
+		{hexToBytes("ffffffffffffffffff"), 0, 9, true, errNumTooBig},
+		{hexToBytes("ffffffffffffffffff7f"), 0, 10, true, errNumTooBig},
+		{hexToBytes("ffffffffffffffffffff"), 0, 10, true, errNumTooBig},
+
+		// The exploit shape from the audit: 40 bytes with v[7]=0x80
+		// previously decoded to math.MinInt64 (because v[39]=0x00
+		// bypassed the sign-mask branch) and made Bytes() panic on the
+		// empty result slice. It must now be rejected.
+		{hexToBytes("00000000000000800000000000000000000000000000000000000000000000000000000000000000"), 0, 40, false, errNumTooBig},
 
 		// Minimally encoded values that are out of range for data that
 		// is interpreted as script numbers with the minimal encoding


### PR DESCRIPTION
## Summary
- `scriptNum.Bytes()` no longer panics when called on `math.MinInt64`. Absolute value is now computed via `uint64`, so MinInt64 encodes as `[0x00 ×7, 0x80, 0x80]` instead of leaving the encode loop with an empty slice that the trailing high-bit check then indexes out of bounds.
- `makeScriptNum` is hard-capped at 8 bytes regardless of the caller-supplied `scriptNumLen`. OP_BIN2NUM / OP_NUM2BIN pass `len(v)` (bounded only by `MaxScriptElementSize = 100_000`), which previously let a peer-supplied 40-byte payload with `v[7]=0x80` decode straight to `MinInt64` and reach the panic above. The cap also closes the `uint8(8*i)` shift wrap that produced bogus `int64` values for inputs > 8 bytes.

Closes the CRITICAL (#4556) and HIGH (#4565) findings from the 2026-04-23 consensus & protocol security audit. The two are tightly coupled — the HIGH is the reachability path for the CRITICAL — so they're fixed together.

## Test plan
- [x] `go test -race ./services/legacy/txscript/...` — clean
- [x] `go build ./...` — clean
- [x] `TestScriptNumBytes` extended with `math.MinInt64` round-trip
- [x] `TestMakeScriptNum` updated: deliberate-overflow 9/10-byte cases and the audit's 40-byte exploit shape (`v[7]=0x80`, len 40) now assert `ErrNumberTooBig`