### PR TITLE
fix(utxo): roll back ProcessConflicting on step-3+ failure

### DIFF
--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -9,6 +9,7 @@ package utxo
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -20,6 +21,15 @@ import (
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"golang.org/x/sync/errgroup"
 )
+
+// step5RetryDelays controls the bounded back-off when SetLocked(false) fails at the very
+// last step of ProcessConflicting. The slice length is the number of attempts; the value
+// at index i is the delay BEFORE attempt i (so index 0 is always zero — the first attempt
+// is immediate). Rolling back at step 5 would create more inconsistency than retrying a
+// simple state update — see ProcessConflicting for rationale.
+//
+// Declared as a package-level var so tests can shrink the delays.
+var step5RetryDelays = []time.Duration{0, 50 * time.Millisecond, 200 * time.Millisecond}
 
 // ProcessConflicting is a method to process conflicting transactions
 // We got a txp (parent), txa and txb. txa and txb are both spending txp[5].
@@ -62,6 +72,46 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "ProcessConflicting")
 
 	defer deferFn()
+
+	// State for the deferred compensating rollback. Each commit phase flips a flag; the
+	// deferred block reads them on the way out and undoes whatever happened — see #4561.
+	// allMarkedHashes mirrors the allMarkedConflicting named return but is read by the
+	// deferred block; a `return nil, nil, err` in the error paths clobbers the named
+	// return before the deferred runs, so we keep a parallel copy that survives.
+	var (
+		step1Committed        bool
+		step2Committed        bool
+		step4Committed        bool
+		step5Failed           bool // distinct from "not committed" — rollback is intentionally skipped
+		affectedParentSpends  []*Spend
+		markedAsNotSpendable  []chainhash.Hash
+		step3SuccessfulSpends []*Spend
+		losingTxHashes        []chainhash.Hash
+		allMarkedHashes       []chainhash.Hash
+	)
+
+	defer func() {
+		if err == nil || !step1Committed {
+			return
+		}
+
+		// Step 5 (SetLocked false) is the last simple state update. Steps 1-4 are correct
+		// at this point; rolling back would re-introduce conflicting flags and unspend the
+		// winner — strictly worse. Surface the error and let the operator unlock manually.
+		if step5Failed {
+			return
+		}
+
+		rollbackErr := rollbackProcessConflicting(ctx, s, conflictingTxHashes, losingTxHashes,
+			allMarkedHashes, markedAsNotSpendable, step3SuccessfulSpends, blockHeight,
+			step2Committed, step4Committed)
+		if rollbackErr != nil {
+			err = errors.NewProcessingError("[ProcessConflicting] MANUAL INTERVENTION REQUIRED: original=%v rollback=%v", err, rollbackErr)
+		}
+
+		losingTxHashesMap = nil
+		allMarkedConflicting = nil
+	}()
 
 	// 0. Get the transactions, check they are conflicting
 	winningTxs := make([]*bt.Tx, len(conflictingTxHashes))
@@ -125,21 +175,25 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 		}
 	}
 
-	losingTxHashes := losingTxHashesMap.Keys()
+	losingTxHashes = losingTxHashesMap.Keys()
 
 	// - 1: mark all losingTxHashesPerConflictingTx as conflicting + all its spending transactions recursively.
-	//   markedOrder is the BFS expansion: every hash now flagged Conflicting=true. Forwarded to callers so
+	//   allMarkedConflicting is the BFS expansion: every hash now flagged Conflicting=true. Forwarded to callers so
 	//   the block-assembly conflictingMap can include the cascaded descendants (not just the immediate losers).
-	affectedParentSpends, markedOrder, err := MarkConflictingRecursively(ctx, s, losingTxHashes)
+	affectedParentSpends, allMarkedHashes, err = MarkConflictingRecursively(ctx, s, losingTxHashes)
 	if err != nil {
 		return nil, nil, err
 	}
