### PR TITLE
[Add] semaphore for blocking aerospike queries

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -417,6 +417,33 @@ func (s *Store) GetSet() string {
 	return s.setName
 }
 
+// registerScanBudget declares a long-running scan service's expected max concurrent
+// connection use with the shared uaerospike client. When the cumulative budget across
+// services exceeds ConnectionQueueSize × pruner_connectionPoolWarningThreshold, a single
+// WARN is emitted with the per-service breakdown so an operator can see exactly which
+// configured concurrencies over-subscribe the pool.
+//
+// Re-registering the same service replaces the prior value, so it is safe to call from
+// scan-construction code that may run multiple times across a process lifetime.
+func (s *Store) registerScanBudget(service string, budget int) {
+	if s.client == nil {
+		return
+	}
+	threshold := s.settings.Pruner.ConnectionPoolWarningThreshold
+	report := s.client.RegisterConnectionBudget(service, budget, threshold)
+	if report.Exceeded {
+		s.logger.Warnf(
+			"Aerospike connection budget exceeded: %d/%d declared (%.1f%% of pool, threshold %.1f%%, recommended max %d). "+
+				"Breakdown by service: %v. "+
+				"Increase ConnectionQueueSize or reduce per-service concurrency to avoid pool starvation.",
+			report.TotalBudget, report.PoolSize,
+			float64(report.TotalBudget)/float64(report.PoolSize)*100,
+			report.Threshold*100,
+			report.Recommended, report.Breakdown,
+		)
+	}
+}
+
 func (s *Store) SetBlockHeight(blockHeight uint32) error {
 	if blockHeight == 0 {
 		return errors.NewInvalidArgumentError("block height cannot be zero")

--- a/stores/utxo/aerospike/consistency_scan.go
+++ b/stores/utxo/aerospike/consistency_scan.go
@@ -73,6 +73,10 @@ func launchConsistencyScan(store *Store, numPartitionQueries int, workerFunc fun
 	partitionsPerQuery := totalPartitions / numPartitionQueries
 	remainingPartitions := totalPartitions % numPartitionQueries
 
+	// Declare this scan's connection use so the shared client can sum across services
+	// and warn when configured concurrency over-subscribes the pool.
+	store.registerScanBudget("consistencyScan", numPartitionQueries)
+
 	workerCtx, cancel := context.WithCancel(context.Background())
 
 	it := &consistencyScanIterator{

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -399,6 +399,11 @@ func (s *Service) getConnectionQueueSize() int {
 // validateConnectionPoolSettings validates that pruner concurrency settings won't exceed
 // the Aerospike connection pool. If they would, automatically adjusts chunkGroupLimit
 // to prevent connection pool exhaustion and logs a WARNING.
+//
+// After auto-adjustment the (possibly reduced) pruner budget is registered with the
+// shared uaerospike client so other long-running query consumers (unmined iterator,
+// consistency scanner) can be summed against the pool and produce a single WARN log
+// when the total over-subscribes ConnectionQueueSize × ConnectionPoolWarningThreshold.
 func (s *Service) validateConnectionPoolSettings() {
 	// Get Aerospike ConnectionQueueSize from client
 	connectionQueueSize := s.getConnectionQueueSize()
@@ -425,12 +430,39 @@ func (s *Service) validateConnectionPoolSettings() {
 			s.chunkGroupLimit, adjusted,
 		)
 		s.chunkGroupLimit = adjusted
+		maxPrunerConnections = (numWorkers * s.chunkGroupLimit) + numWorkers
 	} else {
 		s.logger.Infof(
 			"Pruner connection pool validation passed. Max pruner connections: %d, "+
 				"ConnectionQueueSize: %d (%.1f%% utilization)",
 			maxPrunerConnections, connectionQueueSize,
 			float64(maxPrunerConnections)/float64(connectionQueueSize)*100,
+		)
+	}
+
+	s.registerConnectionBudget("pruner", maxPrunerConnections)
+}
+
+// registerConnectionBudget declares this service's expected max concurrent connection
+// use on the shared uaerospike client and logs a WARN if the cumulative budget across
+// all registered services exceeds ConnectionQueueSize × ConnectionPoolWarningThreshold.
+// The pruner's own auto-adjust above keeps the pruner under threshold in isolation;
+// this log fires when other services (unmined iterator, consistency scanner) push the
+// shared total over the line.
+func (s *Service) registerConnectionBudget(service string, budget int) {
+	if s.client == nil {
+		return
+	}
+	report := s.client.RegisterConnectionBudget(service, budget, s.connectionPoolWarningThreshold)
+	if report.Exceeded {
+		s.logger.Warnf(
+			"Aerospike connection budget exceeded: %d/%d declared (%.1f%% of pool, threshold %.1f%%, recommended max %d). "+
+				"Breakdown by service: %v. "+
+				"Increase ConnectionQueueSize or reduce per-service concurrency to avoid pool starvation.",
+			report.TotalBudget, report.PoolSize,
+			float64(report.TotalBudget)/float64(report.PoolSize)*100,
+			report.Threshold*100,
+			report.Recommended, report.Breakdown,
 		)
 	}
 }

--- a/stores/utxo/aerospike/pruner_provider.go
+++ b/stores/utxo/aerospike/pruner_provider.go
@@ -44,6 +44,12 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 		return prunerServiceInstance, prunerServiceError
 	}
 
+	// Enable the query semaphore on the shared Aerospike client so that
+	// long-running partition scans (QueryPartitions) are rate-limited and
+	// cannot monopolise the connection pool, starving point operations.
+	// Uses the default of 25% of ConnectionQueueSize.
+	s.client.EnableQuerySemaphore(0)
+
 	// Create options for the pruner service
 	opts := aeropruner.Options{
 		Logger:        s.logger,

--- a/stores/utxo/aerospike/pruner_provider.go
+++ b/stores/utxo/aerospike/pruner_provider.go
@@ -44,12 +44,6 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 		return prunerServiceInstance, prunerServiceError
 	}
 
-	// Enable the query semaphore on the shared Aerospike client so that
-	// long-running partition scans (QueryPartitions) are rate-limited and
-	// cannot monopolise the connection pool, starving point operations.
-	// Uses the default of 25% of ConnectionQueueSize.
-	s.client.EnableQuerySemaphore(0)
-
 	// Create options for the pruner service
 	opts := aeropruner.Options{
 		Logger:        s.logger,
@@ -62,12 +56,20 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 		LuaPackage:    LuaPackage,
 	}
 
-	// Create a new pruner service
+	// Create a new pruner service. NewService validates Options.Client, so we wait
+	// to activate the query semaphore until we know the pruner is actually viable.
 	prunerService, err := aeropruner.NewService(s.settings, opts)
 	if err != nil {
 		prunerServiceError = err
 		return nil, err
 	}
+
+	// Enable the query semaphore on the shared Aerospike client so that
+	// long-running partition scans (QueryPartitions) are rate-limited and
+	// cannot monopolise the connection pool, starving point operations.
+	// Uses the default of 25% of ConnectionQueueSize. Idempotent: safe to
+	// call again from other services that perform heavy scans.
+	s.client.EnableQuerySemaphore(0)
 
 	// Store the singleton instance
 	prunerServiceInstance = prunerService

--- a/stores/utxo/aerospike/pruner_provider.go
+++ b/stores/utxo/aerospike/pruner_provider.go
@@ -56,20 +56,12 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 		LuaPackage:    LuaPackage,
 	}
 
-	// Create a new pruner service. NewService validates Options.Client, so we wait
-	// to activate the query semaphore until we know the pruner is actually viable.
+	// Create a new pruner service.
 	prunerService, err := aeropruner.NewService(s.settings, opts)
 	if err != nil {
 		prunerServiceError = err
 		return nil, err
 	}
-
-	// Enable the query semaphore on the shared Aerospike client so that
-	// long-running partition scans (QueryPartitions) are rate-limited and
-	// cannot monopolise the connection pool, starving point operations.
-	// Uses the default of 25% of ConnectionQueueSize. Idempotent: safe to
-	// call again from other services that perform heavy scans.
-	s.client.EnableQuerySemaphore(0)
 
 	// Store the singleton instance
 	prunerServiceInstance = prunerService

--- a/stores/utxo/aerospike/unmined_iterator.go
+++ b/stores/utxo/aerospike/unmined_iterator.go
@@ -135,6 +135,10 @@ func launchPartitionIterator(store *Store, numPartitionQueries int, prunerMode b
 	partitionsPerQuery := totalPartitions / numPartitionQueries
 	remainingPartitions := totalPartitions % numPartitionQueries
 
+	// Declare this scan's connection use so the shared client can sum across services
+	// and warn when configured concurrency over-subscribes the pool.
+	store.registerScanBudget("unminedIterator", numPartitionQueries)
+
 	policy := util.GetAerospikeQueryPolicy(store.settings)
 	policy.IncludeBinData = true
 	policy.RecordQueueSize = 512

--- a/util/uaerospike/client.go
+++ b/util/uaerospike/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/aerospike/aerospike-client-go/v8"
@@ -30,6 +31,13 @@ const (
 
 	// minSemaphoreTimeout is the minimum timeout for semaphore acquisition
 	minSemaphoreTimeout = 100 * time.Millisecond
+
+	// queryActivePollInterval is how often the query-completion goroutine polls
+	// Recordset.IsActive() to detect when a streaming query has finished and the
+	// permit can be released. The interval is short enough that the permit is
+	// released promptly, but long enough that polling overhead is negligible
+	// compared to scan duration (typically minutes).
+	queryActivePollInterval = 100 * time.Millisecond
 )
 
 // getConnectionQueueSize returns the connection queue size from the given policy
@@ -46,6 +54,8 @@ type ClientStats struct {
 	stat             *gocore.Stat
 	operateStat      *gocore.Stat
 	batchOperateStat *gocore.Stat
+	queryStat        *gocore.Stat
+	queryWaitStat    *gocore.Stat
 }
 
 // NewClientStats creates a new ClientStats instance
@@ -55,6 +65,8 @@ func NewClientStats() *ClientStats {
 		stat:             stat,
 		operateStat:      stat.NewStat("Operate").AddRanges(0, 1, 100, 1_000, 10_000, 100_000),
 		batchOperateStat: stat.NewStat("BatchOperate").AddRanges(0, 1, 100, 1_000, 10_000, 100_000),
+		queryStat:        stat.NewStat("Query"),
+		queryWaitStat:    stat.NewStat("QuerySemaphoreWait"),
 	}
 }
 
@@ -64,15 +76,20 @@ func NewClientStats() *ClientStats {
 // It is always initialized and sized to ConnectionQueueSize.
 //
 // querySemaphore gates long-running streaming operations (Query, QueryPartitions).
-// It is nil by default -- queries pass through to the native client unbounded (same as
+// It is unset by default -- queries pass through to the native client unbounded (same as
 // previous behavior). Call EnableQuerySemaphore to activate it for services that perform
-// heavy scans (e.g. pruner, consistency scanner). When nil, the native connection pool
+// heavy scans (e.g. pruner, consistency scanner). When unset, the native connection pool
 // (LimitConnectionsToQueueSize) is the only concurrency limit for queries.
+//
+// querySemaphore is stored as an atomic.Pointer because EnableQuerySemaphore can be called
+// after the Client is shared across goroutines (e.g. from GetPrunerService). Atomic
+// publication ensures concurrent readers in QueryPartitions see a fully constructed channel
+// rather than a torn or nil value.
 type Client struct {
 	*aerospike.Client
-	connSemaphore  chan struct{} // Semaphore for short-lived operations (always set)
-	querySemaphore chan struct{} // Semaphore for long-running query/scan operations (nil until enabled)
-	stats          *ClientStats  // Always initialized, never nil
+	connSemaphore  chan struct{}                 // Semaphore for short-lived operations (always set)
+	querySemaphore atomic.Pointer[chan struct{}] // Semaphore for long-running query/scan operations (unset until EnableQuerySemaphore is called)
+	stats          *ClientStats                  // Always initialized, never nil
 }
 
 // NewClient creates a new Aerospike client with the specified hostname and port.
@@ -329,7 +346,11 @@ func (c *Client) Execute(policy *aerospike.WritePolicy, key *aerospike.Key, pack
 // connection pool and starving short-lived point operations.
 //
 // If maxConcurrentQueries is 0, a default of 25% of ConnectionQueueSize is used.
-// This method must be called before any queries are issued. It is not safe for concurrent use.
+//
+// EnableQuerySemaphore is idempotent: subsequent calls are ignored. This is intentional --
+// once a semaphore is in use, replacing the channel would orphan in-flight permits and could
+// allow more than the configured number of concurrent queries. The first caller wins.
+// It is safe to call concurrently with QueryPartitions/Query.
 func (c *Client) EnableQuerySemaphore(maxConcurrentQueries int) {
 	if maxConcurrentQueries <= 0 {
 		maxConcurrentQueries = int(float64(cap(c.connSemaphore)) * DefaultQuerySemaphoreFraction)
@@ -337,7 +358,23 @@ func (c *Client) EnableQuerySemaphore(maxConcurrentQueries int) {
 			maxConcurrentQueries = 1
 		}
 	}
-	c.querySemaphore = make(chan struct{}, maxConcurrentQueries)
+	sem := make(chan struct{}, maxConcurrentQueries)
+	// CompareAndSwap: only the first caller installs the channel. Concurrent or
+	// subsequent calls observe a non-nil pointer and fail the CAS, leaving the
+	// existing semaphore untouched.
+	c.querySemaphore.CompareAndSwap(nil, &sem)
+}
+
+// loadQuerySemaphore returns the current query semaphore channel, or nil if not enabled.
+// Callers should snapshot the returned channel and use that snapshot for both acquire and
+// release to avoid any chance of releasing into a different channel after a hypothetical
+// reconfiguration.
+func (c *Client) loadQuerySemaphore() chan struct{} {
+	p := c.querySemaphore.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 // QueryPartitions is a wrapper around aerospike.Client.QueryPartitions.
@@ -346,28 +383,34 @@ func (c *Client) EnableQuerySemaphore(maxConcurrentQueries int) {
 // streaming duration and released when the recordset finishes.
 // When the query semaphore is not enabled, calls pass through to the native client directly.
 func (c *Client) QueryPartitions(policy *aerospike.QueryPolicy, statement *aerospike.Statement, partitionFilter *aerospike.PartitionFilter) (*aerospike.Recordset, aerospike.Error) {
-	if c.querySemaphore == nil {
+	sem := c.loadQuerySemaphore()
+	if sem == nil {
 		// No query semaphore configured -- pass through to native client
 		return c.Client.QueryPartitions(policy, statement, partitionFilter)
 	}
 
-	if err := c.acquireQueryPermit(policy); err != nil {
+	waitStart := gocore.CurrentTime()
+	if err := acquireSemaphore(sem, extractTimeout(policy)); err != nil {
 		return nil, err
 	}
+	c.stats.queryWaitStat.AddTime(waitStart)
 
+	queryStart := gocore.CurrentTime()
 	rs, err := c.Client.QueryPartitions(policy, statement, partitionFilter)
 	if err != nil {
-		c.releaseQueryPermit()
+		<-sem
 		return nil, err
 	}
 
-	// Wrap the recordset so the semaphore is released when it completes.
-	// We drain Results() in a goroutine; the channel is closed by the native client
-	// when the query finishes or the recordset is closed by the caller.
+	// Release the permit when the recordset finishes streaming. We MUST NOT read
+	// from rs.Results() here -- it returns the same channel the caller iterates,
+	// and competing reads would silently steal records. Instead, poll IsActive(),
+	// which flips to false either when the native client's signalEnd fires (all
+	// goroutines done) or when the caller invokes Close().
 	go func() {
-		for range rs.Results() { //nolint:revive // intentionally draining to detect completion
-		}
-		c.releaseQueryPermit()
+		waitForRecordsetInactive(rs.IsActive, queryActivePollInterval)
+		<-sem
+		c.stats.queryStat.AddTime(queryStart)
 	}()
 
 	return rs, nil
@@ -380,6 +423,15 @@ func (c *Client) Query(policy *aerospike.QueryPolicy, statement *aerospike.State
 	return c.QueryPartitions(policy, statement, nil)
 }
 
+// waitForRecordsetInactive blocks until isActive returns false, polling at the given interval.
+// Used by the query-semaphore release goroutine to detect recordset completion without
+// competing with the caller for records on Recordset.Results().
+func waitForRecordsetInactive(isActive func() bool, pollInterval time.Duration) {
+	for isActive() {
+		time.Sleep(pollInterval)
+	}
+}
+
 // GetConnectionQueueSize returns the size of the connection semaphore.
 // This represents the maximum number of concurrent short-lived Aerospike operations allowed.
 func (c *Client) GetConnectionQueueSize() int {
@@ -388,10 +440,11 @@ func (c *Client) GetConnectionQueueSize() int {
 
 // GetQuerySemaphoreSize returns the size of the query semaphore, or 0 if not enabled.
 func (c *Client) GetQuerySemaphoreSize() int {
-	if c.querySemaphore == nil {
+	sem := c.loadQuerySemaphore()
+	if sem == nil {
 		return 0
 	}
-	return cap(c.querySemaphore)
+	return cap(sem)
 }
 
 // extractTimeout extracts the TotalTimeout from any Aerospike policy type.
@@ -463,18 +516,6 @@ func (c *Client) acquirePermit(policy any) aerospike.Error {
 // releasePermit releases a permit back to the connection semaphore.
 func (c *Client) releasePermit() {
 	<-c.connSemaphore
-}
-
-// acquireQueryPermit attempts to acquire a permit from the query semaphore.
-// Callers must check that c.querySemaphore != nil before calling.
-func (c *Client) acquireQueryPermit(policy any) aerospike.Error {
-	return acquireSemaphore(c.querySemaphore, extractTimeout(policy))
-}
-
-// releaseQueryPermit releases a permit back to the query semaphore.
-// Callers must check that c.querySemaphore != nil before calling.
-func (c *Client) releaseQueryPermit() {
-	<-c.querySemaphore
 }
 
 // CalculateKeySource generates a key source based on the transaction hash, vout, and batch size.

--- a/util/uaerospike/client.go
+++ b/util/uaerospike/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"sort"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/aerospike/aerospike-client-go/v8"
@@ -18,26 +18,12 @@ const (
 	// if not specified in the client policy
 	DefaultConnectionQueueSize = 128
 
-	// DefaultQuerySemaphoreFraction is the default fraction of ConnectionQueueSize to use
-	// for the query semaphore when EnableQuerySemaphore is called without an explicit size.
-	// Long-running operations (Query, QueryPartitions) hold connections for the entire
-	// streaming duration (potentially minutes), so they get a smaller dedicated budget
-	// to prevent starving short-lived operations.
-	DefaultQuerySemaphoreFraction = 0.25 // 25% of pool for long-running ops
-
 	// semaphoreTimeoutFraction is the fraction of TotalTimeout to use for semaphore acquisition
 	// This ensures the total operation time (semaphore wait + actual operation) stays within bounds
 	semaphoreTimeoutFraction = 0.1 // 10% of total timeout
 
 	// minSemaphoreTimeout is the minimum timeout for semaphore acquisition
 	minSemaphoreTimeout = 100 * time.Millisecond
-
-	// queryActivePollInterval is how often the query-completion goroutine polls
-	// Recordset.IsActive() to detect when a streaming query has finished and the
-	// permit can be released. The interval is short enough that the permit is
-	// released promptly, but long enough that polling overhead is negligible
-	// compared to scan duration (typically minutes).
-	queryActivePollInterval = 100 * time.Millisecond
 )
 
 // getConnectionQueueSize returns the connection queue size from the given policy
@@ -54,8 +40,6 @@ type ClientStats struct {
 	stat             *gocore.Stat
 	operateStat      *gocore.Stat
 	batchOperateStat *gocore.Stat
-	queryStat        *gocore.Stat
-	queryWaitStat    *gocore.Stat
 }
 
 // NewClientStats creates a new ClientStats instance
@@ -65,31 +49,37 @@ func NewClientStats() *ClientStats {
 		stat:             stat,
 		operateStat:      stat.NewStat("Operate").AddRanges(0, 1, 100, 1_000, 10_000, 100_000),
 		batchOperateStat: stat.NewStat("BatchOperate").AddRanges(0, 1, 100, 1_000, 10_000, 100_000),
-		queryStat:        stat.NewStat("Query"),
-		queryWaitStat:    stat.NewStat("QuerySemaphoreWait"),
 	}
 }
 
-// Client is a wrapper around aerospike.Client that provides semaphores to limit concurrent connections.
+// ConnectionBudgetReport summarises declared connection use across services so
+// operators can see when configured concurrency over-subscribes the pool.
 //
-// connSemaphore gates short-lived point operations (Get, Put, Delete, Operate, BatchOperate, Execute).
-// It is always initialized and sized to ConnectionQueueSize.
-//
-// querySemaphore gates long-running streaming operations (Query, QueryPartitions).
-// It is unset by default -- queries pass through to the native client unbounded (same as
-// previous behavior). Call EnableQuerySemaphore to activate it for services that perform
-// heavy scans (e.g. pruner, consistency scanner). When unset, the native connection pool
-// (LimitConnectionsToQueueSize) is the only concurrency limit for queries.
-//
-// querySemaphore is stored as an atomic.Pointer because EnableQuerySemaphore can be called
-// after the Client is shared across goroutines (e.g. from GetPrunerService). Atomic
-// publication ensures concurrent readers in QueryPartitions see a fully constructed channel
-// rather than a torn or nil value.
+// Recommended is computed as int(PoolSize * Threshold). Exceeded is true when
+// TotalBudget > Recommended. The breakdown is a snapshot of all currently
+// registered service budgets, safe to read or mutate by the caller.
+type ConnectionBudgetReport struct {
+	TotalBudget int
+	PoolSize    int
+	Threshold   float64
+	Recommended int
+	Exceeded    bool
+	Breakdown   map[string]int
+}
+
+// Client is a wrapper around aerospike.Client that limits concurrent connections
+// via a single connSemaphore sized to ConnectionQueueSize and exposes a
+// connection-budget registry so each long-running query consumer can declare
+// its max concurrent use. The registry is diagnostic only -- it does not
+// throttle; it lets operators see when configured concurrency would
+// over-subscribe the pool (see RegisterConnectionBudget).
 type Client struct {
 	*aerospike.Client
-	connSemaphore  chan struct{}                 // Semaphore for short-lived operations (always set)
-	querySemaphore atomic.Pointer[chan struct{}] // Semaphore for long-running query/scan operations (unset until EnableQuerySemaphore is called)
-	stats          *ClientStats                  // Always initialized, never nil
+	connSemaphore chan struct{}
+	stats         *ClientStats
+
+	budgetMu sync.Mutex
+	budgets  map[string]int
 }
 
 // NewClient creates a new Aerospike client with the specified hostname and port.
@@ -107,6 +97,7 @@ func NewClient(hostname string, port int) (*Client, error) {
 		Client:        client,
 		connSemaphore: make(chan struct{}, queueSize),
 		stats:         NewClientStats(),
+		budgets:       make(map[string]int),
 	}, nil
 }
 
@@ -166,6 +157,7 @@ func NewClientWithPolicyAndHost(policy *aerospike.ClientPolicy, hosts ...*aerosp
 		Client:        client,
 		connSemaphore: make(chan struct{}, queueSize),
 		stats:         NewClientStats(),
+		budgets:       make(map[string]int),
 	}, nil
 }
 
@@ -340,111 +332,65 @@ func (c *Client) Execute(policy *aerospike.WritePolicy, key *aerospike.Key, pack
 	return c.Client.Execute(policy, key, packageName, functionName, args...)
 }
 
-// EnableQuerySemaphore activates the query semaphore with the given max concurrent queries.
-// This should be called by services that perform long-running scans (pruner, block-assembly
-// unmined iterator, consistency scanner) to prevent streaming queries from monopolising the
-// connection pool and starving short-lived point operations.
+// RegisterConnectionBudget records a service's expected max concurrent connection
+// use and returns a report covering all currently registered services. The
+// registry is diagnostic only: callers use the returned report to emit an
+// operator-facing log when Exceeded is true. It does not throttle.
 //
-// If maxConcurrentQueries is 0, a default of 25% of ConnectionQueueSize is used.
+// Re-registering the same service replaces the prior value (use this when a
+// service's worker count is re-computed). Passing a budget of 0 removes the
+// service from the breakdown.
 //
-// EnableQuerySemaphore is idempotent: subsequent calls are ignored. This is intentional --
-// once a semaphore is in use, replacing the channel would orphan in-flight permits and could
-// allow more than the configured number of concurrent queries. The first caller wins.
-// It is safe to call concurrently with QueryPartitions/Query.
-func (c *Client) EnableQuerySemaphore(maxConcurrentQueries int) {
-	if maxConcurrentQueries <= 0 {
-		maxConcurrentQueries = int(float64(cap(c.connSemaphore)) * DefaultQuerySemaphoreFraction)
-		if maxConcurrentQueries < 1 {
-			maxConcurrentQueries = 1
-		}
+// Concurrent calls from different services are safe. The threshold parameter
+// is applied to the returned report only; it is not persisted.
+func (c *Client) RegisterConnectionBudget(service string, budget int, threshold float64) ConnectionBudgetReport {
+	c.budgetMu.Lock()
+	defer c.budgetMu.Unlock()
+
+	if c.budgets == nil {
+		c.budgets = make(map[string]int)
 	}
-	sem := make(chan struct{}, maxConcurrentQueries)
-	// CompareAndSwap: only the first caller installs the channel. Concurrent or
-	// subsequent calls observe a non-nil pointer and fail the CAS, leaving the
-	// existing semaphore untouched.
-	c.querySemaphore.CompareAndSwap(nil, &sem)
+	if budget <= 0 {
+		delete(c.budgets, service)
+	} else {
+		c.budgets[service] = budget
+	}
+
+	return c.connectionBudgetReportLocked(threshold)
 }
 
-// loadQuerySemaphore returns the current query semaphore channel, or nil if not enabled.
-// Callers should snapshot the returned channel and use that snapshot for both acquire and
-// release to avoid any chance of releasing into a different channel after a hypothetical
-// reconfiguration.
-func (c *Client) loadQuerySemaphore() chan struct{} {
-	p := c.querySemaphore.Load()
-	if p == nil {
-		return nil
-	}
-	return *p
+// ConnectionBudget returns the current cumulative report without changing any
+// registration. Use this for periodic diagnostics or in tests.
+func (c *Client) ConnectionBudget(threshold float64) ConnectionBudgetReport {
+	c.budgetMu.Lock()
+	defer c.budgetMu.Unlock()
+	return c.connectionBudgetReportLocked(threshold)
 }
 
-// QueryPartitions is a wrapper around aerospike.Client.QueryPartitions.
-// When the query semaphore is enabled (via EnableQuerySemaphore), it limits the number of
-// concurrent long-running streaming operations. The semaphore slot is held for the entire
-// streaming duration and released when the recordset finishes.
-// When the query semaphore is not enabled, calls pass through to the native client directly.
-func (c *Client) QueryPartitions(policy *aerospike.QueryPolicy, statement *aerospike.Statement, partitionFilter *aerospike.PartitionFilter) (*aerospike.Recordset, aerospike.Error) {
-	sem := c.loadQuerySemaphore()
-	if sem == nil {
-		// No query semaphore configured -- pass through to native client
-		return c.Client.QueryPartitions(policy, statement, partitionFilter)
+func (c *Client) connectionBudgetReportLocked(threshold float64) ConnectionBudgetReport {
+	poolSize := cap(c.connSemaphore)
+	total := 0
+	breakdown := make(map[string]int, len(c.budgets))
+	for k, v := range c.budgets {
+		total += v
+		breakdown[k] = v
 	}
 
-	waitStart := gocore.CurrentTime()
-	if err := acquireSemaphore(sem, extractTimeout(policy)); err != nil {
-		return nil, err
-	}
-	c.stats.queryWaitStat.AddTime(waitStart)
-
-	queryStart := gocore.CurrentTime()
-	rs, err := c.Client.QueryPartitions(policy, statement, partitionFilter)
-	if err != nil {
-		<-sem
-		return nil, err
-	}
-
-	// Release the permit when the recordset finishes streaming. We MUST NOT read
-	// from rs.Results() here -- it returns the same channel the caller iterates,
-	// and competing reads would silently steal records. Instead, poll IsActive(),
-	// which flips to false either when the native client's signalEnd fires (all
-	// goroutines done) or when the caller invokes Close().
-	go func() {
-		waitForRecordsetInactive(rs.IsActive, queryActivePollInterval)
-		<-sem
-		c.stats.queryStat.AddTime(queryStart)
-	}()
-
-	return rs, nil
-}
-
-// Query is a wrapper around aerospike.Client.Query.
-// When the query semaphore is enabled, it limits concurrent streaming operations.
-// Otherwise, calls pass through to the native client directly.
-func (c *Client) Query(policy *aerospike.QueryPolicy, statement *aerospike.Statement) (*aerospike.Recordset, aerospike.Error) {
-	return c.QueryPartitions(policy, statement, nil)
-}
-
-// waitForRecordsetInactive blocks until isActive returns false, polling at the given interval.
-// Used by the query-semaphore release goroutine to detect recordset completion without
-// competing with the caller for records on Recordset.Results().
-func waitForRecordsetInactive(isActive func() bool, pollInterval time.Duration) {
-	for isActive() {
-		time.Sleep(pollInterval)
+	recommended := int(float64(poolSize) * threshold)
+	return ConnectionBudgetReport{
+		TotalBudget: total,
+		PoolSize:    poolSize,
+		Threshold:   threshold,
+		Recommended: recommended,
+		Exceeded:    total > recommended,
+		Breakdown:   breakdown,
 	}
 }
 
 // GetConnectionQueueSize returns the size of the connection semaphore.
-// This represents the maximum number of concurrent short-lived Aerospike operations allowed.
+// This represents the maximum number of concurrent Aerospike operations allowed.
 func (c *Client) GetConnectionQueueSize() int {
 	return cap(c.connSemaphore)
-}
-
-// GetQuerySemaphoreSize returns the size of the query semaphore, or 0 if not enabled.
-func (c *Client) GetQuerySemaphoreSize() int {
-	sem := c.loadQuerySemaphore()
-	if sem == nil {
-		return 0
-	}
-	return cap(sem)
 }
 
 // extractTimeout extracts the TotalTimeout from any Aerospike policy type.

--- a/util/uaerospike/client.go
+++ b/util/uaerospike/client.go
@@ -17,6 +17,13 @@ const (
 	// if not specified in the client policy
 	DefaultConnectionQueueSize = 128
 
+	// DefaultQuerySemaphoreFraction is the default fraction of ConnectionQueueSize to use
+	// for the query semaphore when EnableQuerySemaphore is called without an explicit size.
+	// Long-running operations (Query, QueryPartitions) hold connections for the entire
+	// streaming duration (potentially minutes), so they get a smaller dedicated budget
+	// to prevent starving short-lived operations.
+	DefaultQuerySemaphoreFraction = 0.25 // 25% of pool for long-running ops
+
 	// semaphoreTimeoutFraction is the fraction of TotalTimeout to use for semaphore acquisition
 	// This ensures the total operation time (semaphore wait + actual operation) stays within bounds
 	semaphoreTimeoutFraction = 0.1 // 10% of total timeout
@@ -51,11 +58,21 @@ func NewClientStats() *ClientStats {
 	}
 }
 
-// Client is a wrapper around aerospike.Client that provides a semaphore to limit concurrent connections.
+// Client is a wrapper around aerospike.Client that provides semaphores to limit concurrent connections.
+//
+// connSemaphore gates short-lived point operations (Get, Put, Delete, Operate, BatchOperate, Execute).
+// It is always initialized and sized to ConnectionQueueSize.
+//
+// querySemaphore gates long-running streaming operations (Query, QueryPartitions).
+// It is nil by default -- queries pass through to the native client unbounded (same as
+// previous behavior). Call EnableQuerySemaphore to activate it for services that perform
+// heavy scans (e.g. pruner, consistency scanner). When nil, the native connection pool
+// (LimitConnectionsToQueueSize) is the only concurrency limit for queries.
 type Client struct {
 	*aerospike.Client
-	connSemaphore chan struct{} // Simple channel-based semaphore
-	stats         *ClientStats  // Always initialized, never nil
+	connSemaphore  chan struct{} // Semaphore for short-lived operations (always set)
+	querySemaphore chan struct{} // Semaphore for long-running query/scan operations (nil until enabled)
+	stats          *ClientStats  // Always initialized, never nil
 }
 
 // NewClient creates a new Aerospike client with the specified hostname and port.
@@ -290,49 +307,131 @@ func (c *Client) BatchOperate(policy *aerospike.BatchPolicy, records []aerospike
 	return c.Client.BatchOperate(policy, records)
 }
 
+// Execute is a wrapper around aerospike.Client.Execute that uses the connection semaphore
+// to limit concurrent connections. Execute runs a server-side UDF on a single key.
+func (c *Client) Execute(policy *aerospike.WritePolicy, key *aerospike.Key, packageName string, functionName string, args ...aerospike.Value) (any, aerospike.Error) {
+	if err := c.acquirePermit(policy); err != nil {
+		return nil, err
+	}
+	defer c.releasePermit()
+
+	start := gocore.CurrentTime()
+	defer func() {
+		c.stats.stat.NewStat("Execute").AddTime(start)
+	}()
+
+	return c.Client.Execute(policy, key, packageName, functionName, args...)
+}
+
+// EnableQuerySemaphore activates the query semaphore with the given max concurrent queries.
+// This should be called by services that perform long-running scans (pruner, block-assembly
+// unmined iterator, consistency scanner) to prevent streaming queries from monopolising the
+// connection pool and starving short-lived point operations.
+//
+// If maxConcurrentQueries is 0, a default of 25% of ConnectionQueueSize is used.
+// This method must be called before any queries are issued. It is not safe for concurrent use.
+func (c *Client) EnableQuerySemaphore(maxConcurrentQueries int) {
+	if maxConcurrentQueries <= 0 {
+		maxConcurrentQueries = int(float64(cap(c.connSemaphore)) * DefaultQuerySemaphoreFraction)
+		if maxConcurrentQueries < 1 {
+			maxConcurrentQueries = 1
+		}
+	}
+	c.querySemaphore = make(chan struct{}, maxConcurrentQueries)
+}
+
+// QueryPartitions is a wrapper around aerospike.Client.QueryPartitions.
+// When the query semaphore is enabled (via EnableQuerySemaphore), it limits the number of
+// concurrent long-running streaming operations. The semaphore slot is held for the entire
+// streaming duration and released when the recordset finishes.
+// When the query semaphore is not enabled, calls pass through to the native client directly.
+func (c *Client) QueryPartitions(policy *aerospike.QueryPolicy, statement *aerospike.Statement, partitionFilter *aerospike.PartitionFilter) (*aerospike.Recordset, aerospike.Error) {
+	if c.querySemaphore == nil {
+		// No query semaphore configured -- pass through to native client
+		return c.Client.QueryPartitions(policy, statement, partitionFilter)
+	}
+
+	if err := c.acquireQueryPermit(policy); err != nil {
+		return nil, err
+	}
+
+	rs, err := c.Client.QueryPartitions(policy, statement, partitionFilter)
+	if err != nil {
+		c.releaseQueryPermit()
+		return nil, err
+	}
+
+	// Wrap the recordset so the semaphore is released when it completes.
+	// We drain Results() in a goroutine; the channel is closed by the native client
+	// when the query finishes or the recordset is closed by the caller.
+	go func() {
+		for range rs.Results() { //nolint:revive // intentionally draining to detect completion
+		}
+		c.releaseQueryPermit()
+	}()
+
+	return rs, nil
+}
+
+// Query is a wrapper around aerospike.Client.Query.
+// When the query semaphore is enabled, it limits concurrent streaming operations.
+// Otherwise, calls pass through to the native client directly.
+func (c *Client) Query(policy *aerospike.QueryPolicy, statement *aerospike.Statement) (*aerospike.Recordset, aerospike.Error) {
+	return c.QueryPartitions(policy, statement, nil)
+}
+
 // GetConnectionQueueSize returns the size of the connection semaphore.
-// This represents the maximum number of concurrent Aerospike operations allowed.
+// This represents the maximum number of concurrent short-lived Aerospike operations allowed.
 func (c *Client) GetConnectionQueueSize() int {
 	return cap(c.connSemaphore)
 }
 
-// acquirePermit attempts to acquire a permit from the connection semaphore with an optional timeout.
-// The policy parameter can be nil, in which case no timeout is used (blocks until available).
-// If the policy has a TotalTimeout > 0, a fraction of that timeout (semaphoreTimeoutFraction)
-// is used for permit acquisition to ensure the total operation time stays within bounds.
-// Returns an error if the timeout expires before a permit becomes available.
-//
-// Accepts any Aerospike policy type (BasePolicy, WritePolicy, BatchPolicy) as they all
-// embed BasePolicy which contains TotalTimeout.
-func (c *Client) acquirePermit(policy any) aerospike.Error {
-	totalTimeout := time.Duration(0)
+// GetQuerySemaphoreSize returns the size of the query semaphore, or 0 if not enabled.
+func (c *Client) GetQuerySemaphoreSize() int {
+	if c.querySemaphore == nil {
+		return 0
+	}
+	return cap(c.querySemaphore)
+}
 
-	// Extract timeout from policy if available
-	if policy != nil {
-		switch p := policy.(type) {
-		case *aerospike.BasePolicy:
-			if p != nil && p.TotalTimeout > 0 {
-				totalTimeout = p.TotalTimeout
-			}
-		case *aerospike.WritePolicy:
-			if p != nil && p.TotalTimeout > 0 {
-				totalTimeout = p.TotalTimeout
-			}
-		case *aerospike.BatchPolicy:
-			if p != nil && p.TotalTimeout > 0 {
-				totalTimeout = p.TotalTimeout
-			}
+// extractTimeout extracts the TotalTimeout from any Aerospike policy type.
+// Returns 0 if the policy is nil or does not have a TotalTimeout set.
+func extractTimeout(policy any) time.Duration {
+	if policy == nil {
+		return 0
+	}
+	switch p := policy.(type) {
+	case *aerospike.BasePolicy:
+		if p != nil && p.TotalTimeout > 0 {
+			return p.TotalTimeout
+		}
+	case *aerospike.WritePolicy:
+		if p != nil && p.TotalTimeout > 0 {
+			return p.TotalTimeout
+		}
+	case *aerospike.BatchPolicy:
+		if p != nil && p.TotalTimeout > 0 {
+			return p.TotalTimeout
+		}
+	case *aerospike.QueryPolicy:
+		if p != nil && p.TotalTimeout > 0 {
+			return p.TotalTimeout
 		}
 	}
+	return 0
+}
 
+// acquireSemaphore attempts to acquire a permit from the given semaphore with an optional timeout.
+// If totalTimeout > 0, a fraction of that timeout (semaphoreTimeoutFraction) is used for
+// acquisition to ensure the total operation time stays within bounds.
+func acquireSemaphore(sem chan struct{}, totalTimeout time.Duration) aerospike.Error {
 	if totalTimeout <= 0 {
 		// No timeout - block until available
-		c.connSemaphore <- struct{}{}
+		sem <- struct{}{}
 		return nil
 	}
 
 	// Calculate semaphore timeout as a fraction of total timeout
-	// This ensures total operation time (semaphore wait + actual operation) stays within bounds
 	semaphoreTimeout := time.Duration(float64(totalTimeout) * semaphoreTimeoutFraction)
 	if semaphoreTimeout < minSemaphoreTimeout {
 		semaphoreTimeout = minSemaphoreTimeout
@@ -342,16 +441,40 @@ func (c *Client) acquirePermit(policy any) aerospike.Error {
 	defer timer.Stop()
 
 	select {
-	case c.connSemaphore <- struct{}{}:
+	case sem <- struct{}{}:
 		return nil
 	case <-timer.C:
 		return aerospike.ErrTimeout
 	}
 }
 
+// acquirePermit attempts to acquire a permit from the connection semaphore with an optional timeout.
+// The policy parameter can be nil, in which case no timeout is used (blocks until available).
+// If the policy has a TotalTimeout > 0, a fraction of that timeout (semaphoreTimeoutFraction)
+// is used for permit acquisition to ensure the total operation time stays within bounds.
+// Returns an error if the timeout expires before a permit becomes available.
+//
+// Accepts any Aerospike policy type (BasePolicy, WritePolicy, BatchPolicy, QueryPolicy) as they all
+// embed BasePolicy which contains TotalTimeout.
+func (c *Client) acquirePermit(policy any) aerospike.Error {
+	return acquireSemaphore(c.connSemaphore, extractTimeout(policy))
+}
+
 // releasePermit releases a permit back to the connection semaphore.
 func (c *Client) releasePermit() {
 	<-c.connSemaphore
+}
+
+// acquireQueryPermit attempts to acquire a permit from the query semaphore.
+// Callers must check that c.querySemaphore != nil before calling.
+func (c *Client) acquireQueryPermit(policy any) aerospike.Error {
+	return acquireSemaphore(c.querySemaphore, extractTimeout(policy))
+}
+
+// releaseQueryPermit releases a permit back to the query semaphore.
+// Callers must check that c.querySemaphore != nil before calling.
+func (c *Client) releaseQueryPermit() {
+	<-c.querySemaphore
 }
 
 // CalculateKeySource generates a key source based on the transaction hash, vout, and batch size.

--- a/util/uaerospike/client_test.go
+++ b/util/uaerospike/client_test.go
@@ -537,6 +537,118 @@ func TestClient_AcquirePermitTimeout(t *testing.T) {
 	})
 }
 
+func TestEnableQuerySemaphore(t *testing.T) {
+	t.Run("default size is 25% of conn pool", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 128),
+			stats:         NewClientStats(),
+		}
+		assert.Equal(t, 0, client.GetQuerySemaphoreSize())
+
+		client.EnableQuerySemaphore(0)                      // 0 means use default fraction
+		assert.Equal(t, 32, client.GetQuerySemaphoreSize()) // 25% of 128
+	})
+
+	t.Run("explicit size", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 256),
+			stats:         NewClientStats(),
+		}
+		client.EnableQuerySemaphore(16)
+		assert.Equal(t, 16, client.GetQuerySemaphoreSize())
+	})
+
+	t.Run("conn semaphore unchanged", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 256),
+			stats:         NewClientStats(),
+		}
+		client.EnableQuerySemaphore(8)
+		assert.Equal(t, 256, client.GetConnectionQueueSize()) // unchanged
+		assert.Equal(t, 8, client.GetQuerySemaphoreSize())
+	})
+
+	t.Run("small pool gets minimum 1", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 2),
+			stats:         NewClientStats(),
+		}
+		client.EnableQuerySemaphore(0)
+		assert.Equal(t, 1, client.GetQuerySemaphoreSize())
+	})
+}
+
+func TestExtractTimeout(t *testing.T) {
+	t.Run("nil policy", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), extractTimeout(nil))
+	})
+
+	t.Run("BasePolicy with timeout", func(t *testing.T) {
+		p := &aerospike.BasePolicy{TotalTimeout: 5 * time.Second}
+		assert.Equal(t, 5*time.Second, extractTimeout(p))
+	})
+
+	t.Run("WritePolicy with timeout", func(t *testing.T) {
+		p := aerospike.NewWritePolicy(0, 0)
+		p.TotalTimeout = 3 * time.Second
+		assert.Equal(t, 3*time.Second, extractTimeout(p))
+	})
+
+	t.Run("BatchPolicy with timeout", func(t *testing.T) {
+		p := aerospike.NewBatchPolicy()
+		p.TotalTimeout = 2 * time.Second
+		assert.Equal(t, 2*time.Second, extractTimeout(p))
+	})
+
+	t.Run("QueryPolicy with timeout", func(t *testing.T) {
+		p := aerospike.NewQueryPolicy()
+		p.TotalTimeout = 10 * time.Second
+		assert.Equal(t, 10*time.Second, extractTimeout(p))
+	})
+
+	t.Run("unknown policy type", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), extractTimeout("not-a-policy"))
+	})
+}
+
+func TestClient_QuerySemaphoreTimeout(t *testing.T) {
+	t.Run("query semaphore timeout with QueryPolicy", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 1),
+			stats:         NewClientStats(),
+		}
+		client.EnableQuerySemaphore(1)
+
+		// Fill the query semaphore
+		client.querySemaphore <- struct{}{}
+
+		policy := aerospike.NewQueryPolicy()
+		policy.TotalTimeout = 1000 * time.Millisecond
+
+		start := time.Now()
+		err := client.acquireQueryPermit(policy)
+		elapsed := time.Since(start)
+
+		assert.Error(t, err)
+		assert.True(t, elapsed >= minSemaphoreTimeout && elapsed < 200*time.Millisecond,
+			"Expected timeout around %v, got %v", minSemaphoreTimeout, elapsed)
+	})
+}
+
+func TestGetConnectionQueueSize_OnlyConnSemaphore(t *testing.T) {
+	client := &Client{
+		connSemaphore: make(chan struct{}, 128),
+		stats:         NewClientStats(),
+	}
+	assert.Equal(t, 128, client.GetConnectionQueueSize())
+	assert.Equal(t, 0, client.GetQuerySemaphoreSize())
+
+	// After enabling query semaphore, conn size is unchanged
+	client.EnableQuerySemaphore(16)
+	assert.Equal(t, 128, client.GetConnectionQueueSize())
+	assert.Equal(t, 16, client.GetQuerySemaphoreSize())
+}
+
 // Test mock functionality separately
 func TestMockAerospikeClient_CompleteCoverage(t *testing.T) {
 	t.Run("mock client functionality", func(t *testing.T) {

--- a/util/uaerospike/client_test.go
+++ b/util/uaerospike/client_test.go
@@ -1,6 +1,8 @@
 package uaerospike
 
 import (
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -828,6 +830,154 @@ func asErr(e aerospike.Error) error {
 	}
 	return e
 }
+
+// TestQuerySemaphore_ConcurrentQueryLimit verifies the core contract of the
+// query semaphore: when N permits are held, an (N+1)th acquirer blocks until
+// one of the in-flight permits is released. This is the behaviour the whole
+// feature exists for -- preventing more than N concurrent long-running scans.
+func TestQuerySemaphore_ConcurrentQueryLimit(t *testing.T) {
+	const limit = 3
+
+	client := &Client{
+		connSemaphore: make(chan struct{}, 16),
+		stats:         NewClientStats(),
+	}
+	client.EnableQuerySemaphore(limit)
+	sem := client.loadQuerySemaphore()
+	require.NotNil(t, sem)
+
+	// Hold all `limit` permits.
+	for i := 0; i < limit; i++ {
+		require.NoError(t, asErr(acquireSemaphore(sem, 0)))
+	}
+
+	// An (N+1)th acquire with timeout must fail because all permits are held.
+	start := time.Now()
+	err := acquireSemaphore(sem, 200*time.Millisecond)
+	require.Error(t, asErr(err))
+	require.GreaterOrEqual(t, time.Since(start), minSemaphoreTimeout)
+
+	// Now release one permit and confirm a new acquire succeeds promptly.
+	released := make(chan struct{})
+	go func() {
+		// Block briefly so the waiter below is parked on the channel before
+		// the slot is freed -- this exercises the wakeup path, not just a
+		// fast-path acquire on a free slot.
+		time.Sleep(20 * time.Millisecond)
+		<-sem
+		close(released)
+	}()
+
+	acquired := make(chan struct{})
+	go func() {
+		require.NoError(t, asErr(acquireSemaphore(sem, 500*time.Millisecond)))
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(1 * time.Second):
+		t.Fatal("acquire did not unblock after a permit was released")
+	}
+	<-released
+
+	// Drain remaining permits to leave the semaphore clean.
+	<-sem
+	<-sem
+	<-sem
+}
+
+// TestQuerySemaphore_GoroutineCleanup verifies that the release goroutine used
+// by QueryPartitions does not leak: after it observes IsActive()==false and
+// releases the permit, the goroutine count returns to baseline.
+//
+// We can't directly invoke QueryPartitions in a unit test because
+// *aerospike.Recordset has no public constructor, so we exercise the same
+// goroutine pattern the wrapper uses: spawn a release goroutine that polls a
+// stand-in IsActive function, then flip it to false and wait for cleanup.
+func TestQuerySemaphore_GoroutineCleanup(t *testing.T) {
+	client := &Client{
+		connSemaphore: make(chan struct{}, 8),
+		stats:         NewClientStats(),
+	}
+	client.EnableQuerySemaphore(2)
+	sem := client.loadQuerySemaphore()
+	require.NotNil(t, sem)
+
+	const cycles = 20
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < cycles; i++ {
+		require.NoError(t, asErr(acquireSemaphore(sem, 0)))
+
+		var active atomic.Bool
+		active.Store(true)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			waitForRecordsetInactive(active.Load, 5*time.Millisecond)
+			<-sem
+			client.stats.queryStat.AddTime(time.Now())
+		}()
+
+		// Simulate the recordset finishing.
+		active.Store(false)
+		wg.Wait()
+	}
+
+	// Give the runtime a moment to schedule any tail-end work, then assert
+	// goroutine count has returned to baseline (within a small tolerance for
+	// runtime workers that may cycle independently).
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		current := runtime.NumGoroutine()
+		if current <= baseline+1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine leak after %d cycles: baseline=%d current=%d", cycles, baseline, current)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Semaphore must be empty -- if any cycle leaked a permit, the channel
+	// length would be non-zero here.
+	assert.Empty(t, sem, "permit leaked: query semaphore should be empty after all cycles")
+}
+
+// TestQuerySemaphore_RepeatedAcquireRelease verifies that the semaphore can be
+// driven through many acquire/release cycles without drift. A subtle off-by-one
+// in the release path (e.g. releasing the wrong channel after a hypothetical
+// reconfiguration, or double-release) would surface as a permit count that
+// disagrees with the channel buffer.
+func TestQuerySemaphore_RepeatedAcquireRelease(t *testing.T) {
+	client := &Client{
+		connSemaphore: make(chan struct{}, 16),
+		stats:         NewClientStats(),
+	}
+	client.EnableQuerySemaphore(4)
+	sem := client.loadQuerySemaphore()
+	require.NotNil(t, sem)
+
+	const iterations = 1_000
+	for i := 0; i < iterations; i++ {
+		require.NoError(t, asErr(acquireSemaphore(sem, 0)))
+		<-sem
+	}
+
+	assert.Empty(t, sem, "permit drift after %d cycles", iterations)
+	assert.Equal(t, 4, cap(sem), "capacity must not change across cycles")
+}
+
+// Note on integration coverage: the recordset-coupled scenarios -- early
+// termination via Close() before consuming, and full consumption to channel
+// close -- require an *aerospike.Recordset, which has no public constructor.
+// They belong in stores/utxo/aerospike/ alongside the existing TestContainers
+// integration tests (e.g. aerospike_test.go) where a real recordset is
+// available. The unit tests above cover the semaphore mechanics and the
+// release-goroutine lifecycle that those integration tests would exercise.
 
 // Test mock functionality separately
 func TestMockAerospikeClient_CompleteCoverage(t *testing.T) {

--- a/util/uaerospike/client_test.go
+++ b/util/uaerospike/client_test.go
@@ -1,6 +1,7 @@
 package uaerospike
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClient_Put(t *testing.T) {
@@ -619,14 +621,16 @@ func TestClient_QuerySemaphoreTimeout(t *testing.T) {
 		}
 		client.EnableQuerySemaphore(1)
 
-		// Fill the query semaphore
-		client.querySemaphore <- struct{}{}
+		// Fill the query semaphore via the public snapshot helper
+		sem := client.loadQuerySemaphore()
+		require.NotNil(t, sem)
+		sem <- struct{}{}
 
 		policy := aerospike.NewQueryPolicy()
 		policy.TotalTimeout = 1000 * time.Millisecond
 
 		start := time.Now()
-		err := client.acquireQueryPermit(policy)
+		err := acquireSemaphore(sem, extractTimeout(policy))
 		elapsed := time.Since(start)
 
 		assert.Error(t, err)
@@ -647,6 +651,182 @@ func TestGetConnectionQueueSize_OnlyConnSemaphore(t *testing.T) {
 	client.EnableQuerySemaphore(16)
 	assert.Equal(t, 128, client.GetConnectionQueueSize())
 	assert.Equal(t, 16, client.GetQuerySemaphoreSize())
+}
+
+// TestEnableQuerySemaphore_Idempotent verifies that the first call wins and subsequent
+// calls do not replace the channel. Replacing a live semaphore would orphan in-flight
+// permits and could allow more than the configured number of concurrent queries.
+func TestEnableQuerySemaphore_Idempotent(t *testing.T) {
+	client := &Client{
+		connSemaphore: make(chan struct{}, 128),
+		stats:         NewClientStats(),
+	}
+
+	client.EnableQuerySemaphore(8)
+	first := client.loadQuerySemaphore()
+	require.NotNil(t, first)
+	assert.Equal(t, 8, cap(first))
+
+	// Second call with a different size must not change the channel
+	client.EnableQuerySemaphore(64)
+	second := client.loadQuerySemaphore()
+	assert.Equal(t, 8, cap(second), "size must not change after second enable")
+	assert.Equal(t, 8, client.GetQuerySemaphoreSize())
+
+	// And the underlying channel must be the same instance: a permit acquired
+	// against the first snapshot is observed by a subsequent loadQuerySemaphore.
+	first <- struct{}{}
+	assert.Len(t, second, 1, "first and second snapshots must reference the same channel")
+}
+
+// TestEnableQuerySemaphore_ConcurrentEnable verifies that concurrent calls to
+// EnableQuerySemaphore are safe -- exactly one channel is installed and
+// GetQuerySemaphoreSize observes a consistent value.
+func TestEnableQuerySemaphore_ConcurrentEnable(t *testing.T) {
+	client := &Client{
+		connSemaphore: make(chan struct{}, 128),
+		stats:         NewClientStats(),
+	}
+
+	const goroutines = 32
+	start := make(chan struct{})
+	done := make(chan struct{}, goroutines)
+	for i := 0; i < goroutines; i++ {
+		size := 4 + i // each caller asks for a different size
+		go func() {
+			<-start
+			client.EnableQuerySemaphore(size)
+			done <- struct{}{}
+		}()
+	}
+	close(start)
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	// Whichever caller won, the channel is non-nil and the size is one of the
+	// requested values. Repeated loads must return the same channel instance.
+	first := client.loadQuerySemaphore()
+	require.NotNil(t, first)
+	require.GreaterOrEqual(t, cap(first), 4)
+	require.Less(t, cap(first), 4+goroutines)
+
+	for range 10 {
+		again := client.loadQuerySemaphore()
+		assert.Equal(t, cap(first), cap(again))
+		// Sending on first must be observable on a re-load (same channel instance).
+		first <- struct{}{}
+		assert.Len(t, again, 1)
+		<-first
+	}
+}
+
+// TestWaitForRecordsetInactive verifies the polling helper returns once
+// isActive flips to false. This is the mechanism the QueryPartitions release
+// goroutine uses INSTEAD of draining Recordset.Results() (which would steal
+// records from the caller).
+func TestWaitForRecordsetInactive(t *testing.T) {
+	t.Run("returns when active flips to false", func(t *testing.T) {
+		var active atomic.Bool
+		active.Store(true)
+
+		done := make(chan struct{})
+		go func() {
+			waitForRecordsetInactive(active.Load, 5*time.Millisecond)
+			close(done)
+		}()
+
+		// Confirm the helper is still polling.
+		select {
+		case <-done:
+			t.Fatal("waitForRecordsetInactive returned while still active")
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		active.Store(false)
+
+		select {
+		case <-done:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("waitForRecordsetInactive did not return after isActive became false")
+		}
+	})
+
+	t.Run("returns immediately if already inactive", func(t *testing.T) {
+		var active atomic.Bool
+		// active.Load defaults to false
+
+		done := make(chan struct{})
+		go func() {
+			waitForRecordsetInactive(active.Load, 1*time.Second)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("waitForRecordsetInactive did not return promptly when already inactive")
+		}
+	})
+}
+
+// TestQuerySemaphore_ReleaseOnInactive verifies that the permit acquired by a
+// (simulated) QueryPartitions call is released once the recordset becomes
+// inactive -- without any goroutine reading from a Results() channel. This is
+// the exact contract that the wrapper relies on; the previous implementation
+// drained Results() and would silently steal records from the caller.
+func TestQuerySemaphore_ReleaseOnInactive(t *testing.T) {
+	client := &Client{
+		connSemaphore: make(chan struct{}, 8),
+		stats:         NewClientStats(),
+	}
+	client.EnableQuerySemaphore(1)
+
+	sem := client.loadQuerySemaphore()
+	require.NotNil(t, sem)
+
+	// Simulate the path through QueryPartitions: acquire the permit and start
+	// the same release goroutine the wrapper uses, polling a stand-in
+	// IsActive() function.
+	require.NoError(t, asErr(acquireSemaphore(sem, 0)))
+
+	var active atomic.Bool
+	active.Store(true)
+
+	go func() {
+		waitForRecordsetInactive(active.Load, 5*time.Millisecond)
+		<-sem
+	}()
+
+	// Permit is currently held -- a second acquire with timeout must fail.
+	policy := aerospike.NewQueryPolicy()
+	policy.TotalTimeout = 200 * time.Millisecond
+	require.Error(t, asErr(acquireSemaphore(sem, extractTimeout(policy))))
+
+	// Mark the recordset inactive: release goroutine should free the permit.
+	active.Store(false)
+
+	// Now the next acquire must succeed within a reasonable window.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		if err := acquireSemaphore(sem, 50*time.Millisecond); err == nil {
+			<-sem
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("permit was not released after recordset became inactive")
+		}
+	}
+}
+
+// asErr converts an aerospike.Error into a standard error so testify's NoError/Error
+// assertions work. Returning the typed nil directly would compare non-nil to a
+// non-nil interface containing a nil pointer.
+func asErr(e aerospike.Error) error {
+	if e == nil {
+		return nil
+	}
+	return e
 }
 
 // Test mock functionality separately

--- a/util/uaerospike/client_test.go
+++ b/util/uaerospike/client_test.go
@@ -1,9 +1,7 @@
 package uaerospike
 
 import (
-	"runtime"
-	"sync"
-	"sync/atomic"
+	"strconv"
 	"testing"
 	"time"
 
@@ -11,7 +9,6 @@ import (
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestClient_Put(t *testing.T) {
@@ -541,47 +538,6 @@ func TestClient_AcquirePermitTimeout(t *testing.T) {
 	})
 }
 
-func TestEnableQuerySemaphore(t *testing.T) {
-	t.Run("default size is 25% of conn pool", func(t *testing.T) {
-		client := &Client{
-			connSemaphore: make(chan struct{}, 128),
-			stats:         NewClientStats(),
-		}
-		assert.Equal(t, 0, client.GetQuerySemaphoreSize())
-
-		client.EnableQuerySemaphore(0)                      // 0 means use default fraction
-		assert.Equal(t, 32, client.GetQuerySemaphoreSize()) // 25% of 128
-	})
-
-	t.Run("explicit size", func(t *testing.T) {
-		client := &Client{
-			connSemaphore: make(chan struct{}, 256),
-			stats:         NewClientStats(),
-		}
-		client.EnableQuerySemaphore(16)
-		assert.Equal(t, 16, client.GetQuerySemaphoreSize())
-	})
-
-	t.Run("conn semaphore unchanged", func(t *testing.T) {
-		client := &Client{
-			connSemaphore: make(chan struct{}, 256),
-			stats:         NewClientStats(),
-		}
-		client.EnableQuerySemaphore(8)
-		assert.Equal(t, 256, client.GetConnectionQueueSize()) // unchanged
-		assert.Equal(t, 8, client.GetQuerySemaphoreSize())
-	})
-
-	t.Run("small pool gets minimum 1", func(t *testing.T) {
-		client := &Client{
-			connSemaphore: make(chan struct{}, 2),
-			stats:         NewClientStats(),
-		}
-		client.EnableQuerySemaphore(0)
-		assert.Equal(t, 1, client.GetQuerySemaphoreSize())
-	})
-}
-
 func TestExtractTimeout(t *testing.T) {
 	t.Run("nil policy", func(t *testing.T) {
 		assert.Equal(t, time.Duration(0), extractTimeout(nil))
@@ -615,369 +571,145 @@ func TestExtractTimeout(t *testing.T) {
 	})
 }
 
-func TestClient_QuerySemaphoreTimeout(t *testing.T) {
-	t.Run("query semaphore timeout with QueryPolicy", func(t *testing.T) {
+func TestClient_QuerySemaphoreTimeoutHelper(t *testing.T) {
+	// Verifies the shared acquireSemaphore helper applies the same fractional-timeout
+	// rule whether the caller passes a QueryPolicy or any other policy type.
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // pre-fill so acquire must wait
+
+	policy := aerospike.NewQueryPolicy()
+	policy.TotalTimeout = 1000 * time.Millisecond
+
+	start := time.Now()
+	err := acquireSemaphore(sem, extractTimeout(policy))
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.True(t, elapsed >= minSemaphoreTimeout && elapsed < 200*time.Millisecond,
+		"Expected timeout around %v, got %v", minSemaphoreTimeout, elapsed)
+}
+
+func TestRegisterConnectionBudget(t *testing.T) {
+	t.Run("under threshold reports not exceeded", func(t *testing.T) {
 		client := &Client{
-			connSemaphore: make(chan struct{}, 1),
+			connSemaphore: make(chan struct{}, 128),
 			stats:         NewClientStats(),
+			budgets:       make(map[string]int),
 		}
-		client.EnableQuerySemaphore(1)
 
-		// Fill the query semaphore via the public snapshot helper
-		sem := client.loadQuerySemaphore()
-		require.NotNil(t, sem)
-		sem <- struct{}{}
+		report := client.RegisterConnectionBudget("pruner", 60, 0.7)
 
-		policy := aerospike.NewQueryPolicy()
-		policy.TotalTimeout = 1000 * time.Millisecond
+		assert.Equal(t, 60, report.TotalBudget)
+		assert.Equal(t, 128, report.PoolSize)
+		assert.InDelta(t, 0.7, report.Threshold, 0.0001)
+		assert.Equal(t, 89, report.Recommended) // int(0.7 * 128)
+		assert.False(t, report.Exceeded)
+		assert.Equal(t, map[string]int{"pruner": 60}, report.Breakdown)
+	})
 
-		start := time.Now()
-		err := acquireSemaphore(sem, extractTimeout(policy))
-		elapsed := time.Since(start)
+	t.Run("sum across services triggers exceeded", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 128),
+			stats:         NewClientStats(),
+			budgets:       make(map[string]int),
+		}
 
-		assert.Error(t, err)
-		assert.True(t, elapsed >= minSemaphoreTimeout && elapsed < 200*time.Millisecond,
-			"Expected timeout around %v, got %v", minSemaphoreTimeout, elapsed)
+		client.RegisterConnectionBudget("pruner", 60, 0.7)
+		report := client.RegisterConnectionBudget("unminedIterator", 40, 0.7)
+
+		assert.Equal(t, 100, report.TotalBudget)
+		assert.True(t, report.Exceeded, "100 > recommended 89")
+		assert.Equal(t, map[string]int{"pruner": 60, "unminedIterator": 40}, report.Breakdown)
+	})
+
+	t.Run("zero or negative budget removes registration", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 128),
+			stats:         NewClientStats(),
+			budgets:       make(map[string]int),
+		}
+
+		client.RegisterConnectionBudget("pruner", 60, 0.7)
+		report := client.RegisterConnectionBudget("pruner", 0, 0.7)
+		assert.Equal(t, 0, report.TotalBudget)
+		assert.Empty(t, report.Breakdown)
+	})
+
+	t.Run("re-registering replaces prior value", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 128),
+			stats:         NewClientStats(),
+			budgets:       make(map[string]int),
+		}
+
+		client.RegisterConnectionBudget("pruner", 60, 0.7)
+		report := client.RegisterConnectionBudget("pruner", 30, 0.7)
+
+		assert.Equal(t, 30, report.TotalBudget)
+		assert.Equal(t, map[string]int{"pruner": 30}, report.Breakdown)
+	})
+
+	t.Run("returned breakdown is a snapshot caller can mutate", func(t *testing.T) {
+		client := &Client{
+			connSemaphore: make(chan struct{}, 128),
+			stats:         NewClientStats(),
+			budgets:       make(map[string]int),
+		}
+
+		report := client.RegisterConnectionBudget("pruner", 60, 0.7)
+		report.Breakdown["unrelated"] = 9999 // must not pollute internal state
+
+		assert.Equal(t, 60, client.ConnectionBudget(0.7).TotalBudget)
+		assert.Equal(t, map[string]int{"pruner": 60}, client.ConnectionBudget(0.7).Breakdown)
 	})
 }
 
