### PR TITLE
fix(txmetacache): restore delete correctness for native and trimmed 

### DIFF
--- a/stores/txmetacache/improved_cache.go
+++ b/stores/txmetacache/improved_cache.go
@@ -642,9 +642,13 @@ type bucketNative struct {
 	// gen is the generation of chunks.
 	gen uint64
 
+	// freeChunksLock guards freeChunks for the Native bucket type.
+	// Native intentionally keeps a dedicated lock for chunk-pool access
+	// instead of relying on b.mu.
 	freeChunksLock sync.Mutex
 
-	// free chunks per bucket
+	// freeChunks contains reusable chunk slabs for this bucket.
+	// Access must be guarded by freeChunksLock.
 	freeChunks []*[ChunkSize]byte
 
 	// currentGenCount tracks the number of entries written in current generation.
@@ -989,10 +993,31 @@ func (b *bucketNative) putChunk(chunk []byte) {
 	b.freeChunksLock.Unlock()
 }
 
+// deleteFromNativeSplitMapShard rebuilds the target shard without h.
+// We do this because go-tx-map's lock-free split map does not currently
+// expose a delete API that keeps the shard length counter in sync.
+func deleteFromNativeSplitMapShard(m *swiss.NativeSplitLockFreeMapUint64, h uint64) {
+	shardIdx := h % uint64(BucketsCount)
+	shards := m.Map()
+	shard, ok := shards[shardIdx]
+	if !ok || shard == nil || !shard.Exists(h) {
+		return
+	}
+
+	rebuiltShard := swiss.NewNativeLockFreeMapUint64(shard.Length())
+	shard.Iter(func(k, v uint64) (stop bool) {
+		if k == h {
+			return false
+		}
+		_ = rebuiltShard.Put(k, v)
+		return false
+	})
+	shards[shardIdx] = rebuiltShard
+}
+
 func (b *bucketNative) Del(h uint64) {
 	b.mu.Lock()
-	shardIdx := h % uint64(BucketsCount)
-	delete(b.m.Map()[shardIdx].Map(), h)
+	deleteFromNativeSplitMapShard(b.m, h)
 	b.mu.Unlock()
 }
 
@@ -1031,7 +1056,9 @@ type bucketTrimmed struct {
 	// gen is the generation of chunks.
 	gen uint64
 
-	// free chunks per bucket.
+	// freeChunks contains reusable chunk slabs for this bucket.
+	// Locking invariant: access is protected by b.mu (write lock), and
+	// getChunk/putChunk must only be called while b.mu is held.
 	freeChunks []*[ChunkSize]byte
 
 	// allocatedChunks is the total number of chunks allocated for the bucket via mmap.
@@ -1386,6 +1413,7 @@ func (b *bucketTrimmed) SetMultiKeysSingleValue(keys [][]byte, value []byte) { /
 	}
 }
 
+// getChunk assumes b.mu is write-locked by the caller.
 func (b *bucketTrimmed) getChunk() ([]byte, error) {
 	if len(b.freeChunks) == 0 {
 		maxChunks := uint64(len(b.chunks))
@@ -1449,6 +1477,7 @@ func (b *bucketTrimmed) getChunk() ([]byte, error) {
 	return p[:], nil
 }
 
+// putChunk assumes b.mu is write-locked by the caller.
 func (b *bucketTrimmed) putChunk(chunk []byte) {
 	if chunk == nil {
 		return
@@ -1460,10 +1489,31 @@ func (b *bucketTrimmed) putChunk(chunk []byte) {
 	b.freeChunks = append(b.freeChunks, p)
 }
 
-// Check if this del strategy for Native current makes more sense?
+// deleteFromSwissSplitMapShard rebuilds the target shard without h.
+// We do this because go-tx-map's lock-free split map does not currently
+// expose a delete API that keeps the shard length counter in sync.
+func deleteFromSwissSplitMapShard(m *swiss.SplitSwissLockFreeMapUint64, h uint64) {
+	shardIdx := h % uint64(BucketsCount)
+	shards := m.Map()
+	shard, ok := shards[shardIdx]
+	if !ok || shard == nil || !shard.Exists(h) {
+		return
+	}
+
+	rebuiltShard := swiss.NewSwissLockFreeMapUint64(shard.Length())
+	shard.Iter(func(k, v uint64) (stop bool) {
+		if k == h {
+			return false
+		}
+		_ = rebuiltShard.Put(k, v)
+		return false
+	})
+	shards[shardIdx] = rebuiltShard
+}
+
 func (b *bucketTrimmed) Del(h uint64) {
 	b.mu.Lock()
-	delete(b.m.Map(), h)
+	deleteFromSwissSplitMapShard(b.m, h)
 	b.mu.Unlock()
 }
 
@@ -1813,7 +1863,9 @@ type bucketUnallocated struct {
 	// gen is the generation of chunks.
 	gen uint64
 
-	// free chunks per bucket
+	// freeChunks contains reusable chunk slabs for this bucket.
+	// Locking invariant: access is protected by b.mu (write lock), and
+	// getChunk/putChunk must only be called while b.mu is held.
 	freeChunks []*[ChunkSize]byte
 
 	// allocatedChunks is the total number of chunks allocated for the bucket
@@ -2139,6 +2191,7 @@ func (b *bucketUnallocated) SetMultiKeysSingleValue(keys [][]byte, value []byte)
 	}
 }
 
+// getChunk assumes b.mu is write-locked by the caller.
 func (b *bucketUnallocated) getChunk() ([]byte, error) {
 	if len(b.freeChunks) == 0 {
 		maxChunks := uint64(len(b.chunks))
@@ -2210,6 +2263,7 @@ func (b *bucketUnallocated) getChunk() ([]byte, error) {
 	return p[:], nil
 }
 
+// putChunk assumes b.mu is write-locked by the caller.
 func (b *bucketUnallocated) putChunk(chunk []byte) {
 	if chunk == nil {
 		return

--- a/stores/txmetacache/improved_cache_test.go
+++ b/stores/txmetacache/improved_cache_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -592,28 +593,25 @@ func TestImprovedCache_DifferentBucketTypes(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, value, dst)
 
-			// Del - some implementations might not immediately remove items from their maps
-			// but they should at least not crash
+			// Capture map size before deleting the key.
+			var statsBeforeDel Stats
+			cache.UpdateStats(&statsBeforeDel)
+
 			cache.Del(key)
-			// For trimmed cache, the item might still appear to exist due to implementation details
-			// but Get should fail
+
+			// Del must remove the key from all bucket implementations.
+			require.False(t, cache.Has(key), "deleted key should not exist in %s", bt.name)
+
 			var delDst []byte
-			getErr := cache.Get(&delDst, key)
-			// Either the key shouldn't exist or we should get an error
-			if cache.Has(key) {
-				// If Has returns true, Get should still work or return specific behavior
-				// This is implementation-dependent for trimmed caches
-				t.Logf("%s bucket type may keep deleted keys in map temporarily", bt.name)
-			} else if getErr != nil {
-				// This is expected behavior after deletion
-				t.Logf("%s bucket type correctly removed deleted key", bt.name)
-			}
+			require.Error(t, cache.Get(&delDst, key), "Get on deleted key should fail in %s", bt.name)
 
 			// UpdateStats
 			var stats Stats
 			cache.UpdateStats(&stats)
 			// Stats should work for all bucket types
 			require.GreaterOrEqual(t, stats.TotalMapSize, uint64(0))
+			require.Less(t, stats.TotalMapSize, statsBeforeDel.TotalMapSize,
+				"map size should shrink after deletion in %s", bt.name)
 		})
 	}
 }
@@ -1339,16 +1337,87 @@ func TestImprovedCache_BucketDelFunctions(t *testing.T) {
 				require.True(t, exists, "Key should exist before deletion in %s", tt.name)
 			}
 
+			var statsBeforeDel Stats
+			cache.UpdateStats(&statsBeforeDel)
+			require.GreaterOrEqual(t, statsBeforeDel.TotalMapSize, uint64(len(testKeys)),
+				"expected map size to include inserted keys in %s", tt.name)
+
 			// Delete keys using cache.Del which calls bucket Del functions
 			for _, key := range testKeys {
 				cache.Del(key)
-				// Don't verify deletion success as some bucket types may not fully support deletion
-				// The goal is to exercise the Del function code paths for coverage
+				require.False(t, cache.Has(key), "deleted key should not exist in %s", tt.name)
+
+				var dst []byte
+				require.Error(t, cache.Get(&dst, key), "Get on deleted key should fail in %s", tt.name)
 			}
 
-			var stats Stats
-			cache.UpdateStats(&stats)
-			t.Logf("%s Del test - ValidEntriesCount: %d", tt.name, stats.ValidEntriesCount)
+			var statsAfterDel Stats
+			cache.UpdateStats(&statsAfterDel)
+			require.Equal(t, uint64(0), statsAfterDel.TotalMapSize,
+				"all inserted keys were deleted in %s", tt.name)
+		})
+	}
+}
+
+func TestImprovedCache_ConcurrentSetGetDelResetAllBucketTypes(t *testing.T) {
+	bucketTypes := []struct {
+		name string
+		typ  BucketType
+	}{
+		{"Native", Native},
+		{"Unallocated", Unallocated},
+		{"Preallocated", Preallocated},
+		{"Trimmed", Trimmed},
+	}
+
+	for _, bt := range bucketTypes {
+		t.Run(bt.name, func(t *testing.T) {
+			cache, err := New(64*1024, bt.typ)
+			require.NoError(t, err)
+			defer cache.Reset()
+
+			const goroutines = 8
+			const operationsPerGoroutine = 200
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			for worker := 0; worker < goroutines; worker++ {
+				wg.Add(1)
+				go func(workerID int) {
+					defer wg.Done()
+					<-start
+
+					for i := 0; i < operationsPerGoroutine; i++ {
+						key := []byte(fmt.Sprintf("race_key_%d_%d", workerID, i%32))
+						value := []byte(fmt.Sprintf("race_value_%d_%d", workerID, i))
+
+						_ = cache.Set(key, value)
+						_ = cache.Has(key)
+
+						var dst []byte
+						_ = cache.Get(&dst, key)
+
+						cache.Del(key)
+
+						if i%40 == 0 {
+							cache.Reset()
+						}
+					}
+				}(worker)
+			}
+
+			close(start)
+			wg.Wait()
+
+			// Ensure cache remains usable after the concurrent mixed workload.
+			finalKey := []byte("post_race_key")
+			finalValue := []byte("post_race_value")
+			require.NoError(t, cache.Set(finalKey, finalValue))
+
+			var dst []byte
+			require.NoError(t, cache.Get(&dst, finalKey))
+			require.Equal(t, finalValue, dst)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- fixed `Del()` correctness for `bucketNative` and `bucketTrimmed` by deleting from the correct shard while keeping shard length accounting accurate.
- For item **3 (freeChunks lock invariant)**, added explicit doc comments:
  - `bucketNative` uses `freeChunksLock`
  - `bucketTrimmed` / `bucketUnallocated` require caller-held `b.mu`
- Added focused tests to lock in behavior across bucket types:
  - after `Del(k)`: `Has(k) == false`
  - `Get(k)` fails
  - map size shrinks after delete
  - concurrent `Set/Get/Del/Reset` stress test

## Validation
- `go test ./stores/txmetacache -run '^$' -count=1` (compile-only)
- Full test suite not run (per request).