### PR TITLE
fix(ci): prevent zombie sticky comments on CCR timeout or race

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,13 @@ permissions:
   pull-requests: write
   id-token: write
 
+# Cancel any in-flight CCR run for the same PR when a new one starts.
+# Prevents zombie "In Progress" sticky comments when two reviews race on the same PR.
+# Fork PRs may have an empty pull_requests array on workflow_run; fall back to head_branch.
+concurrency:
+  group: claude-code-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     name: Claude Code Review
@@ -205,3 +212,31 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+
+      # If the Claude step failed (timeout, API error, runner death), any "In Progress" sticky
+      # comment it created is now a zombie. Mark it Aborted so the PR doesn't show a stuck review.
+      # Concurrency-cancelled runs are intentionally NOT covered: the queued replacement run will
+      # find the existing sticky and update it in-place, so no zombie remains in that case.
+      - name: Mark in-progress sticky comments as aborted
+        if: failure() && steps.pr.outputs.is_draft == 'false' && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          IDS=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select((.user.login == "claude[bot]" or .user.login == "github-actions[bot]") and (.body | startswith("🤖 **Claude Code Review**")) and (.body | contains("In Progress"))) | .id') || true
+          if [ -z "${IDS:-}" ]; then
+            echo "No in-progress Claude sticky comments to clean up."
+            exit 0
+          fi
+          ABORTED_BODY=$(printf '%s\n\n%s\n\n%s' \
+            '🤖 **Claude Code Review**' \
+            '**Status:** Aborted — the review workflow ended before completing.' \
+            "Re-run by pushing a new commit, or inspect the failed run: $RUN_URL")
+          for id in $IDS; do
+            echo "Marking sticky comment $id as aborted"
+            gh api --method PATCH "/repos/$REPO/issues/comments/$id" -f body="$ABORTED_BODY" || true
+          done


### PR DESCRIPTION
## Problem

On PR #845, three stale "🤖 **Claude Code Review** — In Progress" comments accumulated over multiple CCR runs. Each had only the early checkboxes ticked; none reached "Complete". Two root causes in `.github/workflows/claude-code-review.yml`:

1. **No workflow concurrency.** Overlapping CCR runs each independently ran the "find existing sticky" search at the LLM step, and within the race window neither saw the other's just-created comment — so both created new ones.
2. **No timeout cleanup.** When the Claude job hit a timeout or runtime error after creating the sticky but before marking it Complete, the "In Progress" stub stayed forever. Pure prompt-level enforcement of "exactly one sticky" can't recover from this.

## Fix

**A. Workflow-level concurrency group**
```yaml
concurrency:
  group: claude-code-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
  cancel-in-progress: true
```
Ensures only one CCR run per PR is alive at a time. The replacement run finds the existing sticky and updates it in-place, so concurrency-cancellations don't leave zombies. `head_branch` fallback covers fork PRs where `workflow_run.pull_requests` is empty.

**C. Post-step finalizer on failure**
A `failure()`-gated step that queries for any "🤖 **Claude Code Review**" comments containing "In Progress" and PATCHes them to an "Aborted" body with a link to the failed run URL. Only true failures (timeout, API error, runner death) trigger it — concurrency-cancellations are deliberately excluded because the queued replacement run handles those.

## Why not also B (pre-step ID resolution) and D (cleanup-at-start)?

A + C addresses the two observed failure modes. B and D were considered but skipped for now:
- **B** (resolve sticky ID in bash before LLM runs) reduces prompt-drift risk but adds complexity and a second source of truth for the ID. Punt unless A+C proves insufficient.
- **D** (delete duplicate stickies at start) is defensive against the same race A solves at the source. Redundant once A is in place.

## Risks

- **`head_branch` fallback collisions on fork PRs.** Two fork PRs from different forks but with the same branch name would share a concurrency group. Worst case: one run cancels an unrelated PR's review, which then retriggers on the next push. Acceptable for a first iteration; the alternative (collapsing fork PRs into the same group) is no worse than the status quo.
- **Finalizer race during concurrency cancellation.** When run A is cancelled by run B, A's post-step could in theory run while B is updating the sticky. Mitigated by gating on `failure()` only — cancellation does **not** trigger the finalizer, so this race doesn't occur in practice.
- **`gh api -f body=` multi-line handling.** `gh` converts `-f key=value` to JSON for PATCH; multi-line shell variables embed real newlines that gh serialises as `\n`. Confirmed working in similar workflows; if a future GH CLI release changes this, the worst case is an ugly-looking aborted comment, not a workflow failure (the `|| true` guards against errors).

## Verification

- `actionlint .github/workflows/claude-code-review.yml` — clean.
- YAML parses (ruby `YAML.load_file`).
- Behaviour test (manual, post-merge): trigger a CCR run, push another commit before it completes. Expect: first run cancelled, second runs to completion, exactly one sticky comment.

## Not in scope

- `.github/workflows/sonar-pr-analyze.yaml` does not post sticky comments, so it doesn't share this bug. No change needed.