### PR TITLE
fix(legacy): gate quickValidation on checkpoints, not FSM state

### DIFF
--- a/docs/topics/services/legacy.md
+++ b/docs/topics/services/legacy.md
@@ -278,8 +278,8 @@ The Legacy Service converts standard BSV blocks (which don't have subtrees) into
     - **Subtree Metadata:** Parent transaction references are stored to maintain the transaction dependency structure
 
 4. **Validation:**
-    - In legacy sync mode, a quick validation is performed assuming blocks are valid
-    - In normal mode, more thorough validation is performed via the Teranode validation services
+    - For blocks at or below the highest hard-coded checkpoint, a quick validation path is used: subtree re-validation through the Subtree Validation service is skipped and per-UTXO `SetMinedMulti` is bypassed via a pre-assigned block ID. This is safe regardless of FSM state (LEGACYSYNCING or CATCHINGBLOCKS) because PoW plus checkpoint-anchored chain linkage make the block canonical.
+    - For blocks above the highest checkpoint, more thorough validation is performed via the Teranode validation services.
 
 5. **Storage:**
     - The subtree, its data, and metadata are stored in the Subtree Store

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1104,16 +1104,18 @@ func (u *BlockValidation) runOncePerBlock(blockHash *chainhash.Hash, opts *Valid
 
 // buildAddBlockOpts returns AddBlock options for the block.
 //
-// When block.ID is pre-assigned (set by legacy netsync in LEGACYSYNCING mode), it uses that ID
-// and sets mined_set=true upfront. This causes the setMinedChan worker to skip setTxMinedStatus
-// via its existing MinedSet guard (BlockValidation.go setMinedChan worker, MinedSet check),
-// eliminating redundant SetMinedMulti calls for every UTXO.
+// When block.ID is pre-assigned (set by legacy netsync for blocks at/below the highest
+// hard-coded checkpoint), it uses that ID and sets mined_set=true upfront. This causes
+// the setMinedChan worker to skip setTxMinedStatus via its existing MinedSet guard
+// (BlockValidation.go setMinedChan worker, MinedSet check), eliminating redundant
+// SetMinedMulti calls for every UTXO.
 //
 // Trade-off: skipping setTxMinedStatus also skips its post-storage double-spend cross-check
-// (UpdateTxMinedStatus → SetMinedMulti). This is safe for LEGACYSYNCING because:
+// (UpdateTxMinedStatus → SetMinedMulti). This is safe for checkpoint-covered blocks because:
 //  1. block.Valid() performs pre-storage double-spend detection via checkParentExistsOnChain
 //     before AddBlock is called.
-//  2. LEGACYSYNCING processes a canonical chain with trusted historical blocks.
+//  2. Checkpoint-anchored chain linkage plus PoW makes the block canonical regardless of
+//     the FSM state that drove the catch-up.
 //
 // For any block arriving without a pre-assigned ID (block.ID == 0), this function returns nil
 // and AddBlock behaves exactly as before — setTxMinedStatus runs normally.

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -19,7 +19,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
-	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	teranodeblockchain "github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/legacy/bsvutil"
 	"github.com/bsv-blockchain/teranode/services/legacy/peer"
 	"github.com/bsv-blockchain/teranode/services/utxopersister/filestorer"
@@ -282,10 +282,7 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 
 	subtrees = make([]*chainhash.Hash, 0)
 
-	var (
-		subtree    *subtreepkg.Subtree
-		legacyMode bool
-	)
+	var subtree *subtreepkg.Subtree
 
 	// create 1 subtree + subtree.subtreeData
 	// then validate the subtree through the subtreeValidation service
@@ -320,25 +317,29 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 			return nil, 0, err
 		}
 
-		if legacyMode, err = sm.blockchainClient.IsFSMCurrentState(sm.ctx, blockchain_api.FSMStateType_LEGACYSYNCING); err != nil {
-			sm.logger.Errorf("[prepareSubtrees] Failed to get current state: %s", err)
+		blockHeight32, convErr := safeconversion.Int32ToUint32(block.Height())
+		if convErr != nil {
+			return nil, 0, errors.NewProcessingError("[prepareSubtrees] failed to convert block height", convErr)
 		}
 
-		// quick validation mode is used when we are in legacy mode
-		// we can skip some of the processing since we assume the block is valid
-		quickValidationMode := legacyMode
+		// Quick validation is safe whenever the block sits at/below the highest hard-coded
+		// checkpoint for the active network. POW (verified upstream by HasMetTargetDifficulty)
+		// plus checkpoint-anchored chain linkage make the block canonical regardless of which
+		// FSM state drove the catch-up. The checkpoint list is owned by go-chaincfg — see PR
+		// #844 for the matching FSM-RUN gate that relies on the same invariant.
+		quickValidationMode := sm.quickValidationAllowed(blockHeight32)
 
 		if quickValidationMode {
-			// Only in LEGACYSYNCING (LEGACY_SYNC mode) — fetch block ID upfront so UTXOs carry
-			// mined info from creation. This ID is threaded through to blockvalidation via
-			// ProcessBlock so it can call AddBlock(WithID, WithMinedSet(true)) and cause the
-			// setMinedChan worker to skip setTxMinedStatus (MinedSet guard in BlockValidation.go).
+			// Fetch block ID upfront so UTXOs carry mined info from creation. This ID is
+			// threaded through to blockvalidation via ProcessBlock so it can call
+			// AddBlock(WithID, WithMinedSet(true)) and cause the setMinedChan worker to
+			// skip setTxMinedStatus (MinedSet guard in BlockValidation.go).
 			//
-			// Note on ID gaps: GetNextBlockID advances the sequence atomically. If anything fails
-			// after this point (createUtxos error, network error, context cancellation), the ID
-			// is consumed and a gap appears in block IDs. This is acceptable — the blockchain
-			// store tolerates non-contiguous IDs; the sequence is used only as a monotonic counter,
-			// not a contiguous index.
+			// Note on ID gaps: GetNextBlockID advances the sequence atomically. If anything
+			// fails after this point (createUtxos error, network error, context cancellation),
+			// the ID is consumed and a gap appears in block IDs. This is acceptable — the
+			// blockchain store tolerates non-contiguous IDs; the sequence is used only as a
+			// monotonic counter, not a contiguous index.
 			id, idErr := sm.blockchainClient.GetNextBlockID(ctx)
 			if idErr != nil {
 				return nil, 0, errors.NewProcessingError("[prepareSubtrees] failed to get next block ID", idErr)
@@ -357,8 +358,8 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 			return nil, 0, err
 		}
 
-		// we don't need to check the subtree in the subtree validation in legacy or catching blocks mode,
-		// since we already validated the transactions and created all the subtree files needed
+		// In quickValidationMode the transactions and subtree files have already been
+		// produced locally, so we can skip the round-trip through subtreeValidation.
 		if !quickValidationMode {
 			if err = sm.checkSubtreeFromBlock(ctx, block, subtree); err != nil {
 				return nil, 0, err
@@ -369,6 +370,27 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 	}
 
 	return subtrees, blockID, nil
+}
+
+// quickValidationAllowed reports whether the given block height is covered by a
+// hard-coded checkpoint for the active network. Checkpoint-anchored chain linkage
+// combined with the upstream PoW check makes the block canonical, so we can skip
+// subtree re-validation and the per-UTXO setTxMined cross-check.
+//
+// Returns false when the network defines no checkpoints (regtest) or when the
+// block height is above the highest checkpoint — those blocks must follow the
+// regular validation path.
+func (sm *SyncManager) quickValidationAllowed(blockHeight uint32) bool {
+	if sm.chainParams == nil {
+		return false
+	}
+
+	highest := teranodeblockchain.HighestCheckpointHeight(sm.chainParams.Checkpoints)
+	if highest == 0 {
+		return false
+	}
+
+	return blockHeight <= highest
 }
 
 func (sm *SyncManager) checkSubtreeFromBlock(ctx context.Context, block *bsvutil.Block, subtree *subtreepkg.Subtree) error {

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -19,7 +19,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
-	teranodeblockchain "github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/legacy/bsvutil"
 	"github.com/bsv-blockchain/teranode/services/legacy/peer"
 	"github.com/bsv-blockchain/teranode/services/utxopersister/filestorer"
@@ -385,7 +385,7 @@ func (sm *SyncManager) quickValidationAllowed(blockHeight uint32) bool {
 		return false
 	}
 
-	highest := teranodeblockchain.HighestCheckpointHeight(sm.chainParams.Checkpoints)
+	highest := blockchain.HighestCheckpointHeight(sm.chainParams.Checkpoints)
 	if highest == 0 {
 		return false
 	}

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/go-wire"
@@ -785,4 +786,53 @@ func TestPreValidateTransactions_ParentContextCancelled(t *testing.T) {
 	err := sm.PreValidateTransactions(ctx, txMap, chainhash.Hash{}, 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context cancelled")
+}
+
+func TestSyncManager_quickValidationAllowed(t *testing.T) {
+	mainnetHighest := uint32(chaincfg.MainNetParams.Checkpoints[len(chaincfg.MainNetParams.Checkpoints)-1].Height)
+
+	tests := []struct {
+		name        string
+		chainParams *chaincfg.Params
+		height      uint32
+		want        bool
+	}{
+		{
+			name:        "nil chain params",
+			chainParams: nil,
+			height:      100,
+			want:        false,
+		},
+		{
+			name:        "regtest has no checkpoints",
+			chainParams: &chaincfg.RegressionNetParams,
+			height:      0,
+			want:        false,
+		},
+		{
+			name:        "mainnet height 0 is covered",
+			chainParams: &chaincfg.MainNetParams,
+			height:      0,
+			want:        true,
+		},
+		{
+			name:        "mainnet height equal to highest checkpoint is covered",
+			chainParams: &chaincfg.MainNetParams,
+			height:      mainnetHighest,
+			want:        true,
+		},
+		{
+			name:        "mainnet height one above highest checkpoint is not covered",
+			chainParams: &chaincfg.MainNetParams,
+			height:      mainnetHighest + 1,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := &SyncManager{chainParams: tt.chainParams}
+			require.Equal(t, tt.want, sm.quickValidationAllowed(tt.height))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- `prepareSubtrees` in legacy netsync only enabled `quickValidationMode` when the FSM was in `LEGACYSYNCING`. `CATCHINGBLOCKS` (catchup-driven sync from block 0, or after a fork) fell back to the slow path: full subtree re-validation through `subtreeValidation`, no pre-allocated block ID, and per-UTXO `SetMinedMulti` via `setTxMinedStatus`.
- The trust property that makes the fast path safe is **checkpoint coverage + PoW**, not the FSM state that happens to be active. The local chain extending through known checkpoints, combined with the upstream `HasMetTargetDifficulty` check, is what makes the block canonical.
- Replace the FSM-state lookup with a check against the highest hard-coded checkpoint, reusing the helper added in #844 (`blockchain.HighestCheckpointHeight`). Blocks at/below the highest checkpoint take the fast path regardless of FSM state; blocks above it always take the regular validation path.
- Drops the `IsFSMCurrentState` RPC from the per-block hot path. Updates the `buildAddBlockOpts` doc block in `blockvalidation` to describe the broader scope.

## Why this is safe

The fast path skips two things: subtree re-validation through `subtreeValidation`, and `setTxMinedStatus`' post-storage double-spend cross-check. Both are redundant when:

1. `block.Valid()` has already run pre-storage double-spend detection via `checkParentExistsOnChain` before `AddBlock`.
2. The block height is at/below a checkpoint owned by go-chaincfg, so chain linkage from genesis is provably canonical.

This is the same invariant #844 uses to gate the FSM-RUN transition. The checkpoint list is bumped by updating go-chaincfg; the gate moves forward with it.

## Trade-offs / follow-ups

- mainnet's highest checkpoint is currently 938000 (tip is ~948000), so the top ~10k blocks won't get the fast path under any FSM state. Acceptable — they need normal validation anyway, and bumping go-chaincfg's checkpoint list will close the gap.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./services/legacy/netsync/... ./services/blockvalidation/...`
- [x] `go test -race -short ./services/legacy/netsync/` — 49 passed including new `TestSyncManager_quickValidationAllowed` (6 sub-cases: nil chainParams, regtest, mainnet height 0, equal-to-highest, one-above-highest)
- [x] `go test -race -short ./services/blockvalidation/`
- [ ] Manual: legacy sync from block 0 on testnet — verify fast path engages under both LEGACYSYNCING and CATCHINGBLOCKS (look for `[validateTransactionsLegacyMode] created utxos` log line)