### PR TITLE
Look up parent transactions in parallel instead of one at a time

### DIFF
--- a/stores/utxo/aerospike/batch_decorate_bench_test.go
+++ b/stores/utxo/aerospike/batch_decorate_bench_test.go
@@ -1,0 +1,175 @@
+package aerospike
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-batcher/v2"
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+)
+
+// This benchmark compares the current concurrent BatchPreviousOutputsDecorate
+// against the previous sequential implementation, holding everything else equal.
+//
+// It uses a real go-batcher with the production defaults
+// (OutpointBatcherSize=100 items, OutpointBatcherDurationMillis=10 ms)
+// but stubs the per-batch flush callback so we don't need a running Aerospike.
+// The callback signals every item's errCh after a configurable simulated
+// per-batch latency, modelling the Aerospike batch round-trip.
+//
+// The thing under test is therefore the interaction between
+// BatchPreviousOutputsDecorate's per-tx dispatch and the batcher's
+// size-or-timer flush rule — exactly the contention point the PR addresses.
+
+// stubbedBatcherStore builds a *Store that has only the fields needed for
+// BatchPreviousOutputsDecorate + PreviousOutputsDecorate to run. The
+// outpointBatcher uses the real batcher.NewWithPool with a fake flush fn
+// that signals each item's errCh after `simulatedLatency`.
+func stubbedBatcherStore(b testing.TB, concurrency int, simulatedLatency time.Duration) (*Store, func()) {
+	b.Helper()
+
+	tSettings := &settings.Settings{}
+	tSettings.UtxoStore.BatchPreviousOutputsDecorateConcurrency = concurrency
+	// Production defaults — see settings/settings.go:405-406.
+	const outpointBatchSize = 100
+	const outpointBatchDurationMillis = 10
+
+	s := &Store{settings: tSettings}
+
+	flush := func(items []*batchOutpoint) {
+		// Model Aerospike batch round-trip cost: fixed per-call latency,
+		// independent of batch size. This is the realistic shape — Aerospike
+		// batch reads scale sub-linearly with batch size, so the per-batch
+		// fixed cost is what dominates wall clock.
+		time.Sleep(simulatedLatency)
+		for _, item := range items {
+			item.errCh <- nil
+		}
+	}
+
+	bat := batcher.NewWithPool(
+		outpointBatchSize,
+		time.Duration(outpointBatchDurationMillis)*time.Millisecond,
+		flush,
+		true, // background dispatch — matches production
+	)
+	s.outpointBatcher = bat
+
+	cleanup := func() {
+		// Drain any in-flight items by triggering a final flush, then let
+		// the batcher's worker exit naturally on test completion.
+		bat.Trigger()
+	}
+	return s, cleanup
+}
+
+// sequentialBatchPreviousOutputsDecorate is a verbatim copy of the
+// pre-PR implementation (the sequential per-tx loop) so the benchmark
+// compares like-for-like against the current concurrent version.
+func sequentialBatchPreviousOutputsDecorate(s *Store, ctx context.Context, txs []*bt.Tx) error {
+	for _, tx := range txs {
+		if err := s.PreviousOutputsDecorate(ctx, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// makeBenchmarkTxs builds `numTxs` synthetic txs each with `inputsPerTx` inputs.
+// All inputs have nil PreviousTxScript so PreviousOutputsDecorate actually
+// submits them to the batcher (it skips already-decorated inputs).
+func makeBenchmarkTxs(b testing.TB, numTxs, inputsPerTx int) []*bt.Tx {
+	b.Helper()
+	txs := make([]*bt.Tx, numTxs)
+	for i := range txs {
+		tx := &bt.Tx{Version: 1}
+		for j := 0; j < inputsPerTx; j++ {
+			var h chainhash.Hash
+			// Distinct outpoints so the batcher can't dedupe across inputs.
+			h[0] = byte(i)
+			h[1] = byte(j)
+			h[2] = byte(i >> 8)
+			input := &bt.Input{
+				UnlockingScript:    &bscript.Script{},
+				PreviousTxOutIndex: uint32(j),
+			}
+			_ = input.PreviousTxIDAdd(&h)
+			tx.Inputs = append(tx.Inputs, input)
+		}
+		txs[i] = tx
+	}
+	return txs
+}
+
+// resetTxInputs wipes the PreviousTxScript on every input so the next
+// benchmark iteration re-submits them (PreviousOutputsDecorate skips inputs
+// that already have a script set). Without this, subsequent iterations are
+// essentially no-ops.
+//
+// In our stubbed flush the items don't actually get decorated, so the
+// PreviousTxScript stays nil and this reset is a defensive precaution rather
+// than strictly necessary.
+func resetTxInputs(txs []*bt.Tx) {
+	for _, tx := range txs {
+		for _, in := range tx.Inputs {
+			in.PreviousTxScript = nil
+		}
+	}
+}
+
+// BenchmarkBatchPreviousOutputsDecorate compares sequential vs concurrent
+// at several concurrency levels and block sizes, with a simulated Aerospike
+// per-batch latency of 500 µs (typical for an in-region batch read).
+//
+// Block shape: 1000 txs × 3 inputs/tx = 3000 inputs. Average mainnet shape
+// at the time of writing.
+func BenchmarkBatchPreviousOutputsDecorate(b *testing.B) {
+	const simLatency = 500 * time.Microsecond
+	const numTxs = 1000
+	const inputsPerTx = 3
+	ctx := context.Background()
+
+	for _, mode := range []string{"sequential", "concurrent_1", "concurrent_4", "concurrent_16", "concurrent_64"} {
+		mode := mode
+		b.Run(mode, func(b *testing.B) {
+			var (
+				concurrency int
+				runFn       func(s *Store, txs []*bt.Tx) error
+			)
+
+			switch mode {
+			case "sequential":
+				concurrency = 1
+				runFn = func(s *Store, txs []*bt.Tx) error {
+					return sequentialBatchPreviousOutputsDecorate(s, ctx, txs)
+				}
+			default:
+				_, err := fmt.Sscanf(mode, "concurrent_%d", &concurrency)
+				if err != nil {
+					b.Fatalf("parse concurrency: %v", err)
+				}
+				runFn = func(s *Store, txs []*bt.Tx) error {
+					return s.BatchPreviousOutputsDecorate(ctx, txs)
+				}
+			}
+
+			s, cleanup := stubbedBatcherStore(b, concurrency, simLatency)
+			defer cleanup()
+
+			txs := makeBenchmarkTxs(b, numTxs, inputsPerTx)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetTxInputs(txs)
+				if err := runFn(s, txs); err != nil {
+					b.Fatalf("decorate: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -80,6 +80,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	"github.com/ordishs/gocore"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -1188,15 +1189,39 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 }
 
 // BatchPreviousOutputsDecorate fetches previous output information for inputs across
-// multiple transactions. The Aerospike implementation delegates to per-tx PreviousOutputsDecorate
-// which already uses an internal batcher for efficiency.
+// multiple transactions. The Aerospike implementation delegates to per-tx
+// PreviousOutputsDecorate, which puts each input into the shared outpointBatcher and
+// then waits for its own inputs' results. Calling PreviousOutputsDecorate concurrently
+// for each tx lets the outpointBatcher coalesce inputs across transactions into
+// larger Aerospike batch reads, which is critical on large blocks — a sequential
+// per-tx loop would lose that cross-tx batching and regress throughput.
+//
+// Concurrency is bounded by UtxoStore.BatchPreviousOutputsDecorateConcurrency (the
+// same knob used by the SQL store). The default of 4 is conservative: each
+// goroutine submits one tx's worth of inputs into the shared outpointBatcher and
+// blocks on result channels, so a small fan-out is enough to keep the batcher
+// saturated without spawning thousands of goroutines on large blocks.
 func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) error {
-	for _, tx := range txs {
-		if err := s.PreviousOutputsDecorate(ctx, tx); err != nil {
-			return err
-		}
+	if len(txs) == 0 {
+		return nil
 	}
-	return nil
+
+	concurrency := s.settings.UtxoStore.BatchPreviousOutputsDecorateConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	util.SafeSetLimit(g, concurrency)
+
+	for _, tx := range txs {
+		tx := tx
+		g.Go(func() error {
+			return s.PreviousOutputsDecorate(gCtx, tx)
+		})
+	}
+
+	return g.Wait()
 }
 
 func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {


### PR DESCRIPTION
## What this changes

When a block arrives, we need to look up the parent transaction outputs (amount + locking script) for every input in every transaction. Today we do this one transaction at a time. This PR does several transactions in parallel.

## How it works today

Aerospike has a batcher in front of it. Instead of firing one call per input, the batcher collects inputs and sends them off in a single batch when either:

- it has collected 100 inputs (size cap), or
- 10 ms have passed since the first input arrived (timer cap).

Good design — but the old code fed the batcher one transaction at a time:

> submit tx1's 3 inputs → wait for results → submit tx2's 3 inputs → wait → …

A typical tx only has 2 or 3 inputs, nowhere near the 100-input size cap. So the batcher always fell back to the **10 ms timer** before flushing. Every transaction paid that 10 ms wait. On a 1000-tx block that's about 10 seconds of pure timer waiting, even if Aerospike itself is fast.

## The fix

Dispatch each transaction in its own goroutine, bounded by `UtxoStore.BatchPreviousOutputsDecorateConcurrency` (the same knob the SQL store already uses, default **4**). Now several transactions feed inputs into the shared batcher at the same time, so:

- each flush carries inputs from multiple txs instead of just one
- the 10 ms timer wait gets shared across many txs instead of paid once per tx
- if you raise the concurrency high enough, the batcher hits its 100-input size cap and flushes immediately — no timer wait at all

The default of 4 is intentionally cautious. Each goroutine is mostly blocked waiting for batcher results, so a small fan-out is enough to keep the batcher busy. Operators can dial it up.

## Benchmark — proof it's actually faster

`stores/utxo/aerospike/batch_decorate_bench_test.go` drives the real `BatchPreviousOutputsDecorate` against the real `go-batcher` with production-default settings (100 items / 10 ms timer). The only thing faked is the Aerospike call itself — replaced with a 500 µs sleep that models a real Aerospike round-trip.

1000-tx × 3-input block, Apple M3 Max:

| Mode | Time per block | Speedup |
|---|---|---|
| Sequential (today's code) | 10.68 s | 1.00× — baseline |
| Concurrent, cap=1 | 10.72 s | 1.00× — **same as sequential, sanity check** |
| **Concurrent, cap=4** (PR default) | **2.68 s** | **3.99×** |
| Concurrent, cap=16 | 0.68 s | 15.8× |
| Concurrent, cap=64 | 0.019 s | ~570× |

Two things to take from this:

1. **Cap=1 behaves exactly like the old code.** That's the zero-risk fallback — if anyone hits trouble, setting `utxostore_batchPreviousOutputsDecorateConcurrency=1` restores the old behaviour.
2. **At the default cap=4, blocks decorate about 4× faster.** That's the timer-sharing effect exactly as the maths predicts.

## Why is the default only 4 if cap=64 is 570× faster?

Two reasons:

- **Matches the existing SQL store knob.** SQL store uses the same setting at default 4, so operators only have one number to think about.
- **Cautious.** An earlier version of this change (in #723) used `OutpointBatcherSize=1024` as the concurrency cap, which triggered a known legacy-sync OOM. Default 4 has no memory risk; operators with headroom can raise it.

## Tests

- `go build ./...` clean
- `go vet ./stores/utxo/aerospike/...` clean
- `go test -race -short ./stores/utxo/aerospike/` — 464 passed
- New benchmark above

## How this relates to #865

Both PRs attack the same 10 ms timer problem, at different layers:

- **#865**: tells the batcher to flush immediately instead of waiting for the timer (one setting, opt-in).
- **This PR**: parallelises transaction dispatch above the batcher, so the batcher fills up faster.

They compose. Drain mode plus concurrent dispatch is faster than either alone.

## Context

Originally bundled in #723. Pulled out as a focused PR after #723's core change (broadening `quickValidationMode` to `CATCHINGBLOCKS`) was superseded by #847.