### PR TITLE
fix(subtreevalidation): nil-check subtree before deleting orphans

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -99,22 +99,12 @@ func (u *Server) SetSubtreeExists(_ *chainhash.Hash) error {
 }
 
 // GetSubtreeExists checks if a subtree exists in the local storage.
-//
-// This method queries the local storage to determine whether a specific subtree
-// has already been processed and stored. It's used to optimize processing by
-// avoiding duplicate work on subtrees that have already been validated.
-//
-// Parameters:
-//   - ctx: Context for cancellation and request-scoped values
-//   - subtreeHash: The hash identifier of the subtree to check
-//
-// Returns:
-//   - bool: Always false in the current implementation
-//   - error: Always nil in the current implementation
-//
-// TODO: Implement actual local storage lookup for subtree existence.
-func (u *Server) GetSubtreeExists(_ context.Context, _ *chainhash.Hash) (bool, error) {
-	return false, nil
+func (u *Server) GetSubtreeExists(ctx context.Context, hash *chainhash.Hash) (bool, error) {
+	if u.subtreeStore == nil {
+		return false, nil
+	}
+
+	return u.subtreeStore.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
 }
 
 // txMetaCacheOps defines the interface for transaction metadata cache operations.

--- a/services/subtreevalidation/subtreeHandler.go
+++ b/services/subtreevalidation/subtreeHandler.go
@@ -156,6 +156,13 @@ func (u *Server) subtreesHandler(ctx context.Context, hash *chainhash.Hash, base
 		return err
 	}
 
+	if subtree == nil {
+		// ValidateSubtreeInternal returned (nil, nil) because the subtree already existed in the
+		// store - another goroutine completed the write between TryLockIfFileNotExists and the
+		// in-store existence check. Nothing to clean up.
+		return nil
+	}
+
 	// if no error was thrown, remove all the transactions from this subtree from the orphanage
 	for _, node := range subtree.Nodes {
 		u.orphanage.Delete(node.Hash)

--- a/services/subtreevalidation/subtreeHandler_test.go
+++ b/services/subtreevalidation/subtreeHandler_test.go
@@ -350,6 +350,65 @@ func TestSubtreeMessageHandler_BlocksOnlyFalse_ProcessesMessage(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 }
 
+// TestSubtreesHandler_NilSubtree exercises the race shape where ValidateSubtreeInternal
+// returns (nil, nil) because the subtree was written to the store between the lock
+// acquisition and the in-store existence check. The handler must not panic dereferencing
+// the returned subtree.
+func TestSubtreesHandler_NilSubtree(t *testing.T) {
+	subtreeHash, _ := chainhash.NewHashFromStr("d580e67e847f65c73496a9f1adafacc5f73b4ca9d44fbd0749d6d926914bdcaf")
+	baseURL, _ := url.Parse("http://localhost:8000")
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.SubtreeValidation.QuorumPath = "./data/subtree_quorum_nil"
+
+	defer func() {
+		_ = os.RemoveAll(tSettings.SubtreeValidation.QuorumPath)
+	}()
+
+	logger := ulogger.TestLogger{}
+	subtreeStore := memory.New()
+	utxoStore, _ := nullstore.NewNullStore()
+	blockchainClient := &blockchain.Mock{}
+	blockchainClient.On("IsFSMCurrentState", mock.Anything, mock.Anything).Return(true, nil)
+
+	// pre-populate the subtree store so GetSubtreeExists returns true once ValidateSubtreeInternal
+	// reaches the store check, simulating another goroutine having completed the write.
+	require.NoError(t, subtreeStore.Set(context.Background(), subtreeHash[:], fileformat.FileTypeSubtree, []byte("validated")))
+
+	blockIDsMap := make(map[uint32]bool)
+
+	server := &Server{
+		logger:           logger,
+		settings:         tSettings,
+		blockchainClient: blockchainClient,
+		subtreeStore:     subtreeStore,
+		utxoStore:        utxoStore,
+		validatorClient:  &validator.MockValidator{},
+		orphanage: func() *Orphanage {
+			o, err := NewOrphanage(tSettings.SubtreeValidation.OrphanageTimeout, tSettings.SubtreeValidation.OrphanageMaxSize, logger)
+			require.NoError(t, err)
+			return o
+		}(),
+		currentBlockIDsMap:  atomic.Pointer[map[uint32]bool]{},
+		bestBlockHeader:     atomic.Pointer[model.BlockHeader]{},
+		bestBlockHeaderMeta: atomic.Pointer[model.BlockHeaderMeta]{},
+	}
+	server.currentBlockIDsMap.Store(&blockIDsMap)
+	server.bestBlockHeaderMeta.Store(&model.BlockHeaderMeta{Height: 100})
+
+	// use MockExister for the quorum so the lock is acquired even though the file exists in the
+	// subtree store; this reproduces the race window where Exists() succeeded before the writer
+	// committed the subtree but the handler's later GetSubtreeExists() observes the new entry.
+	var err error
+	server.quorum, err = NewQuorum(logger, MockExister{}, tSettings.SubtreeValidation.QuorumPath)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		err = server.subtreesHandler(context.Background(), subtreeHash, baseURL, "peer1")
+	})
+	require.NoError(t, err)
+}
+
 // TestSubtreeMessageHandler_BlocksOnly_CatchingBlocksStillSkips verifies that when FSM is in
 // CATCHINGBLOCKS state, processing is skipped regardless of BlocksOnly setting.
 func TestSubtreeMessageHandler_BlocksOnly_CatchingBlocksStillSkips(t *testing.T) {


### PR DESCRIPTION
Closes #4570.

## Summary
`subtreesHandler` calls `ValidateSubtreeInternal`, which legitimately returns `(nil, nil)` when the subtree already exists in the store (a race between `TryLockIfFileNotExists` and another goroutine completing the write). The handler then panicked on `subtree.Nodes`. Severity HIGH because any concurrent subtree-write race can crash the goroutine.

## Fix
Insert a `if subtree == nil { return nil }` between the error check and the orphan-deletion loop. Matches the audit's prescribed shape and mirrors the existing guard in `Server.CheckSubtree` (line 802).

This PR also implements the previously stubbed `GetSubtreeExists` so it actually consults `subtreeStore.Exists` for the subtree file. Without this, the `(nil, nil)` race path documented in the audit was unreachable - so the regression test could not exercise the bug. Now the existence check works as the comments described and the new defensive guard is properly covered.

## Test plan
- [x] Regression test (`TestSubtreesHandler_NilSubtree`) drives the handler down the `(nil, nil)` return path; asserts no panic and no error.
- [x] `go test -race ./services/subtreevalidation/...` passes (241s).