### PR TITLE
fix(tests): de-flake go test races on main

### DIFF
--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -5,6 +5,11 @@ on:
 env:
   REPO: teranode
   GO_VERSION: '1.26.0'
+  # Disable testcontainers' Ryuk reaper sidecar — Docker Hub rate-limits and
+  # gateway timeouts pulling testcontainers/ryuk:* are the dominant flake
+  # source on CI. Ephemeral runners are torn down regardless, so the reaper
+  # provides no value here. Tests already call container.Terminate() explicitly.
+  TESTCONTAINERS_RYUK_DISABLED: "true"
 
 permissions:
   contents: read

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -12,6 +12,11 @@ env:
   REPO: teranode
   SETTINGS_CONTEXT_DEFAULT: test
   GO_VERSION: "1.26.0"
+  # Disable testcontainers' Ryuk reaper sidecar — Docker Hub rate-limits and
+  # gateway timeouts pulling testcontainers/ryuk:* are the dominant flake
+  # source on CI. Ephemeral runners are torn down regardless, so the reaper
+  # provides no value here. Tests already call container.Terminate() explicitly.
+  TESTCONTAINERS_RYUK_DISABLED: "true"
 
 jobs:
   golangci-lint:

--- a/services/blockassembly/BlockAssembler_test.go
+++ b/services/blockassembly/BlockAssembler_test.go
@@ -869,8 +869,6 @@ func TestBlockAssembly_GetMiningCandidate(t *testing.T) {
 		// Verify genesis block
 		require.Equal(t, chaincfg.RegressionNetParams.GenesisHash, genesisBlock.Hash())
 
-		var completeWg sync.WaitGroup
-		completeWg.Add(1)
 		var seenComplete int
 		done := make(chan struct{})
 		go func() {
@@ -886,7 +884,6 @@ func TestBlockAssembly_GetMiningCandidate(t *testing.T) {
 						assert.Len(t, subtree.Nodes, 4)
 						assert.Equal(t, uint64(999), subtree.Fees)
 						seenComplete++
-						completeWg.Done()
 					}
 
 					if subtreeRequest.ErrChan != nil {
@@ -910,7 +907,13 @@ func TestBlockAssembly_GetMiningCandidate(t *testing.T) {
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash4, Fee: 444, SizeInBytes: 444}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		completeWg.Wait()
+		// Wait until the assembler has committed all 3 txs into the mining candidate.
+		// completeWg.Done() previously fired before the assembler acked the subtree
+		// via ErrChan, so GetMiningCandidate could see NumTxs < 3.
+		require.Eventually(t, func() bool {
+			mc, _, err := testItems.blockAssembler.GetMiningCandidate(ctx)
+			return err == nil && mc != nil && mc.NumTxs == 3
+		}, 5*time.Second, 20*time.Millisecond)
 
 		miningCandidate, subtrees, err := testItems.blockAssembler.GetMiningCandidate(ctx)
 		require.NoError(t, err)

--- a/services/blockassembly/blockassembly_system_test.go
+++ b/services/blockassembly/blockassembly_system_test.go
@@ -1049,14 +1049,24 @@ func TestHandleReorgWithInvalidBlock_Integration(t *testing.T) {
 	err = waitForBestBlockHash(ctx, ba.blockchainClient, chainBHeaders[2].Hash(), 10*time.Second)
 	require.NoError(t, err, "timeout waiting for blockchain to reach chain B tip")
 
-	// Wait for BA to settle on chain B
-	// BA may process the invalidation reorg first (to A1), then advance to chain B.
-	// Either way, it should end up on chain B.
+	// Wait for BA to settle on chain B AND for processed_at to be flushed on
+	// every chain B block. BlockAssembler.reset() stores bestBlock=B3 before
+	// subtreeProcessor.Reset writes processed_at for moveForward blocks, so a
+	// hash-only check can pass while those writes are still in flight.
 	require.Eventually(t, func() bool {
 		currentHeader, _ := ba.blockAssembler.CurrentBlock()
-		return currentHeader.Hash().IsEqual(chainBHeaders[2].Hash())
+		if !currentHeader.Hash().IsEqual(chainBHeaders[2].Hash()) {
+			return false
+		}
+		for _, header := range chainBHeaders {
+			_, meta, err := ba.blockchainClient.GetBlockHeader(ctx, header.Hash())
+			if err != nil || meta.ProcessedAt == nil {
+				return false
+			}
+		}
+		return true
 	}, 15*time.Second, 200*time.Millisecond,
-		"timeout waiting for BA to settle on chain B after reorg with invalid block")
+		"timeout waiting for BA to settle on chain B and flush processed_at after reorg with invalid block")
 
 	// Verify BA is on chain B tip
 	currentHeader, currentHeight := ba.blockAssembler.CurrentBlock()

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -1727,17 +1727,23 @@ func Test_consumerMessageHandler(t *testing.T) {
 		defer bv.blockExistsCache.Stop()
 
 		server := &Server{
-			logger:              logger,
-			settings:            tSettings,
-			blockFoundCh:        make(chan processBlockFound, 10),
+			logger:   logger,
+			settings: tSettings,
+			// Unbuffered: the inner blockHandler goroutine blocks on this send
+			// (no reader in the test), so the handler's select can only fire
+			// ctx.Done(). Without this, the buffered send returned immediately
+			// and racy select could pick errCh=nil.
+			blockFoundCh:        make(chan processBlockFound),
 			blockValidation:     bv,
 			stats:               gocore.NewStat("test"),
 			processBlockNotify:  ttlcache.New[chainhash.Hash, bool](),
 			catchupAlternatives: ttlcache.New[chainhash.Hash, []processBlockCatchup](),
 		}
 
-		// Create a cancellable context
+		// Create a cancellable context, then cancel before invoking the handler
+		// so ctx.Done() is selectable for the very first iteration.
 		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 
 		kafkaMsg := &kafkamessage.KafkaBlockTopicMessage{
 			Hash: hashStr,
@@ -1751,9 +1757,6 @@ func Test_consumerMessageHandler(t *testing.T) {
 		}
 
 		handler := server.consumerMessageHandler(ctx)
-
-		// Cancel the context immediately
-		cancel()
 
 		err = handler(msg)
 		require.Error(t, err)

--- a/stores/blockchain/sql/GenesisHash_test.go
+++ b/stores/blockchain/sql/GenesisHash_test.go
@@ -106,10 +106,9 @@ func TestGenesisHashWrongParams(t *testing.T) {
 			require.NoError(t, err)
 			defer store.Close()
 
-			// Now try to insert the wrong genesis block
-			store.chainParams = tc.wrongParams
-
-			err = store.insertGenesisTransaction(logger)
+			// Pass wrong params explicitly. Avoids racing with background
+			// goroutines that read store.chainParams.
+			err = store.insertGenesisTransaction(logger, tc.wrongParams)
 
 			// Verify we get a configuration error about mismatched genesis hash
 			assert.ErrorContains(t, err, "genesis block hash mismatch")

--- a/stores/blockchain/sql/InvalidateBlock_test.go
+++ b/stores/blockchain/sql/InvalidateBlock_test.go
@@ -35,7 +35,7 @@ func TestSQLInvalidateBlock(t *testing.T) {
 		s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 		require.NoError(t, err)
 
-		err = s.insertGenesisTransaction(ulogger.TestLogger{})
+		err = s.insertGenesisTransaction(ulogger.TestLogger{}, tSettings.ChainCfgParams)
 		require.NoError(t, err)
 
 		_, _, err = s.StoreBlock(context.Background(), block1, "", options.WithMinedSet(true))
@@ -97,7 +97,7 @@ func TestSQLInvalidateBlock(t *testing.T) {
 		s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 		require.NoError(t, err)
 
-		err = s.insertGenesisTransaction(ulogger.TestLogger{})
+		err = s.insertGenesisTransaction(ulogger.TestLogger{}, tSettings.ChainCfgParams)
 		require.NoError(t, err)
 
 		_, _, err = s.StoreBlock(context.Background(), block1, "", options.WithMinedSet(true))

--- a/stores/blockchain/sql/OnMainChain_test.go
+++ b/stores/blockchain/sql/OnMainChain_test.go
@@ -93,7 +93,7 @@ func TestOnMainChain_GenesisOverrideWhenPreBestHashIsNil(t *testing.T) {
 	// Re-seed genesis. This goes through StoreBlock → storeBlock, where
 	// preBestHash is nil (empty DB) so the outer logic computes onMainChain=false.
 	// The override inside storeBlock must set it back to true.
-	require.NoError(t, s.insertGenesisTransaction(ulogger.TestLogger{}))
+	require.NoError(t, s.insertGenesisTransaction(ulogger.TestLogger{}, s.chainParams))
 
 	require.True(t, getOnMainChain(t, s, s.chainParams.GenesisHash[:]),
 		"genesis override must set on_main_chain=true even when preBestHash is nil")

--- a/stores/blockchain/sql/RevalidateBlock_test.go
+++ b/stores/blockchain/sql/RevalidateBlock_test.go
@@ -33,7 +33,7 @@ func TestSQL_RevalidateBlock(t *testing.T) {
 		s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
 		require.NoError(t, err)
 
-		err = s.insertGenesisTransaction(ulogger.TestLogger{})
+		err = s.insertGenesisTransaction(ulogger.TestLogger{}, tSettings.ChainCfgParams)
 		require.NoError(t, err)
 
 		_, _, err = s.StoreBlock(context.Background(), block1, "", options.WithMinedSet(true))

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -243,7 +243,7 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		s.offChainBlockIDs = make(map[uint32]struct{})
 	}
 
-	err = s.insertGenesisTransaction(logger)
+	err = s.insertGenesisTransaction(logger, s.chainParams)
 	if err != nil {
 		return nil, errors.NewStorageError("failed to insert genesis transaction", err)
 	}
@@ -1038,7 +1038,7 @@ func createSqliteSchema(db *usql.DB) error {
 	return nil
 }
 
-func (s *SQL) insertGenesisTransaction(logger ulogger.Logger) error {
+func (s *SQL) insertGenesisTransaction(logger ulogger.Logger, params *chaincfg.Params) error {
 	q := `
 		SELECT
 	     hash
@@ -1060,7 +1060,7 @@ func (s *SQL) insertGenesisTransaction(logger ulogger.Logger) error {
 	}
 
 	if len(hash) == 0 {
-		wireGenesisBlock := s.chainParams.GenesisBlock
+		wireGenesisBlock := params.GenesisBlock
 
 		genesisBlock, err := model.NewBlockFromMsgBlock(wireGenesisBlock, nil)
 		if err != nil {
@@ -1087,9 +1087,9 @@ func (s *SQL) insertGenesisTransaction(logger ulogger.Logger) error {
 		} else if s.engine == util.Postgres {
 			_, _ = s.db.Exec("SET session_replication_role = 'origin'")
 		}
-	} else if !bytes.Equal(hash, s.chainParams.GenesisHash[:]) {
+	} else if !bytes.Equal(hash, params.GenesisHash[:]) {
 		// Check the chainParams genesis block hash is the same as the one in the database
-		return errors.NewConfigurationError("genesis block hash mismatch: bytes is %x, expected %x", hash, s.chainParams.GenesisHash[:])
+		return errors.NewConfigurationError("genesis block hash mismatch: bytes is %x, expected %x", hash, params.GenesisHash[:])
 	}
 
 	return nil

--- a/test/utils/aerospike/aerospike.go
+++ b/test/utils/aerospike/aerospike.go
@@ -3,12 +3,24 @@ package aerospike
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/bsv-blockchain/teranode/stores/utxo/aerospike"
 	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	aerospike2 "github.com/bsv-blockchain/testcontainers-aerospike-go"
 )
+
+// init disables the testcontainers Ryuk reaper sidecar. Ryuk pulls a separate
+// image from Docker Hub which is the dominant flake source on CI runners
+// (rate-limit timeouts, 504 gateway errors). The container is terminated
+// explicitly in the cleanup func returned from InitAerospikeContainer, so the
+// reaper provides no additional safety on ephemeral CI runners.
+func init() {
+	if _, set := os.LookupEnv("TESTCONTAINERS_RYUK_DISABLED"); !set {
+		_ = os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+	}
+}
 
 func InitAerospikeContainer() (string, func() error, error) {
 	aerospike.InitPrometheusMetrics()

--- a/util/kafka/kafka_perf_test.go
+++ b/util/kafka/kafka_perf_test.go
@@ -1,3 +1,5 @@
+//go:build perf
+
 package kafka
 
 import (
@@ -17,10 +19,12 @@ import (
 )
 
 // Performance tests that exercise the real Kafka (Redpanda) path via testcontainers.
-// Run with:  go test -v -run TestPerf -timeout 5m ./util/kafka/
+// Run with:  go test -tags perf -v -run TestPerf -timeout 15m ./util/kafka/
 //
 // These are NOT unit tests — they spin up a Docker container and measure real
 // throughput, latency, and resource behaviour of the producer/consumer stack.
+// Excluded from `make test` via the `perf` build tag because of Docker pull
+// overhead and per-runner CPU variance under -race.
 
 func TestPerfSyncProducerThroughput(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Summary

Six recent push-to-main runs failed in `test_and_lint / Go test` (~18% fail rate over the last 50 main pushes). Same tests recurred across different SHAs — races, not regressions. This PR de-flakes them and reduces shared-runner contention.

| Test | Pkg | Root cause | Fix |
|---|---|---|---|
| `TestGenesisHashWrongParams` | `stores/blockchain/sql` | Mutated `store.chainParams` while `New()` background goroutine read it. | Refactor `insertGenesisTransaction` to take `*chaincfg.Params`; test passes wrong params without mutating shared state. |
| `TestBlockAssembly_GetMiningCandidate` | `services/blockassembly` | `completeWg.Done()` fired before assembler acked subtree via `ErrChan`, so `GetMiningCandidate` could see `NumTxs<3`. | Replace WaitGroup with `require.Eventually` polling `NumTxs == 3`. |
| `TestHandleReorgWithInvalidBlock_Integration` | `services/blockassembly` | `BlockAssembler.reset()` stores `bestBlock=B3` before `subtreeProcessor.Reset` writes `processed_at` for moveForward blocks; hash-only `Eventually` could pass while writes were in flight. | `Eventually` now also requires `processed_at` flushed on every chain B block. |
| `Test_consumerMessageHandler/context_cancellation` | `services/blockvalidation` | `select` raced `ctx.Done()` vs a buffered channel send; on fast-path, send succeeded and `errCh=nil` won. | Cancel before constructing handler + unbuffered `blockFoundCh` so handler's select can only fire `ctx.Done()`. |
| `TestPerfSyncProducerThroughput` (and siblings) | `util/kafka` | Not a unit test — boots Redpanda testcontainer and measures throughput; blows the per-job time budget under `-race`, and wait condition is a log line that fires before Kafka admin API is reliable. | Gate behind `//go:build perf`; `make test` skips them. Run with `go test -tags perf -run TestPerf ./util/kafka/`. |
| `Test_processTransactionInternalAerospike`, `TestExtendedTxa1f6a4ff…` (validator) | `services/propagation`, `services/validator` | Docker Hub timeouts pulling `testcontainers/ryuk:0.13.0` (the testcontainers cleanup sidecar). | Set `TESTCONTAINERS_RYUK_DISABLED=true` in PR/main test workflow envs; also `init()` in `test/utils/aerospike/aerospike.go` for local dev. Tests already `Terminate()` containers explicitly. |

Each fix verified locally under `-race -count=N` — see Test plan below.

## Out of scope

- `TestDaemon_Start_AllServices` (180s timeout, hit twice in window) — root cause is a TOCTOU race in `daemon/test_daemon.go:getFreePort` (open-then-close, port grabbed by another test before service binds). Real fix needs port reservation that survives until service binds. Filed as follow-up; the kafka perf build-tag here removes a major source of port contention which may also reduce its frequency.
- Nightly `Chain Integrity Test` and `run-daemon-tests` are persistently red (30/30 nights) for unrelated reasons — ECR auth on `teranode-coinbase` removed in #4042, and a daemon e2e suite blowing the default 10m Go test timeout. Not addressed here per request.

## Test plan

- [x] `go test -race -count=20 -run TestGenesisHashWrongParams ./stores/blockchain/sql/` — 100/100 pass
- [x] `go test -race -count=10 -run '^TestBlockAssembly_GetMiningCandidate$' ./services/blockassembly/` — 20/20 pass
- [x] `go test -race -count=20 -run Test_consumerMessageHandler ./services/blockvalidation/` — 80/80 pass
- [x] `go test -race -count=3 -run '^TestHandleReorgWithInvalidBlock_Integration$' ./services/blockassembly/` — 3/3 pass
- [x] `go test -timeout 120s ./util/kafka/` — 133 pass, perf tests correctly excluded
- [x] `go test -race -run 'TestGenesisHash|TestInvalidate|TestRevalidate|TestOnMainChain' ./stores/blockchain/sql/` — 38 pass (signature change of internal `insertGenesisTransaction` consumed by 3 callers)
- [x] `go build ./...` — green
- [x] `go vet ./...` — only pre-existing warnings in `test/utils/helper.go`