### PR TITLE
fix(txscript): correct OP_NUM2BIN size-error constant

### DIFF
--- a/services/legacy/txscript/opcode.go
+++ b/services/legacy/txscript/opcode.go
@@ -1500,7 +1500,7 @@ func opcodeNum2bin(op *parsedOpcode, vm *Engine) error {
 
 	if size > MaxScriptElementSize {
 		return scriptError(ErrNumberTooBig,
-			fmt.Sprintf("n is larger than the max of %d", defaultScriptNumLen))
+			fmt.Sprintf("n is larger than the max of %d", MaxScriptElementSize))
 	}
 
 	// encode a as a script num so that we we take the bytes it

--- a/services/legacy/txscript/opcode_test.go
+++ b/services/legacy/txscript/opcode_test.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestOpcodeDisabled tests the opcodeDisabled function manually because all
@@ -208,4 +210,25 @@ func TestOpcodeDisasm(t *testing.T) {
 			continue
 		}
 	}
+}
+
+// TestOpcodeNum2binSizeTooBig verifies that OP_NUM2BIN rejects sizes greater
+// than MaxScriptElementSize and that the returned error message references
+// the correct constant (the value of MaxScriptElementSize, not
+// defaultScriptNumLen). Regression for issue #4591.
+func TestOpcodeNum2binSizeTooBig(t *testing.T) {
+	vm := Engine{}
+
+	vm.dstack.PushByteArray([]byte{0x01})
+	vm.dstack.PushInt(scriptNum(MaxScriptElementSize + 1))
+
+	pop := parsedOpcode{opcode: &opcodeArray[OP_NUM2BIN], data: nil}
+
+	err := opcodeNum2bin(&pop, &vm)
+	require.Error(t, err)
+	require.True(t, IsErrorCode(err, ErrNumberTooBig),
+		"expected ErrNumberTooBig, got %v", err)
+	require.Contains(t, err.Error(), strconv.Itoa(MaxScriptElementSize),
+		"error message should reference MaxScriptElementSize (%d), got %q",
+		MaxScriptElementSize, err.Error())
 }


### PR DESCRIPTION
Closes #4591.

## Summary
`opcodeNum2bin` rejects sizes greater than `MaxScriptElementSize` (100000) but the error message formats `defaultScriptNumLen` (4), so logs read `"n is larger than the max of 4"` when the real cap is 100000. No consensus impact — log/UX only.

## Fix
Format the error against `MaxScriptElementSize` so the message matches the gate.

## Test plan
- [x] Regression test in `services/legacy/txscript/opcode_test.go` exercising `OP_NUM2BIN` with size > `MaxScriptElementSize`; asserts error string contains `100000`.
- [x] `go test -race ./services/legacy/txscript/...` passes.