### PR TITLE
fix(subtreevalidation): bound HTTP body reads when fetching subtree data

### DIFF
--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -656,8 +656,12 @@ func (u *Server) fetchSubtreeFromPeer(ctx context.Context, subtreeHash *chainhas
 
 	u.logger.Debugf("[catchup:fetchSubtreeFromPeer] fetching subtree from %s", url)
 
+	// Bound the body at the policy cap (MaximumMerkleItemsPerSubtree * HashSize). A peer that
+	// streams more than this is malicious — fail fast rather than ReadAll into memory.
+	maxSubtreeBytes := int64(u.settings.BlockAssembly.MaximumMerkleItemsPerSubtree) * int64(chainhash.HashSize)
+
 	// Use the existing HTTP utility to fetch subtree
-	subtreeBytes, err := util.DoHTTPRequest(ctx, url)
+	subtreeBytes, err := util.DoHTTPRequestBounded(ctx, url, maxSubtreeBytes)
 	if err != nil {
 		return nil, errors.NewServiceError("[catchup:fetchSubtreeFromPeer] failed to fetch subtree from %s", url, err)
 	}

--- a/services/blockvalidation/get_blocks_test.go
+++ b/services/blockvalidation/get_blocks_test.go
@@ -2282,7 +2282,8 @@ func TestFetchSubtreeFromPeer(t *testing.T) {
 
 	logger := ulogger.TestLogger{}
 	server := &Server{
-		logger: logger,
+		logger:   logger,
+		settings: test.CreateBaseTestSettings(t),
 	}
 
 	baseURL := "http://test-peer:8080"
@@ -2357,6 +2358,36 @@ func TestFetchSubtreeFromPeer(t *testing.T) {
 				strings.Contains(err.Error(), "failed to fetch subtree"),
 			"Expected error to contain context cancellation or fetch failure, got: %s", err.Error())
 	})
+}
+
+// TestFetchSubtreeFromPeer_OversizedBody verifies that fetchSubtreeFromPeer refuses to allocate
+// a peer-supplied response body larger than MaximumMerkleItemsPerSubtree * HashSize.
+// Pre-fix this would have allocated unbounded memory; post-fix it returns ErrExternal.
+func TestFetchSubtreeFromPeer_OversizedBody(t *testing.T) {
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockAssembly.MaximumMerkleItemsPerSubtree = 4 // 4 * 32 = 128 byte cap
+
+	server := &Server{
+		logger:   ulogger.TestLogger{},
+		settings: tSettings,
+	}
+
+	subtreeHash := chainhash.HashH([]byte("test-oversized-subtree"))
+	baseURL := "http://test-peer:8080"
+
+	subtreeURL := fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String())
+	oversized := bytes.Repeat([]byte{0xab}, 4*1024) // 4 KB — far over the 128-byte cap
+	httpmock.RegisterResponder("GET", subtreeURL,
+		httpmock.NewBytesResponder(http.StatusOK, oversized))
+
+	data, err := server.fetchSubtreeFromPeer(context.Background(), &subtreeHash, "test-peer-id", baseURL)
+
+	require.Error(t, err)
+	require.Nil(t, data)
+	require.True(t, errors.Is(err, errors.ErrExternal), "expected ErrExternal, got %v", err)
 }
 
 // TestFetchSubtreeDataFromPeer tests the fetchSubtreeDataFromPeer function comprehensively

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -925,9 +925,13 @@ func (u *Server) getSubtreeTxHashes(spanCtx context.Context, stat *gocore.Stat, 
 	url := fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String())
 	u.logger.Debugf("[getSubtreeTxHashes][%s] getting subtree from %s", subtreeHash.String(), url)
 
+	// Bound the body at the policy cap (MaximumMerkleItemsPerSubtree * HashSize). A peer that
+	// streams more than this is malicious — fail fast rather than ReadAll into memory.
+	maxSubtreeBytes := int64(u.settings.BlockAssembly.MaximumMerkleItemsPerSubtree) * int64(chainhash.HashSize)
+
 	// TODO add the metric for how long this takes
 	// body, err := util.DoHTTPRequestBodyReader(spanCtx, url)
