### PR TITLE
fix(legacy/netsync): classify and observe pre-warm validation errors

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/blockassemblyutil"
 	"github.com/bsv-blockchain/teranode/util/retry"
@@ -865,6 +866,33 @@ func (sm *SyncManager) PreValidateTransactions(ctx context.Context, txMap *txmap
 		len(pendingTxHashes), totalTxCount, maxRetries)
 }
 
+// classifyAndCountPrewarmError routes a validator error from the pre-warm path
+// (validateTransactions) into the prometheusLegacyNetsyncPrewarmErrors counter
+// and emits a log line at the level appropriate for the class. Pre-warm errors
+// are intentionally dropped — real subtree validation runs later and catches
+// consensus violations on its own — so this helper exists purely to give ops
+// observability into a path that previously silently swallowed every error
+// (see issue #4590).
+func classifyAndCountPrewarmError(logger ulogger.Logger, err error) {
+	switch {
+	case errors.Is(err, errors.ErrTxInvalid):
+		prometheusLegacyNetsyncPrewarmErrors.WithLabelValues("tx_invalid").Inc()
+		logger.Errorf("[validateTransactions][prewarm] critical: tx invalid: %v", err)
+	case errors.Is(err, errors.ErrServiceError):
+		prometheusLegacyNetsyncPrewarmErrors.WithLabelValues("service").Inc()
+		logger.Warnf("[validateTransactions][prewarm] service error (transient): %v", err)
+	case errors.Is(err, errors.ErrTxConflicting), errors.Is(err, errors.ErrTxExists):
+		prometheusLegacyNetsyncPrewarmErrors.WithLabelValues("policy").Inc()
+		logger.Debugf("[validateTransactions][prewarm] expected: %v", err)
+	case errors.Is(err, errors.ErrProcessing):
+		prometheusLegacyNetsyncPrewarmErrors.WithLabelValues("processing").Inc()
+		logger.Warnf("[validateTransactions][prewarm] processing error: %v", err)
+	default:
+		prometheusLegacyNetsyncPrewarmErrors.WithLabelValues("other").Inc()
+		logger.Warnf("[validateTransactions][prewarm] unclassified: %v", err)
+	}
+}
+
 // validateTransactions validates all the transactions in the block in parallel
 // per level. This is done to speed up subtree validation later on.
 // The levels indicate the number of parents in the block.
@@ -913,7 +941,9 @@ func (sm *SyncManager) validateTransactions(ctx context.Context, maxLevel uint32
 
 				timeStart = time.Now()
 
-				_, _ = sm.validationClient.Validate(ctx, blockTxsPerLevel[i][txIdx], blockHeightUint32, validator.WithSkipPolicyChecks(true))
+				if _, validateErr := sm.validationClient.Validate(ctx, blockTxsPerLevel[i][txIdx], blockHeightUint32, validator.WithSkipPolicyChecks(true)); validateErr != nil {
+					classifyAndCountPrewarmError(sm.logger, validateErr)
+				}
 
 				prometheusLegacyNetsyncBlockTxValidate.Observe(float64(time.Since(timeStart).Microseconds()) / 1_000_000)
 			}
@@ -939,7 +969,9 @@ func (sm *SyncManager) validateTransactions(ctx context.Context, maxLevel uint32
 					}
 
 					// send to validation, but only if the parent is not in the same block
-					_, _ = sm.validationClient.Validate(gCtx, blockTxsPerLevel[i][txIdx], blockHeightUint32, validator.WithSkipPolicyChecks(true))
+					if _, validateErr := sm.validationClient.Validate(gCtx, blockTxsPerLevel[i][txIdx], blockHeightUint32, validator.WithSkipPolicyChecks(true)); validateErr != nil {
+						classifyAndCountPrewarmError(sm.logger, validateErr)
+					}
 
 					return nil
 				})

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/expiringmap"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/ordishs/go-bitcoin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1068,6 +1069,62 @@ func TestSyncManager_quickValidationAllowed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sm := &SyncManager{chainParams: tt.chainParams}
 			require.Equal(t, tt.want, sm.quickValidationAllowed(tt.height))
