### PR TITLE
fix(legacy): merge blockID into pre-existing tx in createUtxos

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -640,6 +640,17 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 		return errors.NewProcessingError("failed to convert block height to uint32", err)
 	}
 
+	// Track txs that already exist in the store so we can merge our blockID into their
+	// BlockIDs after the Create pass. The quickValidation fast path skips the async
+	// setTxMinedStatus step entirely (AddBlock with MinedSet=true), so any tx that
+	// pre-existed without our blockID (propagation, prior crashed attempt, or the
+	// pre-fast-path subtreeValidation route) would otherwise stay with empty/wrong
+	// BlockIDs and fail descendant blocks with "has no block IDs".
+	var (
+		existingTxsMu    sync.Mutex
+		existingTxHashes []*chainhash.Hash
+	)
+
 	// create all the utxos first
 	for _, txHash := range txMap.Keys() {
 		txHash := txHash
@@ -656,10 +667,12 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 				SubtreeIdx:  0, // legacy path produces a single subtree at index 0
 			})); err != nil {
 				if errors.Is(err, errors.ErrTxExists) {
-					sm.logger.Debugf("failed to create utxo for tx %s: %s", txHash.String(), err)
-				} else {
-					return err
+					existingTxsMu.Lock()
+					existingTxHashes = append(existingTxHashes, &txHash)
+					existingTxsMu.Unlock()
+					return nil
 				}
+				return err
 			}
 
 			return nil