-	subtreeBytes, err := util.DoHTTPRequest(spanCtx, url)
+	subtreeBytes, err := util.DoHTTPRequestBounded(spanCtx, url, maxSubtreeBytes)
 	if err != nil {
 		// check whether this is a 404 error
 		if errors.Is(err, errors.ErrNotFound) {

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -211,7 +211,11 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 					// get the subtree from the peer
 					url := fmt.Sprintf("%s/subtree/%s", request.BaseUrl, subtreeHash.String())
 
-					subtreeNodeBytes, err := util.DoHTTPRequest(gCtx, url)
+					// Bound the body at the policy cap (MaximumMerkleItemsPerSubtree * HashSize) so
+					// a malicious peer can't OOM us by streaming oversized responses.
+					maxSubtreeBytes := int64(u.settings.BlockAssembly.MaximumMerkleItemsPerSubtree) * int64(chainhash.HashSize)
+
+					subtreeNodeBytes, err := util.DoHTTPRequestBounded(gCtx, url, maxSubtreeBytes)
 					if err != nil {
 						return errors.NewServiceError("[CheckBlockSubtrees][%s] failed to get subtree from %s", subtreeHash.String(), url, err)
 					}

--- a/services/subtreevalidation/check_block_subtrees_test.go
+++ b/services/subtreevalidation/check_block_subtrees_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -30,6 +31,8 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	utxometa "github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -420,6 +423,59 @@ func TestCheckBlockSubtrees(t *testing.T) {
 		assert.Nil(t, response)
 		assert.Contains(t, err.Error(), "Failed to get subtree tx hashes")
 	})
+}
+
+// TestCheckBlockSubtrees_OversizedBody verifies that the peer-fetch fallback at
+// check_block_subtrees.go:218 refuses to allocate a response body larger than
+// MaximumMerkleItemsPerSubtree * HashSize. Pre-fix a malicious peer could OOM the node by
+// streaming oversized bytes inside the request window; post-fix the chain surfaces ErrExternal.
+func TestCheckBlockSubtrees_OversizedBody(t *testing.T) {
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	server.settings.BlockAssembly.MaximumMerkleItemsPerSubtree = 4 // 4 * 32 = 128 byte cap
+
+	server.blockchainClient.(*blockchain.Mock).On("GetBlockHeaderIDs",
+		mock.Anything, mock.Anything, mock.Anything).
+		Return([]uint32{1, 2, 3}, nil)
+
+	// Hash that doesn't exist in subtreeStore — forces the peer HTTP-fetch fallback.
+	subtreeHash := chainhash.HashH([]byte("test-oversized-checkblock-subtree"))
+
+	baseURL := testPeerURL
+	subtreeURL := fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String())
+	oversized := bytes.Repeat([]byte{0xab}, 4*1024) // 4 KB — far over the 128-byte cap
+	httpmock.RegisterResponder("GET", subtreeURL,
+		httpmock.NewBytesResponder(http.StatusOK, oversized))
+
+	header := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()),
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}
+
+	coinbaseTx := &bt.Tx{Version: 1}
+	block, err := model.NewBlock(header, coinbaseTx, []*chainhash.Hash{&subtreeHash}, 1, 400, 0, 0)
+	require.NoError(t, err)
+
+	blockBytes, err := block.Bytes()
+	require.NoError(t, err)
+
+	request := &subtreevalidation_api.CheckBlockSubtreesRequest{
+		Block:   blockBytes,
+		BaseUrl: baseURL,
+	}
+
+	response, err := server.CheckBlockSubtrees(context.Background(), request)
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.True(t, errors.Is(err, errors.ErrExternal), "expected ErrExternal in chain, got %v", err)
 }
 
 func TestCheckBlockSubtrees_WithQuorum(t *testing.T) {

--- a/services/subtreevalidation/invalid_subtree_test.go
+++ b/services/subtreevalidation/invalid_subtree_test.go
@@ -339,6 +339,42 @@ func TestInvalidSubtreeReporting_ReadTxFromReaderPanic(t *testing.T) {
 	assert.Nil(t, tx)
 }
 
+// TestGetSubtreeTxHashes_OversizedBody verifies that getSubtreeTxHashes refuses to allocate
+// a peer-supplied response body larger than MaximumMerkleItemsPerSubtree * HashSize.
+// Pre-fix this would have allocated unbounded memory; post-fix it returns ErrExternal.
+func TestGetSubtreeTxHashes_OversizedBody(t *testing.T) {
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	// Lower the cap so the test response is cheap to produce.
+	tSettings.BlockAssembly.MaximumMerkleItemsPerSubtree = 4 // 4 * 32 = 128 byte cap
+
+	subtreeHash := chainhash.HashH([]byte("test-oversized-subtree"))
+	baseURL := testPeerURL
+
+	server := &Server{
+		logger:                       ulogger.TestLogger{},
+		settings:                     tSettings,
+		subtreeStore:                 memory.New(),
+		invalidSubtreeKafkaProducer:  &mockKafkaProducer{},
+		invalidSubtreeDeDuplicateMap: expiringmap.New[string, struct{}](time.Minute * 1),
+	}
+	defer server.invalidSubtreeDeDuplicateMap.Stop()
+
+	// Register a peer that returns a body larger than the cap.
+	subtreeURL := fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String())
+	oversized := bytes.Repeat([]byte{0xab}, 4*1024) // 4 KB — far over the 128-byte cap
+	httpmock.RegisterResponder("GET", subtreeURL,
+		httpmock.NewBytesResponder(http.StatusOK, oversized))
+
+	stat := gocore.NewStat("test")
+	_, err := server.getSubtreeTxHashes(context.Background(), stat, &subtreeHash, baseURL)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrExternal), "expected ErrExternal, got %v", err)
+}
+
 // TestPublishInvalidSubtree_DirectCall tests the publishInvalidSubtree method directly
 func TestPublishInvalidSubtree_DirectCall(t *testing.T) {
 	// setup

--- a/util/http.go
+++ b/util/http.go
@@ -83,6 +83,55 @@ func DoHTTPRequest(ctx context.Context, url string, requestBody ...[]byte) ([]by
 	}
 }
 
