### PR TITLE
fix(utxo/aerospike): close 4 silent-failure paths in sendStoreBatch

### DIFF
--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -276,6 +276,14 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 	batchWritePolicy.RecordExistsAction = aerospike.CREATE_ONLY
 
 	batchRecords := make([]aerospike.BatchRecordIfc, len(batch))
+	// resultHandledElsewhere[idx] = true means bItem.done has already been notified by
+	// this iteration of sendStoreBatch (either directly via SafeSend below or via a
+	// goroutine that takes ownership of the result), so subsequent error/success
+	// loops MUST NOT send a second notification on the same channel. Without this,
+	// items that were notified pre-BatchOperate would receive a duplicate from the
+	// per-record loop, and items that hit specific aerospike result codes would
+	// silently fall through unnotified.
+	resultHandledElsewhere := make([]bool, len(batch))
 
 	if s.settings.UtxoStore.VerboseDebug {
 		s.logger.Debugf("[STORE_BATCH] sending batch of %d txMetas", len(batch))
@@ -291,6 +299,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 		key, err = aerospike.NewKey(s.namespace, s.setName, bItem.txHash[:])
 		if err != nil {
 			util.SafeSend(bItem.done, err)
+			resultHandledElsewhere[idx] = true
 
 			// NOOP for this record
 			batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
@@ -325,6 +334,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 		binsToStore, err = s.GetBinsToStore(bItem.tx, bItem.blockHeight, bItem.blockIDs, bItem.blockHeights, bItem.subtreeIdxs, external, bItem.txHash, bItem.isCoinbase, bItem.conflicting, bItem.locked) // false is to say this is a normal record, not external.
 		if err != nil {
 			util.SafeSend[error](bItem.done, errors.NewProcessingError("could not get bins to store", err))
+			resultHandledElsewhere[idx] = true
 
 			// NOOP for this record
 			batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
@@ -337,6 +347,8 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 		if len(binsToStore) > 1 {
 			// Make this batch item a NOOP and persist all of these to be written via a queue
 			batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
+			// Goroutine takes ownership of bItem.done; the per-record loop must not touch it.
+			resultHandledElsewhere[idx] = true
 
 			if len(batch[idx].tx.Inputs) == 0 {
 				// This will also create the aerospike records
@@ -387,6 +399,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 					setOptions...,
 				); err != nil && !errors.Is(err, errors.ErrBlobAlreadyExists) {
 					util.SafeSend[error](bItem.done, errors.NewStorageError("error writing outputs to external store [%s]", bItem.txHash.String(), err))
+					resultHandledElsewhere[idx] = true
 					// NOOP for this record
 					batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
 
@@ -405,6 +418,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 					bItem.tx.ExtendedBytes(),
 				); err != nil && !errors.Is(err, errors.ErrBlobAlreadyExists) {
 					util.SafeSend[error](bItem.done, errors.NewStorageError("[sendStoreBatch] error batch writing transaction to external store [%s]", bItem.txHash.String(), err))
+					resultHandledElsewhere[idx] = true
 					// NOOP for this record
 					batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
 
@@ -431,18 +445,26 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 
 	batchID := s.batchID.Add(1)
 
-	err = s.client.BatchOperate(batchPolicy, batchRecords)
+	batchOperate := s.batchOperateFn
+	if batchOperate == nil {
+		batchOperate = s.client.BatchOperate
+	}
+
+	err = batchOperate(batchPolicy, batchRecords)
 	if err != nil {
 		var aErr *aerospike.AerospikeError
 
 		ok := errors.As(err, &aErr)
 		if ok {
 			if aErr.ResultCode == types.KEY_EXISTS_ERROR {
-				// we want to return a tx already exists error on this case
-				// this should only be called with 1 record
-				err = errors.NewTxExistsError("[sendStoreBatch-1] %v already exists in store", batch[0].txHash)
-				for _, bItem := range batch {
-					util.SafeSend(bItem.done, err)
+				// Send a TxExistsError to each item using ITS OWN txHash. The previous
+				// code hard-coded batch[0].txHash for the whole batch, which produced
+				// misleading error messages whenever the batcher grouped >1 item.
+				for idx, bItem := range batch {
+					if resultHandledElsewhere[idx] {
+						continue
+					}
+					util.SafeSend[error](bItem.done, errors.NewTxExistsError("[sendStoreBatch-1] %v already exists in store", bItem.txHash))
 				}
 
 				return
@@ -451,19 +473,36 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 
 		s.logger.Errorf("[STORE_BATCH][batch:%d] error in aerospike map store batch records: %v", batchID, err)
 
-		for _, bItem := range batch {
+		for idx, bItem := range batch {
+			if resultHandledElsewhere[idx] {
+				continue
+			}
 			util.SafeSend(bItem.done, err)
 		}
+
+		// MUST return here. The previous code fell through to the per-record loop
+		// after a top-level non-KEY_EXISTS error, where SafeSend(nil) was called for
+		// any record whose per-record Err happened to be unset — producing spurious
+		// success notifications on top of the real error.
+		return
 	}
 
 	start = stat.NewStat("BatchOperate").AddTime(start)
 
 	// batchOperate may have no errors, but some of the records may have failed
 	for idx, batchRecord := range batchRecords {
+		// Items that were already notified directly (key/bins errors) or that handed
+		// ownership of their done channel to a goroutine (multi-record external path)
+		// must not be touched again here. KEY_NOT_FOUND_ERROR is the expected per-record
+		// outcome for the NOOP placeholder reads — when resultHandledElsewhere is true
+		// we skip without trying to classify the error.
+		if resultHandledElsewhere[idx] {
+			continue
+		}
+
 		err = batchRecord.BatchRec().Err
 		if err != nil {
-			aErr, ok := err.(*aerospike.AerospikeError)
-			if ok {
+			if aErr, ok := err.(*aerospike.AerospikeError); ok {
 				if aErr.ResultCode == types.KEY_EXISTS_ERROR {
 					util.SafeSend[error](batch[idx].done, errors.NewTxExistsError("[sendStoreBatch-2] %v already exists in store", batch[idx].txHash))
 					continue
@@ -476,6 +515,8 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 						continue
 					}
 
+					// The goroutine owns the done channel from here on.
+					resultHandledElsewhere[idx] = true
 					if len(batch[idx].tx.Inputs) == 0 {
 						go s.StorePartialTransactionExternally(ctx, batch[idx], binsToStore)
 					} else {
@@ -484,19 +525,24 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 
 					continue
 				}
-
-				if aErr.ResultCode == types.KEY_NOT_FOUND_ERROR {
-					// This is a NOOP record and the done channel will be called by the external process
-					continue
-				}
-
-				util.SafeSend[error](batch[idx].done, errors.NewStorageError("[STORE_BATCH][%s:%d] error in aerospike store batch record for tx (will retry): %d", batch[idx].txHash.String(), idx, batchID, err))
 			}
-		} else if len(batch[idx].tx.Outputs) <= s.utxoBatchSize {
-			// We notify the done channel that the operation was successful, except
-			// if this item was offloaded to the multi-record queue
-			util.SafeSend(batch[idx].done, nil)
+
+			// Fallback: any other per-record error — including const aerospike.Error
+			// sentinels that fail the *AerospikeError type assertion (e.g. ErrTimeout)
+			// and KEY_NOT_FOUND_ERROR on a real BatchWrite (which is NOT a NOOP) — must
+			// be surfaced. Previously the SafeSend was nested inside the type-asserted
+			// branch and a non-matching error left the caller hung on <-errCh.
+			util.SafeSend[error](batch[idx].done, errors.NewStorageError("[STORE_BATCH][%s:%d] error in aerospike store batch record for tx (will retry): %d", batch[idx].txHash.String(), idx, batchID, err))
+			continue
 		}
+
+		// No per-record error and not handled elsewhere — the BatchWrite succeeded,
+		// so notify success. The previous code gated this on an outputs<=batchSize
+		// comparison that was supposed to be an indirect proxy for "not offloaded";
+		// the resultHandledElsewhere flag now makes that proxy redundant. If outputs
+		// > batchSize the item would already have set resultHandledElsewhere=true and
+		// been skipped above, so reaching this point means we owe the caller a result.
+		util.SafeSend(batch[idx].done, nil)
 	}
 
 	stat.NewStat("postBatchOperate").AddTime(start)

--- a/stores/utxo/aerospike/send_store_batch_test.go
+++ b/stores/utxo/aerospike/send_store_batch_test.go
@@ -1,0 +1,314 @@
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-client-go/v8"
+	"github.com/aerospike/aerospike-client-go/v8/types"
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStoreForSendStoreBatch builds the minimum Store fields sendStoreBatch
+// touches. It deliberately leaves s.client nil — every test installs its own
+// batchOperateFn so BatchOperate is never called through the real client.
+func newTestStoreForSendStoreBatch(t *testing.T) *Store {
+	t.Helper()
+
+	InitPrometheusMetrics()
+
+	tSettings := &settings.Settings{}
+	tSettings.Aerospike.UseDefaultPolicies = true
+	tSettings.UtxoStore.UtxoBatchSize = 20_000
+
+	return &Store{
+		ctx:           context.Background(),
+		namespace:     "test-ns",
+		setName:       "test-set",
+		logger:        ulogger.TestLogger{},
+		settings:      tSettings,
+		utxoBatchSize: tSettings.UtxoStore.UtxoBatchSize,
+	}
+}
+
+// txWithSingleOutput builds a partial transaction (no inputs, one output) so
+// sendStoreBatch's GetBinsToStore takes the fee-zero path without needing a
+// real parent UTXO.
+func txWithSingleOutput(t *testing.T) *bt.Tx {
+	t.Helper()
+	tx := bt.NewTx()
+	require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
+	return tx
+}
+
+// drainOne reads at most one value from ch within timeout; returns ok=true if a
+// value arrived. Used so tests can detect the *absence* of a notification too.
+func drainOne(ch chan error, timeout time.Duration) (error, bool) {
+	select {
+	case v := <-ch:
+		return v, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+// TestSendStoreBatch_TopLevelNonKeyExistsError_NoDuplicateNotification verifies
+// that when BatchOperate returns a non-KEY_EXISTS top-level error, each item's
+// done channel receives exactly ONE notification (the error). The bug was that
+// after notifying all items, control fell through to the per-record loop which
+// then called SafeSend(nil) for any record whose per-record Err was unset —
+// producing a spurious success notification on top of the real error.
+func TestSendStoreBatch_TopLevelNonKeyExistsError_NoDuplicateNotification(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	// Mock BatchOperate to return a top-level network error WITHOUT touching
+	// per-record Err fields. This is the exact shape that triggered the bug.
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, _ []aerospike.BatchRecordIfc) aerospike.Error {
+		return aerospike.ErrNetwork
+	}
+
+	// Build 3 items, each with a BUFFERED done channel (capacity 2) so a
+	// spurious second send is observable instead of being dropped by SafeSend's
+	// closed-channel recovery.
+	batch := make([]*BatchStoreItem, 3)
+	for i := range batch {
+		tx := txWithSingleOutput(t)
+		batch[i] = NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 2))
+	}
+
+	s.sendStoreBatch(batch)
+
+	for i, item := range batch {
+		first, ok := drainOne(item.done, 500*time.Millisecond)
+		require.True(t, ok, "item %d: expected one notification, got none", i)
+		require.Error(t, first, "item %d: expected error notification, got nil", i)
+
+		_, gotSecond := drainOne(item.done, 50*time.Millisecond)
+		require.False(t, gotSecond, "item %d: got a duplicate notification — the per-record loop fell through after the top-level error path", i)
+	}
+}
+
+// TestSendStoreBatch_TopLevelKeyExistsError_EachItemGetsOwnTxHash verifies that
+// when a multi-item batch hits a top-level KEY_EXISTS_ERROR, each item's error
+// message references its OWN txHash, not batch[0]'s. The bug was the message
+// hardcoded "batch[0].txHash" even though the batcher routinely groups dozens
+// of items.
+func TestSendStoreBatch_TopLevelKeyExistsError_EachItemGetsOwnTxHash(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, _ []aerospike.BatchRecordIfc) aerospike.Error {
+		// Synthesize a top-level KEY_EXISTS_ERROR (no const error exists for this code).
+		return &aerospike.AerospikeError{ResultCode: types.KEY_EXISTS_ERROR}
+	}
+
+	batch := make([]*BatchStoreItem, 3)
+	for i := range batch {
+		tx := txWithSingleOutput(t)
+		// Make each tx distinct so its hash is unique. PayToAddress with a
+		// different satoshi value flips the hash.
+		require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint64(100+i)))
+		batch[i] = NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 2))
+	}
+
+	s.sendStoreBatch(batch)
+
+	for i, item := range batch {
+		err, ok := drainOne(item.done, 500*time.Millisecond)
+		require.True(t, ok, "item %d: expected a notification", i)
+		require.Error(t, err, "item %d: expected an error", i)
+		require.Contains(t, err.Error(), item.txHash.String(), "item %d: error message must reference its own txHash, not batch[0]", i)
+	}
+}
+
+// TestSendStoreBatch_PerRecordConstError_StillNotifies verifies that a
+// per-record error of a concrete type other than *AerospikeError still results
+// in a notification on the done channel. The bug was the production-code type
+// assertion `err.(*aerospike.AerospikeError)` returned ok=false for the const
+// error sentinels the client exposes (aerospike.ErrTimeout, ErrNetwork, etc.),
+// and the loop body's fallback SafeSend was nested inside the `if ok` branch.
+// Result: the caller hung on <-errCh forever.
+func TestSendStoreBatch_PerRecordConstError_StillNotifies(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, records []aerospike.BatchRecordIfc) aerospike.Error {
+		// aerospike.ErrTimeout is a *constAerospikeError, which implements
+		// aerospike.Error but does NOT satisfy the `err.(*AerospikeError)`
+		// type assertion in production code.
+		for _, rec := range records {
+			rec.BatchRec().Err = aerospike.ErrTimeout
+		}
+		return nil // top-level OK; the bug is exercised only in the per-record loop
+	}
+
+	tx := txWithSingleOutput(t)
+	batch := []*BatchStoreItem{
+		NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 2)),
+	}
+
+	s.sendStoreBatch(batch)
+
+	err, ok := drainOne(batch[0].done, 500*time.Millisecond)
+	require.True(t, ok, "item must be notified even when per-record error is a const aerospike.Error, not *AerospikeError")
+	require.Error(t, err, "notification must be an error, not nil success")
+}
+
+// TestSendStoreBatch_KeyNotFoundOnRealRecord_NotifiesError verifies that a
+// per-record KEY_NOT_FOUND_ERROR on a record that was NOT a NOOP placeholder
+// produces a notification rather than being silently skipped. The bug was the
+// KEY_NOT_FOUND_ERROR branch assumed every such code meant NOOP and called
+// `continue` without sending — a Create() caller hung if the assumption was
+// ever wrong (e.g. an unusual Aerospike state, a future client change).
+func TestSendStoreBatch_KeyNotFoundOnRealRecord_NotifiesError(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, records []aerospike.BatchRecordIfc) aerospike.Error {
+		// Set KEY_NOT_FOUND_ERROR on every record. With this Store's batch
+		// construction every record IS a real BatchWrite (small single-batch
+		// tx, no goroutine offload), so KEY_NOT_FOUND_ERROR is a real failure
+		// that must be surfaced.
+		notFound := &aerospike.AerospikeError{ResultCode: types.KEY_NOT_FOUND_ERROR}
+		for _, rec := range records {
+			rec.BatchRec().Err = notFound
+		}
+		return nil
+	}
+
+	tx := txWithSingleOutput(t)
+	batch := []*BatchStoreItem{
+		NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 2)),
+	}
+
+	s.sendStoreBatch(batch)
+
+	err, ok := drainOne(batch[0].done, 500*time.Millisecond)
+	require.True(t, ok, "KEY_NOT_FOUND on a real (non-NOOP) BatchWrite must notify the caller")
+	require.Error(t, err, "notification must be an error, not nil success")
+}
+
+// TestSendStoreBatch_AllSuccess_SingleSuccessNotificationPerItem verifies the
+// happy path: BatchOperate returns no error AND no per-record errors → each
+// item receives exactly ONE notification of nil (success). This guards against
+// regressions where the success path accidentally double-sends or skips.
+func TestSendStoreBatch_AllSuccess_SingleSuccessNotificationPerItem(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, _ []aerospike.BatchRecordIfc) aerospike.Error {
+		return nil
+	}
+
+	batch := make([]*BatchStoreItem, 3)
+	for i := range batch {
+		tx := txWithSingleOutput(t)
+		batch[i] = NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 2))
+	}
+
+	s.sendStoreBatch(batch)
+
+	for i, item := range batch {
+		first, ok := drainOne(item.done, 500*time.Millisecond)
+		require.True(t, ok, "item %d: expected success notification", i)
+		require.NoError(t, first, "item %d: expected nil success, got error", i)
+
+		_, gotSecond := drainOne(item.done, 50*time.Millisecond)
+		require.False(t, gotSecond, "item %d: success path must send exactly one notification", i)
+	}
+}
+
+// TestSendStoreBatch_MixedPerRecordResults verifies that when a batch contains
+// a mix of (success, KEY_EXISTS_ERROR, const-error), each item gets exactly the
+// right notification. Tests the per-record loop's classification across all
+// surfaces simultaneously.
+func TestSendStoreBatch_MixedPerRecordResults(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, records []aerospike.BatchRecordIfc) aerospike.Error {
+		// idx 0: success (no err)
+		// idx 1: KEY_EXISTS_ERROR
+		// idx 2: const error (ErrTimeout — fails *AerospikeError type assertion)
+		records[1].BatchRec().Err = &aerospike.AerospikeError{ResultCode: types.KEY_EXISTS_ERROR}
+		records[2].BatchRec().Err = aerospike.ErrTimeout
+		return nil
+	}
+
+	batch := make([]*BatchStoreItem, 3)
+	for i := range batch {
+		tx := txWithSingleOutput(t)
+		batch[i] = NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 2))
+	}
+
+	s.sendStoreBatch(batch)
+
+	// idx 0: success
+	err0, ok := drainOne(batch[0].done, 500*time.Millisecond)
+	require.True(t, ok)
+	require.NoError(t, err0, "item 0 must succeed")
+
+	// idx 1: TxExistsError
+	err1, ok := drainOne(batch[1].done, 500*time.Millisecond)
+	require.True(t, ok)
+	require.Error(t, err1, "item 1 must report an error")
+	require.True(t, errors.Is(err1, errors.ErrTxExists), "item 1 must be TxExistsError, got %v", err1)
+
+	// idx 2: StorageError fallback (const error path)
+	err2, ok := drainOne(batch[2].done, 500*time.Millisecond)
+	require.True(t, ok, "item 2 must notify even for const aerospike error")
+	require.Error(t, err2, "item 2 must report an error")
+
+	// And no duplicates anywhere.
+	for i, item := range batch {
+		_, gotSecond := drainOne(item.done, 50*time.Millisecond)
+		require.False(t, gotSecond, "item %d: must receive exactly one notification", i)
+	}
+}
+
+// TestSendStoreBatch_TopLevelError_DoesNotDuplicateNotifyPreSendItems checks
+// that when a SETUP error (e.g. NewKey failure simulated below isn't directly
+// reachable, so we use GetBinsToStore failure via a transaction with zero
+// outputs) notifies an item, and then BatchOperate ALSO returns a top-level
+// error, the pre-notified item does not receive a SECOND notification from
+// the top-level error loop.
+//
+// The bug being guarded: previously the top-level error loop sent to every
+// item unconditionally, which would duplicate-send to items the setup loop
+// had already notified.
+func TestSendStoreBatch_TopLevelError_DoesNotDuplicateNotifyPreSendItems(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+
+	s.batchOperateFn = func(_ *aerospike.BatchPolicy, _ []aerospike.BatchRecordIfc) aerospike.Error {
+		// Top-level non-KEY_EXISTS error AFTER the setup loop already errored on
+		// item 0 (zero-output tx → GetBinsToStore returns "tx has no outputs").
+		return aerospike.ErrNetwork
+	}
+
+	// Item 0: zero outputs → GetBinsToStore fails in the setup loop → ProcessingError
+	// already sent to item 0.done, NOOP record placed in batchRecords[0].
+	zeroOutputsTx := bt.NewTx()
+	// Item 1: normal single-output tx → real BatchWrite, will hit top-level error.
+	tx1 := txWithSingleOutput(t)
+	batch := []*BatchStoreItem{
+		NewBatchStoreItem(zeroOutputsTx.TxIDChainHash(), false, zeroOutputsTx, 100, nil, 0, make(chan error, 2)),
+		NewBatchStoreItem(tx1.TxIDChainHash(), false, tx1, 100, nil, 0, make(chan error, 2)),
+	}
+
+	s.sendStoreBatch(batch)
+
+	// Item 0 received its ProcessingError from the setup loop; the top-level
+	// error path MUST NOT send a second notification.
+	err0, ok := drainOne(batch[0].done, 500*time.Millisecond)
+	require.True(t, ok)
+	require.Error(t, err0, "item 0 must get its setup-loop error")
+	_, gotSecond := drainOne(batch[0].done, 50*time.Millisecond)
+	require.False(t, gotSecond, "item 0: pre-notified items must not be re-notified by the top-level error path")
+
+	// Item 1 was a real BatchWrite — it should get the top-level error.
+	err1, ok := drainOne(batch[1].done, 500*time.Millisecond)
+	require.True(t, ok)
+	require.Error(t, err1, "item 1 must get the top-level network error")
+	_, gotSecond1 := drainOne(batch[1].done, 50*time.Millisecond)
+	require.False(t, gotSecond1, "item 1: must receive exactly one notification")
+}


