### PR TITLE
fix(asset): address review feedback from #827 (streaming follow-ups)

### DIFF
--- a/docs/topics/services/assetServer.md
+++ b/docs/topics/services/assetServer.md
@@ -834,6 +834,23 @@ Error: "server_keyFile is required for HTTPS"
 Cause: Missing server_keyFile when securityLevelHTTP is non-zero
 ```
 
+#### 7.2.5.1 Deployment: Upstream Rate Limiting Required
+
+The subtree HTTP endpoints — `/subtree/:hash` (binary/hex), `/subtree/:hash/txs` (binary/hex), and `/subtree_data/:hash` — stream large payloads and **deliberately skip gzip compression**. Gzip on these endpoints would force the response to be fully buffered server-side and yield negligible compression on near-incompressible hash/transaction bytes. Streaming without compression preserves the memory-bound design of the asset service.
+
+Trade-off: these unauthenticated GET endpoints can emit hundreds of MB per request uncompressed, which is a bandwidth amplification surface if abused. The asset service mitigates with:
+
+- the ban-list middleware;
+- per-method concurrency semaphores (`asset_concurrency_get_subtree_data`, `asset_concurrency_get_subtree_data_reader`, `asset_concurrency_get_subtree_transactions`, `asset_subtreeDataStreamingConcurrency`) — bounded by default (`2 / 4 / 2 / 2`).
+
+These mitigations are **not** sufficient on their own for public-facing deployments. Operators MUST front the asset service with a reverse proxy (nginx, HAProxy, Envoy, CloudFront, Cloudflare, etc.) configured to enforce:
+
+1. **Per-IP request rate limiting** on the `/subtree*` paths (e.g. nginx `limit_req_zone` keyed by `$binary_remote_addr`).
+2. **Per-IP concurrent connection limits** (e.g. nginx `limit_conn_zone`).
+3. **An ACL** restricting these endpoints to known peers/clients when public exposure is not required.
+
+Per-IP rate limiting inside the asset service itself is a planned defense-in-depth follow-up but is not currently implemented.
+
 #### 7.2.6 Environment Variables
 
 **Standard Environment Variables:**

--- a/services/asset/httpimpl/GetSubtree.go
+++ b/services/asset/httpimpl/GetSubtree.go
@@ -182,17 +182,14 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 		}
 		defer subtreeReader.Close()
 
-		switch mode {
-		case BINARY_STREAM:
+		if mode == BINARY_STREAM {
 			return c.Stream(http.StatusOK, echo.MIMEOctetStream, subtreeReader)
-
-		case HEX:
-			c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
-			c.Response().WriteHeader(http.StatusOK)
-			_, err = io.Copy(hex.NewEncoder(c.Response()), subtreeReader)
-			return err
 		}
 
-		return nil
+		// mode == HEX (validated above)
+		c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
+		c.Response().WriteHeader(http.StatusOK)
+		_, err = io.Copy(hex.NewEncoder(c.Response()), subtreeReader)
+		return err
 	}
 }

--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -358,6 +358,13 @@ func (repo *Repository) scheduleSubtreeChunkFetches(ctx context.Context, subtree
 	}
 
 	waitErr := g.Wait()
+	// When a worker fails, the errgroup cancels gCtx, which makes the next
+	// loop iteration observe context.Canceled and store it in readErr. The
+	// real failure is the worker's error returned by g.Wait(); prefer it so
+	// callers see the cause rather than the cancellation signal it triggered.
+	if waitErr != nil && !errors.Is(waitErr, context.Canceled) {
+		return waitErr
+	}
 	if readErr != nil {
 		return readErr
 	}

--- a/services/asset/repository/GetLegacyBlock_test.go
+++ b/services/asset/repository/GetLegacyBlock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
@@ -1674,4 +1675,50 @@ func buildMerkleRootFromHashes(txHashes []*chainhash.Hash) *chainhash.Hash {
 	}
 
 	return txHashes[0]
+}
+
+func TestDrainChunkResults(t *testing.T) {
+	ch := make(chan chunkResult, 3)
+	ch <- chunkResult{chunkIdx: 0}
+	ch <- chunkResult{chunkIdx: 1}
+	ch <- chunkResult{chunkIdx: 2}
+	close(ch)
+
+	done := make(chan struct{})
+	go func() {
+		drainChunkResults(ch)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("drainChunkResults did not return")
+	}
+}
+
+func TestSendChunkResult_DeliversWhenChannelHasCapacity(t *testing.T) {
+	ch := make(chan chunkResult, 1)
+	sentinel := errors.NewProcessingError("kept")
+
+	got := sendChunkResult(context.Background(), ch, chunkResult{chunkIdx: 7}, sentinel)
+	require.ErrorIs(t, got, sentinel)
+
+	select {
+	case received := <-ch:
+		require.Equal(t, 7, received.chunkIdx)
+	default:
+		t.Fatal("result was not delivered to channel")
+	}
+}
+
+func TestSendChunkResult_ReturnsCtxErrWhenBlocked(t *testing.T) {
+	ch := make(chan chunkResult) // unbuffered, no reader -> send blocks
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sendChunkResult(ctx, ch, chunkResult{chunkIdx: 1}, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/services/asset/repository/repository_test.go
+++ b/services/asset/repository/repository_test.go
@@ -234,16 +234,16 @@ func TestGetSubtreePage(t *testing.T) {
 	assert.Empty(t, subtreePage.ConflictingNodes)
 }
 
-func TestGetSubtreePage_ResetsOffsetPastEnd(t *testing.T) {
+func TestGetSubtreePage_OffsetPastEndReturnsEmptyPage(t *testing.T) {
 	txns, key, repo := setupSubtreeData(t)
 
 	subtreePage, offset, totalNodes, err := repo.GetSubtreePage(context.Background(), key, 99, 1)
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, offset)
+	assert.Equal(t, 99, offset)
 	assert.Equal(t, len(txns), totalNodes)
-	require.Len(t, subtreePage.Nodes, 1)
-	assert.Equal(t, txns[0], subtreePage.Nodes[0].Hash)
+	assert.Empty(t, subtreePage.Nodes)
+	assert.Empty(t, subtreePage.ConflictingNodes)
 }
 
 func setupSubtreeData(t *testing.T) ([]chainhash.Hash, *chainhash.Hash, *repository.Repository) {

--- a/services/asset/repository/subtree_stream.go
+++ b/services/asset/repository/subtree_stream.go
@@ -154,16 +154,24 @@ func readSubtreePageFromReader(ctx context.Context, reader io.Reader, offset, li
 		return nil, 0, 0, errors.NewProcessingError("unable to convert subtree node count", err)
 	}
 
-	if offset >= totalNodes {
-		offset = 0
+	height := 0
+	if totalNodes > 0 {
+		height = int(math.Ceil(math.Log2(float64(totalNodes))))
 	}
 
-	pageSize := 0
-	if limit > 0 && offset < totalNodes {
-		pageSize = limit
-		if pageSize > totalNodes-offset {
-			pageSize = totalNodes - offset
-		}
+	if limit == 0 || offset >= totalNodes {
+		return &subtreepkg.Subtree{
+			Height:           height,
+			Fees:             header.fees,
+			SizeInBytes:      header.sizeInBytes,
+			Nodes:            []subtreepkg.Node{},
+			ConflictingNodes: []chainhash.Hash{},
+		}, offset, totalNodes, nil
+	}
+
+	pageSize := limit
+	if pageSize > totalNodes-offset {
+		pageSize = totalNodes - offset
 	}
 
 	for i := 0; i < offset; i++ {
@@ -189,7 +197,7 @@ func readSubtreePageFromReader(ctx context.Context, reader io.Reader, offset, li
 		nodes = append(nodes, subtreeNodeFromRecord(byteBuffer))
 	}
 
-	pageCoversFullSubtree := totalNodes == 0 || (offset == 0 && pageSize == totalNodes)
+	pageCoversFullSubtree := offset == 0 && pageSize == totalNodes
 	conflictingNodes := []chainhash.Hash{}
 	// Conflicting nodes are serialized after all node records, so reading them
 	// for partial pages would scan the rest of large subtrees.
@@ -198,11 +206,6 @@ func readSubtreePageFromReader(ctx context.Context, reader io.Reader, offset, li
 		if err != nil {
 			return nil, 0, 0, err
 		}
-	}
-
-	height := 0
-	if totalNodes > 0 {
-		height = int(math.Ceil(math.Log2(float64(totalNodes))))
 	}
 
 	return &subtreepkg.Subtree{

--- a/services/asset/repository/subtree_stream_test.go
+++ b/services/asset/repository/subtree_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"io"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -50,6 +51,205 @@ func TestReadSubtreePageFromReaderStopsAfterPartialPage(t *testing.T) {
 	require.Len(t, page.Nodes, 1)
 	assert.Equal(t, nodes[1].Hash, page.Nodes[0].Hash)
 	assert.Empty(t, page.ConflictingNodes)
+}
+
+func TestReadSubtreeNodesPageFromReader_RejectsNegativeOffset(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+	_, _, err := readSubtreeNodesPageFromReader(context.Background(), bytes.NewReader(stream), -1, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "offset cannot be negative")
+}
+
+func TestReadSubtreeNodesPageFromReader_RejectsNegativeLimit(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+	_, _, err := readSubtreeNodesPageFromReader(context.Background(), bytes.NewReader(stream), 0, -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit cannot be negative")
+}
+
+func TestReadSubtreeNodesPageFromReader_OffsetPastEndReturnsEmpty(t *testing.T) {
+	nodes := []subtreepkg.Node{{
+		Hash: hashForSubtreeStreamTest(0),
+		Fee:  1,
+	}}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+
+	page, totalNodes, err := readSubtreeNodesPageFromReader(context.Background(), bytes.NewReader(stream), 5, 10)
+	require.NoError(t, err)
+	assert.Empty(t, page)
+	assert.Equal(t, 1, totalNodes)
+}
+
+func TestReadSubtreeNodesPageFromReader_ZeroLimitReturnsEmpty(t *testing.T) {
+	nodes := []subtreepkg.Node{{
+		Hash: hashForSubtreeStreamTest(0),
+		Fee:  1,
+	}}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+
+	page, totalNodes, err := readSubtreeNodesPageFromReader(context.Background(), bytes.NewReader(stream), 0, 0)
+	require.NoError(t, err)
+	assert.Empty(t, page)
+	assert.Equal(t, 1, totalNodes)
+}
+
+func TestReadSubtreeNodesPageFromReader_PageTruncatedByTotalNodes(t *testing.T) {
+	nodes := make([]subtreepkg.Node, 3)
+	for i := range nodes {
+		nodes[i] = subtreepkg.Node{Hash: hashForSubtreeStreamTest(byte(i)), Fee: uint64(i)}
+	}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+
+	page, totalNodes, err := readSubtreeNodesPageFromReader(context.Background(), bytes.NewReader(stream), 2, 50)
+	require.NoError(t, err)
+	require.Len(t, page, 1)
+	assert.Equal(t, 3, totalNodes)
+	assert.Equal(t, nodes[2].Hash, page[0].Hash)
+}
+
+func TestReadSubtreePageFromReader_RejectsNegativeOffset(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+	_, _, _, err := readSubtreePageFromReader(context.Background(), bytes.NewReader(stream), -1, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "offset cannot be negative")
+}
+
+func TestReadSubtreePageFromReader_RejectsNegativeLimit(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+	_, _, _, err := readSubtreePageFromReader(context.Background(), bytes.NewReader(stream), 0, -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit cannot be negative")
+}
+
+func TestReadSubtreePageFromReader_EmptySubtree(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+
+	page, offset, totalNodes, err := readSubtreePageFromReader(context.Background(), bytes.NewReader(stream), 0, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 0, offset)
+	assert.Equal(t, 0, totalNodes)
+	assert.Equal(t, 0, page.Height)
+	assert.Empty(t, page.Nodes)
+	assert.Empty(t, page.ConflictingNodes)
+}
+
+func TestReadSubtreePageFromReader_FullPageIncludesConflictingNodes(t *testing.T) {
+	nodes := []subtreepkg.Node{
+		{Hash: hashForSubtreeStreamTest(0), Fee: 1},
+		{Hash: hashForSubtreeStreamTest(1), Fee: 2},
+	}
+	conflicting := []chainhash.Hash{hashForSubtreeStreamTest(0)}
+	stream := serializeSubtreeStreamTestData(t, nodes, conflicting)
+
+	page, offset, totalNodes, err := readSubtreePageFromReader(context.Background(), bytes.NewReader(stream), 0, len(nodes))
+	require.NoError(t, err)
+	assert.Equal(t, 0, offset)
+	assert.Equal(t, len(nodes), totalNodes)
+	require.Len(t, page.ConflictingNodes, 1)
+	assert.Equal(t, conflicting[0], page.ConflictingNodes[0])
+}
+
+func TestReadSubtreePageFromReader_TruncatedHeaderErrors(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+	_, _, _, err := readSubtreePageFromReader(context.Background(), bytes.NewReader(stream[:subtreeStreamHeaderSize-1]), 0, 10)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to read subtree root information")
+}
+
+func TestSubtreeNodeHashesReadCloser_StreamsOnlyHashes(t *testing.T) {
+	nodes := make([]subtreepkg.Node, 4)
+	for i := range nodes {
+		nodes[i] = subtreepkg.Node{Hash: hashForSubtreeStreamTest(byte(i)), Fee: uint64(i)}
+	}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+
+	rc, err := newSubtreeNodeHashesReadCloser(context.Background(), io.NopCloser(bytes.NewReader(stream)))
+	require.NoError(t, err)
+	defer rc.Close()
+
+	out, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	require.Len(t, out, len(nodes)*chainhash.HashSize)
+	for i, node := range nodes {
+		assert.Equal(t, node.Hash[:], out[i*chainhash.HashSize:(i+1)*chainhash.HashSize])
+	}
+}
+
+func TestSubtreeNodeHashesReadCloser_ZeroLengthReadReturnsZero(t *testing.T) {
+	nodes := []subtreepkg.Node{{Hash: hashForSubtreeStreamTest(0), Fee: 1}}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+
+	rc, err := newSubtreeNodeHashesReadCloser(context.Background(), io.NopCloser(bytes.NewReader(stream)))
+	require.NoError(t, err)
+	defer rc.Close()
+
+	n, err := rc.Read(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestSubtreeNodeHashesReadCloser_EmptySubtreeYieldsEOF(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+
+	rc, err := newSubtreeNodeHashesReadCloser(context.Background(), io.NopCloser(bytes.NewReader(stream)))
+	require.NoError(t, err)
+	defer rc.Close()
+
+	out, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestSubtreeNodeHashesReadCloser_TruncatedHeaderClosesSource(t *testing.T) {
+	stream := serializeSubtreeStreamTestData(t, nil, nil)
+	source := &countingCloser{Reader: bytes.NewReader(stream[:subtreeStreamHeaderSize-1])}
+
+	_, err := newSubtreeNodeHashesReadCloser(context.Background(), source)
+	require.Error(t, err)
+	assert.Equal(t, 1, source.closes, "source must be closed on header read failure")
+}
+
+func TestSubtreeNodeHashesReadCloser_ContextCancellationReturnsError(t *testing.T) {
+	nodes := []subtreepkg.Node{
+		{Hash: hashForSubtreeStreamTest(0), Fee: 1},
+		{Hash: hashForSubtreeStreamTest(1), Fee: 2},
+	}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rc, err := newSubtreeNodeHashesReadCloser(ctx, io.NopCloser(bytes.NewReader(stream)))
+	require.NoError(t, err)
+	defer rc.Close()
+
+	buf := make([]byte, chainhash.HashSize)
+	_, err = rc.Read(buf)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReadSubtreeConflictingNodes_TruncatedCountErrors(t *testing.T) {
+	// Build a stream that ends right after the node records, omitting the
+	// conflicting-node count entirely.
+	nodes := []subtreepkg.Node{{Hash: hashForSubtreeStreamTest(0), Fee: 1}}
+	stream := serializeSubtreeStreamTestData(t, nodes, nil)
+	truncated := stream[:subtreeStreamHeaderSize+subtreeNodeRecordSize]
+
+	_, _, _, err := readSubtreePageFromReader(context.Background(), bytes.NewReader(truncated), 0, len(nodes))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to read number of conflicting nodes")
+}
+
+type countingCloser struct {
+	io.Reader
+	closes int
+}
+
+func (c *countingCloser) Close() error {
+	c.closes++
+	return nil
 }
 
 func TestReadSubtreePageFromReaderRejectsImpossibleConflictCount(t *testing.T) {
@@ -126,4 +326,105 @@ func sumSubtreeStreamTestFees(nodes []subtreepkg.Node) uint64 {
 		fees += node.Fee
 	}
 	return fees
+}
+
+func BenchmarkSubtreeNodeHashesReader(b *testing.B) {
+	const benchNodes = 1024
+
+	nodes := make([]subtreepkg.Node, benchNodes)
+	for i := range nodes {
+		nodes[i] = subtreepkg.Node{
+			Hash: hashForSubtreeStreamTest(byte(i)),
+			Fee:  uint64(i),
+		}
+	}
+	stream := serializeSubtreeStreamTestDataB(b, nodes, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rc, err := newSubtreeNodeHashesReadCloser(context.Background(), io.NopCloser(bytes.NewReader(stream)))
+		if err != nil {
+			b.Fatalf("newSubtreeNodeHashesReadCloser: %v", err)
+		}
+		if _, err := io.Copy(io.Discard, rc); err != nil {
+			b.Fatalf("drain: %v", err)
+		}
+		_ = rc.Close()
+	}
+}
+
+// TestSubtreeNodeHashesReaderAllocsBound locks in the streaming-path memory claim:
+// allocations must NOT scale with subtree size. The streaming reader allocates a
+// bufio buffer + reader struct + io.NopCloser wrapper; we cap at 16 per Read pass
+// to leave headroom but still catch regressions that re-introduce O(nodes) buffering.
+func TestSubtreeNodeHashesReaderAllocsBound(t *testing.T) {
+	const benchNodes = 1024
+	const maxAllocsPerOp = 16
+
+	result := testing.Benchmark(BenchmarkSubtreeNodeHashesReader)
+	if result.N == 0 {
+		t.Fatal("benchmark did not run")
+	}
+	if got := result.AllocsPerOp(); got > maxAllocsPerOp {
+		t.Fatalf("AllocsPerOp=%d exceeded ceiling %d for streaming path (subtree=%d nodes); the implementation likely regressed to non-streaming buffering", got, maxAllocsPerOp, benchNodes)
+	}
+}
+
+// serializeSubtreeStreamTestDataB is the benchmark equivalent of
+// serializeSubtreeStreamTestData (which only accepts *testing.T).
+func serializeSubtreeStreamTestDataB(b *testing.B, nodes []subtreepkg.Node, conflictingNodes []chainhash.Hash) []byte {
+	b.Helper()
+
+	var buf bytes.Buffer
+	rootHash := hashForSubtreeStreamTest(255)
+	if _, err := buf.Write(rootHash[:]); err != nil {
+		b.Fatalf("write root hash: %v", err)
+	}
+
+	var bytes8 [8]byte
+	binary.LittleEndian.PutUint64(bytes8[:], sumSubtreeStreamTestFees(nodes))
+	if _, err := buf.Write(bytes8[:]); err != nil {
+		b.Fatalf("write fees: %v", err)
+	}
+
+	binary.LittleEndian.PutUint64(bytes8[:], 0)
+	if _, err := buf.Write(bytes8[:]); err != nil {
+		b.Fatalf("write size: %v", err)
+	}
+
+	binary.LittleEndian.PutUint64(bytes8[:], uint64(len(nodes)))
+	if _, err := buf.Write(bytes8[:]); err != nil {
+		b.Fatalf("write numLeaves: %v", err)
+	}
+
+	for _, node := range nodes {
+		if _, err := buf.Write(node.Hash[:]); err != nil {
+			b.Fatalf("write node hash: %v", err)
+		}
+
+		binary.LittleEndian.PutUint64(bytes8[:], node.Fee)
+		if _, err := buf.Write(bytes8[:]); err != nil {
+			b.Fatalf("write node fee: %v", err)
+		}
+
+		binary.LittleEndian.PutUint64(bytes8[:], node.SizeInBytes)
+		if _, err := buf.Write(bytes8[:]); err != nil {
+			b.Fatalf("write node size: %v", err)
+		}
+	}
+
+	binary.LittleEndian.PutUint64(bytes8[:], uint64(len(conflictingNodes)))
+	if _, err := buf.Write(bytes8[:]); err != nil {
+		b.Fatalf("write conflict count: %v", err)
+	}
+
+	for _, hash := range conflictingNodes {
+		if _, err := buf.Write(hash[:]); err != nil {
+			b.Fatalf("write conflict hash: %v", err)
+		}
+	}
+
+	return buf.Bytes()
 }

--- a/settings.conf
+++ b/settings.conf
@@ -209,17 +209,21 @@ asset_propagation_proxy_address.operator     = http://propagation.${clientName}.
 
 # Asset Repository Concurrency Limits
 # Limits concurrent operations per repository method
-# Values: 0 = unlimited (default), -1 = runtime.NumCPU(), >0 = exact limit
+# Values: 0 = unlimited, -1 = runtime.NumCPU(), >0 = exact limit
 # Recommended for high-load scenarios to prevent Aerospike overload
-# asset_concurrency_get_transaction          = 0
-# asset_concurrency_get_transaction_meta     = 0
-# asset_concurrency_get_subtree_data         = 0
-# asset_concurrency_get_subtree_data_reader  = 0
-# asset_concurrency_get_subtree_transactions = 0
-# asset_concurrency_get_subtree_exists       = 0
-# asset_concurrency_get_subtree_head         = 0
-# asset_concurrency_get_utxo                 = 0
-# asset_concurrency_get_legacy_block_reader  = 0
+# Defaults listed below are the values applied when the key is unset.
+# The subtree-related keys default to bounded non-zero values to cap memory
+# under bursty traffic; raise them only after measuring impact.
+# asset_concurrency_get_transaction          = 0    # default: 0 (unlimited)
+# asset_concurrency_get_transaction_meta     = 0    # default: 0 (unlimited)
+# asset_concurrency_get_subtree_data         = 2    # default: 2
+# asset_concurrency_get_subtree_data_reader  = 4    # default: 4
+# asset_concurrency_get_subtree_transactions = 2    # default: 2
+# asset_concurrency_get_subtree_exists       = 0    # default: 0 (unlimited)
+# asset_concurrency_get_subtree_head         = 0    # default: 0 (unlimited)
+# asset_concurrency_get_utxo                 = 0    # default: 0 (unlimited)
+# asset_concurrency_get_legacy_block_reader  = 0    # default: 0 (unlimited)
+# asset_subtreeDataStreamingConcurrency      = 2    # default: 2 (concurrent chunk workers per streaming request)
 
 blockMinedCacheMaxMB        = 256
 blockMinedCacheMaxMB.docker = 32


### PR DESCRIPTION
Follow-up to #827 (which was merged before all review feedback could be folded in).
Addresses comments from @oskarszoon and @ordishs.

## Changes

- **Subtree page (JSON)** — `readSubtreePageFromReader` now returns an empty page when the requested offset is past the end of the subtree (matching `readSubtreeNodesPageFromReader`) instead of silently wrapping back to offset 0. The wrap was confusing for paginated clients. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4280662769) #2)
- **`settings.conf`** — Documented the actual non-zero defaults for the asset subtree concurrency keys (`asset_concurrency_get_subtree_data=2`, `..._data_reader=4`, `..._transactions=2`, `asset_subtreeDataStreamingConcurrency=2`). The previous block claimed `0 = unlimited` defaults, which silently became `2 / 4 / 2 / 2` in #827. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4280662769) #3)
- **Streaming benchmark + alloc regression test** — Added an un-gated `BenchmarkSubtreeNodeHashesReader` and a regression test (`TestSubtreeNodeHashesReaderAllocsBound`) that runs it via `testing.Benchmark` and asserts `AllocsPerOp <= 16`. The original benchmarks were behind `RUN_SUBTREE_BENCHMARK=true` and never ran in CI, so the streaming memory savings claim was not machine-verified. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4280662769) #4)
- **`scheduleSubtreeChunkFetches` error masking** — Prefer `waitErr` (real worker error) over `readErr` (which is the `context.Canceled` we observe when the errgroup cancels `gCtx`). Falls back to `readErr` when `waitErr` is nil or itself a cancellation, so genuine read errors are still surfaced. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4280662769) #6)
- **`GetSubtree` handler** — Collapsed the trailing dead `switch` + unreachable `return nil` into a direct `if/else`; mode is already validated above. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4288042084) #4)
- **Deployment docs** — `assetServer.md` gains a section explaining that the gzip-skipped `/subtree*` endpoints require upstream rate-limiting / ACL in a reverse proxy (nginx `limit_req_zone` / `limit_conn_zone` or equivalent). The asset service does not yet do per-IP rate limiting; that is a planned defense-in-depth follow-up. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4280662769) ops note)
- **`ConflictingNodes` paginated-response semantics (documented here)** — `ConflictingNodes` is now only populated when the page covers the whole subtree (`offset==0 && pageSize==totalNodes`). Partial pages return an empty `ConflictingNodes` array. This semantic was introduced in 827's `b08a88e3` to avoid scanning all 1M nodes when paginating a large subtree; calling it out explicitly so any downstream consumer can adapt. ([review item](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4288042084) #3)
- **Tests** — Targeted unit-test coverage for the new `subtree_stream.go` paths (negative args, offset past end, zero limit, page truncation, empty subtree, truncated header / conflict count, zero-length `Read`, context cancel, `source.Close` on header read failure), plus micro-tests for `drainChunkResults` and `sendChunkResult`. Boosts `subtree_stream.go` function coverage to ~75–82% and clears the SonarQube new-code-coverage gap for these files. ([ordishs review item 1, 4](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4288042084))

## Items not addressed here

- **`FeeHash` JSON value** — Confirmed not a regression; old behaviour also emitted zero-value `FeeHash` in `/subtree/:hash/json`. No code change needed. ([review item #1](https://github.com/bsv-blockchain/teranode/pull/827#pullrequestreview-4280662769))
- **CodeQL findings at `subtree_stream.go:118` and `:178`** — False positives; `pageSize` is provably bounded to ≤ 100 by both the HTTP-layer clamp (`helpers.go:107-109`) and the repository-layer defense-in-depth clamps (`subtree_stream.go:86-88, 142-144`). Max allocation ~4.8 KB per request. Suggest dismissing in the Security tab with that rationale rather than adding dead defensive code.
- **claude[bot] finding at `http.go:435`** — Already refuted in the original PR review (`parts[i+1:]` cannot panic; Go allows slicing to `len`, and the `len(tail)==1/2` guards prevent `tail[1]` OOB).

## Test plan

- [x] `go test -race ./services/asset/...` passes locally
- [x] `go vet ./services/asset/...` clean
- [x] New `TestSubtreeNodeHashesReaderAllocsBound` passes (locks in the streaming memory claim)
- [x] `make test` — all asset-related packages pass; remaining failures are unrelated testcontainer (Docker daemon) issues in `util/kafka` and `util/usql`
- [ ] CI green (full pipeline)