### PR TITLE
fix(propagation): correct HTTP status mapping for missing-parent and duplicate-tx

### DIFF
--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -611,7 +611,11 @@ func (ps *PropagationServer) handleSingleTx(_ context.Context) echo.HandlerFunc 
 		// Process the transaction and return appropriate response
 		err = ps.processTransaction(ctx, &propagation_api.ProcessTransactionRequest{Tx: body})
 		if err != nil {
-			return c.String(httpStatusForTxError(err), "Failed to process transaction: "+errors.UserMessage(err))
+			status := httpStatusForTxError(err)
+			if status >= 200 && status < 300 {
+				return c.String(status, "OK")
+			}
+			return c.String(status, "Failed to process transaction: "+errors.UserMessage(err))
 		}
 
 		return c.String(http.StatusOK, "OK")

--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -624,6 +624,11 @@ func (ps *PropagationServer) handleSingleTx(_ context.Context) echo.HandlerFunc 
 // classified by their actual cause.
 func httpStatusForTxError(err error) int {
 	switch {
+	case errors.Is(err, errors.ErrTxExists):
+		// Duplicate submission of a tx Teranode has already accepted. The
+		// resource is already in the desired state — surface as success so
+		// clients don't treat idempotent resubmits as failures.
+		return http.StatusOK
 	case errors.Is(err, errors.ErrFrozen):
 		return http.StatusForbidden
 	case errors.Is(err, errors.ErrTxInvalidDoubleSpend),
@@ -631,6 +636,8 @@ func httpStatusForTxError(err error) int {
 		errors.Is(err, errors.ErrSpent),
 		errors.Is(err, errors.ErrTxLocked):
 		return http.StatusConflict
+	case errors.Is(err, errors.ErrTxMissingParent):
+		return http.StatusUnprocessableEntity
 	case errors.Is(err, errors.ErrInvalidArgument),
 		errors.Is(err, errors.ErrTxInvalid),
 		errors.Is(err, errors.ErrTxLockTime),

--- a/services/propagation/http_handlers_test.go
+++ b/services/propagation/http_handlers_test.go
@@ -310,7 +310,7 @@ func TestHandleSingleTx(t *testing.T) {
 			name:                "Tx already exists",
 			requestBody:         txBytes,
 			expectedStatusCode:  http.StatusOK,
-			expectedResponse:    "Failed to process transaction",
+			expectedResponse:    "OK",
 			mockValidationError: errors.NewTxExistsError("duplicate submission"),
 		},
 		{

--- a/services/propagation/http_handlers_test.go
+++ b/services/propagation/http_handlers_test.go
@@ -293,6 +293,27 @@ func TestHandleSingleTx(t *testing.T) {
 			mockValidationError: errors.NewProcessingError("validator wrap", errors.NewTxInvalidError("inner reason")),
 		},
 		{
+			name:                "Missing parent tx",
+			requestBody:         txBytes,
+			expectedStatusCode:  http.StatusUnprocessableEntity,
+			expectedResponse:    "Failed to process transaction",
+			mockValidationError: errors.NewTxMissingParentError("parent not in utxo store"),
+		},
+		{
+			name:                "Wrapped missing parent through processing error",
+			requestBody:         txBytes,
+			expectedStatusCode:  http.StatusUnprocessableEntity,
+			expectedResponse:    "Failed to process transaction",
+			mockValidationError: errors.NewProcessingError("validator wrap", errors.NewTxMissingParentError("inner missing parent")),
+		},
+		{
+			name:                "Tx already exists",
+			requestBody:         txBytes,
+			expectedStatusCode:  http.StatusOK,
+			expectedResponse:    "Failed to process transaction",
+			mockValidationError: errors.NewTxExistsError("duplicate submission"),
+		},
+		{
 			name:               "Store error",
 			requestBody:        txBytes,
 			expectedStatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
## Summary

Audit of `httpStatusForTxError` in `services/propagation/Server.go`. Two transaction-related errors were falling through to the default 500 case, conflating validation conditions with infrastructure failures and causing downstream consumers (e.g., Arcade) to retry txs that should be terminal or accepted.

- `ErrTxMissingParent` → **422 Unprocessable Entity**. The tx is structurally valid but its parent isn't in the UTXO store yet. A client-actionable validation-time condition, distinct from 400 (malformed) and 409 (conflict).
- `ErrTxExists` → **200 OK**. Fires when the UTXO store reports the txid is already committed. Semantically the resource is already in the desired state, so this is idempotent success, not a conflict. The "creation in progress" edge case at [aerospike/create.go#L1078](https://github.com/bsv-blockchain/teranode/blob/main/stores/utxo/aerospike/create.go#L1078) is handled by the validator's `CreateInUtxoStore` path before it reaches the HTTP boundary.

Other errors deliberately left at 500 because they indicate genuine infra / data-integrity failures: `ErrUtxoHashMismatch`, `ErrUtxoError`, `ErrStorageError`, `ErrServiceError`, generic `ErrProcessing`, `ErrTxNotFound` (translated upstream to `ErrTxMissingParent`).

## Test plan

- [x] `go test -count=1 ./services/propagation/...` — pass
- [x] `go vet ./services/propagation/...` — clean
- [x] `golangci-lint run ./services/propagation/...` — 0 issues
- [x] Added table cases in `TestHandleSingleTx` for both new mappings, including a `NewProcessingError` wrapper case to verify error-chain walking