### PR DESCRIPTION
## Summary

Closes four code paths in `sendStoreBatch` where `Create()` could either return success while the transaction was not actually persisted, or hang the caller indefinitely with no error returned. Companion fix to #784 (which fixed the same class of bug in `storeExternallyWithLock`).

## The 4 fixed paths

1. **Missing `return` after non-KEY_EXISTS top-level error** — falling through into the per-record loop sent `SafeSend(nil)` for any record whose per-record `Err` was unset (the common case when the top-level call failed before reaching the server). Now returns after error notification.

2. **Wrong txHash in multi-item top-level KEY_EXISTS_ERROR** — was using `batch[0].txHash` for every item in the batch. Now each item's error references its own hash. The comment claimed \"this should only be called with 1 record\" but the default `utxostore_storeBatcherSize` is 100.

3. **Silent hang on non-`*AerospikeError` per-record types** — the fallback `SafeSend` for unknown aerospike result codes was nested inside the `err.(*aerospike.AerospikeError)` type-asserted branch. The Aerospike client exposes const sentinels like `aerospike.ErrTimeout` / `ErrNetwork` whose concrete type is `*constAerospikeError`, not `*AerospikeError`. If one ever appeared in `BatchRec().Err`, the type assertion failed, no `SafeSend` ran, and the caller hung on `<-errCh`. Fallback moved outside the type assertion.

