### PR TITLE
test(blockassembly/subtreeprocessor): add clock seam for deterministic tests

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -311,6 +311,10 @@ type SubtreeProcessor struct {
 
 	// diskTxMap is the disk-backed tx map (non-nil when txMapDirs is set).
 	diskTxMap *DiskTxMap
+
+	// clock is the source of wall time for codepaths that need a deterministic
+	// substitute in tests (validFromMillis calculations). Replaced in tests.
+	clock clock
 }
 
 type State uint32
@@ -449,6 +453,7 @@ func NewSubtreeProcessor(_ context.Context, logger ulogger.Logger, tSettings *se
 		stats:                        gocore.NewStat("subtreeProcessor").NewStat("Add", false),
 		currentRunningState:          atomic.Value{},
 		announcementTicker:           time.NewTicker(tSettings.BlockAssembly.SubtreeAnnouncementInterval),
+		clock:                        realClock{},
 	}
 	stp.currentSubtree.Store(firstSubtree)
 	stp.setCurrentRunningState(StateStarting)
@@ -804,7 +809,7 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 					// Calculate validFromMillis based on DoubleSpendWindow
 					validFromMillis := int64(0)
 					if stp.settings.BlockAssembly.DoubleSpendWindow > 0 {
-						validFromMillis = time.Now().Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
+						validFromMillis = stp.clock.Now().Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
 					}
 
 					for batchNum := 0; batchNum < maxBatchesPerIteration; batchNum++ {
@@ -3781,7 +3786,7 @@ func (stp *SubtreeProcessor) dequeueDuringBlockMovement(transactionMap *SplitSwi
 	queueLength := stp.queue.length()
 	if queueLength > 0 {
 		nrBatchesProcessed := int64(0)
-		validFromMillis := time.Now().Add(-1 * stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
+		validFromMillis := stp.clock.Now().Add(-1 * stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
 
 		for {
 			batch, found := stp.queue.dequeueBatch(validFromMillis)

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -218,6 +218,25 @@ func TestRotate(t *testing.T) {
 	assert.Equal(t, 1, chainedSubtreesLen)
 }
 
+// Test_subtreeProcessorClockOverride verifies the clock seam on
+// SubtreeProcessor. NewSubtreeProcessor must wire a real clock by default,
+// and tests must be able to substitute a fake. The validFromMillis
+// calculation in the Start loop and dequeueDuringBlockMovement reads through
+// stp.clock, so installing a fake here makes those paths deterministic.
+func Test_subtreeProcessorClockOverride(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	newSubtreeChan := make(chan NewSubtreeRequest, 1)
+
+	stp, err := NewSubtreeProcessor(context.Background(), ulogger.TestLogger{}, tSettings, nil, nil, nil, newSubtreeChan)
+	require.NoError(t, err)
+	require.NotNil(t, stp.clock, "default clock must be wired in NewSubtreeProcessor")
+
+	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	stp.clock = fixedClock{t: fixed}
+
+	require.Equal(t, fixed, stp.clock.Now())
+}
+
 func Test_RemoveTxFromSubtrees(t *testing.T) {
 	t.Run("remove transaction from subtrees", func(t *testing.T) {
 		newSubtreeChan := make(chan NewSubtreeRequest)

--- a/services/blockassembly/subtreeprocessor/clock.go
+++ b/services/blockassembly/subtreeprocessor/clock.go
@@ -1,0 +1,15 @@
+// Package subtreeprocessor provides functionality for processing transaction subtrees in Teranode.
+package subtreeprocessor
+
+import "time"
+
+// clock supplies wall time to code paths that need a deterministic substitute
+// in tests. The production implementation is realClock; tests install a fake
+// to drive timestamps without touching wall time.
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }

--- a/services/blockassembly/subtreeprocessor/conflicting_queue_race_test.go
+++ b/services/blockassembly/subtreeprocessor/conflicting_queue_race_test.go
@@ -95,6 +95,80 @@ func TestDequeueDuringBlockMovement_RejectsChildOfConflictingParent(t *testing.T
 		"so its own descendants are caught later in the same drain")
 }
 
+// TestDequeueDuringBlockMovement_ZeroWindowAsymmetry pins, at the real call
+// site, the divergence between the two validFromMillis formulas inside
+// SubtreeProcessor:
+//
+//	Start loop (SubtreeProcessor.go:807-813) zero-guards the calculation:
+//	  if DoubleSpendWindow == 0 → validFromMillis = 0 → queue filter off.
+//
+//	dequeueDuringBlockMovement (SubtreeProcessor.go:3789) does not:
+//	  validFromMillis = clock.Now().Add(-1 * window).UnixMilli() always.
+//
+// With DoubleSpendWindow == 0 (the documented default - see
+// settings/blockassembly_settings.go:29) and the SubtreeProcessor clock
+// equal to the queue clock at enqueue time, the drain formula produces
+// validFromMillis = batch.time, the queue filter at queue.go:96 fires
+// (validFromMillis > 0 && time >= validFromMillis), and the batch is
+// held back.
+//
+// The "+1ms" subtest is the control: advancing only the
+// SubtreeProcessor clock by 1 millisecond is enough to move batch.time
+// strictly below validFromMillis, after which the drain admits it.
+// That is the deterministic equivalent of the time.Sleep(5ms) workaround
+// at conflicting_queue_race_test.go:75.
+func TestDequeueDuringBlockMovement_ZeroWindowAsymmetry(t *testing.T) {
+	t.Run("same_millisecond_batch_is_held_back", func(t *testing.T) {
+		stp := newTestProcessorNoStart(t)
+		require.Zero(t, stp.settings.BlockAssembly.DoubleSpendWindow,
+			"default window is 0; the asymmetry only manifests at 0")
+
+		fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+		stp.clock = fixedClock{t: fixed}
+		stp.queue.clock = fixedClock{t: fixed}
+
+		txHash := chainhash.HashH([]byte("zero-window-same-ms"))
+		stp.queue.enqueueBatch(
+			[]subtreepkg.Node{{Hash: txHash, Fee: 1, SizeInBytes: 220}},
+			[]*subtreepkg.TxInpoints{{}},
+		)
+		require.Equal(t, int64(1), stp.queue.length())
+
+		require.NoError(t, stp.dequeueDuringBlockMovement(nil, nil, nil, true))
+
+		require.Equal(t, int64(1), stp.queue.length(),
+			"drain held back a same-millisecond batch at window=0; the Start "+
+				"loop's zero-guard would have admitted it")
+		require.NotContains(t, collectSubtreeHashes(stp), txHash,
+			"the held-back batch must not appear in chainedSubtrees / currentSubtree")
+	})
+
+	t.Run("control_one_ms_advance_drains_the_batch", func(t *testing.T) {
+		stp := newTestProcessorNoStart(t)
+		require.Zero(t, stp.settings.BlockAssembly.DoubleSpendWindow)
+
+		enqueueAt := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+		drainAt := enqueueAt.Add(1 * time.Millisecond)
+
+		stp.queue.clock = fixedClock{t: enqueueAt}
+		stp.clock = fixedClock{t: drainAt}
+
+		txHash := chainhash.HashH([]byte("zero-window-advance"))
+		stp.queue.enqueueBatch(
+			[]subtreepkg.Node{{Hash: txHash, Fee: 1, SizeInBytes: 220}},
+			[]*subtreepkg.TxInpoints{{}},
+		)
+		require.Equal(t, int64(1), stp.queue.length())
+
+		require.NoError(t, stp.dequeueDuringBlockMovement(nil, nil, nil, true))
+
+		require.Equal(t, int64(0), stp.queue.length(),
+			"1ms advance must let the batch drain")
+		assert.Contains(t, collectSubtreeHashes(stp), txHash,
+			"drained batch must be admitted into the subtree")
+	})
+}
+
 // newTestProcessorNoStart builds a SubtreeProcessor without starting the
 // event-loop goroutine. This lets the test drive dequeueDuringBlockMovement
 // directly with a known queue state and a known conflictingHashes set, with

--- a/services/blockassembly/subtreeprocessor/queue.go
+++ b/services/blockassembly/subtreeprocessor/queue.go
@@ -3,7 +3,6 @@ package subtreeprocessor
 
 import (
 	"sync/atomic"
-	"time"
 
 	"github.com/bsv-blockchain/go-subtree"
 )
@@ -24,19 +23,8 @@ type LockFreeQueue struct {
 	head        *TxBatch                // Points to the head of the queue (sentinel node)
 	tail        atomic.Pointer[TxBatch] // Atomic pointer to the tail
 	queueLength atomic.Int64            // Tracks the current number of batches in the queue
-	clock       queueClock              // Source of batch timestamps; replaced in tests
+	clock       clock                   // Source of batch timestamps; replaced in tests
 }
-
-// queueClock supplies the wall time stamped on each enqueued batch. The
-// production implementation is realQueueClock; tests substitute a fake to
-// drive deterministic batch timestamps without touching wall time.
-type queueClock interface {
-	Now() time.Time
-}
-
-type realQueueClock struct{}
-
-func (realQueueClock) Now() time.Time { return time.Now() }
 
 // NewLockFreeQueue creates and initializes a new LockFreeQueue instance.
 //
@@ -47,7 +35,7 @@ func NewLockFreeQueue() *LockFreeQueue {
 		head:        &TxBatch{},
 		tail:        atomic.Pointer[TxBatch]{},
 		queueLength: atomic.Int64{},
-		clock:       realQueueClock{},
+		clock:       realClock{},
 	}
 }
 

--- a/services/blockassembly/subtreeprocessor/queue.go
+++ b/services/blockassembly/subtreeprocessor/queue.go
@@ -24,7 +24,19 @@ type LockFreeQueue struct {
 	head        *TxBatch                // Points to the head of the queue (sentinel node)
 	tail        atomic.Pointer[TxBatch] // Atomic pointer to the tail
 	queueLength atomic.Int64            // Tracks the current number of batches in the queue
+	clock       queueClock              // Source of batch timestamps; replaced in tests
 }
+
+// queueClock supplies the wall time stamped on each enqueued batch. The
+// production implementation is realQueueClock; tests substitute a fake to
+// drive deterministic batch timestamps without touching wall time.
+type queueClock interface {
+	Now() time.Time
+}
+
+type realQueueClock struct{}
+
+func (realQueueClock) Now() time.Time { return time.Now() }
 
 // NewLockFreeQueue creates and initializes a new LockFreeQueue instance.
 //
@@ -35,6 +47,7 @@ func NewLockFreeQueue() *LockFreeQueue {
 		head:        &TxBatch{},
 		tail:        atomic.Pointer[TxBatch]{},
 		queueLength: atomic.Int64{},
+		clock:       realQueueClock{},
 	}
 }
 
@@ -59,7 +72,7 @@ func (q *LockFreeQueue) enqueueBatch(nodes []subtree.Node, txInpoints []*subtree
 	batch := &TxBatch{
 		nodes:      nodes,
 		txInpoints: txInpoints,
-		time:       time.Now().UnixMilli(),
+		time:       q.clock.Now().UnixMilli(),
 	}
 	batch.next.Store(nil)
 

--- a/services/blockassembly/subtreeprocessor/queue_test.go
+++ b/services/blockassembly/subtreeprocessor/queue_test.go
@@ -145,6 +145,166 @@ func Test_queueClockOverride(t *testing.T) {
 	require.Equal(t, fixed.UnixMilli(), batch.time)
 }
 
+// Test_zeroWindowAsymmetry pins a behavioural divergence between the two
+// validFromMillis formulas used inside SubtreeProcessor.
+//
+//	Start loop (SubtreeProcessor.go:807-813):
+//	  validFromMillis = 0                              if DoubleSpendWindow == 0
+//	  validFromMillis = (now - window).UnixMilli()     otherwise
+//
+//	dequeueDuringBlockMovement (SubtreeProcessor.go:3789):
+//	  validFromMillis = (now - window).UnixMilli()     unconditionally
+//
+// With DoubleSpendWindow == 0 (the documented default - see
+// settings/blockassembly_settings.go:29), the two formulas diverge:
+//   - Start passes 0, the queue's "validFromMillis > 0" guard at
+//     queue.go:96 short-circuits, and same-millisecond batches admit.
+//   - drain passes now.UnixMilli(), the guard does not short-circuit,
+//     and same-millisecond batches are held back.
+//
+// conflicting_queue_race_test.go:71-75 papers over this with a
+// time.Sleep(5*time.Millisecond) before calling
+// dequeueDuringBlockMovement. This test pins the underlying behaviour
+// deterministically via the clock seam, with no real-time waits.
+func Test_zeroWindowAsymmetry(t *testing.T) {
+	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	window := time.Duration(0)
+
+	enqueueAtFixed := func() *LockFreeQueue {
+		q := NewLockFreeQueue()
+		q.clock = fixedClock{t: fixed}
+		q.enqueueBatch(
+			[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},
+			[]*subtree.TxInpoints{{}},
+		)
+		return q
+	}
+
+	t.Run("start_loop_formula_admits_same_millisecond_batch", func(t *testing.T) {
+		// Mirror of the formula at SubtreeProcessor.go:810-813.
+		startValidFromMillis := int64(0)
+		if window > 0 {
+			startValidFromMillis = fixed.Add(-window).UnixMilli()
+		}
+
+		q := enqueueAtFixed()
+		batch, found := q.dequeueBatch(startValidFromMillis)
+		require.True(t, found, "Start loop must admit same-ms batch at window=0")
+		require.Equal(t, fixed.UnixMilli(), batch.time)
+	})
+
+	t.Run("drain_formula_rejects_same_millisecond_batch", func(t *testing.T) {
+		// Mirror of the formula at SubtreeProcessor.go:3789.
+		drainValidFromMillis := fixed.Add(-1 * window).UnixMilli()
+
+		q := enqueueAtFixed()
+		_, found := q.dequeueBatch(drainValidFromMillis)
+		require.False(t, found,
+			"drain currently rejects same-ms batch at window=0; if this assertion "+
+				"flips, the Start/drain asymmetry has been resolved and the "+
+				"workaround in conflicting_queue_race_test.go:75 can likely be removed")
+	})
+}
+
+// Test_validFromMillisBoundaries pins the inclusive-reject semantics and
+// the negative/zero-bypass behaviour of the queue's validFromMillis
+// filter at queue.go:96:
+//
+//	if validFromMillis > 0 && next.time >= validFromMillis {
+//	    return nil, false
+//	}
+//
+// Two pieces worth documenting beyond the asymmetry test above:
+//
+//   - Boundary: batch.time == validFromMillis is rejected (>= is
+//     inclusive). batch.time == validFromMillis - 1 admits. A future
+//     change to "strictly greater than" would silently widen the
+//     admission window by one millisecond.
+//
+//   - Defensive bypass: validFromMillis <= 0 short-circuits filtering
+//     entirely. Any caller producing a non-positive cutoff (e.g. via
+//     clock.Now() before the unix epoch, or a window larger than the
+//     current millisecond timestamp) silently disables double-spend
+//     protection for that dequeue. Both call sites in SubtreeProcessor
+//     compute Now().Add(-window).UnixMilli(); in production
+//     Now().UnixMilli() is in the trillions so this guard is dormant,
+//     but a future caller or a test built on time.Time{} would trip it.
+func Test_validFromMillisBoundaries(t *testing.T) {
+	t.Run("inclusive_reject_at_boundary", func(t *testing.T) {
+		fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+		q := NewLockFreeQueue()
+		q.clock = fixedClock{t: fixed}
+		q.enqueueBatch(
+			[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},
+			[]*subtree.TxInpoints{{}},
+		)
+		_, found := q.dequeueBatch(fixed.UnixMilli())
+		require.False(t, found, "batch.time == validFromMillis must be rejected")
+	})
+
+	t.Run("admit_one_below_boundary", func(t *testing.T) {
+		fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+		q := NewLockFreeQueue()
+		q.clock = fixedClock{t: fixed}
+		q.enqueueBatch(
+			[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},
+			[]*subtree.TxInpoints{{}},
+		)
+		_, found := q.dequeueBatch(fixed.UnixMilli() + 1)
+		require.True(t, found, "batch.time == validFromMillis - 1 must admit")
+	})
+
+	t.Run("negative_validFromMillis_bypasses_filter", func(t *testing.T) {
+		fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+		q := NewLockFreeQueue()
+		q.clock = fixedClock{t: fixed}
+		q.enqueueBatch(
+			[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},
+			[]*subtree.TxInpoints{{}},
+		)
+		// validFromMillis = -1 → guard ("> 0") short-circuits, filter off.
+		batch, found := q.dequeueBatch(-1)
+		require.True(t, found, "negative validFromMillis must short-circuit the filter")
+		require.Equal(t, fixed.UnixMilli(), batch.time)
+	})
+}
+
+// Test_clockBackwardJumpHoldsBatchesLonger characterizes how the queue
+// behaves when the drain clock jumps backwards relative to the enqueue
+// clock - the kind of jump an NTP correction can introduce mid-flight.
+//
+//	enqueue at T=10_000_000, batch.time = 10_000_000
+//	drain at  T= 5_000_000, window = 200ms → validFromMillis = 4_999_800
+//	batch.time (10_000_000) >= validFromMillis (4_999_800) → rejected
+//
+// The batch stays queued until the drain clock catches back up past
+// (batch.time + window). In production this means an NTP step
+// backwards during block movement can stall the drain until wall time
+// re-advances, even though the batch itself is fully aged. Documented
+// here so the behaviour does not surprise anyone tracking down a
+// post-NTP-correction stall.
+func Test_clockBackwardJumpHoldsBatchesLonger(t *testing.T) {
+	enqueueAt := time.UnixMilli(10_000_000).UTC()
+	q := NewLockFreeQueue()
+	q.clock = fixedClock{t: enqueueAt}
+	q.enqueueBatch(
+		[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},
+		[]*subtree.TxInpoints{{}},
+	)
+
+	const window = 200 * time.Millisecond
+
+	drainAtBack := time.UnixMilli(5_000_000).UTC() // clock stepped backwards
+	_, found := q.dequeueBatch(drainAtBack.Add(-window).UnixMilli())
+	require.False(t, found, "batch held back while drain clock is behind enqueue clock")
+
+	// Once wall time recovers past (batch.time + window) the batch drains.
+	drainAtRecovered := enqueueAt.Add(window + time.Millisecond)
+	batch, found := q.dequeueBatch(drainAtRecovered.Add(-window).UnixMilli())
+	require.True(t, found, "batch drains once drain clock recovers")
+	require.Equal(t, enqueueAt.UnixMilli(), batch.time)
+}
+
 func Test_queue2Threads(t *testing.T) {
 	q := NewLockFreeQueue()
 

--- a/services/blockassembly/subtreeprocessor/queue_test.go
+++ b/services/blockassembly/subtreeprocessor/queue_test.go
@@ -122,9 +122,9 @@ func Test_queueWithTime(t *testing.T) {
 	assert.Equal(t, 10, batches)
 }
 
-type fixedQueueClock struct{ t time.Time }
+type fixedClock struct{ t time.Time }
 
-func (f fixedQueueClock) Now() time.Time { return f.t }
+func (f fixedClock) Now() time.Time { return f.t }
 
 // Test_queueClockOverride verifies the clock seam: when a fake clock is
 // installed, batch.time matches the fake's value rather than wall time.
@@ -133,7 +133,7 @@ func Test_queueClockOverride(t *testing.T) {
 	q := NewLockFreeQueue()
 
 	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
-	q.clock = fixedQueueClock{t: fixed}
+	q.clock = fixedClock{t: fixed}
 
 	q.enqueueBatch(
 		[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},

--- a/services/blockassembly/subtreeprocessor/queue_test.go
+++ b/services/blockassembly/subtreeprocessor/queue_test.go
@@ -122,6 +122,29 @@ func Test_queueWithTime(t *testing.T) {
 	assert.Equal(t, 10, batches)
 }
 
+type fixedQueueClock struct{ t time.Time }
+
+func (f fixedQueueClock) Now() time.Time { return f.t }
+
+// Test_queueClockOverride verifies the clock seam: when a fake clock is
+// installed, batch.time matches the fake's value rather than wall time.
+// This is the hook tests will use to drive deterministic batch timestamps.
+func Test_queueClockOverride(t *testing.T) {
+	q := NewLockFreeQueue()
+
+	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	q.clock = fixedQueueClock{t: fixed}
+
+	q.enqueueBatch(
+		[]subtree.Node{{Hash: chainhash.Hash{}, Fee: 1, SizeInBytes: 0}},
+		[]*subtree.TxInpoints{{}},
+	)
+
+	batch, found := q.dequeueBatch(0)
+	require.True(t, found)
+	require.Equal(t, fixed.UnixMilli(), batch.time)
+}
+
 func Test_queue2Threads(t *testing.T) {
 	q := NewLockFreeQueue()
 


### PR DESCRIPTION
## Summary

Introduces an unexported `clock` interface in `services/blockassembly/subtreeprocessor`, injected into `LockFreeQueue` and `SubtreeProcessor`. The production default is `realClock{}` (calls `time.Now()`); tests install a fake to drive deterministic timestamps without `time.Sleep`.

Three `time.Now()` call sites are now mediated by the seam:
- `queue.go:63` - `batch.time` on enqueue
- `SubtreeProcessor.go:812` - `validFromMillis` in the Start-loop dequeue
- `SubtreeProcessor.go:3789` - `validFromMillis` in `dequeueDuringBlockMovement`

Five new tests / nine subtests in `queue_test.go` and `conflicting_queue_race_test.go` use the seam to characterize the queue's `validFromMillis` filter at queue.go:96 (boundary semantics, negative-cutoff bypass, clock-backstep behaviour, and the asymmetry between the two `validFromMillis` formulas at `DoubleSpendWindow=0`).

## Motivation

`blockassembly` has time-dependent correctness logic gated by `DoubleSpendWindow`. The existing test workaround for this is `time.Sleep` (`conflicting_queue_race_test.go:75` sleeps 5ms before calling `dequeueDuringBlockMovement`). A clock seam replaces wall-time waits with deterministic time, which is the prerequisite for any property/invariant testing of reorgs and drain ordering.

## Perf gate

The hot path is `LockFreeQueue.enqueueBatch` (one timestamp per batch, called from every producer). Benchmarked on this machine with `-count=30 -benchtime=10s` before merging, and again same-day same-machine after the SubtreeProcessor seam was added:

|                 | baseline (`main`) | with seam   |
|-----------------|-------------------|-------------|
| BenchmarkQueue  | 170.4n ± 2%       | 170.3n ± 2% |
| p-value         | -                 | 0.566 (n=10) |

No measurable regression. Interface dispatch at the timestamp call is free here.

## Latent finding (not addressed in this PR)

While writing the characterization tests, the two `validFromMillis` formulas diverge at `DoubleSpendWindow == 0` (the documented default):

- Start loop (`:807-813`) - zero-guarded: `validFromMillis = 0` → queue filter off.
- `dequeueDuringBlockMovement` (`:3789`) - unconditional: `validFromMillis = Now().UnixMilli()` → filter active, rejects same-ms batches.

`conflicting_queue_race_test.go:71-75` papers over this with a 5ms sleep. The tests in this PR pin the current (asymmetric) behaviour. I'll open a follow-up to align the drain formula with the Start-loop zero-guard once this seam lands.

## Test plan

- [x] `go vet ./services/blockassembly/subtreeprocessor/` - clean
- [x] `go test -race -count=1 ./services/blockassembly/subtreeprocessor/` - pass (153s)
- [x] `go test -race -count=1 ./services/blockassembly/` - pass (102s)
- [x] Benchmark gate above (n=30 × 10s, then n=10 × 10s same-day re-check)
- [ ] CI: `staticcheck` and `golangci-lint` are pinned to Go 1.25.5 locally vs the repo's Go 1.26.0 toolchain - pre-existing tooling mismatch, expecting CI to run clean.