### PR TITLE
chore(blockassembly): regenerate pb.go to match proto comments

### DIFF
--- a/services/blockassembly/blockassembly_api/blockassembly_api.pb.go
+++ b/services/blockassembly/blockassembly_api/blockassembly_api.pb.go
@@ -852,11 +852,12 @@ func (x *StateMessage) GetSubtrees() []string {
 	return nil
 }
 
-// Response containing the current difficulty of the blockchain.
+// Response containing the difficulty required for the next block (not the
+// current tip's difficulty).
 type GetCurrentDifficultyResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Difficulty    float64                `protobuf:"fixed64,1,opt,name=difficulty,proto3" json:"difficulty,omitempty"` // the current difficulty of the blockchain
-	BlockHash     []byte                 `protobuf:"bytes,2,opt,name=blockHash,proto3" json:"blockHash,omitempty"`     // the hash of the block at which the difficulty is measured
+	Difficulty    float64                `protobuf:"fixed64,1,opt,name=difficulty,proto3" json:"difficulty,omitempty"` // the difficulty the NEXT block must satisfy
+	BlockHash     []byte                 `protobuf:"bytes,2,opt,name=blockHash,proto3" json:"blockHash,omitempty"`     // the hash of the current chain tip, provided as context
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/services/blockassembly/blockassembly_api/blockassembly_api_grpc.pb.go
+++ b/services/blockassembly/blockassembly_api/blockassembly_api_grpc.pb.go
@@ -68,8 +68,12 @@ type BlockAssemblyAPIClient interface {
 	// GetMiningCandidate retrieves a block template ready for mining.
 	// Includes all necessary components for miners to begin work.
 	GetMiningCandidate(ctx context.Context, in *GetMiningCandidateRequest, opts ...grpc.CallOption) (*model.MiningCandidate, error)
-	// GetCurrentDifficulty retrieves the current network mining difficulty.
-	// Used by miners to understand the current mining requirements.
+	// GetCurrentDifficulty retrieves the difficulty required for the NEXT block,
+	// not the current tip's difficulty. Computed against the current chain tip
+	// and the current wall-clock time, so the value reflects any retargeting that
+	// would apply to a block produced now. The returned BlockHash is the current
+	// tip's hash, provided as context. Despite the name, this is effectively
+	// "GetNextRequiredDifficulty"; the original name is retained for compatibility.
 	GetCurrentDifficulty(ctx context.Context, in *EmptyMessage, opts ...grpc.CallOption) (*GetCurrentDifficultyResponse, error)
 	// SubmitMiningSolution submits a solved block to the network.
 	// Includes the proof-of-work solution and block details.
@@ -329,8 +333,12 @@ type BlockAssemblyAPIServer interface {
 	// GetMiningCandidate retrieves a block template ready for mining.
 	// Includes all necessary components for miners to begin work.
 	GetMiningCandidate(context.Context, *GetMiningCandidateRequest) (*model.MiningCandidate, error)
-	// GetCurrentDifficulty retrieves the current network mining difficulty.
-	// Used by miners to understand the current mining requirements.
+	// GetCurrentDifficulty retrieves the difficulty required for the NEXT block,
+	// not the current tip's difficulty. Computed against the current chain tip
+	// and the current wall-clock time, so the value reflects any retargeting that
+	// would apply to a block produced now. The returned BlockHash is the current
+	// tip's hash, provided as context. Despite the name, this is effectively
+	// "GetNextRequiredDifficulty"; the original name is retained for compatibility.
 	GetCurrentDifficulty(context.Context, *EmptyMessage) (*GetCurrentDifficultyResponse, error)
 	// SubmitMiningSolution submits a solved block to the network.
 	// Includes the proof-of-work solution and block details.


### PR DESCRIPTION
## Summary

PR #796 (`docs: per-package spec framework + services/blockassembly reference`, by @icellan) updated the doc comment on `GetCurrentDifficultyResponse` in `services/blockassembly/blockassembly_api/blockassembly_api.proto`:

\`\`\`diff
- // Response containing the current difficulty of the blockchain.
+ // Response containing the difficulty required for the next block (not the
+ // current tip's difficulty).
\`\`\`

…but the corresponding generated files were not regenerated, leaving \`*.pb.go\` out of sync with the proto source.

## What this PR does

Runs \`make gen\` so the generated code matches the proto. Diff is **comment-only** in the generated Go — no struct, field, or wire-format changes.

## How this surfaced

Came up while running \`make gen\` for unrelated peer-registry work (#832). \`git diff --quiet\` after \`make gen\` is part of that PR's acceptance, so the drift had to be either fixed or excluded — splitting it out keeps each PR focused.

## Test plan

- [x] \`make gen\` produces no further diff
- [x] \`go build ./...\` clean
- [x] \`go vet ./services/blockassembly/...\` clean