### PR TITLE
Ensure atomic file store publication

### DIFF
--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -559,6 +559,47 @@ func (s *File) errorOnOverwrite(filename string, opts *options.Options) error {
 	return nil
 }
 
+func (s *File) storeRelPath(filename string) (string, error) {
+	if filename == "" {
+		return "", errors.NewInvalidArgumentError("file store path is empty")
+	}
+
+	rel, err := filepath.Rel(s.path, filename)
+	if err != nil {
+		return "", errors.NewStorageError("[File][%s] failed to calculate relative file path", filename, err)
+	}
+
+	if rel == "." || !filepath.IsLocal(rel) {
+		return "", errors.NewInvalidArgumentError("[File][%s] path escapes file store root %s", filename, s.path)
+	}
+
+	return rel, nil
+}
+
+func (s *File) openStoreRoot() (*os.Root, error) {
+	root, err := os.OpenRoot(s.path)
+	if err != nil {
+		return nil, errors.NewStorageError("[File][%s] failed to open store root", s.path, err)
+	}
+
+	return root, nil
+}
+
+func (s *File) removeStorePath(filename string) error {
+	rel, err := s.storeRelPath(filename)
+	if err != nil {
+		return err
+	}
+
+	root, err := s.openStoreRoot()
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	return root.Remove(rel)
+}
+
 // SetFromReader stores a blob in the file store from a streaming reader.
 // This method is more memory-efficient than Set for large blobs as it streams data
 // directly to disk without loading the entire blob into memory. It handles file creation,
