### PR TITLE
fix(kafka): per-partition fan-out + sticky-partitioner producer keys

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -136,6 +136,12 @@ type txMetaCacheOps interface {
 	// This method allows direct storage of pre-serialized metadata for performance optimization.
 	// Returns an error if the cache operation fails.
 	SetCacheFromBytes(key, txMetaBytes []byte) error
+
+	// SetCacheMulti stores multiple cache entries in a single call.
+	// Implementations are expected to fan out across the cache's bucket-shard locks so that
+	// a single Kafka message containing many entries acquires each touched bucket lock once
+	// instead of once per entry. Critical for txmetaHandler throughput under heavy load.
+	SetCacheMulti(keys [][]byte, values [][]byte) error
 }
 
 // SetTxMetaCacheFromBytes stores raw transaction metadata bytes in the cache.
@@ -160,6 +166,20 @@ func (u *Server) SetTxMetaCacheFromBytes(_ context.Context, key, txMetaBytes []b
 		return cache.SetCacheFromBytes(key, txMetaBytes)
 	}
 
+	return nil
+}
+
+// SetTxMetaCacheMulti stores multiple transaction metadata entries in the cache in a single call.
+// Used by the Kafka txmeta handler to batch all ADD entries from one Kafka message into a single
+// cache call, allowing the cache's per-bucket locks to be acquired once per touched bucket
+// (rather than once per entry, sequentially, as the previous one-at-a-time path did).
+func (u *Server) SetTxMetaCacheMulti(_ context.Context, keys [][]byte, values [][]byte) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if cache, ok := u.utxoStore.(txMetaCacheOps); ok {
+		return cache.SetCacheMulti(keys, values)
+	}
 	return nil
 }
 

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -170,9 +170,15 @@ func (u *Server) SetTxMetaCacheFromBytes(_ context.Context, key, txMetaBytes []b
 }
 
 // SetTxMetaCacheMulti stores multiple transaction metadata entries in the cache in a single call.
-// Used by the Kafka txmeta handler to batch all ADD entries from one Kafka message into a single
-// cache call, allowing the cache's per-bucket locks to be acquired once per touched bucket
-// (rather than once per entry, sequentially, as the previous one-at-a-time path did).
+//
+// Reserved for a future batched fan-out optimisation of the Kafka txmeta handler: the
+// intent is that a single Kafka message containing N ADD entries can be applied as one
+// SetCacheMulti call, letting the underlying cache acquire each touched per-bucket lock
+// once per call instead of once per entry. The current txmetaHandler is sharded across
+// 256 hash-byte worker goroutines and applies entries one at a time via
+// SetTxMetaCacheFromBytes — it does NOT call this method yet. Kept on the interface so
+// alternative cache implementations can implement the fan-out today and the handler can
+// be migrated later without an interface change.
 func (u *Server) SetTxMetaCacheMulti(_ context.Context, keys [][]byte, values [][]byte) error {
 	if len(keys) == 0 {
 		return nil

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -52,8 +52,40 @@ func (u *Server) txmetaMessageHandler(ctx context.Context) func(msg *kafka.Kafka
 //	[4 bytes]  - content length (uint32, little-endian) - 0 for DELETE
 //	[N bytes]  - content (metaBytes) - only for ADD
 //
-// Processing errors are logged and the message is marked as completed
-// to prevent infinite retry loops on malformed data.
+// Entries are sharded by the first byte of the tx hash across
+// txmetaWorkerShardCount (256) worker goroutines, each draining its own
+// bounded channel (txmetaWorkerQueueSize). Sharding by hash byte preserves
+// per-key ordering: every operation for the same hash lands in the same
+// shard and is therefore applied in arrival order. Per-shard parallelism
+// gives us 256-way concurrency without the per-entry-goroutine cost that
+// an earlier design suffered (89K goroutine queue depth at ~1.1M
+// entries/sec, p50 enqueue→complete ~80 ms; spawn+queue dominated the
+// microsecond-scale cache writes).
+//
+// On full shard queues:
+//
+//   - During startup (before u.txmetaCaughtUp latches) the enqueue blocks,
+//     propagating backpressure into the Kafka poll loop so the cold cache
+//     is rebuilt without dropping entries.
+//
+//   - Once caught up (any partition reaches its tail) the enqueue is
+//     drop-on-full and the remainder of the current Kafka batch is
+//     abandoned. The cache will be repopulated from Kafka on the next
+//     restart; live ADDs that are dropped fall through to the UTXO store
+//     on the next BatchDecorate. enqueueTxmetaWorkItem logs a Warn.
+//
+// Memory: ADD content is COPIED out of msg.Value because the worker may
+// run after the puller has advanced past this Kafka record. DELETE entries
+// store only the 32-byte chainhash.Hash by value (no allocation).
+//
+// Errors:
+//
+//   - Truncated message: logged and acked (return nil) to avoid infinite
+//     retry loops on corrupt input.
+//
+//   - Enqueue error (shard channel send fails for a reason other than
+//     full): returned, so the Kafka offset stays uncommitted and the
+//     message is re-delivered on restart.
 func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) error {
 	if msg == nil || len(msg.Value) < 4 {
 		return nil

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -963,8 +963,10 @@ func (v *Validator) sendTxMetaToKafka(data *meta.Data, txHash *chainhash.Hash) e
 			isDelete:  false,
 		}})
 
+		// Hash key spreads single-item fallback messages evenly across partitions
+		// instead of bunching on franz-go's StickyKeyPartitioner default for nil keys.
 		v.txmetaKafkaProducerClient.Publish(&kafka.Message{
-			Key:   nil,
+			Key:   txHash[:],
 			Value: value,
 		})
 	}