-func TestGetConnectionQueueSize_OnlyConnSemaphore(t *testing.T) {
+func TestConnectionBudget_NoRegistrations(t *testing.T) {
 	client := &Client{
-		connSemaphore: make(chan struct{}, 128),
+		connSemaphore: make(chan struct{}, 64),
 		stats:         NewClientStats(),
+		budgets:       make(map[string]int),
 	}
-	assert.Equal(t, 128, client.GetConnectionQueueSize())
-	assert.Equal(t, 0, client.GetQuerySemaphoreSize())
 
-	// After enabling query semaphore, conn size is unchanged
-	client.EnableQuerySemaphore(16)
-	assert.Equal(t, 128, client.GetConnectionQueueSize())
-	assert.Equal(t, 16, client.GetQuerySemaphoreSize())
+	report := client.ConnectionBudget(0.7)
+	assert.Equal(t, 0, report.TotalBudget)
+	assert.Equal(t, 64, report.PoolSize)
+	assert.Equal(t, 44, report.Recommended) // int(0.7 * 64)
+	assert.False(t, report.Exceeded)
+	assert.Empty(t, report.Breakdown)
 }
 
-// TestEnableQuerySemaphore_Idempotent verifies that the first call wins and subsequent
-// calls do not replace the channel. Replacing a live semaphore would orphan in-flight
-// permits and could allow more than the configured number of concurrent queries.
-func TestEnableQuerySemaphore_Idempotent(t *testing.T) {
+// TestRegisterConnectionBudget_Concurrent verifies the registry is safe under
+// concurrent registration from multiple services -- the final total reflects
+// every registered budget exactly once.
+func TestRegisterConnectionBudget_Concurrent(t *testing.T) {
 	client := &Client{
 		connSemaphore: make(chan struct{}, 128),
 		stats:         NewClientStats(),
+		budgets:       make(map[string]int),
 	}
 
-	client.EnableQuerySemaphore(8)
-	first := client.loadQuerySemaphore()
-	require.NotNil(t, first)
-	assert.Equal(t, 8, cap(first))
-
-	// Second call with a different size must not change the channel
-	client.EnableQuerySemaphore(64)
-	second := client.loadQuerySemaphore()
-	assert.Equal(t, 8, cap(second), "size must not change after second enable")
-	assert.Equal(t, 8, client.GetQuerySemaphoreSize())
-
-	// And the underlying channel must be the same instance: a permit acquired
-	// against the first snapshot is observed by a subsequent loadQuerySemaphore.
-	first <- struct{}{}
-	assert.Len(t, second, 1, "first and second snapshots must reference the same channel")
-}
-
-// TestEnableQuerySemaphore_ConcurrentEnable verifies that concurrent calls to
-// EnableQuerySemaphore are safe -- exactly one channel is installed and
-// GetQuerySemaphoreSize observes a consistent value.
-func TestEnableQuerySemaphore_ConcurrentEnable(t *testing.T) {
-	client := &Client{
-		connSemaphore: make(chan struct{}, 128),
-		stats:         NewClientStats(),
-	}
-
-	const goroutines = 32
+	const services = 16
+	const perService = 8
 	start := make(chan struct{})
-	done := make(chan struct{}, goroutines)
-	for i := 0; i < goroutines; i++ {
-		size := 4 + i // each caller asks for a different size
+	done := make(chan struct{}, services)
+	for i := 0; i < services; i++ {
+		name := "service-" + strconv.Itoa(i)
 		go func() {
 			<-start
-			client.EnableQuerySemaphore(size)
+			client.RegisterConnectionBudget(name, perService, 0.7)
 			done <- struct{}{}
 		}()
 	}
 	close(start)
-	for i := 0; i < goroutines; i++ {
+	for i := 0; i < services; i++ {
 		<-done
 	}
 
-	// Whichever caller won, the channel is non-nil and the size is one of the
-	// requested values. Repeated loads must return the same channel instance.
-	first := client.loadQuerySemaphore()
-	require.NotNil(t, first)
-	require.GreaterOrEqual(t, cap(first), 4)
-	require.Less(t, cap(first), 4+goroutines)
-
-	for range 10 {
-		again := client.loadQuerySemaphore()
-		assert.Equal(t, cap(first), cap(again))
-		// Sending on first must be observable on a re-load (same channel instance).
-		first <- struct{}{}
-		assert.Len(t, again, 1)
-		<-first
-	}
+	final := client.ConnectionBudget(0.7)
+	assert.Equal(t, services*perService, final.TotalBudget)
+	assert.Len(t, final.Breakdown, services)
 }
-
-// TestWaitForRecordsetInactive verifies the polling helper returns once
-// isActive flips to false. This is the mechanism the QueryPartitions release
-// goroutine uses INSTEAD of draining Recordset.Results() (which would steal
-// records from the caller).
-func TestWaitForRecordsetInactive(t *testing.T) {
-	t.Run("returns when active flips to false", func(t *testing.T) {
-		var active atomic.Bool
-		active.Store(true)
-
-		done := make(chan struct{})
-		go func() {
-			waitForRecordsetInactive(active.Load, 5*time.Millisecond)
-			close(done)
-		}()
-
-		// Confirm the helper is still polling.
-		select {
-		case <-done:
-			t.Fatal("waitForRecordsetInactive returned while still active")
-		case <-time.After(20 * time.Millisecond):
-		}
-
-		active.Store(false)
-
-		select {
-		case <-done:
-		case <-time.After(200 * time.Millisecond):
-			t.Fatal("waitForRecordsetInactive did not return after isActive became false")
-		}
-	})
-
-	t.Run("returns immediately if already inactive", func(t *testing.T) {
-		var active atomic.Bool
-		// active.Load defaults to false
-
-		done := make(chan struct{})
-		go func() {
-			waitForRecordsetInactive(active.Load, 1*time.Second)
-			close(done)
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(50 * time.Millisecond):
-			t.Fatal("waitForRecordsetInactive did not return promptly when already inactive")
-		}
-	})
-}
-
-// TestQuerySemaphore_ReleaseOnInactive verifies that the permit acquired by a
-// (simulated) QueryPartitions call is released once the recordset becomes
-// inactive -- without any goroutine reading from a Results() channel. This is
-// the exact contract that the wrapper relies on; the previous implementation
-// drained Results() and would silently steal records from the caller.
-func TestQuerySemaphore_ReleaseOnInactive(t *testing.T) {
-	client := &Client{
-		connSemaphore: make(chan struct{}, 8),
-		stats:         NewClientStats(),
-	}
-	client.EnableQuerySemaphore(1)
-
-	sem := client.loadQuerySemaphore()
-	require.NotNil(t, sem)
-
-	// Simulate the path through QueryPartitions: acquire the permit and start
-	// the same release goroutine the wrapper uses, polling a stand-in
-	// IsActive() function.
-	require.NoError(t, asErr(acquireSemaphore(sem, 0)))
-
-	var active atomic.Bool
-	active.Store(true)
-
-	go func() {
-		waitForRecordsetInactive(active.Load, 5*time.Millisecond)
-		<-sem
-	}()
-
-	// Permit is currently held -- a second acquire with timeout must fail.
-	policy := aerospike.NewQueryPolicy()
-	policy.TotalTimeout = 200 * time.Millisecond
-	require.Error(t, asErr(acquireSemaphore(sem, extractTimeout(policy))))
-
-	// Mark the recordset inactive: release goroutine should free the permit.
-	active.Store(false)
-
-	// Now the next acquire must succeed within a reasonable window.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for {
-		if err := acquireSemaphore(sem, 50*time.Millisecond); err == nil {
-			<-sem
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("permit was not released after recordset became inactive")
-		}
-	}
-}
-
-// asErr converts an aerospike.Error into a standard error so testify's NoError/Error
-// assertions work. Returning the typed nil directly would compare non-nil to a
-// non-nil interface containing a nil pointer.
-func asErr(e aerospike.Error) error {
-	if e == nil {
-		return nil
-	}
-	return e
-}
-
-// TestQuerySemaphore_ConcurrentQueryLimit verifies the core contract of the
-// query semaphore: when N permits are held, an (N+1)th acquirer blocks until
-// one of the in-flight permits is released. This is the behaviour the whole
-// feature exists for -- preventing more than N concurrent long-running scans.
-func TestQuerySemaphore_ConcurrentQueryLimit(t *testing.T) {
-	const limit = 3
-
-	client := &Client{
-		connSemaphore: make(chan struct{}, 16),
-		stats:         NewClientStats(),
-	}
-	client.EnableQuerySemaphore(limit)
-	sem := client.loadQuerySemaphore()
-	require.NotNil(t, sem)
-
-	// Hold all `limit` permits.
-	for i := 0; i < limit; i++ {
-		require.NoError(t, asErr(acquireSemaphore(sem, 0)))
-	}
-
-	// An (N+1)th acquire with timeout must fail because all permits are held.
-	start := time.Now()
-	err := acquireSemaphore(sem, 200*time.Millisecond)
-	require.Error(t, asErr(err))
-	require.GreaterOrEqual(t, time.Since(start), minSemaphoreTimeout)
-
-	// Now release one permit and confirm a new acquire succeeds promptly.
-	released := make(chan struct{})
-	go func() {
-		// Block briefly so the waiter below is parked on the channel before
-		// the slot is freed -- this exercises the wakeup path, not just a
-		// fast-path acquire on a free slot.
-		time.Sleep(20 * time.Millisecond)
-		<-sem
-		close(released)
-	}()
-
-	acquired := make(chan struct{})
-	go func() {
-		require.NoError(t, asErr(acquireSemaphore(sem, 500*time.Millisecond)))
-		close(acquired)
-	}()
-
-	select {
-	case <-acquired:
-	case <-time.After(1 * time.Second):
-		t.Fatal("acquire did not unblock after a permit was released")
-	}
-	<-released
-
-	// Drain remaining permits to leave the semaphore clean.
-	<-sem
-	<-sem
-	<-sem
-}
-
-// TestQuerySemaphore_GoroutineCleanup verifies that the release goroutine used
-// by QueryPartitions does not leak: after it observes IsActive()==false and
-// releases the permit, the goroutine count returns to baseline.
-//
-// We can't directly invoke QueryPartitions in a unit test because
-// *aerospike.Recordset has no public constructor, so we exercise the same
-// goroutine pattern the wrapper uses: spawn a release goroutine that polls a
-// stand-in IsActive function, then flip it to false and wait for cleanup.
-func TestQuerySemaphore_GoroutineCleanup(t *testing.T) {
-	client := &Client{
-		connSemaphore: make(chan struct{}, 8),
-		stats:         NewClientStats(),
-	}
-	client.EnableQuerySemaphore(2)
-	sem := client.loadQuerySemaphore()
-	require.NotNil(t, sem)
-
-	const cycles = 20
-	baseline := runtime.NumGoroutine()
-
-	for i := 0; i < cycles; i++ {
-		require.NoError(t, asErr(acquireSemaphore(sem, 0)))
-
-		var active atomic.Bool
-		active.Store(true)
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			waitForRecordsetInactive(active.Load, 5*time.Millisecond)
-			<-sem
-			client.stats.queryStat.AddTime(time.Now())
-		}()
-
-		// Simulate the recordset finishing.
-		active.Store(false)
-		wg.Wait()
-	}
-
-	// Give the runtime a moment to schedule any tail-end work, then assert
-	// goroutine count has returned to baseline (within a small tolerance for
-	// runtime workers that may cycle independently).
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for {
-		current := runtime.NumGoroutine()
-		if current <= baseline+1 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("goroutine leak after %d cycles: baseline=%d current=%d", cycles, baseline, current)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	// Semaphore must be empty -- if any cycle leaked a permit, the channel
-	// length would be non-zero here.
-	assert.Empty(t, sem, "permit leaked: query semaphore should be empty after all cycles")
-}
-
-// TestQuerySemaphore_RepeatedAcquireRelease verifies that the semaphore can be
-// driven through many acquire/release cycles without drift. A subtle off-by-one
-// in the release path (e.g. releasing the wrong channel after a hypothetical
-// reconfiguration, or double-release) would surface as a permit count that
-// disagrees with the channel buffer.
-func TestQuerySemaphore_RepeatedAcquireRelease(t *testing.T) {
-	client := &Client{
-		connSemaphore: make(chan struct{}, 16),
-		stats:         NewClientStats(),
-	}
-	client.EnableQuerySemaphore(4)
-	sem := client.loadQuerySemaphore()
-	require.NotNil(t, sem)
-
-	const iterations = 1_000
-	for i := 0; i < iterations; i++ {
-		require.NoError(t, asErr(acquireSemaphore(sem, 0)))
-		<-sem
-	}
-
-	assert.Empty(t, sem, "permit drift after %d cycles", iterations)
-	assert.Equal(t, 4, cap(sem), "capacity must not change across cycles")
-}
-
-// Note on integration coverage: the recordset-coupled scenarios -- early
-// termination via Close() before consuming, and full consumption to channel
-// close -- require an *aerospike.Recordset, which has no public constructor.
-// They belong in stores/utxo/aerospike/ alongside the existing TestContainers
-// integration tests (e.g. aerospike_test.go) where a real recordset is
-// available. The unit tests above cover the semaphore mechanics and the
-// release-goroutine lifecycle that those integration tests would exercise.
 
 // Test mock functionality separately
 func TestMockAerospikeClient_CompleteCoverage(t *testing.T) {

--- a/util/uaerospike/mock.go
+++ b/util/uaerospike/mock.go
@@ -23,15 +23,18 @@ type MockAerospikeClient struct {
 	GetCalled          int
 	OperateCalled      int
 	BatchOperateCalled int
+	ExecuteCalled      int
 	CloseCalled        int
 
 	// Store last call parameters for verification
-	LastKey        *aerospike.Key
-	LastBinMap     aerospike.BinMap
-	LastBins       []*aerospike.Bin
-	LastBinNames   []string
-	LastOperations []*aerospike.Operation
-	LastRecords    []aerospike.BatchRecordIfc
+	LastKey          *aerospike.Key
+	LastBinMap       aerospike.BinMap
+	LastBins         []*aerospike.Bin
+	LastBinNames     []string
+	LastOperations   []*aerospike.Operation
+	LastRecords      []aerospike.BatchRecordIfc
+	LastPackageName  string
+	LastFunctionName string
 
 	// Synchronization for concurrent access
 	mu sync.RWMutex
@@ -133,6 +136,22 @@ func (m *MockAerospikeClient) BatchOperate(policy *aerospike.BatchPolicy, record
 	return nil
 }
 
+// Execute implements the aerospike Execute (UDF) operation
+func (m *MockAerospikeClient) Execute(policy *aerospike.WritePolicy, key *aerospike.Key, packageName string, functionName string, args ...aerospike.Value) (any, aerospike.Error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.ExecuteCalled++
+	m.LastKey = key
+	m.LastPackageName = packageName
+	m.LastFunctionName = functionName
+
+	if m.ShouldError {
+		return nil, m.ErrorToReturn
+	}
+	return nil, nil
+}
+
 // Close implements the aerospike Close operation
 func (m *MockAerospikeClient) Close() {
 	m.mu.Lock()
@@ -177,6 +196,7 @@ func (m *MockAerospikeClient) Reset() {
 	m.GetCalled = 0
 	m.OperateCalled = 0
 	m.BatchOperateCalled = 0
+	m.ExecuteCalled = 0
 	m.CloseCalled = 0
 
 	m.LastKey = nil
@@ -185,6 +205,8 @@ func (m *MockAerospikeClient) Reset() {
 	m.LastBinNames = nil
 	m.LastOperations = nil
 	m.LastRecords = nil
+	m.LastPackageName = ""
+	m.LastFunctionName = ""
 }
 
 // MockAerospikeError is a mock implementation of aerospike.Error for testing


### PR DESCRIPTION
Long running connections that perform large scans on aerospike, like the ones used by the pruner, are blocking as they take a long time. the problem is that these connections share the pool with normal connections. this leads to two problems

1) connection exhaustion where a bunch of simple queries cannot acquire any connection from the pool thus timing out. This is specially problematic for connections such as the aerospike healthchecks to confirm that aerospike is healthy and responding. Failure to pass these healthchecks will stop the pods
2) high % of long running queries would add a lot of load on the aerospike servers doing these large secondary index scans. Thus aerospike cannot respond to any other queries