### PR TITLE
fix(docker): repair healthcheck shell syntax and enable zombie reaping

### DIFF
--- a/deploy/docker/base/docker-teranode.yml
+++ b/deploy/docker/base/docker-teranode.yml
@@ -1,6 +1,7 @@
 x-teranode-base:
   &teranode-base
   image: ghcr.io/bsv-blockchain/teranode:v0.14.4
+  init: true
   networks:
     - teranode-network
   volumes:
@@ -21,7 +22,7 @@ services:
     entrypoint: [ "/app/entrypoint.sh" ]
     command: [ "-blockchain=1" ]
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8087" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8087" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -39,7 +40,7 @@ services:
       blockchain:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8091" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8091" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -68,7 +69,7 @@ services:
       blockchain:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8086" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8086" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -85,7 +86,7 @@ services:
       blockchain:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8088" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8088" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -101,7 +102,7 @@ services:
       blockchain:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8085" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8085" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -135,7 +136,7 @@ services:
       blockassembly:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8084" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8084" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -153,7 +154,7 @@ services:
       blockchain:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "9905" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 9905" ]
       interval: 5s
       timeout: 30s
       retries: 10
@@ -181,7 +182,7 @@ services:
       blockchain:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "netstat", "-ltn", "|", "grep", "-c", "8096" ]
+      test: [ "CMD-SHELL", "netstat -ltn | grep -c 8096" ]
       interval: 5s
       timeout: 30s
       retries: 10


### PR DESCRIPTION
The CMD-SHELL form expects a single command string; passing it as a multi-element array makes Docker run `sh -c "netstat" -ltn "|" grep -c <port>`, which executes `netstat` with no arguments and discards the rest as ignored positional params. Under load the resulting full socket dump exceeds the 30s timeout, the healthcheck is SIGKILLed, and the orphaned `netstat` is reparented to teranode.run (PID 1 in the container). Because teranode.run doesn't reap children, every failed probe leaks a `<defunct>` netstat, which accumulates without bound.

Fix both layers:

- collapse each `test:` to single-string form so the pipeline actually runs
- set `init: true` on the shared anchor so Docker injects tini as PID 1 and reaps any orphaned children defensively