### PR TITLE
fix(utxo/aerospike): gate spend-filter-expressions on utxoBatchSize==1

### DIFF
--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -451,6 +451,14 @@ type keyIgnoreLocked struct {
 	ignoreLocked      bool
 }
 
+// useExpressionSpend returns true when the expression-based spend path is safe for
+// the configured store. Multi-UTXO records (utxoBatchSize > 1) require Lua because
+// Aerospike expressions cannot byte-compare list elements, so the offset alone cannot
+// uniquely identify the target UTXO and ListSetOp would mutate the wrong slot.
+func (s *Store) useExpressionSpend() bool {
+	return s.settings.Aerospike.EnableSpendFilterExpressions && s.utxoBatchSize == 1
+}
+
 // sendSpendBatchLua processes a batch of spend requests via Lua scripts or expressions.
 // The function:
 //  1. Groups spends by transaction
@@ -460,8 +468,11 @@ type keyIgnoreLocked struct {
 //  5. Manages DAH settings
 //  6. Updates external storage
 func (s *Store) sendSpendBatchLua(batch []*batchSpend) {
-	// Use expression-based implementation if enabled
-	if s.settings.Aerospike.EnableSpendFilterExpressions {
+	// Use expression-based implementation only when each Aerospike record holds a single
+	// UTXO (utxoBatchSize == 1). With multiple UTXOs per record, the expression cannot
+	// byte-compare the specific UTXO hash at a list offset, so we fall back to Lua which
+	// performs the strict precondition check inside the UDF.
+	if s.useExpressionSpend() {
 		s.SpendMultiWithExpressions(s.ctx, batch)
 		return
 	}

--- a/stores/utxo/aerospike/spend_expressions_gate_test.go
+++ b/stores/utxo/aerospike/spend_expressions_gate_test.go
@@ -1,0 +1,63 @@
+package aerospike
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseExpressionSpend(t *testing.T) {
+	tests := []struct {
+		name              string
+		enableExpressions bool
+		utxoBatchSize     int
+		want              bool
+	}{
+		{
+			name:              "enabled and single utxo per record",
+			enableExpressions: true,
+			utxoBatchSize:     1,
+			want:              true,
+		},
+		{
+			name:              "enabled but multi utxo per record",
+			enableExpressions: true,
+			utxoBatchSize:     2,
+			want:              false,
+		},
+		{
+			name:              "enabled but invalid zero batch size",
+			enableExpressions: true,
+			utxoBatchSize:     0,
+			want:              false,
+		},
+		{
+			name:              "disabled with single utxo",
+			enableExpressions: false,
+			utxoBatchSize:     1,
+			want:              false,
+		},
+		{
+			name:              "disabled with multi utxo",
+			enableExpressions: false,
+			utxoBatchSize:     20000,
+			want:              false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Store{
+				settings: &settings.Settings{
+					Aerospike: settings.AerospikeSettings{
+						EnableSpendFilterExpressions: tc.enableExpressions,
+					},
+				},
+				utxoBatchSize: tc.utxoBatchSize,
+			}
+
+			require.Equal(t, tc.want, s.useExpressionSpend())
+		})
+	}
+}


### PR DESCRIPTION
Closes #4587.

## Summary
The Aerospike spend-filter-expression path (`SpendMultiWithExpressions`) cannot byte-compare a UTXO hash at a list offset (an admitted Aerospike-expression limitation). When `utxoBatchSize > 1`, multiple UTXOs share a record and the offset alone doesn't uniquely identify the target — `ListSetOp` would mutate the wrong slot before discovering the mismatch. When `utxoBatchSize == 1`, each record holds exactly one UTXO so the offset is unambiguous and the expression path is safe.

## Fix
Gate the expression path on `utxoBatchSize == 1`. Multi-UTXO records fall back to the Lua path, which performs the strict UTXO-hash precondition check inside the UDF.

## Test plan
- [x] `useExpressionSpend()` helper unit-tested for all four combinations of `(EnableSpendFilterExpressions, utxoBatchSize)`.
- [x] `go test -race -tags aerospike ./stores/utxo/aerospike/...` passes.