### PR TITLE
fix(blockassembly): close subtree readers to plug read-permit leak

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1385,6 +1385,10 @@ func (stp *SubtreeProcessor) getConflictingNodes(ctx context.Context, block *mod
 				}
 			}
 
+			defer func() {
+				_ = subtreeReader.Close()
+			}()
+
 			subtreeConflictingNodes, err := subtreepkg.DeserializeSubtreeConflictingFromReader(subtreeReader)
 			if err != nil {
 				return errors.NewProcessingError("[moveForwardBlock][%s] error deserializing subtree conflicting nodes", block.String(), err)
@@ -3186,6 +3190,10 @@ func (stp *SubtreeProcessor) moveBackBlockGetSubtrees(ctx context.Context, block
 					return errors.NewServiceError("[moveBackBlock:GetSubtrees][%s] error getting subtree meta %s", block.String(), subtreeHash.String(), err)
 				}
 
+				defer func() {
+					_ = subtreeMetaReader.Close()
+				}()
+
 				subtreeMeta, err := subtreepkg.NewSubtreeMetaFromReader(subtree, subtreeMetaReader)
 				if err != nil {
 					return errors.NewProcessingError("[moveBackBlock:GetSubtrees][%s] error deserializing subtree meta", block.String(), err)
@@ -4380,6 +4388,10 @@ func (stp *SubtreeProcessor) getSubtreeAndConflictingTransactionsMap(ctx context
 			return nil, nil, errors.NewServiceError("error getting subtree %s", subtreeHash.String())
 		}
 	}
+
+	defer func() {
+		_ = subtreeReader.Close()
+	}()
 
 	subtree := &subtreepkg.Subtree{}
 	if err = subtree.DeserializeFromReader(subtreeReader); err != nil {

--- a/services/blockassembly/subtreeprocessor/subtree_reader_leak_test.go
+++ b/services/blockassembly/subtreeprocessor/subtree_reader_leak_test.go
@@ -1,0 +1,216 @@
+package subtreeprocessor
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/stores/blob"
+	blob_memory "github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// countingBlobStore wraps a blob.Store and counts how many io.ReadCloser handles
+// returned by GetIoReader are closed. Used by leak tests to detect callers that
+// open a reader but never call Close — in production this drains the file-store
+// global read-permit semaphore.
+type countingBlobStore struct {
+	blob.Store
+	opens  atomic.Int64
+	closes atomic.Int64
+}
+
+func newCountingBlobStore(inner blob.Store) *countingBlobStore {
+	return &countingBlobStore{Store: inner}
+}
+
+func (c *countingBlobStore) GetIoReader(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (io.ReadCloser, error) {
+	rc, err := c.Store.GetIoReader(ctx, key, fileType, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	c.opens.Add(1)
+
+	return &countingReadCloser{ReadCloser: rc, parent: c}, nil
+}
+
+type countingReadCloser struct {
+	io.ReadCloser
+	parent *countingBlobStore
+	once   atomic.Bool
+}
+
+func (r *countingReadCloser) Close() error {
+	if r.once.CompareAndSwap(false, true) {
+		r.parent.closes.Add(1)
+	}
+
+	return r.ReadCloser.Close()
+}
+
+// TestSubtreeProcessor_getConflictingNodes_closesReader regression test for the
+// production observation on teranode-mainnet-eu-1 where block-assembly drained
+// the file-store read-permit semaphore. getConflictingNodes opened the subtree
+// reader inside an errgroup goroutine but never closed it, leaking one permit
+// per subtree per moveForwardBlock call.
+func TestSubtreeProcessor_getConflictingNodes_closesReader(t *testing.T) {
+	inner := blob_memory.New()
+	counting := newCountingBlobStore(inner)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockAssembly.InitialMerkleItemsPerSubtree = 4
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(t.Context(), ulogger.TestLogger{}, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	blockchainClient := &blockchain.Mock{}
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 1)
+
+	stp, err := NewSubtreeProcessor(t.Context(), ulogger.TestLogger{}, tSettings, counting, blockchainClient, utxoStore, newSubtreeChan)
+	require.NoError(t, err)
+
+	s1 := createSubtree(t, 4, true)
+	s1Bytes, err := s1.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s1.RootHash()[:], fileformat.FileTypeSubtree, s1Bytes))
+
+	s2 := createSubtree(t, 4, false)
+	s2Bytes, err := s2.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s2.RootHash()[:], fileformat.FileTypeSubtree, s2Bytes))
+
+	block := &model.Block{
+		Header:   prevBlockHeader,
+		Subtrees: []*chainhash.Hash{s1.RootHash(), s2.RootHash()},
+	}
+
+	_, err = stp.getConflictingNodes(t.Context(), block)
+	require.NoError(t, err)
+
+	opens := counting.opens.Load()
+	closes := counting.closes.Load()
+
+	require.Greater(t, opens, int64(0), "test exercise didn't open any readers — assertion vacuous")
+	require.Equal(t, opens, closes,
+		"read-permit leak in getConflictingNodes: opens=%d closes=%d (every GetIoReader must close its ReadCloser)",
+		opens, closes)
+}
+
+// TestSubtreeProcessor_moveBackBlockGetSubtrees_closesSubtreeMetaReader
+// exercises the moveBackBlock GetSubtrees branch with
+// StoreTxInpointsForSubtreeMeta enabled. The branch opens both a subtree reader
+// (closed via defer) AND a subtree-meta reader. The meta reader was never
+// closed, leaking permits during every reorg.
+func TestSubtreeProcessor_moveBackBlockGetSubtrees_closesSubtreeMetaReader(t *testing.T) {
+	inner := blob_memory.New()
+	counting := newCountingBlobStore(inner)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockAssembly.InitialMerkleItemsPerSubtree = 4
+	tSettings.BlockAssembly.StoreTxInpointsForSubtreeMeta = true
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(t.Context(), ulogger.TestLogger{}, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 1)
+
+	stp, err := NewSubtreeProcessor(t.Context(), ulogger.TestLogger{}, tSettings, counting, nil, utxoStore, newSubtreeChan)
+	require.NoError(t, err)
+
+	s1 := createSubtree(t, 4, true)
+	s1Bytes, err := s1.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s1.RootHash()[:], fileformat.FileTypeSubtree, s1Bytes))
+
+	sm1 := createSubtreeMeta(t, s1)
+	sm1Bytes, err := sm1.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s1.RootHash()[:], fileformat.FileTypeSubtreeMeta, sm1Bytes))
+
+	s2 := createSubtree(t, 4, false)
+	s2Bytes, err := s2.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s2.RootHash()[:], fileformat.FileTypeSubtree, s2Bytes))
+
+	sm2 := createSubtreeMeta(t, s2)
+	sm2Bytes, err := sm2.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s2.RootHash()[:], fileformat.FileTypeSubtreeMeta, sm2Bytes))
+
+	_, _, _, err = stp.moveBackBlockGetSubtrees(t.Context(), &model.Block{
+		Header:   prevBlockHeader,
+		Subtrees: []*chainhash.Hash{s1.RootHash(), s2.RootHash()},
+	})
+	require.NoError(t, err)
+
+	opens := counting.opens.Load()
+	closes := counting.closes.Load()
+
+	require.GreaterOrEqual(t, opens, int64(4), "expected at least 4 opens (2 subtrees × subtree+meta)")
+	require.Equal(t, opens, closes,
+		"read-permit leak in moveBackBlockGetSubtrees: opens=%d closes=%d", opens, closes)
+}
+
+// TestSubtreeProcessor_getSubtreeAndConflictingTransactionsMap_closesReader
+// regression test for the third leak site: function fetches the subtree but
+// never closes the reader.
+func TestSubtreeProcessor_getSubtreeAndConflictingTransactionsMap_closesReader(t *testing.T) {
+	inner := blob_memory.New()
+	counting := newCountingBlobStore(inner)
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(t.Context(), ulogger.TestLogger{}, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 1)
+
+	stp, err := NewSubtreeProcessor(t.Context(), ulogger.TestLogger{}, tSettings, counting, nil, utxoStore, newSubtreeChan)
+	require.NoError(t, err)
+
+	s, err := subtreepkg.NewTreeByLeafCount(4)
+	require.NoError(t, err)
+
+	tx1 := chainhash.HashH([]byte("leak-test-tx1"))
+	tx2 := chainhash.HashH([]byte("leak-test-tx2"))
+	tx3 := chainhash.HashH([]byte("leak-test-tx3"))
+	require.NoError(t, s.AddNode(tx1, 1, 100))
+	require.NoError(t, s.AddNode(tx2, 2, 200))
+	require.NoError(t, s.AddNode(tx3, 3, 300))
+
+	sBytes, err := s.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, inner.Set(t.Context(), s.RootHash()[:], fileformat.FileTypeSubtree, sBytes))
+
+	_, _, err = stp.getSubtreeAndConflictingTransactionsMap(t.Context(), s.RootHash(), []chainhash.Hash{tx1, tx3})
+	require.NoError(t, err)
+
+	opens := counting.opens.Load()
+	closes := counting.closes.Load()
+
+	require.Greater(t, opens, int64(0), "test didn't exercise GetIoReader")
+	require.Equal(t, opens, closes,
+		"read-permit leak in getSubtreeAndConflictingTransactionsMap: opens=%d closes=%d", opens, closes)
+}


