### PR TITLE
rpc: map missing getblockhash heights

### DIFF
--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -228,6 +228,13 @@ func handleGetBlockHash(ctx context.Context, s *RPCServer, cmd interface{}, _ <-
 	// Load the raw block bytes from the database.
 	b, err := s.blockchainClient.GetBlockByHeight(ctx, indexUint32)
 	if err != nil {
+		if errors.Is(err, errors.ErrBlockNotFound) {
+			return nil, &bsvjson.RPCError{
+				Code:    bsvjson.ErrRPCBlockNotFound,
+				Message: "Block not found",
+			}
+		}
+
 		return nil, err
 	}
 

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -1498,6 +1498,33 @@ func TestHandleGetBlockHashComprehensive(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "block not found")
 	})
+
+	t.Run("missing height returns RPC block not found", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockByHeight", mock.Anything, uint32(101)).Return(
+			(*model.Block)(nil), errors.NewBlockNotFoundError("block not found at height"),
+		)
+
+		s := &RPCServer{
+			logger:           logger,
+			blockchainClient: mockClient,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.MainNetParams,
+			},
+		}
+
+		cmd := &bsvjson.GetBlockHashCmd{
+			Index: 101,
+		}
+
+		_, err := handleGetBlockHash(context.Background(), s, cmd, nil)
+		require.Error(t, err)
+
+		rpcErr, ok := err.(*bsvjson.RPCError)
+		require.True(t, ok)
+		assert.Equal(t, bsvjson.ErrRPCBlockNotFound, rpcErr.Code)
+		assert.Contains(t, rpcErr.Message, "Block not found")
+	})
 }
 
 // TestHandleGetBlockHeaderComprehensive tests the handleGetBlockHeader handler


### PR DESCRIPTION
## Summary

- Return a JSON-RPC block-not-found error when `getblockhash` asks for a height that is not present.
- Preserve existing behavior for non-block-not-found blockchain errors.
- Add regression coverage for the missing-height path in the `getblockhash` handler.

## Context

The coinbase RPC monitor probes `getblockhash(lastHeight+1)` to discover whether a new block exists. When the node is at height `N`, a request for height `N+1` is an expected miss, not an internal RPC server failure.

Before this change, the `getblockhash` handler returned the raw blockchain `ErrBlockNotFound` error. The RPC response marshalling path treated non-`RPCError` values as internal failures, which produced noisy logs like:

```text
RPC server internal RPC error: BLOCK_NOT_FOUND ... block not found at height
```

## Change

`handleGetBlockHash` now maps `errors.ErrBlockNotFound` to `bsvjson.ErrRPCBlockNotFound`. That keeps the RPC response semantically correct for callers and prevents expected tip-probing misses from being logged as internal RPC errors.

## Testing

- `go test ./services/rpc -run 'TestHandleGetBlockHashComprehensive' -count=1`
- `go test ./services/rpc -count=1`
- Commit hook checks passed, including Go linter and whitespace checks.

## Notes

- No changes were made to the coinbase service.
- The worktree contained an unrelated untracked `SET_TX_MINED_INVARIANT_FIX_PLAN.md`; it was not included in this branch.