### PR TITLE
fix(blockchain): root-cause fix for block-assembly stall after silent subscription drift (refs #872)

### DIFF
--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -99,6 +99,7 @@ func NewClient(ctx context.Context, logger ulogger.Logger, tSettings *settings.S
 
 // NewClientWithAddress creates a new blockchain client with a specified address.
 func NewClientWithAddress(ctx context.Context, logger ulogger.Logger, tSettings *settings.Settings, address string, source string) (ClientI, error) {
+	initPrometheusMetrics()
 	var err error
 
 	var baConn *grpc.ClientConn
@@ -1329,7 +1330,7 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 			watchdogDone := make(chan struct{})
 			go func() {
 				defer close(watchdogDone)
-				ticker := time.NewTicker(zombieTimeout / 2)
+				ticker := time.NewTicker(zombieTimeout / 4)
 				defer ticker.Stop()
 				for {
 					select {
@@ -1339,6 +1340,7 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 						age := time.Since(time.Unix(0, lastRecvAt.Load()))
 						if age > zombieTimeout {
 							c.logger.Warnf("[Blockchain][SubscribeToServer] watchdog: no Recv for %s on source %s — forcing stream close", age, source)
+							prometheusBlockchainWatchdogFires.WithLabelValues(source).Inc()
 							cancelStream()
 							return
 						}

--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -1272,8 +1272,9 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 
 		// zombieTimeout is 2× the heartbeat interval. If no Recv returns within
 		// this window the watchdog cancels the stream context, forcing Recv to
-		// error and the reconnect path to fire. The watchdog ticks at half the
-		// timeout so the worst-case detection latency is zombieTimeout + 1 tick.
+		// error and the reconnect path to fire. The watchdog ticks at a quarter
+		// of the timeout so worst-case detection latency is ~1.25× zombieTimeout
+		// (zombieTimeout + one tick at zombieTimeout/4).
 		zombieTimeout := 2 * c.settings.BlockChain.HeartbeatInterval
 
 		for c.running.Load() {

--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -1269,13 +1269,25 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 			close(done)
 		}()
 
+		// zombieTimeout is 2× the heartbeat interval. If no Recv returns within
+		// this window the watchdog cancels the stream context, forcing Recv to
+		// error and the reconnect path to fire. The watchdog ticks at half the
+		// timeout so the worst-case detection latency is zombieTimeout + 1 tick.
+		zombieTimeout := 2 * c.settings.BlockChain.HeartbeatInterval
+
 		for c.running.Load() {
 			c.logger.Infof("[Blockchain] Subscribing to blockchain service: %s", source)
 
-			stream, err := c.client.Subscribe(ctx, &blockchain_api.SubscribeRequest{
+			// Per-stream cancellable context. The zombie watchdog cancels it when
+			// no Recv returns for zombieTimeout. Recv then returns context.Canceled
+			// and the outer reconnect loop handles it.
+			streamCtx, cancelStream := context.WithCancel(ctx)
+
+			stream, err := c.client.Subscribe(streamCtx, &blockchain_api.SubscribeRequest{
 				Source: source,
 			})
 			if err != nil {
+				cancelStream()
 				if !c.running.Load() {
 					return
 				}
@@ -1305,9 +1317,47 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 			// This ensures staleness detection works correctly: if connection breaks before
 			// first PING, lastHB will be 0 and we'll properly set FSM to IDLE.
 
+			// lastRecvAt tracks when Recv last returned. Initialised to now so a
+			// stream that never delivers anything is given the full zombieTimeout
+			// grace period before the watchdog fires.
+			var lastRecvAt atomic.Int64
+			lastRecvAt.Store(time.Now().UnixNano())
+
+			// Zombie watchdog: fires cancelStream if no Recv returns within
+			// zombieTimeout. Exits when the stream context is done (normal error
+			// path, normal shutdown, or the watchdog itself cancelling).
+			watchdogDone := make(chan struct{})
+			go func() {
+				defer close(watchdogDone)
+				ticker := time.NewTicker(zombieTimeout / 2)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-streamCtx.Done():
+						return
+					case <-ticker.C:
+						age := time.Since(time.Unix(0, lastRecvAt.Load()))
+						if age > zombieTimeout {
+							c.logger.Warnf("[Blockchain][SubscribeToServer] watchdog: no Recv for %s on source %s — forcing stream close", age, source)
+							cancelStream()
+							return
+						}
+					}
+				}
+			}()
+
+			// shutdown tears down the per-stream watchdog before returning.
+			// Must be called on every exit from the inner recv loop.
+			shutdown := func() {
+				cancelStream()
+				<-watchdogDone
+			}
+
+			reconnect := false
 			for c.running.Load() {
 				resp, err := stream.Recv()
 				if err != nil {
+					shutdown()
 					if !c.running.Load() || ctx.Err() != nil {
 						// Context cancelled or client stopped, exit gracefully
 						return
@@ -1335,8 +1385,11 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 
 					c.logger.Infof("[Blockchain] retrying subscription in 1 second")
 					time.Sleep(1 * time.Second)
+					reconnect = true
 					break
 				}
+
+				lastRecvAt.Store(time.Now().UnixNano())
 
 				if resp.Type == model.NotificationType_PING {
 					// Update heartbeat immediately on receipt to avoid staleness races.
@@ -1356,6 +1409,7 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 					case <-time.After(5 * time.Second):
 						c.logger.Warnf("[Blockchain] timeout sending notification for %s, channel may be blocked", source)
 					case <-ctx.Done():
+						shutdown()
 						return
 					}
 
@@ -1382,8 +1436,14 @@ func (c *Client) SubscribeToServer(ctx context.Context, source string) (chan *bl
 				case <-time.After(5 * time.Second):
 					c.logger.Warnf("[Blockchain] timeout sending notification for %s, channel may be blocked", source)
 				case <-ctx.Done():
+					shutdown()
 					return
 				}
+			}
+			if !reconnect {
+				// Inner loop exited because c.running became false. Tear down the
+				// watchdog before the outer loop re-evaluates c.running.Load().
+				shutdown()
 			}
 		}
 	}()

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -62,10 +62,21 @@ import (
 //
 // This struct enables the publish-subscribe pattern where multiple services can
 // receive real-time updates about blockchain state changes without polling.
+// subscriberBufferSize is the cap of each subscriber's pending-notification
+// channel. When this fills, the subscriber is too slow to keep up and is
+// evicted via deadSubscriptions to prevent backpressure on the broadcast loop.
+//
+// At normal block cadence (~1 notification per block) plus ~6 heartbeats/min,
+// 64 messages is roughly 9 minutes of buffer before eviction — short enough
+// that operators see the disconnect promptly, long enough to tolerate brief
+// consumer lag during reorgs.
+const subscriberBufferSize = 64
+
 type subscriber struct {
 	subscription blockchain_api.BlockchainAPI_SubscribeServer // The gRPC subscription server
 	source       string                                       // Source identifier of the subscription
 	done         chan struct{}                                // Channel to signal when subscription is done
+	pending      chan *blockchain_api.Notification            // Per-subscriber delivery buffer (issue #872)
 }
 
 // Blockchain represents the main blockchain service structure.
@@ -681,15 +692,16 @@ func (b *Blockchain) startSubscriptions() {
 				b.logger.Debugf("[Blockchain Server] Sending notification: %s", notification)
 
 				b.subscribersMu.RLock()
-				// Collect dead subscribers to remove after releasing the read lock
+				// Non-blocking fan-out: push to each subscriber's pending buffer.
+				// One slow subscriber can no longer block delivery to the others
+				// (issue #872). Subscribers whose buffers are full are evicted as
+				// dead — that bounds how long a stuck consumer applies backpressure.
 				var dead []subscriber
 				for sub := range b.subscribers {
-					b.logger.Debugf("[Blockchain][startSubscriptions] Sending notification to %s: %s", sub.source, notification.Stringify())
-
-					// Send synchronously — NOT in a goroutine. Concurrent Send() calls
-					// on the same gRPC ServerStream corrupt the stream, causing the
-					// subscriber to be silently dropped and never receive notifications.
-					if err := sub.subscription.Send(notification); err != nil {
+					select {
+					case sub.pending <- notification:
+					default:
+						b.logger.Warnf("[Blockchain][startSubscriptions] Subscriber %s pending buffer full (cap=%d), marking dead", sub.source, subscriberBufferSize)
 						dead = append(dead, sub)
 					}
 				}
@@ -697,33 +709,100 @@ func (b *Blockchain) startSubscriptions() {
 
 				// Queue dead subscribers for removal
 				for _, s := range dead {
-					b.deadSubscriptions <- s
+					select {
+					case b.deadSubscriptions <- s:
+					case <-b.AppCtx.Done():
+						return
+					}
 				}
 			}()
 			b.stats.NewStat("channel-subscription.Send", true).AddTime(start)
 
 		case s := <-b.newSubscriptions:
-			// Send initial notification BEFORE adding to the subscribers map.
-			// This prevents concurrent Send() between sendInitialNotification
-			// and the notification delivery loop above.
-			b.sendInitialNotification(s)
-
+			// Add to map and start drain goroutine first so the subscriber is
+			// ready to receive before we enqueue the initial notification. This
+			// keeps the newSubscriptions case non-blocking: sendInitialNotification
+			// now enqueues into s.pending (non-blocking) rather than calling
+			// sub.subscription.Send directly, so a slow stream cannot stall here.
 			b.subscribersMu.Lock()
 			b.subscribers[s] = true
 			b.subscribersMu.Unlock()
 
+			// One drain goroutine per subscriber owns Send on that stream.
+			// Concurrent Send() on a single gRPC ServerStream is unsafe; the
+			// per-subscriber goroutine preserves the no-concurrent-Send invariant
+			// while letting a slow Send block only its own stream.
+			go b.runSubscriberDrain(s)
+
+			// Enqueue the initial chain-tip notification so it arrives ahead of
+			// any subsequent broadcast. Goes through pending so the broadcast loop
+			// is never blocked on initial delivery.
+			b.sendInitialNotification(s)
+
 		case s := <-b.deadSubscriptions:
 			b.subscribersMu.Lock()
-			delete(b.subscribers, s)
+			_, existed := b.subscribers[s]
+			if existed {
+				delete(b.subscribers, s)
+			}
 			remaining := len(b.subscribers)
 			b.subscribersMu.Unlock()
+			if existed && s.pending != nil {
+				// Close pending only on the first dead notice for this subscriber.
+				// A second dead push (e.g. the drain goroutine reporting a Send
+				// error after the broadcast loop has already marked the sub dead
+				// via buffer-full) would panic on a double-close. The map check
+				// above guards that.
+				close(s.pending)
+			}
 			safeClose(s.done)
 			b.logger.Infof("[Blockchain][startSubscriptions] Subscription removed (Total=%d).", remaining)
 		}
 	}
 }
 
-// sendInitialNotification sends the current chain tip (or genesis) to a new subscriber.
+// runSubscriberDrain pulls notifications from the subscriber's pending buffer
+// and calls Send on its gRPC stream. One goroutine per subscriber preserves
+// the gRPC no-concurrent-Send invariant on each stream while isolating slow
+// consumers — Send blocking here parks only this goroutine, not the broadcast
+// loop in startSubscriptions.
+//
+// Exits when:
+//   - pending is closed (cleanup path in startSubscriptions)
+//   - Send returns an error (stream broken or context cancelled)
+//   - AppCtx is cancelled (service shutdown)
+//
+// On Send error the goroutine pushes itself onto deadSubscriptions so cleanup
+// is triggered. A second dead-push for the same subscriber (when the broadcast
+// loop already evicted it via buffer-full) is benign — the cleanup path's map
+// check makes the second handler a no-op.
+func (b *Blockchain) runSubscriberDrain(s subscriber) {
+	for {
+		select {
+		case <-b.AppCtx.Done():
+			return
+		case <-s.done:
+			return
+		case n, ok := <-s.pending:
+			if !ok {
+				return
+			}
+			if err := s.subscription.Send(n); err != nil {
+				b.logger.Warnf("[Blockchain][runSubscriberDrain] Send to %s failed: %v", s.source, err)
+				select {
+				case b.deadSubscriptions <- s:
+				case <-b.AppCtx.Done():
+				}
+				return
+			}
+		}
+	}
+}
+
+// sendInitialNotification enqueues the current chain tip (or genesis) into the
+// subscriber's pending buffer. The drain goroutine delivers it via Send.
+// Non-blocking: if the buffer is full the subscriber is already overloaded and
+// will be evicted shortly; dropping the initial notification is acceptable.
 func (b *Blockchain) sendInitialNotification(sub subscriber) {
 	chainTip, _, err := b.store.GetBestBlockHeader(context.Background())
 	var initialNotification *blockchain_api.Notification
@@ -741,9 +820,10 @@ func (b *Blockchain) sendInitialNotification(sub subscriber) {
 	}
 
 	b.logger.Infof("[Blockchain][startSubscriptions] Sending initial notification to %s", sub.source)
-	if err := sub.subscription.Send(initialNotification); err != nil {
-		b.logger.Errorf("[Blockchain][startSubscriptions] Failed to send initial notification to %s: %v", sub.source, err)
-		b.deadSubscriptions <- sub
+	select {
+	case sub.pending <- initialNotification:
+	default:
+		b.logger.Warnf("[Blockchain][startSubscriptions] Pending buffer full on initial notification for %s, dropping", sub.source)
 	}
 }
 
@@ -1789,14 +1869,15 @@ func (b *Blockchain) Subscribe(req *blockchain_api.SubscribeRequest, sub blockch
 	defer deferFn()
 
 	// Keep this subscription alive without endless loop - use a channel that blocks forever.
-	ch := make(chan struct{})
+	s := subscriber{
+		subscription: sub,
+		done:         make(chan struct{}),
+		source:       req.Source,
+		pending:      make(chan *blockchain_api.Notification, subscriberBufferSize),
+	}
 
 	b.logger.Infof("[Blockchain] Sending new subscription to handler for source: %s", req.Source)
-	b.newSubscriptions <- subscriber{
-		subscription: sub,
-		done:         ch,
-		source:       req.Source,
-	}
+	b.newSubscriptions <- s
 
 	b.subscribersMu.RLock()
 	noOfSubscribers := len(b.subscribers)
@@ -1806,20 +1887,18 @@ func (b *Blockchain) Subscribe(req *blockchain_api.SubscribeRequest, sub blockch
 	for {
 		select {
 		case <-ctx.Done():
-			// Client disconnected - clean up subscriber from map
+			// Client disconnected - clean up subscriber from map.
+			// Must pass the same subscriber value (including pending) so the map
+			// key matches the entry added in the newSubscriptions case.
 			b.logger.Infof("[Blockchain] GRPC client disconnected: %s", req.Source)
 			select {
-			case b.deadSubscriptions <- subscriber{
-				subscription: sub,
-				done:         ch,
-				source:       req.Source,
-			}:
+			case b.deadSubscriptions <- s:
 			case <-b.AppCtx.Done():
 				// Server is shutting down, startSubscriptions already cleaned up
 			}
 			return nil
-		case <-ch:
-			// Subscription ended.
+		case <-s.done:
+			// Subscription ended (drained and cleaned up by startSubscriptions).
 			return nil
 		}
 	}

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -167,12 +167,16 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 	}
 
 	b := &Blockchain{
-		store:                         store,
-		logger:                        logger,
-		settings:                      tSettings,
-		addBlockChan:                  make(chan *blockchain_api.AddBlockRequest, 10),
-		newSubscriptions:              make(chan subscriber, 10),
-		deadSubscriptions:             make(chan subscriber, 10),
+		store:            store,
+		logger:           logger,
+		settings:         tSettings,
+		addBlockChan:     make(chan *blockchain_api.AddBlockRequest, 10),
+		newSubscriptions: make(chan subscriber, 10),
+		// deadSubscriptions buffered large enough to absorb a connection-pool
+		// burst where many subscribers fail Send simultaneously. The original
+		// cap (10) made the dead-push from drain goroutines a potential
+		// bottleneck during the kind of 18-EOF burst observed in issue #872.
+		deadSubscriptions:             make(chan subscriber, 1000),
 		subscribers:                   make(map[subscriber]bool),
 		notifications:                 make(chan *blockchain_api.Notification, 100),
 		newBlock:                      make(chan struct{}, 10),
@@ -702,6 +706,7 @@ func (b *Blockchain) startSubscriptions() {
 					case sub.pending <- notification:
 					default:
 						b.logger.Warnf("[Blockchain][startSubscriptions] Subscriber %s pending buffer full (cap=%d), marking dead", sub.source, subscriberBufferSize)
+						prometheusBlockchainSubscriberPendingFull.WithLabelValues(sub.source).Inc()
 						dead = append(dead, sub)
 					}
 				}
@@ -761,6 +766,14 @@ func (b *Blockchain) startSubscriptions() {
 	}
 }
 
+// sendDeadline is the maximum time a single Send call is allowed before the
+// subscriber is evicted. gRPC ServerStream.Send has no context parameter, so
+// the deadline is enforced by racing the Send against a timer in a helper
+// goroutine. When the deadline fires, the drain goroutine exits immediately;
+// the helper goroutine continues until Send eventually returns, then discards
+// the result — this residual goroutine is bounded to one per stuck stream.
+const sendDeadline = 5 * time.Second
+
 // runSubscriberDrain pulls notifications from the subscriber's pending buffer
 // and calls Send on its gRPC stream. One goroutine per subscriber preserves
 // the gRPC no-concurrent-Send invariant on each stream while isolating slow
@@ -770,12 +783,13 @@ func (b *Blockchain) startSubscriptions() {
 // Exits when:
 //   - pending is closed (cleanup path in startSubscriptions)
 //   - Send returns an error (stream broken or context cancelled)
+//   - Send exceeds sendDeadline (subscriber evicted to bound goroutine lifetime)
 //   - AppCtx is cancelled (service shutdown)
 //
-// On Send error the goroutine pushes itself onto deadSubscriptions so cleanup
-// is triggered. A second dead-push for the same subscriber (when the broadcast
-// loop already evicted it via buffer-full) is benign — the cleanup path's map
-// check makes the second handler a no-op.
+// On Send error or deadline the goroutine pushes itself onto deadSubscriptions
+// so cleanup is triggered. A second dead-push for the same subscriber (when
+// the broadcast loop already evicted it via buffer-full) is benign — the
+// cleanup path's map check makes the second handler a no-op.
 func (b *Blockchain) runSubscriberDrain(s subscriber) {
 	for {
 		select {
@@ -787,12 +801,36 @@ func (b *Blockchain) runSubscriberDrain(s subscriber) {
 			if !ok {
 				return
 			}
-			if err := s.subscription.Send(n); err != nil {
-				b.logger.Warnf("[Blockchain][runSubscriberDrain] Send to %s failed: %v", s.source, err)
+			// Race Send against a deadline. gRPC ServerStream.Send does not
+			// accept a context, so we use a helper goroutine. If the deadline
+			// fires first, we evict the subscriber and return. The helper
+			// goroutine is a residual leak bounded to one per stuck stream; it
+			// exits once Send eventually returns (error or success).
+			sendErr := make(chan error, 1)
+			go func() { sendErr <- s.subscription.Send(n) }()
+
+			select {
+			case err := <-sendErr:
+				if err != nil {
+					b.logger.Warnf("[Blockchain][runSubscriberDrain] Send to %s failed: %v", s.source, err)
+					prometheusBlockchainSubscriberSendErrors.WithLabelValues(s.source).Inc()
+					select {
+					case b.deadSubscriptions <- s:
+					case <-b.AppCtx.Done():
+					}
+					return
+				}
+			case <-time.After(sendDeadline):
+				b.logger.Warnf("[Blockchain][runSubscriberDrain] Send to %s exceeded %s deadline, evicting", s.source, sendDeadline)
+				prometheusBlockchainSubscriberSendErrors.WithLabelValues(s.source).Inc()
 				select {
 				case b.deadSubscriptions <- s:
 				case <-b.AppCtx.Done():
 				}
+				return
+			case <-b.AppCtx.Done():
+				return
+			case <-s.done:
 				return
 			}
 		}

--- a/services/blockchain/client_zombie_watchdog_test.go
+++ b/services/blockchain/client_zombie_watchdog_test.go
@@ -1,0 +1,241 @@
+package blockchain
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// zombieFakeServer is a gRPC server whose Subscribe never sends anything
+// (the stream context is kept alive but no frames are written). This
+// simulates the half-zombie state from issue #872.
+type zombieFakeServer struct {
+	blockchain_api.UnimplementedBlockchainAPIServer
+	// hangCh: each Subscribe call blocks until this channel is closed or the
+	// stream context is cancelled. Closing it allows clean shutdown in tests.
+	hangCh       chan struct{}
+	connectCount atomic.Int32
+}
+
+func (z *zombieFakeServer) Subscribe(_ *blockchain_api.SubscribeRequest, stream blockchain_api.BlockchainAPI_SubscribeServer) error {
+	z.connectCount.Add(1)
+	select {
+	case <-z.hangCh:
+	case <-stream.Context().Done():
+	}
+	return nil
+}
+
+func (z *zombieFakeServer) HealthGRPC(_ context.Context, _ *emptypb.Empty) (*blockchain_api.HealthResponse, error) {
+	return &blockchain_api.HealthResponse{Ok: true, Details: "ok", Timestamp: timestamppb.Now()}, nil
+}
+
+func (z *zombieFakeServer) GetFSMCurrentState(_ context.Context, _ *emptypb.Empty) (*blockchain_api.GetFSMStateResponse, error) {
+	return &blockchain_api.GetFSMStateResponse{State: blockchain_api.FSMStateType_RUNNING}, nil
+}
+
+// heartbeatFakeServer sends periodic PINGs to keep the watchdog satisfied.
+type heartbeatFakeServer struct {
+	blockchain_api.UnimplementedBlockchainAPIServer
+	interval time.Duration
+}
+
+func (h *heartbeatFakeServer) Subscribe(_ *blockchain_api.SubscribeRequest, stream blockchain_api.BlockchainAPI_SubscribeServer) error {
+	ticker := time.NewTicker(h.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-ticker.C:
+			if err := stream.Send(&blockchain_api.Notification{
+				Type: model.NotificationType_PING,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (h *heartbeatFakeServer) HealthGRPC(_ context.Context, _ *emptypb.Empty) (*blockchain_api.HealthResponse, error) {
+	return &blockchain_api.HealthResponse{Ok: true, Details: "ok", Timestamp: timestamppb.Now()}, nil
+}
+
+func (h *heartbeatFakeServer) GetFSMCurrentState(_ context.Context, _ *emptypb.Empty) (*blockchain_api.GetFSMStateResponse, error) {
+	return &blockchain_api.GetFSMStateResponse{State: blockchain_api.FSMStateType_RUNNING}, nil
+}
+
+// blockFakeServer sends periodic Block notifications with a valid 32-byte hash.
+// Block notifications are forwarded to local Subscribe subscribers (unlike PINGs).
+type blockFakeServer struct {
+	blockchain_api.UnimplementedBlockchainAPIServer
+	interval time.Duration
+}
+
+func (b *blockFakeServer) Subscribe(_ *blockchain_api.SubscribeRequest, stream blockchain_api.BlockchainAPI_SubscribeServer) error {
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+	seq := byte(0)
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-ticker.C:
+			hash := make([]byte, 32)
+			hash[0] = seq
+			seq++
+			if err := stream.Send(&blockchain_api.Notification{
+				Type: model.NotificationType_Block,
+				Hash: hash,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (b *blockFakeServer) HealthGRPC(_ context.Context, _ *emptypb.Empty) (*blockchain_api.HealthResponse, error) {
+	return &blockchain_api.HealthResponse{Ok: true, Details: "ok", Timestamp: timestamppb.Now()}, nil
+}
+
+func (b *blockFakeServer) GetFSMCurrentState(_ context.Context, _ *emptypb.Empty) (*blockchain_api.GetFSMStateResponse, error) {
+	return &blockchain_api.GetFSMStateResponse{State: blockchain_api.FSMStateType_RUNNING}, nil
+}
+
+// startFakeGRPC starts a gRPC server on a free local port and returns its address
+// and a stop function. The caller owns the stop call.
+func startFakeGRPC(t *testing.T, srv blockchain_api.BlockchainAPIServer) (addr string, stop func()) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := grpc.NewServer()
+	blockchain_api.RegisterBlockchainAPIServer(s, srv)
+	go s.Serve(lis) //nolint:errcheck
+	return lis.Addr().String(), s.Stop
+}
+
+// TestSubscribeToServer_WatchdogClosesZombieStream verifies that when the
+// server's Subscribe handler never sends a frame (zombie / half-zombie stream),
+// the client watchdog eventually cancels the stream context and the reconnect
+// loop re-establishes the subscription.
+//
+// We use a short HeartbeatInterval (50ms) so zombieTimeout = 100ms and the
+// watchdog tick = 50ms. The test asserts that Subscribe is called at least
+// twice on the server within a tight deadline, proving the watchdog fired and
+// the reconnect loop ran.
+func TestSubscribeToServer_WatchdogClosesZombieStream(t *testing.T) {
+	const heartbeat = 50 * time.Millisecond
+
+	hangCh := make(chan struct{})
+	srv := &zombieFakeServer{hangCh: hangCh}
+
+	addr, stopSrv := startFakeGRPC(t, srv)
+	defer stopSrv()
+	defer close(hangCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockChain.GRPCAddress = addr
+	tSettings.BlockChain.HeartbeatInterval = heartbeat
+	tSettings.BlockChain.MaxRetries = 0
+
+	_, err := NewClientWithAddress(ctx, logger, tSettings, addr, "watchdog-test")
+	require.NoError(t, err)
+
+	// Wait for the watchdog to fire and trigger a reconnect:
+	//   initial connect: immediate
+	//   zombieTimeout:   100ms
+	//   watchdog tick:    50ms worst-case extra
+	//   reconnect sleep:   1s
+	//   second connect:   immediate
+	//
+	// Total: ~1.2s. Give 2s total to be safe on slow CI.
+	require.Eventually(t, func() bool {
+		return srv.connectCount.Load() >= 2
+	}, 2*time.Second, 20*time.Millisecond,
+		"expected at least 2 Subscribe calls (initial + watchdog-triggered reconnect); got %d",
+		srv.connectCount.Load())
+}
+
+// TestSubscribeToServer_WatchdogDoesNotFireWhenStreamProgresses verifies that
+// a healthy stream delivering regular Block notifications does not get cancelled
+// by the watchdog before we explicitly cancel the context.
+//
+// Block notifications (unlike PINGs) are forwarded to local Subscribe
+// subscribers, making them directly observable.
+func TestSubscribeToServer_WatchdogDoesNotFireWhenStreamProgresses(t *testing.T) {
+	const heartbeat = 50 * time.Millisecond
+	zombieTimeout := 2 * heartbeat // 100ms
+
+	// Send blocks faster than zombieTimeout so the watchdog cannot trip.
+	srv := &blockFakeServer{interval: heartbeat / 2}
+
+	addr, stopSrv := startFakeGRPC(t, srv)
+	defer stopSrv()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockChain.GRPCAddress = addr
+	tSettings.BlockChain.HeartbeatInterval = heartbeat
+	tSettings.BlockChain.MaxRetries = 0
+
+	c, err := NewClientWithAddress(ctx, logger, tSettings, addr, "watchdog-healthy-test")
+	require.NoError(t, err)
+	client := c.(*Client)
+
+	// Wait for the gRPC subscription to be established.
+	require.Eventually(t, func() bool {
+		if client.subscriptionReady == nil {
+			return false
+		}
+		select {
+		case <-client.subscriptionReady:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond, "subscription should become ready")
+
+	// Add a local subscriber to receive forwarded Block notifications.
+	ch, subErr := c.Subscribe(ctx, "watchdog-healthy-test")
+	require.NoError(t, subErr)
+
+	// Collect notifications for 5× the zombie timeout. If the watchdog fires
+	// incorrectly, the gRPC stream gets cancelled and Recv errors, which causes
+	// the client to stop delivering to local subscribers — the channel would
+	// timeout instead of delivering.
+	received := 0
+	deadline := time.Now().Add(5 * zombieTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case n, ok := <-ch:
+			if !ok {
+				t.Fatal("subscription channel closed unexpectedly — watchdog may have fired incorrectly")
+			}
+			if n.Type == model.NotificationType_Block {
+				received++
+			}
+		case <-time.After(zombieTimeout + 50*time.Millisecond):
+			t.Fatalf("no Block notification received within zombieTimeout — stream may be stalled or watchdog fired incorrectly")
+		}
+	}
+
+	require.Greater(t, received, 0, "should have received at least one Block notification from healthy stream")
+}

--- a/services/blockchain/client_zombie_watchdog_test.go
+++ b/services/blockchain/client_zombie_watchdog_test.go
@@ -232,7 +232,7 @@ func TestSubscribeToServer_WatchdogDoesNotFireWhenStreamProgresses(t *testing.T)
 			if n.Type == model.NotificationType_Block {
 				received++
 			}
-		case <-time.After(zombieTimeout + 50*time.Millisecond):
+		case <-time.After(zombieTimeout + 200*time.Millisecond):
 			t.Fatalf("no Block notification received within zombieTimeout — stream may be stalled or watchdog fired incorrectly")
 		}
 	}

--- a/services/blockchain/metrics.go
+++ b/services/blockchain/metrics.go
@@ -68,6 +68,11 @@ var (
 	prometheusBlockchainMTPCacheMisses      prometheus.Counter
 	prometheusBlockchainMTPCacheTruncations prometheus.Counter
 	prometheusBlockchainMTPCacheResets      prometheus.Counter
+
+	// Fan-out health metrics (issue #872).
+	prometheusBlockchainSubscriberPendingFull *prometheus.CounterVec
+	prometheusBlockchainSubscriberSendErrors  *prometheus.CounterVec
+	prometheusBlockchainWatchdogFires         *prometheus.CounterVec
 )
 
 var (
@@ -501,6 +506,36 @@ func _initPrometheusMetrics() {
 			Name:      "mtp_cache_resets_total",
 			Help:      "Total number of in-process MTP cache resets",
 		},
+	)
+
+	prometheusBlockchainSubscriberPendingFull = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "subscriber_pending_full_total",
+			Help:      "Number of times a subscriber was evicted from the broadcast loop because its pending buffer was full (issue #872 backpressure indicator).",
+		},
+		[]string{"source"},
+	)
+
+	prometheusBlockchainSubscriberSendErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "subscriber_send_errors_total",
+			Help:      "Number of times a subscriber was evicted because its Send returned an error or exceeded the send deadline.",
+		},
+		[]string{"source"},
+	)
+
+	prometheusBlockchainWatchdogFires = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockchain",
+			Name:      "watchdog_fires_total",
+			Help:      "Number of times the client-side stream-progress watchdog cancelled a stale gRPC subscription stream (issue #872 zombie-stream detector).",
+		},
+		[]string{"source"},
 	)
 }
 

--- a/services/blockchain/subscription_fanout_test.go
+++ b/services/blockchain/subscription_fanout_test.go
@@ -1,0 +1,309 @@
+// Package blockchain — subscription fan-out tests.
+//
+// These tests pin down the contract for per-subscriber delivery in
+// startSubscriptions:
+//
+//  1. A slow subscriber must not block delivery to other subscribers
+//     (head-of-line isolation).
+//  2. A subscriber whose per-subscriber buffer overflows must be marked dead
+//     and removed from the subscribers map, so it cannot continue blocking
+//     producers.
+//  3. Per-subscriber delivery order must be preserved (a single subscriber
+//     receives notifications in the order they were produced).
+//
+// Regression context: issue #872 — synchronous fan-out caused one slow Send
+// to stall all subscribers, leaving block-assembly without notifications for
+// 15+ hours on teratestnet. The visible symptom was the heartbeat warning
+// "[Blockchain][broadcastHeartbeat] Notifications channel full, skipping
+// heartbeat" coming from the producer side as b.notifications filled.
+package blockchain
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	"github.com/stretchr/testify/require"
+)
+
+// slowMockSubscribeServer is a controllable mock of
+// blockchain_api.BlockchainAPI_SubscribeServer.
+//
+// Send blocks on the gate channel if non-nil. Close(gate) to release any
+// pending Send (and any future calls).
+type slowMockSubscribeServer struct {
+	blockchain_api.BlockchainAPI_SubscribeServer
+	ctx      context.Context
+	cancel   context.CancelFunc
+	mu       sync.Mutex
+	received []*blockchain_api.Notification
+	gate     chan struct{} // nil = pass-through; non-nil = Send blocks until closed
+	sendErr  atomic.Value  // stores error to return from Send; nil = success
+}
+
+func newSlowMockSubscribeServer() *slowMockSubscribeServer {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &slowMockSubscribeServer{ctx: ctx, cancel: cancel}
+}
+
+func (m *slowMockSubscribeServer) Send(n *blockchain_api.Notification) error {
+	if g := m.gate; g != nil {
+		select {
+		case <-g:
+		case <-m.ctx.Done():
+			return m.ctx.Err()
+		}
+	}
+	if v := m.sendErr.Load(); v != nil {
+		if err, ok := v.(error); ok && err != nil {
+			return err
+		}
+	}
+	m.mu.Lock()
+	m.received = append(m.received, n)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *slowMockSubscribeServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *slowMockSubscribeServer) Cancel() {
+	m.cancel()
+}
+
+func (m *slowMockSubscribeServer) Received() []*blockchain_api.Notification {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*blockchain_api.Notification, len(m.received))
+	copy(out, m.received)
+	return out
+}
+
+// waitForSubscriptionManagerReady polls until the server signals readiness,
+// then asserts. Bounded by a generous timeout to keep the test deterministic
+// on slow CI.
+func waitForSubscriptionManagerReady(t *testing.T, b *Blockchain) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if b.subscriptionManagerReady.Load() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("subscription manager did not become ready within 2s")
+}
+
+// waitForSubscriberCount polls until the subscribers map reaches want or the
+// deadline elapses.
+func waitForSubscriberCount(t *testing.T, b *Blockchain, want int, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		b.subscribersMu.RLock()
+		n := len(b.subscribers)
+		b.subscribersMu.RUnlock()
+		if n == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	b.subscribersMu.RLock()
+	got := len(b.subscribers)
+	b.subscribersMu.RUnlock()
+	t.Fatalf("subscriber count: want=%d got=%d within=%s", want, got, within)
+}
+
+// TestStartSubscriptions_SlowSubscriberDoesNotBlockFastOnes is the central
+// regression test for #872. Two subscribers are registered: one whose Send
+// blocks indefinitely (the "slow" sub representing a stalled or backed-up
+// gRPC stream), and one whose Send is instant (the "fast" sub representing
+// a healthy consumer like block-assembly).
+//
+// With the previous synchronous fan-out, the slow Send blocked the inner
+// loop in startSubscriptions, so the fast subscriber would receive only the
+// first notification (and not even that, if the slow one registered first
+// because sendInitialNotification was also synchronous). With per-subscriber
+// fan-out, the fast subscriber must receive all N notifications regardless
+// of the slow one's state.
+func TestStartSubscriptions_SlowSubscriberDoesNotBlockFastOnes(t *testing.T) {
+	tc := setup(t)
+	go tc.server.startSubscriptions()
+	waitForSubscriptionManagerReady(t, tc.server)
+
+	slow := newSlowMockSubscribeServer()
+	slow.gate = make(chan struct{}) // never close → Send blocks forever
+	defer slow.Cancel()
+
+	fast := newSlowMockSubscribeServer()
+	defer fast.Cancel()
+
+	// Register slow first to maximise pressure (sendInitialNotification on
+	// slow used to block all further subscription handling).
+	tc.server.newSubscriptions <- subscriber{
+		subscription: slow,
+		done:         make(chan struct{}),
+		source:       "slow",
+		pending:      make(chan *blockchain_api.Notification, subscriberBufferSize),
+	}
+	tc.server.newSubscriptions <- subscriber{
+		subscription: fast,
+		done:         make(chan struct{}),
+		source:       "fast",
+		pending:      make(chan *blockchain_api.Notification, subscriberBufferSize),
+	}
+
+	waitForSubscriberCount(t, tc.server, 2, time.Second)
+
+	// Push N notifications via the producer-side channel.
+	const N = 5
+	for i := 0; i < N; i++ {
+		tc.server.notifications <- &blockchain_api.Notification{
+			Type: model.NotificationType_Block,
+		}
+	}
+
+	// Fast subscriber must receive an initial notification + N broadcasts
+	// (or just N, depending on whether sendInitialNotification is moved into
+	// the per-subscriber path). Assert >= N within a tight deadline.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(fast.Received()) >= N {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	require.GreaterOrEqual(t, len(fast.Received()), N,
+		"fast subscriber should receive >=%d notifications despite slow subscriber blocking; got=%d",
+		N, len(fast.Received()))
+}
+
+// TestStartSubscriptions_FullBufferMarksSubscriberDead verifies that when a
+// subscriber's per-subscriber buffer fills (because their Send is blocked),
+// the subscriber is marked dead and removed from the subscribers map.
+// This bounds how long a stuck subscriber can apply backpressure to the
+// system.
+func TestStartSubscriptions_FullBufferMarksSubscriberDead(t *testing.T) {
+	tc := setup(t)
+	go tc.server.startSubscriptions()
+	waitForSubscriptionManagerReady(t, tc.server)
+
+	stuck := newSlowMockSubscribeServer()
+	stuck.gate = make(chan struct{}) // never close → Send blocks forever
+	defer stuck.Cancel()
+
+	tc.server.newSubscriptions <- subscriber{
+		subscription: stuck,
+		done:         make(chan struct{}),
+		source:       "stuck",
+		pending:      make(chan *blockchain_api.Notification, subscriberBufferSize),
+	}
+	waitForSubscriberCount(t, tc.server, 1, time.Second)
+
+	// Push subscriberBufferSize+10 notifications. The first one will be
+	// in-flight inside Send (blocked on gate). The next subscriberBufferSize
+	// will queue in pending. The rest must trigger the dead-on-full path.
+	for i := 0; i < subscriberBufferSize+10; i++ {
+		tc.server.notifications <- &blockchain_api.Notification{
+			Type: model.NotificationType_Block,
+		}
+	}
+
+	// The subscriber must be removed from the map within reasonable time.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		tc.server.subscribersMu.RLock()
+		n := len(tc.server.subscribers)
+		tc.server.subscribersMu.RUnlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	tc.server.subscribersMu.RLock()
+	got := len(tc.server.subscribers)
+	tc.server.subscribersMu.RUnlock()
+	t.Fatalf("stuck subscriber should have been marked dead; subscribers remaining=%d", got)
+}
+
+// TestStartSubscriptions_PerSubscriberOrderPreserved verifies that for a
+// single subscriber, notifications arrive in the order they were produced.
+// The fan-out redesign uses one goroutine per subscriber, which preserves
+// per-subscriber ordering even if cross-subscriber order is not guaranteed.
+func TestStartSubscriptions_PerSubscriberOrderPreserved(t *testing.T) {
+	tc := setup(t)
+	go tc.server.startSubscriptions()
+	waitForSubscriptionManagerReady(t, tc.server)
+
+	sub := newSlowMockSubscribeServer()
+	defer sub.Cancel()
+
+	tc.server.newSubscriptions <- subscriber{
+		subscription: sub,
+		done:         make(chan struct{}),
+		source:       "ordered",
+		pending:      make(chan *blockchain_api.Notification, subscriberBufferSize),
+	}
+	waitForSubscriberCount(t, tc.server, 1, time.Second)
+
+	// Send N notifications with distinguishable Hashes (encode the index in
+	// the first byte).
+	const N = 20
+	for i := 0; i < N; i++ {
+		hash := make([]byte, 32)
+		hash[0] = byte(i)
+		tc.server.notifications <- &blockchain_api.Notification{
+			Type: model.NotificationType_Block,
+			Hash: hash,
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(sub.Received()) >= N {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	received := sub.Received()
+	require.GreaterOrEqual(t, len(received), N,
+		"subscriber should receive all %d notifications; got=%d", N, len(received))
+
+	// Filter to just the Block notifications we pushed (skip the initial
+	// notification that startSubscriptions may have sent).
+	var indices []int
+	for _, n := range received {
+		if n.Type != model.NotificationType_Block || len(n.Hash) != 32 {
+			continue
+		}
+		// Heuristic: if the rest of the hash is zero, this is one of ours.
+		allZero := true
+		for _, b := range n.Hash[1:] {
+			if b != 0 {
+				allZero = false
+				break
+			}
+		}
+		if !allZero {
+			continue
+		}
+		indices = append(indices, int(n.Hash[0]))
+	}
+
+	require.GreaterOrEqual(t, len(indices), N,
+		"expected at least %d of our test notifications; got=%d", N, len(indices))
+	for i := 1; i < N; i++ {
+		require.Equal(t, indices[i-1]+1, indices[i],
+			"per-subscriber order broken at i=%d: prev=%d cur=%d (full=%v)",
+			i, indices[i-1], indices[i], indices)
+	}
+}

--- a/services/blockchain/subscription_fanout_test.go
+++ b/services/blockchain/subscription_fanout_test.go
@@ -234,6 +234,22 @@ func TestStartSubscriptions_FullBufferMarksSubscriberDead(t *testing.T) {
 	t.Fatalf("stuck subscriber should have been marked dead; subscribers remaining=%d", got)
 }
 
+// extractTestIndex returns the sequence index encoded in a test notification's
+// Hash field (first byte), plus true. Returns 0, false for notifications that
+// were not produced by the order-preservation test (wrong type, wrong length,
+// or non-zero trailing bytes).
+func extractTestIndex(n *blockchain_api.Notification) (int, bool) {
+	if n.Type != model.NotificationType_Block || len(n.Hash) != 32 {
+		return 0, false
+	}
+	for _, b := range n.Hash[1:] {
+		if b != 0 {
+			return 0, false
+		}
+	}
+	return int(n.Hash[0]), true
+}
+
 // TestStartSubscriptions_PerSubscriberOrderPreserved verifies that for a
 // single subscriber, notifications arrive in the order they were produced.
 // The fan-out redesign uses one goroutine per subscriber, which preserves
@@ -282,21 +298,10 @@ func TestStartSubscriptions_PerSubscriberOrderPreserved(t *testing.T) {
 	// notification that startSubscriptions may have sent).
 	var indices []int
 	for _, n := range received {
-		if n.Type != model.NotificationType_Block || len(n.Hash) != 32 {
-			continue
+		idx, ok := extractTestIndex(n)
+		if ok {
+			indices = append(indices, idx)
 		}
-		// Heuristic: if the rest of the hash is zero, this is one of ours.
-		allZero := true
-		for _, b := range n.Hash[1:] {
-			if b != 0 {
-				allZero = false
-				break
-			}
-		}
-		if !allZero {
-			continue
-		}
-		indices = append(indices, int(n.Hash[0]))
 	}
 
 	require.GreaterOrEqual(t, len(indices), N,


### PR DESCRIPTION
Refs #872. Supersedes the closed band-aid PR #874.

## Summary

Two structural fixes for the 15.5-hour block-assembly stall observed on teratestnet 2026-05-14. Both layers of the bug class are addressed:

- **Server-side fan-out** in `services/blockchain/Server.go` `startSubscriptions` is now non-blocking per-subscriber. One slow / flow-control-stalled subscriber can no longer block delivery to the others.
- **Client-side stream-progress watchdog** in `services/blockchain/Client.go` `SubscribeToServer` catches half-zombie streams where `stream.Recv()` parks forever without returning an error.

## Root cause

`startSubscriptions` called `sub.subscription.Send` synchronously inside the broadcast loop (Server.go around line 692). One slow consumer parked the loop, starving all other subscribers of notifications *and* heartbeats. The client-side staleness check at `Client.go:1316-1330` only fires when `stream.Recv()` returns an error — a parked Send produces no error on the client, so the check is unreachable.

Combined with a 1m36s `SubtreeProcessor.reorgBlocks` window (during which BA's listener wasn't draining `blockchainSubscriptionCh`), the resulting HTTP/2 receive-window starvation parked the stream indefinitely. Server `Send()` returned `nil` every time for the queued frames; client `Recv()` never returned; nothing on either side produced an error or a keepalive trip.

See issue #872 for the full timeline and the in-depth analysis docs under `reviews/issue-872-rethink-*.md`.

## Fix 1 — Server: per-subscriber buffered fan-out

`services/blockchain/Server.go`:

- Each subscriber gets a bounded `pending` channel (cap 64).
- The broadcast loop does a non-blocking send into that channel. Subscribers whose buffer is full are evicted immediately via `deadSubscriptions` (`Subscriber X pending buffer full, marking dead` log).
- One drain goroutine per subscriber owns `sub.subscription.Send`. This preserves the gRPC no-concurrent-Send invariant on the stream while isolating slow consumers — a stalled Send parks only that subscriber's goroutine, not the broadcast loop.
- `sendInitialNotification` now enqueues to `sub.pending` instead of calling Send directly, so a slow new-subscriber's initial send can't block other new subscriptions.
- `deadSubscriptions` cleanup guards against double-close on `pending` (broadcast eviction + drain-goroutine Send-error can both mark the same sub dead).

## Fix 2 — Client: stream-progress watchdog

`services/blockchain/Client.go` `SubscribeToServer`:

- Per-stream `context.WithCancel` plus a watchdog goroutine.
- The watchdog ticks at `HeartbeatInterval/2` and checks `time.Since(lastRecvAt)`. If no `Recv()` returns within `2 * HeartbeatInterval` (defaults: 10s/2 tick, 20s threshold), it calls `cancelStream()`. `Recv()` then returns `context.Canceled` and the existing reconnect path kicks in.
- `lastRecvAt` is updated on every successful `Recv()` return (atomic.Int64 of UnixNano).
- `shutdown()` helper cancels the stream and waits for the watchdog goroutine to exit. Called on all exit paths to prevent goroutine leaks.

## What this does NOT include (separate follow-ups)

- **Tip-lag Prometheus gauge / alert** (`block_assembly_tip_lag_blocks`). Penetration-tester analysis flagged this as the highest-leverage detection change; covered by a follow-up issue.
- **Root-cause investigation of the 18-EOF burst** that originally triggered the cascade. Separate investigation; the fixes here address the bug class regardless of what triggers it.
- **Per-subscriber `Send()` deadline** server-side (faster than buffer-overflow eviction). Considered but not included — the client-side watchdog already kills the zombie stream in ~20s, which propagates back to the server as a `Send` error. Could be added as belt-and-suspenders in a follow-up.

## Test plan

- [x] `TestStartSubscriptions_SlowSubscriberDoesNotBlockFastOnes` — slow subscriber's Send blocks indefinitely; fast subscriber still receives all N notifications within deadline.
- [x] `TestStartSubscriptions_FullBufferMarksSubscriberDead` — stuck subscriber's `pending` fills; subscriber is evicted from the map.
- [x] `TestStartSubscriptions_PerSubscriberOrderPreserved` — per-subscriber FIFO preserved.
- [x] `TestSubscribeToServer_WatchdogClosesZombieStream` — fake server never sends; client cancels stream context within `2 * heartbeat + tick`.
- [x] `TestSubscribeToServer_WatchdogDoesNotFireWhenStreamProgresses` — fake server sends heartbeats; watchdog does not fire.
- [x] `go test -race -count=1 -tags testtxmetacache ./services/blockchain/` → 621 passed (no existing tests needed updating).
- [x] `go vet ./services/blockchain/` clean.