-	allMarkedConflicting = markedOrder
+
+	allMarkedConflicting = allMarkedHashes
+	step1Committed = true
 
 	// - 2: un-spend txa, marking the input txs as not spendable (txp & txq)
 	if err = s.Unspend(ctx, affectedParentSpends, true); err != nil {
 		return nil, nil, errors.NewProcessingError("error unspending affected parent spends", err)
 	}
+
+	step2Committed = true
 
 	// get the unique hashes of the transactions that were marked as not spendable
 	markedAsNotSpendableHashesUnique := make(map[chainhash.Hash]struct{})
@@ -147,22 +201,30 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 		markedAsNotSpendableHashesUnique[*spend.TxID] = struct{}{}
 	}
 
-	markedAsNotSpendableHashes := make([]chainhash.Hash, 0, len(markedAsNotSpendableHashesUnique))
+	markedAsNotSpendable = make([]chainhash.Hash, 0, len(markedAsNotSpendableHashesUnique))
 	for hash := range markedAsNotSpendableHashesUnique {
-		markedAsNotSpendableHashes = append(markedAsNotSpendableHashes, hash)
+		markedAsNotSpendable = append(markedAsNotSpendable, hash)
 	}
 
 	// - 3: spend tx_double_spend as normal (ignoring the not spendable flag)
 	var tErr *errors.Error
 
 	for _, tx := range winningTxs {
-		spends, err := s.Spend(ctx, tx, blockHeight, IgnoreFlags{
+		spends, spendErr := s.Spend(ctx, tx, blockHeight, IgnoreFlags{
 			IgnoreConflicting: true,
 			IgnoreLocked:      true,
 		})
-		if err != nil {
-			if errors.As(err, &tErr) {
-				// add all the spend errors to the error chain
+		// Capture per-input partial successes regardless of overall outcome so the rollback
+		// can undo them via Unspend(false) (parents at step 3 entry were unlocked-by-us, so
+		// the unspend MUST NOT relock).
+		for _, sp := range spends {
+			if sp != nil && sp.Err == nil {
+				step3SuccessfulSpends = append(step3SuccessfulSpends, sp)
+			}
+		}
+
+		if spendErr != nil {
+			if errors.As(spendErr, &tErr) {
 				for _, spend := range spends {
 					if spend.Err != nil {
 						tErr.SetWrappedErr(spend.Err)
@@ -170,6 +232,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 				}
 			}
 
+			err = spendErr
 			return nil, nil, err
 		}
 	}
@@ -179,12 +242,113 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 		return nil, nil, err
 	}
 
-	// - 5: mark txp & txq as spendable again
-	if err = s.SetLocked(ctx, markedAsNotSpendableHashes, false); err != nil {
+	step4Committed = true
+
+	// - 5: mark txp & txq as spendable again. Step 5 is a near-final state update; rolling
+	// the entire commit back now would re-introduce the very inconsistencies we just fixed.
+	// Retry with bounded back-off and surface any persistent failure for operator action.
+	if err = setLockedWithRetry(ctx, s, markedAsNotSpendable, false); err != nil {
+		step5Failed = true
 		return nil, nil, err
 	}
 
 	return losingTxHashesMap, allMarkedConflicting, nil
+}
+
+// rollbackProcessConflicting reverses the committed phases of ProcessConflicting in
+// reverse-of-forward order. It is best-effort: each sub-step's error is collected via
+// errors.Join so subsequent sub-steps still run. If the caller sees a non-nil return
+// the UTXO store may be in an inconsistent state — see ProcessConflicting deferred
+// block which tags this as MANUAL INTERVENTION REQUIRED.
+func rollbackProcessConflicting(ctx context.Context, s Store, conflictingTxHashes,
+	losingTxHashes, allMarkedHashes, markedAsNotSpendable []chainhash.Hash,
+	step3SuccessfulSpends []*Spend, blockHeight uint32, step2Committed, step4Committed bool) error {
+	var rollbackErr error
+
+	// 1. Undo step 4 first (re-mark winners as conflicting) so the system briefly observes
+	// "everything is conflicting" rather than "winner accepted but parents still missing
+	// their spend record".
+	if step4Committed {
+		if _, _, e := s.SetConflicting(ctx, conflictingTxHashes, true); e != nil {
+			rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 4 (re-mark winners conflicting) failed", e))
+		}
+	}
+
+	// 2. Undo step 3 partial spends. Pass flagAsLocked=false because parents were already
+	// unlocked when we entered step 3 (the lock was applied at step 2, which we will undo
+	// further down — keeping them locked here would leak state past the rollback).
+	if len(step3SuccessfulSpends) > 0 {
+		if e := s.Unspend(ctx, step3SuccessfulSpends, false); e != nil {
+			rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 3 (unspend partial winning spends) failed", e))
+		}
+	}
+
+	// 3. Undo step 2: re-spend the losing txs to restore the original spending_data on
+	// affectedParentSpends. Parents are still locked at this point, so we MUST set
+	// IgnoreLocked. The losing txs are also marked conflicting at this point — same
+	// reason for IgnoreConflicting.
+	if step2Committed {
+		for _, h := range losingTxHashes {
+			h := h
+
+			txMeta, e := s.Get(ctx, &h, fields.Tx)
+			if e != nil {
+				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (fetch losing tx) failed", e))
+				continue
+			}
+
+			if txMeta == nil || txMeta.Tx == nil {
+				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (losing tx %s has no body)", h.String()))
+				continue
+			}
+
+			if _, e := s.Spend(ctx, txMeta.Tx, blockHeight, IgnoreFlags{IgnoreConflicting: true, IgnoreLocked: true}); e != nil {
+				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (re-spend losing tx %s) failed", h.String(), e))
+			}
+		}
+	}
+
+	// 4. Undo step 1: clear the conflicting flag on every hash MarkConflictingRecursively
+	// added (cascaded children included).
+	if len(allMarkedHashes) > 0 {
+		if _, _, e := s.SetConflicting(ctx, allMarkedHashes, false); e != nil {
+			rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 1 (clear conflicting flag) failed", e))
+		}
+	}
+
+	// 5. Undo the lock applied at step 2 (only attempted if step 2 actually committed).
+	if step2Committed && len(markedAsNotSpendable) > 0 {
+		if e := s.SetLocked(ctx, markedAsNotSpendable, false); e != nil {
+			rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 lock (SetLocked false) failed", e))
+		}
+	}
+
+	return rollbackErr
+}
+
+// setLockedWithRetry retries SetLocked with a bounded back-off — a deliberate exception
+// to "always roll back". By the time we reach step 5 every other phase is committed and
+// correct; the only inconsistency a SetLocked failure introduces is parents that are
+// still locked. Rolling back here would re-introduce conflicting markers and unspend the
+// winner — strictly worse than retrying a simple state update.
+func setLockedWithRetry(ctx context.Context, s Store, hashes []chainhash.Hash, value bool) error {
+	var err error
+
+	for _, delay := range step5RetryDelays {
+		if delay > 0 {
+			select {
+			case <-ctx.Done():
+				return errors.NewProcessingError("setLockedWithRetry aborted by context", ctx.Err())
+			case <-time.After(delay):
+			}
+		}
+
+		if err = s.SetLocked(ctx, hashes, value); err == nil {
+			return nil
+		}
+	}
+
+	return err
 }
 
 // MarkConflictingRecursively marks the given transactions as conflicting, and iteratively marks all their spending

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -86,7 +86,6 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 		affectedParentSpends  []*Spend
 		markedAsNotSpendable  []chainhash.Hash
 		step3SuccessfulSpends []*Spend
-		losingTxHashes        []chainhash.Hash
 		allMarkedHashes       []chainhash.Hash
 	)
 
@@ -102,7 +101,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 			return
 		}
 
-		rollbackErr := rollbackProcessConflicting(ctx, s, conflictingTxHashes, losingTxHashes,
+		rollbackErr := rollbackProcessConflicting(ctx, s, conflictingTxHashes,
 			allMarkedHashes, markedAsNotSpendable, step3SuccessfulSpends, blockHeight,
 			step2Committed, step4Committed)
 		if rollbackErr != nil {
@@ -175,7 +174,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 		}
 	}
 
-	losingTxHashes = losingTxHashesMap.Keys()
+	losingTxHashes := losingTxHashesMap.Keys()
 
 	// - 1: mark all losingTxHashesPerConflictingTx as conflicting + all its spending transactions recursively.
 	//   allMarkedConflicting is the BFS expansion: every hash now flagged Conflicting=true. Forwarded to callers so
@@ -261,7 +260,7 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 // the UTXO store may be in an inconsistent state — see ProcessConflicting deferred
 // block which tags this as MANUAL INTERVENTION REQUIRED.
 func rollbackProcessConflicting(ctx context.Context, s Store, conflictingTxHashes,
-	losingTxHashes, allMarkedHashes, markedAsNotSpendable []chainhash.Hash,
+	allMarkedHashes, markedAsNotSpendable []chainhash.Hash,
 	step3SuccessfulSpends []*Spend, blockHeight uint32, step2Committed, step4Committed bool) error {
 	var rollbackErr error
 
@@ -274,36 +273,45 @@ func rollbackProcessConflicting(ctx context.Context, s Store, conflictingTxHashe
 		}
 	}
 
-	// 2. Undo step 3 partial spends. Pass flagAsLocked=false because parents were already
-	// unlocked when we entered step 3 (the lock was applied at step 2, which we will undo
-	// further down — keeping them locked here would leak state past the rollback).
+	// 2. Undo step 3 partial spends. Pass flagAsLocked=false: step 3 used IgnoreLocked, so
+	// re-locking here is meaningless — the parents are still locked from step 2 and that
+	// lock will be cleared together at step 5 of the rollback (SetLocked false below).
 	if len(step3SuccessfulSpends) > 0 {
 		if e := s.Unspend(ctx, step3SuccessfulSpends, false); e != nil {
 			rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 3 (unspend partial winning spends) failed", e))
 		}
 	}
 
-	// 3. Undo step 2: re-spend the losing txs to restore the original spending_data on
-	// affectedParentSpends. Parents are still locked at this point, so we MUST set
-	// IgnoreLocked. The losing txs are also marked conflicting at this point — same
-	// reason for IgnoreConflicting.
+	// 3. Undo step 2: re-spend every tx the cascade marked conflicting so the original
+	// spending_data is restored on affectedParentSpends. We iterate allMarkedHashes — not
+	// just losingTxHashes — because MarkConflictingRecursively does a BFS that reaches
+	// spending descendants of the counter-conflicting set, and step 2's Unspend covered
+	// the parents of that whole cascade. Skipping descendants would leave their parent
+	// UTXOs unspent and the store in a torn state. Parents are still locked here, so we
+	// MUST set IgnoreLocked; the cascade is still flagged conflicting, so IgnoreConflicting.
+	// A descendant's body may be unfetchable (pruned, frozen placeholder, or missing) —
+	// log via rollbackErr and continue rather than abort the rest of the unwind.
 	if step2Committed {
-		for _, h := range losingTxHashes {
+		for _, h := range allMarkedHashes {
 			h := h
+
+			if h.Equal(subtree.CoinbasePlaceholderHashValue) {
+				continue
+			}
 
 			txMeta, e := s.Get(ctx, &h, fields.Tx)
 			if e != nil {
-				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (fetch losing tx) failed", e))
+				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (fetch tx %s) failed", h.String(), e))
 				continue
 			}
 
 			if txMeta == nil || txMeta.Tx == nil {
-				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (losing tx %s has no body)", h.String()))
+				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (tx %s has no body)", h.String()))
 				continue
 			}
 
 			if _, e := s.Spend(ctx, txMeta.Tx, blockHeight, IgnoreFlags{IgnoreConflicting: true, IgnoreLocked: true}); e != nil {
-				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (re-spend losing tx %s) failed", h.String(), e))
+				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (re-spend tx %s) failed", h.String(), e))
 			}
 		}
 	}

--- a/stores/utxo/process_conflicting_rollback_test.go
+++ b/stores/utxo/process_conflicting_rollback_test.go
@@ -226,3 +226,149 @@ func TestProcessConflictingRollback_Step5RetryExhausted(t *testing.T) {
 	// step-5 exhausted retry must NOT roll back: no extra Spend / SetConflicting / Unspend.
 	mockStore.AssertExpectations(t)
 }
+
+// TestProcessConflictingRollback_PartialStep3Spend exercises the rollback path when step 3
+// produces a mix of successful and failing per-input spends. The successful spends are
+// captured into step3SuccessfulSpends and must be undone via Unspend(false) — flagAsLocked
+// is false because step 3 used IgnoreLocked, so re-locking would be meaningless (the lock
+// from step 2 is still in place and will be cleared at the SetLocked(false) step below).
+func TestProcessConflictingRollback_PartialStep3Spend(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	conflictingTxHash := createTestHash("rollback-partial-winning-tx")
+	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
+	losingTxHash := createTestHash("rollback-partial-losing-tx")
+
+	winningTx := createTestTransaction()
+	losingTx := createTestTransaction()
+
+	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
+		Tx:          winningTx,
+		Conflicting: true,
+	}, nil).Once()
+
+	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
+		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+
+	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
+
+	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
+
+	// step 3: Spend(winningTx) returns one successful per-input spend AND one failing
+	// per-input spend, with a non-nil function-level error. ProcessConflicting must
+	// capture only the successful spend into step3SuccessfulSpends.
+	parent1 := createTestHash("rollback-partial-parent-1")
+	parent2 := createTestHash("rollback-partial-parent-2")
+	successSpend := &Spend{TxID: &parent1, Vout: 0}
+	failSpend := &Spend{TxID: &parent2, Vout: 0, Err: errors.NewProcessingError("input-level spend failure")}
+
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{successSpend, failSpend}, errors.NewTxInvalidError("aggregate spend failed")).Once()
+
+	// rollback expectations (reverse order):
+	// 3a. step-3 partial successes are undone with flagAsLocked=false
+	mockStore.On("Unspend", mock.Anything, []*Spend{successSpend}, []bool{false}).Return(nil).Once()
+	// 3b. re-spend losing tx (need to fetch it first)
+	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
+		Tx: losingTx,
+	}, nil).Once()
+	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+	// 3c. SetConflicting(allMarkedHashes, false) — undoes step 1
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
+	// 3d. SetLocked(parents, false) — undoes step 2's lock
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return(nil).Once()
+
+	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "aggregate spend failed")
+	mockStore.AssertExpectations(t)
+}
+
+// TestProcessConflictingRollback_CascadeDescendants exercises the rollback path when
+// MarkConflictingRecursively reaches descendants beyond the counter-conflicting set
+// returned by GetCounterConflicting. The rollback must re-spend every descendant the
+// cascade marked, not just the losingTxHashes — otherwise the descendants' parent UTXOs
+// remain unspent after rollback. The descendant in this test has no fetchable body in
+// the store; the rollback must surface that error via rollbackErr but still complete the
+// remaining unwind steps.
+func TestProcessConflictingRollback_CascadeDescendants(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	conflictingTxHash := createTestHash("rollback-cascade-winning-tx")
+	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
+	losingTxHash := createTestHash("rollback-cascade-losing-tx")
+	descendantHash := createTestHash("rollback-cascade-descendant-tx")
+
+	winningTx := createTestTransaction()
+	losingTx := createTestTransaction()
+
+	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
+		Tx:          winningTx,
+		Conflicting: true,
+	}, nil).Once()
+
+	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
+		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+
+	// step 1: MarkConflictingRecursively first marks the losing tx and its BFS yields a
+	// descendant. The second SetConflicting call (for the descendant) returns no further
+	// children, terminating the BFS. allMarkedHashes ends up [losingTxHash, descendantHash].
+	losingSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
+	descendantSpends := []*Spend{{TxID: &descendantHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+		Return(losingSpends, []chainhash.Hash{descendantHash}, nil).Once()
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{descendantHash}, true).
+		Return(descendantSpends, []chainhash.Hash{}, nil).Once()
+
+	// step 2: Unspend on the combined affected parent spends commits successfully.
+	mockStore.On("Unspend", mock.Anything, append([]*Spend{}, losingSpends[0], descendantSpends[0]), []bool{true}).
+		Return(nil).Once()
+
+	// step 3: Spend(winningTx) FAILS — no per-input partial successes.
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
+
+	// rollback path:
+	// 3a. step-3 had no successful spends → no Unspend call for partial spends.
+	// 3b. re-spend losing tx body
+	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
+		Tx: losingTx,
+	}, nil).Once()
+	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+	// 3c. attempt to fetch descendant body — store has nothing for it, surface but continue
+	mockStore.On("Get", mock.Anything, &descendantHash, mock.Anything).
+		Return((*meta.Data)(nil), errors.NewNotFoundError("descendant not found")).Once()
+	// 3d. SetConflicting(allMarkedHashes, false) — clears flag on losing AND descendant
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash, descendantHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
+	// 3e. SetLocked(false) on the unique parents marked unspendable
+	mockStore.On("SetLocked", mock.Anything, mock.MatchedBy(func(hs []chainhash.Hash) bool {
+		// affectedParentSpends covers parents of both losing + descendant; both have
+		// vout=0 with TxID = losingTxHash / descendantHash, so unique parents are exactly
+		// those two hashes.
+		if len(hs) != 2 {
+			return false
+		}
+		seen := map[chainhash.Hash]bool{hs[0]: true, hs[1]: true}
+		return seen[losingTxHash] && seen[descendantHash]
+	}), false).Return(nil).Once()
+
+	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MANUAL INTERVENTION REQUIRED")
+	require.Contains(t, err.Error(), "spend failed")
+	require.Contains(t, err.Error(), "descendant not found")
+	mockStore.AssertExpectations(t)
+}

