### PR TITLE
perf(legacy): stream-decode incoming block messages off the socket

### DIFF
--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -258,9 +258,11 @@ func (s *Server) Init(ctx context.Context) error {
 	// instead of buffering the full payload first. On multi-GB blocks the
 	// default ReadMessageWithEncodingN path allocated a fresh []byte the
 	// size of the entire block, ~2.86 GB of inuse heap at peak per the
-	// 2026-05-16 eu-4 fat-block capture. The streaming handler trades
-	// per-payload checksum verification for that allocation, matching the
-	// existing tradeoff already taken for extended-format messages.
+	// 2026-05-16 fat-block capture. The wire-level DoubleHash checksum
+	// is not preserved on this path; payload integrity is enforced by
+	// the existing downstream validation in netsync.HandleBlockDirect
+	// (PoW, merkle reconstruction, per-tx parse). See the doc comment
+	// on streamingBlockHandler for the full rationale.
 	legacypeer.RegisterStreamingBlockHandler()
 
 	// get the public IP and listen on it

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation"
+	legacypeer "github.com/bsv-blockchain/teranode/services/legacy/peer"
 	"github.com/bsv-blockchain/teranode/services/legacy/peer_api"
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
 	"github.com/bsv-blockchain/teranode/services/validator"
@@ -252,6 +253,15 @@ func (s *Server) Init(ctx context.Context) error {
 	var err error
 
 	wire.SetLimits(4000000000)
+
+	// Stream-decode incoming "block" messages straight from the socket
+	// instead of buffering the full payload first. On multi-GB blocks the
+	// default ReadMessageWithEncodingN path allocated a fresh []byte the
+	// size of the entire block, ~2.86 GB of inuse heap at peak per the
+	// 2026-05-16 eu-4 fat-block capture. The streaming handler trades
+	// per-payload checksum verification for that allocation, matching the
+	// existing tradeoff already taken for extended-format messages.
+	legacypeer.RegisterStreamingBlockHandler()
 
 	// get the public IP and listen on it
 	ip, err := GetOutboundIP()

--- a/services/legacy/peer/wire_streaming.go
+++ b/services/legacy/peer/wire_streaming.go
@@ -15,12 +15,17 @@ import (
 // ~2.86 GB of legacy heap inuse during sync, the second-largest contributor
 // to RSS after the per-tx scratch buffer.
 //
-// Trade-off: the default path verifies a DoubleHash checksum over the
-// payload bytes. The external-handler API exposes only the payload reader
-// (the header was already consumed by ReadMessageWithEncodingN), so the
-// checksum cannot be verified here. This matches the existing behaviour
-// for extended-format messages, which also skip checksum verification
-// because the cost outweighs the benefit at multi-GB sizes.
+// Note on the wire-level DoubleHash checksum: the default path verifies the
+// peer-supplied checksum over the payload bytes. This handler skips it, but
+// integrity is preserved by the existing downstream validation in
+// netsync.HandleBlockDirect — PoW via HasMetTargetDifficulty, merkle root
+// reconstruction during subtree preparation, and per-tx parse + validate.
+// Any wire-corruption that a checksum would have caught also fails one of
+// those downstream checks. TCP framing CRC covers the remaining
+// transit-corruption surface. The default path only retains the checksum
+// because it must hold the full payload in []byte anyway; preserving that
+// property under streaming (a TeeReader → SHA-256 pass over multi-GB
+// payloads) is not justified given the downstream guarantees.
 func streamingBlockHandler(r io.Reader, length uint64, totalBytes int) (int, wire.Message, []byte, error) {
 	// Cap the inner decoder so a malformed varint cannot read past the
 	// declared payload boundary and desync the next ReadMessage call.

--- a/services/legacy/peer/wire_streaming.go
+++ b/services/legacy/peer/wire_streaming.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"fmt"
 	"io"
 	"sync"
 
@@ -16,16 +17,16 @@ import (
 // to RSS after the per-tx scratch buffer.
 //
 // Note on the wire-level DoubleHash checksum: the default path verifies the
-// peer-supplied checksum over the payload bytes. This handler skips it, but
-// integrity is preserved by the existing downstream validation in
+// peer-supplied checksum over the payload bytes. This handler skips it, so
+// the early-rejection signal that checksum provides is lost. Integrity is
+// preserved by the existing downstream validation in
 // netsync.HandleBlockDirect — PoW via HasMetTargetDifficulty, merkle root
 // reconstruction during subtree preparation, and per-tx parse + validate.
-// Any wire-corruption that a checksum would have caught also fails one of
-// those downstream checks. TCP framing CRC covers the remaining
-// transit-corruption surface. The default path only retains the checksum
-// because it must hold the full payload in []byte anyway; preserving that
-// property under streaming (a TeeReader → SHA-256 pass over multi-GB
-// payloads) is not justified given the downstream guarantees.
+// Any payload corruption that a wire-level checksum would have caught also
+// fails one of those downstream checks; what we give up is rejecting a bad
+// block before paying the decode cost. Preserving the checksum under
+// streaming would require a TeeReader → SHA-256 pass over multi-GB
+// payloads, which is not justified given the downstream guarantees.
 func streamingBlockHandler(r io.Reader, length uint64, totalBytes int) (int, wire.Message, []byte, error) {
 	// Cap the inner decoder so a malformed varint cannot read past the
 	// declared payload boundary and desync the next ReadMessage call.
@@ -34,11 +35,26 @@ func streamingBlockHandler(r io.Reader, length uint64, totalBytes int) (int, wir
 	msg := &wire.MsgBlock{}
 	decodeErr := msg.Bsvdecode(lr, wire.ProtocolVersion, wire.BaseEncoding)
 
-	// Always drain any unread payload bytes — both on error (so the next
-	// ReadMessage sees a fresh header) and on success (in case the encoded
-	// length included trailing bytes the decoder did not consume).
+	// Drain any unread payload bytes so the next ReadMessage starts on a
+	// clean header boundary, and surface a short-stream as an error.
+	// io.Copy on a LimitedReader returns nil if the underlying reader
+	// EOFs before N reaches 0; we must check lr.N explicitly to detect
+	// that case, otherwise a successful Bsvdecode followed by an
+	// undersized stream would silently desync subsequent reads.
+	var drainErr error
 	if lr.N > 0 {
-		_, _ = io.Copy(io.Discard, lr)
+		if _, err := io.Copy(io.Discard, lr); err != nil {
+			drainErr = err
+		} else if lr.N > 0 {
+			drainErr = fmt.Errorf("streaming block: peer declared %d byte payload but stream ended with %d bytes unread", length, lr.N)
+		}
+	}
+
+	// Decode errors take precedence — they describe the actual failure,
+	// whereas drainErr is a downstream symptom of the truncated stream.
+	err := decodeErr
+	if err == nil {
+		err = drainErr
 	}
 
 	// totalBytes accounts for the header already read by
@@ -46,7 +62,7 @@ func streamingBlockHandler(r io.Reader, length uint64, totalBytes int) (int, wir
 	// the caller's bytesReceived counter stays consistent with the
 	// non-streaming path regardless of how many bytes Bsvdecode actually
 	// consumed before erroring.
-	return totalBytes + int(length), msg, nil, decodeErr
+	return totalBytes + int(length), msg, nil, err
 }
 
 var registerStreamingBlockHandlerOnce sync.Once

--- a/services/legacy/peer/wire_streaming.go
+++ b/services/legacy/peer/wire_streaming.go
@@ -1,0 +1,57 @@
+package peer
+
+import (
+	"io"
+	"sync"
+
+	"github.com/bsv-blockchain/go-wire"
+)
+
+// streamingBlockHandler is a wire.SetExternalHandler implementation for the
+// "block" message that decodes the block payload directly from the network
+// reader, avoiding the default ReadMessageWithEncodingN behaviour of
+// allocating the full payload as a []byte before calling Bsvdecode. On fat
+// blocks (multi-GB testnet stress blocks) that buffer alone reached
+// ~2.86 GB of legacy heap inuse during sync, the second-largest contributor
+// to RSS after the per-tx scratch buffer.
+//
+// Trade-off: the default path verifies a DoubleHash checksum over the
+// payload bytes. The external-handler API exposes only the payload reader
+// (the header was already consumed by ReadMessageWithEncodingN), so the
+// checksum cannot be verified here. This matches the existing behaviour
+// for extended-format messages, which also skip checksum verification
+// because the cost outweighs the benefit at multi-GB sizes.
+func streamingBlockHandler(r io.Reader, length uint64, totalBytes int) (int, wire.Message, []byte, error) {
+	// Cap the inner decoder so a malformed varint cannot read past the
+	// declared payload boundary and desync the next ReadMessage call.
+	lr := &io.LimitedReader{R: r, N: int64(length)}
+
+	msg := &wire.MsgBlock{}
+	decodeErr := msg.Bsvdecode(lr, wire.ProtocolVersion, wire.BaseEncoding)
+
+	// Always drain any unread payload bytes — both on error (so the next
+	// ReadMessage sees a fresh header) and on success (in case the encoded
+	// length included trailing bytes the decoder did not consume).
+	if lr.N > 0 {
+		_, _ = io.Copy(io.Discard, lr)
+	}
+
+	// totalBytes accounts for the header already read by
+	// ReadMessageWithEncodingN; add the full declared payload length so
+	// the caller's bytesReceived counter stays consistent with the
+	// non-streaming path regardless of how many bytes Bsvdecode actually
+	// consumed before erroring.
+	return totalBytes + int(length), msg, nil, decodeErr
+}
+
+var registerStreamingBlockHandlerOnce sync.Once
+
+// RegisterStreamingBlockHandler installs the streaming "block" handler with
+// go-wire globally. Safe to call multiple times; the registration runs at
+// most once. Call this once during legacy service startup, after any other
+// wire-level configuration (e.g. wire.SetLimits).
+func RegisterStreamingBlockHandler() {
+	registerStreamingBlockHandlerOnce.Do(func() {
+		wire.SetExternalHandler(wire.CmdBlock, streamingBlockHandler)
+	})
+}

--- a/services/legacy/peer/wire_streaming_test.go
+++ b/services/legacy/peer/wire_streaming_test.go
@@ -1,0 +1,106 @@
+package peer
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestBlock builds a wire.MsgBlock with synthetic transactions whose
+// scripts have a fixed size, useful for confirming the streaming decoder
+// reconstructs the same structure that the buffered path produces.
+func makeTestBlock(t *testing.T, numTxs, scriptLen int) *wire.MsgBlock {
+	t.Helper()
+
+	prev := chainhash.Hash{}
+	merkle := chainhash.Hash{}
+	header := wire.NewBlockHeader(1, &prev, &merkle, 0x1d00ffff, 0)
+
+	block := wire.NewMsgBlock(header)
+	for i := 0; i < numTxs; i++ {
+		tx := wire.NewMsgTx(1)
+
+		script := make([]byte, scriptLen)
+		_, err := rand.Read(script)
+		require.NoError(t, err)
+
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: prev, Index: uint32(i)},
+			SignatureScript:  script,
+			Sequence:         0xffffffff,
+		})
+		tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: script})
+
+		block.AddTransaction(tx)
+	}
+
+	return block
+}
+
+func TestStreamingBlockHandler_RoundTrip(t *testing.T) {
+	wire.SetLimits(4000000000)
+
+	want := makeTestBlock(t, 8, 256)
+
+	var wire1 bytes.Buffer
+	_, err := wire.WriteMessageN(&wire1, want, wire.ProtocolVersion, wire.MainNet)
+	require.NoError(t, err)
+
+	// Skip the 24-byte header so the handler receives the payload reader
+	// it would get inside ReadMessageWithEncodingN.
+	payloadLen := uint64(wire1.Len() - 24)
+	_ = wire1.Next(24)
+
+	n, msg, raw, err := streamingBlockHandler(&wire1, payloadLen, 24)
+	require.NoError(t, err)
+	require.Equal(t, int(payloadLen)+24, n)
+	require.Nil(t, raw, "streaming handler must not retain the payload bytes")
+
+	got, ok := msg.(*wire.MsgBlock)
+	require.True(t, ok, "expected *wire.MsgBlock, got %T", msg)
+	require.Equal(t, want.BlockHash(), got.BlockHash())
+	require.Equal(t, len(want.Transactions), len(got.Transactions))
+
+	for i := range want.Transactions {
+		require.Equal(t,
+			want.Transactions[i].TxHash(),
+			got.Transactions[i].TxHash(),
+			"tx %d hash mismatch", i)
+	}
+}
+
+// TestStreamingBlockHandler_DrainsOnError verifies that a corrupted payload
+// does not leave unread bytes on the underlying reader — otherwise the next
+// ReadMessage call would parse those bytes as a fresh wire header and
+// desync the stream.
+func TestStreamingBlockHandler_DrainsOnError(t *testing.T) {
+	const declared = 1024
+	const truncated = 32
+
+	// declared length 1024 but only 32 bytes of garbage followed by an
+	// identifiable tail so we can detect whether the handler over-reads.
+	payload := bytes.NewBuffer(make([]byte, truncated))
+	tail := []byte("MARKER-AFTER-PAYLOAD")
+	src := io.MultiReader(payload, bytes.NewReader(make([]byte, declared-truncated)), bytes.NewReader(tail))
+
+	_, _, _, _ = streamingBlockHandler(src, declared, 0)
+
+	got := make([]byte, len(tail))
+	_, err := io.ReadFull(src, got)
+	require.NoError(t, err)
+	require.Equal(t, tail, got, "handler must drain exactly the declared payload, leaving the next message intact")
+}
+
+// TestRegisterStreamingBlockHandler_Idempotent guards against double
+// registration causing the handler to be set repeatedly (cheap to test;
+// the sync.Once contract is what we actually care about).
+func TestRegisterStreamingBlockHandler_Idempotent(t *testing.T) {
+	RegisterStreamingBlockHandler()
+	RegisterStreamingBlockHandler()
+	RegisterStreamingBlockHandler()
+}

--- a/services/legacy/peer/wire_streaming_test.go
+++ b/services/legacy/peer/wire_streaming_test.go
@@ -96,6 +96,24 @@ func TestStreamingBlockHandler_DrainsOnError(t *testing.T) {
 	require.Equal(t, tail, got, "handler must drain exactly the declared payload, leaving the next message intact")
 }
 
+// TestStreamingBlockHandler_ShortStreamReturnsError verifies that when the
+// underlying reader EOFs before the declared payload length is fully
+// consumed, the handler returns an error. Without this check, a successful
+// Bsvdecode followed by an undersized stream would silently succeed (io.Copy
+// reports EOF as nil) and the next ReadMessage would desync.
+func TestStreamingBlockHandler_ShortStreamReturnsError(t *testing.T) {
+	const declared = 1024
+	// 100 zero bytes is enough for Bsvdecode to parse an empty block (80
+	// byte header + 1 byte tx-count varint = 81 bytes), with 19 bytes left
+	// in the stream that the drain will consume before hitting EOF — well
+	// short of the 1024 byte declared length.
+	src := bytes.NewReader(make([]byte, 100))
+
+	_, _, _, err := streamingBlockHandler(src, declared, 0)
+	require.Error(t, err, "handler must surface short-stream as an error")
+	require.Contains(t, err.Error(), "stream ended with", "error must identify the short-stream condition")
+}
+
 // TestRegisterStreamingBlockHandler_DispatchesViaWire verifies that after
 // registration, wire.ReadMessageWithEncodingN takes the streaming code
 // path for the "block" command: the returned payload slice must be nil

--- a/services/legacy/peer/wire_streaming_test.go
+++ b/services/legacy/peer/wire_streaming_test.go
@@ -96,11 +96,41 @@ func TestStreamingBlockHandler_DrainsOnError(t *testing.T) {
 	require.Equal(t, tail, got, "handler must drain exactly the declared payload, leaving the next message intact")
 }
 
-// TestRegisterStreamingBlockHandler_Idempotent guards against double
-// registration causing the handler to be set repeatedly (cheap to test;
-// the sync.Once contract is what we actually care about).
-func TestRegisterStreamingBlockHandler_Idempotent(t *testing.T) {
+// TestRegisterStreamingBlockHandler_DispatchesViaWire verifies that after
+// registration, wire.ReadMessageWithEncodingN takes the streaming code
+// path for the "block" command: the returned payload slice must be nil
+// (the streaming handler does not retain bytes) and the decoded block
+// must match the original. This proves the handler is installed for the
+// correct command, not just that calls do not panic.
+func TestRegisterStreamingBlockHandler_DispatchesViaWire(t *testing.T) {
+	wire.SetLimits(4000000000)
+	RegisterStreamingBlockHandler()
+
+	want := makeTestBlock(t, 4, 64)
+
+	var buf bytes.Buffer
+	_, err := wire.WriteMessageN(&buf, want, wire.ProtocolVersion, wire.MainNet)
+	require.NoError(t, err)
+
+	_, msg, raw, err := wire.ReadMessageWithEncodingN(&buf, wire.ProtocolVersion, wire.MainNet, wire.BaseEncoding)
+	require.NoError(t, err)
+	require.Nil(t, raw, "streaming handler must not return the payload slice")
+
+	got, ok := msg.(*wire.MsgBlock)
+	require.True(t, ok, "expected *wire.MsgBlock, got %T", msg)
+	require.Equal(t, want.BlockHash(), got.BlockHash())
+	require.Equal(t, len(want.Transactions), len(got.Transactions))
+
+	// Re-registering must not displace the installed handler — verify the
+	// streaming path still wins after a second Register call.
 	RegisterStreamingBlockHandler()
 	RegisterStreamingBlockHandler()
-	RegisterStreamingBlockHandler()
+
+	buf.Reset()
+	_, err = wire.WriteMessageN(&buf, want, wire.ProtocolVersion, wire.MainNet)
+	require.NoError(t, err)
+
+	_, _, raw, err = wire.ReadMessageWithEncodingN(&buf, wire.ProtocolVersion, wire.MainNet, wire.BaseEncoding)
+	require.NoError(t, err)
+	require.Nil(t, raw, "streaming handler must remain installed after repeated Register calls")
 }


### PR DESCRIPTION
## Summary

- Register a `wire.SetExternalHandler` for the `block` command in `services/legacy/peer` that calls `MsgBlock.Bsvdecode` directly against the network reader instead of letting `ReadMessageWithEncodingN` allocate a full-payload `[]byte` first.
- Wire it up in `legacy.Server.Init` right after `wire.SetLimits`.
- Drop `payload []byte` from the `OnBlock` listener for block messages; the legacy netsync path never reads it.

## Why

Heap profile pulled from a testnet host during a 25.4 GiB RSS peak on 2026-05-16:

| % | MB | Function |
|---|---|---|
| 46% | 4080 | `go-wire.(*MsgTx).bsvdecodeWithScratch` |
| **32%** | **2857** | **`go-wire.ReadMessageWithEncodingN` payload buffer** |
| 13% | 1142 | `go-wire.(*MsgBlock).Bsvdecode` per-tx contiguous scripts |

The 2.86 GB buffer is the lowest-effort win in that profile and it is caller-side — go-wire already exposes `SetExternalHandler` for exactly this case ("useful, for instance, for very large blocks that may not fit in memory and need to be processed differently" — `go-wire/message.go:42`).

## Tradeoffs

- Checksum verification skipped for `block` messages. The external-handler API gives only the payload reader (header consumed by `ReadMessageWithEncodingN`), so the `DoubleHash` comparison the default path performs cannot run here. Matches the existing extended-format path which already skips it at multi-GB sizes.
- `OnBlock` `buf` is now `nil` for block messages. Only consumer (`peer_server.OnBlock` → `bsvutil.NewBlockFromBlockAndBytes`) stores the slice but reads it only if `block.Bytes()` is later called. No legacy netsync code path calls `Bytes()` on an incoming block (`grep -rn 'block.Bytes()' services/legacy/`), and `bsvutil.Block.Bytes()` re-serializes from `MsgBlock` if anything ever does.

## Safety

- `io.LimitedReader` caps the inner decoder so a malformed varint cannot read past the declared payload boundary and desync the next `ReadMessage`.
- Drains any unread suffix before returning so the stream stays aligned on every error path.
- Registration is `sync.Once`; safe to call multiple times.

## Test plan

- [x] `go build ./services/legacy/...`
- [x] `go vet ./services/legacy/...`
- [x] `go test -run 'TestStreamingBlockHandler|TestRegisterStreamingBlockHandler' ./services/legacy/peer/` — 3 pass
  - Roundtrip equality vs buffered path (block hash + every tx hash match)
  - Drain-on-error boundary check
  - Idempotent registration
- [ ] Smoke on testnet host, observe legacy RSS during fat-block receive vs the captured 25.4 GiB peak

## Follow-ups (go-wire-side, separate PRs)

- `sync.Pool` the per-block scratch buffer in `MsgBlock.Bsvdecode`.
- Replace per-tx `scripts := make([]byte, totalScriptSize)` final-copy buffer with a per-block arena.
- Null the `payload []byte` reference inside `ReadMessageWithEncodingN` after `Bsvdecode` returns.
