### PR TITLE
fix(subtreevalidation): two-mode txmeta enqueue (block during backfill, drop+warn live)

### DIFF
--- a/services/subtreevalidation/Server.go
+++ b/services/subtreevalidation/Server.go
@@ -139,6 +139,12 @@ type Server struct {
 	txmetaWorkerCancel   context.CancelFunc
 	txmetaWorkerQueues   []chan txmetaWorkItem
 	txmetaWorkerWg       sync.WaitGroup
+	// txmetaCaughtUp is a one-way latch. While false, the txmeta handler blocks on
+	// the shard worker queues so backfill cannot drop messages. The latch flips
+	// to true the first time a Kafka message is observed at the partition's
+	// high water mark, after which the handler drops on full (preserving live-
+	// traffic backpressure semantics).
+	txmetaCaughtUp atomic.Bool
 }
 
 // New creates a new Server instance with the provided dependencies.

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -116,10 +116,10 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 			return err
 		}
 		if !ok {
-			// Caught-up (normal) mode: shard queue is full. The remainder of the
-			// batch is abandoned; the cache will be repopulated from Kafka on the
-			// next restart (best-effort by design). Caller side already logged a
-			// warning.
+			// Caught-up (normal) mode: shard queue is full. The remainder of
+			// the batch is abandoned; the cache will be repopulated from Kafka
+			// on the next restart (best-effort by design).
+			// enqueueTxmetaWorkItem has already emitted the Warn log.
 			return nil
 		}
 	}
@@ -134,8 +134,25 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 // maybeMarkTxmetaCaughtUp flips the txmetaCaughtUp latch the first time a Kafka
 // message is observed at the partition's high water mark. HighWaterMark is the
 // next offset that will be produced; msg.Offset+1 == HighWaterMark means this
-// message is the current tail of the partition. The latch is one-way: once set
-// it stays set even if the consumer falls behind later.
+// message is the current tail of the partition.
+//
+// Latch semantics (deliberate trade-offs):
+//
+//   - One-way: once set it stays set even if the consumer falls behind later
+//     (e.g., a long pause and re-catch-up). Live drop semantics persist.
+//
+//   - Any-partition: for multi-partition txmeta topics, the latch flips as
+//     soon as ANY assigned partition reaches its tail, not when all do. This
+//     is intentional — txmeta is sharded by tx hash, partitions are evenly
+//     loaded under normal traffic, so seeing the tail on one partition is a
+//     strong signal we're broadly caught up. A stricter per-partition gating
+//     would extend cold-cache blocking unnecessarily if one partition is
+//     temporarily empty or slow.
+//
+//   - Fail-closed on HighWaterMark<=0: an unset HWM (in-memory consumer,
+//     hand-constructed messages) keeps the latch in startup (blocking) mode.
+//     Smoke tests are low-throughput so the shard queues should never fill,
+//     making the blocking mode effectively a no-op there.
 func (u *Server) maybeMarkTxmetaCaughtUp(msg *kafka.KafkaMessage) {
 	if u.txmetaCaughtUp.Load() {
 		return

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -111,12 +111,41 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 			content:    content,
 			enqueuedAt: time.Now(),
 		}
-		if err := u.enqueueTxmetaWorkItem(workItem); err != nil {
+		ok, err := u.enqueueTxmetaWorkItem(ctx, workItem)
+		if err != nil {
 			return err
+		}
+		if !ok {
+			// Caught-up (normal) mode: shard queue is full. The remainder of the
+			// batch is abandoned; the cache will be repopulated from Kafka on the
+			// next restart (best-effort by design). Caller side already logged a
+			// warning.
+			return nil
 		}
 	}
 
+	// Latch from startup (blocking) to caught-up (drop-on-full) mode the first
+	// time we observe a message at the partition's tail. One-way: never reverts.
+	u.maybeMarkTxmetaCaughtUp(msg)
+
 	return nil
+}
+
+// maybeMarkTxmetaCaughtUp flips the txmetaCaughtUp latch the first time a Kafka
+// message is observed at the partition's high water mark. HighWaterMark is the
+// next offset that will be produced; msg.Offset+1 == HighWaterMark means this
+// message is the current tail of the partition. The latch is one-way: once set
+// it stays set even if the consumer falls behind later.
+func (u *Server) maybeMarkTxmetaCaughtUp(msg *kafka.KafkaMessage) {
+	if u.txmetaCaughtUp.Load() {
+		return
+	}
+	if msg.HighWaterMark <= 0 || msg.Offset+1 < msg.HighWaterMark {
+		return
+	}
+	if u.txmetaCaughtUp.CompareAndSwap(false, true) {
+		u.logger.Infof("[txmetaHandler] caught up on %s partition %d at offset %d (HWM %d); switching to drop-on-full mode", msg.Topic, msg.Partition, msg.Offset, msg.HighWaterMark)
+	}
 }
 
 func (u *Server) ensureTxmetaWorkers(ctx context.Context) error {
@@ -176,13 +205,40 @@ func (u *Server) processTxmetaWorkItem(workItem txmetaWorkItem) {
 	}
 }
 
