### PR TITLE
fix(blockchain): reject FSM RUN below highest network checkpoint

### DIFF
--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
@@ -2589,6 +2590,21 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 		}
 	}
 
+	// Refuse to transition to RUNNING while the local chain tip is still below
+	// the network's highest hard-coded checkpoint. Pre-checkpoint heights are
+	// guaranteed to be deep history (mainnet's highest is block 938000), so a
+	// node sitting below them is mid-IBD even if a catchup worker thinks it
+	// has finished its current chunk. Going to RUNNING in that state lets the
+	// mempool/validator operate under pre-Genesis output rules and the legacy
+	// service relay tx invs that post-Genesis peers ban on sight
+	// (`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`).
+	if eventReq.Event == blockchain_api.FSMEventType_RUN {
+		if err := b.guardRunBelowHighestCheckpoint(ctx); err != nil {
+			b.logger.Warnf("[Blockchain Server] RUN rejected: %s", err.Error())
+			return nil, errors.WrapGRPC(err)
+		}
+	}
+
 	err := b.finiteStateMachine.Event(ctx, eventReq.Event.String())
 	if err != nil {
 		b.logger.Debugf("[Blockchain Server] Error sending event to FSM, state has not changed.")
@@ -2629,6 +2645,55 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 	b.stateChangeTimestamp = time.Now()
 
 	return resp, nil
+}
+
+// guardRunBelowHighestCheckpoint blocks the RUN transition when the local
+// chain tip has not yet reached the highest hard-coded checkpoint for the
+// active network. Returns nil when the chain has reached the checkpoint, the
+// network defines no checkpoints (regtest, brand-new networks), or the store
+// has no chain tip yet (returns a state error so the caller retries later).
+func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
+	if b.settings == nil || b.settings.ChainCfgParams == nil {
+		return nil
+	}
+
+	highest := highestCheckpointHeight(b.settings.ChainCfgParams.Checkpoints)
+	if highest == 0 {
+		return nil
+	}
+
+	_, meta, err := b.store.GetBestBlockHeader(ctx)
+	if err != nil {
+		return errors.NewStateError("cannot read best block header to evaluate RUN gate", err)
+	}
+	if meta == nil {
+		return errors.NewStateError("best block header meta unavailable; refusing RUN")
+	}
+
+	if meta.Height < highest {
+		return errors.NewStateError(
+			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s",
+			meta.Height, highest, b.settings.ChainCfgParams.Name,
+		)
+	}
+
+	return nil
+}
+
+// highestCheckpointHeight returns the largest Height in the supplied
+// checkpoint list, or 0 if the list is empty.
+func highestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
+	var highest uint32
+	for _, cp := range checkpoints {
+		if cp.Height < 0 {
+			continue
+		}
+		h := uint32(cp.Height)
+		if h > highest {
+			highest = h
+		}
+	}
+	return highest
 }
 
 // Run transitions the blockchain service to the running state.

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2657,7 +2657,7 @@ func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
 		return nil
 	}
 
-	highest := highestCheckpointHeight(b.settings.ChainCfgParams.Checkpoints)
+	highest := HighestCheckpointHeight(b.settings.ChainCfgParams.Checkpoints)
 	if highest == 0 {
 		return nil
 	}
@@ -2680,9 +2680,11 @@ func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
 	return nil
 }
 
