### PR TITLE
fix(util/http): default POST Content-Type to application/octet-stream

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -226,11 +226,17 @@ func executeHTTPRequest(ctx context.Context, cancelFn context.CancelFunc, rawURL
 		return nil, cancelFn, errors.NewServiceError("failed to create http request", err)
 	}
 
-	// If there is a request body assume we want a POST and write request body
+	// If there is a request body assume we want a POST and write request body.
+	// Content-Type is application/octet-stream because every internal POST that
+	// goes through this helper sends raw bytes (e.g. /api/v1/subtree/{hash}/txs
+	// streams packed 32-byte tx hashes). Tagging it as application/json caused a
+	// WAF in front of asset (ModSecurity) to run the JSON body parser, fail on
+	// the binary payload, and reject the request with HTTP 400 — degrading peer
+	// catchup reputation across the network.
 	if len(requestBody) > 0 && requestBody[0] != nil {
 		req.Body = io.NopCloser(bytes.NewReader(requestBody[0]))
 		req.Method = http.MethodPost
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Type", "application/octet-stream")
 	}
 
 	var resp *http.Response

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -37,7 +37,7 @@ func TestDoHTTPRequestPOST(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestDoHTTPRequestBodyReaderPOST(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -389,7 +389,7 @@ func TestDoHTTPRequestEmptyRequestBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Empty slice still triggers POST because len(requestBody) > 0
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		assert.Equal(t, []byte{}, body)
@@ -426,7 +426,7 @@ func TestDoHTTPRequestNilRequestBody(t *testing.T) {
 func TestDoHTTPRequestMultipleRequestBodies(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

`util/http.go:DoHTTPRequest` hardcoded `Content-Type: application/json` for every POST request body. The only internal caller that sends a body via this helper is `subtreevalidation.getMissingTransactionsBatch`, which streams packed 32-byte tx hashes — binary data, never JSON.

When that POST traverses a ModSecurity WAF (deployed in front of the mainnet asset ingress), the JSON request body parser is selected based on the header, fails on binary content, and Rule `200002` (`Failed to parse request body`) denies the request with HTTP 400 + an HTML error page.

The downstream effect is severe: each rejected `getMissingTransactionsBatch` call counts as a catchup failure against the source peer. Reputation math (`successRate * 0.6 + baseScore * 0.4 - recentFailurePenalty`) drives reputation toward 5.0 over time, eventually starving sync entirely. Observed in production on `mainnet-eu-1` peers (`mainnet.gorillanode.io`, `mainnet2.gorillanode.io`, `bsva-ovh-teranode-eu-3`).

ModSecurity log excerpt:

`````
Rule 200002 - Failed to parse request body.
data: "JSON parsing error: lexical error: invalid char in json text.\x0a"
Content-Type: application/json
Content-Length: 32
URI: /api/v1/subtree/{hash}/txs
`````

## Fix

Switch the default Content-Type from `application/json` to `application/octet-stream`. This matches every body shape the helper actually carries today. There are no JSON-body callers — if one is added later it should set the header explicitly rather than relying on the helper default.

## Changes

- `util/http.go`: change hardcoded `Content-Type` to `application/octet-stream`, document the WAF interaction in a comment so future readers don't revert it.
- `util/http_test.go`: update the four POST test assertions that checked for the old header.

## Test plan

- [x] `go test ./util/ -run 'TestDoHTTPRequest' -count=1` — 29 passed
- [x] `go vet ./util/...` — clean
- [ ] Verify on staging that `getMissingTransactionsBatch` no longer 400s when traversing a ModSecurity-fronted ingress
- [ ] Watch peer reputation stays >50 over a sync cycle on mainnet-eu-1 after deployment

## Notes

A complementary infra patch is being applied to the ModSecurity rule set on the affected ingress to add a path-scoped `requestBodyAccess=Off` for `/api/v1/(subtree/{hash}/txs|tx|txs)`. That covers older peers still sending the wrong header until they upgrade past this PR.