+		})
+	}
+}
+
+// TestClassifyAndCountPrewarmError verifies that classifyAndCountPrewarmError routes
+// each validator error class to the correct prometheusLegacyNetsyncPrewarmErrors label,
+// preserving the silent-drop semantics flagged by issue #4590 while restoring observability.
+func TestClassifyAndCountPrewarmError(t *testing.T) {
+	initPrometheusMetrics()
+
+	tests := []struct {
+		name  string
+		err   error
+		label string
+	}{
+		{
+			name:  "tx_invalid",
+			err:   errors.NewTxInvalidError("script failed"),
+			label: "tx_invalid",
+		},
+		{
+			name:  "service",
+			err:   errors.NewServiceError("validator unavailable"),
+			label: "service",
+		},
+		{
+			name:  "processing",
+			err:   errors.NewProcessingError("transient processing error"),
+			label: "processing",
+		},
+		{
+			name:  "policy_conflicting",
+			err:   errors.NewTxConflictingError("double-spend in mempool"),
+			label: "policy",
+		},
+		{
+			name:  "policy_already_exists",
+			err:   errors.NewTxExistsError("already in mempool"),
+			label: "policy",
+		},
+		{
+			name:  "other",
+			err:   errors.NewStorageError("disk full"),
+			label: "other",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := prometheusLegacyNetsyncPrewarmErrors.WithLabelValues(tt.label)
+			before := testutil.ToFloat64(counter)
+
+			classifyAndCountPrewarmError(ulogger.TestLogger{}, tt.err)
+
+			after := testutil.ToFloat64(counter)
+			require.Equal(t, before+1, after, "counter for label %q must increment by 1", tt.label)
 		})
 	}
 }

--- a/services/legacy/netsync/metrics.go
+++ b/services/legacy/netsync/metrics.go
@@ -28,6 +28,14 @@ var (
 	prometheusLegacyNetsyncOrphans                        prometheus.Gauge
 	prometheusLegacyNetsyncOrphanTime                     prometheus.Histogram
 
+	// prometheusLegacyNetsyncPrewarmErrors counts validator errors observed during the
+	// pre-warm path in validateTransactions, labelled by error class. The pre-warm runs
+	// before full subtree validation and intentionally drops errors (real validation
+	// catches consensus violations on its own), but ops still need a signal so they
+	// can detect bursts of service/processing failures that would otherwise be silent.
+	// Class labels: tx_invalid, service, processing, policy, other.
+	prometheusLegacyNetsyncPrewarmErrors *prometheus.CounterVec
+
 	prometheusMetricsInitOnce sync.Once
 )
 
@@ -204,4 +212,12 @@ func _initPrometheusMetrics() {
 		Buckets:   util.MetricsBucketsSeconds,
 	})
 	prometheus.MustRegister(prometheusLegacyNetsyncOrphanTime)
+
+	prometheusLegacyNetsyncPrewarmErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "teranode",
+		Subsystem: "legacy_netsync",
+		Name:      "prewarm_validation_errors_total",
+		Help:      "Number of validator errors observed during the pre-warm path in validateTransactions, by class",
+	}, []string{"class"})
+	prometheus.MustRegister(prometheusLegacyNetsyncPrewarmErrors)
 }


### PR DESCRIPTION
Closes #4590.

## Summary
The `validateTransactions` pre-warm path discarded all errors from `validationClient.Validate` with `_, _ =`. Policy errors during pre-warm are expected (warm-up runs before full validation), but critical errors (service unavailable, consensus-level tx invalidity, processing failures) were also silently swallowed. Ops had no signal that pre-warm was failing.

## Decision
Add observability (log + counter), keep drop semantics. Same pattern as #4585 (PR #781). Real validation runs at subtree-validation time and catches consensus violations on its own — making pre-warm part of the validation gate would risk false-positive block rejections from classification mistakes.

## Fix
- New `prometheusLegacyNetsyncPrewarmErrors` counter vec with `class` label (`tx_invalid`, `service`, `processing`, `policy`, `other`).
- New helper `classifyAndCountPrewarmError(logger, err)` that classifies via `errors.Is` and logs at the appropriate level (debug for policy, warn for service/processing/other, error for tx_invalid).
- Both pre-warm `Validate` call sites in `validateTransactions` (small-batch path and goroutine-pool path) now capture the error and route through the helper.
- Drop semantics preserved: function still returns nil; `g.Wait()` still ignored.

## Test plan
- [x] Unit tests on `classifyAndCountPrewarmError` for each class; assert counter increments.
- [x] `go test -race ./services/legacy/netsync/...` passes.