### PR TITLE
perf(blockchain): in-process MTP cache for GetMedianTimePastForHeights / Range

### DIFF
--- a/services/blockchain/LocalClient.go
+++ b/services/blockchain/LocalClient.go
@@ -595,6 +595,13 @@ func (c *LocalClient) CompleteBlobDeletionBatch(ctx context.Context, batchToken 
 
 // GetMedianTimePastForHeights returns the MTP for one or more block heights.
 // MTP values are read from pre-stored block metadata rather than recomputed on demand.
+//
+// Note: this implementation intentionally bypasses the in-process MTP cache held by
+// the Blockchain service instance (mtpCache). LocalClient is used by callers that do
+// not share a Blockchain service instance — it wraps the store directly. Wiring a
+// shared cache across the LocalClient/Server boundary is out of scope; callers that
+// need cache-accelerated MTP lookups should use the Blockchain gRPC/service interface
+// instead.
 func (c *LocalClient) GetMedianTimePastForHeights(ctx context.Context, heights []uint32) ([]uint32, error) {
 	if len(heights) == 0 {
 		return []uint32{}, nil
@@ -631,6 +638,13 @@ func (c *LocalClient) GetMedianTimePastForHeights(ctx context.Context, heights [
 // GetMedianTimePastRange returns the MTP values for all blocks in [fromHeight, toHeight].
 // Returns a dense slice where result[i] = MTP for height (fromHeight + i).
 // Blocks missing from the canonical chain (e.g. heights below 11) are left as zero.
+//
+// Note: this implementation intentionally bypasses the in-process MTP cache held by
+// the Blockchain service instance (mtpCache). LocalClient is used by callers that do
+// not share a Blockchain service instance — it wraps the store directly. Wiring a
+// shared cache across the LocalClient/Server boundary is out of scope; callers that
+// need cache-accelerated MTP lookups should use the Blockchain gRPC/service interface
+// instead.
 func (c *LocalClient) GetMedianTimePastRange(ctx context.Context, fromHeight, toHeight uint32) ([]uint32, error) {
 	if toHeight < fromHeight {
 		return []uint32{}, nil

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -107,6 +107,12 @@ type Blockchain struct {
 	// Blob deletion batch token management
 	batchTokens   map[string]*blobDeletionBatchToken // Active batch tokens
 	batchTokensMu sync.RWMutex                       // Mutex for batch tokens map
+
+	// In-process Median Time Past cache. Avoids re-fetching MTP values from the
+	// store on every block validation and validator MTP refresh — the store-level
+	// responseCache is wiped per StoreBlock, so committed-block MTPs there have
+	// near-zero hit rate during sync.
+	mtpCache *mtpCache
 }
 
 // blobDeletionBatchToken represents an acquired batch of deletions with a lock.
@@ -163,6 +169,7 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 		AppCtx:                        ctx,
 		blocksFinalKafkaAsyncProducer: blocksFinalKafkaAsyncProducer,
 		batchTokens:                   make(map[string]*blobDeletionBatchToken),
+		mtpCache:                      newMTPCache(),
 	}
 
 	// Initialize subscription manager as not ready
@@ -846,6 +853,11 @@ func (b *Blockchain) AddBlock(ctx context.Context, request *blockchain_api.AddBl
 	// Clear difficulty cache when chain state changes to prevent stale cached values
 	// from causing incorrect difficulty calculations during rapid block processing
 	b.difficulty.ResetCache()
+
+	// Drop any speculative MTP cache entries at or above the new block's height
+	// so the next GetMedianTimePastRange/ForHeights call repopulates them from the
+	// store. Heights below the new block remain valid.
+	b.mtpCache.truncate(height)
 
 	b.logger.Infof("[AddBlock] stored block %s (ID: %d, height: %d)", block.Hash(), ID, height)
 
@@ -2067,6 +2079,11 @@ func (b *Blockchain) InvalidateBlock(ctx context.Context, request *blockchain_ap
 	// Clear any cached difficulty that may depend on the previous best tip
 	b.difficulty.ResetCache()
 
+	// Reorg-style invalidation: cached MTP for the invalidated block and its
+	// descendants is no longer authoritative. Drop everything; the next query
+	// will repopulate from the store on the new winning chain.
+	b.mtpCache.reset()
+
 	// send notification about the block being invalidated, this will trigger all listeners to reconsider best block
 	if _, err = b.SendNotification(ctx, &blockchain_api.Notification{
 		Type: model.NotificationType_Block,
@@ -2169,6 +2186,11 @@ func (b *Blockchain) RevalidateBlock(ctx context.Context, request *blockchain_ap
 
 	// Clear any cached difficulty that may depend on the previous best tip
 	b.difficulty.ResetCache()
+
+	// Revalidation can change which block is considered canonical at heights
+	// from the revalidated block forward. Drop the MTP cache so the next query
+	// repopulates from the store.
+	b.mtpCache.reset()
 
 	return &emptypb.Empty{}, nil
 }

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2079,10 +2079,16 @@ func (b *Blockchain) InvalidateBlock(ctx context.Context, request *blockchain_ap
 	// Clear any cached difficulty that may depend on the previous best tip
 	b.difficulty.ResetCache()
 
-	// Reorg-style invalidation: cached MTP for the invalidated block and its
-	// descendants is no longer authoritative. Drop everything; the next query
-	// will repopulate from the store on the new winning chain.
-	b.mtpCache.reset()
+	// Reorg-style invalidation: MTP for heights at and above the invalidated block
+	// is no longer authoritative. Truncate from that height so ancestors below it
+	// remain cached. Fall back to a full reset if the header lookup fails — that
+	// is the safe behaviour and should not happen under normal operation.
+	if _, invalidateMeta, lookupErr := b.store.GetBlockHeader(ctx, blockHash); lookupErr == nil {
+		b.mtpCache.truncate(invalidateMeta.Height)
+	} else {
+		b.logger.Debugf("[InvalidateBlock] could not look up height for %s to truncate MTP cache, resetting: %v", blockHash, lookupErr)
+		b.mtpCache.reset()
+	}
 
 	// send notification about the block being invalidated, this will trigger all listeners to reconsider best block
 	if _, err = b.SendNotification(ctx, &blockchain_api.Notification{
@@ -2187,10 +2193,15 @@ func (b *Blockchain) RevalidateBlock(ctx context.Context, request *blockchain_ap
 	// Clear any cached difficulty that may depend on the previous best tip
 	b.difficulty.ResetCache()
 
-	// Revalidation can change which block is considered canonical at heights
-	// from the revalidated block forward. Drop the MTP cache so the next query
-	// repopulates from the store.
-	b.mtpCache.reset()
+	// Revalidation can change which block is considered canonical at heights from
+	// the revalidated block forward. Truncate from that height so ancestors below
+	// it remain cached. Fall back to a full reset if the header lookup fails.
+	if _, revalidateMeta, lookupErr := b.store.GetBlockHeader(ctx, blockHash); lookupErr == nil {
+		b.mtpCache.truncate(revalidateMeta.Height)
+	} else {
+		b.logger.Debugf("[RevalidateBlock] could not look up height for %s to truncate MTP cache, resetting: %v", blockHash, lookupErr)
+		b.mtpCache.reset()
+	}
 
 	return &emptypb.Empty{}, nil
 }

--- a/services/blockchain/median_time_past.go
+++ b/services/blockchain/median_time_past.go
@@ -70,6 +70,20 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 		}
 	}
 
+	// Try the in-process cache first. The store-level responseCache is wiped
+	// per StoreBlock, so it has near-zero hit rate for committed-block MTP
+	// during sync; this cache survives across StoreBlock and is only invalidated
+	// on chain reorganisation.
+	if b.mtpCache != nil {
+		if cached, ok := b.mtpCache.getRange(minHeight, maxHeight); ok {
+			mtps := make([]uint32, len(heights))
+			for i, height := range heights {
+				mtps[i] = cached[height-minHeight]
+			}
+			return mtps, nil
+		}
+	}
+
 	_, metas, err := b.store.GetBlockHeadersByHeight(ctx, minHeight, maxHeight)
 	if err != nil {
 		return nil, errors.NewProcessingError("[Blockchain][GetMedianTimePastForHeights] failed to get block headers from %d to %d", minHeight, maxHeight, err)
@@ -95,6 +109,21 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 		mtps[i] = mtpByHeight[height]
 	}
 
+	// Cache the dense range for future calls. We only cache values for heights
+	// that we actually fetched from the store; the not-yet-persisted top is
+	// recomputed on the fly so we deliberately skip caching it (its MTP is
+	// finalised when the block is persisted via AddBlock, which truncates this
+	// height anyway).
+	if b.mtpCache != nil && len(metas) > 0 {
+		dense := make([]uint32, maxHeight-minHeight+1)
+		for _, meta := range metas {
+			if meta.Height >= minHeight && meta.Height <= maxHeight {
+				dense[meta.Height-minHeight] = meta.MedianTimePast
+			}
+		}
+		b.mtpCache.putRange(minHeight, dense)
+	}
+
 	return mtps, nil
 }
 
@@ -104,6 +133,14 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 func (b *Blockchain) GetMedianTimePastRange(ctx context.Context, fromHeight, toHeight uint32) ([]uint32, error) {
 	if toHeight < fromHeight {
 		return []uint32{}, nil
+	}
+
+	// Try the in-process cache first. See note on caching in
+	// GetMedianTimePastForHeights for rationale.
+	if b.mtpCache != nil {
+		if cached, ok := b.mtpCache.getRange(fromHeight, toHeight); ok {
+			return cached, nil
+		}
 	}
 
 	_, metas, err := b.store.GetBlockHeadersByHeight(ctx, fromHeight, toHeight)
@@ -125,6 +162,19 @@ func (b *Blockchain) GetMedianTimePastRange(ctx context.Context, fromHeight, toH
 			return nil, err
 		}
 		result[toHeight-fromHeight] = computed
+	}
+
+	// Cache the persisted-block portion of the range. Skip the not-yet-persisted
+	// top entry — its MTP is finalised by AddBlock, which truncates the cache
+	// at that height.
+	if b.mtpCache != nil && len(metas) > 0 {
+		cacheTop := toHeight
+		if topMissing {
+			cacheTop = toHeight - 1
+		}
+		if cacheTop >= fromHeight {
+			b.mtpCache.putRange(fromHeight, result[:cacheTop-fromHeight+1])
+		}
 	}
 
 	return result, nil

--- a/services/blockchain/median_time_past.go
+++ b/services/blockchain/median_time_past.go
@@ -73,8 +73,12 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 	// Try the in-process cache first. The store-level responseCache is wiped
 	// per StoreBlock, so it has near-zero hit rate for committed-block MTP
 	// during sync; this cache survives across StoreBlock and is only invalidated
-	// on chain reorganisation.
+	// on chain reorganisation. Snapshot the cache generation BEFORE the store
+	// read so a concurrent reorg between read and writeback can be detected via
+	// putRangeIfGen and the (now-stale) write rejected.
+	var cacheGen uint64
 	if b.mtpCache != nil {
+		cacheGen = b.mtpCache.generation()
 		if cached, ok := b.mtpCache.getRange(minHeight, maxHeight); ok {
 			mtps := make([]uint32, len(heights))
 			for i, height := range heights {
@@ -114,6 +118,10 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 	// is not yet persisted), exclude it from the cache write so we do not
 	// overwrite a slot that might already hold a genuine cached value, and so the
 	// zero-as-miss sentinel is not incorrectly served on the next cache hit.
+	//
+	// putRangeIfGen rejects the write if a concurrent truncate/reset bumped the
+	// generation since the cacheGen snapshot taken before the store read — so a
+	// reorg that lands mid-fetch cannot poison the cache with pre-reorg MTPs.
 	if b.mtpCache != nil && len(metas) > 0 {
 		topMissing := metas[len(metas)-1].Height < maxHeight
 		cacheTop := maxHeight
@@ -127,7 +135,7 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 					dense[meta.Height-minHeight] = meta.MedianTimePast
 				}
 			}
-			b.mtpCache.putRange(minHeight, dense)
+			b.mtpCache.putRangeIfGen(minHeight, dense, cacheGen)
 		}
 	}
 
@@ -143,8 +151,11 @@ func (b *Blockchain) GetMedianTimePastRange(ctx context.Context, fromHeight, toH
 	}
 
 	// Try the in-process cache first. See note on caching in
-	// GetMedianTimePastForHeights for rationale.
+	// GetMedianTimePastForHeights for rationale; same generation-snapshot
+	// pattern is used here to detect concurrent reorg invalidation.
+	var cacheGen uint64
 	if b.mtpCache != nil {
+		cacheGen = b.mtpCache.generation()
 		if cached, ok := b.mtpCache.getRange(fromHeight, toHeight); ok {
 			return cached, nil
 		}
@@ -173,14 +184,15 @@ func (b *Blockchain) GetMedianTimePastRange(ctx context.Context, fromHeight, toH
 
 	// Cache the persisted-block portion of the range. Skip the not-yet-persisted
 	// top entry — its MTP is finalised by AddBlock, which truncates the cache
-	// at that height.
+	// at that height. putRangeIfGen rejects the write if a concurrent reorg
+	// bumped the generation since cacheGen was snapshotted.
 	if b.mtpCache != nil && len(metas) > 0 {
 		cacheTop := toHeight
 		if topMissing {
 			cacheTop = toHeight - 1
 		}
 		if cacheTop >= fromHeight {
-			b.mtpCache.putRange(fromHeight, result[:cacheTop-fromHeight+1])
+			b.mtpCache.putRangeIfGen(fromHeight, result[:cacheTop-fromHeight+1], cacheGen)
 		}
 	}
 

--- a/services/blockchain/median_time_past.go
+++ b/services/blockchain/median_time_past.go
@@ -109,19 +109,26 @@ func (b *Blockchain) GetMedianTimePastForHeights(ctx context.Context, heights []
 		mtps[i] = mtpByHeight[height]
 	}
 
-	// Cache the dense range for future calls. We only cache values for heights
-	// that we actually fetched from the store; the not-yet-persisted top is
-	// recomputed on the fly so we deliberately skip caching it (its MTP is
-	// finalised when the block is persisted via AddBlock, which truncates this
-	// height anyway).
+	// Cache the persisted-block portion of the range. Mirror the cacheTop logic
+	// from GetMedianTimePastRange: if maxHeight was not in the store (the block
+	// is not yet persisted), exclude it from the cache write so we do not
+	// overwrite a slot that might already hold a genuine cached value, and so the
+	// zero-as-miss sentinel is not incorrectly served on the next cache hit.
 	if b.mtpCache != nil && len(metas) > 0 {
-		dense := make([]uint32, maxHeight-minHeight+1)
-		for _, meta := range metas {
-			if meta.Height >= minHeight && meta.Height <= maxHeight {
-				dense[meta.Height-minHeight] = meta.MedianTimePast
-			}
+		topMissing := metas[len(metas)-1].Height < maxHeight
+		cacheTop := maxHeight
+		if topMissing {
+			cacheTop = maxHeight - 1
 		}
-		b.mtpCache.putRange(minHeight, dense)
+		if cacheTop >= minHeight {
+			dense := make([]uint32, cacheTop-minHeight+1)
+			for _, meta := range metas {
+				if meta.Height >= minHeight && meta.Height <= cacheTop {
+					dense[meta.Height-minHeight] = meta.MedianTimePast
+				}
+			}
+			b.mtpCache.putRange(minHeight, dense)
+		}
 	}
 
 	return mtps, nil

--- a/services/blockchain/metrics.go
+++ b/services/blockchain/metrics.go
@@ -63,6 +63,11 @@ var (
 	prometheusBlockchainGetBlockLocator                      prometheus.Histogram
 	prometheusBlockchainLocateBlockHeaders                   prometheus.Histogram
 	// prometheusExportBlockDb                        prometheus.Histogram
+
+	prometheusBlockchainMTPCacheHits        prometheus.Counter
+	prometheusBlockchainMTPCacheMisses      prometheus.Counter
+	prometheusBlockchainMTPCacheTruncations prometheus.Counter
+	prometheusBlockchainMTPCacheResets      prometheus.Counter
 )
 
 var (
@@ -459,6 +464,42 @@ func _initPrometheusMetrics() {
 			Name:      "locate_block_headers",
 			Help:      "Histogram of LocateBlockHeaders calls to the blockchain service",
 			Buckets:   util.MetricsBucketsMilliSeconds,
+		},
+	)
+
+	prometheusBlockchainMTPCacheHits = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "mtp_cache_hits_total",
+			Help:      "Total number of in-process MTP cache hits",
+		},
+	)
+
+	prometheusBlockchainMTPCacheMisses = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "mtp_cache_misses_total",
+			Help:      "Total number of in-process MTP cache misses",
+		},
+	)
+
+	prometheusBlockchainMTPCacheTruncations = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "mtp_cache_truncations_total",
+			Help:      "Total number of in-process MTP cache truncations",
+		},
+	)
+
+	prometheusBlockchainMTPCacheResets = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "mtp_cache_resets_total",
+			Help:      "Total number of in-process MTP cache resets",
 		},
 	)
 }

--- a/services/blockchain/mtp_cache.go
+++ b/services/blockchain/mtp_cache.go
@@ -1,0 +1,119 @@
+package blockchain
+
+import "sync"
+
+// mtpCache holds Median Time Past values indexed by block height. It is owned by
+// the Blockchain service and serves GetMedianTimePastForHeights /
+// GetMedianTimePastRange without round-tripping through the storage layer's
+// per-StoreBlock cache invalidation.
+//
+// MTP for height h depends on block_time of heights [h-11, h-1] (BIP113).
+// The values for committed blocks are immutable until a chain reorganisation
+// changes which block sits at a given height — at that point we truncate from
+// the affected height onward and let subsequent queries repopulate.
+//
+// Lookups are O(1); the cache is a contiguous slice indexed by height. Memory
+// is bounded by chain length (~4 bytes per block, ~5 MB at 1.27M heights).
+type mtpCache struct {
+	mu   sync.RWMutex
+	mtps []uint32
+}
+
+// newMTPCache returns an empty cache. Entries are added lazily on cache
+// misses.
+func newMTPCache() *mtpCache {
+	return &mtpCache{}
+}
+
+// getRange returns cached MTP values for [fromHeight, toHeight] or false if
+// the cache does not fully cover the range. A zero entry is treated as "not
+// covered" so genuine zero MTP values (e.g. heights below MedianTimeBlocks)
+// are re-fetched and confirmed instead of silently served.
+func (c *mtpCache) getRange(fromHeight, toHeight uint32) ([]uint32, bool) {
+	if toHeight < fromHeight {
+		return []uint32{}, true
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if uint32(len(c.mtps)) <= toHeight {
+		return nil, false
+	}
+
+	out := make([]uint32, toHeight-fromHeight+1)
+	for h := fromHeight; h <= toHeight; h++ {
+		mtp := c.mtps[h]
+		if mtp == 0 && h >= mtpMedianTimeBlocks {
+			// Sentinel: never populated for a height where MTP could be
+			// non-zero. Force a miss so the caller refetches.
+			return nil, false
+		}
+		out[h-fromHeight] = mtp
+	}
+	return out, true
+}
+
+// get returns the cached MTP for a single height, or false on miss. Same
+// zero-as-miss semantics as getRange for heights >= MedianTimeBlocks.
+func (c *mtpCache) get(height uint32) (uint32, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if uint32(len(c.mtps)) <= height {
+		return 0, false
+	}
+	mtp := c.mtps[height]
+	if mtp == 0 && height >= mtpMedianTimeBlocks {
+		return 0, false
+	}
+	return mtp, true
+}
+
+// putRange stores MTP values for [fromHeight, fromHeight+len(mtps)-1].
+// Slots are grown as needed; existing entries are overwritten so reorg-driven
+// repopulations replace stale values cleanly.
+func (c *mtpCache) putRange(fromHeight uint32, mtps []uint32) {
+	if len(mtps) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	end := fromHeight + uint32(len(mtps))
+	if uint32(len(c.mtps)) < end {
+		grow := end - uint32(len(c.mtps))
+		c.mtps = append(c.mtps, make([]uint32, grow)...)
+	}
+	for i, mtp := range mtps {
+		c.mtps[fromHeight+uint32(i)] = mtp
+	}
+}
+
+// truncate drops all cached entries with height >= fromHeight. Callers invoke
+// this after StoreBlock (to discard any speculative top-of-chain entry) and on
+// chain reorganisation paths (InvalidateBlock, RevalidateBlock) where blocks
+// from fromHeight upward may move chains.
+func (c *mtpCache) truncate(fromHeight uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if uint32(len(c.mtps)) > fromHeight {
+		c.mtps = c.mtps[:fromHeight]
+	}
+}
+
+// reset clears the entire cache. Used on store-wide events (e.g. test resets)
+// where the safest action is to refetch everything.
+func (c *mtpCache) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.mtps = c.mtps[:0]
+}
+
+// mtpMedianTimeBlocks mirrors MedianTimeBlocks in median_time_past.go to avoid
+// an import cycle within the package; kept as a typed local constant for the
+// zero-as-miss sentinel.
+const mtpMedianTimeBlocks uint32 = 11

--- a/services/blockchain/mtp_cache.go
+++ b/services/blockchain/mtp_cache.go
@@ -38,18 +38,27 @@ func (c *mtpCache) getRange(fromHeight, toHeight uint32) ([]uint32, bool) {
 	defer c.mu.RUnlock()
 
 	if uint32(len(c.mtps)) <= toHeight {
+		if prometheusBlockchainMTPCacheMisses != nil {
+			prometheusBlockchainMTPCacheMisses.Inc()
+		}
 		return nil, false
 	}
 
 	out := make([]uint32, toHeight-fromHeight+1)
 	for h := fromHeight; h <= toHeight; h++ {
 		mtp := c.mtps[h]
-		if mtp == 0 && h >= mtpMedianTimeBlocks {
+		if mtp == 0 && h >= uint32(MedianTimeBlocks) {
 			// Sentinel: never populated for a height where MTP could be
 			// non-zero. Force a miss so the caller refetches.
+			if prometheusBlockchainMTPCacheMisses != nil {
+				prometheusBlockchainMTPCacheMisses.Inc()
+			}
 			return nil, false
 		}
 		out[h-fromHeight] = mtp
+	}
+	if prometheusBlockchainMTPCacheHits != nil {
+		prometheusBlockchainMTPCacheHits.Inc()
 	}
 	return out, true
 }
@@ -61,11 +70,20 @@ func (c *mtpCache) get(height uint32) (uint32, bool) {
 	defer c.mu.RUnlock()
 
 	if uint32(len(c.mtps)) <= height {
+		if prometheusBlockchainMTPCacheMisses != nil {
+			prometheusBlockchainMTPCacheMisses.Inc()
+		}
 		return 0, false
 	}
 	mtp := c.mtps[height]
-	if mtp == 0 && height >= mtpMedianTimeBlocks {
+	if mtp == 0 && height >= uint32(MedianTimeBlocks) {
+		if prometheusBlockchainMTPCacheMisses != nil {
+			prometheusBlockchainMTPCacheMisses.Inc()
+		}
 		return 0, false
+	}
+	if prometheusBlockchainMTPCacheHits != nil {
+		prometheusBlockchainMTPCacheHits.Inc()
 	}
 	return mtp, true
 }
@@ -102,6 +120,9 @@ func (c *mtpCache) truncate(fromHeight uint32) {
 	if uint32(len(c.mtps)) > fromHeight {
 		c.mtps = c.mtps[:fromHeight]
 	}
+	if prometheusBlockchainMTPCacheTruncations != nil {
+		prometheusBlockchainMTPCacheTruncations.Inc()
+	}
 }
 
 // reset clears the entire cache. Used on store-wide events (e.g. test resets)
@@ -111,9 +132,7 @@ func (c *mtpCache) reset() {
 	defer c.mu.Unlock()
 
 	c.mtps = c.mtps[:0]
+	if prometheusBlockchainMTPCacheResets != nil {
+		prometheusBlockchainMTPCacheResets.Inc()
+	}
 }
-
-// mtpMedianTimeBlocks mirrors MedianTimeBlocks in median_time_past.go to avoid
-// an import cycle within the package; kept as a typed local constant for the
-// zero-as-miss sentinel.
-const mtpMedianTimeBlocks uint32 = 11

--- a/services/blockchain/mtp_cache.go
+++ b/services/blockchain/mtp_cache.go
@@ -1,6 +1,9 @@
 package blockchain
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // mtpCache holds Median Time Past values indexed by block height. It is owned by
 // the Blockchain service and serves GetMedianTimePastForHeights /
@@ -14,9 +17,18 @@ import "sync"
 //
 // Lookups are O(1); the cache is a contiguous slice indexed by height. Memory
 // is bounded by chain length (~4 bytes per block, ~5 MB at 1.27M heights).
+//
+// A generation counter guards against a TOCTOU race between a Get* path that
+// reads from the store and a concurrent reorg that truncates / resets the
+// cache. Callers snapshot the generation before the store read via
+// generation(), and write back via putRangeIfGen which only commits if the
+// snapshot still matches the current generation. truncate / reset bump the
+// generation atomically so any in-flight putRangeIfGen call from a stale
+// view is rejected.
 type mtpCache struct {
 	mu   sync.RWMutex
 	mtps []uint32
+	gen  atomic.Uint64
 }
 
 // newMTPCache returns an empty cache. Entries are added lazily on cache
@@ -88,9 +100,22 @@ func (c *mtpCache) get(height uint32) (uint32, bool) {
 	return mtp, true
 }
 
+// generation returns the current cache generation. Snapshot this before
+// reading from the store, then pass the snapshot to putRangeIfGen. If a
+// concurrent truncate or reset bumps the generation between the snapshot and
+// the write, putRangeIfGen will discard the write so stale (pre-reorg) values
+// cannot poison the cache.
+func (c *mtpCache) generation() uint64 {
+	return c.gen.Load()
+}
+
 // putRange stores MTP values for [fromHeight, fromHeight+len(mtps)-1].
 // Slots are grown as needed; existing entries are overwritten so reorg-driven
 // repopulations replace stale values cleanly.
+//
+// This unguarded variant is used by tests and other callers that already hold
+// some external synchronisation. Production Get* paths must use putRangeIfGen
+// instead, with a generation snapshot taken before the upstream store read.
 func (c *mtpCache) putRange(fromHeight uint32, mtps []uint32) {
 	if len(mtps) == 0 {
 		return
@@ -99,6 +124,31 @@ func (c *mtpCache) putRange(fromHeight uint32, mtps []uint32) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.putRangeLocked(fromHeight, mtps)
+}
+
+// putRangeIfGen commits the write only if the cache generation still matches
+// the snapshot. Returns true if the write was applied, false if it was
+// rejected because a truncate or reset bumped the generation since the
+// snapshot. Used by Get* paths to close the read-store/write-cache TOCTOU
+// window with concurrent reorg invalidations.
+func (c *mtpCache) putRangeIfGen(fromHeight uint32, mtps []uint32, snapshot uint64) bool {
+	if len(mtps) == 0 {
+		return true
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.gen.Load() != snapshot {
+		return false
+	}
+	c.putRangeLocked(fromHeight, mtps)
+	return true
+}
+
+// putRangeLocked is the shared write body. Caller must hold c.mu for writing.
+func (c *mtpCache) putRangeLocked(fromHeight uint32, mtps []uint32) {
 	end := fromHeight + uint32(len(mtps))
 	if uint32(len(c.mtps)) < end {
 		grow := end - uint32(len(c.mtps))
@@ -112,7 +162,8 @@ func (c *mtpCache) putRange(fromHeight uint32, mtps []uint32) {
 // truncate drops all cached entries with height >= fromHeight. Callers invoke
 // this after StoreBlock (to discard any speculative top-of-chain entry) and on
 // chain reorganisation paths (InvalidateBlock, RevalidateBlock) where blocks
-// from fromHeight upward may move chains.
+// from fromHeight upward may move chains. Bumps the generation so any
+// in-flight putRangeIfGen call from a stale view is rejected.
 func (c *mtpCache) truncate(fromHeight uint32) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -120,18 +171,21 @@ func (c *mtpCache) truncate(fromHeight uint32) {
 	if uint32(len(c.mtps)) > fromHeight {
 		c.mtps = c.mtps[:fromHeight]
 	}
+	c.gen.Add(1)
 	if prometheusBlockchainMTPCacheTruncations != nil {
 		prometheusBlockchainMTPCacheTruncations.Inc()
 	}
 }
 
 // reset clears the entire cache. Used on store-wide events (e.g. test resets)
-// where the safest action is to refetch everything.
+// where the safest action is to refetch everything. Bumps the generation so
+// any in-flight putRangeIfGen call from a stale view is rejected.
 func (c *mtpCache) reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.mtps = c.mtps[:0]
+	c.gen.Add(1)
 	if prometheusBlockchainMTPCacheResets != nil {
 		prometheusBlockchainMTPCacheResets.Inc()
 	}

--- a/services/blockchain/mtp_cache_integration_test.go
+++ b/services/blockchain/mtp_cache_integration_test.go
@@ -1,0 +1,165 @@
+package blockchain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMTPCacheIntegration_RangeConsultsCache verifies that GetMedianTimePastRange
+// returns pre-populated cache values without hitting the store.
+func TestMTPCacheIntegration_RangeConsultsCache(t *testing.T) {
+	ctx := setup(t)
+	ctx.server.settings.ChainCfgParams.CSVHeight = 0
+
+	// Pre-populate the cache with known MTP values for heights 1..5.
+	// Heights 0..10 have zero MTP by BIP113 (below MedianTimeBlocks), but the
+	// cache zero-as-miss sentinel only fires for height >= 11. Use non-zero
+	// values below 11 to make the assertion unambiguous.
+	knownMTPs := []uint32{100, 200, 300, 400, 500}
+	ctx.server.mtpCache.putRange(1, knownMTPs)
+
+	// Call the public method. It should hit the cache and return the values we
+	// stored without consulting the store (which has no data for these heights
+	// beyond the genesis block at height 0).
+	got, err := ctx.server.GetMedianTimePastRange(context.Background(), 1, 5)
+	require.NoError(t, err)
+	require.Equal(t, knownMTPs, got, "GetMedianTimePastRange must return pre-populated cache values")
+}
+
+// TestMTPCacheIntegration_RangePopulatesCache verifies that a store fetch on a
+// cache miss causes the persisted-block portion of the range to be stored in the
+// cache for subsequent calls.
+func TestMTPCacheIntegration_RangePopulatesCache(t *testing.T) {
+	ctx := setup(t)
+	ctx.server.settings.ChainCfgParams.CSVHeight = 0
+
+	// Build a chain of 15 blocks so MTP is non-trivial (heights 1–14, genesis=0).
+	for i := 1; i <= 14; i++ {
+		blk := createTestBlockAtHeight(ctx, t, uint32(i), uint32(1000000+i*600))
+		_, _, err := ctx.server.store.StoreBlock(context.Background(), blk, "")
+		require.NoError(t, err)
+	}
+
+	// First call — cache miss, must hit the store and populate the cache.
+	result, err := ctx.server.GetMedianTimePastRange(context.Background(), 11, 14)
+	require.NoError(t, err)
+	require.Len(t, result, 4)
+
+	// Now the cache should hold the same values for [11,14].
+	for i, h := uint32(0), uint32(11); h <= 14; h, i = h+1, i+1 {
+		cached, ok := ctx.server.mtpCache.get(h)
+		require.True(t, ok, "height %d must be present in cache after store fetch", h)
+		require.Equal(t, result[i], cached, "cache value at height %d must match store result", h)
+	}
+}
+
+// TestMTPCacheIntegration_SpeculativeTopExcluded verifies that if toHeight is not
+// yet persisted (the "speculative top"), that slot is not written to the cache.
+func TestMTPCacheIntegration_SpeculativeTopExcluded(t *testing.T) {
+	ctx := setup(t)
+	ctx.server.settings.ChainCfgParams.CSVHeight = 0
+
+	// Store blocks 1..13 (heights 1–13, genesis=0). Height 14 is NOT stored.
+	for i := 1; i <= 13; i++ {
+		blk := createTestBlockAtHeight(ctx, t, uint32(i), uint32(1000000+i*600))
+		_, _, err := ctx.server.store.StoreBlock(context.Background(), blk, "")
+		require.NoError(t, err)
+	}
+
+	// Request up to height 14 (which is not persisted).
+	_, err := ctx.server.GetMedianTimePastRange(context.Background(), 11, 14)
+	require.NoError(t, err)
+
+	// Height 13 (the highest persisted block in range) must be in the cache.
+	_, ok := ctx.server.mtpCache.get(13)
+	require.True(t, ok, "height 13 (highest persisted) must be cached")
+
+	// Height 14 (not persisted / speculative top) must NOT be in the cache.
+	_, ok = ctx.server.mtpCache.get(14)
+	require.False(t, ok, "height 14 (speculative top, not yet persisted) must not be cached")
+}
+
+// TestMTPCacheIntegration_AddBlockTruncatesCache verifies that AddBlock truncates
+// the MTP cache at the new block's height, so stale pre-populated slots are dropped.
+func TestMTPCacheIntegration_AddBlockTruncatesCache(t *testing.T) {
+	ctx := setup(t)
+
+	// Store blocks 1 and 2 so we have a valid prev-block for block 3.
+	prevHash := ctx.server.settings.ChainCfgParams.GenesisHash
+	for i := 1; i <= 2; i++ {
+		blk := createTestBlockAtHeight(ctx, t, uint32(i), uint32(1000000+i*600))
+		_, _, err := ctx.server.store.StoreBlock(context.Background(), blk, "")
+		require.NoError(t, err)
+		prevHash = blk.Header.Hash()
+	}
+
+	// Pre-populate the cache with values at heights 3 and 4 (stale speculative entries).
+	ctx.server.mtpCache.putRange(3, []uint32{999, 888})
+
+	_, ok := ctx.server.mtpCache.get(3)
+	require.True(t, ok, "precondition: height 3 must be in cache before AddBlock")
+
+	// Build block 3 and add it via the service path (which calls truncate).
+	blk3 := createTestBlockAtHeight(ctx, t, 3, uint32(1000000+3*600))
+	blk3.Header.HashPrevBlock = prevHash
+
+	addReq := &blockchain_api.AddBlockRequest{
+		Header:           blk3.Header.Bytes(),
+		CoinbaseTx:       blk3.CoinbaseTx.Bytes(),
+		SubtreeHashes:    [][]byte{blk3.Subtrees[0].CloneBytes()},
+		TransactionCount: blk3.TransactionCount,
+		SizeInBytes:      blk3.SizeInBytes,
+		PeerId:           "test-peer",
+	}
+	_, err := ctx.server.AddBlock(context.Background(), addReq)
+	require.NoError(t, err)
+
+	// Height 3 must have been truncated from the cache.
+	_, ok = ctx.server.mtpCache.get(3)
+	require.False(t, ok, "height 3 must be dropped from cache after AddBlock at that height")
+}
+
+// TestMTPCacheIntegration_InvalidateBlockTruncatesCache verifies that InvalidateBlock
+// truncates the MTP cache from the invalidated block's height, leaving lower entries
+// intact.
+func TestMTPCacheIntegration_InvalidateBlockTruncatesCache(t *testing.T) {
+	ctx := setup(t)
+	ctx.server.settings.ChainCfgParams.CSVHeight = 0
+
+	// Store blocks 1..3.
+	for i := 1; i <= 3; i++ {
+		blk := createTestBlockAtHeight(ctx, t, uint32(i), uint32(1000000+i*600))
+		_, _, err := ctx.server.store.StoreBlock(context.Background(), blk, "")
+		require.NoError(t, err)
+	}
+
+	// Pre-populate cache for heights 1..9 (below MedianTimeBlocks so zero is valid).
+	ctx.server.mtpCache.putRange(1, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9})
+
+	// Retrieve block 2's hash so we can pass it to InvalidateBlock.
+	headers, _, err := ctx.server.store.GetBlockHeadersByHeight(context.Background(), 2, 2)
+	require.NoError(t, err)
+	require.Len(t, headers, 1)
+	blockHash := headers[0].Hash()
+
+	// InvalidateBlock should truncate at height 2, leaving height 1 intact.
+	_, err = ctx.server.InvalidateBlock(context.Background(), &blockchain_api.InvalidateBlockRequest{
+		BlockHash: blockHash.CloneBytes(),
+	})
+	require.NoError(t, err)
+
+	// Height 1 (below the invalidated height 2) must still be cached.
+	mtp1, ok := ctx.server.mtpCache.get(1)
+	require.True(t, ok, "height 1 (below invalidated) must remain in cache")
+	require.Equal(t, uint32(1), mtp1)
+
+	// Height 2 and above must be gone.
+	_, ok = ctx.server.mtpCache.get(2)
+	require.False(t, ok, "height 2 (invalidated block) must be truncated from cache")
+
+	_, ok = ctx.server.mtpCache.get(3)
+	require.False(t, ok, "height 3 (above invalidated) must be truncated from cache")
+}

--- a/services/blockchain/mtp_cache_test.go
+++ b/services/blockchain/mtp_cache_test.go
@@ -110,6 +110,61 @@ func TestMTPCache_Overwrite(t *testing.T) {
 	assert.Equal(t, []uint32{5, 100, 101, 102, 9}, got)
 }
 
+func TestMTPCache_PutRangeIfGen_AcceptsMatchingGeneration(t *testing.T) {
+	c := newMTPCache()
+	gen := c.generation()
+
+	ok := c.putRangeIfGen(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, gen)
+	assert.True(t, ok, "matching generation must be accepted")
+
+	got, ok := c.getRange(0, 11)
+	require.True(t, ok)
+	assert.Equal(t, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, got)
+}
+
+func TestMTPCache_PutRangeIfGen_RejectsAfterTruncate(t *testing.T) {
+	c := newMTPCache()
+	// Pre-populate so a later putRangeIfGen with a stale snapshot would
+	// otherwise overwrite real data.
+	c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
+
+	// Snapshot generation BEFORE the simulated reorg.
+	staleGen := c.generation()
+
+	// Concurrent reorg: truncate from height 5 onwards. Bumps generation.
+	c.truncate(5)
+
+	// Stale writeback: tries to put 12 entries from height 0. Heights 5-11
+	// would be poisoned with pre-reorg values if the gen check were missing.
+	stalePayload := []uint32{1, 2, 3, 4, 5, 999, 999, 999, 999, 999, 999, 999}
+	ok := c.putRangeIfGen(0, stalePayload, staleGen)
+	assert.False(t, ok, "stale generation must be rejected")
+
+	// Heights 0-4 still have their pre-truncate values; heights >=5 should
+	// miss (truncated, not repopulated by the rejected write).
+	for h := uint32(0); h <= 4; h++ {
+		mtp, hit := c.get(h)
+		require.True(t, hit, "height %d must still be cached after truncate; pre-existing values below the truncate point are preserved", h)
+		assert.Equal(t, h+1, mtp)
+	}
+	for h := uint32(5); h <= 11; h++ {
+		_, hit := c.get(h)
+		assert.False(t, hit, "height %d must be a miss; the rejected stale write must not have repopulated it", h)
+	}
+}
+
+func TestMTPCache_PutRangeIfGen_RejectsAfterReset(t *testing.T) {
+	c := newMTPCache()
+	staleGen := c.generation()
+	c.reset() // bumps generation even on an empty cache
+
+	ok := c.putRangeIfGen(0, []uint32{1, 2, 3}, staleGen)
+	assert.False(t, ok, "stale generation must be rejected after reset")
+
+	_, hit := c.get(0)
+	assert.False(t, hit, "rejected write must not populate cache")
+}
+
 func TestMTPCache_ConcurrentReadWrite(t *testing.T) {
 	c := newMTPCache()
 	c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20})

--- a/services/blockchain/mtp_cache_test.go
+++ b/services/blockchain/mtp_cache_test.go
@@ -1,0 +1,138 @@
+package blockchain
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMTPCache_EmptyMisses(t *testing.T) {
+	c := newMTPCache()
+
+	// Single get on empty cache misses
+	_, ok := c.get(5)
+	assert.False(t, ok)
+
+	// Range get on empty cache misses
+	out, ok := c.getRange(0, 10)
+	assert.False(t, ok)
+	assert.Nil(t, out)
+
+	// Empty range (toHeight < fromHeight) returns empty + ok=true
+	out, ok = c.getRange(10, 5)
+	assert.True(t, ok)
+	assert.Empty(t, out)
+}
+
+func TestMTPCache_PutGetRange(t *testing.T) {
+	c := newMTPCache()
+
+	// Heights 0..14 all populated; below MedianTimeBlocks (11) we still
+	// expect cache hits because the entries were explicitly stored, but
+	// store non-zero values to avoid the zero-as-miss sentinel.
+	values := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	c.putRange(0, values)
+
+	got, ok := c.getRange(0, 14)
+	require.True(t, ok)
+	assert.Equal(t, values, got)
+
+	got, ok = c.getRange(5, 10)
+	require.True(t, ok)
+	assert.Equal(t, []uint32{6, 7, 8, 9, 10, 11}, got)
+
+	mtp, ok := c.get(11)
+	require.True(t, ok)
+	assert.Equal(t, uint32(12), mtp)
+}
+
+func TestMTPCache_RangeBeyondCacheMisses(t *testing.T) {
+	c := newMTPCache()
+	c.putRange(0, []uint32{1, 2, 3})
+
+	_, ok := c.getRange(0, 5)
+	assert.False(t, ok, "range exceeding cache should miss")
+}
+
+func TestMTPCache_ZeroSentinelAtMTPHeight(t *testing.T) {
+	c := newMTPCache()
+	// Slot 11 left as zero — at or above MedianTimeBlocks, treat as miss so
+	// caller refetches and confirms.
+	c.putRange(0, []uint32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+
+	_, ok := c.get(11)
+	assert.False(t, ok, "zero at height >= 11 must be treated as miss")
+
+	// Below MedianTimeBlocks, zero is valid (genuine MTP=0 for early heights)
+	mtp, ok := c.get(5)
+	require.True(t, ok)
+	assert.Equal(t, uint32(0), mtp)
+}
+
+func TestMTPCache_Truncate(t *testing.T) {
+	c := newMTPCache()
+	c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
+
+	c.truncate(10)
+
+	_, ok := c.get(10)
+	assert.False(t, ok, "height >= truncate point must miss")
+
+	mtp, ok := c.get(9)
+	require.True(t, ok)
+	assert.Equal(t, uint32(10), mtp)
+
+	// Truncate beyond current length is a no-op
+	c.truncate(100)
+	_, ok = c.get(9)
+	assert.True(t, ok)
+}
+
+func TestMTPCache_Reset(t *testing.T) {
+	c := newMTPCache()
+	c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
+	c.reset()
+
+	_, ok := c.get(0)
+	assert.False(t, ok, "after reset, all entries miss")
+}
+
+func TestMTPCache_Overwrite(t *testing.T) {
+	c := newMTPCache()
+	c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
+	// Overwrite with new values (e.g. reorg-driven repopulation)
+	c.putRange(5, []uint32{100, 101, 102})
+
+	got, ok := c.getRange(4, 8)
+	require.True(t, ok)
+	assert.Equal(t, []uint32{5, 100, 101, 102, 9}, got)
+}
+
+func TestMTPCache_ConcurrentReadWrite(t *testing.T) {
+	c := newMTPCache()
+	c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+
+	var wg sync.WaitGroup
+	const readers = 16
+	const iters = 1000
+
+	wg.Add(readers + 1)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, _ = c.getRange(0, 19)
+			}
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		for j := 0; j < iters; j++ {
+			c.putRange(0, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Add a service-level Median Time Past (MTP) cache on `Blockchain` so per-block validation and the validator's `EnsureMTPLoaded` refresh don't round-trip through the SQL store on every call.

The SQL store's `responseCache` is wiped on every `StoreBlock` via `ResetResponseCache` (`stores/blockchain/sql/sql.go:1117`), so MTP queries hit the database every block during sync. This in-process cache lives on the `Blockchain` service, survives `StoreBlock`, and only invalidates on chain reorganisation paths.

## Why

`pg_stat_statements` on a fresh testnet sync (eu-4 v0.15.0-beta-5) showed the small recursive-CTE walks (mostly MTP / 100-deep validation queries) at 163 calls × ~17.5 rows × 0.30 ms = ~49 ms total over a few minutes. After PR #817 (`on_main_chain` fast path) those calls run via the partial-index path — but they still incur a DB round-trip per block. This cache eliminates the round-trip when the answer is already in memory.

The validator service already maintains its own `mtpStore` that grows with sync and calls `GetMedianTimePastRange` to refresh a 12-height overlap window per block. After this PR those refreshes are served from in-process memory on the blockchain service rather than running the query in the storage layer.

## Implementation

**`services/blockchain/mtp_cache.go`** (new): lock-protected `[]uint32` indexed by height. O(1) lookup, bounded by chain length (~5 MB at 1.27M heights).

**`services/blockchain/median_time_past.go`** (modified):
- `GetMedianTimePastForHeights`: probe cache for the requested `[min, max]` range; on miss fetch via `GetBlockHeadersByHeight` and write the persisted-block portion back into the cache.
- `GetMedianTimePastRange`: same pattern. Skips caching the not-yet-persisted top entry — its MTP is computed on-the-fly and finalised by `AddBlock`, which truncates the cache at that height.

**`services/blockchain/Server.go`** (modified):
- New `mtpCache` field, initialised in `New`.
- `AddBlock`: `truncate(height)` after `StoreBlock` so any speculative top-of-chain entry is dropped; heights below the new tip remain valid.
- `InvalidateBlock` / `RevalidateBlock`: full `reset()` — chain shape can change at any height from the (re)validated block forward; safest to repopulate from the store.

**Zero-as-miss sentinel** for heights `>= MedianTimeBlocks` (11): ensures a genuinely unpopulated slot is treated as a miss, while below height 11 a zero MTP is a real value.

## Test plan

- [x] `go test -race ./services/blockchain/...` — 628 pass, including 8 new MTP cache tests
- [x] `go test ./services/validator/...` — 275 pass (validator is the heavy MTP consumer; behaviour unchanged)
- [x] `go vet ./services/blockchain/...` — clean
- [x] `go build ./services/blockchain/...` — success

`mtp_cache_test.go` covers: empty miss, put/get range, range exceeding cache, zero-as-miss sentinel, truncate at and beyond cache length, full reset, overwrite (reorg-driven repopulation), concurrent read/write under `-race`.

## Memory footprint

A `uint32` per height. At current testnet (~1.27M blocks): ~5 MB. At 10M blocks: ~40 MB. Cap is implicit via chain length; the cache only grows when queried, so a freshly started node carries near-zero overhead until the first MTP query.