### PR TITLE
fix(blockassembly): reconcile tip with blockchain on startup

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -61,6 +61,10 @@ var (
 
 	// StateMovingUp indicates the processor is moving up the blockchain
 	StateMovingUp State = 6
+
+	// StateReconciling indicates the processor is reconciling its tip with
+	// the blockchain after startup or a missed-notification window.
+	StateReconciling State = 7
 )
 
 var StateStrings = map[State]string{
@@ -70,6 +74,7 @@ var StateStrings = map[State]string{
 	StateBlockchainSubscription: "blockchainSubscription",
 	StateReorging:               "reorging",
 	StateMovingUp:               "movingUp",
+	StateReconciling:            "reconciling",
 }
 
 // BlockAssembler manages the assembly of new blocks and coordinates mining operations.
@@ -343,7 +348,7 @@ func (b *BlockAssembler) startChannelListeners(ctx context.Context) (err error) 
 				b.setCurrentRunningState(StateRunning)
 
 			case <-b.reconcileCh:
-				b.setCurrentRunningState(StateBlockchainSubscription)
+				b.setCurrentRunningState(StateReconciling)
 				b.processNewBlockAnnouncement(ctx)
 				b.setCurrentRunningState(StateRunning)
 			} // select

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -128,6 +128,11 @@ type BlockAssembler struct {
 	// resetCh handles reset requests for the assembler
 	resetCh chan resetRequest
 
+	// reconcileCh signals the channel listener to reconcile BA's tip with the
+	// blockchain service's tip via processNewBlockAnnouncement. Buffered cap 1
+	// so multiple triggers coalesce into a single reconciliation pass.
+	reconcileCh chan struct{}
+
 	// currentRunningState tracks the current operational state
 	currentRunningState atomic.Value
 
@@ -217,6 +222,7 @@ func NewBlockAssembler(ctx context.Context, logger ulogger.Logger, tSettings *se
 		currentChainMapIDs:  make(map[uint32]struct{}, tSettings.BlockAssembly.MaxBlockReorgCatchup),
 		defaultMiningNBits:  defaultMiningBits,
 		resetCh:             make(chan resetRequest, 2),
+		reconcileCh:         make(chan struct{}, 1),
 		currentRunningState: atomic.Value{},
 	}
 
@@ -280,6 +286,13 @@ func (b *BlockAssembler) startChannelListeners(ctx context.Context) (err error) 
 		return errors.NewProcessingError("[BlockAssembler] error subscribing to blockchain notifications: %v", err)
 	}
 
+	// Trigger an initial reconcile against the blockchain tip. After a crash
+	// or any window where notifications were dropped, the persisted checkpoint
+	// loaded by initState may lag the chain. processNewBlockAnnouncement's
+	// reorg path replays missing blocks from the common ancestor; on a healthy
+	// node it returns early when hashes match.
+	b.triggerReconcile()
+
 	b.wg.Add(1)
 	go func() {
 		defer b.wg.Done()
@@ -328,11 +341,26 @@ func (b *BlockAssembler) startChannelListeners(ctx context.Context) (err error) 
 				}
 
 				b.setCurrentRunningState(StateRunning)
+
+			case <-b.reconcileCh:
+				b.setCurrentRunningState(StateBlockchainSubscription)
+				b.processNewBlockAnnouncement(ctx)
+				b.setCurrentRunningState(StateRunning)
 			} // select
 		} // for
 	}()
 
 	return nil
+}
+
+// triggerReconcile asks the channel listener to run processNewBlockAnnouncement.
+// The send is non-blocking — reconcileCh is buffered cap 1 and acts as a
+// coalescing signal, so concurrent triggers fold into a single pass.
+func (b *BlockAssembler) triggerReconcile() {
+	select {
+	case b.reconcileCh <- struct{}{}:
+	default:
+	}
 }
 
 // reset performs a full reset of the block assembler state by clearing all subtrees and reloading from blockchain.

--- a/services/blockassembly/BlockAssembler_test.go
+++ b/services/blockassembly/BlockAssembler_test.go
@@ -2988,3 +2988,94 @@ func TestReset_ConflictDetectionViaValidateInputs(t *testing.T) {
 	require.False(t, containsHash(hashes, *txAHash),
 		"after reset(validateInputs=true), a tx whose input is spent by another tx must NOT be in block assembly")
 }
