### PR TITLE
fix(validator): synchronise mtpStore with sync.RWMutex

### DIFF
--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -1315,23 +1315,39 @@ func (v *Validator) validateTransaction(ctx context.Context, tx *bt.Tx, blockHei
 	//   ARE in the DB, and EnsureMTPLoaded stores the result at mtpStore[blockHeight].
 	blockMTPHeight := blockHeight
 
-	// Hold the read lock for the duration of the MTP lookups. This serialises against
-	// EnsureMTPLoaded writers (append + in-place overlap patch), which may run concurrently
-	// when blocks N and N+1 are validated in parallel. RLock is uncontended in the
-	// steady-state path where EnsureMTPLoaded has already populated the range.
+	// Hold the read lock only for the MTP lookups themselves, not for the subsequent
+	// ValidateBIP68 call which works on the copied utxoMTPs / blockMTP values. This
+	// serialises against EnsureMTPLoaded writers (append + in-place overlap patch) for
+	// the cross-block case (block N+1 extending mtpStore while block N's per-tx
+	// goroutines read it) without holding the lock through ECDSA / sequence-lock
+	// arithmetic. RLock is uncontended in the steady-state path where EnsureMTPLoaded
+	// has already populated the range.
+	utxoMTPs, blockMTP, err := v.readMTPsLocked(blockMTPHeight, utxoHeights)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	return v.txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
+}
+
+// readMTPsLocked returns the per-input MTP values and the block MTP for use by
+// validateTransaction. It takes the mtpStore read lock for the duration of the
+// reads only and releases it before returning. The caller is free to use the
+// returned slice / value without further synchronisation.
+func (v *Validator) readMTPsLocked(blockMTPHeight uint32, utxoHeights []uint32) ([]uint32, uint32, error) {
 	v.mtpMu.RLock()
 	defer v.mtpMu.RUnlock()
 
 	// Guard against a missing EnsureMTPLoaded call. In normal operation this cannot
 	// happen because Server.go calls EnsureMTPLoaded before spawning goroutines.
 	if uint32(len(v.mtpStore)) <= blockMTPHeight {
-		err := errors.NewProcessingError("[Validator][validateTransaction] MTP store not loaded up to height %d (store length %d); EnsureMTPLoaded must be called before block validation", blockMTPHeight, len(v.mtpStore))
-		span.RecordError(err)
-		return err
+		return nil, 0, errors.NewProcessingError("[Validator][validateTransaction] MTP store not loaded up to height %d (store length %d); EnsureMTPLoaded must be called before block validation", blockMTPHeight, len(v.mtpStore))
 	}
 
 	storeLen := uint32(len(v.mtpStore))
 	utxoMTPs := make([]uint32, len(utxoHeights))
+
 	for i, h := range utxoHeights {
 		if h >= storeLen {
 			utxoMTPs[i] = v.mtpStore[blockMTPHeight]
@@ -1339,9 +1355,8 @@ func (v *Validator) validateTransaction(ctx context.Context, tx *bt.Tx, blockHei
 			utxoMTPs[i] = v.mtpStore[h]
 		}
 	}
-	blockMTP := v.mtpStore[blockMTPHeight]
 
-	return v.txValidator.ValidateBIP68(tx, blockHeight, utxoHeights, utxoMTPs, blockMTP)
+	return utxoMTPs, v.mtpStore[blockMTPHeight], nil
 }
 
 // validateTransactionScripts performs script validation for a transaction

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bsv-blockchain/go-batcher/v2"
@@ -157,8 +158,19 @@ type Validator struct {
 	// Memory cost: ~4 MB per million blocks (one uint32 per block), negligible for any
 	// foreseeable chain length.
 	//
-	// EnsureMTPLoaded must be called (once, serially) before concurrent per-tx goroutines
-	// access this slice, so no locking is required for reads.
+	// mtpMu guards concurrent access to mtpStore.
+	//   - EnsureMTPLoaded acquires the write lock for the duration of the fetch + append +
+	//     in-place overlap patch. Concurrent EnsureMTPLoaded callers serialise; the second
+	//     one fast-paths out after acquiring the lock if the first already populated the
+	//     range it needs.
+	//   - validateTransaction acquires the read lock around its MTP lookups. This protects
+	//     against the cross-block case where block N's per-tx goroutines are still reading
+	//     while block N+1's EnsureMTPLoaded is appending or patching overlap entries (the
+	//     append re-allocates the backing array; the in-place patch mutates indices that
+	//     readers may be addressing).
+	// Same-block contention is negligible: EnsureMTPLoaded runs once per block before per-tx
+	// goroutines start, and per-tx readers only contend with each other on the read lock.
+	mtpMu    sync.RWMutex
 	mtpStore []uint32
 }
 
@@ -1195,7 +1207,12 @@ func (v *Validator) EnsureMTPLoaded(ctx context.Context, blockHeight uint32) err
 	//     clamps those lookups to blockMTPHeight.
 	needed := blockHeight
 
-	// Fast path: store already covers the needed height.
+	v.mtpMu.Lock()
+	defer v.mtpMu.Unlock()
+
+	// Fast path: store already covers the needed height.  A concurrent EnsureMTPLoaded
+	// that won the lock may have already populated the store; re-checking here avoids a
+	// redundant gRPC fetch.
 	currentLen := uint32(len(v.mtpStore))
 	if currentLen > needed {
 		return nil
@@ -1297,6 +1314,13 @@ func (v *Validator) validateTransaction(ctx context.Context, tx *bt.Tx, blockHei
 	//   computes it on the fly from the block_time values of [N-11, N-1] which
 	//   ARE in the DB, and EnsureMTPLoaded stores the result at mtpStore[blockHeight].
 	blockMTPHeight := blockHeight
+
+	// Hold the read lock for the duration of the MTP lookups. This serialises against
+	// EnsureMTPLoaded writers (append + in-place overlap patch), which may run concurrently
+	// when blocks N and N+1 are validated in parallel. RLock is uncontended in the
+	// steady-state path where EnsureMTPLoaded has already populated the range.
+	v.mtpMu.RLock()
+	defer v.mtpMu.RUnlock()
 
 	// Guard against a missing EnsureMTPLoaded call. In normal operation this cannot
 	// happen because Server.go calls EnsureMTPLoaded before spawning goroutines.

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1788,6 +1788,83 @@ func TestReadMTPsLocked_ClampsOutOfRangeUTXOs(t *testing.T) {
 	require.Equal(t, uint32(1_700_000_020), blockMTP)
 }
 
+// TestValidateTransaction_BIP68PathReadsMTPStore drives validateTransaction
+// through the SkipPolicyChecks BIP68 branch with a populated mtpStore. The
+// goal is coverage on the MTP-reading code path (`readMTPsLocked` call,
+// error wiring, ValidateBIP68 invocation) — the actual BIP68 lock-time
+// arithmetic is exercised by the dedicated TxValidator_bip68 tests.
+func TestValidateTransaction_BIP68PathReadsMTPStore(t *testing.T) {
+	initPrometheusMetrics()
+
+	// Mainnet sets CSVHeight = 419328; choose a height comfortably above so
+	// the BIP68 gate at the top of validateTransaction lets us through.
+	const blockHeight = uint32(500_000)
+
+	tx, err := bt.NewTxFromString("010000000000000000ef01f80f63b70d76242a60f6a222e536f1383b6ac11ff69bb0b026871dfe8255ae5e010000006a47304402204dcc5d16184a0f5b73a56a9984de0156e60f486af4b9feb304c1e7a0bebeba50022029d2c4f7614438a3bb33b90ea6251aa760a2e6645068338faab2e65f7a54ca700121033ce8391ba0f2ffa4b39947920a28958b14569c382dab826e3e86253d6f2d6be6ffffffff906ca312000000001976a9143a570d7cd342bb8cf54193d2919d12f1b85f03cc88ac022000fc09000000001976a914dc1b13bfce97785162b14dc583947bc2e379eaa288ac501ea708000000001976a9144e70c86128dc5d236d7d79bd9e011e25ce9295aa88ac00000000")
+	require.NoError(t, err)
+	require.True(t, tx.IsExtended())
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.ChainCfgParams, _ = chaincfg.GetChainParams("mainnet")
+
+	// blockchainClient just needs to be non-nil for the gate at the top of
+	// validateTransaction; mtpStore is pre-populated so readMTPsLocked finds
+	// the values it needs without a fetch.
+	mtpStore := make([]uint32, blockHeight+1)
+	for i := range mtpStore {
+		mtpStore[i] = uint32(1_700_000_000 + i)
+	}
+
+	v := &Validator{
+		logger:           ulogger.TestLogger{},
+		settings:         tSettings,
+		txValidator:      NewTxValidator(ulogger.TestLogger{}, tSettings),
+		blockchainClient: &blockchain.Mock{},
+		stats:            gocore.NewStat("validator_test"),
+		mtpStore:         mtpStore,
+	}
+
+	ctx, _, endSpan := tracing.Tracer("validator").Start(context.Background(), "Test")
+	defer endSpan()
+
+	// utxoHeight at blockHeight-1 is well within the populated range so the
+	// per-input MTP lookup uses mtpStore[h] (the in-range branch).
+	err = v.validateTransaction(ctx, tx, blockHeight, []uint32{blockHeight - 1}, &Options{SkipPolicyChecks: true})
+	require.NoError(t, err)
+}
+
+// TestValidateTransaction_BIP68GuardFiresOnUnpopulatedStore drives
+// validateTransaction with SkipPolicyChecks=true and an empty mtpStore. The
+// readMTPsLocked guard must fire and surface a processing error to the
+// caller via span.RecordError + return.
+func TestValidateTransaction_BIP68GuardFiresOnUnpopulatedStore(t *testing.T) {
+	initPrometheusMetrics()
+
+	const blockHeight = uint32(500_000)
+
+	tx, err := bt.NewTxFromString("010000000000000000ef01f80f63b70d76242a60f6a222e536f1383b6ac11ff69bb0b026871dfe8255ae5e010000006a47304402204dcc5d16184a0f5b73a56a9984de0156e60f486af4b9feb304c1e7a0bebeba50022029d2c4f7614438a3bb33b90ea6251aa760a2e6645068338faab2e65f7a54ca700121033ce8391ba0f2ffa4b39947920a28958b14569c382dab826e3e86253d6f2d6be6ffffffff906ca312000000001976a9143a570d7cd342bb8cf54193d2919d12f1b85f03cc88ac022000fc09000000001976a914dc1b13bfce97785162b14dc583947bc2e379eaa288ac501ea708000000001976a9144e70c86128dc5d236d7d79bd9e011e25ce9295aa88ac00000000")
+	require.NoError(t, err)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.ChainCfgParams, _ = chaincfg.GetChainParams("mainnet")
+
+	v := &Validator{
+		logger:           ulogger.TestLogger{},
+		settings:         tSettings,
+		txValidator:      NewTxValidator(ulogger.TestLogger{}, tSettings),
+		blockchainClient: &blockchain.Mock{},
+		stats:            gocore.NewStat("validator_test"),
+		// mtpStore intentionally empty
+	}
+
+	ctx, _, endSpan := tracing.Tracer("validator").Start(context.Background(), "Test")
+	defer endSpan()
+
+	err = v.validateTransaction(ctx, tx, blockHeight, []uint32{blockHeight - 1}, &Options{SkipPolicyChecks: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MTP store not loaded up to height")
+}
+
 // TestReadMTPsLocked_GuardFiresOnUnpopulatedStore verifies the guard returns a
 // processing error when EnsureMTPLoaded has not populated the store up to the
 // requested blockMTPHeight (in normal operation this cannot happen because

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,6 +43,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
@@ -1571,4 +1573,161 @@ func TestValidator_TwoPhaseCommitCompletesAfterTxMetaSerializationFailure(t *tes
 	err = realStore.GetMeta(ctx, txs[1].TxIDChainHash(), storedMeta)
 	require.NoError(t, err)
 	assert.False(t, storedMeta.Locked, "tx should be unlocked after 2PC completes despite txmeta serialization failure")
+}
+
+// TestEnsureMTPLoaded_ConcurrentCallsNeitherHangsNorRaces verifies that two concurrent
+// EnsureMTPLoaded callers at the same blockHeight do not race on mtpStore.
+//
+// Prior to the mutex fix, the race detector reported a data race here because both
+// goroutines simultaneously read len(v.mtpStore)==0 and then both appended to it.
+// The test must be run with -race to catch the regression.
+func TestEnsureMTPLoaded_ConcurrentCallsNeitherHangsNorRaces(t *testing.T) {
+	const blockHeight = uint32(1_000_000) // well above RegressionNet CSVHeight=576
+
+	// Build a dense MTP slice that GetMedianTimePastRange would return.
+	// The range fetched is [0, blockHeight], so length = blockHeight+1.
+	mtpValues := make([]uint32, blockHeight+1)
+	for i := range mtpValues {
+		mtpValues[i] = uint32(1_700_000_000 + i) // plausible unix timestamps
+	}
+
+	// slowBlockchainClient introduces a brief pause so that both goroutines are
+	// likely inside EnsureMTPLoaded concurrently when the race would occur.
+	mockClient := &blockchain.Mock{}
+	mockClient.On("GetMedianTimePastRange", mock.Anything, uint32(0), blockHeight).
+		After(5*time.Millisecond).
+		Return(mtpValues, nil)
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	v := &Validator{
+		logger:           ulogger.TestLogger{},
+		settings:         tSettings,
+		blockchainClient: mockClient,
+		stats:            gocore.NewStat("validator_test"),
+	}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+
+	// Launch two concurrent EnsureMTPLoaded calls, mirroring the production scenario
+	// where two CheckSubtreeFromBlock RPCs arrive before the first has populated mtpStore.
+	for i := range 2 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = v.EnsureMTPLoaded(ctx, blockHeight)
+		}(i)
+	}
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+
+	// After both calls complete the store must be fully populated.
+	require.Equal(t, int(blockHeight+1), len(v.mtpStore),
+		"mtpStore must have exactly blockHeight+1 entries after concurrent load")
+
+	// Spot-check a few values to confirm correct data (not a corrupted merge).
+	require.Equal(t, uint32(1_700_000_000), v.mtpStore[0])
+	require.Equal(t, uint32(1_700_000_000+blockHeight), v.mtpStore[blockHeight])
+}
+
+// TestEnsureMTPLoaded_CrossBlockReadersAndWritersDoNotRace verifies that
+// readers using the same pattern as validateTransaction (RLock + indexing)
+// can run concurrently with an EnsureMTPLoaded extension for a later block
+// without the race detector firing. The append in EnsureMTPLoaded may
+// re-allocate the backing array and the overlap patch mutates entries
+// in-place, so unsynchronised readers would race on slice-header / cell
+// reads.
+//
+// This guards the cross-block scenario raised in PR review: block N's
+// per-transaction goroutines are still reading mtpStore when block N+1's
+// EnsureMTPLoaded runs.
+func TestEnsureMTPLoaded_CrossBlockReadersAndWritersDoNotRace(t *testing.T) {
+	const (
+		initialHeight  = uint32(1_000_000)
+		extendedHeight = uint32(1_000_500)
+	)
+
+	initialMTPs := make([]uint32, initialHeight+1)
+	for i := range initialMTPs {
+		initialMTPs[i] = uint32(1_700_000_000 + i)
+	}
+
+	// Second call refetches an mtpReorgOverlap-deep tail and the new heights:
+	//   fromHeight = (initialHeight+1) - mtpReorgOverlap
+	//   range     = [fromHeight, extendedHeight], so length = extendedHeight - fromHeight + 1.
+	extendFrom := (initialHeight + 1) - mtpReorgOverlap
+	extendedLen := extendedHeight - extendFrom + 1
+	extendedMTPs := make([]uint32, extendedLen)
+	for i := range extendedMTPs {
+		extendedMTPs[i] = uint32(1_700_000_000) + extendFrom + uint32(i)
+	}
+
+	mockClient := &blockchain.Mock{}
+	mockClient.On("GetMedianTimePastRange", mock.Anything, uint32(0), initialHeight).
+		Return(initialMTPs, nil).Once()
+	mockClient.On("GetMedianTimePastRange", mock.Anything, extendFrom, extendedHeight).
+		After(2*time.Millisecond).
+		Return(extendedMTPs, nil).Once()
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	v := &Validator{
+		logger:           ulogger.TestLogger{},
+		settings:         tSettings,
+		blockchainClient: mockClient,
+		stats:            gocore.NewStat("validator_test"),
+	}
+
+	ctx := context.Background()
+
+	// Prime the store at the initial height so the second EnsureMTPLoaded
+	// hits the extension path (overlap patch + append).
+	require.NoError(t, v.EnsureMTPLoaded(ctx, initialHeight))
+
+	const readers = 8
+	const readsPerGoroutine = 200
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < readsPerGoroutine; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Mimic validateTransaction's read pattern: take RLock,
+				// snapshot len, index a few entries.
+				v.mtpMu.RLock()
+				storeLen := uint32(len(v.mtpStore))
+				if storeLen > 0 {
+					_ = v.mtpStore[0]
+					_ = v.mtpStore[storeLen-1]
+					_ = v.mtpStore[storeLen/2]
+				}
+				v.mtpMu.RUnlock()
+			}
+		}()
+	}
+
+	// Concurrently extend the store to a later block height. Without the
+	// reader-side RLock this append/patch races with the readers.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, v.EnsureMTPLoaded(ctx, extendedHeight))
+	}()
+
+	wg.Wait()
+	close(stop)
+
+	require.GreaterOrEqual(t, len(v.mtpStore), int(extendedHeight+1))
 }

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1593,10 +1593,13 @@ func TestEnsureMTPLoaded_ConcurrentCallsNeitherHangsNorRaces(t *testing.T) {
 
 	// slowBlockchainClient introduces a brief pause so that both goroutines are
 	// likely inside EnsureMTPLoaded concurrently when the race would occur.
+	// Once() asserts that exactly one fetch is issued: the second concurrent
+	// caller must fast-path out under the mutex without re-fetching, which is
+	// the production failure mode this test guards against.
 	mockClient := &blockchain.Mock{}
 	mockClient.On("GetMedianTimePastRange", mock.Anything, uint32(0), blockHeight).
 		After(5*time.Millisecond).
-		Return(mtpValues, nil)
+		Return(mtpValues, nil).Once()
 
 	tSettings := test.CreateBaseTestSettings(t)
 
@@ -1632,6 +1635,10 @@ func TestEnsureMTPLoaded_ConcurrentCallsNeitherHangsNorRaces(t *testing.T) {
 	// Spot-check a few values to confirm correct data (not a corrupted merge).
 	require.Equal(t, uint32(1_700_000_000), v.mtpStore[0])
 	require.Equal(t, uint32(1_700_000_000+blockHeight), v.mtpStore[blockHeight])
+
+	// Asserts exactly-one fetch (Once() above). Without the mutex both callers
+	// would each issue a 1.45 M-entry fetch — the production CPU peg.
+	mockClient.AssertExpectations(t)
 }
 
 // TestEnsureMTPLoaded_CrossBlockReadersAndWritersDoNotRace verifies that
@@ -1720,14 +1727,23 @@ func TestEnsureMTPLoaded_CrossBlockReadersAndWritersDoNotRace(t *testing.T) {
 
 	// Concurrently extend the store to a later block height. Without the
 	// reader-side RLock this append/patch races with the readers.
+	var extendErr error
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		require.NoError(t, v.EnsureMTPLoaded(ctx, extendedHeight))
+		// require.* uses runtime.Goexit which only stops the goroutine it runs
+		// in; capture and assert from the main test goroutine after wg.Wait.
+		extendErr = v.EnsureMTPLoaded(ctx, extendedHeight)
 	}()
 
 	wg.Wait()
 	close(stop)
 
+	require.NoError(t, extendErr)
 	require.GreaterOrEqual(t, len(v.mtpStore), int(extendedHeight+1))
+
+	// Asserts the initial-load + extension pair both fired exactly once
+	// (each .Once() above) — defends against accidental over-fetch.
+	mockClient.AssertExpectations(t)
 }

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1747,3 +1747,60 @@ func TestEnsureMTPLoaded_CrossBlockReadersAndWritersDoNotRace(t *testing.T) {
 	// (each .Once() above) — defends against accidental over-fetch.
 	mockClient.AssertExpectations(t)
 }