### PR DESCRIPTION
## Summary

Three sites in `services/blockassembly/subtreeprocessor/SubtreeProcessor.go` opened readers via `subtreeStore.GetIoReader` and never called `Close`. Each unclosed reader holds a slot in the global file-store read semaphore (768 slots default), so the pool drains over time on hosts with sustained block-assembly activity.

## Production observation

`teranode-mainnet-eu-1`, **1257 events in 6 days**, 100% on `block-assembly` subsystem (Coralogix):

```
STORAGE_ERROR (69): [File][openFileWithFallback] failed to acquire read permit
 -> CONTEXT_CANCELED (7): [File] read operation canceled while waiting for semaphore permit
 -> UNKNOWN (0): context canceled
```

Pattern is bursty: 1016 events in a 5-hour window, then quiet, then another burst — consistent with sustained drain followed by pod restart and gradual re-leak.

## Root cause

Once the read-permit pool is drained, `Block.GetAndValidateSubtrees` (`model/Block.go:1147`) cannot acquire a permit within the 25 s timeout. The wait-group ctx then cancels and sibling fetches return `CONTEXT_CANCELED`. All three retries via `retry.Retry(gCtx, ...)` reuse the same canceled `gCtx` and fail fast — that is why the user sees `given up after 3 attempts`.

