### PR TITLE
fix(legacy): suppress tx relay while FSM != RUNNING

### DIFF
--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -1506,6 +1506,11 @@ func (s *server) AnnounceNewTransactions(txns []*netsync.TxHashAndFee) {
 		return
 	}
 
+	// Suppress tx relay while the node is not in RUNNING state. See canRelayTx.
+	if !s.canRelayTx() {
+		return
+	}
+
 	// Generate and relay inventory vectors for all newly accepted
 	// transactions.
 	s.relayTransactions(txns)
@@ -2590,11 +2595,38 @@ func (s *server) BanPeer(sp *serverPeer) {
 	s.banPeers <- sp
 }
 
+// canRelayTx reports whether the legacy server may emit transaction inventory
+// to its peers. Transactions must only be relayed once the node is fully
+// synced (FSM RUNNING). While syncing (LEGACYSYNCING/CATCHINGBLOCKS) the local
+// chain tip may sit below the Genesis activation height, in which case the
+// validator accepts pre-Genesis-only outputs such as P2SH. Re-broadcasting
+// those to post-Genesis peers earns an instant ban for `bad-txns-vout-p2sh`.
+//
+// The check is cheap: blockchain.Client serves GetFSMCurrentState from a
+// locally-cached atomic, so callers may invoke this per-inv without RPC cost.
+// Fails closed: any error reading the state suppresses relay.
+func (s *server) canRelayTx() bool {
+	if s.blockchainClient == nil {
+		return true
+	}
+	running, err := s.blockchainClient.IsFSMCurrentState(s.ctx, blockchain.FSMStateRUNNING)
+	if err != nil {
+		return false
+	}
+	return running
+}
+
 // RelayInventory relays the passed inventory vector to all connected peers
 // that are not already known to have it.
 func (s *server) RelayInventory(invVect *wire.InvVect, data interface{}) {
 	// check listen mode - if listen_only or silent, don't relay inventory
 	if s.settings.P2P.ListenMode == settings.ListenModeListenOnly || s.settings.P2P.ListenMode == settings.ListenModeSilent {
+		return
+	}
+
+	// Suppress tx invs while the node is not in RUNNING state. Block invs
+	// are still relayed (block sync is gated separately in netsync.manager).
+	if invVect != nil && invVect.Type == wire.InvTypeTx && !s.canRelayTx() {
 		return
 	}
 

--- a/services/legacy/peer_server_test.go
+++ b/services/legacy/peer_server_test.go
@@ -1,16 +1,22 @@
 package legacy
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/legacy/addrmgr"
 	"github.com/bsv-blockchain/teranode/services/legacy/netsync"
+	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // TestAddKnownAddresses tests that the addKnownAddresses function properly adds
@@ -438,6 +444,134 @@ func TestBroadcastMsgStructure(t *testing.T) {
 	assert.Equal(t, pingMsg, msg.message)
 	assert.Equal(t, excludePeers, msg.excludePeers)
 	assert.Len(t, msg.excludePeers, 2)
+}
+
+// newTestServerForRelay builds a minimal server suitable for exercising the
+// transaction-relay gating logic. The relayInv channel is buffered so the
+// goroutine spawned by RelayInventory can complete without a consumer.
+func newTestServerForRelay(t *testing.T, fsmState blockchain.FSMStateType, fsmErr error) (*server, *blockchain.Mock) {
+	t.Helper()
+
+	mockBC := &blockchain.Mock{}
+	mockBC.On("IsFSMCurrentState", mock.Anything, blockchain.FSMStateRUNNING).
+		Return(fsmState == blockchain.FSMStateRUNNING, fsmErr)
+
+	s := &server{
+		ctx:              context.Background(),
+		settings:         &settings.Settings{},
+		blockchainClient: mockBC,
+		relayInv:         make(chan relayMsg, 16),
+	}
+	return s, mockBC
+}
+
+// drain reports how many relayMsg entries arrived on relayInv within the
+// timeout. RelayInventory dispatches via a goroutine, so a short timeout is
+// enough to observe (or rule out) a send.
+func drain(ch chan relayMsg, timeout time.Duration) []relayMsg {
+	var got []relayMsg
+	deadline := time.After(timeout)
+	for {
+		select {
+		case m := <-ch:
+			got = append(got, m)
+		case <-deadline:
+			return got
+		}
+	}
+}
+
+// TestCanRelayTx_FSMStates verifies the FSM-state gate that determines
+// whether the legacy server may emit transaction inventory. The node must
+// only relay tx when the blockchain FSM is RUNNING; LEGACYSYNCING and
+// CATCHINGBLOCKS both suppress relay. Any error reading the FSM also
+// suppresses relay (fail closed).
+func TestCanRelayTx_FSMStates(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    blockchain.FSMStateType
+		stateErr error
+		want     bool
+	}{
+		{name: "RUNNING permits relay", state: blockchain.FSMStateRUNNING, want: true},
+		{name: "LEGACYSYNCING suppresses relay", state: blockchain.FSMStateLEGACYSYNCING, want: false},
+		{name: "CATCHINGBLOCKS suppresses relay", state: blockchain.FSMStateCATCHINGBLOCKS, want: false},
+		{name: "IDLE suppresses relay", state: blockchain.FSMStateIDLE, want: false},
+		{name: "FSM error fails closed", state: blockchain.FSMStateRUNNING, stateErr: errors.NewError("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, mockBC := newTestServerForRelay(t, tt.state, tt.stateErr)
+			require.Equal(t, tt.want, s.canRelayTx())
+			mockBC.AssertExpectations(t)
+		})
+	}
+}
+
+// TestCanRelayTx_NilBlockchainClient verifies that a server constructed
+// without a blockchain client (defensive path; should not occur in
+// production) permits relay rather than panicking.
+func TestCanRelayTx_NilBlockchainClient(t *testing.T) {
+	s := &server{ctx: context.Background(), settings: &settings.Settings{}}
+	require.True(t, s.canRelayTx())
+}
+
+// TestRelayInventory_SuppressesTxWhenNotRunning is the regression test for
+// the SV-node ban incident: while the node is in CATCHINGBLOCKS (or any
+// non-RUNNING state) the legacy server must not emit transaction inventory
+// to its peers. The local chain tip can sit below the Genesis activation
+// height during IBD, in which case the validator accepts pre-Genesis-only
+// outputs (e.g. P2SH); re-broadcasting them earns an instant ban on the
+// post-Genesis BSV network for `bad-txns-vout-p2sh`.
+func TestRelayInventory_SuppressesTxWhenNotRunning(t *testing.T) {
+	s, _ := newTestServerForRelay(t, blockchain.FSMStateCATCHINGBLOCKS, nil)
+	hash := chainhash.Hash{0xde, 0xad}
+	s.RelayInventory(wire.NewInvVect(wire.InvTypeTx, &hash), &netsync.TxHashAndFee{TxHash: hash, Fee: 1, Size: 100})
+	require.Empty(t, drain(s.relayInv, 50*time.Millisecond), "tx inv must not be relayed while FSM != RUNNING")
+}
+
+// TestRelayInventory_RelaysTxWhenRunning verifies the positive case: tx
+// inventory is emitted when the FSM has reached RUNNING.
+func TestRelayInventory_RelaysTxWhenRunning(t *testing.T) {
+	s, _ := newTestServerForRelay(t, blockchain.FSMStateRUNNING, nil)
+	hash := chainhash.Hash{0xbe, 0xef}
+	iv := wire.NewInvVect(wire.InvTypeTx, &hash)
+	s.RelayInventory(iv, &netsync.TxHashAndFee{TxHash: hash, Fee: 1, Size: 100})
+	got := drain(s.relayInv, 200*time.Millisecond)
+	require.Len(t, got, 1)
+	require.Equal(t, iv, got[0].invVect)
+}
+
+// TestRelayInventory_AlwaysRelaysBlockInvs guards against an over-broad
+// fix: block inventory must continue to flow during legacy sync /
+// catch-up, otherwise outbound block announcements break. The FSM gate
+// applies to tx invs only.
+func TestRelayInventory_AlwaysRelaysBlockInvs(t *testing.T) {
+	for _, state := range []blockchain.FSMStateType{
+		blockchain.FSMStateRUNNING,
+		blockchain.FSMStateCATCHINGBLOCKS,
+		blockchain.FSMStateLEGACYSYNCING,
+	} {
+		t.Run(state.String(), func(t *testing.T) {
+			s, _ := newTestServerForRelay(t, state, nil)
+			hash := chainhash.Hash{0xab}
+			iv := wire.NewInvVect(wire.InvTypeBlock, &hash)
+			s.RelayInventory(iv, nil)
+			require.Len(t, drain(s.relayInv, 200*time.Millisecond), 1, "block inv must always relay")
+		})
+	}
+}
+
+// TestAnnounceNewTransactions_SuppressedWhenNotRunning verifies that the
+// public mempool-relay entry point (called from netsync.handle_block.go
+// for orphan-pool drain and from netsync.manager.go after direct tx
+// accept) also honours the FSM gate.
+func TestAnnounceNewTransactions_SuppressedWhenNotRunning(t *testing.T) {
+	s, _ := newTestServerForRelay(t, blockchain.FSMStateCATCHINGBLOCKS, nil)
+	hash := chainhash.Hash{0xca, 0xfe}
+	s.AnnounceNewTransactions([]*netsync.TxHashAndFee{{TxHash: hash, Fee: 1, Size: 100}})
+	require.Empty(t, drain(s.relayInv, 50*time.Millisecond), "AnnounceNewTransactions must not relay tx while FSM != RUNNING")
 }
 
 // TestRelayMsgStructure tests the relayMsg structure


