### PR TITLE
fix(utxo/aerospike): surface BatchOperate error in storeExternallyWithLock

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -136,6 +136,9 @@ type Store struct {
 	indexMutex          sync.Mutex    // Mutex for index creation operations
 	indexOnce           sync.Once     // Ensures index creation/wait is only done once per process
 	spendLuaPackages    []string      // Pre-initialized array of Lua package names for spend operations
+
+	// batchOperateFn is a test-only override for s.client.BatchOperate; nil means use the real client.
+	batchOperateFn func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error
 }
 
 // New creates a new Aerospike-based UTXO store.

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -888,7 +888,16 @@ func (s *Store) storeExternallyWithLock(
 	}
 
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
-	_ = s.client.BatchOperate(batchPolicy, batchRecords)
+
+	batchOperate := s.batchOperateFn
+	if batchOperate == nil {
+		batchOperate = s.client.BatchOperate
+	}
+
+	if err := batchOperate(batchPolicy, batchRecords); err != nil {
+		util.SafeSend[error](bItem.done, errors.NewProcessingError("[%s] BatchOperate failed for tx %s", funcName, bItem.txHash, err))
+		return
+	}
 
 	// Check results - KEY_EXISTS_ERROR means recovery (completing previous attempt)
 	hasFailures := false

--- a/stores/utxo/aerospike/create_external_test.go
+++ b/stores/utxo/aerospike/create_external_test.go
@@ -259,3 +259,39 @@ func TestCreatingBinRemoval(t *testing.T) {
 		t.Logf("Small transaction: creating bin was never set (as expected)")
 	})
 }
+
+// TestStoreExternallyWithLock_BatchOperateFails verifies that a top-level error
+// from BatchOperate (e.g. connection lost, all-nodes timeout) is surfaced through
+// bItem.done rather than silently treated as success.
+func TestStoreExternallyWithLock_BatchOperateFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	settings := test.CreateBaseTestSettings(t)
+
+	client, store, _, cleanup := initAerospike(t, settings, logger)
+	defer cleanup()
+
+	cleanDB(t, client)
+
+	tx := createTransactionWithOutputs(settings.UtxoStore.UtxoBatchSize + 1)
+
+	store.SetBatchOperateFn(func(_ *aerospike.BatchPolicy, _ []aerospike.BatchRecordIfc) aerospike.Error {
+		return aerospike.ErrNetwork
+	})
+	defer store.SetBatchOperateFn(nil)
+
+	bItem, binsToStore := prepareBatchStoreItem(t, store, tx, 100, []uint32{}, []uint32{}, []int{})
+	go store.StoreTransactionExternally(ctx, bItem, binsToStore)
+
+	err := bItem.RecvDone()
+	require.Error(t, err, "BatchOperate failure must be surfaced to bItem.done")
+
+	var teranodeErr *errors.Error
+	require.True(t, errors.As(err, &teranodeErr), "error should be a teranode errors.Error: %v", err)
+	require.True(t, teranodeErr.Is(errors.ErrProcessing), "error should be a ProcessingError: %v", err)
+	require.Contains(t, err.Error(), tx.TxIDChainHash().String(), "error should mention the tx hash")
+}

--- a/stores/utxo/aerospike/test_helper.go
+++ b/stores/utxo/aerospike/test_helper.go
@@ -56,6 +56,7 @@
 package aerospike
 
 import (
+	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -67,6 +68,12 @@ import (
 // SetClient was implemented to facilitate testing
 func (s *Store) SetClient(c *uaerospike.Client) {
 	s.client = c
+}
+
+// SetBatchOperateFn was implemented to facilitate testing of error paths
+// that require BatchOperate to fail without disrupting the rest of the client.
+func (s *Store) SetBatchOperateFn(fn func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error) {
+	s.batchOperateFn = fn
 }
 
 // GetSettings was implemented to facilitate testing


### PR DESCRIPTION
Closes #4588.

## Summary
`storeExternallyWithLock` discarded the top-level error from `s.client.BatchOperate(...)` with `_ =`. If the entire batch call failed (connection lost, timeout), per-record error checking ran against an unpopulated result set, `hasFailures` stayed false, and the function reported transaction creation as successful even though no records were written.

## Fix
Capture the top-level error from `BatchOperate`. On non-nil, send a wrapped `ProcessingError` to `bItem.done` and return immediately. Per-record error iteration is unchanged for the success-of-call path.

A small test seam (`batchOperateFn` field + `SetBatchOperateFn` helper) was added so the regression test can drive the BatchOperate-failure path without TestContainers-level connection disruption. Production code path defaults to `s.client.BatchOperate` when the override is unset.

## Test plan
- [x] Regression test injects a network-error `aerospike.Error` via the test seam; asserts `bItem.done` receives a non-nil `ProcessingError` referencing the tx hash.
- [x] Verified test fails on the unpatched code (top-level error swallowed, `bItem.done` got nil).
- [x] `go test -race ./stores/utxo/aerospike/...` passes.