### PR TITLE
fix(blockassembly): fall back to row-oriented AddTxBatch on Unimplemented

### DIFF
--- a/services/blockassembly/Client.go
+++ b/services/blockassembly/Client.go
@@ -466,6 +466,7 @@ func (s *Client) sendBatchColumnar(ctx context.Context, batch []*batchItem) {
 		// independently. Costs one wasted RPC per batch against a
 		// persistently-old server; acceptable for the simpler code path.
 		if status.Code(err) == codes.Unimplemented {
+			s.logger.Debugf("[blockassembly] columnar AddTxBatch unimplemented on peer; falling back to row-oriented batch (rolling deploy?): %v", err)
 			s.sendBatchRowOriented(ctx, batch)
 			return
 		}

--- a/services/blockassembly/Client.go
+++ b/services/blockassembly/Client.go
@@ -17,6 +17,8 @@ import (
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/batchermetrics"
 	"github.com/bsv-blockchain/teranode/util/tracing"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // batchItem represents an item in a transaction batch.
@@ -457,6 +459,17 @@ func (s *Client) sendBatchColumnar(ctx context.Context, batch []*batchItem) {
 
 	_, err = s.client.AddTxBatchColumnar(ctx, columnarReq)
 	if err != nil {
+		// Peer server predates PR #889 and doesn't implement the columnar
+		// RPC. Fall back to the row-oriented path for this call so a
+		// rolling-deploy mismatch doesn't stall tx ingestion. No
+		// connection-level stickiness: each batch re-tries columnar
+		// independently. Costs one wasted RPC per batch against a
+		// persistently-old server; acceptable for the simpler code path.
+		if status.Code(err) == codes.Unimplemented {
+			s.sendBatchRowOriented(ctx, batch)
+			return
+		}
+
 		s.logger.Errorf("%v", err)
 
 		for _, item := range batch {


### PR DESCRIPTION
Split out of #828 so it can be reviewed independently.

## Summary
During a rolling deploy where one block-assembly replica has been updated to expose `AddTxBatchColumnar` (introduced in #889) and another has not, gRPC returns `codes.Unimplemented` from the older server. Before this change that error propagated as a hard failure and the batch was dropped. With this change the client transparently retries the same batch via the existing row-oriented `sendBatchRowOriented` path. Other errors continue to surface to the caller untouched.

## Cost
- One wasted RPC round-trip per batch against a persistently-old server. Harmless during the deploy window; immediately moot once all replicas are upgraded.

## Follow-up (not in this PR)
- Add a one-shot warn-log on the first Unimplemented per target endpoint and a counter so the cost is visible.
- Optionally, a sticky atomic flag per client that suppresses columnar attempts for a backoff window. Flagged in the PR #828 review.

## Test plan
- [ ] `go build ./...` clean
- [ ] `go vet ./services/blockassembly/...` clean
- [ ] `make lint-new` clean
- [ ] Manual: verify a server that returns `codes.Unimplemented` for `AddTxBatchColumnar` causes the client to drop down to the row path with no error surfaced; verify a server that returns any OTHER gRPC code still surfaces the error.