+
+// TestTriggerReconcile verifies that triggerReconcile is non-blocking and
+// coalesces concurrent triggers into a single pending signal.
+func TestTriggerReconcile(t *testing.T) {
+	ba := &BlockAssembler{
+		reconcileCh: make(chan struct{}, 1),
+	}
+
+	// First trigger lands.
+	ba.triggerReconcile()
+	require.Len(t, ba.reconcileCh, 1, "first trigger should buffer one signal")
+
+	// Second trigger must not block; channel stays at cap 1 (coalesced).
+	done := make(chan struct{})
+	go func() {
+		ba.triggerReconcile()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("triggerReconcile blocked instead of coalescing")
+	}
+	require.Len(t, ba.reconcileCh, 1, "second trigger must coalesce, not stack")
+
+	// Drain.
+	<-ba.reconcileCh
+	require.Empty(t, ba.reconcileCh)
+}
+
+// TestStart_TriggersReconcileOnStartup verifies that Start fires a reconcile
+// against the blockchain tip after subscribing. With no notifications queued
+// on the subscription channel, only the new reconcile path can drive
+// processNewBlockAnnouncement — which calls GetBestBlockHeader. Asserting that
+// call proves the wiring delivers.
+func TestStart_TriggersReconcileOnStartup(t *testing.T) {
+	initPrometheusMetrics()
+
+	tSettings := createTestSettings(t)
+	tSettings.ChainCfgParams.Net = wire.MainNet
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStoreInst, err := utxostoresql.New(t.Context(), ulogger.TestLogger{}, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	stats := gocore.NewStat("test")
+
+	// Persisted checkpoint at genesis. processNewBlockAnnouncement compares
+	// that against GetBestBlockHeader (also genesis here) — same hash, returns
+	// early via the IsEqual branch. No reorg/move-forward mocks needed.
+	checkpointHeader := model.GenesisBlockHeader
+	checkpointBytes := make([]byte, 4+80)
+	binary.LittleEndian.PutUint32(checkpointBytes[:4], 0)
+	copy(checkpointBytes[4:], checkpointHeader.Bytes())
+
+	// Atomic counter incremented from the mock's Run callback so the
+	// race detector sees ordered access (instead of polling mock.Calls
+	// concurrently with the BA goroutine writing to it).
+	var getBestCalls atomic.Int32
+
+	bc := &blockchain.Mock{}
+	bc.On("GetState", mock.Anything, mock.Anything).Return(checkpointBytes, nil)
+	bc.On("SetState", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	bc.On("GetBestBlockHeader", mock.Anything).
+		Run(func(mock.Arguments) { getBestCalls.Add(1) }).
+		Return(checkpointHeader, &model.BlockHeaderMeta{Height: 0}, nil)
+	bc.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return([]*model.BlockHeader{checkpointHeader}, []*model.BlockHeaderMeta{{Height: 0}}, nil)
+	bc.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{0}, nil)
+	bc.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	bc.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.ErrNotFound)
+	runningState := blockchain.FSMStateRUNNING
+	bc.On("GetFSMCurrentState", mock.Anything).Return(&runningState, nil)
+
+	// Empty subscription — no pre-loaded notifications. Any call to
+	// GetBestBlockHeader after Start must come from the reconcile path.
+	subChan := make(chan *blockchain_api.Notification, 1)
+	bc.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
+
+	ba, err := NewBlockAssembler(t.Context(), ulogger.TestLogger{}, tSettings, stats, utxoStoreInst, nil, bc, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ba)
+
+	require.NoError(t, ba.Start(t.Context()))
+
+	// Reconcile fires asynchronously via the channel listener goroutine.
+	require.Eventually(t, func() bool {
+		return getBestCalls.Load() > 0
+	}, 2*time.Second, 20*time.Millisecond, "expected GetBestBlockHeader to be called via reconcile path after Start")
+}


### PR DESCRIPTION
## Summary

Block assembly now reconciles its tip with the blockchain service on every startup. Previously, a crash (or any window where notifications were dropped by `broadcastHeartbeat`'s `select default` on a full channel) would leave BA stuck at its persisted checkpoint until manual intervention — visible as `block assembly is behind, block height N, block assembly height M` in legacy sync.

## What changed

- `BlockAssembler` gains a buffered (cap 1) `reconcileCh` and a `triggerReconcile` helper.
- `startChannelListeners` fires `triggerReconcile` once after subscribing.
- A new select case in the existing channel-listener loop consumes that signal and calls `processNewBlockAnnouncement`.
- `processNewBlockAnnouncement` is unchanged. It already handles the cases we need:
  - Equal hash → early return (no-op on healthy startup; one extra `GetBestBlockHeader` RPC).
  - `chainTip.HashPrevBlock != BA tip` → reorg path → `getReorgBlocks` finds common ancestor and replays missing blocks via `subtreeProcessor.Reorg(moveBack=[], moveForward=[gap])`.
  - Sequential next block → `MoveForwardBlock`.

The signal goes through the same select that already serialises resets and live notifications, so no new concurrency surface. The channel is a generic recovery hook — if the heartbeat-drop bug is addressed via a server-side `RESYNC` sentinel later, that signal can route into the same channel.

## Out of scope

- `broadcastHeartbeat`'s silent drop on a full channel (`services/blockchain/Server.go:632`) is still latent but no longer causes a permanent stall, since restarts now self-heal.
- Legacy `CatchUpBlocks` FSM-state log spam from `services/legacy/netsync/manager.go:570-574`.

Both can ship as separate PRs.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./services/blockassembly/...` — clean
- [x] `go test -race -tags testtxmetacache ./services/blockassembly/` — 373 pass
- [x] `staticcheck ./services/blockassembly/...` — clean
- [x] `golangci-lint run ./services/blockassembly/...` — only pre-existing prealloc warnings
- [x] `TestTriggerReconcile` — verifies the helper is non-blocking and coalesces concurrent triggers
- [x] `TestStart_TriggersReconcileOnStartup` — uses an empty subscription channel so the only code path that can invoke `processNewBlockAnnouncement` is the new reconcile wiring; asserts `GetBestBlockHeader` is called after `Start`
- [ ] Manual: kill BA mid-sync on a testnet node, confirm BA tip converges to chain tip without operator intervention