--- a/stores/utxo/process_conflicting_rollback_test.go
+++ b/stores/utxo/process_conflicting_rollback_test.go
@@ -1,0 +1,228 @@
+package utxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessConflictingRollback_Step3Failure verifies that when the winning-tx Spend
+// (step 3) fails after step 1 (mark losing tx conflicting) and step 2 (unspend parents +
+// lock them) have committed, the deferred rollback restores the original state:
+//   - step-3 partial spends are unspent (we accumulate spends per-tx; the failing tx had no
+//     successful per-input spend in this fixture, so step 3 contributes nothing to undo)
+//   - losing tx is re-spent against the parent so the parent's spending_data is restored
+//   - the losing tx is no longer marked conflicting
+//   - the parents are no longer locked
+func TestProcessConflictingRollback_Step3Failure(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	conflictingTxHash := createTestHash("rollback-step3-winning-tx")
+	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
+	losingTxHash := createTestHash("rollback-step3-losing-tx")
+
+	winningTx := createTestTransaction()
+	losingTx := createTestTransaction()
+
+	// step 0: fetch winning tx + check it is conflicting + get counter conflicting
+	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
+		Tx:          winningTx,
+		Conflicting: true,
+	}, nil).Once()
+
+	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
+		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+
+	// step 1: MarkConflictingRecursively → SetConflicting(losing, true)
+	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
+
+	// step 2: Unspend(affectedSpends, true) commits successfully (locks parents)
+	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
+
+	// step 3: Spend(winningTx) FAILS — no per-input partial successes
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
+
+	// rollback expectations (reverse order):
+	// 3a. step-3 had no successful spends → no Unspend call for step3SuccessfulSpends
+	// 3b. re-spend losing tx (need to fetch it first)
+	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
+		Tx: losingTx,
+	}, nil).Once()
+	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+	// 3c. SetConflicting(allMarkedHashes, false) — undoes step 1
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
+	// 3d. SetLocked(parents, false) — undoes step 2's lock
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return(nil).Once()
+
+	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spend failed")
+	mockStore.AssertExpectations(t)
+}
+
+// TestProcessConflictingRollback_RollbackAlsoFails verifies that when the rollback itself
+// fails (here: the SetConflicting(false) sub-step fails), the returned error mentions both
+// the original failure and the rollback failure, and includes the "MANUAL INTERVENTION
+// REQUIRED" tag so an operator notices.
+func TestProcessConflictingRollback_RollbackAlsoFails(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	conflictingTxHash := createTestHash("rollback-fail-winning-tx")
+	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
+	losingTxHash := createTestHash("rollback-fail-losing-tx")
+
+	winningTx := createTestTransaction()
+	losingTx := createTestTransaction()
+
+	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
+		Tx:          winningTx,
+		Conflicting: true,
+	}, nil).Once()
+
+	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
+		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+
+	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
+
+	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
+
+	// step 3 fails
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
+
+	// rollback path:
+	// re-fetch losing tx
+	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
+		Tx: losingTx,
+	}, nil).Once()
+	// re-spend losing tx (rollback step 2) succeeds
+	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+	// SetConflicting(false) FAILS — rollback failure
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, errors.NewProcessingError("set conflicting false failed")).Once()
+	// SetLocked(false) still attempted (best-effort) and succeeds
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return(nil).Once()
+
+	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MANUAL INTERVENTION REQUIRED")
+	require.Contains(t, err.Error(), "spend failed")
+	require.Contains(t, err.Error(), "set conflicting false failed")
+	mockStore.AssertExpectations(t)
+}
+
+// TestProcessConflictingRollback_Step5RetrySucceeds verifies the bounded retry on step-5
+// SetLocked(false) failure: when SetLocked fails the first two times and succeeds on the
+// third attempt, ProcessConflicting reports success without rolling back the rest of the
+// commit.
+func TestProcessConflictingRollback_Step5RetrySucceeds(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	conflictingTxHash := createTestHash("rollback-retry-winning-tx")
+	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
+	losingTxHash := createTestHash("rollback-retry-losing-tx")
+
+	winningTx := createTestTransaction()
+
+	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
+		Tx:          winningTx,
+		Conflicting: true,
+	}, nil).Once()
+
+	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
+		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+
+	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
+
+	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
+
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+
+	mockStore.On("SetConflicting", mock.Anything, conflictingTxHashes, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
+
+	// step 5: SetLocked(false) fails twice, succeeds the third time
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return(errors.NewProcessingError("transient lock failure")).Twice()
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return(nil).Once()
+
+	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Exists(losingTxHash))
+	mockStore.AssertExpectations(t)
+}
+
+// TestProcessConflictingRollback_Step5RetryExhausted verifies that when all SetLocked(false)
+// retries fail, the returned error surfaces the failure but the function does NOT roll back
+// the rest of the (correct) commit — only parents are still locked, which is recoverable
+// by manual SetLocked.
+func TestProcessConflictingRollback_Step5RetryExhausted(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	conflictingTxHash := createTestHash("rollback-retry-exhausted-winning-tx")
+	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
+	losingTxHash := createTestHash("rollback-retry-exhausted-losing-tx")
+
+	winningTx := createTestTransaction()
+
+	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
+		Tx:          winningTx,
+		Conflicting: true,
+	}, nil).Once()
+
+	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
+		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+
+	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
+
+	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
+
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+
+	mockStore.On("SetConflicting", mock.Anything, conflictingTxHashes, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
+
+	// step 5 fails on every attempt — 3 attempts total
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return(errors.NewProcessingError("persistent lock failure")).Times(3)
+
+	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "persistent lock failure")
+	// step-5 exhausted retry must NOT roll back: no extra Spend / SetConflicting / Unspend.
+	mockStore.AssertExpectations(t)
+}

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -179,6 +179,10 @@ func TestProcessConflicting_UnspendError(t *testing.T) {
 	mockStore.On("Unspend", mock.Anything, mock.Anything, mock.Anything).
 		Return(errors.NewProcessingError("unspend failed"))
 
+	// step 2 failed → rollback only undoes step 1 (clear conflicting flag).
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil)
+
 	// Execute test
 	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})
 
