### PR TITLE
fix(blockassembly): cascade-filter descendants of rejected unmined txs

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -1534,6 +1534,19 @@ func (b *BlockAssembler) validateParentChain(
 
 	b.logger.Infof("[BlockAssembler][validateParentChain] Starting parent chain validation for %d unmined transactions", len(unminedTxs))
 
+	filteringEnabled := b.settings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs
+
+	// Cascade tracking: when a parent is conflicting (or descended from a conflicting
+	// tx via this run), we must reject the child AND propagate the conflicting flag.
+	// The sort order (createdAt) processes parents before children, so by the time we
+	// reach a child, any rejected ancestor in our list is already in these maps.
+	//   - conflictingDescendants: cascade triggered by a conflicting ancestor; gets
+	//     propagated to the UTXO store via MarkConflictingRecursively at end of run
+	//   - rejectedHashes: superset — any tx filtered for any reason; used purely
+	//     in-memory to cascade-filter descendants
+	conflictingDescendants := make(map[chainhash.Hash]struct{})
+	rejectedHashes := make(map[chainhash.Hash]struct{})
+
 	// OPTIMIZATION: Two-pass approach to minimize memory usage
 	// Pass 1: Collect only the parent hashes that are actually referenced
 	// This is MUCH smaller than indexing all transactions
@@ -1662,6 +1675,29 @@ func (b *BlockAssembler) validateParentChain(
 			unminedParents := make([]chainhash.Hash, 0) // Track which parents are unmined
 
 			for _, parentTxID := range parentHashes {
+				// Cascade: parent was filtered earlier in this run as conflicting (or
+				// descendant of conflicting). Reject this child too AND propagate the
+				// conflicting flag — the parent's store metadata may not yet reflect
+				// the conflict, so we cannot rely on parentMeta.Conflicting alone.
+				if _, isConflictingCascade := conflictingDescendants[parentTxID]; isConflictingCascade {
+					allParentsValid = false
+					invalidReason = fmt.Sprintf("parent tx %s is conflicting (cascade)", parentTxID.String())
+					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					if filteringEnabled {
+						conflictingDescendants[tx.Hash] = struct{}{}
+					}
+					break
+				}
+
+				// Cascade: parent was filtered earlier in this run for some other reason
+				// (missing, orphaned, etc). Reject without marking conflicting.
+				if _, isRejectedCascade := rejectedHashes[parentTxID]; isRejectedCascade {
+					allParentsValid = false
+					invalidReason = fmt.Sprintf("parent tx %s was filtered earlier in this run (cascade)", parentTxID.String())
+					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					break
+				}
+
 				// Check if parent exists in UTXO store
 				parentMeta, exists := parentMetadata[parentTxID]
 				if !exists {
@@ -1677,6 +1713,9 @@ func (b *BlockAssembler) validateParentChain(
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s is conflicting", parentTxID.String())
 					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					if filteringEnabled {
+						conflictingDescendants[tx.Hash] = struct{}{}
+					}
 					break
 				}
 
@@ -1777,8 +1816,9 @@ func (b *BlockAssembler) validateParentChain(
 				validTxs = append(validTxs, tx)
 			} else {
 				// Transaction has invalid parent chain - use setting to decide whether to exclude
-				if b.settings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs {
-					// Filtering enabled - skip this transaction
+				if filteringEnabled {
+					// Filtering enabled - skip and track for cascade filtering of descendants
+					rejectedHashes[tx.Hash] = struct{}{}
 					skippedCount++
 				} else {
 					// Filtering disabled (default) - keep transaction despite invalid parents
@@ -1788,8 +1828,24 @@ func (b *BlockAssembler) validateParentChain(
 		}
 	}
 
+	// Propagate conflicting flag to UTXO store for cascaded descendants. This prevents
+	// future restarts from re-discovering the same orphans and leaking them into block
+	// assembly. Best-effort: even on failure the in-memory filter has already protected
+	// the current run.
+	if len(conflictingDescendants) > 0 {
+		cascadeHashes := make([]chainhash.Hash, 0, len(conflictingDescendants))
+		for h := range conflictingDescendants {
+			cascadeHashes = append(cascadeHashes, h)
+		}
+		if _, _, mErr := utxo.MarkConflictingRecursively(ctx, b.utxoStore, cascadeHashes); mErr != nil {
+			b.logger.Errorf("[BlockAssembler][validateParentChain] failed to mark %d cascaded conflicting txs: %v", len(cascadeHashes), mErr)
+		} else {
+			b.logger.Infof("[BlockAssembler][validateParentChain] marked %d txs conflicting (descendants of conflicting parents)", len(cascadeHashes))
+		}
+	}
+
 	filteringStatus := "disabled"
-	if b.settings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs {
+	if filteringEnabled {
 		filteringStatus = "enabled"
 	}
 

--- a/services/blockassembly/filter_transactions_test.go
+++ b/services/blockassembly/filter_transactions_test.go
@@ -358,6 +358,12 @@ func TestValidateParentChain_RejectsChildOfConflictingParent(t *testing.T) {
 		}).
 		Return(nil)
 
+	// MarkConflictingRecursively → SetConflicting on the cascaded child.
+	// First call: marks the child, returns no further spending children → cascade ends.
+	mockStore.On("SetConflicting", mock.Anything, mock.MatchedBy(func(hashes []chainhash.Hash) bool {
+		return len(hashes) == 1 && hashes[0].IsEqual(&childHash)
+	}), true).Return([]*utxo.Spend{}, []chainhash.Hash{}, nil).Once()
+
 	bestBlockHeaderIDsMap := map[uint32]bool{1: true}
 
 	validTxs, err := blockAssembler.validateParentChain(ctx, unminedTxs, bestBlockHeaderIDsMap)
@@ -430,4 +436,202 @@ func TestValidateParentChain_BatchDecorateRequestsConflicting(t *testing.T) {
 
 	require.Contains(t, capturedFields, fields.Conflicting,
 		"validateParentChain must request fields.Conflicting from the store")
+}
+
+// TestValidateParentChain_RecursivelyFiltersConflictingDescendants is the regression test
+// for the cascade hole: when a parent is conflicting, only its DIRECT children were
+// previously filtered. Grandchildren and deeper descendants leaked into block assembly,
+// producing invalid blocks. The fix tracks rejected hashes in-memory across the run so
+// that any tx whose ancestor was filtered as conflicting is also filtered AND propagated
+// to the UTXO store as conflicting.
+func TestValidateParentChain_RecursivelyFiltersConflictingDescendants(t *testing.T) {
+	ctx := context.Background()
+
+	mockStore := new(utxo.MockUtxostore)
+	logger := ulogger.TestLogger{}
+
+	testSettings := &settings.Settings{}
+	testSettings.BlockAssembly.ParentValidationBatchSize = 50
+	testSettings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs = true
+
+	blockAssembler := &BlockAssembler{
+		utxoStore: mockStore,
+		settings:  testSettings,
+		logger:    logger,
+	}
+
+	// Chain: conflictingParent -> childB -> childC -> childD
+	// conflictingParent is NOT in the unmined list (filtered by iterator), but is
+	// returned by BatchDecorate with Conflicting=true.
+	// childB, childC, childD ARE in the unmined list. All three must be filtered.
+	var conflictingParentHash chainhash.Hash
+	for j := range conflictingParentHash {
+		conflictingParentHash[j] = 0xA0
+	}
+
+	var bHash chainhash.Hash
+	for j := range bHash {
+		bHash[j] = 0xB0
+	}
+
+	var cHash chainhash.Hash
+	for j := range cHash {
+		cHash[j] = 0xC0
+	}
+
+	var dHash chainhash.Hash
+	for j := range dHash {
+		dHash[j] = 0xD0
+	}
+
+	childB := &utxo.UnminedTransaction{
+		Node:       &subtree.Node{Hash: bHash, Fee: 1000, SizeInBytes: 250},
+		TxInpoints: &subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{conflictingParentHash}, Idxs: [][]uint32{{0}}},
+		CreatedAt:  1,
+	}
+	childC := &utxo.UnminedTransaction{
+		Node:       &subtree.Node{Hash: cHash, Fee: 1000, SizeInBytes: 250},
+		TxInpoints: &subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{bHash}, Idxs: [][]uint32{{0}}},
+		CreatedAt:  2,
+	}
+	childD := &utxo.UnminedTransaction{
+		Node:       &subtree.Node{Hash: dHash, Fee: 1000, SizeInBytes: 250},
+		TxInpoints: &subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{cHash}, Idxs: [][]uint32{{0}}},
+		CreatedAt:  3,
+	}
+
+	unminedTxs := []*utxo.UnminedTransaction{childB, childC, childD}
+
+	mockStore.On("BatchDecorate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			for _, unresolved := range args.Get(1).([]*utxo.UnresolvedMetaData) {
+				switch {
+				case unresolved.Hash.IsEqual(&conflictingParentHash):
+					// Real conflicting parent — store says Conflicting=true.
+					unresolved.Data = &meta.Data{
+						BlockIDs:     []uint32{},
+						UnminedSince: 1,
+						Conflicting:  true,
+					}
+				case unresolved.Hash.IsEqual(&bHash), unresolved.Hash.IsEqual(&cHash):
+					// Cascade-affected. Store does NOT yet reflect conflicting
+					// (that's the bug — the cascade marker hadn't propagated).
+					// Without the fix, these would pass the parentMeta.Conflicting
+					// check and leak through.
+					unresolved.Data = &meta.Data{
+						BlockIDs:     []uint32{},
+						UnminedSince: 1,
+						Conflicting:  false,
+					}
+				}
+			}
+		}).
+		Return(nil)
+
+	// All three cascaded txs must be marked conflicting in the store. The map order
+	// is non-deterministic, so we just assert the call happens with all three hashes
+	// in the first batch (childB, childC, childD all reach SetConflicting since the
+	// in-memory cascade tracked them up-front).
+	mockStore.On("SetConflicting", mock.Anything, mock.MatchedBy(func(hashes []chainhash.Hash) bool {
+		if len(hashes) != 3 {
+			return false
+		}
+		seen := map[chainhash.Hash]bool{}
+		for _, h := range hashes {
+			seen[h] = true
+		}
+		return seen[bHash] && seen[cHash] && seen[dHash]
+	}), true).Return([]*utxo.Spend{}, []chainhash.Hash{}, nil).Once()
+
+	bestBlockHeaderIDsMap := map[uint32]bool{1: true}
+
+	validTxs, err := blockAssembler.validateParentChain(ctx, unminedTxs, bestBlockHeaderIDsMap)
+	require.NoError(t, err)
+	require.Empty(t, validTxs,
+		"all descendants of a conflicting parent must be cascade-filtered, not just direct children")
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestValidateParentChain_RecursivelyFiltersOtherInvalidDescendants verifies that the
+// in-memory cascade also works for non-conflicting rejection reasons (e.g. parent missing
+// from store). These are filtered out but NOT marked conflicting — the parent isn't
+// conflicting, just orphaned, and we shouldn't flip a tx to conflicting on weak evidence.
+func TestValidateParentChain_RecursivelyFiltersOtherInvalidDescendants(t *testing.T) {
+	ctx := context.Background()
+
+	mockStore := new(utxo.MockUtxostore)
+	logger := ulogger.TestLogger{}
+
+	testSettings := &settings.Settings{}
+	testSettings.BlockAssembly.ParentValidationBatchSize = 50
+	testSettings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs = true
+
+	blockAssembler := &BlockAssembler{
+		utxoStore: mockStore,
+		settings:  testSettings,
+		logger:    logger,
+	}
+
+	// Chain: missingParent (not in store, not in list) -> childB (in list) -> childC (in list)
+	var missingParentHash chainhash.Hash
+	for j := range missingParentHash {
+		missingParentHash[j] = 0x10
+	}
+
+	var bHash chainhash.Hash
+	for j := range bHash {
+		bHash[j] = 0x20
+	}
+
+	var cHash chainhash.Hash
+	for j := range cHash {
+		cHash[j] = 0x30
+	}
+
+	childB := &utxo.UnminedTransaction{
+		Node:       &subtree.Node{Hash: bHash, Fee: 1000, SizeInBytes: 250},
+		TxInpoints: &subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{missingParentHash}, Idxs: [][]uint32{{0}}},
+		CreatedAt:  1,
+	}
+	childC := &utxo.UnminedTransaction{
+		Node:       &subtree.Node{Hash: cHash, Fee: 1000, SizeInBytes: 250},
+		TxInpoints: &subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{bHash}, Idxs: [][]uint32{{0}}},
+		CreatedAt:  2,
+	}
+
+	unminedTxs := []*utxo.UnminedTransaction{childB, childC}
+
+	mockStore.On("BatchDecorate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			for _, unresolved := range args.Get(1).([]*utxo.UnresolvedMetaData) {
+				switch {
+				case unresolved.Hash.IsEqual(&missingParentHash):
+					// Truly missing — BatchDecorate signals not-found.
+					unresolved.Err = errors.ErrNotFound
+				case unresolved.Hash.IsEqual(&bHash):
+					// Without the cascade fix, B's metadata looks fine and C would slip through.
+					unresolved.Data = &meta.Data{
+						BlockIDs:     []uint32{},
+						UnminedSince: 1,
+						Conflicting:  false,
+					}
+				}
+			}
+		}).
+		Return(nil)
+
+	// SetConflicting must NOT be called — these aren't conflicting, just orphaned.
+	// (mockStore.AssertExpectations will fail if any On() expectation is unmet, but
+	// no expectation was set for SetConflicting, so calling it would surface as an
+	// "unexpected call" panic — exactly what we want.)
+
+	bestBlockHeaderIDsMap := map[uint32]bool{1: true}
+
+	validTxs, err := blockAssembler.validateParentChain(ctx, unminedTxs, bestBlockHeaderIDsMap)
+	require.NoError(t, err)
+	require.Empty(t, validTxs,
+		"descendants of a missing parent must be cascade-filtered too")
+
+	mockStore.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

