### PR TITLE
fix(legacy/netsync): bounds-check parent output index in ExtendTransaction

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1250,6 +1250,14 @@ func (sm *SyncManager) ExtendTransaction(ctx context.Context, tx *bt.Tx, txMap *
 			g.Go(func() error {
 				txWrapper.SomeParentsInBlock = true
 
+				// Parent Outputs are populated at wire-parse time and never mutated afterwards,
+				// so the bounds check is safe to run before WaitForParent and lets us reject
+				// malformed peer blocks without burning up to 120s on the polling loop.
+				if input.PreviousTxOutIndex >= uint32(len(prevTxWrapper.Tx.Outputs)) {
+					return errors.NewTxInvalidError("tx %s input %d references out-of-range output %d on parent %s (has %d outputs)",
+						tx.TxIDChainHash(), i, input.PreviousTxOutIndex, prevTxHash, len(prevTxWrapper.Tx.Outputs))
+				}
+
 				// we do have a parent, but since everything is happening in parallel, we need to check if the parent has
 				// already been extended
 				timeOut := time.After(120 * time.Second)
@@ -1266,11 +1274,6 @@ func (sm *SyncManager) ExtendTransaction(ctx context.Context, tx *bt.Tx, txMap *
 
 						time.Sleep(10 * time.Millisecond) // wait for the parent transaction to be extended
 					}
-				}
-
-				if input.PreviousTxOutIndex >= uint32(len(prevTxWrapper.Tx.Outputs)) {
-					return errors.NewTxInvalidError("tx %s input %d references out-of-range output %d on parent %s (has %d outputs)",
-						tx.TxIDChainHash(), i, input.PreviousTxOutIndex, prevTxHash, len(prevTxWrapper.Tx.Outputs))
 				}
 
 				// No lock needed - each goroutine writes to a unique index

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1009,7 +1009,7 @@ func (sm *SyncManager) extendFromTxMap(ctx context.Context, tx *bt.Tx, txMap *tx
 		txWrapper.SomeParentsInBlock = true
 
 		if input.PreviousTxOutIndex >= uint32(len(prevTxWrapper.Tx.Outputs)) {
-			return errors.NewProcessingError("tx %s input %d references invalid output index %d (parent %s has %d outputs)",
+			return errors.NewTxInvalidError("tx %s input %d references out-of-range output %d on parent %s (has %d outputs)",
 				tx.TxIDChainHash(), i, input.PreviousTxOutIndex, prevTxHash, len(prevTxWrapper.Tx.Outputs))
 		}
 

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1268,6 +1268,11 @@ func (sm *SyncManager) ExtendTransaction(ctx context.Context, tx *bt.Tx, txMap *
 					}
 				}
 
+				if input.PreviousTxOutIndex >= uint32(len(prevTxWrapper.Tx.Outputs)) {
+					return errors.NewTxInvalidError("tx %s input %d references out-of-range output %d on parent %s (has %d outputs)",
+						tx.TxIDChainHash(), i, input.PreviousTxOutIndex, prevTxHash, len(prevTxWrapper.Tx.Outputs))
+				}
+
 				// No lock needed - each goroutine writes to a unique index
 				tx.Inputs[i].PreviousTxSatoshis = prevTxWrapper.Tx.Outputs[input.PreviousTxOutIndex].Satoshis
 				tx.Inputs[i].PreviousTxScript = bscript.NewFromBytes(*prevTxWrapper.Tx.Outputs[input.PreviousTxOutIndex].LockingScript)

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -510,17 +510,11 @@ func TestSyncManager_ExtendTransaction(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestSyncManager_ExtendTransaction_OOB verifies that ExtendTransaction returns
-// a TxInvalidError (rather than panicking) when a child input references a
-// parent output index that exceeds the parent's number of outputs. Regression
-// test for issue #4564.
-func TestSyncManager_ExtendTransaction_OOB(t *testing.T) {
-	initPrometheusMetrics()
-
-	sm := &SyncManager{
-		settings: test.CreateBaseTestSettings(t),
-		logger:   ulogger.TestLogger{},
-	}
+// buildOOBFixture constructs a parent (2 outputs) and a child whose only input
+// references PreviousTxOutIndex == 5, plus a txMap containing both. Shared by
+// the ExtendTransaction and extendFromTxMap regression tests for issue #4564.
+func buildOOBFixture(t *testing.T) (*chainhash.Hash, *bt.Tx, *txmap.SyncedMap[chainhash.Hash, *TxMapWrapper]) {
+	t.Helper()
 
 	parentScript := &bscript.Script{}
 	parent := &bt.Tx{
@@ -552,12 +546,45 @@ func TestSyncManager_ExtendTransaction_OOB(t *testing.T) {
 	txMap.Set(*parentHash, &TxMapWrapper{Tx: parent})
 	txMap.Set(*child.TxIDChainHash(), &TxMapWrapper{Tx: child})
 
+	return parentHash, child, txMap
+}
+
+// TestSyncManager_ExtendTransaction_OOB verifies that ExtendTransaction returns
+// a TxInvalidError (rather than panicking) when a child input references a
+// parent output index that exceeds the parent's number of outputs. Regression
+// test for issue #4564.
+func TestSyncManager_ExtendTransaction_OOB(t *testing.T) {
+	initPrometheusMetrics()
+
+	sm := &SyncManager{
+		settings: test.CreateBaseTestSettings(t),
+		logger:   ulogger.TestLogger{},
+	}
+
+	parentHash, child, txMap := buildOOBFixture(t)
+
 	err := sm.ExtendTransaction(context.Background(), child, txMap)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.ErrTxInvalid), "expected TxInvalid error, got %v", err)
-	require.Contains(t, err.Error(), "out-of-range output 5")
 	require.Contains(t, err.Error(), parentHash.String())
-	require.Contains(t, err.Error(), "has 2 outputs")
+}
+
+// TestSyncManager_extendFromTxMap_OOB verifies the same OOB guard on the
+// same-block phase-1 path. Regression test for issue #4564.
+func TestSyncManager_extendFromTxMap_OOB(t *testing.T) {
+	initPrometheusMetrics()
+
+	sm := &SyncManager{
+		settings: test.CreateBaseTestSettings(t),
+		logger:   ulogger.TestLogger{},
+	}
+
+	parentHash, child, txMap := buildOOBFixture(t)
+
+	err := sm.extendFromTxMap(context.Background(), child, txMap)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxInvalid), "expected TxInvalid error, got %v", err)
+	require.Contains(t, err.Error(), parentHash.String())
 }
 
 // countingValidator tracks how many times Validate is called and optionally fails

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -510,6 +510,56 @@ func TestSyncManager_ExtendTransaction(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestSyncManager_ExtendTransaction_OOB verifies that ExtendTransaction returns
+// a TxInvalidError (rather than panicking) when a child input references a
+// parent output index that exceeds the parent's number of outputs. Regression
+// test for issue #4564.
+func TestSyncManager_ExtendTransaction_OOB(t *testing.T) {
+	initPrometheusMetrics()
+
+	sm := &SyncManager{
+		settings: test.CreateBaseTestSettings(t),
+		logger:   ulogger.TestLogger{},
+	}
+
+	parentScript := &bscript.Script{}
+	parent := &bt.Tx{
+		Version: 1,
+		Inputs:  []*bt.Input{},
+		Outputs: []*bt.Output{
+			{Satoshis: 100, LockingScript: parentScript},
+			{Satoshis: 200, LockingScript: parentScript},
+		},
+	}
+	parent.SetExtended(true)
+	parentHash := parent.TxIDChainHash()
+
+	child := &bt.Tx{
+		Version: 1,
+		Inputs: []*bt.Input{
+			{
+				UnlockingScript:    &bscript.Script{},
+				PreviousTxOutIndex: 5,
+			},
+		},
+		Outputs: []*bt.Output{
+			{Satoshis: 50, LockingScript: &bscript.Script{}},
+		},
+	}
+	require.NoError(t, child.Inputs[0].PreviousTxIDAdd(parentHash))
+
+	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](2)
+	txMap.Set(*parentHash, &TxMapWrapper{Tx: parent})
+	txMap.Set(*child.TxIDChainHash(), &TxMapWrapper{Tx: child})
+
+	err := sm.ExtendTransaction(context.Background(), child, txMap)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxInvalid), "expected TxInvalid error, got %v", err)
+	require.Contains(t, err.Error(), "out-of-range output 5")
+	require.Contains(t, err.Error(), parentHash.String())
+	require.Contains(t, err.Error(), "has 2 outputs")
+}
+
 // countingValidator tracks how many times Validate is called and optionally fails
 // the first N calls. It checks context cancellation to detect cascade behavior.
 type countingValidator struct {


### PR DESCRIPTION
Closes #4564.

## Summary
`ExtendTransaction` dereferences `prevTxWrapper.Tx.Outputs[input.PreviousTxOutIndex]` without a bounds check. A peer can send a block where a child tx references its in-block parent with `PreviousTxOutIndex >= len(parent.Outputs)`, panicking the node before full block validation runs. The phase-1 path (`extendFromTxMap`, around line 1011) already had this guard; the parallel path in `ExtendTransaction` (lines ~1272-1273) was missed.

## Fix
Insert the same shape of bounds check that exists in `extendFromTxMap`, immediately before the dereference. On out-of-range, return `errors.NewTxInvalidError(...)` with the full context (offending tx, input index, parent, output count). The block came from a peer; the transaction is invalid, so `TxInvalidError` is more semantically correct than `ProcessingError`.

## Test plan
- [x] Regression test `TestSyncManager_ExtendTransaction_OOB` constructs a parent with 2 outputs and a child whose input has `PreviousTxOutIndex == 5`; pre-fix panics with `index out of range [5] with length 2`; post-fix returns `TxInvalidError` with the expected message.
- [x] `go test -race ./services/legacy/netsync/...` passes.