### PR DESCRIPTION
## Summary

- The legacy server's outbound transaction-relay paths (`AnnounceNewTransactions`, `RelayInventory` for tx invs) are not gated by FSM state. While the node is in `LEGACYSYNCING` / `CATCHINGBLOCKS` and its local chain tip is below the Genesis activation height, `validator.checkOutputs` accepts pre-Genesis-only outputs (notably P2SH). Re-broadcasting those tx to post-Genesis peers earns an instant ban (`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`) on the BSV legacy network.
- This PR adds an FSM gate (`canRelayTx`) to both outbound entry points. Block invs are still relayed in every state — only tx invs are suppressed.

## Background incident

On `bsva-ovh-teranode-eu-3` (mainnet, height ~293k; Genesis at 620538):
```
2026-05-11 16:17:13 [worker10-H-TxnValidatorPool] Misbehaving: 57.129.99.214:36734 peer=496846 (0 -> 100) reason: bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED
2026-05-11 18:01:38 [worker64-H-TxnValidatorPool] Misbehaving: 57.129.99.214:60550 peer=498492 (0 -> 100) reason: bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED
```
Second ban triggered immediately after a manual `clearbanned`. eu-3 chain state at the time of the ban was ~block 293030 (well below Genesis), so the validator treated P2SH as valid and the unguarded relay paths broadcast the tx to seed-mainnet-eu-1.