## Leak sites fixed

| Line | Function | When hit |
|------|----------|----------|
| `getConflictingNodes` errgroup body | every `moveForwardBlock` + `Reset` per subtree | hot path on every new block |
| `moveBackBlockGetSubtrees` `subtreeMetaReader` | `StoreTxInpointsForSubtreeMeta` branch | every reorg |
| `getSubtreeAndConflictingTransactionsMap` | conflict-resolution path | post-reorg conflict cleanup |

Each fix adds a `defer subtreeReader.Close()` / `defer subtreeMetaReader.Close()` immediately after the successful `GetIoReader`. Memory store wraps in `io.NopCloser`; file store uses `sync.Once`-guarded release; double-close is safe.

## Regression test

`subtree_reader_leak_test.go` introduces a `countingBlobStore` wrapper that tracks `GetIoReader` opens against `ReadCloser.Close` calls and asserts `opens == closes` after exercising each leaky function.

Without the fix, the tests measure:

- `getConflictingNodes` — opens=2 closes=0
- `moveBackBlockGetSubtrees` — opens=4 closes=2
- `getSubtreeAndConflictingTransactionsMap` — opens=1 closes=0

After the fix, all three pass.

## Test plan

- [x] `go test -race -count=1 ./services/blockassembly/subtreeprocessor/` — 179 pass
- [x] `go test -race -count=1 ./services/blockassembly/...` — 571 pass
- [x] `go vet ./services/blockassembly/...` — clean
- [x] New tests verified RED before fix, GREEN after fix
- [ ] Watch `teranode-mainnet-eu-1` post-deploy: expect no `failed to acquire read permit` warnings on `block-assembly` after pod restart

## Out of scope

`Block.GetAndValidateSubtrees` retries through the same canceled errgroup `gCtx`, so retries fail fast under load. Worth a follow-up — not bundled here.

## Affected versions

`v0.14.0` through `v0.15.0-beta-5` all contain the leak. Backport candidates if a production cherry-pick is desired.