### PR TITLE
fix(subtreevalidation): add metrics for dropped malformed Kafka messages

### DIFF
--- a/services/subtreevalidation/metrics.go
+++ b/services/subtreevalidation/metrics.go
@@ -77,6 +77,13 @@ var (
 	// This counter tracks how often errors occur when updating the transaction metadata cache
 	// from Kafka messages, which helps identify issues with the cache or Kafka connection.
 	prometheusSubtreeValidationSetTXMetaCacheKafkaErrors prometheus.Counter
+
+	// prometheusSubtreeKafkaMalformed counts malformed Kafka subtree messages that were dropped,
+	// labelled by the reason for the drop. Returning nil from the consumer for permanently-malformed
+	// messages preserves Kafka offset progression (avoids a poison-pill retry loop), but ops still
+	// need a signal so they can detect malformed-message bursts that would otherwise be invisible.
+	// Reason labels: nil_message, too_short, unmarshal_failure, bad_hash, bad_url.
+	prometheusSubtreeKafkaMalformed *prometheus.CounterVec
 )
 
 var (
@@ -184,5 +191,15 @@ func _initPrometheusMetrics() {
 			Name:      "set_tx_meta_cache_kafka_errors",
 			Help:      "Number of errors setting tx meta cache from kafka",
 		},
+	)
+
+	prometheusSubtreeKafkaMalformed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "subtreevalidation",
+			Name:      "kafka_malformed_messages_total",
+			Help:      "Number of malformed Kafka subtree messages dropped, by reason",
+		},
+		[]string{"reason"},
 	)
 }

