### PR TITLE
fix(subtreevalidation): fix retry counter inflation and extract retry-wait logic

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -798,7 +798,7 @@ func (u *Server) waitForRetryOrPriority(ctx context.Context, subtreeHash string,
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.NewContextCanceledError("[ValidateSubtreeInternal][%s] context canceled while waiting to retry", subtreeHash, ctx.Err())
+			return errors.NewContextCanceledError("[ValidateSubtreeInternal][%s] context canceled while waiting to retry: %v", subtreeHash, ctx.Err())
 		case <-timer.C:
 			return nil
 		case <-ticker.C:

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -617,7 +617,9 @@ func (u *Server) ValidateSubtreeInternal(ctx context.Context, v ValidateSubtree,
 	txMetaSlice := make([]metaSliceItem, len(txHashes))
 
 	for attempt := 1; attempt <= maxRetries+1; attempt++ {
-		prometheusSubtreeValidationValidateSubtreeRetry.Inc()
+		if attempt > 1 {
+			prometheusSubtreeValidationValidateSubtreeRetry.Inc()
+		}
 
 		var logMsg string
 
@@ -641,16 +643,8 @@ func (u *Server) ValidateSubtreeInternal(ctx context.Context, v ValidateSubtree,
 		if err != nil {
 			if errors.Is(err, errors.ErrThresholdExceeded) {
 				u.logger.Warnf("[ValidateSubtreeInternal][%s] [attempt #%d] too many missing txmeta entries in cache (fail fast check only, will retry)", v.SubtreeHash.String(), attempt)
-				select {
-				case <-ctx.Done():
-					break
-				case <-time.After(retrySleepDuration):
-					break
-				case <-time.After(10 * time.Millisecond):
-					if u.isPrioritySubtreeCheckActive(v.SubtreeHash.String()) {
-						// break early - this is now a priority request. what the hell are we doing waiting around?
-						break
-					}
+				if waitErr := u.waitForRetryOrPriority(ctx, v.SubtreeHash.String(), retrySleepDuration); waitErr != nil {
+					return nil, waitErr
 				}
 
 				continue
@@ -788,6 +782,31 @@ func (u *Server) ValidateSubtreeInternal(ctx context.Context, v ValidateSubtree,
 	}
 
 	return subtree, nil
+}
+
+func (u *Server) waitForRetryOrPriority(ctx context.Context, subtreeHash string, retrySleepDuration time.Duration) error {
+	if retrySleepDuration <= 0 || u.isPrioritySubtreeCheckActive(subtreeHash) {
+		return nil
+	}
+
+	timer := time.NewTimer(retrySleepDuration)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.NewContextCanceledError("[ValidateSubtreeInternal][%s] context canceled while waiting to retry", subtreeHash, ctx.Err())
+		case <-timer.C:
+			return nil
+		case <-ticker.C:
+			if u.isPrioritySubtreeCheckActive(subtreeHash) {
+				return nil
+			}
+		}
+	}
 }
 
 func (u *Server) storeSubtreeFiles(ctx context.Context, stat *gocore.Stat, subtreeHash *chainhash.Hash, subtree *subtreepkg.Subtree, subtreeMeta *subtreepkg.Meta) error {

--- a/services/subtreevalidation/SubtreeValidation_test.go
+++ b/services/subtreevalidation/SubtreeValidation_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
@@ -38,6 +39,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/kafka" //nolint:gci
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/jarcoal/httpmock"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -298,6 +300,45 @@ func TestValidateSubtreeInternal_DuplicateTxid(t *testing.T) {
 	require.True(t, errors.Is(err, errors.ErrBlockInvalid), "expected ErrBlockInvalid, got %v", err)
 	require.Contains(t, err.Error(), "duplicate")
 	require.Contains(t, err.Error(), hash1.String())
+}
+
+func TestValidateSubtreeInternal_RetryBackoffAndMetrics(t *testing.T) {
+	InitPrometheusMetrics()
+
+	utxoStore, validatorClient, txStore, subtreeStore, blockchainClient, deferFunc := setup(t)
+	defer deferFunc()
+
+	retrySleep := 40 * time.Millisecond
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Block.FailFastValidation = true
+	tSettings.BlockValidation.ValidationWarmupCount = 0
+	tSettings.BlockValidation.ValidationMaxRetries = 2
+	tSettings.BlockValidation.RetrySleep = retrySleep
+	tSettings.BlockValidation.ValidationRetrySleep = retrySleep
+	tSettings.SubtreeValidation.ProcessTxMetaUsingCacheMissingTxThreshold = 1
+
+	nilConsumer := &kafka.KafkaConsumerGroup{}
+	subtreeValidation, err := New(context.Background(), ulogger.TestLogger{}, tSettings, subtreeStore, txStore, utxoStore, validatorClient, blockchainClient, nilConsumer, nilConsumer, nil)
+	require.NoError(t, err)
+
+	retryCounterStart := testutil.ToFloat64(prometheusSubtreeValidationValidateSubtreeRetry)
+
+	v := ValidateSubtree{
+		SubtreeHash:   *hash1,
+		BaseURL:       "not-a-url",
+		TxHashes:      []chainhash.Hash{*hash1, *hash2},
+		AllowFailFast: true,
+	}
+
+	start := time.Now()
+	_, err = subtreeValidation.ValidateSubtreeInternal(context.Background(), v, chaincfg.GenesisActivationHeight, nil)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+
+	retryCounterDelta := testutil.ToFloat64(prometheusSubtreeValidationValidateSubtreeRetry) - retryCounterStart
+	assert.Equal(t, float64(2), retryCounterDelta, "maxRetries=2 should produce exactly 2 retries (3 total attempts)")
+	assert.GreaterOrEqual(t, elapsed, 2*retrySleep, "retry loop should wait retrySleepDuration between retry attempts")
 }
 
 func TestServer_prepareTxsPerLevel(t *testing.T) {


### PR DESCRIPTION
## Summary

Two correctness fixes to `ValidateSubtreeInternal`: a metric counter that was over-counting on every validation, and a retry-wait `select` that silently swallowed context cancellation instead of propagating it.

## Changes

### Retry counter (`SubtreeValidation.go`)
- `prometheusSubtreeValidationValidateSubtreeRetry` was incremented unconditionally on `attempt=1`, inflating the metric by 1 on every successful first-attempt validation
- Counter now only increments when `attempt > 1` — i.e. on actual retries

### Retry-wait logic
- Extracted the three-case `select` into `waitForRetryOrPriority(ctx, subtreeHash, duration)`
- The old `select` used `break` inside a `case`, which exits the select but **not** the retry loop — context cancellation was silently ignored
- The new helper correctly returns a `ContextCanceledError` on `ctx.Done()`, propagating cancellation all the way up
- Priority early-exit (`isPrioritySubtreeCheckActive`) is preserved via a 10 ms polling ticker

## Tests
- `TestValidateSubtreeInternal_RetryBackoffAndMetrics` — asserts:
  - With `maxRetries=2`, the counter increments by **exactly 2** (not 3)
  - Total elapsed time is **≥ 2 × retrySleepDuration**, confirming the backoff is actually applied between retries