@@ -197,12 +201,15 @@ func TestProcessConflicting_SpendError(t *testing.T) {
 	conflictingTxHashes := []chainhash.Hash{conflictingTxHash}
 	losingTxHash := createTestHash("losing-tx")
 	testTx := createTestTransaction()
+	// Use a distinct fixture for the losing tx so the mock can differentiate the
+	// step-3 Spend(winning) failure from the rollback Spend(losing) call.
+	losingTx := createTestTransactionWithInputs(losingTxHash, 1)
 
 	// Mock successful setup calls
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          testTx,
 		Conflicting: true,
-	}, nil)
+	}, nil).Once()
 
 	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
 		Return([]chainhash.Hash{losingTxHash}, nil)
@@ -221,6 +228,17 @@ func TestProcessConflicting_SpendError(t *testing.T) {
 	}
 	mockStore.On("Spend", mock.Anything, testTx, mock.Anything, mock.Anything).
 		Return([]*Spend{spendWithError}, errors.NewTxInvalidError("spend failed"))
+
+	// step-3 failure rollback path: re-fetch losing tx body, re-spend it, clear conflicting,
+	// unlock parents. (No partial successful step-3 spends — the only spend has Err != nil.)
+	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
+		Tx: losingTx,
+	}, nil).Once()
+	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil)
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).Return(nil)
 
 	// Execute test
 	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]bool{})


