### PR TITLE
docs(model): use SVNode/Bitcoin Protocol terminology in NBit comments

### DIFF
--- a/model/NBit.go
+++ b/model/NBit.go
@@ -56,7 +56,7 @@ func (b NBit) CloneBytes() []byte {
 
 // CalculateTarget from nBits returns the target as a big.Int.
 // Returns big.NewInt(0) for malformed nBits (negative-encoded or overflowing
-// 256 bits), matching Bitcoin Core's arith_uint256::SetCompact rejection
+// 256 bits), matching SVNode's arith_uint256::SetCompact rejection
 // criteria. A zero target makes any positive hash fail the PoW comparison
 // and contributes zero chainwork — the safe semantic for a malformed value.
 func (b NBit) CalculateTarget() *big.Int {
@@ -65,7 +65,7 @@ func (b NBit) CalculateTarget() *big.Int {
 	exponent := nb >> 24
 	mantissa := nb & 0x007FFFFF
 
-	// Reject malformed encodings. Bitcoin Core requires a non-zero mantissa
+	// Reject malformed encodings. The Bitcoin Protocol requires a non-zero mantissa
 	// for both negative and overflow flags — a zero mantissa just encodes
 	// the value zero, regardless of sign bit or exponent.
 	if mantissa != 0 {
@@ -98,11 +98,10 @@ func (b NBit) CalculateTarget() *big.Int {
 // CalculateDifficulty from nBits using the standard Bitcoin algorithm
 func (b NBit) CalculateDifficulty() *big.Float {
 	// This implementation follows the standard Bitcoin difficulty calculation
-	// as used in both Bitcoin Core and SV Node:
-	// https://github.com/bitcoin/bitcoin/blob/master/src/rpc/blockchain.cpp
+	// as used in SVNode:
 	// https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/rpc/blockchain.cpp
 	//
-	// The algorithm is identical in both implementations:
+	// The algorithm:
 	// double GetDifficulty(const CBlockIndex& blockindex) {
 	//     int nShift = (blockindex.nBits >> 24) & 0xff;
 	//     double dDiff = (double)0x0000ffff / (double)(blockindex.nBits & 0x00ffffff);

--- a/model/NBit_test.go
+++ b/model/NBit_test.go
@@ -71,7 +71,7 @@ func TestCalculateTarget_NegativeNBitsRejected(t *testing.T) {
 	})
 
 	t.Run("sign bit set with zero mantissa is just zero, not negative", func(t *testing.T) {
-		// 0x1d800000 — sign bit set but mantissa is zero. Bitcoin Core treats
+		// 0x1d800000 — sign bit set but mantissa is zero. The Bitcoin Protocol treats
 		// this as the value zero (fNegative requires nWord != 0). The end-state
 		// is a zero target either way, but we exercise the precondition here.
 		bits, err := NewNBitFromString("1d800000")
@@ -96,7 +96,7 @@ func TestCalculateTarget_NegativeNBitsRejected(t *testing.T) {
 }
 
 func TestCalculateTarget_OverflowRejected(t *testing.T) {
-	// Overflow rules per Bitcoin Core's arith_uint256::SetCompact:
+	// Overflow rules per SVNode's arith_uint256::SetCompact:
 	//   - exponent > 34            → any non-zero mantissa overflows 2^256
 	//   - mantissa > 0xff   && exp > 33
 	//   - mantissa > 0xffff && exp > 32
@@ -145,7 +145,7 @@ func TestBlock911636Difficulty(t *testing.T) {
 	// This test verifies the standard Bitcoin difficulty calculation
 	// Block 911636 has nBits value 0x180f9ff5
 	// Note: SVNode may report a different value (~35858832210.37) which appears
-	// to be incorrect based on the SV Node C++ source code analysis
+	// to be incorrect based on the SVNode C++ source code analysis
 
 	bits, err := NewNBitFromString("180f9ff5")
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestBlock911636Difficulty(t *testing.T) {
 	difficultyFloat, _ := difficulty.Float64()
 
 	// Expected difficulty using standard Bitcoin algorithm
-	// This matches what Bitcoin Core and SV Node C++ code produces
+	// This matches what SVNode C++ code produces
 	expectedDifficulty := 70368426346.669891357421875
 
 	t.Logf("nBits: 0x180f9ff5")

--- a/services/blockassembly/mining/mine_test.go
+++ b/services/blockassembly/mining/mine_test.go
@@ -22,7 +22,7 @@ func createTestMiningCandidate() *model.MiningCandidate {
 		Time:          uint32(time.Now().Unix()),
 		NBits:         []byte{0xff, 0xff, 0x7f, 0x20}, // Very easy difficulty for testing (nBits 0x207fffff, little-endian)
 		Height:        100,
-		CoinbaseValue: 5000000000, // 50 BTC in satoshis
+		CoinbaseValue: 5000000000, // 50 BSV in satoshis
 	}
 }
 


### PR DESCRIPTION
Follow-up to #779 to align the comments added in that PR with project terminology.

## Summary

- Replace `Bitcoin Core` with `SVNode` where the reference is to the C++ implementation (e.g. `arith_uint256::SetCompact`, `C++ code produces`).
- Replace `Bitcoin Core` with `Bitcoin Protocol` where the reference is to a protocol-level rule (mantissa requirements, treatment of `0x1d800000`).
- Drop the upstream BTC repo URL from `CalculateDifficulty`'s reference block; the SVNode URL stays as the canonical reference.
- Normalize the one remaining `SV Node` (two tokens) to `SVNode`.
- Replace `BTC` with `BSV` in the satoshi-unit comment in `mine_test.go`.

No code or test logic changes — comments only.

## Test plan

- [x] `go test -race ./model/...` passes
- [x] `go test -race ./services/blockassembly/mining/...` passes
- [x] `go vet ./model/... ./services/blockassembly/mining/...` clean
- [x] `grep -n "Bitcoin Core\|SV Node\|BTC\b"` on the three files returns nothing