4. **KEY_NOT_FOUND_ERROR assumption** — code unconditionally treated KEY_NOT_FOUND_ERROR as a NOOP-placeholder marker and `continue`d without notifying. A real BatchWrite returning KEY_NOT_FOUND_ERROR (Aerospike client edge cases, future client changes) would silently hang the caller. NOOP intent is now tracked explicitly via a new `resultHandledElsewhere []bool` so only intentional NOOPs are skipped.

## Bonus fix uncovered while implementing

Top-level error notification looped over **all** items including those already notified by the setup loop (NewKey / GetBinsToStore / external-store failures). The `resultHandledElsewhere` flag suppresses those duplicates too.

## Refactor for testability

Added the `s.batchOperateFn` seam to `sendStoreBatch` (already present in `storeExternallyWithLock` via #784) so the per-record paths can be unit-tested without an Aerospike server. Same field, same pattern.

## Test plan

New file `stores/utxo/aerospike/send_store_batch_test.go` — 7 unit tests, no testcontainers required:

- [x] `TopLevelNonKeyExistsError_NoDuplicateNotification` — fails before fix (item receives 2 notifications)
- [x] `TopLevelKeyExistsError_EachItemGetsOwnTxHash` — fails before fix (item 1's error names batch[0]'s hash)
- [x] `PerRecordConstError_StillNotifies` — fails before fix (hangs on `aerospike.ErrTimeout`)
- [x] `KeyNotFoundOnRealRecord_NotifiesError` — fails before fix (silent skip on non-NOOP record)
- [x] `AllSuccess_SingleSuccessNotificationPerItem` — happy-path regression guard
- [x] `MixedPerRecordResults` — verifies classification of success + KEY_EXISTS + const-error in one batch
- [x] `TopLevelError_DoesNotDuplicateNotifyPreSendItems` — top-level error loop doesn't re-notify pre-notified items

Each error-path test was verified to **fail on `main`** before the fix, then **pass after**.

- [x] `go build ./...`
- [x] `go vet ./stores/utxo/aerospike/`
- [x] `go test -race -run TestSendStoreBatch ./stores/utxo/aerospike/` — 7/7 pass