-// highestCheckpointHeight returns the largest Height in the supplied
-// checkpoint list, or 0 if the list is empty.
-func highestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
+// HighestCheckpointHeight returns the largest Height in the supplied
+// checkpoint list, or 0 if the list is empty. Exported so callers in
+// other packages (e.g. blockvalidation) can share the same definition
+// rather than maintaining a parallel copy.
+func HighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 	var highest uint32
 	for _, cp := range checkpoints {
 		if cp.Height < 0 {

--- a/services/blockchain/Server_fsm_run_gate_test.go
+++ b/services/blockchain/Server_fsm_run_gate_test.go
@@ -1,0 +1,180 @@
+package blockchain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHighestCheckpointHeight covers the small helper used to derive the
+// guard threshold from a network's hard-coded checkpoint list.
+func TestHighestCheckpointHeight(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []chaincfg.Checkpoint
+		want uint32
+	}{
+		{name: "nil list", in: nil, want: 0},
+		{name: "empty list", in: []chaincfg.Checkpoint{}, want: 0},
+		{
+			name: "single entry",
+			in:   []chaincfg.Checkpoint{{Height: 600000}},
+			want: 600000,
+		},
+		{
+			name: "unordered list picks max",
+			in: []chaincfg.Checkpoint{
+				{Height: 200000},
+				{Height: 938000},
+				{Height: 500000},
+			},
+			want: 938000,
+		},
+		{name: "mainnet params", in: chaincfg.MainNetParams.Checkpoints, want: 938000},
+		{name: "regtest has no checkpoints", in: chaincfg.RegressionNetParams.Checkpoints, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, highestCheckpointHeight(tt.in))
+		})
+	}
+}
+
+// fsmGateStore is a minimal store stub that implements just the methods
+// guardRunBelowHighestCheckpoint touches (GetBestBlockHeader). It is
+// embedded in errorStore so the rest of the Store interface is satisfied
+// by the parent MockStore.
+type fsmGateStore struct {
+	errorStore
+}
+
+func (s *fsmGateStore) GetBestBlockHeader(ctx context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+	args := s.Called(ctx)
+	hdr, _ := args.Get(0).(*model.BlockHeader)
+	meta, _ := args.Get(1).(*model.BlockHeaderMeta)
+	return hdr, meta, args.Error(2)
+}
+
+// newTestBlockchainForGate returns a *Blockchain with just enough state for
+// guardRunBelowHighestCheckpoint to run: store + settings + logger.
+func newTestBlockchainForGate(t *testing.T, params *chaincfg.Params, store *fsmGateStore) *Blockchain {
+	t.Helper()
+	return &Blockchain{
+		logger:   ulogger.TestLogger{},
+		store:    store,
+		settings: &settings.Settings{ChainCfgParams: params},
+	}
+}
+
+// TestGuardRunBelowHighestCheckpoint is the regression test for the FSM
+// RUN gate. While the local chain tip sits below the network's highest
+// hard-coded checkpoint the blockchain server must refuse RUN, regardless
+// of which caller (catchup, legacy startSync, etc.) initiated it.
+//
+// Triggering RUN early during a deep IBD lets the mempool/validator run
+// under pre-Genesis output rules (chain height < 620538 on mainnet) and
+// the legacy service relay tx invs that current peers ban on sight
+// (`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`).
+func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	highest := highestCheckpointHeight(chaincfg.MainNetParams.Checkpoints)
+	require.Greater(t, highest, uint32(0), "mainnet must have at least one checkpoint")
+
+	tests := []struct {
+		name       string
+		params     *chaincfg.Params
+		height     uint32
+		storeErr   error
+		nilMeta    bool
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:       "below highest checkpoint rejects",
+			params:     &chaincfg.MainNetParams,
+			height:     highest - 1,
+			wantErr:    true,
+			wantSubstr: "refusing RUN",
+		},
+		{
+			name:    "exactly at highest checkpoint permits",
+			params:  &chaincfg.MainNetParams,
+			height:  highest,
+			wantErr: false,
+		},
+		{
+			name:    "above highest checkpoint permits",
+			params:  &chaincfg.MainNetParams,
+			height:  highest + 100,
+			wantErr: false,
+		},
+		{
+			name:    "network with no checkpoints permits",
+			params:  &chaincfg.RegressionNetParams,
+			height:  0,
+			wantErr: false,
+		},
+		{
+			name:       "store error fails closed",
+			params:     &chaincfg.MainNetParams,
+			storeErr:   errors.NewError("forced read failure"),
+			wantErr:    true,
+			wantSubstr: "cannot read best block header",
+		},
+		{
+			name:       "nil meta fails closed",
+			params:     &chaincfg.MainNetParams,
+			nilMeta:    true,
+			wantErr:    true,
+			wantSubstr: "best block header meta unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fsmGateStore{}
+			hdr := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
+			var meta *model.BlockHeaderMeta
+			if !tt.nilMeta {
+				meta = &model.BlockHeaderMeta{Height: tt.height}
+			}
+			store.On("GetBestBlockHeader", mock.Anything).Return(hdr, meta, tt.storeErr)
+
+			b := newTestBlockchainForGate(t, tt.params, store)
+
+			err := b.guardRunBelowHighestCheckpoint(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantSubstr != "" {
+					require.Contains(t, err.Error(), tt.wantSubstr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestGuardRunBelowHighestCheckpoint_NilSettings verifies the defensive
+// path: missing settings or ChainCfgParams short-circuits to allow RUN.
+// Production code always populates these, but the guard must not panic.
+func TestGuardRunBelowHighestCheckpoint_NilSettings(t *testing.T) {
+	t.Run("nil settings", func(t *testing.T) {
+		b := &Blockchain{logger: ulogger.TestLogger{}}
+		require.NoError(t, b.guardRunBelowHighestCheckpoint(context.Background()))
+	})
+
+	t.Run("nil ChainCfgParams", func(t *testing.T) {
+		b := &Blockchain{logger: ulogger.TestLogger{}, settings: &settings.Settings{}}
+		require.NoError(t, b.guardRunBelowHighestCheckpoint(context.Background()))
+	})
+}

--- a/services/blockchain/server_fsm_run_gate_test.go
+++ b/services/blockchain/server_fsm_run_gate_test.go
@@ -44,7 +44,7 @@ func TestHighestCheckpointHeight(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, highestCheckpointHeight(tt.in))
+			require.Equal(t, tt.want, HighestCheckpointHeight(tt.in))
 		})
 	}
 }
