### PR TITLE
perf(aerospike): fan out BatchPreviousOutputsDecorate per-tx

### DIFF
--- a/stores/utxo/aerospike/aerospike_server_test.go
+++ b/stores/utxo/aerospike/aerospike_server_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/teranode/errors"
@@ -1416,6 +1417,75 @@ func TestStoreDecorate(t *testing.T) {
 		// check field values for vout 1 - item 4
 		assert.Len(t, *childTx.Inputs[4].PreviousTxScript, 25)
 		assert.Equal(t, uint64(2_000_000), childTx.Inputs[4].PreviousTxSatoshis)
+	})
+
+	t.Run("aerospike_BatchPreviousOutputsDecorate", func(t *testing.T) {
+		// Covers the per-tx fan-out inside BatchPreviousOutputsDecorate: multiple
+		// child txs decorate concurrently, every input across every child must end
+		// up populated, and the shared outpoint batcher must dedupe the parent
+		// fetch even though three goroutines race to request it.
+		cleanDB(t, client)
+
+		_, createErr := store.Create(ctx, tx, 0)
+		require.NoError(t, createErr)
+
+		// Each child references two different outputs of the same parent. Three
+		// children -> six inputs across the batch, exercising the errgroup fan-out
+		// and the batcher's dedup of the shared parent.
+		newChild := func(vout1, vout2 uint32) *bt.Tx {
+			child := &bt.Tx{}
+
+			in1 := &bt.Input{PreviousTxOutIndex: vout1}
+			_ = in1.PreviousTxIDAdd(tx.TxIDChainHash())
+			child.Inputs = append(child.Inputs, in1)
+
+			in2 := &bt.Input{PreviousTxOutIndex: vout2}
+			_ = in2.PreviousTxIDAdd(tx.TxIDChainHash())
+			child.Inputs = append(child.Inputs, in2)
+
+			return child
+		}
+
+		child1 := newChild(0, 4)
+		child2 := newChild(1, 2)
+		child3 := newChild(3, 0) // vout 0 also referenced by child1 -> dedup path
+
+		batchErr := store.BatchPreviousOutputsDecorate(ctx, []*bt.Tx{child1, child2, child3})
+		require.NoError(t, batchErr)
+
+		// Expected satoshis taken from the same parent fixture used by the
+		// aerospike_PreviousOutputsDecorate subtest above.
+		expected := map[uint32]uint64{
+			0: 5_000_000,
+			1: 2_000_000,
+			2: 20_000,
+			3: 20_000,
+			4: 2_817_689,
+		}
+		for _, child := range []*bt.Tx{child1, child2, child3} {
+			for i, input := range child.Inputs {
+				require.NotNil(t, input.PreviousTxScript, "input %d not decorated", i)
+				assert.Len(t, *input.PreviousTxScript, 25)
+				assert.Equal(t, expected[input.PreviousTxOutIndex], input.PreviousTxSatoshis,
+					"wrong satoshis for vout %d", input.PreviousTxOutIndex)
+			}
+		}
+
+		// Empty + nil-tolerance: empty slice is a no-op; an already-decorated
+		// input must not be touched (PreviousOutputsDecorate skips on
+		// PreviousTxScript != nil, which the batch path relies on).
+		require.NoError(t, store.BatchPreviousOutputsDecorate(ctx, nil))
+		require.NoError(t, store.BatchPreviousOutputsDecorate(ctx, []*bt.Tx{}))
+
+		preserved := newChild(0, 1)
+		sentinel := bscript.NewFromBytes([]byte{0xde, 0xad, 0xbe, 0xef})
+		preserved.Inputs[0].PreviousTxScript = sentinel
+		preserved.Inputs[0].PreviousTxSatoshis = 999
+		require.NoError(t, store.BatchPreviousOutputsDecorate(ctx, []*bt.Tx{preserved}))
+		assert.Same(t, sentinel, preserved.Inputs[0].PreviousTxScript, "already-decorated input was overwritten")
+		assert.Equal(t, uint64(999), preserved.Inputs[0].PreviousTxSatoshis)
+		// the other input should still have been decorated from the store
+		assert.Equal(t, expected[1], preserved.Inputs[1].PreviousTxSatoshis)
 	})
 }
 

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -80,6 +80,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	"github.com/ordishs/gocore"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -1188,63 +1189,26 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 }
 
 // BatchPreviousOutputsDecorate fetches previous output information for inputs across