## Trigger paths (both unguarded prior to this PR)

- `services/legacy/netsync/handle_block.go:185-195` — orphan-pool drain after each accepted block calls `peerNotifier.AnnounceNewTransactions(acceptedTxs)`.
- `services/legacy/netsync/manager.go:1004` — direct tx accept after `handleTxMsg`.

Both funnel into `server.AnnounceNewTransactions` / `server.RelayInventory` in `services/legacy/peer_server.go`. Those two functions checked only `P2P.ListenMode` (added in #589 for the silent-mode kill switch) — no FSM gate.

## Why this wasn't a regression

History check (`git log -S 'AnnounceNewTransactions'` and `-S 'relayTransactions'` on `services/legacy/peer_server.go`) shows the functions were introduced in the original WIP legacy commit (`c33490517`) and never gated. The symmetric **inbound** INV path *did* get an FSM gate in Sept 2024 (`dc2971de8`, `977071daa` — "process transactions when in RUNNING mode"). The outbound side was simply missed. Bug stayed latent because eu-3-class nodes normally run at tip — it only fires when chain < Genesis, which is uncommon outside of fresh IBD from low height.

## Implementation

- New helper `(s *server) canRelayTx() bool` in `peer_server.go` next to `BanPeer`/`RelayInventory`. Calls `blockchainClient.IsFSMCurrentState(ctx, FSMStateRUNNING)`. Fails closed on error.
- `AnnounceNewTransactions`: early-return if `!canRelayTx()`.
- `RelayInventory`: same gate, but only when `invVect.Type == wire.InvTypeTx`. Block invs continue unconditionally so block sync still works during legacy/catch-up.

### Performance

The check is cheap. `blockchain.Client.GetFSMCurrentState` (Client.go:1670) serves from a locally-cached `atomic.Pointer[FSMStateType]` (`c.fmsState`), updated by the FSM subscription handler (Client.go:188-190 on `NotificationType_FSMState`). Hot path = atomic load + dereference + bool compare (~5 ns). Cold path = one gRPC fallback before the first subscription event, then cached for the rest of the process lifetime. No per-tx RPC.

## Test plan

`services/legacy/peer_server_test.go`:
- `TestCanRelayTx_FSMStates` — table-driven across RUNNING / LEGACYSYNCING / CATCHINGBLOCKS / IDLE plus the FSM-error case.
- `TestCanRelayTx_NilBlockchainClient` — defensive path returns `true` without panicking.
- `TestRelayInventory_SuppressesTxWhenNotRunning` — regression test for the ban incident: tx inv must not hit `relayInv` when FSM = CATCHINGBLOCKS.
- `TestRelayInventory_RelaysTxWhenRunning` — positive case: tx inv flows when RUNNING.
- `TestRelayInventory_AlwaysRelaysBlockInvs` — guards against over-broad fix; block invs must flow in every state.
- `TestAnnounceNewTransactions_SuppressedWhenNotRunning` — covers the public entry called from the orphan-pool drain.

- [x] `go build ./services/legacy/...`
- [x] `go test -count=1 -race ./services/legacy/...` → 330 passed
- [x] `go vet ./services/legacy/...`

## Follow-ups (out of scope)

- The validator's `checkOutputs` gating P2SH on `localChainHeight` rather than on `tipHeight or max(localHeight, ActivationHeight)` is the deeper issue: even with this PR, if the node receives a tx via direct gossip while in RUNNING but its chain tip drifts below Genesis (e.g. after a deep reorg), the same broadcast leak can occur. Worth a follow-up to make Genesis enforcement tip-aware (or gate the validator's mempool-accept path on FSM state as well).
- Separate bug noted from the incident logs: FSM bounces between RUNNING and CATCHINGBLOCKS while still at height 293k. The "Run" event is being fired too eagerly somewhere in the catchup state machine; tracked separately.