### PR TITLE
[Fix] reduce kernel call to check is terminal on every log message

### DIFF
--- a/ulogger/init.go
+++ b/ulogger/init.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/rs/zerolog"
-	"golang.org/x/term"
 )
 
 func InitLogger(progname string, tSettings *settings.Settings) Logger {
@@ -14,11 +13,9 @@ func InitLogger(progname string, tSettings *settings.Settings) Logger {
 		WithLevel(logLevel),
 	}
 
-	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
-
 	output := zerolog.ConsoleWriter{
 		Out:     os.Stdout,
-		NoColor: !isTerminal, // Disable color if output is not a terminal
+		NoColor: !isStdoutTerminal(), // Disable color if output is not a terminal
 	}
 
 	logOptions = append(logOptions, WithWriter(output))

--- a/ulogger/options.go
+++ b/ulogger/options.go
@@ -4,10 +4,26 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/term"
 )
+
+// cachedIsTerminal caches the result of term.IsTerminal so it is only
+// called once per process instead of on every DefaultOptions() invocation.
+// The ioctl syscall it performs is expensive under high concurrency.
+var (
+	cachedIsTerminal     bool
+	cachedIsTerminalOnce sync.Once
+)
+
+func isStdoutTerminal() bool {
+	cachedIsTerminalOnce.Do(func() {
+		cachedIsTerminal = term.IsTerminal(int(os.Stdout.Fd()))
+	})
+	return cachedIsTerminal
+}
 
 type Options struct {
 	logLevel      string
@@ -21,11 +37,9 @@ type Options struct {
 type Option func(*Options)
 
 func DefaultOptions() *Options {
-	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
-
 	output := zerolog.ConsoleWriter{
 		Out:     os.Stdout,
-		NoColor: !isTerminal, // Disable color if output is not a terminal
+		NoColor: !isStdoutTerminal(), // Disable color if output is not a terminal
 	}
 
 	return &Options{

--- a/ulogger/zerologger.go
+++ b/ulogger/zerologger.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ordishs/gocore"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/term"
 )
 
 type ZLoggerWrapper struct {
@@ -70,7 +69,7 @@ func NewZeroLogger(service string, options ...Option) *ZLoggerWrapper {
 }
 
 func prettyZeroLogger(service string, opts *Options, jsonLoggingEnabled bool) *ZLoggerWrapper {
-	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
+	isTerminal := isStdoutTerminal()
 
 	// Cache working directory once at logger initialization to avoid expensive syscall on every log message
 	cachedCwd, _ := os.Getwd()


### PR DESCRIPTION
reduce unnecessary kernel calls to check isTerminal on every log initialization