@@ -86,7 +86,7 @@ func newTestBlockchainForGate(t *testing.T, params *chaincfg.Params, store *fsmG
 // (`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`).
 func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
 	ctx := context.Background()
-	highest := highestCheckpointHeight(chaincfg.MainNetParams.Checkpoints)
+	highest := HighestCheckpointHeight(chaincfg.MainNetParams.Checkpoints)
 	require.Greater(t, highest, uint32(0), "mainnet must have at least one checkpoint")
 
 	tests := []struct {

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1336,7 +1336,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 
 		// Skip difficulty validation for blocks at or below the highest checkpoint
 		// These blocks are already verified by checkpoints, so we don't need to validate difficulty
-		highestCheckpointHeight := getHighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
+		highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
 		skipDifficultyCheck := block.Height <= highestCheckpointHeight
 
 		if skipDifficultyCheck {
@@ -1761,7 +1761,7 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 
 	// Skip difficulty validation for blocks at or below the highest checkpoint
 	// These blocks are already verified by checkpoints, so we don't need to validate difficulty
-	highestCheckpointHeight := getHighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
+	highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
 	skipDifficultyCheck := blockData.block.Height <= highestCheckpointHeight
 
 	if skipDifficultyCheck {

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -524,16 +524,19 @@ func (u *Server) Init(ctx context.Context) (err error) {
 		u.blockValidation = NewBlockValidation(ctx, u.logger, u.settings, u.blockchainClient, u.subtreeStore, u.txStore, u.utxoStore, u.validatorClient, subtreeValidationClient)
 	}
 
-	// if our FSM state is CATCHINGBLOCKS, this is probably a remnant of a crash, put the node back in RUNNING state
+	// if our FSM state is CATCHINGBLOCKS, this is probably a remnant of a crash, put the node back in RUNNING state.
+	// The blockchain server may legitimately refuse the RUN transition (e.g. local tip below the network's highest
+	// hard-coded checkpoint), in which case we stay in CATCHINGBLOCKS — real catchup will drive the transition
+	// later. Log and continue rather than crashing init.
 	isCatchingBlocks, err := u.blockchainClient.IsFSMCurrentState(ctx, blockchain.FSMStateCATCHINGBLOCKS)
 	if err != nil {
 		u.logger.Errorf("[Init] failed to check if FSM currently catching blocks: %v", err)
 	}
 
 	if isCatchingBlocks {
-		u.logger.Infof("[Init] FSM is in CATCHINGBLOCKS state, setting it to RUNNING")
+		u.logger.Infof("[Init] FSM is in CATCHINGBLOCKS state, attempting to restore to RUNNING")
 		if err = u.blockchainClient.Run(ctx, "blockvalidation"); err != nil {
-			return errors.NewServiceError("[Init] failed to set FSM state to RUNNING", err)
+			u.logger.Warnf("[Init] RUN rejected, staying in CATCHINGBLOCKS until catchup advances the chain: %v", err)
 		}
 	}
 

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -524,22 +524,6 @@ func (u *Server) Init(ctx context.Context) (err error) {
 		u.blockValidation = NewBlockValidation(ctx, u.logger, u.settings, u.blockchainClient, u.subtreeStore, u.txStore, u.utxoStore, u.validatorClient, subtreeValidationClient)
 	}
 
-	// if our FSM state is CATCHINGBLOCKS, this is probably a remnant of a crash, put the node back in RUNNING state.
-	// The blockchain server may legitimately refuse the RUN transition (e.g. local tip below the network's highest
-	// hard-coded checkpoint), in which case we stay in CATCHINGBLOCKS — real catchup will drive the transition
-	// later. Log and continue rather than crashing init.
-	isCatchingBlocks, err := u.blockchainClient.IsFSMCurrentState(ctx, blockchain.FSMStateCATCHINGBLOCKS)
-	if err != nil {
-		u.logger.Errorf("[Init] failed to check if FSM currently catching blocks: %v", err)
-	}
-
-	if isCatchingBlocks {
-		u.logger.Infof("[Init] FSM is in CATCHINGBLOCKS state, attempting to restore to RUNNING")
-		if err = u.blockchainClient.Run(ctx, "blockvalidation"); err != nil {
-			u.logger.Warnf("[Init] RUN rejected, staying in CATCHINGBLOCKS until catchup advances the chain: %v", err)
-		}
-	}
-
 	go u.processBlockNotify.Start()
 	go u.catchupAlternatives.Start()
 

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -679,7 +679,7 @@ func (u *Server) verifyCheckpointsInHeaderChain(catchupCtx *CatchupContext) erro
 //   - error: If checkpoint verification fails (hash mismatch)
 func (u *Server) verifyCheckpointsAgainstHeaders(catchupCtx *CatchupContext) (int, error) {
 	// Get the highest checkpoint height for reference
-	highestCheckpointHeight := getHighestCheckpointHeight(catchupCtx.checkpoints)
+	highestCheckpointHeight := blockchain.HighestCheckpointHeight(catchupCtx.checkpoints)
 	catchupCtx.highestCheckpointHeight = highestCheckpointHeight
 
 	firstBlockHeight := catchupCtx.commonAncestorMeta.Height + 1
@@ -1143,21 +1143,6 @@ func (u *Server) tryQuickValidation(ctx context.Context, block *model.Block, cat
 
 	// Quick validation succeeded, skip normal validation
 	return false, nil
-}
-
-// getHighestCheckpointHeight returns the height of the highest checkpoint
-func getHighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
-	if len(checkpoints) == 0 {
-		return 0
-	}
-
-	var highestHeight uint32
-	for _, checkpoint := range checkpoints {
-		if uint32(checkpoint.Height) > highestHeight {
-			highestHeight = uint32(checkpoint.Height)
-		}
-	}
-	return highestHeight
 }
 
 // getLowestCheckpointHeight returns the height of the lowest checkpoint


### PR DESCRIPTION
## Summary

- Block the `FSMEventType_RUN` transition in `Blockchain.SendFSMEvent` whenever the local chain tip is below the network's highest hard-coded checkpoint. Catchup callers continue to log the rejection and re-enter CATCHINGBLOCKS, so the node stops bouncing between states while mid-IBD.
- Remove the unconditional Init-time RUN flip in `blockvalidation.Server.Init` (added in #3672). It bypassed the gate and was the load-bearing reason the node could lie about being RUNNING during IBD. Crash recovery from a stuck CATCHINGBLOCKS state is already covered by legacy `startSync` and `restoreFSMState` (both now subject to the gate).
- Networks with no checkpoints (regtest, brand-new chains) bypass the gate. Mainnet's highest is currently `938000`, testnet3's is `1700000` (`go-chaincfg.MainNetParams.Checkpoints` / `TestNet3Params.Checkpoints`).

## Why

Follow-up to #843. While investigating that ban incident on `bsva-ovh-teranode-eu-3` (chain tip ~293k, mainnet highest checkpoint 938000), Coralogix showed 30 `Sending Run event blockvalidation/Server (CATCHINGBLOCKS => Run)` log lines in 2.5 hours, all from `services/blockvalidation/catchup.go:973 restoreFSMState`. The `defer u.restoreFSMState(ctx, catchupCtx)` at `catchup.go:790` flips state back to RUN unconditionally on every catchup chunk exit, regardless of whether the chain is actually caught up to network tip. Each RUN window let the legacy service emit at least one P2SH-bearing tx inv to seed-mainnet-eu-1 and earn `bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED` (the re-ban at 18:01:38 lines up exactly with the same-second RUN event).

Investigation also surfaced a second path: `blockvalidation.Server.Init` (added by PR #3672) checks at startup whether FSM is in CATCHINGBLOCKS and, if so, sends RUN with no consultation of chain height. Comment in the original PR: "this is probably a remnant of a crash". Intent was reasonable (don't pin the node in CATCHINGBLOCKS if the prior process crashed mid-catchup), but the implementation lies about progress whenever the chain genuinely is mid-IBD on restart. The right invariant is the one this PR enforces in `SendFSMEvent`.

## Implementation

`services/blockchain/Server.go`:
- New `guardRunBelowHighestCheckpoint(ctx)` helper. Reads `b.store.GetBestBlockHeader(ctx)`; compares meta height against `blockchain.HighestCheckpointHeight(b.settings.ChainCfgParams.Checkpoints)`. Returns `errors.NewStateError(...)` when below.
- New exported `HighestCheckpointHeight([]chaincfg.Checkpoint) uint32` helper. Replaces the private duplicate previously in `services/blockvalidation/catchup.go`.
- `SendFSMEvent` calls the guard for `FSMEventType_RUN`. The existing CATCHINGBLOCKS-cannot-be-manually-exited gate is preserved.

`services/blockvalidation/Server.go`:
- Remove the Init-time RUN flip (lines 527-541 before this PR). With the gate in place it was actively dangerous; without the gate it was the source of the eu-3 ban incident. Crash recovery for a stuck CATCHINGBLOCKS state still works through:
  - `services/legacy/netsync/manager.go:546 startSync` — issues RUN when a peer reports the same height as the local tip.
  - `services/blockvalidation/catchup.go:973 restoreFSMState` — defers RUN at the end of every catchup chunk.
  Both now go through the gate, so neither can fire while the local tip is below the highest checkpoint.

`services/blockvalidation/catchup.go`, `services/blockvalidation/BlockValidation.go`:
- Drop the private `getHighestCheckpointHeight`; rewire the three callsites (`catchup.go:682`, `BlockValidation.go:1339`, `BlockValidation.go:1764`) to the shared `blockchain.HighestCheckpointHeight`.

Caller behaviour for `Run` rejection:
- `services/legacy/netsync/manager.go:546,1345,1973` — already log+continue.
- `services/blockvalidation/catchup.go:973` — already log+continue.
- `services/blockvalidation/Server.go` — Init flip removed entirely.

No caller crashes on the new rejection; they just stay in CATCHINGBLOCKS until catchup genuinely passes the highest checkpoint.

### Edge cases

- Networks with no checkpoints (regtest, brand-new chains): `HighestCheckpointHeight` returns 0 → guard returns nil → RUN allowed.
- Missing `settings.ChainCfgParams`: guard returns nil (defensive; production always populates).
- Store read error or nil meta: fails closed (`StateError`) so the node retries later rather than slipping into RUN with unknown chain state.

## Test plan

`services/blockchain/server_fsm_run_gate_test.go`:
- `TestHighestCheckpointHeight` — nil/empty/unordered + MainNet (938000) + RegTest (0).
- `TestGuardRunBelowHighestCheckpoint` — table-driven: below/at/above checkpoint, no-checkpoint network permits, store error fails closed, nil meta fails closed.
- `TestGuardRunBelowHighestCheckpoint_NilSettings` — defensive paths.

- [x] `go build ./...`
- [x] `go test -count=1 -race ./services/blockchain/` → 609 pass
- [x] `go test -count=1 -race ./services/blockvalidation/` → 562 pass
- [x] `go test -count=1 -race ./services/blockvalidation/ ./services/legacy/netsync/` → 605 pass (downstream callers unaffected)
- [x] `go vet ./services/blockchain/...`
- [x] Manual: starting testnet daemon from a mid-IBD chain state (height 1481322) no longer crashes Init; node comes up in CATCHINGBLOCKS and catchup runs.

## Follow-ups

- The deeper issue (`restoreFSMState` issues RUN even when more catchup is needed) is mitigated by the gate but worth a separate change to make `restoreFSMState` consult "are we actually at tip?" before transitioning. Avoids the constant rejection log spam during IBD.
- Mainnet checkpoint list in `go-chaincfg` is currently stale (highest = 938000, real tip ~948677). Update the checkpoints periodically so the gate threshold tracks reality.
- Pair with #843 to fully close the SV-node ban vector: #843 stops outbound tx relay while not RUNNING; this PR stops bogus RUN transitions while below checkpoint.