--- a/services/subtreevalidation/subtreeHandler.go
+++ b/services/subtreevalidation/subtreeHandler.go
@@ -34,11 +34,13 @@ func (u *Server) subtreeMessageHandler(ctx context.Context) func(msg *kafka.Kafk
 	return func(msg *kafka.KafkaMessage) error {
 		if msg == nil {
 			u.logger.Errorf("[subtreeMessageHandler] received nil message")
+			prometheusSubtreeKafkaMalformed.WithLabelValues("nil_message").Inc()
 			return nil
 		}
 
 		if len(msg.Value) < 32 {
 			u.logger.Errorf("[subtreeMessageHandler] received subtree message of only %d bytes", len(msg.Value))
+			prometheusSubtreeKafkaMalformed.WithLabelValues("too_short").Inc()
 			return nil
 		}
 
@@ -67,18 +69,21 @@ func (u *Server) subtreeMessageHandler(ctx context.Context) func(msg *kafka.Kafk
 		var kafkaMsg kafkamessage.KafkaSubtreeTopicMessage
 		if err := proto.Unmarshal(msg.Value, &kafkaMsg); err != nil {
 			u.logger.Errorf("[subtreeMessageHandler] failed to unmarshal kafka message: %v", err)
+			prometheusSubtreeKafkaMalformed.WithLabelValues("unmarshal_failure").Inc()
 			return nil
 		}
 
 		hash, err := chainhash.NewHashFromStr(kafkaMsg.Hash)
 		if err != nil {
 			u.logger.Errorf("[subtreeMessageHandler] failed to parse block hash from message: %v", err)
+			prometheusSubtreeKafkaMalformed.WithLabelValues("bad_hash").Inc()
 			return nil
 		}
 
 		baseURL, err := url.Parse(kafkaMsg.URL)
 		if err != nil {
 			u.logger.Errorf("[subtreeMessageHandler] failed to parse block base url from message: %v", err)
+			prometheusSubtreeKafkaMalformed.WithLabelValues("bad_url").Inc()
 			return nil
 		}
 

--- a/services/subtreevalidation/subtreeHandler_test.go
+++ b/services/subtreevalidation/subtreeHandler_test.go
@@ -25,6 +25,7 @@ import (
 	kafkamessage "github.com/bsv-blockchain/teranode/util/kafka/kafka_message"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/jarcoal/httpmock"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -391,4 +392,119 @@ func TestSubtreeMessageHandler_BlocksOnly_CatchingBlocksStillSkips(t *testing.T)
 
 	time.Sleep(100 * time.Millisecond)
 	assert.False(t, validateSubtreeCalled.Load(), "ValidateSubtreeInternal should not be called when FSM is CATCHINGBLOCKS")
+}
+
+// newMalformedTestServer builds a minimal Server suitable for exercising the malformed-message
+// drop paths in subtreeMessageHandler. The blockchain client returns RUNNING so we reach the
+// proto/hash/url parsing stages; tests that drop earlier (nil, too-short) never call it.
+func newMalformedTestServer(t *testing.T) *testServer {
+	t.Helper()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.SubtreeValidation.BlocksOnly = false
+
+	blockchainClient := &blockchain.Mock{}
+	runningState := blockchain.FSMStateRUNNING
+	blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&runningState, nil)
+
+	return &testServer{
+		Server: Server{
+			logger:           ulogger.TestLogger{},
+			settings:         tSettings,
+			blockchainClient: blockchainClient,
+		},
+	}
+}
+
+// TestSubtreeMessageHandler_MalformedMetric verifies that each silent-drop path in
+// subtreeMessageHandler increments prometheusSubtreeKafkaMalformed with the correct reason
+// label, while still returning nil (preserving drop semantics — see issue #4585).
+func TestSubtreeMessageHandler_MalformedMetric(t *testing.T) {
+	InitPrometheusMetrics()
+
+	subtreeHash, err := chainhash.NewHashFromStr("d580e67e847f65c73496a9f1adafacc5f73b4ca9d44fbd0749d6d926914bdcaf")
+	require.NoError(t, err)
+
+	validProtoBytes, err := proto.Marshal(&kafkamessage.KafkaSubtreeTopicMessage{
+		Hash:   subtreeHash.String(),
+		URL:    "http://localhost:8000",
+		PeerId: "peer1",
+	})
+	require.NoError(t, err)
+
+	badHashBytes, err := proto.Marshal(&kafkamessage.KafkaSubtreeTopicMessage{
+		Hash:   "not-a-hex-hash",
+		URL:    "http://localhost:8000",
+		PeerId: "peer1",
+	})
+	require.NoError(t, err)
+
+	badURLBytes, err := proto.Marshal(&kafkamessage.KafkaSubtreeTopicMessage{
+		Hash:   subtreeHash.String(),
+		URL:    "http://\x00bad-url",
+		PeerId: "peer1",
+	})
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(validProtoBytes), 32, "valid proto bytes should clear too-short check")
+	require.GreaterOrEqual(t, len(badHashBytes), 32, "bad-hash proto bytes should clear too-short check")
+	require.GreaterOrEqual(t, len(badURLBytes), 32, "bad-url proto bytes should clear too-short check")
+
+	// 32 bytes of 0xFF is well-formed at the byte level (clears the < 32 check)
+	// but does not parse as a KafkaSubtreeTopicMessage.
+	unparseable := make([]byte, 32)
+	for i := range unparseable {
+		unparseable[i] = 0xFF
+	}
+
+	tests := []struct {
+		name   string
+		reason string
+		msg    *kafka.KafkaMessage
+	}{
+		{
+			name:   "nil_message",
+			reason: "nil_message",
+			msg:    nil,
+		},
+		{
+			name:   "too_short",
+			reason: "too_short",
+			msg:    &kafka.KafkaMessage{Value: make([]byte, 31)},
+		},
+		{
+			name:   "unmarshal_failure",
+			reason: "unmarshal_failure",
+			msg:    &kafka.KafkaMessage{Value: unparseable},
+		},
+		{
+			name:   "bad_hash",
+			reason: "bad_hash",
+			msg:    &kafka.KafkaMessage{Value: badHashBytes},
+		},
+		{
+			name:   "bad_url",
+			reason: "bad_url",
+			msg:    &kafka.KafkaMessage{Value: badURLBytes},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newMalformedTestServer(t)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			counter := prometheusSubtreeKafkaMalformed.WithLabelValues(tt.reason)
+			before := testutil.ToFloat64(counter)
+
+			handler := server.subtreeMessageHandler(ctx)
+			handlerErr := handler(tt.msg)
+			require.NoError(t, handlerErr, "malformed messages must drop, not error")
+
+			after := testutil.ToFloat64(counter)
+			require.Equal(t, before+1, after, "counter for reason %q should increment by 1", tt.reason)
+		})
+	}
 }


### PR DESCRIPTION
Closes #4585.

## Summary
The subtree Kafka handler silently dropped malformed messages by returning `nil` — bypassing retry/back-pressure/DLQ semantics AND giving ops zero observability into the drop rate. The audit (#4585) flagged this and suggested either returning errors or adding metrics.

## Decision
Keep drop semantics, add metrics. Returning errors for permanently-malformed messages would put the Kafka consumer into a poison-pill retry loop. A `kafka_malformed_messages_total` counter with a `reason` label gives ops the drop-rate signal without changing consumer-protocol behaviour.

## Fix
- New `prometheusSubtreeKafkaMalformed` counter vec with `reason` label.
- Increment at each of the 5 drop paths: `nil_message`, `too_short`, `unmarshal_failure`, `bad_hash`, `bad_url`.
- All `return nil` and log lines unchanged.

## Test plan
- [x] One subtest per drop reason; assert the corresponding counter increments and the handler returns nil.
- [x] `go test -race ./services/subtreevalidation/...` passes.