### PR TITLE
docs(blockvalidation): explain fork-depth boundary against coinbase maturity

### DIFF
--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -516,6 +516,12 @@ func (u *Server) findCommonAncestor(ctx context.Context, catchupCtx *CatchupCont
 func (u *Server) validateForkDepth(catchupCtx *CatchupContext) error {
 	u.logger.Debugf("[catchup][%s] Step 3: Validating fork depth against coinbase maturity", catchupCtx.blockUpTo.Hash().String())
 
+	// Reject only when fork depth strictly exceeds CoinbaseMaturity. A reorg of depth d
+	// invalidates a coinbase at height G iff G >= H - d + 1; for that coinbase to have
+	// been spent in the old chain we need G + CoinbaseMaturity <= H, which has a solution
+	// only when d > CoinbaseMaturity. So d == CoinbaseMaturity is safe (no matured
+	// coinbase in the reorged range can yet have been spent), and `>` is the correct
+	// operator here, not `>=`. See issue #4592.
 	if catchupCtx.forkDepth > uint32(u.settings.ChainCfgParams.CoinbaseMaturity) {
 		u.logger.Errorf("[catchup][%s] fork depth (%d blocks) exceeds coinbase maturity (%d blocks)", catchupCtx.blockUpTo.Hash().String(), catchupCtx.forkDepth, u.settings.ChainCfgParams.CoinbaseMaturity)
 

--- a/services/blockvalidation/catchup_quickvalidation_test.go
+++ b/services/blockvalidation/catchup_quickvalidation_test.go
@@ -256,6 +256,48 @@ func TestValidateForkDepth(t *testing.T) {
 	})
 }
 
+// TestValidateForkDepth_Boundary locks in the boundary semantics of validateForkDepth
+// against CoinbaseMaturity. See issue #4592 for the proof: a reorg of depth d invalidates
+// a coinbase at height G iff G >= H - d + 1; for that coinbase to have been spent in the
+// old chain we need G + CoinbaseMaturity <= H, which has a solution only when
+// d > CoinbaseMaturity. So d == CoinbaseMaturity is safe and the operator must remain `>`.
+func TestValidateForkDepth_Boundary(t *testing.T) {
+	const coinbaseMaturity = 100
+
+	tests := []struct {
+		name      string
+		forkDepth uint32
+		wantErr   bool
+	}{
+		{name: "depth N-1 below maturity is accepted", forkDepth: coinbaseMaturity - 1, wantErr: false},
+		{name: "depth N at maturity is accepted (boundary)", forkDepth: coinbaseMaturity, wantErr: false},
+		{name: "depth N+1 above maturity is rejected", forkDepth: coinbaseMaturity + 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suite := NewCatchupTestSuite(t)
+			defer suite.Cleanup()
+
+			suite.Server.settings.ChainCfgParams.CoinbaseMaturity = coinbaseMaturity
+
+			catchupCtx := &CatchupContext{
+				blockUpTo: testhelpers.CreateTestBlocks(t, 1)[0],
+				forkDepth: tt.forkDepth,
+				peerID:    "peer-boundary",
+			}
+
+			err := suite.Server.validateForkDepth(catchupCtx)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "exceeds coinbase maturity")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestRecordMaliciousAttempt tests the recordMaliciousAttempt method
 func TestRecordMaliciousAttempt(t *testing.T) {
 	t.Run("should record malicious attempt with peer metrics", func(t *testing.T) {


### PR DESCRIPTION
Closes #4592.

## Summary
The audit (#4592) flagged the operator in `validateForkDepth` (`forkDepth > CoinbaseMaturity`) as possibly off-by-one and asked whether `>=` was the stricter-and-correct reading. Working through the maturity arithmetic shows `>` is correct: a reorg of depth `d == CoinbaseMaturity` cannot invalidate a *spent* matured coinbase, because the deepest reorged coinbase first matures at `H + 1`, after the current old-chain tip `H`. Only `d > CoinbaseMaturity` admits a height range where a spent matured coinbase could be reorged out.

## Change
- Add a 4-6 line comment in `validateForkDepth` summarising the proof and citing #4592.
- Add a boundary regression test that locks in the three cases (`d == N-1` accepted, `d == N` accepted, `d == N+1` rejected) so a future refactor cannot silently flip the operator.

## Test plan
- [x] Boundary test passes on `main` (the operator was always correct).
- [x] `go test -race ./services/blockvalidation/...` passes.