-func (u *Server) enqueueTxmetaWorkItem(workItem txmetaWorkItem) error {
+// enqueueTxmetaWorkItem dispatches a work item to the shard worker queue. Two
+// modes:
+//
+//   - Startup mode (txmetaCaughtUp == false): block on send until the worker
+//     accepts the item or ctx is cancelled. This applies natural backpressure
+//     to the Kafka consumer during catch-up so no work is dropped while the
+//     cache is cold.
+//
+//   - Caught-up mode (txmetaCaughtUp == true): non-blocking send; if the shard
+//     queue is full, log a warning and signal the caller to abandon the
+//     remainder of the batch. Live-traffic backpressure is by design
+//     best-effort (the cache repopulates from Kafka on restart).
+//
+// Returns (true, nil) on successful enqueue, (false, nil) when an item was
+// dropped in caught-up mode, and (false, ctx.Err()) when ctx is cancelled
+// during a startup-mode blocking send.
+func (u *Server) enqueueTxmetaWorkItem(ctx context.Context, workItem txmetaWorkItem) (bool, error) {
 	shard := int(workItem.hash[0]) % len(u.txmetaWorkerQueues)
+	ch := u.txmetaWorkerQueues[shard]
+
+	if u.txmetaCaughtUp.Load() {
+		select {
+		case ch <- workItem:
+			return true, nil
+		default:
+			u.logger.Warnf("[txmetaHandler] txmeta worker queue full for shard %d, dropping remainder of batch", shard)
+			return false, nil
+		}
+	}
 
 	select {
-	case u.txmetaWorkerQueues[shard] <- workItem:
-		return nil
-	default:
-		return errors.NewProcessingError("[txmetaHandler] txmeta worker queue full for shard %d", shard)
+	case ch <- workItem:
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
 	}
 }

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -393,12 +394,18 @@ func TestServer_txmetaHandler_PreservesPerKeyOrdering(t *testing.T) {
 	assert.Equal(t, []string{"add", "delete"}, operations)
 }
 
-func TestServer_txmetaHandler_ReturnsErrorWhenQueueFull(t *testing.T) {
+// TestServer_txmetaHandler_CaughtUpModeDropsOnFullQueue verifies that once the
+// caught-up latch is set, a full shard queue causes the batch to be silently
+// abandoned (no error returned to the kafka consumer) so the failure mode is
+// logged at Warn level instead of Error.
+func TestServer_txmetaHandler_CaughtUpModeDropsOnFullQueue(t *testing.T) {
 	server := &Server{
 		logger: ulogger.TestLogger{},
 	}
+	server.txmetaCaughtUp.Store(true)
 
-	// Pretend workers are already initialized with a permanently full shard queue.
+	// Pretend workers are already initialized; an unbuffered channel with no
+	// reader is always "full" for a non-blocking send.
 	server.txmetaWorkerInitOnce.Do(func() {})
 	server.txmetaWorkerQueues = []chan txmetaWorkItem{
 		make(chan txmetaWorkItem),
@@ -408,6 +415,158 @@ func TestServer_txmetaHandler_ReturnsErrorWhenQueueFull(t *testing.T) {
 	message := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
 
 	err := server.txmetaHandler(context.Background(), message)
+	assert.NoError(t, err)
+}
+
+// TestServer_txmetaHandler_StartupModeBlocksUntilDrained verifies the startup
+// mode applies backpressure: when the shard queue is full and the latch is not
+// set, the handler waits for the worker to drain instead of dropping.
+func TestServer_txmetaHandler_StartupModeBlocksUntilDrained(t *testing.T) {
+	server := &Server{
+		logger: ulogger.TestLogger{},
+	}
+	// Latch defaults to false (startup mode).
+
+	server.txmetaWorkerInitOnce.Do(func() {})
+	ch := make(chan txmetaWorkItem, 1)
+	server.txmetaWorkerQueues = []chan txmetaWorkItem{ch}
+
+	// Pre-fill the queue. Any further send blocks until a reader appears.
+	ch <- txmetaWorkItem{}
+
+	// Drain a single item after a short delay; this should unblock the handler.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		<-ch // drain the prefill
+	}()
+
+	hash := chainhash.Hash{0}
+	message := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
+
+	start := time.Now()
+	err := server.txmetaHandler(context.Background(), message)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond, "handler should have blocked until drained")
+	// The new item should now be sitting in the queue.
+	assert.Len(t, ch, 1)
+}
+
+// TestServer_txmetaHandler_StartupModeUnblocksOnContextCancel verifies that a
+// startup-mode blocking send unblocks when the context is cancelled, so the
+// service shutdown is not blocked by a stuck worker.
+func TestServer_txmetaHandler_StartupModeUnblocksOnContextCancel(t *testing.T) {
+	server := &Server{
+		logger: ulogger.TestLogger{},
+	}
+
+	server.txmetaWorkerInitOnce.Do(func() {})
+	ch := make(chan txmetaWorkItem) // unbuffered, no reader -> always blocks
+	server.txmetaWorkerQueues = []chan txmetaWorkItem{ch}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	hash := chainhash.Hash{0}
+	message := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
+
+	err := server.txmetaHandler(ctx, message)
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, errors.ErrProcessing))
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+// TestServer_txmetaHandler_LatchFlipsAtHighWaterMark verifies that observing a
+// message at the partition tail (msg.Offset+1 == HighWaterMark) flips the
+// caught-up latch.
+func TestServer_txmetaHandler_LatchFlipsAtHighWaterMark(t *testing.T) {
+	mockLogger := &mockLogger{}
+	mockCache := &mockCache{}
+	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+	mockLogger.On("Infof", mock.Anything, mock.Anything).Return()
+
+	server := &Server{
+		logger:    mockLogger,
+		utxoStore: mockCache,
+	}
+
+	hash := chainhash.Hash{7}
+	msg := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
+	msg.Topic = "txmeta"
+	msg.Partition = 0
+	msg.Offset = 99
+	msg.HighWaterMark = 100 // Offset+1 == HWM => tail
+
+	require.False(t, server.txmetaCaughtUp.Load())
+
+	err := server.txmetaHandler(context.Background(), msg)
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return server.txmetaCaughtUp.Load()
+	}, 2*time.Second, 10*time.Millisecond, "latch should flip on tail message")
+}
+
+// TestServer_txmetaHandler_LatchIgnoredWhenHighWaterMarkUnset verifies that an
+// unpopulated HighWaterMark (zero value) does NOT prematurely flip the latch.
+// This protects callers that wire a KafkaMessage by hand without HWM info.
+func TestServer_txmetaHandler_LatchIgnoredWhenHighWaterMarkUnset(t *testing.T) {
+	mockLogger := &mockLogger{}
+	mockCache := &mockCache{}
+	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+
+	server := &Server{
+		logger:    mockLogger,
+		utxoStore: mockCache,
+	}
+
+	hash := chainhash.Hash{7}
+	msg := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
+	msg.Offset = 0
+	msg.HighWaterMark = 0 // unset
+
+	err := server.txmetaHandler(context.Background(), msg)
+	assert.NoError(t, err)
+
+	// Give the worker a moment in case the latch were going to flip async.
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, server.txmetaCaughtUp.Load(), "latch must not flip when HWM is unset")
+}
+
+// TestServer_txmetaHandler_LatchIsOneWay verifies that once the latch is set,
+// subsequent messages that look like they are lagging (Offset+1 < HWM) do not
+// revert the latch.
+func TestServer_txmetaHandler_LatchIsOneWay(t *testing.T) {
+	mockLogger := &mockLogger{}
+	mockCache := &mockCache{}
+	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+	mockLogger.On("Infof", mock.Anything, mock.Anything).Return()
+
+	server := &Server{
+		logger:    mockLogger,
+		utxoStore: mockCache,
+	}
+
+	hash := chainhash.Hash{9}
+
+	// First message at the tail -> flips latch.
+	first := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("a"))
+	first.Offset = 10
+	first.HighWaterMark = 11
+	require.NoError(t, server.txmetaHandler(context.Background(), first))
+
+	assert.Eventually(t, func() bool {
+		return server.txmetaCaughtUp.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Second message lagging far behind a moved-on HWM. Latch must remain set.
+	second := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("b"))
+	second.Offset = 12
+	second.HighWaterMark = 5000
+	require.NoError(t, server.txmetaHandler(context.Background(), second))
+
+	assert.True(t, server.txmetaCaughtUp.Load(), "latch is one-way; must not revert")
 }

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -30,6 +30,10 @@ type KafkaMessage struct {
 	Partition int32
 	Offset    int64
 	Timestamp time.Time
+	// HighWaterMark is the partition's high water mark (the next offset that will be
+	// produced) at the time this fetch response was returned. Consumers can compare
+	// Offset+1 against HighWaterMark to detect "caught up to the live tail".
+	HighWaterMark int64
 }
 
 // KafkaConsumerGroupI defines the interface for Kafka consumer group operations.
