### PR TITLE
fix(subtreevalidation): replace unbounded goroutine per Kafka message with bounded shard worker pool

### DIFF
--- a/services/subtreevalidation/Server.go
+++ b/services/subtreevalidation/Server.go
@@ -108,9 +108,6 @@ type Server struct {
 
 	// invalidSubtreeKafkaProducer publishes invalid subtree events to Kafka
 	invalidSubtreeKafkaProducer kafka.KafkaAsyncProducerI
-	// invalidSubtreeProducerChannel is the dedicated producer channel used by invalidSubtreeKafkaProducer.
-	// Keeping this on the server ensures Start and Publish operate on the same channel lifecycle.
-	invalidSubtreeProducerChannel chan *kafka.Message
 
 	// invalidSubtreeLock is used to synchronize access to the invalid subtree producer
 	invalidSubtreeLock sync.Mutex
@@ -249,9 +246,7 @@ func New(
 		if err != nil {
 			logger.Errorf("Failed to create Kafka producer for invalid subtrees: %v", err)
 		} else {
-			// Start the producer with a dedicated server-owned channel so producer start/publish share one lifecycle.
-			u.invalidSubtreeProducerChannel = make(chan *kafka.Message, 100)
-			u.invalidSubtreeKafkaProducer.Start(ctx, u.invalidSubtreeProducerChannel)
+			u.invalidSubtreeKafkaProducer.Start(ctx, make(chan *kafka.Message, 100))
 		}
 	} else {
 		logger.Infof("No Kafka topic configured for invalid subtrees")

--- a/services/subtreevalidation/Server.go
+++ b/services/subtreevalidation/Server.go
@@ -108,6 +108,9 @@ type Server struct {
 
 	// invalidSubtreeKafkaProducer publishes invalid subtree events to Kafka
 	invalidSubtreeKafkaProducer kafka.KafkaAsyncProducerI
+	// invalidSubtreeProducerChannel is the dedicated producer channel used by invalidSubtreeKafkaProducer.
+	// Keeping this on the server ensures Start and Publish operate on the same channel lifecycle.
+	invalidSubtreeProducerChannel chan *kafka.Message
 
 	// invalidSubtreeLock is used to synchronize access to the invalid subtree producer
 	invalidSubtreeLock sync.Mutex
@@ -133,6 +136,12 @@ type Server struct {
 
 	// quorum manages distributed locking for subtree validation
 	quorum *Quorum
+
+	// txmeta worker pool state.
+	txmetaWorkerInitOnce sync.Once
+	txmetaWorkerCancel   context.CancelFunc
+	txmetaWorkerQueues   []chan txmetaWorkItem
+	txmetaWorkerWg       sync.WaitGroup
 }
 
 // New creates a new Server instance with the provided dependencies.
@@ -240,8 +249,9 @@ func New(
 		if err != nil {
 			logger.Errorf("Failed to create Kafka producer for invalid subtrees: %v", err)
 		} else {
-			// Start the producer with a message channel
-			go u.invalidSubtreeKafkaProducer.Start(ctx, make(chan *kafka.Message, 100))
+			// Start the producer with a dedicated server-owned channel so producer start/publish share one lifecycle.
+			u.invalidSubtreeProducerChannel = make(chan *kafka.Message, 100)
+			u.invalidSubtreeKafkaProducer.Start(ctx, u.invalidSubtreeProducerChannel)
 		}
 	} else {
 		logger.Infof("No Kafka topic configured for invalid subtrees")
@@ -552,6 +562,17 @@ func (u *Server) Stop(_ context.Context) error {
 	if u.txmetaConsumerClient != nil {
 		if err := u.txmetaConsumerClient.Close(); err != nil {
 			u.logger.Errorf("[BlockValidation] failed to close kafka consumer gracefully: %v", err)
+		}
+	}
+
+	if u.txmetaWorkerCancel != nil {
+		u.txmetaWorkerCancel()
+	}
+	u.txmetaWorkerWg.Wait()
+
+	if u.invalidSubtreeKafkaProducer != nil {
+		if err := u.invalidSubtreeKafkaProducer.Stop(); err != nil {
+			u.logger.Errorf("[BlockValidation] failed to stop invalid subtree kafka producer gracefully: %v", err)
 		}
 	}
 

--- a/services/subtreevalidation/invalid_subtree_test.go
+++ b/services/subtreevalidation/invalid_subtree_test.go
@@ -395,7 +395,7 @@ func TestPublishInvalidSubtree_EndToEndMemoryKafka(t *testing.T) {
 
 	producerCh := make(chan *kafka.Message, 100)
 	producer.Start(ctx, producerCh)
-	defer producer.Stop()
+	defer func() { require.NoError(t, producer.Stop()) }()
 
 	consumer := setupMemoryKafkaConsumer(t, "invalid-subtrees-topic")
 	defer consumer.Close()

--- a/services/subtreevalidation/invalid_subtree_test.go
+++ b/services/subtreevalidation/invalid_subtree_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -375,4 +376,62 @@ func TestPublishInvalidSubtree_DirectCall(t *testing.T) {
 
 	// verify the Kafka message key is the subtree hash
 	assert.Equal(t, []byte(subtreeHash), kafkaProducer.messages[0].Key)
+}
+
+func TestPublishInvalidSubtree_EndToEndMemoryKafka(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Kafka.InvalidSubtrees = "invalid-subtrees-topic"
+
+	invalidSubtreeURL, err := url.Parse("memory://localhost:9092/invalid-subtrees-topic")
+	require.NoError(t, err)
+	tSettings.Kafka.InvalidSubtreesConfig = invalidSubtreeURL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	producer, err := initialiseInvalidSubtreeKafkaProducer(ctx, ulogger.TestLogger{}, tSettings)
+	require.NoError(t, err)
+	require.NotNil(t, producer)
+
+	producerCh := make(chan *kafka.Message, 100)
+	producer.Start(ctx, producerCh)
+	defer producer.Stop()
+
+	consumer := setupMemoryKafkaConsumer(t, "invalid-subtrees-topic")
+	defer consumer.Close()
+
+	delivered := make(chan *kafkamessage.KafkaInvalidSubtreeTopicMessage, 1)
+	consumer.Start(ctx, func(message *kafka.KafkaMessage) error {
+		var received kafkamessage.KafkaInvalidSubtreeTopicMessage
+		if err := proto.Unmarshal(message.Value, &received); err != nil {
+			return err
+		}
+		select {
+		case delivered <- &received:
+		default:
+		}
+		return nil
+	}, kafka.WithLogErrorAndMoveOn())
+	// In-memory consumer registration is async; wait briefly so the first publish is not missed.
+	time.Sleep(50 * time.Millisecond)
+
+	server := &Server{
+		logger:                        ulogger.TestLogger{},
+		settings:                      tSettings,
+		invalidSubtreeKafkaProducer:   producer,
+		invalidSubtreeProducerChannel: producerCh,
+		invalidSubtreeDeDuplicateMap:  expiringmap.New[string, struct{}](time.Minute),
+	}
+	defer server.invalidSubtreeDeDuplicateMap.Stop()
+
+	server.publishInvalidSubtree(ctx, "subtree-hash-e2e", testPeerURL, "e2e_reason")
+
+	select {
+	case msg := <-delivered:
+		require.Equal(t, "subtree-hash-e2e", msg.SubtreeHash)
+		require.Equal(t, testPeerURL, msg.PeerUrl)
+		require.Equal(t, "e2e_reason", msg.Reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for invalid subtree kafka message")
+	}
 }

--- a/services/subtreevalidation/invalid_subtree_test.go
+++ b/services/subtreevalidation/invalid_subtree_test.go
@@ -416,11 +416,10 @@ func TestPublishInvalidSubtree_EndToEndMemoryKafka(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	server := &Server{
-		logger:                        ulogger.TestLogger{},
-		settings:                      tSettings,
-		invalidSubtreeKafkaProducer:   producer,
-		invalidSubtreeProducerChannel: producerCh,
-		invalidSubtreeDeDuplicateMap:  expiringmap.New[string, struct{}](time.Minute),
+		logger:                       ulogger.TestLogger{},
+		settings:                     tSettings,
+		invalidSubtreeKafkaProducer:  producer,
+		invalidSubtreeDeDuplicateMap: expiringmap.New[string, struct{}](time.Minute),
 	}
 	defer server.invalidSubtreeDeDuplicateMap.Stop()
 

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/util/kafka"
 )
 
@@ -17,7 +18,20 @@ const (
 	txmetaActionADD = byte(0)
 	// txmetaActionDELETE represents the DELETE action for txmeta batch messages
 	txmetaActionDELETE = byte(1)
+
+	// txmetaWorkerShardCount shards work by hash byte to preserve per-key ordering.
+	txmetaWorkerShardCount = 256
+	// txmetaWorkerQueueSize bounds in-flight work per shard to avoid unbounded goroutine growth.
+	txmetaWorkerQueueSize = 256
 )
+
+type txmetaWorkItem struct {
+	ctx        context.Context
+	hash       chainhash.Hash
+	action     byte
+	content    []byte
+	enqueuedAt time.Time
+}
 
 // txmetaMessageHandler returns a Kafka message handler for transaction metadata operations.
 //
@@ -45,68 +59,127 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 		return nil
 	}
 
-	// Process the message asynchronously to avoid blocking the Kafka consumer.
-	// Errors are logged but do not prevent message acknowledgment.
-	go func() {
-		startTime := time.Now()
+	if err := u.ensureTxmetaWorkers(ctx); err != nil {
+		return err
+	}
 
-		data := msg.Value
-		offset := 0
+	data := msg.Value
+	offset := 0
 
-		// Read entry count
-		if len(data) < 4 {
-			return
+	// Read entry count
+	entryCount := binary.LittleEndian.Uint32(data[offset:])
+	offset += 4
+
+	var hash chainhash.Hash
+
+	// Parse and dispatch each entry to a bounded shard worker queue.
+	for i := uint32(0); i < entryCount; i++ {
+		// Check minimum bytes for hash + action + length
+		if offset+32+1+4 > len(data) {
+			u.logger.Errorf("[txmetaHandler] truncated message at entry %d", i)
+			return nil
 		}
-		entryCount := binary.LittleEndian.Uint32(data[offset:])
+
+		// Read hash (32 bytes)
+		copy(hash[:], data[offset:offset+32])
+		offset += 32
+
+		// Read action (1 byte)
+		action := data[offset]
+		offset++
+
+		// Read content length (4 bytes)
+		contentLen := binary.LittleEndian.Uint32(data[offset:])
 		offset += 4
 
-		var hash chainhash.Hash
-
-		// Process each entry
-		for i := uint32(0); i < entryCount; i++ {
-			// Check minimum bytes for hash + action + length
-			if offset+32+1+4 > len(data) {
-				u.logger.Errorf("[txmetaHandler] truncated message at entry %d", i)
-				return
-			}
-
-			// Read hash (32 bytes)
-			copy(hash[:], data[offset:offset+32])
-			offset += 32
-
-			// Read action (1 byte)
-			action := data[offset]
-			offset++
-
-			// Read content length (4 bytes)
-			contentLen := binary.LittleEndian.Uint32(data[offset:])
-			offset += 4
-
-			if action == txmetaActionDELETE {
-				// Handle DELETE
-				if err := u.DelTxMetaCache(ctx, &hash); err != nil {
-					prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-					u.logger.Errorf("[txmetaHandler][%s] failed to delete tx meta data: %v", hash, err)
-				}
-				prometheusSubtreeValidationDelTXMetaCacheKafka.Observe(float64(time.Since(startTime).Microseconds()) / 1_000_000)
-			} else {
-				// Handle ADD
-				if offset+int(contentLen) > len(data) {
-					u.logger.Errorf("[txmetaHandler] truncated content at entry %d", i)
-					return
-				}
-
-				content := data[offset : offset+int(contentLen)]
-				offset += int(contentLen)
-
-				if err := u.SetTxMetaCacheFromBytes(ctx, hash[:], content); err != nil {
-					prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-					u.logger.Debugf("[txmetaHandler][%s] failed to set tx meta data: %v", hash, err)
-				}
-				prometheusSubtreeValidationSetTXMetaCacheKafka.Observe(float64(time.Since(startTime).Microseconds()) / 1_000_000)
-			}
+		if offset+int(contentLen) > len(data) {
+			u.logger.Errorf("[txmetaHandler] truncated content at entry %d", i)
+			return nil
 		}
-	}()
+
+		var content []byte
+		if action == txmetaActionADD {
+			content = make([]byte, contentLen)
+			copy(content, data[offset:offset+int(contentLen)])
+		}
+		offset += int(contentLen)
+
+		workItem := txmetaWorkItem{
+			ctx:        ctx,
+			hash:       hash,
+			action:     action,
+			content:    content,
+			enqueuedAt: time.Now(),
+		}
+		if err := u.enqueueTxmetaWorkItem(workItem); err != nil {
+			return err
+		}
+	}
 
 	return nil
+}
+
+func (u *Server) ensureTxmetaWorkers(ctx context.Context) error {
+	u.txmetaWorkerInitOnce.Do(func() {
+		workerCtx, cancel := context.WithCancel(ctx)
+		u.txmetaWorkerCancel = cancel
+
+		u.txmetaWorkerQueues = make([]chan txmetaWorkItem, txmetaWorkerShardCount)
+		for shard := 0; shard < txmetaWorkerShardCount; shard++ {
+			ch := make(chan txmetaWorkItem, txmetaWorkerQueueSize)
+			u.txmetaWorkerQueues[shard] = ch
+			u.txmetaWorkerWg.Add(1)
+			go u.runTxmetaWorker(workerCtx, ch)
+		}
+	})
+
+	if len(u.txmetaWorkerQueues) == 0 {
+		return errors.NewProcessingError("[txmetaHandler] txmeta worker queues not initialized")
+	}
+
+	return nil
+}
+
+func (u *Server) runTxmetaWorker(ctx context.Context, workQueue <-chan txmetaWorkItem) {
+	defer u.txmetaWorkerWg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case workItem := <-workQueue:
+			u.processTxmetaWorkItem(workItem)
+		}
+	}
+}
+
+func (u *Server) processTxmetaWorkItem(workItem txmetaWorkItem) {
+	switch workItem.action {
+	case txmetaActionDELETE:
+		if err := u.DelTxMetaCache(workItem.ctx, &workItem.hash); err != nil {
+			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+			u.logger.Errorf("[txmetaHandler][%s] failed to delete tx meta data: %v", workItem.hash, err)
+		}
+		prometheusSubtreeValidationDelTXMetaCacheKafka.Observe(float64(time.Since(workItem.enqueuedAt).Microseconds()) / 1_000_000)
+	case txmetaActionADD:
+		if err := u.SetTxMetaCacheFromBytes(workItem.ctx, workItem.hash[:], workItem.content); err != nil {
+			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+			u.logger.Debugf("[txmetaHandler][%s] failed to set tx meta data: %v", workItem.hash, err)
+		}
+		prometheusSubtreeValidationSetTXMetaCacheKafka.Observe(float64(time.Since(workItem.enqueuedAt).Microseconds()) / 1_000_000)
+	default:
+		prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+		u.logger.Errorf("[txmetaHandler][%s] unknown txmeta action: %d", workItem.hash, workItem.action)
+	}
+}
+
+func (u *Server) enqueueTxmetaWorkItem(workItem txmetaWorkItem) error {
+	shard := int(workItem.hash[0]) % len(u.txmetaWorkerQueues)
+
+	select {
+	case u.txmetaWorkerQueues[shard] <- workItem:
+		return nil
+	default:
+		return errors.NewProcessingError("[txmetaHandler] txmeta worker queue full for shard %d", shard)
+	}
 }

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -143,6 +143,9 @@ func (u *Server) ensureTxmetaWorkers(ctx context.Context) error {
 func (u *Server) runTxmetaWorker(ctx context.Context, workQueue <-chan txmetaWorkItem) {
 	defer u.txmetaWorkerWg.Done()
 
+	// Workers exit immediately on context cancellation without draining remaining
+	// queue items. This is intentional: in-flight txmeta updates are best-effort
+	// and the cache will be repopulated from Kafka on restart.
 	for {
 		select {
 		case <-ctx.Done():

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -240,6 +241,37 @@ func createKafkaMessage(t *testing.T, delete bool, content []byte) *kafka.KafkaM
 	}
 }
 
+func createKafkaMessageForHash(t *testing.T, hash chainhash.Hash, action byte, content []byte) *kafka.KafkaMessage {
+	t.Helper()
+
+	contentLen := uint32(len(content))
+	if action == txmetaActionDELETE {
+		contentLen = 0
+	}
+
+	dataSize := 4 + 32 + 1 + 4 + int(contentLen)
+	data := make([]byte, dataSize)
+	offset := 0
+
+	binary.LittleEndian.PutUint32(data[offset:], 1)
+	offset += 4
+
+	copy(data[offset:], hash[:])
+	offset += 32
+
+	data[offset] = action
+	offset++
+
+	binary.LittleEndian.PutUint32(data[offset:], contentLen)
+	offset += 4
+
+	if contentLen > 0 {
+		copy(data[offset:], content[:int(contentLen)])
+	}
+
+	return &kafka.KafkaMessage{Value: data}
+}
+
 func TestServer_txmetaHandler(t *testing.T) {
 	// Note: The handler processes messages asynchronously (in a goroutine) and always returns nil.
 	// Tests verify proper parsing of the binary batch format.
@@ -312,4 +344,70 @@ func TestServer_txmetaHandler(t *testing.T) {
 			mockCache.AssertExpectations(t)
 		})
 	}
+}
+
+func TestServer_txmetaHandler_PreservesPerKeyOrdering(t *testing.T) {
+	mockLogger := &mockLogger{}
+	mockCache := &mockCache{}
+
+	var (
+		operationMu sync.Mutex
+		operations  []string
+	)
+
+	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		operationMu.Lock()
+		defer operationMu.Unlock()
+		operations = append(operations, "add")
+	})
+
+	mockCache.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).Return(nil).Run(func(args mock.Arguments) {
+		operationMu.Lock()
+		defer operationMu.Unlock()
+		operations = append(operations, "delete")
+	})
+
+	server := &Server{
+		logger:    mockLogger,
+		utxoStore: mockCache,
+	}
+
+	hash := chainhash.Hash{42}
+	addMessage := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
+	deleteMessage := createKafkaMessageForHash(t, hash, txmetaActionDELETE, nil)
+
+	err := server.txmetaHandler(context.Background(), addMessage)
+	assert.NoError(t, err)
+
+	err = server.txmetaHandler(context.Background(), deleteMessage)
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		operationMu.Lock()
+		defer operationMu.Unlock()
+		return len(operations) == 2
+	}, 2*time.Second, 10*time.Millisecond)
+
+	operationMu.Lock()
+	defer operationMu.Unlock()
+	assert.Equal(t, []string{"add", "delete"}, operations)
+}
+
+func TestServer_txmetaHandler_ReturnsErrorWhenQueueFull(t *testing.T) {
+	server := &Server{
+		logger: ulogger.TestLogger{},
+	}
+
+	// Pretend workers are already initialized with a permanently full shard queue.
+	server.txmetaWorkerInitOnce.Do(func() {})
+	server.txmetaWorkerQueues = []chan txmetaWorkItem{
+		make(chan txmetaWorkItem),
+	}
+
+	hash := chainhash.Hash{0}
+	message := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
+
+	err := server.txmetaHandler(context.Background(), message)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, errors.ErrProcessing))
 }

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -273,7 +273,7 @@ func createKafkaMessageForHash(t *testing.T, hash chainhash.Hash, action byte, c
 }
 
 func TestServer_txmetaHandler(t *testing.T) {
-	// Note: The handler processes messages asynchronously (in a goroutine) and always returns nil.
+	// Note: The handler dispatches work to bounded shard workers and may return an error if a queue is full.
 	// Tests verify proper parsing of the binary batch format.
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

The txmeta Kafka handler was spawning an unbounded goroutine per message, which could exhaust memory under sustained load. This PR replaces that pattern with a **256-shard bounded worker pool** and fixes the invalid-subtree producer lifecycle.

## Changes

### txmeta handler (`txmetaHandler.go`)
- Removed the `go func()` goroutine-per-message pattern
- Introduced a 256-shard worker pool (`txmetaWorkerShardCount`) keyed by `hash[0]`, preserving **per-key ordering** while allowing parallelism across different keys
- Each shard has a fixed-size queue (`txmetaWorkerQueueSize = 256`); a full queue returns an error so the Kafka consumer can apply backpressure instead of silently dropping work
- Workers are lazily initialised once via `sync.Once` and cleanly shut down in `Stop()`

### Invalid subtree producer (`Server.go`)
- The producer channel is now server-owned (`invalidSubtreeProducerChannel`) so `Start` and `Publish` always share the same channel lifecycle
- `Stop()` now explicitly calls `invalidSubtreeKafkaProducer.Stop()` to drain inflight messages on shutdown

## Tests
- `TestServer_txmetaHandler_PreservesPerKeyOrdering` — verifies ADD then DELETE on the same key are processed in order
- `TestServer_txmetaHandler_ReturnsErrorWhenQueueFull` — verifies backpressure error is returned when shard queue is full
- `TestPublishInvalidSubtree_EndToEndMemoryKafka` — end-to-end round-trip through the in-memory Kafka broker verifying message delivery