### PR TITLE
fix(utxo/aerospike): surface external-store err in remaining sites

### DIFF
--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -386,7 +386,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 					wrapper.Bytes(),
 					setOptions...,
 				); err != nil && !errors.Is(err, errors.ErrBlobAlreadyExists) {
-					util.SafeSend[error](bItem.done, errors.NewStorageError("error writing outputs to external store [%s]", bItem.txHash.String()))
+					util.SafeSend[error](bItem.done, errors.NewStorageError("error writing outputs to external store [%s]", bItem.txHash.String(), err))
 					// NOOP for this record
 					batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
 
@@ -404,7 +404,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 					fileformat.FileTypeTx,
 					bItem.tx.ExtendedBytes(),
 				); err != nil && !errors.Is(err, errors.ErrBlobAlreadyExists) {
-					util.SafeSend[error](bItem.done, errors.NewStorageError("[sendStoreBatch] error batch writing transaction to external store [%s]", bItem.txHash.String()))
+					util.SafeSend[error](bItem.done, errors.NewStorageError("[sendStoreBatch] error batch writing transaction to external store [%s]", bItem.txHash.String(), err))
 					// NOOP for this record
 					batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
 
@@ -859,7 +859,7 @@ func (s *Store) storeExternallyWithLock(
 	// deletion of external files directly when pruning Aerospike records.
 	timeStart := time.Now()
 	if err := s.externalStore.Set(ctx, bItem.txHash[:], fileType, blobData, options.WithDeleteAt(0)); err != nil && !errors.Is(err, errors.ErrBlobAlreadyExists) {
-		util.SafeSend[error](bItem.done, errors.NewStorageError("[%s] error writing to external store [%s]", funcName, bItem.txHash.String()))
+		util.SafeSend[error](bItem.done, errors.NewStorageError("[%s] error writing to external store [%s]", funcName, bItem.txHash.String(), err))
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Surfaces the underlying error when `externalStore.Set` fails in the three remaining sites in `stores/utxo/aerospike/create.go` that previously dropped the cause.
- Follow-up to #784 (which surfaced the `BatchOperate` error in the same file). These three sibling sites use the same pattern but were missed.

## Why this matters

When the external blob `Set` failed, callers (validator, seeder, propagation) would see only:

```
STORAGE_ERROR (69): [StorePartialTransactionExternally] error writing to external store [<txid>]
```

…with no way to tell whether the cause was `ENOSPC`, `EACCES`, an IO error, a permissions issue, or a remote blob backend failure.

After this change the full cause chain is logged, e.g.:

```
STORAGE_ERROR (69): [StorePartialTransactionExternally] error writing to external store [<txid>]
  -> STORAGE_ERROR (69): [File][SetFromReader] [<path>] failed to create file
  -> UNKNOWN (0): open <path>: no space left on device
```

A recent seeder run on a quickstart-style setup made this concrete: the underlying cause was OrbStack disk space exhaustion on the macOS host, which is not directly visible from inside the container — `df` inside the seeder reports the VM's view, while the actual cap is the host's free space. The opaque error sent debugging in entirely the wrong direction. With the cause threaded through, the `no space left on device` would have been visible in the very first failure log line.

## Sites updated

All in `stores/utxo/aerospike/create.go`:

- `storeExternallyWithLock` — partial/full external transaction write (line 862)
- `sendStoreBatch` outputs path (line 389)
- `sendStoreBatch` tx path (line 407)

The change is purely diagnostic: existing variadic params on `errors.NewStorageError` already accept a trailing `error`, which gets wrapped into the chain. No behavioural or control-flow change.

## Test plan

- [x] `go build ./stores/utxo/aerospike/...`
- [x] `go vet ./stores/utxo/aerospike/...`
- [ ] Existing aerospike package tests
- [x] Manual: induce a write failure (e.g. read-only external store path) and confirm the cause appears in the chain