@@ -460,26 +464,30 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 						continue
 					}
 
-					fetches.EachRecord(func(record *kgo.Record) {
-						kafkaMsg := &KafkaMessage{
-							Key:       record.Key,
-							Value:     record.Value,
-							Topic:     record.Topic,
-							Partition: record.Partition,
-							Offset:    record.Offset,
-							Timestamp: record.Timestamp,
-						}
+					fetches.EachPartition(func(p kgo.FetchTopicPartition) {
+						hwm := p.HighWatermark
+						for _, record := range p.Records {
+							kafkaMsg := &KafkaMessage{
+								Key:           record.Key,
+								Value:         record.Value,
+								Topic:         record.Topic,
+								Partition:     record.Partition,
+								Offset:        record.Offset,
+								Timestamp:     record.Timestamp,
+								HighWaterMark: hwm,
+							}
 
-						if err := consumerFn(kafkaMsg); err != nil {
-							k.Config.Logger.Errorf("[kafka_consumer] failed to process message (topic: %s, partition: %d, offset: %d): %v",
-								record.Topic, record.Partition, record.Offset, err)
-							return
-						}
+							if err := consumerFn(kafkaMsg); err != nil {
+								k.Config.Logger.Errorf("[kafka_consumer] failed to process message (topic: %s, partition: %d, offset: %d): %v",
+									record.Topic, record.Partition, record.Offset, err)
+								return
+							}
 
-						if !k.Config.AutoCommitEnabled {
-							uncommittedMu.Lock()
-							uncommittedRecords = append(uncommittedRecords, record)
-							uncommittedMu.Unlock()
+							if !k.Config.AutoCommitEnabled {
+								uncommittedMu.Lock()
+								uncommittedRecords = append(uncommittedRecords, record)
+								uncommittedMu.Unlock()
+							}
 						}
 					})
 
@@ -684,12 +692,13 @@ func (h *inMemoryConsumerHandler) Cleanup(_ inmemorykafka.ConsumerGroupSession) 
 func (h *inMemoryConsumerHandler) ConsumeClaim(session inmemorykafka.ConsumerGroupSession, claim inmemorykafka.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
 		kafkaMsg := &KafkaMessage{
-			Key:       message.Key,
-			Value:     message.Value,
-			Topic:     message.Topic,
-			Partition: message.Partition,
-			Offset:    message.Offset,
-			Timestamp: message.Timestamp,
+			Key:           message.Key,
+			Value:         message.Value,
+			Topic:         message.Topic,
+			Partition:     message.Partition,
+			Offset:        message.Offset,
+			Timestamp:     message.Timestamp,
+			HighWaterMark: claim.HighWaterMarkOffset(),
 		}
 
 		var err error

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -480,7 +480,11 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 							if err := consumerFn(kafkaMsg); err != nil {
 								k.Config.Logger.Errorf("[kafka_consumer] failed to process message (topic: %s, partition: %d, offset: %d): %v",
 									record.Topic, record.Partition, record.Offset, err)
-								return
+								// Continue to the next record. Skipping the
+								// uncommittedRecords append keeps the failed
+								// record from being marked done, matching the
+								// pre-refactor EachRecord behavior.
+								continue
 							}
 
 							if !k.Config.AutoCommitEnabled {


### PR DESCRIPTION
## Summary

Replaces the unconditional drop-on-full behavior in the txmeta shard worker pool (introduced in #858) with a mode latched off the Kafka partition high water mark:

- **Startup** (catching up to the live tail): blocking enqueue with ctx escape so **no txmeta cache updates are dropped** while the cache is cold. The Kafka consumer is naturally paced by the slowest shard worker.
- **Caught up** (latched the first time `msg.Offset+1 >= msg.HighWaterMark`): non-blocking enqueue; a full shard queue is now logged at **Warn** instead of Error, and the remainder of the batch is abandoned (cache repopulates from Kafka on restart — best-effort by design).

The latch is **one-way**: once set it stays set, so a long re-catch-up later still operates in live (drop) mode.

### Why

In production we see this Error log spamming during scale tests:
```
ERROR | [kafka_consumer] error processing kafka message on topic txmeta-... skipping: PROCESSING (4): [txmetaHandler] txmeta worker queue full for shard 155
```
This is the documented best-effort drop firing, so it shouldn't be logged at Error level. And during initial backfill, dropping txmeta updates leaves the cache cold for those entries — better to apply backpressure to Kafka until we're caught up.

### Changes

- `util/kafka/kafka_consumer.go`: added `HighWaterMark int64` to `KafkaMessage`; switched the franz-go fetch loop from `EachRecord` to `EachPartition` to read `p.HighWatermark`; populated HWM in the in-memory consumer via `claim.HighWaterMarkOffset()`. Field is additive — other consumers ignore it.
- `services/subtreevalidation/Server.go`: added `txmetaCaughtUp atomic.Bool` latch.
- `services/subtreevalidation/txmetaHandler.go`: two-mode `enqueueTxmetaWorkItem`; `maybeMarkTxmetaCaughtUp` flips the latch on the partition tail.
- `services/subtreevalidation/txmetaHandler_test.go`: replaced the now-invalid `ReturnsErrorWhenQueueFull` test with six tests covering caught-up drop, startup blocking, ctx-cancel unblock, latch flip on HWM, no flip when HWM unset, and one-way latch behavior.

### Latch design (deliberate trade-offs)

Documented in code at `maybeMarkTxmetaCaughtUp`:

- **One-way.** A node that catches up, runs for hours, then falls badly behind (extended pause) operates in drop mode through the re-catch-up. If you'd rather it re-arm on lag, that's a small follow-up.
- **Any-partition.** For multi-partition txmeta topics, the latch flips as soon as ANY assigned partition reaches its tail. txmeta is sharded by tx hash and partitions are evenly loaded under normal traffic, so seeing one tail is a strong signal we're broadly caught up. A stricter per-partition gating would extend cold-cache blocking unnecessarily if one partition is temporarily empty or slow.
- **Fail-closed on `HighWaterMark<=0`.** An unset HWM (in-memory consumer, hand-built messages) keeps the latch in startup (blocking) mode. Smoke tests are low-throughput, so the shard queues should never fill and the blocking mode is effectively a no-op there.
- **Abort-on-first-full-shard preserved.** In drop mode the rest of the batch is still abandoned on first full shard. This matches the prior semantic; widening it to "skip full shards but enqueue to others" is a separate change.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./services/subtreevalidation/... ./util/kafka/...` clean
- [x] `staticcheck ./services/subtreevalidation/... ./util/kafka/...` clean
- [x] `golangci-lint run ./services/subtreevalidation/... ./util/kafka/...` clean (pre-existing prealloc warnings in unrelated test files)
- [x] `go test -race -count=1 ./services/subtreevalidation/... ./util/kafka/...` all pass
- [ ] Verify in scale-test environment that the production Error log is gone and startup no longer drops txmeta updates while catching up.