-// multiple transactions in one flat pass through the outpoint batcher.
+// multiple transactions, fanning the per-tx decorations out across goroutines so the
+// shared outpoint batcher fills by size from concurrent pushes instead of idling at
+// its per-tx duration timer.
 //
-// The naive per-tx loop (PreviousOutputsDecorate called once per tx) is correct but
-// pathologically slow during legacy sync: a typical tx has ~2 inputs, far below
-// the batcher's size threshold (OutpointBatcherSize, default 100/4096 depending on
-// override), so each per-tx call waits the full OutpointBatcherDurationMillis timer
-// before the batch fires. That makes wall time scale as O(N_tx * duration) — e.g.
-// 2856 tx × 5 ms ≈ 14 s observed in production.
-//
-// Flattening every input across every tx into one Put loop lets the batcher fill by
-// size for the bulk of the work, collapsing wall time to roughly
-// O(total_inputs / OutpointBatcherSize) aerospike round-trips plus at most one
-// duration-timer flush for the tail.
-func (s *Store) BatchPreviousOutputsDecorate(_ context.Context, txs []*bt.Tx) error {
-	totalInputs := 0
-	for _, tx := range txs {
-		if tx == nil {
-			continue
-		}
-		totalInputs += len(tx.Inputs)
-	}
-	if totalInputs == 0 {
-		return nil
-	}
-
-	errChans := make([]chan error, 0, totalInputs)
+// A serial per-tx loop was correct but pathologically slow during legacy sync: a
+// typical tx contributes ~2 inputs - far below OutpointBatcherSize - so each call
+// waited the full OutpointBatcherDurationMillis before the batch fired, making wall
+// time scale as O(N_tx * duration) - e.g. 2856 tx x 5 ms ~= 14 s observed in
+// production.
+func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) error {
+	g, gCtx := errgroup.WithContext(ctx)
 
 	for _, tx := range txs {
-		if tx == nil {
-			continue
-		}
-		for _, input := range tx.Inputs {
-			if input == nil || input.PreviousTxScript != nil {
-				// already decorated (e.g. by an earlier same-block phase) — skip.
-				continue
-			}
-
-			errChan := make(chan error, 1)
-			errChans = append(errChans, errChan)
-
-			s.outpointBatcher.Put(&batchOutpoint{
-				outpoint: input,
-				errCh:    errChan,
-			})
-		}
+		tx := tx
+		g.Go(func() error {
+			return s.PreviousOutputsDecorate(gCtx, tx)
+		})
 	}
 
-	// Drain all results. Each errChan is buffered (cap 1) and writes go through
-	// sendErrorAndClose, so returning early on the first error never blocks
-	// in-flight batcher workers — they complete their non-blocking send and exit.
-	for _, errChan := range errChans {
-		if err := <-errChan; err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return g.Wait()
 }
 
 func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -1198,8 +1198,15 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 // waited the full OutpointBatcherDurationMillis before the batch fired, making wall
 // time scale as O(N_tx * duration) - e.g. 2856 tx x 5 ms ~= 14 s observed in
 // production.
+//
+// Fan-out is bounded by UtxoStore.OutpointBatcherSize to keep memory predictable
+// on large blocks and to mirror the Phase 1 errgroup bound in the legacy caller
+// (services/legacy/netsync/handle_block.go). Throughput is not affected by the
+// bound: the actual ceiling is BatcherMaxConcurrent aerospike batches in flight,
+// not the goroutine count, since producers are mostly parked on errChan receives.
 func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) error {
 	g, gCtx := errgroup.WithContext(ctx)
+	util.SafeSetLimit(g, s.settings.UtxoStore.OutpointBatcherSize)
 
 	for _, tx := range txs {
 		tx := tx

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -1188,14 +1188,62 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 }
 
 // BatchPreviousOutputsDecorate fetches previous output information for inputs across
-// multiple transactions. The Aerospike implementation delegates to per-tx PreviousOutputsDecorate
-// which already uses an internal batcher for efficiency.
-func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) error {
+// multiple transactions in one flat pass through the outpoint batcher.
+//
+// The naive per-tx loop (PreviousOutputsDecorate called once per tx) is correct but
+// pathologically slow during legacy sync: a typical tx has ~2 inputs, far below
+// the batcher's size threshold (OutpointBatcherSize, default 100/4096 depending on
+// override), so each per-tx call waits the full OutpointBatcherDurationMillis timer
+// before the batch fires. That makes wall time scale as O(N_tx * duration) — e.g.
+// 2856 tx × 5 ms ≈ 14 s observed in production.
+//
+// Flattening every input across every tx into one Put loop lets the batcher fill by
+// size for the bulk of the work, collapsing wall time to roughly
+// O(total_inputs / OutpointBatcherSize) aerospike round-trips plus at most one
+// duration-timer flush for the tail.
+func (s *Store) BatchPreviousOutputsDecorate(_ context.Context, txs []*bt.Tx) error {
+	totalInputs := 0
 	for _, tx := range txs {
-		if err := s.PreviousOutputsDecorate(ctx, tx); err != nil {
+		if tx == nil {
+			continue
+		}
+		totalInputs += len(tx.Inputs)
+	}
+	if totalInputs == 0 {
+		return nil
+	}
+
+	errChans := make([]chan error, 0, totalInputs)
+
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		for _, input := range tx.Inputs {
+			if input == nil || input.PreviousTxScript != nil {
+				// already decorated (e.g. by an earlier same-block phase) — skip.
+				continue
+			}
+
+			errChan := make(chan error, 1)
+			errChans = append(errChans, errChan)
+
+			s.outpointBatcher.Put(&batchOutpoint{
+				outpoint: input,
+				errCh:    errChan,
+			})
+		}
+	}
+
+	// Drain all results. Each errChan is buffered (cap 1) and writes go through
+	// sendErrorAndClose, so returning early on the first error never blocks
+	// in-flight batcher workers — they complete their non-blocking send and exit.
+	for _, errChan := range errChans {
+		if err := <-errChan; err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`stores/utxo/aerospike.(*Store).BatchPreviousOutputsDecorate` looped per-tx and called the per-tx decorate path serially. On legacy sync this forced one `OutpointBatcherDurationMillis` flush per transaction (default 10 ms; 5 ms on our mainnet prod nodes) because each per-tx call only queued ~2 inputs - well below `OutpointBatcherSize` - so the batcher always waited the full timer before firing.

Observed on `bsva-ovh-teranode-eu-3` mainnet legacy sync at height ~381.5k:

| Block tx count | `extendTransactions` wall |
|----------------|---------------------------|
| 2856           | 14.34 s                   |
| 2820           | 13.84 s                   |
| 2076           | 11.18 s                   |
| 1620           | 8.31 s                    |
| 997            | 5.39 s                    |

Wall time tracked `5 ms x N_tx` almost exactly. CPU was ~16% of one core; the 30 s CPU profile + goroutine dump showed exactly one `PreviousOutputsDecorate` in flight and zero `sendOutpointBatch` workers running while the loop waited - the aerospike batcher pool sat idle.

## Change

`BatchPreviousOutputsDecorate` now wraps the per-tx `PreviousOutputsDecorate` calls in an `errgroup` so they push into the shared outpoint batcher concurrently. The batcher fills by size from concurrent producers instead of idling at its per-tx duration timer.

Existing per-tx behaviour (skip already-decorated inputs, dedup parent fetches across the batch, external-store cache) is unchanged - we just stop serialising the producers.

## Expected impact

For a 2856-tx block: `extendTransactions` ~14 s -> a few aerospike round-trips (~10-50 ms).

Callers that benefit:
- `services/legacy/netsync/handle_block.go:1029` - block ingest phase 2
- `services/blockvalidation/quick_validate.go:1081, 1419` - catchup decorate

## Tests added

`aerospike_BatchPreviousOutputsDecorate` subtest under `TestAerospike` covers:
- Multiple child txs decorated in one call - every input across every child is populated with the correct satoshis / locking script.
- Shared parent across children - same parent vout referenced by two children exercises the batcher's dedup of the underlying aerospike fetch even though goroutines race to request it.
- Empty / nil tx slice - no-op.
- Already-decorated input preserved - `PreviousTxScript != nil` inputs must not be overwritten (the early-skip in `PreviousOutputsDecorate` is what stops Phase 1's txMap work from being clobbered by Phase 2 in the legacy caller).

The function had no direct test in the aerospike package before this PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./stores/utxo/aerospike/...` clean
- [x] `go test -race -count=1 ./stores/utxo/aerospike/...` - all subtests pass (524 total, +1 new)
- [x] Deploy to `bsva-ovh-teranode-eu-3`, confirm `extendTransactions DONE in` log line drops by at least one order of magnitude on multi-thousand-tx blocks
- [x] Confirm block sync rate improves on mainnet legacy sync from same starting height