### PR TITLE
fix(blockassembly): size incomplete-subtree snapshot from source capacity

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -985,13 +985,28 @@ func (stp *SubtreeProcessor) resetAnnouncementTicker() {
 // It creates a new subtree with the same configuration and copies all nodes (except coinbase placeholder)
 // from the current subtree.
 //
+// The new subtree is sized to match the source subtree's capacity, not the current
+// currentItemsPerFile setting. adjustSubtreeSize can shrink currentItemsPerFile
+// between blocks while the in-flight currentSubtree retains its larger original
+// capacity; sizing the copy off currentItemsPerFile in that window would overflow.
+//
 // Returns:
 //   - *subtreepkg.Subtree: The incomplete subtree copy, or nil if creation failed
 //   - error: Any error encountered during subtree creation or node copying
 func (stp *SubtreeProcessor) createIncompleteSubtreeCopy() (*subtreepkg.Subtree, error) {
-	itemsPerFile := int(stp.currentItemsPerFile.Load())
+	currentSt := stp.currentSubtree.Load()
+	if currentSt == nil {
+		return nil, errors.NewProcessingError("createIncompleteSubtreeCopy: no current subtree")
+	}
 
-	incompleteSubtree, err := subtreepkg.NewTreeByLeafCount(itemsPerFile)
+	capacity := currentSt.Size()
+	if capacity <= 0 {
+		// Fall back to the configured size if the current subtree somehow reports
+		// no capacity; NewTreeByLeafCount will reject zero/negative values.
+		capacity = int(stp.currentItemsPerFile.Load())
+	}
+
+	incompleteSubtree, err := subtreepkg.NewTreeByLeafCount(capacity)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1017,6 @@ func (stp *SubtreeProcessor) createIncompleteSubtreeCopy() (*subtreepkg.Subtree,
 	}
 
 	// Copy all nodes from current subtree (skipping the coinbase placeholder at index 0)
-	currentSt := stp.currentSubtree.Load()
 	for _, node := range currentSt.Nodes[1:] {
 		if err = incompleteSubtree.AddSubtreeNodeWithoutLock(node); err != nil {
 			return nil, err

--- a/services/blockassembly/subtreeprocessor/incomplete_subtree_copy_test.go
+++ b/services/blockassembly/subtreeprocessor/incomplete_subtree_copy_test.go
@@ -1,0 +1,66 @@
+package subtreeprocessor
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateIncompleteSubtreeCopy_AfterShrink reproduces a snapshot failure that
+// occurred when adjustSubtreeSize had reduced currentItemsPerFile while an
+// in-flight currentSubtree retained its larger original capacity. Sizing the
+// snapshot copy off currentItemsPerFile in that window overflowed when copying
+// the source nodes; sizing it off the source's capacity does not.
+func TestCreateIncompleteSubtreeCopy_AfterShrink(t *testing.T) {
+	stp, cleanup := setupSubtreeProcessorForBench(t, 8)
+	defer cleanup()
+
+	// Build a subtree at the original (larger) capacity and fill it past the
+	// shrunk capacity, so the bug — if reintroduced — would overflow the copy.
+	source, err := subtreepkg.NewTreeByLeafCount(8)
+	require.NoError(t, err)
+	require.NoError(t, source.AddCoinbaseNode())
+
+	const realNodes = 5 // coinbase + 5 = 6 nodes in an 8-cap source
+	for i := 0; i < realNodes; i++ {
+		var h chainhash.Hash
+		h[0] = byte(i + 1)
+		require.NoError(t, source.AddSubtreeNode(subtreepkg.Node{Hash: h, Fee: uint64(i + 1)}))
+	}
+
+	stp.currentSubtree.Store(source)
+	// Simulate adjustSubtreeSize shrinking the per-file count below the source's
+	// node count after a block was finalized.
+	stp.currentItemsPerFile.Store(4)
+
+	snapshot, err := stp.createIncompleteSubtreeCopy()
+	require.NoError(t, err, "copying an in-flight subtree must not fail when currentItemsPerFile has shrunk")
+	require.NotNil(t, snapshot)
+
+	// The snapshot must contain the coinbase placeholder plus every real node
+	// from the source — nothing dropped, nothing duplicated.
+	require.Equal(t, source.Length(), snapshot.Length())
+	require.GreaterOrEqual(t, snapshot.Size(), source.Length())
+	require.Equal(t, source.Fees, snapshot.Fees)
+
+	for i := 1; i < source.Length(); i++ {
+		require.Equal(t, source.Nodes[i].Hash, snapshot.Nodes[i].Hash, "node %d hash must match", i)
+		require.Equal(t, source.Nodes[i].Fee, snapshot.Nodes[i].Fee, "node %d fee must match", i)
+	}
+}
+
+// TestCreateIncompleteSubtreeCopy_NilCurrent guards against a nil-deref when
+// the snapshot is requested with no current subtree set.
+func TestCreateIncompleteSubtreeCopy_NilCurrent(t *testing.T) {
+	stp, cleanup := setupSubtreeProcessorForBench(t, 8)
+	defer cleanup()
+
+	// Explicitly clear the current subtree.
+	stp.currentSubtree.Store((*subtreepkg.Subtree)(nil))
+
+	snapshot, err := stp.createIncompleteSubtreeCopy()
+	require.Error(t, err)
+	require.Nil(t, snapshot)
+}


### PR DESCRIPTION
## Summary

Fixes a runtime error observed in block assembly:

```
ERROR | SubtreeProcessor.go:644 | blockassembly | [SubtreeProcessor] error creating incomplete subtree snapshot: subtree is full
```

`createIncompleteSubtreeCopy` allocated the snapshot subtree using `currentItemsPerFile`. `adjustSubtreeSize` (called from `finalizeBlockProcessing`) can shrink `currentItemsPerFile` between blocks, while the in-flight `currentSubtree` retains its larger original capacity. When a mining request lands in that window, the copy is smaller than the source and overflows when copying nodes.

## Reproduction

`adjustSubtreeSize` is called every block (`SubtreeProcessor.go:3488` from `finalizeBlockProcessing`) and may store a smaller value into `currentItemsPerFile` based on observed TPS. The new value applies to the *next* subtree, but the in-flight `currentSubtree` keeps its old capacity. If `GetIncompleteSubtreeMiningData` is called before the next subtree is created (and `chainedSubtreeCount == 0`, e.g. immediately after a block where the chain rotated), the snapshot path runs:

```go
itemsPerFile := int(stp.currentItemsPerFile.Load())          // shrunk value
incompleteSubtree, _ := subtreepkg.NewTreeByLeafCount(itemsPerFile)  // smaller capacity
// ...
for _, node := range currentSt.Nodes[1:] {                   // larger source
    incompleteSubtree.AddSubtreeNodeWithoutLock(node)        // overflows → "subtree is full"
}
```

The new test `TestCreateIncompleteSubtreeCopy_AfterShrink` reproduces this deterministically: it stores a cap-8 subtree filled to 6 nodes into `currentSubtree`, sets `currentItemsPerFile` to 4, and calls `createIncompleteSubtreeCopy`. Without the fix, the test fails with the exact error message from production:

```
Error: Received unexpected error:
       subtree is full
--- FAIL: TestCreateIncompleteSubtreeCopy_AfterShrink
```

With the fix, it passes.

## Fix

Size the snapshot off `currentSt.Size()`, not `currentItemsPerFile`. The copy then always has at least the capacity needed to hold every node of the source. Falls back to `currentItemsPerFile` only if the source reports a non-positive capacity. Also rejects the snapshot up front when no current subtree is set, instead of dereferencing nil during the copy loop.

```go
currentSt := stp.currentSubtree.Load()
if currentSt == nil {
    return nil, errors.NewProcessingError("createIncompleteSubtreeCopy: no current subtree")
}

capacity := currentSt.Size()
if capacity <= 0 {
    capacity = int(stp.currentItemsPerFile.Load())
}

incompleteSubtree, err := subtreepkg.NewTreeByLeafCount(capacity)
```

## Impact

This affects all three callers of `createIncompleteSubtreeCopy`:

- `getSubtreesChan` handler (mining request, line 569)
- `getIncompleteSubtreeDataChan` handler — **the path producing the error in the report** (line 642)
- Periodic announcement ticker (line 781)

Any of them could hit the overflow when `currentItemsPerFile` had shrunk; the on-demand mining path is what reported it because it is the most frequently exercised.

## Out of scope

- This does not change `adjustSubtreeSize` behaviour. The dynamic resize itself is fine — only the snapshot copy was making a wrong assumption about source capacity.
- This is independent of #798 (skip periodic partial near full); both edit `createIncompleteSubtreeCopy`'s neighbourhood but at different concerns.

## Test plan

- [x] `go build ./services/blockassembly/subtreeprocessor/...` — clean
- [x] `go vet ./services/blockassembly/subtreeprocessor/...` — clean
- [x] `staticcheck ./services/blockassembly/subtreeprocessor/...` — clean
- [x] `TestCreateIncompleteSubtreeCopy_AfterShrink` — passes with fix, fails with exact production error message without fix
- [x] `TestCreateIncompleteSubtreeCopy_NilCurrent` — guards the nil-current path
- [ ] Reviewer to confirm the error no longer appears in their node run

## Files

- `services/blockassembly/subtreeprocessor/SubtreeProcessor.go` — size snapshot from source capacity; nil-source guard
- `services/blockassembly/subtreeprocessor/incomplete_subtree_copy_test.go` — new regression tests