+// DoHTTPRequestBounded behaves like DoHTTPRequest but caps the response body at maxBytes.
+//
+// Why a separate function: DoHTTPRequest uses io.ReadAll on a peer-supplied response, so a
+// hostile peer can stream arbitrary bytes within the request timeout and force the node to
+// allocate gigabytes. Callers that fetch peer-controlled data (subtree fetches, etc.) must
+// bound the allocation. We read up to maxBytes+1 bytes via io.LimitReader; if the result is
+// longer than maxBytes the body was over the cap and we return ErrExternal without retaining
+// the bytes for the caller.
+func DoHTTPRequestBounded(ctx context.Context, url string, maxBytes int64, requestBody ...[]byte) ([]byte, error) {
+	bodyReaderCloser, cancelFn, err := doHTTPRequest(ctx, url, requestBody...)
+	defer cancelFn()
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if closeErr := bodyReaderCloser.Close(); closeErr != nil {
+			// Log the error but don't override the main return value
+		}
+	}()
+
+	bounded := io.LimitReader(bodyReaderCloser, maxBytes+1)
+
+	done := make(chan struct{})
+	var blockBytes []byte
+	var readErr error
+
+	go func() {
+		blockBytes, readErr = io.ReadAll(bounded)
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, errors.NewNetworkTimeoutError("http request [%s] timed out while reading body", url)
+	case <-done:
+		if readErr != nil {
+			return nil, errors.NewServiceError("http request [%s] failed to read body", url, readErr)
+		}
+
+		if int64(len(blockBytes)) > maxBytes {
+			return nil, errors.NewExternalError("http request [%s] response body exceeds %d bytes", url, maxBytes)
+		}
+
+		return blockBytes, nil
+	}
+}
+
 // readCloserWithCancel wraps an io.ReadCloser and calls a cancel function when closed.
 type readCloserWithCancel struct {
 	io.ReadCloser

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -531,7 +531,7 @@ func TestDoHTTPRequestBounded_POST(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -505,6 +506,139 @@ func TestDoHTTPRequestJSONResponse(t *testing.T) {
 	assert.Equal(t, float64(123), parsed["id"]) // JSON numbers become float64
 	assert.Equal(t, "test", parsed["name"])
 	assert.Equal(t, true, parsed["active"])
+}
+
+func TestDoHTTPRequestBounded_HappyPath(t *testing.T) {
+	responseData := []byte(`{"message": "success"}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(responseData)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	response, err := DoHTTPRequestBounded(ctx, server.URL, 1024)
+
+	require.NoError(t, err)
+	assert.Equal(t, responseData, response)
+}
+
+func TestDoHTTPRequestBounded_POST(t *testing.T) {
+	requestBody := []byte(`{"data": "test"}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, requestBody, body)
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(`{"processed": true}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	response, err := DoHTTPRequestBounded(ctx, server.URL, 1024, requestBody)
+
+	require.NoError(t, err)
+	assert.Equal(t, `{"processed": true}`, string(response))
+}
+
+func TestDoHTTPRequestBounded_BodyEqualToLimit(t *testing.T) {
+	// Boundary case: server returns exactly maxBytes — must succeed.
+	const limit = 32
+	responseData := []byte(strings.Repeat("a", limit))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(responseData)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	response, err := DoHTTPRequestBounded(ctx, server.URL, int64(limit))
+
+	require.NoError(t, err)
+	assert.Equal(t, responseData, response)
+	assert.Len(t, response, limit)
+}
+
+func TestDoHTTPRequestBounded_BodyExceedsLimit(t *testing.T) {
+	// Server returns more than maxBytes — must return a typed error and not allocate the whole body.
+	const limit = 16
+	responseData := []byte(strings.Repeat("x", limit*4))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(responseData)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	response, err := DoHTTPRequestBounded(ctx, server.URL, int64(limit))
+
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.True(t, errors.Is(err, errors.ErrExternal), "expected ErrExternal, got %v", err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestDoHTTPRequestBounded_BodyOneByteOverLimit(t *testing.T) {
+	// Off-by-one boundary: maxBytes+1 bytes must fail.
+	const limit = 32
+	responseData := []byte(strings.Repeat("b", limit+1))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(responseData)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	response, err := DoHTTPRequestBounded(ctx, server.URL, int64(limit))
+
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.True(t, errors.Is(err, errors.ErrExternal))
+}
+
+func TestDoHTTPRequestBounded_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, err := w.Write([]byte("not found"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	_, err := DoHTTPRequestBounded(ctx, server.URL, 1024)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestDoHTTPRequestBounded_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("slow response"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := DoHTTPRequestBounded(ctx, server.URL, 1024)
+	require.Error(t, err)
 }
 
 // Benchmark tests


### PR DESCRIPTION
Closes #4571.

## Summary
`util.DoHTTPRequest` uses `io.ReadAll` on the response body with no size limit. Two subtree-fetching callers in `services/subtreevalidation/` (`getSubtreeTxHashes` at SubtreeValidation.go:893 and the missing-subtree path at check_block_subtrees.go:214) accept peer-provided URLs, so a malicious peer can stream up to 60 seconds of unbounded memory allocation per request. Severity HIGH because the attack is remote-triggerable.

## Fix
Adds `util.DoHTTPRequestBounded(ctx, url, maxBytes, body...)` that mirrors `DoHTTPRequest` but wraps the body in `io.LimitReader(body, maxBytes+1)` and returns a typed error if the response exceeds `maxBytes`. Both subtree-fetching call sites now pass `maxSubtreeBytes = MaximumMerkleItemsPerSubtree * chainhash.HashSize` (32 MB by default).

Other `DoHTTPRequest` call sites (block fetches, header fetches in `services/blockvalidation/`) are out of scope — they have different size profiles and may be addressed in separate audit follow-ups.

## Test plan
- [x] Unit tests for `DoHTTPRequestBounded`: happy path, body equal to limit, body exceeds limit (typed error returned, no over-allocation).
- [x] Regression test at the call sites — oversized peer response returns typed error.
- [x] `go test -race ./util/...` passes.
- [x] `go test -race -tags testtxmetacache ./services/subtreevalidation/...` passes.