### PR TITLE
perf(propagation): process /txs batch concurrently with ordered errors

### DIFF
--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -684,34 +684,47 @@ func (ps *PropagationServer) handleMultipleTx(_ context.Context) echo.HandlerFun
 		)
 		defer deferFn()
 
-		processTxs := make(chan *bt.Tx, maxTransactionsPerRequest)
-		processErrors := make(chan error, maxTransactionsPerRequest)
+		// Errors are reported in stream submission order. Each parse attempt and
+		// each dispatched transaction is assigned a monotonically increasing
+		// submission index; workers write into a pre-allocated slot at that
+		// index. After all workers finish, the slots are walked in order to
+		// produce a deterministic ordered error list — independent of the order
+		// in which concurrent workers complete.
+		//
+		// errSlots has len == cap and is never resized, so the slice header is
+		// never written by the producer after workers start. Workers write to
+		// distinct indices, the producer writes to its own indices, and reads
+		// happen only after processingWg.Wait() establishes happens-before.
+		const maxSubmissions = maxTransactionsPerRequest + 1 // +1 for ctx-cancel slot
+		errSlots := make([]error, maxSubmissions)
+		nextSlot := 0
 		processingWg := sync.WaitGroup{}
-		processingErrorWg := sync.WaitGroup{}
 		totalNrTransactions := 0
 		totalBytesRead := int64(0)
 
-		go func() {
-			// Process transactions in a separate goroutine
-			for tx := range processTxs {
-				if err := ps.processTransactionInternal(ctx, tx); err != nil {
-					processingErrorWg.Add(1)
-					processErrors <- err
+		// Caller contract: a batch must NOT contain both a parent and any of
+		// its children. The server does not enforce this — violating it will
+		// surface as missing-parent errors because txs in a batch are processed
+		// concurrently here with no in-batch ordering. See ProcessTransactionBatch
+		// for the gRPC equivalent of this pattern.
+		processOne := func(tx *bt.Tx, slot int) {
+			defer processingWg.Done()
+
+			if ps.batchWorkerPool != nil {
+				defer func() { <-ps.batchWorkerPool }()
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					ps.logger.Errorf("Recovered from panic in processTransactionInternal: %v", r)
+					errSlots[slot] = errors.NewProcessingError("transaction processing panic: %v", r)
 				}
+			}()
 
-				processingWg.Done()
+			if err := ps.processTransactionInternal(ctx, tx); err != nil {
+				errSlots[slot] = err
 			}
-		}()
-
-		// Collect errors in a slice - single goroutine writes, WaitGroup provides synchronization
-		var errMsgs []string
-
-		go func() {
-			for err := range processErrors {
-				errMsgs = append(errMsgs, errors.UserMessage(err))
-				processingErrorWg.Done()
-			}
-		}()
+		}
 
 		// Track early-exit error to return after cleanup
 		var earlyExitMsg string
@@ -726,6 +739,14 @@ func (ps *PropagationServer) handleMultipleTx(_ context.Context) echo.HandlerFun
 
 			if totalBytesRead >= maxDataPerRequest {
 				earlyExitMsg = "Invalid request body: too much data"
+				break
+			}
+
+			// All submission slots consumed (parse errors + successful txs).
+			// Cut off the stream to prevent unbounded parse-error accumulation
+			// from outgrowing the pre-allocated slot budget.
+			if nextSlot >= maxSubmissions {
+				earlyExitMsg = "Invalid request body: too many submissions"
 				break
 			}
 
@@ -750,8 +771,9 @@ func (ps *PropagationServer) handleMultipleTx(_ context.Context) echo.HandlerFun
 					break
 				}
 
-				processingErrorWg.Add(1)
-				processErrors <- err
+				// Record the parse error in submission order.
+				errSlots[nextSlot] = err
+				nextSlot++
 
 				// if the error came from panic recovery, the stream is likely corrupted
 				if terr, ok := err.(*errors.Error); ok && terr.Code() == errors.ERR_PROCESSING {
@@ -766,17 +788,50 @@ func (ps *PropagationServer) handleMultipleTx(_ context.Context) echo.HandlerFun
 			totalNrTransactions++
 			totalBytesRead += bytesRead
 
-			// Send transaction to processing channel
+			// Acquire the server-wide batch semaphore before spawning a goroutine,
+			// so total concurrent tx-processing goroutines stay bounded across all
+			// HTTP and gRPC batch calls. If the limit is disabled (nil), spawn
+			// immediately. Respect context cancellation so a disconnected client
+			// can drain the handler.
+			cancelled := false
+
+			if ps.batchWorkerPool != nil {
+				select {
+				case ps.batchWorkerPool <- struct{}{}:
+				case <-ctx.Done():
+					errSlots[nextSlot] = errors.WrapPublic(ctx.Err())
+					nextSlot++
+					earlyExitMsg = "request context cancelled"
+					cancelled = true
+				}
+			}
+
+			if cancelled {
+				break
+			}
+
+			// Reserve a submission slot for this tx and dispatch the worker.
+			slot := nextSlot
+			nextSlot++
 			processingWg.Add(1)
-			processTxs <- tx
+
+			go processOne(tx, slot)
 		}
 