### PR DESCRIPTION
Closes #4561.

## Summary
`ProcessConflicting` runs a 5-phase commit to resolve double-spend conflicts during a reorg. Steps 1-2 commit (mark losing txs conflicting + unspend parents + lock them) before step 3 (`Spend` of winning tx). If step 3 or later fails, no rollback runs — parents stay locked permanently, losing txs stay conflicting permanently, and future reorgs cannot re-apply the transactions. The audit (#4561) classified this as CRITICAL because the failure mode is **stuck reorg / permanent UTXO lockout**.

## Fix
Adds a deferred compensating rollback that fires on any step-2+ failure when at least step 1 committed:

1. Re-mark the winning conflicting hashes (only if step 4 had committed).
2. Undo any partial step-3 spends (`Unspend` the spends whose `.Err == nil`).
3. Re-spend losing txs to restore the original parent spending_data (using `Spend(losingTx, IgnoreConflicting, IgnoreLocked)`; the losing tx body is fetched via `Get` in the rollback path).
4. `SetConflicting(allMarkedHashes, false)` to clear the recursive conflict markers from step 1.
5. `SetLocked(parents, false)` to undo step 2's lock.

Step 5 (`SetLocked(false)`) failures are retried with a bounded back-off (3 attempts: 0ms / 50ms / 200ms) before returning. By the time we reach step 5, steps 1-4 are correct; rolling back would re-introduce the very inconsistencies just fixed and create a strictly worse state. The retry path explicitly skips rollback even on exhausted retry — only parents are still locked, which is recoverable manually.

If rollback itself fails, the function returns a wrapped error tagged `MANUAL INTERVENTION REQUIRED` containing both the original failure and the rollback failure.

## Test plan
- [x] Happy path still passes (no behaviour change on success).
- [x] Step-3 failure with successful rollback: parents unlocked, losing txs unmarked, original-state restored.
- [x] Step-3 failure with rollback also failing: returned error mentions both, contains "MANUAL INTERVENTION REQUIRED".
- [x] Step-5 transient failure: retries succeed on 3rd attempt, overall success.
- [x] Step-5 persistent failure: 3 attempts exhausted, error surfaced WITHOUT rollback (avoids re-introducing inconsistency).
- [x] Pre-existing `TestProcessConflicting_UnspendError` and `TestProcessConflicting_SpendError` updated to expect the new rollback calls.
- [x] `go test -race ./stores/utxo/...` and `-tags aerospike` variants pass.