### PR TITLE
fix(model): reject malformed nBits in CalculateTarget

### DIFF
--- a/model/NBit.go
+++ b/model/NBit.go
@@ -54,14 +54,36 @@ func (b NBit) CloneBytes() []byte {
 	return b[:]
 }
 
-// CalculateTarget from nBits returns the target as a big.Int
+// CalculateTarget from nBits returns the target as a big.Int.
+// Returns big.NewInt(0) for malformed nBits (negative-encoded or overflowing
+// 256 bits), matching Bitcoin Core's arith_uint256::SetCompact rejection
+// criteria. A zero target makes any positive hash fail the PoW comparison
+// and contributes zero chainwork — the safe semantic for a malformed value.
 func (b NBit) CalculateTarget() *big.Int {
 	nb := binary.LittleEndian.Uint32(b[:])
 
 	exponent := nb >> 24
 	mantissa := nb & 0x007FFFFF
 
-	// Invalid nBits
+	// Reject malformed encodings. Bitcoin Core requires a non-zero mantissa
+	// for both negative and overflow flags — a zero mantissa just encodes
+	// the value zero, regardless of sign bit or exponent.
+	if mantissa != 0 {
+		// Negative-encoded: sign bit set in mantissa byte.
+		if nb&0x00800000 != 0 {
+			return big.NewInt(0)
+		}
+		// Overflow: target would exceed 2^256.
+		//   exponent > 34         → any non-zero mantissa overflows
+		//   mantissa > 0xff   + exponent > 33 → 9+ bits shifted by 240+
+		//   mantissa > 0xffff + exponent > 32 → 17+ bits shifted by 232+
+		if exponent > 34 ||
+			(mantissa > 0xff && exponent > 33) ||
+			(mantissa > 0xffff && exponent > 32) {
+			return big.NewInt(0)
+		}
+	}
+
 	if exponent <= 3 {
 		mantissa >>= 8 * (3 - exponent)
 		return big.NewInt(int64(mantissa))

--- a/model/NBit_test.go
+++ b/model/NBit_test.go
@@ -48,6 +48,99 @@ func TestCalculateTarget(t *testing.T) {
 	require.Equal(t, "380009881215830907712605183958726704270100120947772096512", target.String())
 }
 
+func TestCalculateTarget_NegativeNBitsRejected(t *testing.T) {
+	t.Run("sign bit set returns zero target", func(t *testing.T) {
+		// nBits 0x1d800001 has the mantissa sign bit (0x00800000) set.
+		// Pre-fix this returned a small positive target (mantissa masked, then shifted).
+		// Post-fix this is rejected with a zero target so PoW comparison can never succeed.
+		bits, err := NewNBitFromString("1d800001")
+		require.NoError(t, err)
+
+		target := bits.CalculateTarget()
+		require.Equal(t, 0, target.Sign(), "negative-encoded nBits must yield zero target")
+		require.Equal(t, 0, target.Cmp(big.NewInt(0)))
+	})
+
+	t.Run("sign bit set with non-trivial mantissa returns zero target", func(t *testing.T) {
+		// 0x1d8fffff — sign bit set, large mantissa, would be a tempting "easy" target if masked.
+		bits, err := NewNBitFromString("1d8fffff")
+		require.NoError(t, err)
+
+		target := bits.CalculateTarget()
+		require.Equal(t, 0, target.Sign())
+	})
+
+	t.Run("sign bit set with zero mantissa is just zero, not negative", func(t *testing.T) {
+		// 0x1d800000 — sign bit set but mantissa is zero. Bitcoin Core treats
+		// this as the value zero (fNegative requires nWord != 0). The end-state
+		// is a zero target either way, but we exercise the precondition here.
+		bits, err := NewNBitFromString("1d800000")
+		require.NoError(t, err)
+
+		target := bits.CalculateTarget()
+		require.Equal(t, 0, target.Sign())
+	})
+
+	t.Run("genesis nBits 0x1d00ffff returns expected positive target", func(t *testing.T) {
+		// Bitcoin genesis nBits — sign bit clear, well-trodden happy path.
+		bits, err := NewNBitFromString("1d00ffff")
+		require.NoError(t, err)
+
+		target := bits.CalculateTarget()
+		require.Equal(t, 1, target.Sign())
+		// 0x00ffff << (8 * (0x1d - 3)) = 0xffff0000000000000000000000000000000000000000000000000000
+		expected, ok := new(big.Int).SetString("00000000FFFF0000000000000000000000000000000000000000000000000000", 16)
+		require.True(t, ok)
+		require.Equal(t, 0, target.Cmp(expected))
+	})
+}
+
+func TestCalculateTarget_OverflowRejected(t *testing.T) {
+	// Overflow rules per Bitcoin Core's arith_uint256::SetCompact:
+	//   - exponent > 34            → any non-zero mantissa overflows 2^256
+	//   - mantissa > 0xff   && exp > 33
+	//   - mantissa > 0xffff && exp > 32
+	cases := []struct {
+		name  string
+		nBits string
+	}{
+		{"exponent 35 overflows with smallest mantissa", "23000001"},
+		{"exponent 36 overflows", "24000001"},
+		{"exponent 34 with mantissa 0x000100 overflows", "22000100"},
+		{"exponent 34 with max mantissa overflows", "227fffff"},
+		{"exponent 33 with mantissa 0x010000 overflows", "21010000"},
+		{"exponent 33 with max mantissa overflows", "217fffff"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bits, err := NewNBitFromString(tc.nBits)
+			require.NoError(t, err)
+			require.Equal(t, 0, bits.CalculateTarget().Sign(),
+				"overflowing nBits must yield zero target")
+		})
+	}
+}
+
+func TestCalculateTarget_OverflowBoundary(t *testing.T) {
+	// Values exactly at the 256-bit boundary — must NOT be flagged as overflow.
+	cases := []struct {
+		name  string
+		nBits string
+	}{
+		{"exponent 34 with mantissa 0x0000ff fits (8 + 248 = 256 bits)", "220000ff"},
+		{"exponent 33 with mantissa 0x00ffff fits (16 + 240 = 256 bits)", "2100ffff"},
+		{"exponent 32 with mantissa 0x7fffff fits (23 + 232 = 255 bits)", "207fffff"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bits, err := NewNBitFromString(tc.nBits)
+			require.NoError(t, err)
+			require.Equal(t, 1, bits.CalculateTarget().Sign(),
+				"boundary nBits must yield positive target")
+		})
+	}
+}
+
 func TestBlock911636Difficulty(t *testing.T) {
 	// This test verifies the standard Bitcoin difficulty calculation
 	// Block 911636 has nBits value 0x180f9ff5

--- a/services/blockassembly/mining/mine_test.go
+++ b/services/blockassembly/mining/mine_test.go
@@ -20,7 +20,7 @@ func createTestMiningCandidate() *model.MiningCandidate {
 		PreviousHash:  subtree.CoinbasePlaceholderHash.CloneBytes(),
 		MerkleProof:   [][]byte{subtree.CoinbasePlaceholderHash.CloneBytes()},
 		Time:          uint32(time.Now().Unix()),
-		NBits:         []byte{0x20, 0x7f, 0xff, 0xff}, // Very easy difficulty for testing
+		NBits:         []byte{0xff, 0xff, 0x7f, 0x20}, // Very easy difficulty for testing (nBits 0x207fffff, little-endian)
 		Height:        100,
 		CoinbaseValue: 5000000000, // 50 BTC in satoshis
 	}
@@ -82,7 +82,7 @@ func TestMine_ContextCancellation(t *testing.T) {
 
 	candidate := createTestMiningCandidate()
 	// Set impossible difficulty to ensure mining would never succeed
-	candidate.NBits = []byte{0x1d, 0x00, 0x00, 0x01} // Nearly impossible difficulty
+	candidate.NBits = []byte{0x01, 0x00, 0x00, 0x1d} // Nearly impossible difficulty (nBits 0x1d000001, little-endian)
 	tSettings := createTestSettings()
 
 	solution, err := Mine(ctx, tSettings, candidate, nil)
@@ -101,7 +101,7 @@ func TestMine_ContextCancellationDuringMining(t *testing.T) {
 
 	candidate := createTestMiningCandidate()
 	// Use easy difficulty but cancel immediately after starting
-	candidate.NBits = []byte{0x20, 0x7f, 0xff, 0xff} // Easy difficulty
+	candidate.NBits = []byte{0xff, 0xff, 0x7f, 0x20} // Easy difficulty (nBits 0x207fffff, little-endian)
 	tSettings := createTestSettings()
 
 	// Cancel the context after a very short delay to test the context check in the loop
@@ -169,19 +169,19 @@ func TestMine_DifferentDifficultyLevels(t *testing.T) {
 	}{
 		{
 			name:       "very easy difficulty",
-			nBits:      []byte{0x20, 0x7f, 0xff, 0xff}, // Very easy
+			nBits:      []byte{0xff, 0xff, 0x7f, 0x20}, // Very easy (nBits 0x207fffff, little-endian)
 			shouldFind: true,
 			timeout:    5 * time.Second,
 		},
 		{
 			name:       "easy difficulty",
-			nBits:      []byte{0x1f, 0x7f, 0xff, 0xff}, // Easy
+			nBits:      []byte{0xff, 0xff, 0x7f, 0x1f}, // Easy (nBits 0x1f7fffff, little-endian)
 			shouldFind: true,
 			timeout:    10 * time.Second,
 		},
 		{
 			name:       "moderate difficulty",
-			nBits:      []byte{0x1e, 0x7f, 0xff, 0xff}, // Moderate
+			nBits:      []byte{0xff, 0xff, 0x7f, 0x1e}, // Moderate (nBits 0x1e7fffff, little-endian)
 			shouldFind: true,
 			timeout:    30 * time.Second,
 		},
@@ -289,7 +289,7 @@ func TestMine_WithNilSettings(t *testing.T) {
 func BenchmarkMine_EasyDifficulty(b *testing.B) {
 	ctx := context.Background()
 	candidate := createTestMiningCandidate()
-	candidate.NBits = []byte{0x20, 0x7f, 0xff, 0xff} // Very easy difficulty
+	candidate.NBits = []byte{0xff, 0xff, 0x7f, 0x20} // Very easy difficulty (nBits 0x207fffff, little-endian)
 	tSettings := createTestSettings()
 
 	b.ResetTimer()
@@ -308,7 +308,7 @@ func BenchmarkMine_EasyDifficulty(b *testing.B) {
 func BenchmarkMine_WithAddress(b *testing.B) {
 	ctx := context.Background()
 	candidate := createTestMiningCandidate()
-	candidate.NBits = []byte{0x20, 0x7f, 0xff, 0xff} // Very easy difficulty
+	candidate.NBits = []byte{0xff, 0xff, 0x7f, 0x20} // Very easy difficulty (nBits 0x207fffff, little-endian)
 	tSettings := createTestSettings()
 	address := "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
 


### PR DESCRIPTION
Closes #4583.

## Summary
`NBit.CalculateTarget` had two gaps relative to SVNode's `arith_uint256::SetCompact`:

1. **Negative-encoded nBits** — the mantissa was masked with `& 0x007FFFFF`, silently dropping the sign bit. A malformed `nBits` with the sign bit set yielded a smaller *positive* target (more easily satisfied) instead of being rejected.
2. **Overflow** — large exponents (e.g. `nSize > 34`, or smaller mantissa/exponent combinations) could produce targets exceeding 2^256. The current callers do not bound-check the result, so an overflowing target would make any hash trivially satisfy the PoW comparison.

The audit (#4583) flagged the negative-encoding case as a defense-in-depth gap. The overflow case is the same class of bug — both let a malformed `nBits` slip through as an artificially easy target. Existing callers (`HasMetTargetDifficulty`, `chainwork`) currently handle the *negative* case correctly via the comparison/`Sign` guard, but a future bypass of those guards could allow malformed nBits to slip through. The overflow case is already exploitable today via any caller that doesn't bound the target against `powLimit`.

## Fix
At the top of `CalculateTarget`, reject malformed encodings by returning `big.NewInt(0)`:

- Negative: `mantissa != 0 && nb & 0x00800000 != 0` (matches SVNode's `fNegative` — `nWord != 0` precondition is required so that `0x1d800000` is treated as the value zero, not as negative).
- Overflow: `mantissa != 0 && (exp > 34 || (mantissa > 0xff && exp > 33) || (mantissa > 0xffff && exp > 32))` (matches SVNode's `fOverflow`).

Both existing callers already treat a zero-or-negative target as "block fails PoW / contributes no chainwork", so the system-level behaviour is unchanged — the rejection just happens earlier and explicitly.

## Test plan
- [x] Negative-encoded nBits → zero target (sign bit alone, sign bit + large mantissa).
- [x] Zero-mantissa-with-sign-bit edge case (`0x1d800000`) → zero target, exercising the `mantissa != 0` precondition.
- [x] Overflow rejection: `exp > 34`, `exp == 34 && mantissa > 0xff`, `exp == 33 && mantissa > 0xffff`, plus max-mantissa variants.
- [x] 256-bit boundary that must NOT be flagged: `0x220000ff`, `0x2100ffff`, `0x207fffff`.
- [x] Genesis nBits `0x1d00ffff` → expected positive target (happy-path regression).
- [x] `go test -race ./model/...` passes.
- [x] `go test -race ./services/blockchain/work/... ./services/blockvalidation/catchup/...` passes (downstream consumers).