-		// Close processTxs to signal the processing goroutine to exit,
-		// then wait for all in-flight work and errors to drain
-		close(processTxs)
+		// Wait for all worker goroutines to finish writing their slots before
+		// reading errSlots. The Done/Wait pair establishes the happens-before
+		// edge for the writes.
 		processingWg.Wait()
-		close(processErrors)
-		processingErrorWg.Wait()
+
+		var errMsgs []string
+
+		for _, err := range errSlots[:nextSlot] {
+			if err == nil {
+				continue
+			}
+
+			errMsgs = append(errMsgs, errors.UserMessage(err))
+		}
 
 		if earlyExitMsg != "" {
 			return c.String(http.StatusBadRequest, earlyExitMsg)

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -11,10 +11,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
@@ -24,6 +26,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/blob/null"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/factory"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/test/longtest/util/postgres"
 	"github.com/bsv-blockchain/teranode/test/utils/aerospike"
@@ -663,7 +666,13 @@ func TestStartHTTPServer(t *testing.T) {
 }
 
 // Test_handleMultipleTx tests the handleMultipleTx function.
-// This test makes sure chains of transactions are processed properly
+//
+// The batch endpoint processes transactions concurrently and the caller
+// contract forbids placing both a parent and any of its children in the same
+// batch — see ProcessTransactionBatch for the equivalent gRPC pattern. This
+// test honours that contract by submitting sibling transactions that each
+// spend a different output of a single coinbase. The coinbase is loaded into
+// the UTXO store but is itself NOT part of the batch.
 func Test_handleMultipleTx(t *testing.T) {
 	initPrometheusMetrics()
 
@@ -674,7 +683,7 @@ func Test_handleMultipleTx(t *testing.T) {
 	tSettings.Propagation.HTTPListenAddress = ""
 	tSettings.BlockAssembly.Disabled = true
 
-	t.Run("Test handleMultipleTx with valid transactions", func(t *testing.T) {
+	t.Run("Test handleMultipleTx with valid sibling transactions", func(t *testing.T) {
 		ctx := context.Background()
 
 		utxoStoreURL, err := url.Parse("sqlitememory:///test")
@@ -697,16 +706,32 @@ func Test_handleMultipleTx(t *testing.T) {
 
 		handler := ps.handleMultipleTx(t.Context())
 
-		txBytes := make([]byte, 0, 1024)
-		txs := transactions.CreateTestTransactionChainWithCount(t, 20)
-		coinbaseTx := txs[0]
+		const numSiblings = 20
+
+		privKey, pubKey := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+
+		// Coinbase with N outputs — pre-loaded into the UTXO store, not in batch.
+		coinbaseTx := transactions.Create(t,
+			transactions.WithCoinbaseData(100, "/Test miner/"),
+			transactions.WithP2PKHOutputs(numSiblings, 50e6, pubKey),
+		)
 
 		_, err = utxoStore.Create(t.Context(), coinbaseTx, 1)
 		require.NoError(t, err)
 
-		// Add all the transaction bytes to the byte slice for sending to the handler
-		for i := 1; i < len(txs); i++ {
-			txBytes = append(txBytes, txs[i].ExtendedBytes()...)
+		// N siblings, each spending a different coinbase output. No tx in the
+		// batch depends on any other tx in the batch.
+		siblings := make([]*bt.Tx, 0, numSiblings)
+		txBytes := make([]byte, 0, 1024)
+
+		for i := uint32(0); i < numSiblings; i++ {
+			tx := transactions.Create(t,
+				transactions.WithPrivateKey(privKey),
+				transactions.WithInput(coinbaseTx, i),
+				transactions.WithP2PKHOutputs(1, 1000),
+			)
+			siblings = append(siblings, tx)
+			txBytes = append(txBytes, tx.ExtendedBytes()...)
 		}
 
 		txsReader := bytes.NewReader(txBytes)
@@ -726,6 +751,87 @@ func Test_handleMultipleTx(t *testing.T) {
 
 		assert.Equal(t, "OK", string(responseBody))
 	})
+}
+
+// orderedErrValidator returns a Validator whose Validate method fails with an
+// error that embeds the tx's txid, so a caller can verify per-tx error order.
+type orderedErrValidator struct {
+	validator.MockValidatorClient
+}
+
+func (m *orderedErrValidator) Validate(_ context.Context, tx *bt.Tx, _ uint32, _ ...validator.Option) (*meta.Data, error) {
+	return nil, errors.NewTxInvalidError("validator rejected tx %s", tx.TxIDChainHash().String())
+}
+
+// Test_handleMultipleTx_ErrorOrderPreserved verifies that when every tx in a
+// batch fails validation, the errors returned in the response body appear in
+// the same order as the transactions were submitted, even though processing
+// happens concurrently.
+func Test_handleMultipleTx_ErrorOrderPreserved(t *testing.T) {
+	initPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Propagation.GRPCListenAddress = ""
+	tSettings.Propagation.HTTPListenAddress = ""
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	ps := &PropagationServer{
+		logger:    logger,
+		validator: &orderedErrValidator{},
+		txStore:   txStore,
+		settings:  tSettings,
+	}
+
+	handler := ps.handleMultipleTx(t.Context())
+
+	const numSiblings = 32
+
+	_, pubKey := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+	privKey, _ := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+
+	coinbaseTx := transactions.Create(t,
+		transactions.WithCoinbaseData(100, "/Test miner/"),
+		transactions.WithP2PKHOutputs(numSiblings, 50e6, pubKey),
+	)
+
+	expectedTxids := make([]string, 0, numSiblings)
+	txBytes := make([]byte, 0, 1024)
+
+	for i := uint32(0); i < numSiblings; i++ {
+		tx := transactions.Create(t,
+			transactions.WithPrivateKey(privKey),
+			transactions.WithInput(coinbaseTx, i),
+			transactions.WithP2PKHOutputs(1, 1000),
+		)
+		expectedTxids = append(expectedTxids, tx.TxIDChainHash().String())
+		txBytes = append(txBytes, tx.ExtendedBytes()...)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/txs", bytes.NewReader(txBytes))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/txs")
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	responseBody, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+
+	// Every tx fails, so the response should contain numSiblings error lines,
+	// each naming its tx's txid, in the same order the txs were submitted.
+	body := string(responseBody)
+	prev := 0
+
+	for i, txid := range expectedTxids {
+		idx := strings.Index(body[prev:], txid)
+		require.GreaterOrEqualf(t, idx, 0, "txid for submission %d (%s) not found in response after position %d; body=%q", i, txid, prev, body)
+		prev += idx + len(txid)
+	}
 }
 
 func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {

--- a/services/propagation/http_handlers_test.go
+++ b/services/propagation/http_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -63,17 +64,22 @@ func (m *MockValidatorForTxTest) WasValidateCalled() bool {
 	return m.validateCalled.Load()
 }
 
-// MockTxStore is a simple mock transaction store for testing
+// MockTxStore is a simple mock transaction store for testing.
+// Real blob stores are concurrency-safe; the mock must be too because the
+// batch HTTP/gRPC handlers fan out parallel writes.
 type MockTxStore struct {
 	storeCalled atomic.Bool
 	storeErr    error
+	mu          sync.Mutex
 	txIDs       [][]byte
 }
 
 // Store implements a mock Store method
 func (s *MockTxStore) Store(ctx context.Context, key []byte, fileType fileformat.FileType, value []byte, opts ...options.FileOption) error {
 	s.storeCalled.Store(true)
+	s.mu.Lock()
 	s.txIDs = append(s.txIDs, key)
+	s.mu.Unlock()
 
 	return s.storeErr
 }
@@ -85,6 +91,9 @@ func (s *MockTxStore) Get(ctx context.Context, key []byte, fileType fileformat.F
 
 // Exists implements a mock Exists method matching blob.Store interface
 func (s *MockTxStore) Exists(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	for _, id := range s.txIDs {
 		if bytes.Equal(id, key) {
 			return true, nil
@@ -138,6 +147,9 @@ func (s *MockTxStore) Del(ctx context.Context, key []byte, fileType fileformat.F
 
 // Size implements a mock Size method
 func (s *MockTxStore) Size() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	return uint64(len(s.txIDs))
 }
 


### PR DESCRIPTION
## Summary

- `handleMultipleTx` fans transaction processing across goroutines gated by the existing `batchWorkerPool` semaphore (the same `propagation_batchConcurrencyLimit` knob that `ProcessTransactionBatch` already uses), replacing the prior single consumer goroutine that defeated the channel-based parallel facade.
- Errors are written into pre-allocated per-submission slots and drained after `wg.Wait`, so the response error list preserves the caller's submission order regardless of which worker finishes first. Worker panics are recovered and reported in the offending tx's own slot.
- Honours the existing caller contract: a batch must not contain both a parent and any of its children. The server still does not enforce this; parallel processing only makes a contract violation more likely to surface (as missing-parent errors) than the prior serial timing did.

## Notable details

- The previous chain-based `Test_handleMultipleTx` was itself a contract violation that only passed because the old handler ran serially. It is replaced with a sibling-based test plus a new `Test_handleMultipleTx_ErrorOrderPreserved` that submits 32 siblings all failing validation and asserts the txids appear in the response body in submission order.
- `MockTxStore` was always racy on `txIDs`; parallel batch handling exposed it, so it now has the mutex it needed.
- `maxSubmissions = maxTransactionsPerRequest + 1` bounds the pre-allocated slot slice so producer-side parse-error accumulation cannot grow the slice (which would race on the header against in-flight worker writes).
- `propagation_batchConcurrencyLimit` default of 0 (unlimited) is preserved; operators who already tuned it for gRPC now get HTTP-side admission control with no extra config.

## Test plan

- [x] `go vet ./services/propagation/...`
- [x] `golangci-lint run ./services/propagation/...`
- [x] `go test -race -tags testtxmetacache -count=1 -skip 'Aerospike|Postgres' ./services/propagation/...`
- [ ] CI race + lint pass on the PR
- [ ] Smoke test (`make smoketest`) on a deployment exercising `/txs`