+
+// TestReadMTPsLocked_HappyPath verifies the reader helper returns the per-input
+// MTP values and the block MTP correctly when mtpStore is fully populated.
+func TestReadMTPsLocked_HappyPath(t *testing.T) {
+	v := &Validator{
+		logger: ulogger.TestLogger{},
+		mtpStore: []uint32{
+			1_700_000_000, // height 0
+			1_700_000_010, // height 1
+			1_700_000_020, // height 2
+			1_700_000_030, // height 3
+			1_700_000_040, // height 4
+		},
+	}
+
+	utxoMTPs, blockMTP, err := v.readMTPsLocked(4, []uint32{0, 2, 3})
+	require.NoError(t, err)
+	require.Equal(t, []uint32{1_700_000_000, 1_700_000_020, 1_700_000_030}, utxoMTPs)
+	require.Equal(t, uint32(1_700_000_040), blockMTP)
+}
+
+// TestReadMTPsLocked_ClampsOutOfRangeUTXOs verifies that utxoHeights at or above
+// the store length fall back to the blockMTP value (matches the production
+// behaviour for unconfirmed parents whose effective height is blockState.Height+1
+// and may exceed blockMTPHeight).
+func TestReadMTPsLocked_ClampsOutOfRangeUTXOs(t *testing.T) {
+	v := &Validator{
+		logger: ulogger.TestLogger{},
+		mtpStore: []uint32{
+			1_700_000_000,
+			1_700_000_010,
+			1_700_000_020,
+		},
+	}
+
+	utxoMTPs, blockMTP, err := v.readMTPsLocked(2, []uint32{0, 99, 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint32{1_700_000_000, 1_700_000_020, 1_700_000_010}, utxoMTPs)
+	require.Equal(t, uint32(1_700_000_020), blockMTP)
+}
+
+// TestReadMTPsLocked_GuardFiresOnUnpopulatedStore verifies the guard returns a
+// processing error when EnsureMTPLoaded has not populated the store up to the
+// requested blockMTPHeight (in normal operation this cannot happen because
+// Server.go calls EnsureMTPLoaded before per-tx goroutines start).
+func TestReadMTPsLocked_GuardFiresOnUnpopulatedStore(t *testing.T) {
+	v := &Validator{
+		logger:   ulogger.TestLogger{},
+		mtpStore: []uint32{1_700_000_000, 1_700_000_010}, // length 2, asking for height 5
+	}
+
+	utxoMTPs, blockMTP, err := v.readMTPsLocked(5, []uint32{0})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MTP store not loaded up to height 5")
+	require.Nil(t, utxoMTPs)
+	require.Equal(t, uint32(0), blockMTP)
+}


### PR DESCRIPTION
## TL;DR

Validator's in-memory Median Time Past cache (`mtpStore`) had no synchronisation. Two concurrent populate calls — followed by a third reader — could each see an empty cache, both fetch ~1.45 M entries, race on the append, and corrupt the slice. Once corrupted, the BIP68 guard in `validateTransaction` rejected every transaction, and `ValidateSubtreeInternal`'s outer retry loop re-issued the 1.45 M-entry fetch on every retry — pegging CPU and stalling sync indefinitely.

This PR adds a `sync.RWMutex` around `mtpStore`, so populates serialise (the second caller fast-paths out instead of re-fetching) and readers don't observe torn state during a populate.

## Why this only surfaced at one block on testnet

The bug is **not** block-specific — there is nothing about block 1,451,504 that triggers it. The trigger is a timing window during the first `EnsureMTPLoaded` call after validator startup, which exists at every block ≥ `CSVHeight` (testnet `CSVHeight` = 770,112).

What aligned on the testnet stall:

1. The validator was cold-started (empty `mtpStore`) and was being driven by a legacy sync.
2. The first legacy `CheckSubtreeFromBlock` RPC for a post-CSV block kicked off `EnsureMTPLoaded`, which had to fetch ~1.45 M MTP entries from the blockchain store. That fetch is the only slow operation in the call.
3. While the fetch was still in flight, the legacy client's request timeout fired and it retried `CheckSubtreeFromBlock`. The retry entered `EnsureMTPLoaded` with `len(mtpStore)` still 0, started its own 1.45 M-entry fetch, and raced the original on the slice append.
4. The corruption tripped the BIP68 height guard in `validateTransaction`. `ValidateSubtreeInternal`'s outer retry loop re-issued the fetch on every retry — minutes per attempt — producing the multi-hour CPU peg observed on the box.

Block 1,451,504 is simply where the validator happened to be when these timings aligned. Mainnet has not surfaced it because mainnet validators tend to be long-lived (the cache populates once and the race window closes), and mainnet legacy peers are less prone to the retry-on-timeout pattern testnet sees.

## Detail: the two races

1. **Same-block writer-writer.** Two concurrent `CheckSubtreeFromBlock` RPCs (legacy retries a call while the first is still in flight) both observed an empty `mtpStore`, both fetched ~1.45 M MTP entries, and both raced on the append — corrupting the store. The corruption tripped the guard in `validateTransaction`, which surfaced an error to the outer retry loop in `ValidateSubtreeInternal`. Each retry repeated the 1.45 M-entry fetch, producing the multi-hour CPU peg and sync stall observed on testnet around block 1,451,504.
2. **Cross-block reader-writer.** While block N's per-transaction goroutines read `mtpStore` inside `validateTransaction`, block N+1's `EnsureMTPLoaded` can run concurrently. The append re-allocates the backing array and the overlap patch mutates entries in place, so unsynchronised readers observe torn slice headers / cell values.

## Fix

`services/validator/Validator.go`:
- `mtpMu sync.RWMutex` on `Validator`.
- `EnsureMTPLoaded` acquires the write lock for the full body. The second same-block caller fast-paths out after acquiring the lock when the range it needs is already populated (no second gRPC fetch).
- `validateTransaction` reads the MTP values via a small `readMTPsLocked` helper that takes the read lock only for the lookups themselves and releases it before `ValidateBIP68` runs. Cross-block writers serialise behind any in-flight readers; the per-tx ECDSA / sequence-lock work is unconstrained by the lock.

`services/validator/Validator_test.go`:
- `TestEnsureMTPLoaded_ConcurrentCallsNeitherHangsNorRaces`: two same-block `EnsureMTPLoaded` calls against an empty store. Mock is `.Once()` and the test asserts `mockClient.AssertExpectations(t)`, so a regression that re-fetches without racing (the production failure mode) fails the assertion. Fails under `-race` without the write lock; passes with it.
- `TestEnsureMTPLoaded_CrossBlockReadersAndWritersDoNotRace`: eight readers indexing `mtpStore` via the `validateTransaction` pattern while a writer extends the store to a later block height. Fails under `-race` without the read lock; passes with it. Asserts mock expectations to defend against accidental over-fetch.

## Test plan

- [x] `go vet ./services/validator/...` — clean
- [x] `go test -race ./services/validator/` — 277 passed, 0 failed
- [x] `go test -race -run TestEnsureMTPLoaded ./services/validator/` — both targeted race tests pass
- [x] `golangci-lint run ./services/validator/...` — clean
- [x] `staticcheck ./services/validator/...` — clean
- [ ] Reviewer to confirm no other call sites read `mtpStore` outside `validateTransaction` (already grepped — only `EnsureMTPLoaded` itself touches it elsewhere, under the write lock)

## Commits

- `cdec5b3d3` — original fix: `sync.RWMutex` + reader / writer locking + both race tests
- `d334b5f77` — review feedback: extract `readMTPsLocked` to drop the read lock before `ValidateBIP68`; tighten test mock expectations (`Once()` + `AssertExpectations`); replace `require.*` in goroutines with main-goroutine assertion

## Notes for reviewer

The `mtpStore` field and `EnsureMTPLoaded` were introduced in #547 ("Re-implement BIP68"); the race has been latent since that PR.

`EnsureMTPLoaded` intentionally holds the write lock through `GetMedianTimePastRange` — releasing for the fetch reintroduces the same-block redundant-fetch race. The cold-start fetch (~1.45 M entries) runs once at startup before any per-tx readers; per-block extension fetches are tiny (12-overlap + new heights) and fast. A `golang.org/x/sync/singleflight` wrapper would be a cleaner alternative if read-blocking ever shows up in profiling. (Open thread: [r3213721754](https://github.com/bsv-blockchain/teranode/pull/838#discussion_r3213721754).)