### PR TITLE
fix(blockassembly/subtreeprocessor): stop losing the boundary batch in Reset drain

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1347,15 +1347,15 @@ func (stp *SubtreeProcessor) reset(blockHeader *model.BlockHeader, moveBackBlock
 		}
 	}
 
-	// dequeue all batches
+	// dequeue all batches enqueued up to the time anchor below. Batches
+	// arriving concurrently after this anchor (e.g. fresh producer
+	// enqueues during the reset) are intentionally left in the queue.
 	stp.logger.Warnf("[SubtreeProcessor][Reset] Dequeueing all transactions")
 
-	validUntilMillis := time.Now().UnixMilli()
+	validUntilMillis := stp.clock.Now().UnixMilli()
 
 	for {
-		batch, found := stp.queue.dequeueBatch(0)
-		if !found || batch.time > validUntilMillis {
-			// we are done
+		if _, found := stp.queue.dequeueBatchUntil(validUntilMillis); !found {
 			break
 		}
 	}

--- a/services/blockassembly/subtreeprocessor/queue.go
+++ b/services/blockassembly/subtreeprocessor/queue.go
@@ -103,6 +103,37 @@ func (q *LockFreeQueue) dequeueBatch(validFromMillis int64) (*TxBatch, bool) {
 	return next, true
 }
 
+// dequeueBatchUntil removes and returns the next batch only if its time
+// is at or before maxTimeMillis. The "inclusive-until" semantics
+// (batch.time <= maxTimeMillis admits) complement dequeueBatch's
+// "exclusive-from" semantics (batch.time < validFromMillis admits).
+//
+// Unlike dequeueBatch, this method peeks at batch.time BEFORE removing
+// the batch from the queue, so callers that want to stop at a time
+// boundary do not lose the boundary batch on the floor.
+//
+// NOTE - This operation is not thread-safe and should only be called
+// from a single thread.
+//
+// Parameters:
+//   - maxTimeMillis: Inclusive upper bound on batch.time for admission.
+//
+// Returns:
+//   - *TxBatch: The dequeued batch, or nil if the queue is empty or the
+//     head batch's time exceeds maxTimeMillis.
+//   - bool: True iff a batch was dequeued.
+func (q *LockFreeQueue) dequeueBatchUntil(maxTimeMillis int64) (*TxBatch, bool) {
+	next := q.head.next.Load()
+	if next == nil || next.time > maxTimeMillis {
+		return nil, false
+	}
+
+	q.head = next
+	q.queueLength.Add(-int64(len(next.nodes))) // gosec:nolint
+
+	return next, true
+}
+
 // IsEmpty checks if the queue contains any batches.
 //
 // Returns:

--- a/services/blockassembly/subtreeprocessor/queue_test.go
+++ b/services/blockassembly/subtreeprocessor/queue_test.go
@@ -305,6 +305,65 @@ func Test_clockBackwardJumpHoldsBatchesLonger(t *testing.T) {
 	require.Equal(t, enqueueAt.UnixMilli(), batch.time)
 }
 
+// Test_dequeueBatchUntilPreservesPostBoundaryBatch pins the
+// inclusive-until admit semantics of dequeueBatchUntil. The boundary
+// batch (batch.time == maxTimeMillis) is admitted; any batch with
+// batch.time > maxTimeMillis is rejected without being removed from
+// the queue.
+//
+// Regression guard for the Reset drain loop bug: the previous
+// implementation called dequeueBatch(0) then checked batch.time
+// post-hoc, which removed the boundary batch from the queue before
+// discovering it was too new. dequeueBatchUntil peeks first.
+func Test_dequeueBatchUntilPreservesPostBoundaryBatch(t *testing.T) {
+	preSnapshot := time.UnixMilli(1_700_000_000_000).UTC()
+	postSnapshot := preSnapshot.Add(10 * time.Millisecond)
+
+	q := NewLockFreeQueue()
+
+	q.clock = fixedClock{t: preSnapshot}
+	q.enqueueBatch(
+		[]subtree.Node{{Hash: chainhash.HashH([]byte("pre")), Fee: 1, SizeInBytes: 0}},
+		[]*subtree.TxInpoints{{}},
+	)
+
+	q.clock = fixedClock{t: postSnapshot}
+	q.enqueueBatch(
+		[]subtree.Node{{Hash: chainhash.HashH([]byte("post")), Fee: 2, SizeInBytes: 0}},
+		[]*subtree.TxInpoints{{}},
+	)
+	require.Equal(t, int64(2), q.length(), "precondition: both batches enqueued")
+
+	// Drain everything up to and including preSnapshot.
+	var consumedFees []uint64
+	for {
+		batch, found := q.dequeueBatchUntil(preSnapshot.UnixMilli())
+		if !found {
+			break
+		}
+		consumedFees = append(consumedFees, batch.nodes[0].Fee)
+	}
+
+	require.Equal(t, []uint64{1}, consumedFees,
+		"pre-snapshot batch must drain inside the loop body")
+	require.Equal(t, int64(1), q.length(),
+		"post-snapshot batch must survive: dequeueBatchUntil peeks before consuming")
+
+	// Boundary check: a batch enqueued at exactly maxTimeMillis admits.
+	q2 := NewLockFreeQueue()
+	q2.clock = fixedClock{t: preSnapshot}
+	q2.enqueueBatch(
+		[]subtree.Node{{Hash: chainhash.HashH([]byte("boundary")), Fee: 1, SizeInBytes: 0}},
+		[]*subtree.TxInpoints{{}},
+	)
+	_, found := q2.dequeueBatchUntil(preSnapshot.UnixMilli())
+	require.True(t, found, "batch.time == maxTimeMillis must admit (inclusive-until)")
+
+	// Empty queue returns false without touching state.
+	_, found = q2.dequeueBatchUntil(preSnapshot.UnixMilli())
+	require.False(t, found, "empty queue returns false")
+}
+
 func Test_queue2Threads(t *testing.T) {
 	q := NewLockFreeQueue()
 


### PR DESCRIPTION
## Summary

The Reset drain loop at `SubtreeProcessor.go:1355-1361` silently drops one boundary batch per `Reset` call. Fix: introduce `LockFreeQueue.dequeueBatchUntil` (peek-before-dequeue) and rewrite the drain loop to use it.

## The bug

```go
validUntilMillis := time.Now().UnixMilli()
for {
    batch, found := stp.queue.dequeueBatch(0)
    if !found || batch.time > validUntilMillis {
        // we are done
        break
    }
}
```

`dequeueBatch(0)` bypasses the queue filter and removes the head batch unconditionally. *Then* `batch.time` is checked. If the batch is too new, the loop breaks - but the batch is already gone from the queue and nothing puts it back. Net effect: one batch worth of fresh txs lost per `Reset` call.

`Reset` runs during reorgs, FSM transitions, and recovery operations. Under heavy concurrent enqueue (the documented use case for this codebase), each `Reset` statistically catches a batch in the window between `time.Now()` snapshot and the drain reaching the boundary. Those txs never get mined.

## Fix

New `dequeueBatchUntil` on `LockFreeQueue` with inclusive-until semantics (`admit iff batch.time <= maxTimeMillis`). Peeks at `batch.time` *before* removing the batch, so the boundary batch is never lost.

The Reset drain becomes:

```go
validUntilMillis := stp.clock.Now().UnixMilli()
for {
    if _, found := stp.queue.dequeueBatchUntil(validUntilMillis); !found {
        break
    }
}
```

Also switches the time anchor from `time.Now()` to `stp.clock.Now()` so the Reset path runs through the existing clock seam - consistent with the other validFromMillis call sites and necessary for deterministic future testing of Reset under reorg pressure.

## Test changes

- **New** `Test_dequeueBatchUntilPreservesPostBoundaryBatch` - regression guard. Enqueues a pre-snapshot and a post-snapshot batch via the clock seam, drains up to the snapshot, asserts the post-snapshot batch survives in the queue. Also covers the inclusive boundary (`batch.time == maxTimeMillis` admits) and the empty-queue case.

## Test plan

- [x] `go vet ./services/blockassembly/subtreeprocessor/` - clean
- [x] `go test -race -count=1 ./services/blockassembly/subtreeprocessor/` - pass (155s). `TestResetMarksAssemblyTxsAsNotOnLongestChainBeforeClearing` still passes - Reset behavior is preserved for the documented invariants.
- [x] `go test -race -count=1 ./services/blockassembly/` - pass (101s).

## Series context

Fourth in a series from the same investigation:
- #841 (merged) - clock seam: package-level `clock` interface enabling deterministic time-dependent tests.
- #846 (merged) - zero-guard `validFromMillis` in `dequeueDuringBlockMovement`.
- #848 (open) - rapid property tests for the validFromMillis admit logic.
- this PR - Reset drain boundary fix.

Independent of #848 - depends only on #841's clock seam (already on main).