### PR TITLE
fix(blockassembly/subtreeprocessor): zero-guard validFromMillis in dequeueDuringBlockMovement

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -3786,7 +3786,15 @@ func (stp *SubtreeProcessor) dequeueDuringBlockMovement(transactionMap *SplitSwi
 	queueLength := stp.queue.length()
 	if queueLength > 0 {
 		nrBatchesProcessed := int64(0)
-		validFromMillis := stp.clock.Now().Add(-1 * stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
+		// Match the Start-loop zero-guard at the default-case dequeue
+		// (line 810-813): a zero DoubleSpendWindow disables the queue
+		// filter entirely. Without this guard, the drain computes
+		// Now().UnixMilli() and the queue filter at queue.go:96 holds
+		// back same-millisecond batches under the default config.
+		validFromMillis := int64(0)
+		if stp.settings.BlockAssembly.DoubleSpendWindow > 0 {
+			validFromMillis = stp.clock.Now().Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
+		}
 
 		for {
 			batch, found := stp.queue.dequeueBatch(validFromMillis)

--- a/services/blockassembly/subtreeprocessor/conflicting_queue_race_test.go
+++ b/services/blockassembly/subtreeprocessor/conflicting_queue_race_test.go
@@ -63,16 +63,19 @@ func TestDequeueDuringBlockMovement_RejectsChildOfConflictingParent(t *testing.T
 		Idxs:           [][]uint32{{0}},
 	}
 
+	// Pin both clocks to the same instant so this test is deterministic
+	// (no wall-time waits). With DoubleSpendWindow=0 the queue filter is
+	// disabled at both call sites, so dequeueDuringBlockMovement admits
+	// same-millisecond batches and the test exercises the conflicting-
+	// parent rejection path directly.
+	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	stp.clock = fixedClock{t: fixed}
+	stp.queue.clock = fixedClock{t: fixed}
+
 	stp.queue.enqueueBatch(
 		[]subtreepkg.Node{childNode, otherNode},
 		[]*subtreepkg.TxInpoints{childInpoints, otherInpoints},
 	)
-
-	// dequeueDuringBlockMovement holds back batches enqueued at-or-after
-	// (now - DoubleSpendWindow). Default window is 0, so it holds batches
-	// with time == now. A short sleep moves batch.time strictly into the
-	// past so the drain releases it.
-	time.Sleep(5 * time.Millisecond)
 
 	conflictingHashes := map[chainhash.Hash]struct{}{
 		parentHash: {},
@@ -95,33 +98,24 @@ func TestDequeueDuringBlockMovement_RejectsChildOfConflictingParent(t *testing.T
 		"so its own descendants are caught later in the same drain")
 }
 
-// TestDequeueDuringBlockMovement_ZeroWindowAsymmetry pins, at the real call
-// site, the divergence between the two validFromMillis formulas inside
-// SubtreeProcessor:
+// TestDequeueDuringBlockMovement_ZeroWindowAdmitsSameMillisecond pins,
+// at the real call site, that dequeueDuringBlockMovement admits
+// same-millisecond batches when DoubleSpendWindow=0 (the documented
+// default - see settings/blockassembly_settings.go:29). Both the Start
+// loop (SubtreeProcessor.go:807-813) and the drain
+// (SubtreeProcessor.go:3789-3796) zero-guard the calculation, so
+// neither activates the queue filter at queue.go:96 and a batch
+// enqueued in the same millisecond as the drain is included.
 //
-//	Start loop (SubtreeProcessor.go:807-813) zero-guards the calculation:
-//	  if DoubleSpendWindow == 0 → validFromMillis = 0 → queue filter off.
-//
-//	dequeueDuringBlockMovement (SubtreeProcessor.go:3789) does not:
-//	  validFromMillis = clock.Now().Add(-1 * window).UnixMilli() always.
-//
-// With DoubleSpendWindow == 0 (the documented default - see
-// settings/blockassembly_settings.go:29) and the SubtreeProcessor clock
-// equal to the queue clock at enqueue time, the drain formula produces
-// validFromMillis = batch.time, the queue filter at queue.go:96 fires
-// (validFromMillis > 0 && time >= validFromMillis), and the batch is
-// held back.
-//
-// The "+1ms" subtest is the control: advancing only the
-// SubtreeProcessor clock by 1 millisecond is enough to move batch.time
-// strictly below validFromMillis, after which the drain admits it.
-// That is the deterministic equivalent of the time.Sleep(5ms) workaround
-// at conflicting_queue_race_test.go:75.
-func TestDequeueDuringBlockMovement_ZeroWindowAsymmetry(t *testing.T) {
-	t.Run("same_millisecond_batch_is_held_back", func(t *testing.T) {
+// The "+1ms" subtest exercises a different scenario where the
+// SubtreeProcessor clock has advanced past the enqueue clock; in
+// that case the drain admits via the (now - window) cutoff rather than
+// via the zero-guard.
+func TestDequeueDuringBlockMovement_ZeroWindowAdmitsSameMillisecond(t *testing.T) {
+	t.Run("same_millisecond_batch_admits", func(t *testing.T) {
 		stp := newTestProcessorNoStart(t)
 		require.Zero(t, stp.settings.BlockAssembly.DoubleSpendWindow,
-			"default window is 0; the asymmetry only manifests at 0")
+			"default window is 0; zero-guard parity is the property being asserted")
 
 		fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
 		stp.clock = fixedClock{t: fixed}
@@ -136,11 +130,10 @@ func TestDequeueDuringBlockMovement_ZeroWindowAsymmetry(t *testing.T) {
 
 		require.NoError(t, stp.dequeueDuringBlockMovement(nil, nil, nil, true))
 
-		require.Equal(t, int64(1), stp.queue.length(),
-			"drain held back a same-millisecond batch at window=0; the Start "+
-				"loop's zero-guard would have admitted it")
-		require.NotContains(t, collectSubtreeHashes(stp), txHash,
-			"the held-back batch must not appear in chainedSubtrees / currentSubtree")
+		require.Equal(t, int64(0), stp.queue.length(),
+			"drain must admit same-ms batch at window=0 via zero-guard parity")
+		require.Contains(t, collectSubtreeHashes(stp), txHash,
+			"the admitted batch must appear in chainedSubtrees / currentSubtree")
 	})
 
 	t.Run("control_one_ms_advance_drains_the_batch", func(t *testing.T) {

--- a/services/blockassembly/subtreeprocessor/queue_test.go
+++ b/services/blockassembly/subtreeprocessor/queue_test.go
@@ -145,28 +145,26 @@ func Test_queueClockOverride(t *testing.T) {
 	require.Equal(t, fixed.UnixMilli(), batch.time)
 }
 
-// Test_zeroWindowAsymmetry pins a behavioural divergence between the two
-// validFromMillis formulas used inside SubtreeProcessor.
+// Test_zeroWindowFormulasAgree asserts parity between the two
+// validFromMillis formulas inside SubtreeProcessor at DoubleSpendWindow=0
+// (the documented default - see settings/blockassembly_settings.go:29).
+// Both call sites now zero-guard the calculation, so neither activates
+// the queue filter at queue.go:96 and both admit same-millisecond
+// batches.
 //
 //	Start loop (SubtreeProcessor.go:807-813):
 //	  validFromMillis = 0                              if DoubleSpendWindow == 0
 //	  validFromMillis = (now - window).UnixMilli()     otherwise
 //
-//	dequeueDuringBlockMovement (SubtreeProcessor.go:3789):
-//	  validFromMillis = (now - window).UnixMilli()     unconditionally
+//	dequeueDuringBlockMovement (SubtreeProcessor.go:3789-3796):
+//	  validFromMillis = 0                              if DoubleSpendWindow == 0
+//	  validFromMillis = (now - window).UnixMilli()     otherwise
 //
-// With DoubleSpendWindow == 0 (the documented default - see
-// settings/blockassembly_settings.go:29), the two formulas diverge:
-//   - Start passes 0, the queue's "validFromMillis > 0" guard at
-//     queue.go:96 short-circuits, and same-millisecond batches admit.
-//   - drain passes now.UnixMilli(), the guard does not short-circuit,
-//     and same-millisecond batches are held back.
-//
-// conflicting_queue_race_test.go:71-75 papers over this with a
-// time.Sleep(5*time.Millisecond) before calling
-// dequeueDuringBlockMovement. This test pins the underlying behaviour
-// deterministically via the clock seam, with no real-time waits.
-func Test_zeroWindowAsymmetry(t *testing.T) {
+// Before the fix, the drain formula was unconditional, which held back
+// same-millisecond batches under the default config. This test pins the
+// post-fix parity. If a future change removes either zero-guard, the
+// corresponding subtest will fail.
+func Test_zeroWindowFormulasAgree(t *testing.T) {
 	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
 	window := time.Duration(0)
 
@@ -193,16 +191,18 @@ func Test_zeroWindowAsymmetry(t *testing.T) {
 		require.Equal(t, fixed.UnixMilli(), batch.time)
 	})
 
-	t.Run("drain_formula_rejects_same_millisecond_batch", func(t *testing.T) {
-		// Mirror of the formula at SubtreeProcessor.go:3789.
-		drainValidFromMillis := fixed.Add(-1 * window).UnixMilli()
+	t.Run("drain_formula_admits_same_millisecond_batch", func(t *testing.T) {
+		// Mirror of the formula at SubtreeProcessor.go:3789-3796.
+		drainValidFromMillis := int64(0)
+		if window > 0 {
+			drainValidFromMillis = fixed.Add(-window).UnixMilli()
+		}
 
 		q := enqueueAtFixed()
-		_, found := q.dequeueBatch(drainValidFromMillis)
-		require.False(t, found,
-			"drain currently rejects same-ms batch at window=0; if this assertion "+
-				"flips, the Start/drain asymmetry has been resolved and the "+
-				"workaround in conflicting_queue_race_test.go:75 can likely be removed")
+		batch, found := q.dequeueBatch(drainValidFromMillis)
+		require.True(t, found, "drain must admit same-ms batch at window=0 "+
+			"(zero-guard parity with the Start loop)")
+		require.Equal(t, fixed.UnixMilli(), batch.time)
 	})
 }
 


### PR DESCRIPTION
## Summary

Mirrors the Start-loop's zero-guard at `dequeueDuringBlockMovement` so `DoubleSpendWindow == 0` disables the queue filter consistently across both call sites. Closes a same-millisecond admission gap that only manifests under the default config.

## The bug

The Start-loop dequeue at `SubtreeProcessor.go:810-813` zero-guards the calculation:

```go
validFromMillis := int64(0)
if stp.settings.BlockAssembly.DoubleSpendWindow > 0 {
    validFromMillis = stp.clock.Now().Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
}
```

`dequeueDuringBlockMovement` (pre-fix `:3789`) skipped that guard and ran the calculation unconditionally:

```go
validFromMillis := stp.clock.Now().Add(-1 * stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
```

At `DoubleSpendWindow == 0` that yields `clock.Now().UnixMilli()` (`> 0`), which trips the queue filter at `queue.go:96` (`validFromMillis > 0 && time >= validFromMillis`) and rejects any batch enqueued in the same millisecond as the drain.

`DoubleSpendWindow` defaults to `0` (`settings/blockassembly_settings.go:29`). Under the default config, a block-movement drain could miss fresh batches that the Start loop would have admitted, leaving them queued for the next iteration. The fix is one zero-guard, mirroring the Start loop verbatim.

This was characterized in #841 and is the asymmetry called out in that PR's "Latent finding" section.

## Test changes

- **`Test_zeroWindowAsymmetry` → `Test_zeroWindowFormulasAgree`** - renamed and flipped the drain subtest to assert admission. The test now pins post-fix parity between the two formulas.
- **`TestDequeueDuringBlockMovement_ZeroWindowAsymmetry` → `...AdmitsSameMillisecond`** - flipped `same_millisecond_batch_is_held_back` to assert the batch drains. Kept the `+1ms` control subtest as a separate `(now - window)` cutoff smoke.
- **`TestDequeueDuringBlockMovement_RejectsChildOfConflictingParent`** - replaced the `time.Sleep(5 * time.Millisecond)` workaround with the clock seam (both `stp.clock` and `stp.queue.clock` pin to the same instant). With the fix, the batch admits at window=0 and the conflicting-parent rejection path is exercised deterministically. No more wall-time wait.

## Test plan

- [x] `go vet ./services/blockassembly/...` - clean
- [x] `go test -race -count=1 ./services/blockassembly/subtreeprocessor/` - pass (164s)
- [x] `go test -race -count=1 ./services/blockassembly/` - pass (101s)
- [x] BenchmarkQueue sanity (control plane, not hot path): 154-193 ns/op, in line with previous runs.

## Notes

- Production change: 5 added lines + 1 modified line in `SubtreeProcessor.go`, no API change, no new imports.
- The fix is on a control-plane path (only runs during block movement) so it does not affect the hot tx-batching path.
- Builds on #841 (the clock seam) for test determinism; both characterization tests and the de-flaked race test use `fixedClock` to drive timestamps without `time.Sleep`.