@@ -618,7 +659,7 @@ func (s *File) SetFromReader(ctx context.Context, key []byte, fileType fileforma
 
 		if cleanupTmpFile {
 			// Remove temp file on any error path to prevent incomplete files
-			if removeErr := os.Remove(tmpFilename); removeErr != nil && !os.IsNotExist(removeErr) {
+			if removeErr := s.removeStorePath(tmpFilename); removeErr != nil && !os.IsNotExist(removeErr) {
 				s.logger.Warnf("[File][SetFromReader] failed to remove temp file %s: %v", tmpFilename, removeErr)
 			}
 		}
@@ -660,7 +701,7 @@ func (s *File) SetFromReader(ctx context.Context, key []byte, fileType fileforma
 
 	// Write SHA256 hash file
 	if err = s.writeHashFile(hasher, filename); err != nil {
-		if removeErr := os.Remove(filename); removeErr != nil && !os.IsNotExist(removeErr) {
+		if removeErr := s.removeStorePath(filename); removeErr != nil && !os.IsNotExist(removeErr) {
 			s.logger.Warnf("[File][SetFromReader] failed to remove blob file %s after hash write error: %v", filename, removeErr)
 		}
 
@@ -1143,8 +1184,19 @@ func (s *File) Del(ctx context.Context, key []byte, fileType fileformat.FileType
 func (s *File) createTempSibling(filename string, perm os.FileMode) (*os.File, string, error) {
 	const maxAttempts = 10
 
-	dir := filepath.Dir(filename)
-	base := filepath.Base(filename)
+	finalRel, err := s.storeRelPath(filename)
+	if err != nil {
+		return nil, "", err
+	}
+
+	root, err := s.openStoreRoot()
+	if err != nil {
+		return nil, "", err
+	}
+	defer root.Close()
+
+	dir := filepath.Dir(finalRel)
+	base := filepath.Base(finalRel)
 
 	for i := 0; i < maxAttempts; i++ {
 		randNum, err := rand.Int(rand.Reader, big.NewInt(1<<63-1))
@@ -1152,11 +1204,11 @@ func (s *File) createTempSibling(filename string, perm os.FileMode) (*os.File, s
 			return nil, "", errors.NewStorageError("[File][%s] failed to generate temporary filename", filename, err)
 		}
 
-		tmpFilename := filepath.Join(dir, fmt.Sprintf(".%s.%d.tmp", base, randNum))
+		tmpRel := filepath.Join(dir, fmt.Sprintf(".%s.%d.tmp", base, randNum))
 		//nolint:gosec // Blob store files intentionally preserve the existing 0644 file mode.
-		file, err := os.OpenFile(tmpFilename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+		file, err := root.OpenFile(tmpRel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
 		if err == nil {
-			return file, tmpFilename, nil
+			return file, filepath.Join(s.path, tmpRel), nil
 		}
 
 		if os.IsExist(err) {
@@ -1209,7 +1261,20 @@ func (s *File) syncAndCloseTempFile(file *os.File, tmpFilename string) error {
 // at debug level and do not turn an already-successful rename into a failed blob write.
 // Callers should rely on it as a durability improvement, not as a portable hard guarantee.
 func (s *File) syncParentDirBestEffort(filename string) {
-	dir, err := os.Open(filepath.Dir(filename))
+	rel, err := s.storeRelPath(filename)
+	if err != nil {
+		s.debugf("[File][%s] failed to calculate parent directory for sync: %v", filename, err)
+		return
+	}
+
+	root, err := s.openStoreRoot()
+	if err != nil {
+		s.debugf("[File][%s] failed to open store root for parent sync: %v", filename, err)
+		return
+	}
+	defer root.Close()
+
+	dir, err := root.Open(filepath.Dir(rel))
 	if err != nil {
 		s.debugf("[File][%s] failed to open parent directory for sync: %v", filename, err)
 		return
@@ -1224,7 +1289,7 @@ func (s *File) syncParentDirBestEffort(filename string) {
 // renameTempFile publishes a completed temp file at its final filename.
 //
 // The temp file must be a sibling of filename; createTempSibling enforces that pattern.
-// When source and destination are on the same filesystem, os.Rename makes the final path
+// When source and destination are on the same filesystem, rename makes the final path
 // appear atomically, so readers either see the previous complete file or the new complete
 // file, never a partially written final file.
 //
@@ -1237,8 +1302,24 @@ func (s *File) syncParentDirBestEffort(filename string) {
 // name is more likely to survive a crash. That directory sync is best-effort; see
 // syncParentDirBestEffort for the portability caveat.
 func (s *File) renameTempFile(tmpFilename, filename string) error {
-	if err := os.Rename(tmpFilename, filename); err != nil {
-		if fileInfo, statErr := os.Stat(filename); statErr == nil && !fileInfo.IsDir() {
+	tmpRel, err := s.storeRelPath(tmpFilename)
+	if err != nil {
+		return err
+	}
+
+	finalRel, err := s.storeRelPath(filename)
+	if err != nil {
+		return err
+	}
+
+	root, err := s.openStoreRoot()
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	if err := root.Rename(tmpRel, finalRel); err != nil {
+		if fileInfo, statErr := root.Stat(finalRel); statErr == nil && !fileInfo.IsDir() {
 			return errors.NewBlobAlreadyExistsError("[File][%s] already exists in store", filename)
 		}
 
@@ -1280,7 +1361,7 @@ func (s *File) writeFileAtomically(filename string, data []byte, perm os.FileMod
 		}
 
 		if cleanupTmpFile {
-			if removeErr := os.Remove(tmpFilename); removeErr != nil && !os.IsNotExist(removeErr) {
+			if removeErr := s.removeStorePath(tmpFilename); removeErr != nil && !os.IsNotExist(removeErr) {
 				s.logger.Warnf("[File][%s] failed to remove temporary file: %v", tmpFilename, removeErr)
 			}
 		}

--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -161,7 +161,7 @@ const (
 //    should be well under the system limit to account for other file descriptors
 //    (network sockets, log files, etc.). Default: 768 + 256 = 1024.
 //    ALL file operations MUST be protected by semaphores, including those in background
-//    goroutines (loadDAHs, cleanup), to ensure ulimit protection is comprehensive.
+//    cleanup goroutines, to ensure ulimit protection is comprehensive.
 //
 // 2. INITIALIZATION REQUIREMENT:
 //    InitSemaphores() MUST be called in main() before ANY file store operations begin.
@@ -176,15 +176,7 @@ const (
 //    - Calling it before any file operations that use the semaphores
 //    - Not testing the initialization function in the same suite as code using it
 //
-// 4. INTERNAL VARIANTS PATTERN:
-//    To avoid nested semaphore acquisition (which reduces effective capacity and wastes
-//    ulimit protection), helper functions have two variants:
-//    - Public versions (e.g., readDAHFromFile): acquire semaphore for standalone/background use
-//    - Internal versions (e.g., readDAHFromFile_internal): no semaphore, for use within
-//      already-protected contexts (API operations like SetFromReader that hold semaphores)
-//    This ensures every file operation is protected exactly once, maximizing ulimit protection.
-//
-// 5. SEPARATE READ/WRITE SEMAPHORES:
+// 4. SEPARATE READ/WRITE SEMAPHORES:
 //    Using separate semaphores prevents deadlocks where write operations holding the
 //    write semaphore are blocked waiting for pipe data, while the operations that
 //    would provide that data (ProcessSubtree reads) cannot acquire read slots because
@@ -474,81 +466,6 @@ func (s *File) SetCurrentBlockHeight(height uint32) {
 	s.currentBlockHeight.Store(height)
 }
 
-// readDAHFromFile_internal reads a DAH value from file WITHOUT semaphore protection.
-// Caller must hold appropriate semaphore or be in a context where protection isn't needed.
-func (s *File) readDAHFromFile_internal(fileName string) (uint32, error) {
-	// read the dah
-	dahBytes, err := os.ReadFile(fileName)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return 0, errors.NewNotFoundError("[File] DAH file %s not found", fileName)
-		}
-
-		return 0, errors.NewStorageError("[File] failed to read DAH file", err)
-	}
-
-	// Trim whitespace and validate content
-	dahStr := strings.TrimSpace(string(dahBytes))
-	if dahStr == "" {
-		return 0, errors.NewProcessingError("[File] DAH file %s is empty", fileName)
-	}
-
-	dah, err := strconv.ParseUint(dahStr, 10, 32)
-	if err != nil {
-		return 0, errors.NewProcessingError("[File] failed to parse DAH from %s: %s", fileName, dahStr)
-	}
-
-	// Validate DAH value - should never be 0
-	if dah == 0 {
-		return 0, errors.NewProcessingError("[File] invalid DAH value 0 in file %s", fileName)
-	}
-
-	return uint32(dah), nil
-}
-
-// readDAHFromFile reads a DAH value from file WITH semaphore protection.
-// Use this for background operations or when caller doesn't hold a semaphore.
-func (s *File) readDAHFromFile(fileName string) (uint32, error) {
-	ctx := context.Background()
-	if err := acquireReadPermit(ctx); err != nil {
-		return 0, err
-	}
-	defer releaseReadPermit()
-
-	return s.readDAHFromFile_internal(fileName)
-}
-
-// writeDAHToFileInternal writes a DAH value to file WITHOUT semaphore protection.
-// Caller must hold appropriate semaphore.
-func (s *File) writeDAHToFileInternal(dahFilename string, dah uint32) error {
-	// Validate DAH value before writing
-	if dah == 0 {
-		return errors.NewProcessingError("[File] attempted to write invalid DAH value 0 to file %s", dahFilename)
-	}
-
-	dahContent := []byte(strconv.FormatUint(uint64(dah), 10))
-
-	// Write directly to the file
-	//nolint:gosec // G306: Expect WriteFile permissions to be 0600 or less (gosec)
-	if err := os.WriteFile(dahFilename, dahContent, 0644); err != nil {
-		return errors.NewStorageError("[File][%s] failed to write DAH to file", dahFilename, err)
-	}
-
-	return nil
-}
-
-// writeDAHToFile writes a DAH value to file WITH semaphore protection.
-// Use this when caller doesn't already hold a semaphore.
-func (s *File) writeDAHToFile(dahFilename string, dah uint32) error {
-	ctx := context.Background()
-	if err := acquireWritePermit(ctx); err != nil {
-		return err
-	}
-	defer releaseWritePermit()
-
-	return s.writeDAHToFileInternal(dahFilename, dah)
-}
-
 // Health checks the health status of the file-based blob store.
 // It verifies that the storage directory exists and is accessible by attempting to
 // create a temporary file. This ensures that the store can perform basic read/write
@@ -684,25 +601,21 @@ func (s *File) SetFromReader(ctx context.Context, key []byte, fileType fileforma
 		return err
 	}
 
-	// Generate a cryptographically secure random number
-	randNum, err := rand.Int(rand.Reader, big.NewInt(1<<63-1))
+	file, tmpFilename, err := s.createTempSibling(filename, 0644)
 	if err != nil {
-		return errors.NewStorageError("[File][SetFromReader] failed to generate random number", err)
-	}
-
-	tmpFilename := fmt.Sprintf("%s.%d.tmp", filename, randNum)
-
-	// Create the file first
-	file, err := os.Create(tmpFilename)
-	if err != nil {
-		return errors.NewStorageError("[File][SetFromReader] [%s] failed to create file", filename, err)
+		return err
 	}
 
 	// Track whether we should clean up the temp file on exit.
 	// Default to true (cleanup); only set to false on success path after rename.
 	cleanupTmpFile := true
 	defer func() {
-		file.Close()
+		if file != nil {
+			if closeErr := file.Close(); closeErr != nil {
+				s.logger.Warnf("[File][SetFromReader] failed to close temp file %s during cleanup: %v", tmpFilename, closeErr)
+			}
+		}
+
 		if cleanupTmpFile {
 			// Remove temp file on any error path to prevent incomplete files
 			if removeErr := os.Remove(tmpFilename); removeErr != nil && !os.IsNotExist(removeErr) {
@@ -733,25 +646,24 @@ func (s *File) SetFromReader(ctx context.Context, key []byte, fileType fileforma
 		return errors.NewStorageError("[File][SetFromReader] [%s] reader provided zero bytes of data", filename)
 	}
 
-	// Success path - don't cleanup temp file, we're about to rename it
-	cleanupTmpFile = false
+	if err = s.syncAndCloseTempFile(file, tmpFilename); err != nil {
+		file = nil
+		return err
+	}
+	file = nil
 
 	// rename the file to remove the .tmp extension
-	if err = os.Rename(tmpFilename, filename); err != nil {
-		// check is some other process has created this file before us
-		if _, statErr := os.Stat(filename); statErr != nil {
-			// Rename failed and file doesn't exist - clean up temp file
-			_ = os.Remove(tmpFilename)
-			return errors.NewStorageError("[File][SetFromReader] [%s] failed to rename file from tmp", filename, err)
-		} else {
-			// Another process created the file - clean up our temp file
-			_ = os.Remove(tmpFilename)
-			s.logger.Warnf("[File][SetFromReader] [%s] already exists so another process created it first", filename)
-		}
+	if err = s.renameTempFile(tmpFilename, filename); err != nil {
+		return err
 	}
+	cleanupTmpFile = false
 
 	// Write SHA256 hash file
 	if err = s.writeHashFile(hasher, filename); err != nil {
+		if removeErr := os.Remove(filename); removeErr != nil && !os.IsNotExist(removeErr) {
+			s.logger.Warnf("[File][SetFromReader] failed to remove blob file %s after hash write error: %v", filename, removeErr)
+		}
+
 		return errors.NewStorageError("[File][SetFromReader] failed to write hash file", err)
 	}
 
@@ -773,22 +685,9 @@ func (s *File) writeHashFile(hasher hash.Hash, filename string) error {
 		base)
 
 	hashFilename := filename + checksumExtension
-	tmpHashFilename := hashFilename + ".tmp"
 
-	var err error
-
-	//nolint:gosec // G306: Expect WriteFile permissions to be 0600 or less (gosec)
-	if err = os.WriteFile(tmpHashFilename, []byte(hashStr), 0644); err != nil {
-		return errors.NewStorageError("[File] failed to write hash file", err)
-	}
-
-	if err = os.Rename(tmpHashFilename, hashFilename); err != nil {
-		// check is some other process has created this file before us
-		if _, statErr := os.Stat(hashFilename); statErr != nil {
-			return errors.NewStorageError("[File] failed to rename hash file", err)
-		} else {
-			s.logger.Warnf("[File] hash file %s already exists so another process created it first", hashFilename)
-		}
+	if err := s.writeFileAtomically(hashFilename, []byte(hashStr), 0644); err != nil {
+		return errors.NewStorageError("[File][%s] failed to write hash file atomically", hashFilename, err)
 	}
 
 	return nil
@@ -868,8 +767,8 @@ func (s *File) constructFilename(key []byte, fileType fileformat.FileType, opts 
 
 // SetDAH sets the Delete-At-Height (DAH) value for a blob in the file store.
 // The DAH value determines at which blockchain height the blob will be automatically deleted.
-// This implementation stores the DAH value in a separate file with the same name as the blob
-// but with a .dah extension, and also maintains an in-memory map of DAH values for quick access.
+// This implementation schedules or cancels deletion via the configured blob deletion scheduler;
+// the pruner service owns deletion execution.
 //
 // If the store has DisableDAH=true, this method returns immediately without error, as DAH
 // functionality is disabled for this store (lifecycle managed externally).
@@ -1224,4 +1123,183 @@ func (s *File) Del(ctx context.Context, key []byte, fileType fileformat.FileType
 	return nil
 }
 
-// findFilesByExtension removed - was only used by loadDAHs which has been removed
+// createTempSibling creates a new temporary file in the same directory as filename.
+//
+// The same-directory constraint is intentional. POSIX rename is atomic only when the
+// source and destination are on the same filesystem, so callers that intend to publish
+// data with renameTempFile must first write to a sibling of the final path. The temp
+// filename includes the final basename, a cryptographically random suffix, and ".tmp";
+// this keeps operational debugging straightforward while avoiding collisions between
+// concurrent writers for the same blob.
+//
+// The file is opened with O_EXCL so an existing temp path is never truncated. Random
+// collisions are retried a small fixed number of times. Any non-collision creation
+// failure is returned immediately because it usually indicates a real storage problem
+// such as permissions, a missing directory, or an exhausted filesystem.
+//
+// The caller owns the returned file descriptor and must close it. On any failure after
+// this function returns successfully, the caller is also responsible for removing the
+// returned temporary filename.
+func (s *File) createTempSibling(filename string, perm os.FileMode) (*os.File, string, error) {
+	const maxAttempts = 10
+
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+
+	for i := 0; i < maxAttempts; i++ {
+		randNum, err := rand.Int(rand.Reader, big.NewInt(1<<63-1))
+		if err != nil {
+			return nil, "", errors.NewStorageError("[File][%s] failed to generate temporary filename", filename, err)
+		}
+
+		tmpFilename := filepath.Join(dir, fmt.Sprintf(".%s.%d.tmp", base, randNum))
+		//nolint:gosec // Blob store files intentionally preserve the existing 0644 file mode.
+		file, err := os.OpenFile(tmpFilename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+		if err == nil {
+			return file, tmpFilename, nil
+		}
+
+		if os.IsExist(err) {
+			continue
+		}
+
+		return nil, "", errors.NewStorageError("[File][%s] failed to create temporary file", filename, err)
+	}
+
+	return nil, "", errors.NewStorageError("[File][%s] failed to create unique temporary file after %d attempts", filename, maxAttempts)
+}
+
+// syncAndCloseTempFile flushes a temporary file's contents to stable storage and closes it.
+//
+// This helper is used immediately before publishing a temp file with renameTempFile.
+// Syncing before rename prevents the final filename from becoming visible while the
+// data still only exists in userspace or kernel buffers. That does not make the whole
+// operation fully crash-proof by itself: the directory entry created by the later rename
+// has its own durability boundary, handled best-effort by syncParentDirBestEffort.
+//
+// Close errors are treated as write failures. Some filesystems report delayed write
+// errors on close, so a caller must not publish the temp file if this function returns
+// an error. If Sync fails, this function still attempts to close the descriptor and logs
+// a close failure without replacing the original sync error.
+func (s *File) syncAndCloseTempFile(file *os.File, tmpFilename string) error {
+	if err := file.Sync(); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			s.logger.Warnf("[File][%s] failed to close temporary file after sync error: %v", tmpFilename, closeErr)
+		}
+
+		return errors.NewStorageError("[File][%s] failed to sync temporary file", tmpFilename, err)
+	}
+
+	if err := file.Close(); err != nil {
+		return errors.NewStorageError("[File][%s] failed to close temporary file", tmpFilename, err)
+	}
+
+	return nil
+}
+
+// syncParentDirBestEffort attempts to persist the directory entry for filename.
+//
+// After os.Rename succeeds, readers will observe the final filename atomically. A crash
+// immediately after rename can still lose the directory update on some filesystems unless
+// the parent directory is synced. This helper performs that extra durability step where
+// the platform and filesystem allow it.
+//
+// Directory sync support is not consistent across all operating systems, mounted volumes,
+// and network filesystems. For that reason this helper is best-effort: failures are logged
+// at debug level and do not turn an already-successful rename into a failed blob write.
+// Callers should rely on it as a durability improvement, not as a portable hard guarantee.
+func (s *File) syncParentDirBestEffort(filename string) {
+	dir, err := os.Open(filepath.Dir(filename))
+	if err != nil {
+		s.debugf("[File][%s] failed to open parent directory for sync: %v", filename, err)
+		return
+	}
+	defer dir.Close()
+
+	if err := dir.Sync(); err != nil {
+		s.debugf("[File][%s] failed to sync parent directory: %v", filename, err)
+	}
+}
+
+// renameTempFile publishes a completed temp file at its final filename.
+//
+// The temp file must be a sibling of filename; createTempSibling enforces that pattern.
+// When source and destination are on the same filesystem, os.Rename makes the final path
+// appear atomically, so readers either see the previous complete file or the new complete
+// file, never a partially written final file.
+//
+// If rename fails and a regular file already exists at the final path, the error is
+// normalized to ErrBlobAlreadyExists. That preserves the blob store's no-overwrite
+// contract for races where another writer published the same blob between the initial
+// existence check and this rename. Other rename failures are reported as storage errors.
+//
+// On success this helper also attempts to sync the parent directory so the newly published
+// name is more likely to survive a crash. That directory sync is best-effort; see
+// syncParentDirBestEffort for the portability caveat.
+func (s *File) renameTempFile(tmpFilename, filename string) error {
+	if err := os.Rename(tmpFilename, filename); err != nil {
+		if fileInfo, statErr := os.Stat(filename); statErr == nil && !fileInfo.IsDir() {
+			return errors.NewBlobAlreadyExistsError("[File][%s] already exists in store", filename)
+		}
+
+		return errors.NewStorageError("[File][%s] failed to rename temporary file %s", filename, tmpFilename, err)
+	}
+
+	s.syncParentDirBestEffort(filename)
+	return nil
+}
+
+// writeFileAtomically writes a small sidecar file via temp-file publication.
+//
+// This is used for metadata sidecars such as checksum files, where the complete payload is
+// already available in memory. It mirrors the blob publication sequence used by
+// SetFromReader: create a sibling temp file, write the full payload, sync and close it,
+// then rename it into place. The final filename is not created or replaced until all data
+// has been written successfully.
+//
+// The helper owns cleanup for the temp path. Any error before a successful rename leaves
+// cleanupTmpFile set and the deferred cleanup removes the temp file. After a successful
+// rename, cleanup is disabled because tmpFilename no longer exists. The file descriptor is
+// also closed during cleanup if an early return happens before syncAndCloseTempFile takes
+// ownership of closing it.
+//
+// Callers should use this only for bounded in-memory data. Large blob bodies should continue
+// to use SetFromReader so they can be streamed without loading the full content into memory.
+func (s *File) writeFileAtomically(filename string, data []byte, perm os.FileMode) error {
+	file, tmpFilename, err := s.createTempSibling(filename, perm)
+	if err != nil {
+		return err
+	}
+
+	cleanupTmpFile := true
+	defer func() {
+		if file != nil {
+			if closeErr := file.Close(); closeErr != nil {
+				s.logger.Warnf("[File][%s] failed to close temporary file during cleanup: %v", tmpFilename, closeErr)
+			}
+		}
+
+		if cleanupTmpFile {
+			if removeErr := os.Remove(tmpFilename); removeErr != nil && !os.IsNotExist(removeErr) {
+				s.logger.Warnf("[File][%s] failed to remove temporary file: %v", tmpFilename, removeErr)
+			}
+		}
+	}()
+
+	if _, err = file.Write(data); err != nil {
+		return errors.NewStorageError("[File][%s] failed to write temporary file", filename, err)
+	}
+
+	if err = s.syncAndCloseTempFile(file, tmpFilename); err != nil {
+		file = nil
+		return err
+	}
+	file = nil
+
+	if err = s.renameTempFile(tmpFilename, filename); err != nil {
+		return err
+	}
+	cleanupTmpFile = false
+
+	return nil
+}

--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"math"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -50,6 +51,43 @@ import (
 )
 
 const checksumExtension = ".sha256"
+
+// fsyncMode controls how aggressively the file store flushes data to stable storage
+// during atomic publication. Set via the `fsyncMode` URL parameter.
+//
+//   - fsyncModeFull (default): fsync the temp file, then fsync the parent directory
+//     after rename. Correct on ext4/xfs/btrfs even across a crash; required for the
+//     atomic-publication guarantee on those filesystems.
+//   - fsyncModeData: fsync the temp file only; skip the parent-directory fsync. Final
+//     file content is durable but the directory entry of the freshly renamed name can
+//     be lost across a crash on Linux. Useful on filesystems where directory fsync is
+//     expensive or unsupported (notably NFS-backed paths) while still preserving the
+//     content of already-published files.
+//   - fsyncModeNone: skip both fsyncs. The rename remains atomic from the perspective
+//     of concurrent readers, but neither the file content nor its directory entry is
+//     guaranteed durable across a crash. Operators who choose this opt out of crash
+//     safety in exchange for throughput; only appropriate when the host filesystem
+//     provides its own durability guarantees or when the data is regenerable.
+type fsyncMode uint8
+
+const (
+	fsyncModeFull fsyncMode = iota
+	fsyncModeData
+	fsyncModeNone
+)
+
+func parseFsyncMode(s string) (fsyncMode, error) {
+	switch strings.ToLower(s) {
+	case "", "full":
+		return fsyncModeFull, nil
+	case "data":
+		return fsyncModeData, nil
+	case "none":
+		return fsyncModeNone, nil
+	default:
+		return fsyncModeFull, errors.NewConfigurationError("[File] invalid fsyncMode %q (must be full|data|none)", s)
+	}
+}
 
 // File implements the blob.Store interface using the local filesystem for storage.
 // It provides a robust, persistent blob storage solution with features like automatic
@@ -85,6 +123,8 @@ type File struct {
 	blobDeletionScheduler options.BlobDeletionScheduler
 	// storeType identifies which blob store this is
 	storeType storetypes.BlobStoreType
+	// fsyncMode controls fsync behaviour during atomic publication; see fsyncMode docs.
+	fsyncMode fsyncMode
 }
 
 func (s *File) debugEnabled() bool {
@@ -413,6 +453,11 @@ func newStore(logger ulogger.Logger, storeURL *url.URL, opts ...options.StoreOpt
 		storeOpts.DisableDAH = disableDAH == "true"
 	}
 
+	parsedFsyncMode, err := parseFsyncMode(storeURL.Query().Get("fsyncMode"))
+	if err != nil {
+		return nil, err
+	}
+
 	if len(storeOpts.SubDirectory) > 0 {
 		if err := os.MkdirAll(filepath.Join(path, storeOpts.SubDirectory), 0755); err != nil {
 			return nil, errors.NewStorageError("[File] failed to create sub directory", err)
@@ -426,6 +471,7 @@ func newStore(logger ulogger.Logger, storeURL *url.URL, opts ...options.StoreOpt
 		persistSubDir:         storeOpts.PersistSubDir,
 		blobDeletionScheduler: storeOpts.BlobDeletionScheduler,
 		storeType:             storeOpts.StoreType,
+		fsyncMode:             parsedFsyncMode,
 	}
 
 	// Check if longterm storage options are provided
@@ -694,7 +740,7 @@ func (s *File) SetFromReader(ctx context.Context, key []byte, fileType fileforma
 	file = nil
 
 	// rename the file to remove the .tmp extension
-	if err = s.renameTempFile(tmpFilename, filename); err != nil {
+	if err = s.renameTempFile(tmpFilename, filename, merged.AllowOverwrite); err != nil {
 		return err
 	}
 	cleanupTmpFile = false
@@ -727,7 +773,9 @@ func (s *File) writeHashFile(hasher hash.Hash, filename string) error {
 
 	hashFilename := filename + checksumExtension
 
-	if err := s.writeFileAtomically(hashFilename, []byte(hashStr), 0644); err != nil {
+	// Allow overwrite for the checksum sidecar: it always corresponds to the most recent
+	// blob publication, mirroring the pre-PR behaviour that used os.WriteFile.
+	if err := s.writeFileAtomically(hashFilename, []byte(hashStr), 0644, true); err != nil {
 		return errors.NewStorageError("[File][%s] failed to write hash file atomically", hashFilename, err)
 	}
 
@@ -1153,10 +1201,17 @@ func (s *File) Del(ctx context.Context, key []byte, fileType fileformat.FileType
 	}
 
 	// Try to remove the hash prefix directory if now empty (best-effort, ignore errors).
-	// os.Remove on a non-empty directory returns an error, so this is safe.
-	// Only attempt if the parent is a subdirectory of the store root (i.e. a hash prefix dir).
+	// root.Remove on a non-empty directory returns an error, so this is safe. Routing through
+	// the store root keeps the operation inside the os.Root sandbox so it cannot follow a
+	// symlink out of the store, and is consistent with the rest of the path handling in this
+	// file (CodeQL #119).
 	if dir := filepath.Dir(fileName); dir != s.path && len(filepath.Base(dir)) <= 2 {
-		_ = os.Remove(dir)
+		if rel, relErr := s.storeRelPath(dir); relErr == nil {
+			if root, rootErr := s.openStoreRoot(); rootErr == nil {
+				_ = root.Remove(rel)
+				_ = root.Close()
+			}
+		}
 	}
 
 	s.logger.Debugf("[FILE_DEL] Successfully deleted file: %s", fileName)
@@ -1199,7 +1254,7 @@ func (s *File) createTempSibling(filename string, perm os.FileMode) (*os.File, s
 	base := filepath.Base(finalRel)
 
 	for i := 0; i < maxAttempts; i++ {
-		randNum, err := rand.Int(rand.Reader, big.NewInt(1<<63-1))
+		randNum, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 		if err != nil {
 			return nil, "", errors.NewStorageError("[File][%s] failed to generate temporary filename", filename, err)
 		}
@@ -1234,12 +1289,14 @@ func (s *File) createTempSibling(filename string, perm os.FileMode) (*os.File, s
 // an error. If Sync fails, this function still attempts to close the descriptor and logs
 // a close failure without replacing the original sync error.
 func (s *File) syncAndCloseTempFile(file *os.File, tmpFilename string) error {
-	if err := file.Sync(); err != nil {
-		if closeErr := file.Close(); closeErr != nil {
-			s.logger.Warnf("[File][%s] failed to close temporary file after sync error: %v", tmpFilename, closeErr)
-		}
+	if s.fsyncMode != fsyncModeNone {
+		if err := file.Sync(); err != nil {
+			if closeErr := file.Close(); closeErr != nil {
+				s.logger.Warnf("[File][%s] failed to close temporary file after sync error: %v", tmpFilename, closeErr)
+			}
 
-		return errors.NewStorageError("[File][%s] failed to sync temporary file", tmpFilename, err)
+			return errors.NewStorageError("[File][%s] failed to sync temporary file", tmpFilename, err)
+		}
 	}
 
 	if err := file.Close(); err != nil {
@@ -1251,16 +1308,25 @@ func (s *File) syncAndCloseTempFile(file *os.File, tmpFilename string) error {
 
 // syncParentDirBestEffort attempts to persist the directory entry for filename.
 //
-// After os.Rename succeeds, readers will observe the final filename atomically. A crash
-// immediately after rename can still lose the directory update on some filesystems unless
-// the parent directory is synced. This helper performs that extra durability step where
-// the platform and filesystem allow it.
+// On ext4, xfs, and btrfs — the dominant production Linux filesystems — this directory
+// sync is correctness-critical for crash safety, not a "nice to have". After os.Rename
+// succeeds, readers will observe the final filename atomically, but the directory entry
+// is held in cache until the parent directory itself is synced. A crash between rename
+// and the next checkpoint can therefore lose the freshly published file's name even when
+// the file's data has been fsynced. Removing this call regresses crash safety on those
+// filesystems; future maintainers should not delete it under the assumption that "best
+// effort" implies optional.
 //
-// Directory sync support is not consistent across all operating systems, mounted volumes,
-// and network filesystems. For that reason this helper is best-effort: failures are logged
-// at debug level and do not turn an already-successful rename into a failed blob write.
-// Callers should rely on it as a durability improvement, not as a portable hard guarantee.
+// The "best-effort" framing applies only to failure handling: directory sync is not
+// supported uniformly across platforms (notably some Windows and network-attached
+// filesystems), so a failure to open or sync the parent directory is logged at debug
+// level rather than turning an already-successful rename into a failed blob write.
+// Where the platform supports it, this call is a correctness step and must run.
 func (s *File) syncParentDirBestEffort(filename string) {
+	if s.fsyncMode != fsyncModeFull {
+		return
+	}
+
 	rel, err := s.storeRelPath(filename)
 	if err != nil {
 		s.debugf("[File][%s] failed to calculate parent directory for sync: %v", filename, err)
@@ -1293,15 +1359,23 @@ func (s *File) syncParentDirBestEffort(filename string) {
 // appear atomically, so readers either see the previous complete file or the new complete
 // file, never a partially written final file.
 //
-// If rename fails and a regular file already exists at the final path, the error is
-// normalized to ErrBlobAlreadyExists. That preserves the blob store's no-overwrite
-// contract for races where another writer published the same blob between the initial
-// existence check and this rename. Other rename failures are reported as storage errors.
+// Cross-platform rename semantics differ when the destination already exists:
+//
+//   - POSIX (Linux, macOS, *BSD): rename(2) atomically replaces an existing regular file
+//     with the same name. The "destination exists" branch below is therefore unreachable
+//     on those platforms; an existing final file is silently overwritten on rename. The
+//     blob store's no-overwrite contract is enforced by SetFromReader's earlier call to
+//     errorOnOverwrite, not here. There is a small TOCTOU window between that check and
+//     this rename in which two concurrent writers can both pass the check and then race
+//     on rename — that race is out of scope for this helper.
+//   - Windows / some non-POSIX targets: rename can fail when the destination exists. The
+//     fallback handles that case: if allowOverwrite is true we remove the destination and
+//     retry the rename; otherwise we normalize the error to ErrBlobAlreadyExists.
 //
 // On success this helper also attempts to sync the parent directory so the newly published
-// name is more likely to survive a crash. That directory sync is best-effort; see
-// syncParentDirBestEffort for the portability caveat.
-func (s *File) renameTempFile(tmpFilename, filename string) error {
+// name is more likely to survive a crash. That directory sync is correctness-critical on
+// ext4/xfs/btrfs and best-effort everywhere else; see syncParentDirBestEffort.
+func (s *File) renameTempFile(tmpFilename, filename string, allowOverwrite bool) error {
 	tmpRel, err := s.storeRelPath(tmpFilename)
 	if err != nil {
 		return err
@@ -1320,7 +1394,22 @@ func (s *File) renameTempFile(tmpFilename, filename string) error {
 
 	if err := root.Rename(tmpRel, finalRel); err != nil {
 		if fileInfo, statErr := root.Stat(finalRel); statErr == nil && !fileInfo.IsDir() {
-			return errors.NewBlobAlreadyExistsError("[File][%s] already exists in store", filename)
+			if !allowOverwrite {
+				return errors.NewBlobAlreadyExistsError("[File][%s] already exists in store", filename)
+			}
+
+			// Non-POSIX path: rename refused to replace an existing destination but the caller
+			// asked for overwrite semantics. Remove the destination and retry.
+			if removeErr := root.Remove(finalRel); removeErr != nil {
+				return errors.NewStorageError("[File][%s] failed to remove existing file before overwrite", filename, removeErr)
+			}
+
+			if retryErr := root.Rename(tmpRel, finalRel); retryErr != nil {
+				return errors.NewStorageError("[File][%s] failed to rename temporary file %s after overwrite cleanup", filename, tmpFilename, retryErr)
+			}
+
+			s.syncParentDirBestEffort(filename)
+			return nil
 		}
 
 		return errors.NewStorageError("[File][%s] failed to rename temporary file %s", filename, tmpFilename, err)
@@ -1346,7 +1435,10 @@ func (s *File) renameTempFile(tmpFilename, filename string) error {
 //
 // Callers should use this only for bounded in-memory data. Large blob bodies should continue
 // to use SetFromReader so they can be streamed without loading the full content into memory.
-func (s *File) writeFileAtomically(filename string, data []byte, perm os.FileMode) error {
+//
+// allowOverwrite is forwarded to renameTempFile; see that function for the cross-platform
+// behaviour when the final filename already exists.
+func (s *File) writeFileAtomically(filename string, data []byte, perm os.FileMode, allowOverwrite bool) error {
 	file, tmpFilename, err := s.createTempSibling(filename, perm)
 	if err != nil {
 		return err
@@ -1377,7 +1469,7 @@ func (s *File) writeFileAtomically(filename string, data []byte, perm os.FileMod
 	}
 	file = nil
 
-	if err = s.renameTempFile(tmpFilename, filename); err != nil {
+	if err = s.renameTempFile(tmpFilename, filename, allowOverwrite); err != nil {
 		return err
 	}
 	cleanupTmpFile = false

--- a/stores/blob/file/file_test.go
+++ b/stores/blob/file/file_test.go
@@ -523,6 +523,67 @@ func TestSetFromReader_CleansUpTempFileOnPipeClose(t *testing.T) {
 	})
 }
 
+func TestSetFromReader_DoesNotExposeFinalFileUntilReaderCompletes(t *testing.T) {
+	tempDir := t.TempDir()
+
+	u, err := url.Parse("file://" + tempDir)
+	require.NoError(t, err)
+
+	f, err := New(ulogger.TestLogger{}, u)
+	require.NoError(t, err)
+
+	key := []byte("streaming-atomic-publication")
+	filename, err := f.options.ConstructFilename(tempDir, key, fileformat.FileTypeTesting)
+	require.NoError(t, err)
+
+	reader, writer := io.Pipe()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- f.SetFromReader(context.Background(), key, fileformat.FileTypeTesting, reader)
+	}()
+
+	_, err = writer.Write([]byte("partial payload"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filename)
+	require.True(t, os.IsNotExist(err), "final filename must not be visible while the reader is still open")
+
+	require.NoError(t, writer.Close())
+	require.NoError(t, <-done)
+
+	_, err = os.Stat(filename)
+	require.NoError(t, err, "final filename should be visible after the reader completes")
+}
+
+func TestSetFromReader_RemovesBlobWhenChecksumPublicationFails(t *testing.T) {
+	tempDir := t.TempDir()
+
+	u, err := url.Parse("file://" + tempDir)
+	require.NoError(t, err)
+
+	f, err := New(ulogger.TestLogger{}, u)
+	require.NoError(t, err)
+
+	key := []byte("checksum-publication-fails")
+	filename, err := f.options.ConstructFilename(tempDir, key, fileformat.FileTypeTesting)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Mkdir(filename+checksumExtension, 0755))
+
+	err = f.Set(context.Background(), key, fileformat.FileTypeTesting, []byte("value"))
+	require.Error(t, err)
+
+	_, statErr := os.Stat(filename)
+	require.True(t, os.IsNotExist(statErr), "blob final filename should not remain after checksum publication fails")
+
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		require.False(t, strings.HasSuffix(entry.Name(), ".tmp"), "temporary file should be cleaned up: %s", entry.Name())
+	}
+}
+
 func TestFileGetHead(t *testing.T) {
 	t.Run("get head of content", func(t *testing.T) {
 		// Get a temporary directory
@@ -1244,175 +1305,4 @@ func TestFileChecksumNotDeletedOnDelete(t *testing.T) {
 	// Check if checksum file still exists - this is the bug
 	_, err = os.Stat(filename)
 	require.True(t, os.IsNotExist(err), "Checksum file should be removed when content file is deleted")
-}
-
-func TestDAHZeroHandling(t *testing.T) {
-	t.Skip("DAH functionality now requires pruner service - covered by e2e tests")
-	t.Run("readDAHFromFile with DAH 0 returns error", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test-dah-zero")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		u, err := url.Parse("file://" + tempDir)
-		require.NoError(t, err)
-
-		f, err := New(ulogger.TestLogger{}, u)
-		require.NoError(t, err)
-
-		// Create a DAH file with value 0
-		dahFile := filepath.Join(tempDir, "test.dah")
-		err = os.WriteFile(dahFile, []byte("0"), 0o600)
-		require.NoError(t, err)
-
-		// Try to read it
-		dah, err := f.readDAHFromFile(dahFile)
-		require.Error(t, err, "should return error for DAH 0")
-		require.Contains(t, err.Error(), "invalid DAH value 0")
-		require.Equal(t, uint32(0), dah)
-	})
-
-	t.Run("readDAHFromFile with empty file returns error", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test-dah-empty")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		u, err := url.Parse("file://" + tempDir)
-		require.NoError(t, err)
-
-		f, err := New(ulogger.TestLogger{}, u)
-		require.NoError(t, err)
-
-		// Create an empty DAH file
-		dahFile := filepath.Join(tempDir, "test.dah")
-		err = os.WriteFile(dahFile, []byte(""), 0o600)
-		require.NoError(t, err)
-
-		// Try to read it
-		dah, err := f.readDAHFromFile(dahFile)
-		require.Error(t, err, "should return error for empty DAH file")
-		require.Contains(t, err.Error(), "DAH file")
-		require.Contains(t, err.Error(), "is empty")
-		require.Equal(t, uint32(0), dah)
-	})
-
-	t.Run("readDAHFromFile with whitespace only returns error", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test-dah-whitespace")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		u, err := url.Parse("file://" + tempDir)
-		require.NoError(t, err)
-
-		f, err := New(ulogger.TestLogger{}, u)
-		require.NoError(t, err)
-
-		// Create a DAH file with only whitespace
-		dahFile := filepath.Join(tempDir, "test.dah")
-		err = os.WriteFile(dahFile, []byte("  \n\t  "), 0o600)
-		require.NoError(t, err)
-
-		// Try to read it
-		dah, err := f.readDAHFromFile(dahFile)
-		require.Error(t, err, "should return error for whitespace-only DAH file")
-		require.Contains(t, err.Error(), "DAH file")
-		require.Contains(t, err.Error(), "is empty")
-		require.Equal(t, uint32(0), dah)
-	})
-
-	t.Run("SetDAH with 0 removes DAH file", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test-setdah-zero")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		u, err := url.Parse("file://" + tempDir)
-		require.NoError(t, err)
-
-		f, err := New(ulogger.TestLogger{}, u)
-		require.NoError(t, err)
-
-		key := "test-key"
-		content := []byte("test content")
-
-		// Put a file
-		err = f.Set(context.Background(), []byte(key), fileformat.FileTypeTesting, content)
-		require.NoError(t, err)
-
-		// Set DAH to a valid value first
-		err = f.SetDAH(context.Background(), []byte(key), fileformat.FileTypeTesting, 100)
-		require.NoError(t, err)
-
-		// Verify DAH file exists
-		merged := options.MergeOptions(f.options, []options.FileOption{})
-		filename, err := merged.ConstructFilename(tempDir, []byte(key), fileformat.FileTypeTesting)
-		require.NoError(t, err)
-		dahFile := filename + ".dah"
-		_, err = os.Stat(dahFile)
-		require.NoError(t, err, "DAH file should exist")
-
-		// Set DAH to 0
-		err = f.SetDAH(context.Background(), []byte(key), fileformat.FileTypeTesting, 0)
-		require.NoError(t, err)
-
-		// Verify DAH file is removed
-		_, err = os.Stat(dahFile)
-		require.True(t, os.IsNotExist(err), "DAH file should be removed when DAH is set to 0")
-
-		// Verify blob file still exists
-		_, err = os.Stat(filename)
-		require.NoError(t, err, "Blob file should still exist")
-	})
-
-	t.Run("writeDAHToFile validation prevents DAH 0", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test-write-dah-zero")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		u, err := url.Parse("file://" + tempDir)
-		require.NoError(t, err)
-
-		f, err := New(ulogger.TestLogger{}, u)
-		require.NoError(t, err)
-
-		dahFile := filepath.Join(tempDir, "test.dah")
-
-		// Attempt to write DAH 0
-		err = f.writeDAHToFile(dahFile, 0)
-		require.Error(t, err, "Should error when attempting to write DAH 0")
-		require.Contains(t, err.Error(), "invalid DAH value 0")
-
-		// Verify no file was created
-		_, err = os.Stat(dahFile)
-		require.True(t, os.IsNotExist(err), "DAH file should not exist")
-
-		// Verify no temp file was left behind
-		_, err = os.Stat(dahFile + ".tmp")
-		require.True(t, os.IsNotExist(err), "Temp file should not exist")
-	})
-
-	t.Run("writeDAHToFile uses fsync", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test-write-dah-fsync")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		u, err := url.Parse("file://" + tempDir)
-		require.NoError(t, err)
-
-		f, err := New(ulogger.TestLogger{}, u)
-		require.NoError(t, err)
-
-		dahFile := filepath.Join(tempDir, "test.dah")
-
-		// Write a valid DAH
-		err = f.writeDAHToFile(dahFile, 12345)
-		require.NoError(t, err)
-
-		// Verify file exists and contains correct value
-		content, err := os.ReadFile(dahFile)
-		require.NoError(t, err)
-		require.Equal(t, "12345", string(content))
-
-		// Verify no temp file was left behind
-		_, err = os.Stat(dahFile + ".tmp")
-		require.True(t, os.IsNotExist(err), "Temp file should be cleaned up")
-	})
 }

--- a/stores/blob/file/file_test.go
+++ b/stores/blob/file/file_test.go
@@ -584,6 +584,26 @@ func TestSetFromReader_RemovesBlobWhenChecksumPublicationFails(t *testing.T) {
 	}
 }
 
+func TestFileStoreRelPath(t *testing.T) {
+	tempDir := t.TempDir()
+	f := &File{path: tempDir}
+
+	rel, err := f.storeRelPath(filepath.Join(tempDir, "subdir", "blob.testing"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("subdir", "blob.testing"), rel)
+
+	_, err = f.storeRelPath(filepath.Join(tempDir, "..", "outside.testing"))
+	require.Error(t, err)
+
+	_, err = f.storeRelPath(tempDir + "-sibling/blob.testing")
+	require.Error(t, err)
+
+	f = &File{path: filepath.Join("relative", "store")}
+	rel, err = f.storeRelPath(filepath.Join("relative", "store", "subdir", "blob.testing"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("subdir", "blob.testing"), rel)
+}
+
 func TestFileGetHead(t *testing.T) {
 	t.Run("get head of content", func(t *testing.T) {
 		// Get a temporary directory

--- a/stores/blob/file/file_test.go
+++ b/stores/blob/file/file_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/teranode/errors"
@@ -581,6 +582,212 @@ func TestSetFromReader_RemovesBlobWhenChecksumPublicationFails(t *testing.T) {
 	require.NoError(t, err)
 	for _, entry := range entries {
 		require.False(t, strings.HasSuffix(entry.Name(), ".tmp"), "temporary file should be cleaned up: %s", entry.Name())
+	}
+}
+
+func TestSetFromReader_ConcurrentWritersNeverExposePartialFinal(t *testing.T) {
+	tempDir := t.TempDir()
+
+	u, err := url.Parse("file://" + tempDir)
+	require.NoError(t, err)
+
+	f, err := New(ulogger.TestLogger{}, u)
+	require.NoError(t, err)
+
+	key := []byte("concurrent-atomic-publication")
+
+	// Build the expected complete file payload (header + body) once so the reader can
+	// match against it. Every successful read of the final file must be byte-identical
+	// to this payload — never a truncated prefix.
+	body := bytes.Repeat([]byte("XYZ"), 4096)
+	header := fileformat.NewHeader(fileformat.FileTypeTesting)
+
+	var expected bytes.Buffer
+	require.NoError(t, header.Write(&expected))
+	expected.Write(body)
+	expectedBytes := expected.Bytes()
+
+	filename, err := f.options.ConstructFilename(tempDir, key, fileformat.FileTypeTesting)
+	require.NoError(t, err)
+
+	const writers = 8
+	stop := make(chan struct{})
+	writerErrs := make(chan error, writers)
+	writerWG := sync.WaitGroup{}
+
+	for i := 0; i < writers; i++ {
+		writerWG.Add(1)
+		go func() {
+			defer writerWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				if err := f.Set(context.Background(), key, fileformat.FileTypeTesting, body, options.WithAllowOverwrite(true)); err != nil {
+					writerErrs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	// Reader loop: every successful read must be byte-identical to expectedBytes. A
+	// partial read here would mean the atomic-publication invariant was violated.
+	readerDone := make(chan struct{})
+	var readerErr error
+
+	go func() {
+		defer close(readerDone)
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			data, err := os.ReadFile(filename)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				readerErr = err
+				return
+			}
+
+			if !bytes.Equal(data, expectedBytes) {
+				readerErr = errors.NewStorageError("observed partial final file: got %d bytes, expected %d", len(data), len(expectedBytes))
+				return
+			}
+		}
+	}()
+
+	<-readerDone
+	close(stop)
+	writerWG.Wait()
+	close(writerErrs)
+
+	for err := range writerErrs {
+		require.NoError(t, err)
+	}
+	require.NoError(t, readerErr)
+}
+
+func TestRenameTempFile_OverwriteAndRejectSemantics(t *testing.T) {
+	// renameTempFile's cross-platform contract: on POSIX, rename atomically replaces an
+	// existing destination regardless of allowOverwrite; on non-POSIX, allowOverwrite
+	// controls whether an existing destination is replaced or whether ErrBlobAlreadyExists
+	// is returned. This test documents the observable POSIX behaviour and exercises both
+	// allowOverwrite values so a regression on either branch shows up.
+	tempDir := t.TempDir()
+
+	u, err := url.Parse("file://" + tempDir)
+	require.NoError(t, err)
+
+	f, err := New(ulogger.TestLogger{}, u)
+	require.NoError(t, err)
+
+	key := []byte("rename-temp-file-semantics")
+
+	require.NoError(t, f.Set(context.Background(), key, fileformat.FileTypeTesting, []byte("first")))
+
+	// allowOverwrite=true: the second publication should replace the first cleanly.
+	require.NoError(t, f.Set(context.Background(), key, fileformat.FileTypeTesting, []byte("second"), options.WithAllowOverwrite(true)))
+
+	got, err := f.Get(context.Background(), key, fileformat.FileTypeTesting)
+	require.NoError(t, err)
+	require.Equal(t, []byte("second"), got)
+
+	// allowOverwrite=false: errorOnOverwrite stops the call before renameTempFile is
+	// reached, so the existing value must remain intact.
+	err = f.Set(context.Background(), key, fileformat.FileTypeTesting, []byte("third"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrBlobAlreadyExists), "expected ErrBlobAlreadyExists, got %v", err)
+
+	got, err = f.Get(context.Background(), key, fileformat.FileTypeTesting)
+	require.NoError(t, err)
+	require.Equal(t, []byte("second"), got)
+}
+
+func TestParseFsyncMode(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want fsyncMode
+		ok   bool
+	}{
+		{"", fsyncModeFull, true},
+		{"full", fsyncModeFull, true},
+		{"FULL", fsyncModeFull, true},
+		{"data", fsyncModeData, true},
+		{"none", fsyncModeNone, true},
+		{"bogus", fsyncModeFull, false},
+	} {
+		got, err := parseFsyncMode(tc.in)
+		if tc.ok {
+			require.NoError(t, err, "input=%q", tc.in)
+			require.Equal(t, tc.want, got, "input=%q", tc.in)
+		} else {
+			require.Error(t, err, "input=%q", tc.in)
+		}
+	}
+}
+
+func TestNewWithFsyncMode(t *testing.T) {
+	tempDir := t.TempDir()
+
+	for _, mode := range []string{"full", "data", "none"} {
+		t.Run(mode, func(t *testing.T) {
+			u, err := url.Parse("file://" + tempDir + "?fsyncMode=" + mode)
+			require.NoError(t, err)
+
+			f, err := New(ulogger.TestLogger{}, u)
+			require.NoError(t, err)
+
+			key := []byte("fsync-mode-" + mode)
+			require.NoError(t, f.Set(context.Background(), key, fileformat.FileTypeTesting, []byte("value")))
+
+			got, err := f.Get(context.Background(), key, fileformat.FileTypeTesting)
+			require.NoError(t, err)
+			require.Equal(t, []byte("value"), got)
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		u, err := url.Parse("file://" + tempDir + "?fsyncMode=bogus")
+		require.NoError(t, err)
+
+		_, err = New(ulogger.TestLogger{}, u)
+		require.Error(t, err)
+	})
+}
+
+// BenchmarkSetFromReader_FsyncModes measures the cost of the atomic-publication path
+// across the three fsyncMode levels. fsync overhead dominates the small-payload case
+// on local filesystems and is intended to make any regression in the fsync schedule
+// visible in CI. Operators sizing for NFS-backed deployments can compare the gap
+// between fsyncModeFull and fsyncModeNone here against measurements on their target
+// filesystem to decide whether to opt out of the directory fsync.
+func BenchmarkSetFromReader_FsyncModes(b *testing.B) {
+	for _, payloadSize := range []int{256, 4 * 1024, 64 * 1024} {
+		for _, mode := range []string{"full", "data", "none"} {
+			b.Run(fmt.Sprintf("payload=%dB/mode=%s", payloadSize, mode), func(b *testing.B) {
+				tempDir := b.TempDir()
+
+				u, err := url.Parse("file://" + tempDir + "?fsyncMode=" + mode)
+				require.NoError(b, err)
+
+				f, err := New(ulogger.TestLogger{}, u)
+				require.NoError(b, err)
+
+				payload := bytes.Repeat([]byte("x"), payloadSize)
+				ctx := context.Background()
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					key := []byte(fmt.Sprintf("bench-%d", i))
+					if err := f.Set(ctx, key, fileformat.FileTypeTesting, payload); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the file-backed blob store so final blob and checksum filenames are not exposed until their contents have been fully written, synced, closed, and atomically renamed into place.

This addresses production observations of partly written files appearing under their final filenames.

## Changes

- Writes blob data to a sibling temporary file before publishing the final filename.
- Syncs and closes the temporary blob file before renaming it into place.
- Writes checksum sidecar files using the same temporary-file publication pattern.
- Removes stale file-local `.dah` helper code and tests; blob delete-at-height behavior remains in the scheduler/pruner flow.
- Adds focused tests that verify:
  - the final blob filename is not visible while a streaming write is still open;
  - a checksum publication failure removes the just-published blob;
  - temporary files are cleaned up on failed writes.
- Adds detailed documentation for the atomic publication helper functions and their durability limits.

## Branch context

This branch has been rebased onto `main` and the PR targets `main`. Since the branch previously sat on `feat/teranode-native-ops`, this PR also includes the native-Aerospike commit stack from that base branch in addition to the file-store commit.

## Notes

- The helper functions use same-directory temporary files so `os.Rename` publishes within one filesystem.
- Parent directory sync is best-effort because support varies by platform and filesystem.
- The file mode intentionally preserves the existing blob-store behavior.
- Public `SetDAH` remains available for current block assembly and block persister call sites, but the file store implementation schedules or cancels deletion through the blob deletion scheduler. The pruner service owns deletion execution.

## Verification

Passed after rebasing onto `main`:

- `go test -count=1 ./stores/blob/file`
- `go test -race -count=1 ./stores/blob/file`
- `go test -count=1 ./stores/blob/...`
- `go vet ./stores/blob/...`
- `git diff --check`

Previously passed before the rebase:

- commit hooks

Repository-wide checks were also attempted earlier. `go test ./...` and `go vet ./...` are not green in this local environment due to unrelated existing or environment-heavy failures, including version-format validation, txmetacache timeout, toxiproxy/Docker/Postgres/SV-node/Kafka/e2e failures, and existing copy-lock warnings in test utilities.