`validateParentChain` previously rejected only **direct** children of conflicting parents. Grandchildren and deeper descendants slipped through because the parent's UTXO store metadata had not yet been updated with the conflicting flag — so the existing `parentMeta.Conflicting` check returned false for cascade-affected txs.

Result: invalid txs leaked into block assembly on restart, producing invalid blocks (matches the production symptom in the bug report — direct children skipped, deeper descendants admitted).

## What changed

In `services/blockassembly/BlockAssembler.go::validateParentChain`:

- Track rejected tx hashes in two in-memory maps as the sorted list is walked:
  - `conflictingDescendants`: cascade triggered by a conflicting ancestor
  - `rejectedHashes`: superset for any rejection reason
- Sort order (`createdAt`) guarantees parents are processed before children, so checking these maps at the top of the parent loop catches all descendants.
- After the run, propagate the conflicting flag to the UTXO store via `utxo.MarkConflictingRecursively` so future restarts don't re-discover the same orphans.

Cascade only activates when `OnRestartRemoveInvalidParentChainTxs=true`, preserving existing opt-out semantics.

Non-conflicting rejection reasons (missing parent, wrong-chain, ordering) now also cascade-filter their descendants. This is stricter than before — txs that previously slipped through due to a missing-but-not-conflicting ancestor will now be filtered. Correct, but worth flagging for anyone tracking historical skip counts.

## Out of scope

`loadUnminedTransactionsWithDiskSort` does not call `validateParentChain` at all — pre-existing gap, not fixed here. The reported bug shows the in-memory path. Worth a follow-up if disk-sort gets enabled in production.

## Test plan

- [x] `go test -run TestValidateParentChain ./services/blockassembly` — 7 passed (was 5; added `RecursivelyFiltersConflictingDescendants` and `RecursivelyFiltersOtherInvalidDescendants`)
- [x] `go test -tags=testtxmetacache ./services/blockassembly` — 373 passed
- [x] `go vet ./services/blockassembly/...` — clean
- [x] Existing `RejectsChildOfConflictingParent` updated to mock `SetConflicting` (now invoked via `MarkConflictingRecursively`)