### PR TITLE
perf(subtreevalidation): reuse pooled bufio.Reader for body / subtreeData reads

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -1247,11 +1247,15 @@ func (u *Server) getSubtreeMissingTxs(ctx context.Context, subtreeHash chainhash
 						// this is less efficient than reading straight to disk with SetFromReader, but we need to validate the
 						// data before storing it on disk
 						// Use pooled buffered reader to reduce syscalls and avoid per-call 1MB buffer allocation.
+						// defer the pool return so a panic / future early return still releases the reader,
+						// matching the pattern used at check_block_subtrees.go:201 and the second callsite below.
 						bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
 						bufferedReader.Reset(body)
+						defer func() {
+							bufferedReader.Reset(nil) // clear reference before returning to pool
+							bufioReaderPool.Put(bufferedReader)
+						}()
 						subtreeData, err := subtreepkg.NewSubtreeDataFromReader(subtreeForData, bufferedReader)
-						bufferedReader.Reset(nil) // clear reference before returning to pool
-						bufioReaderPool.Put(bufferedReader)
 						_ = body.Close()
 						if err != nil {
 							u.logger.Errorf("[validateSubtree][%s] failed to create subtree data from reader: %v", subtreeHash.String(), err)

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -1246,8 +1246,12 @@ func (u *Server) getSubtreeMissingTxs(ctx context.Context, subtreeHash chainhash
 						// load the subtree data, making sure to validate it against the subtree txs
 						// this is less efficient than reading straight to disk with SetFromReader, but we need to validate the
 						// data before storing it on disk
-						// Use buffered reader to reduce syscalls - each tx.ReadFrom() makes many small reads
-						subtreeData, err := subtreepkg.NewSubtreeDataFromReader(subtreeForData, bufio.NewReaderSize(body, 1024*1024))
+						// Use pooled buffered reader to reduce syscalls and avoid per-call 1MB buffer allocation.
+						bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
+						bufferedReader.Reset(body)
+						subtreeData, err := subtreepkg.NewSubtreeDataFromReader(subtreeForData, bufferedReader)
+						bufferedReader.Reset(nil) // clear reference before returning to pool
+						bufioReaderPool.Put(bufferedReader)
 						_ = body.Close()
 						if err != nil {
 							u.logger.Errorf("[validateSubtree][%s] failed to create subtree data from reader: %v", subtreeHash.String(), err)
@@ -1705,8 +1709,14 @@ func (u *Server) getMissingTransactionsFromFile(ctx context.Context, subtreeHash
 	}
 	defer subtreeDataReader.Close()
 
-	// Use buffered reader to reduce syscalls - each tx.ReadFrom() makes many small reads
-	subtreeData, err := subtreepkg.NewSubtreeDataFromReader(subtree, bufio.NewReaderSize(subtreeDataReader, 1024*1024))
+	// Use pooled buffered reader to reduce syscalls and avoid per-call 1MB buffer allocation.
+	bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
+	bufferedReader.Reset(subtreeDataReader)
+	defer func() {
+		bufferedReader.Reset(nil) // clear reference before returning to pool
+		bufioReaderPool.Put(bufferedReader)
+	}()
+	subtreeData, err := subtreepkg.NewSubtreeDataFromReader(subtree, bufferedReader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Two callsites in `services/subtreevalidation/SubtreeValidation.go` allocated a fresh 1 MB `bufio.Reader` on every call. Switch them to use the existing `bufioReaderPool` (already at `check_block_subtrees.go:29` and used by three other callsites in the same package).

- `validateSubtree` (~line 1250) — wrapping the HTTP body during peer fetch
- `getMissingTransactionsFromFile` (~line 1709) — wrapping the subtree blob reader

## Why

Heap profile on a fresh testnet sync (47 min uptime on eu-4, v0.15.0-beta-5) showed `bufio.NewReaderSize` as the top alloc-space contributor inside the subtreevalidation service: **16.08 GB cumulative (44.94% of total package alloc)** in <1 hour. These 1 MB buffers are allocated and immediately discarded, hammering the Go GC during legacy IBD where the code paths run frequently.

After this change those callsites reuse pooled readers; the cumulative allocation drops to near zero (initial pool fill only), reducing GC pressure on the hot sync path.

## Pattern reference

`services/subtreevalidation/check_block_subtrees.go:198-204` is the existing pattern, which this PR mirrors at the two missed callsites:

```go
bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
bufferedReader.Reset(reader)
defer func() {
    bufferedReader.Reset(nil) // clear reference before returning to pool
    bufioReaderPool.Put(bufferedReader)
}()
```

## Test plan

- [x] `go build ./services/subtreevalidation/...` — success
- [x] `go vet ./services/subtreevalidation/...` — clean
- [x] `go test -short ./services/subtreevalidation/...` — pass (17.8s)
- [ ] Re-profile after merge: alloc rate of `bufio.NewReaderSize` should drop to near zero in subtreevalidation service.