@@ -975,6 +977,17 @@ func (v *Validator) sendTxMetaToKafka(data *meta.Data, txHash *chainhash.Hash) e
 }
 
 // sendTxMetaBatch serializes and publishes a batch of TxMeta items to Kafka.
+//
+// The Kafka message key is set to the first item's tx hash. With franz-go's default
+// StickyKeyPartitioner this hashes onto a single partition deterministically, which:
+//  1. Distributes traffic evenly across the topic's partitions (tx hashes are uniform).
+//  2. Keeps every record from one batch on the same partition (preserves any
+//     intra-batch ordering the consumer might rely on).
+//
+// Previously Key was nil, which makes StickyKeyPartitioner equivalent to a
+// StickyPartitioner — bunching consecutive batches onto the same partition until
+// linger expires. That created bursty partition usage and the observed Kafka-read
+// throughput oscillation on the consumer side.
 func (v *Validator) sendTxMetaBatch(batch []*txmetaBatchItem) {
 	if len(batch) == 0 {
 		return
@@ -983,7 +996,7 @@ func (v *Validator) sendTxMetaBatch(batch []*txmetaBatchItem) {
 	value := serializeTxMetaBatch(batch)
 
 	v.txmetaKafkaProducerClient.Publish(&kafka.Message{
-		Key:   nil,
+		Key:   batch[0].hash[:],
 		Value: value,
 	})
 }

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -488,13 +488,34 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 			// even though they were successfully processed.
 			var partitionWg sync.WaitGroup
 
+			// partitionLocks serialises processing within a single partition
+			// across consecutive fetches. PollFetches returns immediately and
+			// can hand us a second batch from partition P before the goroutine
+			// processing the first batch has finished. Without a per-partition
+			// lock, batch B could mark/append a later offset while batch A is
+			// mid-way; a subsequent commitRecords would then advance the
+			// partition past records A had not yet processed, and if A later
+			// fails on an earlier offset the broker never re-delivers them.
+			// One mutex per partition is allocated lazily on first use; the
+			// number of partitions is bounded by the topic config.
+			var partitionLocks sync.Map // map[int32]*sync.Mutex
+
+			// shutdownDrain captures everything in flight on every exit path.
+			// Must run for context cancellation AND for fetch errors that
+			// indicate the client is closing (ErrClientClosed / ctx.Canceled),
+			// otherwise records processed after the last ticker commit are
+			// lost despite successful processing.
+			shutdownDrain := func() {
+				partitionWg.Wait()
+				uncommittedMu.Lock()
+				k.commitRecords(uncommittedRecords)
+				uncommittedMu.Unlock()
+			}
+
 			for {
 				select {
 				case <-internalCtx.Done():
-					partitionWg.Wait()
-					uncommittedMu.Lock()
-					k.commitRecords(uncommittedRecords)
-					uncommittedMu.Unlock()
+					shutdownDrain()
 					return
 				default:
 				}
@@ -505,6 +526,7 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 					for _, err := range errs {
 						if errors.Is(err.Err, context.Canceled) || errors.Is(err.Err, kgo.ErrClientClosed) {
 							k.Config.Logger.Debugf("Kafka consumer shutdown: %v", err.Err)
+							shutdownDrain()
 							return
 						}
 						k.Config.Logger.Errorf("Kafka consumer error on topic %s partition %d: %v", err.Topic, err.Partition, err.Err)
@@ -522,9 +544,17 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 					// and the goroutine below outlives it.
 					hwm := p.HighWatermark
 
+					muIface, _ := partitionLocks.LoadOrStore(p.Partition, &sync.Mutex{})
+					mu := muIface.(*sync.Mutex)
+
 					partitionWg.Add(1)
-					go func(records []*kgo.Record, hwm int64) {
+					go func(records []*kgo.Record, hwm int64, mu *sync.Mutex) {
 						defer partitionWg.Done()
+						// Serialise processing within this partition. Different
+						// partitions remain parallel; cross-partition ordering is
+						// not preserved (and was never claimed).
+						mu.Lock()
+						defer mu.Unlock()
 						for _, record := range records {
 							select {
 							case <-internalCtx.Done():
@@ -562,7 +592,7 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 								uncommittedMu.Unlock()
 							}
 						}
-					}(p.Records, hwm)
+					}(p.Records, hwm, mu)
 				})
 
 				select {

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -318,7 +318,18 @@ func NewKafkaConsumerGroup(cfg KafkaConsumerConfig) (*KafkaConsumerGroup, error)
 	}
 
 	// Configure auto-commit
-	if !cfg.AutoCommitEnabled {
+	//
+	// AutoCommitEnabled=true → AutoCommitMarks: franz-go auto-commits only records that
+	// the consume loop has explicitly marked via MarkCommitRecords. Combined with the
+	// per-partition consume loop (Start), we mark a record only after consumerFn has
+	// returned without error, so a record that caused an error or never reached its
+	// handler does not get committed silently by the auto-commit timer.
+	//
+	// AutoCommitEnabled=false → DisableAutoCommit: callers manage commits via the
+	// uncommittedRecords slice + commitTicker in Start.
+	if cfg.AutoCommitEnabled {
+		opts = append(opts, kgo.AutoCommitMarks())
+	} else {
 		opts = append(opts, kgo.DisableAutoCommit())
 	}
 
@@ -435,7 +446,29 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 	go func() {
 		defer cancel()
 
-		// Main consume loop
+		// Main consume loop — fire-and-forget per-partition fan-out, no barrier.
+		//
+		//   [franz-go background fetcher → local record buffer]
+		//             ↓
+		//   [puller goroutine: tight PollFetches loop]
+		//             ↓                ↓                ↓
+		//   [partition 0 goroutine] [partition 1 goroutine] [partition N goroutine]
+		//             ↓                ↓                ↓
+		//                consumerFn (sequential within each goroutine)
+		//
+		// franz-go's EachPartition is dumb-serial — three nested for-loops
+		// calling fn synchronously. To recover the cross-partition parallelism
+		// that c2402191f intended, we spawn a goroutine per partition per
+		// fetch. The puller does NOT wait for those goroutines (no
+		// partitionWg.Wait), so PollFetches is called again immediately and
+		// franz-go's local buffer keeps draining.
+		//
+		// Trade-off: per-partition ordering is preserved within a single
+		// fetch's batch, but NOT across fetches — two consecutive fetches for
+		// the same partition can dispatch two goroutines that run concurrently.
+		// Handlers that depend on strict cross-fetch ordering must enforce it
+		// themselves. txmeta entries are independent (and DELETE is sync inside
+		// txmetaHandler) so the txmeta hot path is fine.
 		go func() {
 			k.Config.Logger.Debugf("[kafka] starting consumer for group %s on topic %s", k.Config.ConsumerGroupID, k.Config.Topic)
 
@@ -445,28 +478,60 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 			uncommittedRecords := make([]*kgo.Record, 0)
 			var uncommittedMu sync.Mutex
 
+			// partitionWg tracks the per-partition goroutines spawned below.
+			// We deliberately do NOT wait on it between fetches (that was the
+			// barrier #868bdbb06 removed for steady-state throughput). It is
+			// waited on EXACTLY ONCE at shutdown so the final commitRecords
+			// captures everything that finished processing — without it, a
+			// goroutine mid-consumerFn appends to uncommittedRecords AFTER the
+			// final commit has run, leaving its records uncommitted on disk
+			// even though they were successfully processed.
+			var partitionWg sync.WaitGroup
+
 			for {
 				select {
 				case <-internalCtx.Done():
+					partitionWg.Wait()
+					uncommittedMu.Lock()
 					k.commitRecords(uncommittedRecords)
+					uncommittedMu.Unlock()
 					return
 				default:
-					fetches := k.client.PollFetches(internalCtx)
+				}
 
-					if errs := fetches.Errors(); len(errs) > 0 {
-						for _, err := range errs {
-							if errors.Is(err.Err, context.Canceled) || errors.Is(err.Err, kgo.ErrClientClosed) {
-								k.Config.Logger.Debugf("Kafka consumer shutdown: %v", err.Err)
-								return
-							}
-							k.Config.Logger.Errorf("Kafka consumer error on topic %s partition %d: %v", err.Topic, err.Partition, err.Err)
+				fetches := k.client.PollFetches(internalCtx)
+
+				if errs := fetches.Errors(); len(errs) > 0 {
+					for _, err := range errs {
+						if errors.Is(err.Err, context.Canceled) || errors.Is(err.Err, kgo.ErrClientClosed) {
+							k.Config.Logger.Debugf("Kafka consumer shutdown: %v", err.Err)
+							return
 						}
-						continue
+						k.Config.Logger.Errorf("Kafka consumer error on topic %s partition %d: %v", err.Topic, err.Partition, err.Err)
+					}
+					continue
+				}
+
+				fetches.EachPartition(func(p kgo.FetchTopicPartition) {
+					if len(p.Records) == 0 {
+						return
 					}
 
-					fetches.EachPartition(func(p kgo.FetchTopicPartition) {
-						hwm := p.HighWatermark
-						for _, record := range p.Records {
+					// Capture HighWatermark in the outer scope: the kgo.FetchTopicPartition
+					// value `p` is only valid for the duration of this synchronous callback,
+					// and the goroutine below outlives it.
+					hwm := p.HighWatermark
+
+					partitionWg.Add(1)
+					go func(records []*kgo.Record, hwm int64) {
+						defer partitionWg.Done()
+						for _, record := range records {
+							select {
+							case <-internalCtx.Done():
+								return
+							default:
+							}
+
 							kafkaMsg := &KafkaMessage{
 								Key:           record.Key,
 								Value:         record.Value,
@@ -480,31 +545,35 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 							if err := consumerFn(kafkaMsg); err != nil {
 								k.Config.Logger.Errorf("[kafka_consumer] failed to process message (topic: %s, partition: %d, offset: %d): %v",
 									record.Topic, record.Partition, record.Offset, err)
-								// Continue to the next record. Skipping the
-								// uncommittedRecords append keeps the failed
-								// record from being marked done, matching the
-								// pre-refactor EachRecord behavior.
-								continue
+								// Don't mark this or any later record in this
+								// batch — leave them uncommitted so rebalance/
+								// restart re-delivers.
+								return
 							}
 
-							if !k.Config.AutoCommitEnabled {
+							if k.Config.AutoCommitEnabled {
+								// MarkCommitRecords locks internal commit state
+								// in franz-go, so concurrent calls from many
+								// per-partition goroutines are safe.
+								k.client.MarkCommitRecords(record)
+							} else {
 								uncommittedMu.Lock()
 								uncommittedRecords = append(uncommittedRecords, record)
 								uncommittedMu.Unlock()
 							}
 						}
-					})
+					}(p.Records, hwm)
+				})
 
-					select {
-					case <-commitTicker.C:
-						uncommittedMu.Lock()
-						if len(uncommittedRecords) > 0 {
-							k.commitRecords(uncommittedRecords)
-							uncommittedRecords = uncommittedRecords[:0]
-						}
-						uncommittedMu.Unlock()
-					default:
+				select {
+				case <-commitTicker.C:
+					uncommittedMu.Lock()
+					if len(uncommittedRecords) > 0 {
+						k.commitRecords(uncommittedRecords)
+						uncommittedRecords = uncommittedRecords[:0]
 					}
+					uncommittedMu.Unlock()
+				default:
 				}
 			}
 		}()


### PR DESCRIPTION
Split out of #828 so it can be reviewed independently.

## Consumer (util/kafka/kafka_consumer.go)
- Dispatches each fetch's per-partition records to a goroutine without a between-fetch barrier (no `partitionWg.Wait` between `PollFetches`). franz-go's local buffer keeps draining while one slow partition is in flight.
- Goroutines drain into a shared `uncommittedRecords` slice under a mutex.
- Shutdown waits on a single `partitionWg.Wait` so the final `commitRecords` captures every record that completed processing — fixes a window where a goroutine mid-`consumerFn` appended after the puller had committed and returned.
- `AutoCommitEnabled` uses `MarkCommitRecords` (lock-internal in franz-go, safe from many goroutines concurrently).
- Threads the partition's `HighWaterMark` (added upstream in PR #891) into each `KafkaMessage` so handlers can detect "caught up to live tail."

## Producer (services/validator/Validator.go)
- `sendTxMetaToKafka` / `sendTxMetaBatch` set the message `Key` to the (first) tx hash. With franz-go's default `StickyKeyPartitioner` this hashes onto a single partition deterministically:
  - Distributes traffic evenly across partitions (tx hashes are uniform).
  - Keeps every record from one batch on the same partition (preserves intra-batch ordering).
- Nil keys previously degraded `StickyKeyPartitioner` to a `StickyPartitioner`, bunching consecutive batches onto the same partition until linger expired. Symptom on the consumer side was bursty per-partition read throughput.

## txmetaHandler (services/subtreevalidation/txmetaHandler.go)
- Shards Kafka ADD/DELETE entries by the first byte of the tx hash across 256 worker goroutines with bounded per-shard queues. Per-key ordering preserved (same hash → same shard → arrival order).
- Switches between two modes on a one-way latch (`txmetaCaughtUp`): blocking-on-full during startup (cold cache rebuild), drop-on-full once any assigned partition reaches its tail.
- Truncated messages are logged and acked to avoid infinite redelivery on corrupt input.

## Cache interface (services/subtreevalidation/SubtreeValidation.go)
- Adds `SetCacheMulti(keys, values [][]byte) error` to `txMetaCacheOps` and a corresponding `SetTxMetaCacheMulti` server method. Not yet called from the handler — kept for a future batched fan-out optimisation.

## Test plan
- [ ] `go build ./...` clean
- [ ] `go vet ./util/kafka/... ./services/validator/... ./services/subtreevalidation/...` clean
- [ ] `make lint-new` clean
- [ ] Soak test against a saturated txmeta topic: consumer p99 should not spike when one partition is slower than others; producer load should distribute across all partitions instead of bunching.