@@ -669,6 +682,21 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 	// wait for all utxos to be created
 	if err = g.Wait(); err != nil {
 		return errors.NewProcessingError("failed to create utxos", err)
+	}
+
+	// Merge our blockID into any tx that already existed. Without this, those txs
+	// keep their stale (or empty) BlockIDs and the next block's validOrderAndBlessed
+	// check fails in model/Block.go getParentTxMetaBlockIDs.
+	if len(existingTxHashes) > 0 {
+		sm.logger.Debugf("[createUtxos] merging blockID %d into %d pre-existing tx(s)", blockID, len(existingTxHashes))
+		if _, err = sm.utxoStore.SetMinedMulti(ctx, existingTxHashes, utxo.MinedBlockInfo{
+			BlockID:        blockID,
+			BlockHeight:    blockHeightUint32,
+			SubtreeIdx:     0,
+			OnLongestChain: true,
+		}); err != nil {
+			return errors.NewProcessingError("failed to merge blockID into %d pre-existing txs", len(existingTxHashes), err)
+		}
 	}
 
 	return nil

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -28,8 +29,10 @@ import (
 	"github.com/bsv-blockchain/teranode/services/legacy/testdata"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/nullstore"
+	utxosql "github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/expiringmap"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -786,6 +789,64 @@ func TestPreValidateTransactions_ParentContextCancelled(t *testing.T) {
 	err := sm.PreValidateTransactions(ctx, txMap, chainhash.Hash{}, 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context cancelled")
+}
+
+// TestSyncManager_createUtxos_MergesBlockIDsForExistingTxs verifies that when a tx
+// already exists in the utxo store (e.g. created by an earlier crashed attempt or by
+// the propagation path) createUtxos merges the current block's ID into the existing
+// record's BlockIDs instead of silently dropping it. Without the merge, the next
+// block's validOrderAndBlessed check fails with "has no block IDs" in
+// model/Block.go getParentTxMetaBlockIDs.
+func TestSyncManager_createUtxos_MergesBlockIDsForExistingTxs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	storeURL, err := url.Parse("sqlitememory:///test_create_utxos_merge")
+	require.NoError(t, err)
+
+	utxoStore, err := utxosql.New(ctx, logger, tSettings, storeURL)
+	require.NoError(t, err)
+
+	// Build a real, signable-shaped tx without inputs (parent placeholder).
+	tx := bt.NewTx()
+	tx.Version = 1
+	require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
+	txHash := *tx.TxIDChainHash()
+
+	// Pre-create the tx in the store WITHOUT any MinedBlockInfo. This simulates
+	// the state after a slow-path subtreeValidation run (or propagation arrival
+	// before the block) that lands the tx with empty BlockIDs.
+	_, err = utxoStore.Create(ctx, tx, 100)
+	require.NoError(t, err)
+
+	pre, err := utxoStore.Get(ctx, &txHash, fields.BlockIDs)
+	require.NoError(t, err)
+	require.Empty(t, pre.BlockIDs, "tx should start with empty BlockIDs to reproduce the bug")
+
+	// Wire up a SyncManager just enough for createUtxos. createUtxos only
+	// touches utxoStore, settings, logger and the txMap — no need for full DI.
+	sm := &SyncManager{
+		settings:  tSettings,
+		logger:    logger,
+		utxoStore: utxoStore,
+	}
+
+	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](1)
+	txMap.Set(txHash, &TxMapWrapper{Tx: tx})
+
+	block := bsvutil.NewBlock(&wire.MsgBlock{Header: wire.BlockHeader{Version: 1}})
+	block.SetHeight(100)
+
+	const expectedBlockID uint32 = 42
+	require.NoError(t, sm.createUtxos(ctx, txMap, block, expectedBlockID))
+
+	post, err := utxoStore.Get(ctx, &txHash, fields.BlockIDs)
+	require.NoError(t, err)
+	require.Contains(t, post.BlockIDs, expectedBlockID,
+		"createUtxos must merge blockID %d into the pre-existing tx", expectedBlockID)
 }
 
 func TestSyncManager_quickValidationAllowed(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes `BLOCK_INVALID (11): parent transaction X of tx Y has no block IDs` that stalled both `bsva-ovh-teranode-eu-3` (mainnet, height 302,681) and `bsva-ovh-teranode-ttn-eu-4` (testnet, height 1,512,911) within ~8 minutes of each other on 2026-05-12 after upgrade to v0.15.0-beta-10.

## Root cause

PR #711 (commit 95dbe3223) added a quickValidation fast path: legacy netsync pre-assigns a block ID, bakes it into UTXO records during `createUtxos`, and skips the async `setTxMinedStatus` step by calling `AddBlock(WithID, WithMinedSet(true))`.

The fast path relies on `createUtxos` putting the block ID into every tx's `BlockIDs` at creation time. But when `utxoStore.Create` returned `ErrTxExists` for a tx that pre-existed (propagation arrival, prior crashed attempt, or the pre-fast-path subtreeValidation route), the previous code logged at Debug and returned `nil`:

```go
if errors.Is(err, errors.ErrTxExists) {
    sm.logger.Debugf("failed to create utxo for tx %s: %s", txHash.String(), err)
} else {
    return err
}
```

The new block's ID was never merged into the existing tx's `BlockIDs`. Subsequent blocks failed `validOrderAndBlessed` in `model/Block.go:1070-1072` (`getParentTxMetaBlockIDs`) and cascaded — every descendant block marked invalid, and the `setTxMined` recovery path with `unsetMined=true` then cleared BlockIDs on txs in those invalid blocks, deepening the corruption.

Pre-v0.15 the async `setTxMinedStatus` → `SetMinedMulti` path performed this merge implicitly after block accept. The fast path short-circuited that.

## Fix

Mirror the pattern from `services/blockvalidation/quick_validate.go:1106-1161` `createAndSpendUTXOsForBatch`:

1. During the parallel `Create` pass, collect tx hashes that returned `ErrTxExists`.
2. After the errgroup waits, issue one `SetMinedMulti` to merge the new blockID into all pre-existing records.

## Reproduction timeline (eu-3, from Coralogix archive)

- `14:56:19Z` legacy on pre-upgrade version starts processing block 302680 via the slow path (`extendTransactions` → `subtreeValidation`); subtreeValidation creates txs in the utxo store with empty BlockIDs.
- `14:56:24Z` legacy errors: `SUBTREE_ERROR (29): failed to check subtree → rpc Canceled` (user-initiated upgrade restart).
- `14:56:45Z` v0.15.0-beta-10 starts.
- `14:56:55Z` legacy fast path `createUtxos` runs for block 302680. Tx `54ea96a0…` already exists in store with empty BlockIDs → `ErrTxExists` → silently dropped.
- `14:56:56Z` blockvalidation `AddBlock` stores 302680 with mined_set=true; setMinedChan worker logs "block already has mined_set true, skipping setTxMined".
- `14:56:58Z` blockvalidation processes 302681; child tx `543094cd…` has parent `54ea96a0…` (which lives in 302680's subtree); `getParentTxMetaBlockIDs` finds it in store with empty BlockIDs → `BLOCK_INVALID`. Cascade follows.

## Test plan

- [x] `go test -race ./services/legacy/netsync/...` — 50 passed, including new `TestSyncManager_createUtxos_MergesBlockIDsForExistingTxs` which pre-creates a tx in a sqlitememory utxo store with empty BlockIDs, runs `createUtxos`, and asserts the new blockID was merged in.
- [x] `go vet ./services/legacy/netsync/... ./model/...`
- [x] `golangci-lint run ./services/legacy/netsync/...`
- [x] `staticcheck ./services/legacy/netsync/...`
- [ ] Verify recovery on eu-3 / ttn-eu-4: deploy patched binary, then `reconsiderblock` on the invalid chain tip. Validation will re-execute, this time merging block IDs into the orphaned txs.

## Notes

- Both affected hosts were resetting per user direction; the fix prevents recurrence.
- Other callers of `utxoStore.Create` with `WithMinedBlockInfo` should be audited for the same `ErrTxExists` silent-drop pattern; the equivalent path in `services/blockvalidation/quick_validate.go` already handles it correctly via a Phase 1.5 batch update.