### PR TITLE
fix(asset): return 404 when subtreeData cannot be regenerated

### DIFF
--- a/services/asset/repository/GetSubtreeData.go
+++ b/services/asset/repository/GetSubtreeData.go
@@ -80,6 +80,30 @@ func (repo *Repository) GetSubtreeDataReader(ctx context.Context, subtreeHash *c
 		}, nil
 	}
 
+	// SubtreeData doesn't exist. The on-demand fallback (dualStreamWithFileCreation)
+	// regenerates the data from the underlying subtree file in a goroutine *after* the
+	// HTTP handler has committed to 200 OK. If neither the subtree nor the
+	// subtreeToCheck file is present we cannot regenerate, and the handler would
+	// otherwise emit "200 OK + empty body", which peers report as
+	// ErrSubtreeLengthMismatch. Surface a NotFound instead so the handler returns 404
+	// and callers can attempt another peer.
+	subtreeExists, existsErr := repo.SubtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtree)
+	if existsErr != nil {
+		releaseSemaphorePermit(repo.semGetSubtreeDataReader)
+		return nil, existsErr
+	}
+	if !subtreeExists {
+		toCheckExists, toCheckErr := repo.SubtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtreeToCheck)
+		if toCheckErr != nil {
+			releaseSemaphorePermit(repo.semGetSubtreeDataReader)
+			return nil, toCheckErr
+		}
+		if !toCheckExists {
+			releaseSemaphorePermit(repo.semGetSubtreeDataReader)
+			return nil, errors.NewNotFoundError("subtree %s not found", subtreeHash.String())
+		}
+	}
+
 	// File doesn't exist - create it on-demand while streaming to HTTP response
 	return repo.dualStreamWithFileCreation(ctx, subtreeHash)
 }

--- a/services/asset/repository/GetSubtreeData.go
+++ b/services/asset/repository/GetSubtreeData.go
@@ -67,7 +67,14 @@ func (repo *Repository) GetSubtreeDataReader(ctx context.Context, subtreeHash *c
 	// Note: semaphore will be released when the returned reader is closed
 
 	subtreeDataExists, err := repo.SubtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtreeData)
-	if err == nil && subtreeDataExists {
+	if err != nil {
+		// Surface storage errors instead of falling through to the NotFound /
+		// on-demand path — otherwise an IO failure here would be silently
+		// reclassified as 404 or trigger an unnecessary regeneration attempt.
+		releaseSemaphorePermit(repo.semGetSubtreeDataReader)
+		return nil, err
+	}
+	if subtreeDataExists {
 		reader, err := repo.SubtreeStore.GetIoReader(ctx, subtreeHash[:], fileformat.FileTypeSubtreeData)
 		if err != nil {
 			releaseSemaphorePermit(repo.semGetSubtreeDataReader)

--- a/services/asset/repository/GetSubtreeData_test.go
+++ b/services/asset/repository/GetSubtreeData_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/utxopersister/filestorer"
 	"github.com/bsv-blockchain/teranode/util/tracing"
@@ -58,6 +59,19 @@ func TestGetSubtreeDataWithReader(t *testing.T) {
 
 		// close the reader
 		require.NoError(t, r.Close())
+	})
+
+	t.Run("returns NotFound when neither subtreeData nor subtree exists", func(t *testing.T) {
+		// Regression: previously the on-demand fallback committed to 200 OK and then
+		// failed inside a goroutine, leaving peers with a truncated body that parsed
+		// as ErrSubtreeLengthMismatch. With no source data on disk the repository
+		// must surface NotFound up front so the HTTP layer can emit 404.
+		resetQuorumForTests()
+		ctx, subtree, _ := setupSubtreeReaderTest(t)
+
+		_, err := ctx.repo.GetSubtreeDataReader(t.Context(), subtree.RootHash())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errors.ErrNotFound), "expected ErrNotFound, got: %v", err)
 	})
 
 	t.Run("get subtree from utxo store and verify file creation", func(t *testing.T) {

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -640,8 +640,10 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 		}
 	}
 
-	// All peers failed
-	return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s, last error: %v", subtreeHash.String(), lastErr)
+	// All peers failed. errors.NewServiceError extracts the trailing error param as
+	// the wrapped error, so a "%v" placeholder for lastErr would render as
+	// %!v(MISSING). The wrapped error is preserved in the chain.
+	return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s", subtreeHash.String(), lastErr)
 }
 
 // fetchSubtreeFromPeer fetches subtree (for subtreeToCheck) from a peer via HTTP


### PR DESCRIPTION
## Summary

- When a peer requests `/subtree_data/<hash>` and the file is missing, the asset service falls back to `dualStreamWithFileCreation`, which commits to **HTTP 200 OK** before spawning a goroutine to regenerate the data from the underlying subtree. If neither the `subtree` nor the `subtreeToCheck` file is present, the goroutine errors out, the pipe is closed mid-stream, and the peer receives **200 OK + empty body**. The catchup client (`fetchAndStoreSubtreeData`) then parses that as `subtree.ErrSubtreeLengthMismatch` (`"subtree length does not match tx data length"`), masking what is really a NotFound and causing wasted retries across all alternative peers.
- Pre-check both source files in `GetSubtreeDataReader` before entering the dual-stream path; return `errors.NewNotFoundError` if neither exists so the HTTP handler emits a proper **404** and catchup can try the next peer instead.
- Also drop the trailing `, last error: %v` in `fetchAndStoreSubtreeAndSubtreeData`'s aggregate error. `errors.NewServiceError` extracts the trailing `error` param as the wrapped error, so the placeholder rendered as `%!v(MISSING)` in production logs. The wrapped error is preserved in the error chain.

## Observed error in production

```
PROCESSING (4): [catchup:fetchAndStoreSubtreeData] Peer 12D3KooWBLLMRg6z... (http://asset-cache.dev-...svc.cluster.local:9090/api/v1) provided incomplete subtree data for 5c5c1aca... -> UNKNOWN (0): subtree length does not match tx data length
```

Root cause: asset returns `200 OK` with a truncated/empty body when on-demand regeneration cannot find the source subtree. The nginx cache-proxy passes the response through (chunked transfer, so the `skip_cache_empty` map keeps the broken response out of cache — confirmed safe).

## Test plan

- [x] `go vet ./services/asset/... ./services/blockvalidation/...`
- [x] `go build ./services/asset/... ./services/blockvalidation/...`
- [x] `go test ./services/asset/...` (all pass)
- [x] `go test ./services/blockvalidation/` (all pass)
- [x] New regression test: `TestGetSubtreeDataWithReader/returns_NotFound_when_neither_subtreeData_nor_subtree_exists` asserts `errors.Is(err, errors.ErrNotFound)` when source data is absent.
- [ ] Verify in a dev cluster that requesting an unknown subtree hash now returns `HTTP 404` from the asset and that catchup peer-retry treats it as a clean not-found rather than `ErrSubtreeLengthMismatch`.

## Notes

- Only the cold path (subtreeData missing) gets two extra `Exists()` calls. Hot path is unchanged.
- Race-test failures in `model.DiskParentSpendsMap` observed during local `go test -race` are pre-existing on `main` (verified by stashing my changes) and unrelated to this fix.