### PR TITLE
perf(subtree-validation): cut hot-path allocations on cache miss and meta serialization

### DIFF
--- a/services/subtreevalidation/orphanage.go
+++ b/services/subtreevalidation/orphanage.go
@@ -94,8 +94,14 @@ func (o *Orphanage) Delete(txHash chainhash.Hash) {
 	defer o.lock.Unlock()
 
 	o.txMap.Delete(txHash)
-	o.logger.Debugf("[Orphanage] Removed transaction %s (size: %d/%d)",
-		txHash.String(), o.txMap.Len(), o.maxSize)
+	// Guard arg evaluation: Go evaluates Debugf arguments at the call site
+	// regardless of log level, so txHash.String() (hex-encodes 32 bytes,
+	// allocates ~64 B) runs on every delete. Profiling showed this single
+	// log line accounted for >1 TB of allocations / 45 s on a 1M-tx subtree.
+	if o.logger.LogLevel() <= ulogger.LogLevelDebug {
+		o.logger.Debugf("[Orphanage] Removed transaction %s (size: %d/%d)",
+			txHash.String(), o.txMap.Len(), o.maxSize)
+	}
 }
 
 // Len returns the current number of entries in the orphanage.

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1575,15 +1575,29 @@ func (c *CorruptMetaUtxoStore) Create(ctx context.Context, tx *bt.Tx, blockHeigh
 		return nil, err
 	}
 
-	// Corrupt TxInpoints: add an extra parent hash without a corresponding Idxs entry.
-	// This causes TxInpoints.Serialize() to return ErrParentTxHashesMismatch,
-	// which makes MetaBytes() fail inside sendTxMetaToKafka.
-	metaData.TxInpoints.ParentTxHashes = append(metaData.TxInpoints.ParentTxHashes, chainhash.Hash{0xDE, 0xAD})
+	// Corrupt TxInpoints: append extra parent hashes so that ParentTxHashes is
+	// strictly longer than the internal packed vout layout (one count + per-parent
+	// vouts). go-subtree v1.4.1's Serialize fails fast with ErrParentTxHashesMismatch
+	// when len(voutIdxs) < len(ParentTxHashes); v1.3.x checked an exact equality,
+	// so a single appended hash used to suffice. Adding three keeps the test
+	// portable across both checks.
+	metaData.TxInpoints.ParentTxHashes = append(
+		metaData.TxInpoints.ParentTxHashes,
+		chainhash.Hash{0xDE, 0xAD},
+		chainhash.Hash{0xBE, 0xEF},
+		chainhash.Hash{0xCA, 0xFE},
+	)
+
 	return metaData, nil
 }
 
 func TestValidator_TwoPhaseCommitCompletesAfterTxMetaSerializationFailure(t *testing.T) {
 	tracing.SetupMockTracer()
+	// sendTxMetaToKafka records to prometheusValidatorSendToBlockValidationKafka,
+	// which is registered lazily via sync.Once in initPrometheusMetrics. Without
+	// this call the histogram is nil and .Observe panics when the test is the
+	// first (or only) Validator test in the run.
+	initPrometheusMetrics()
 
 	ctx := context.Background()
 	logger := ulogger.NewErrorTestLogger(t)

--- a/stores/txmetacache/improved_cache.go
+++ b/stores/txmetacache/improved_cache.go
@@ -591,7 +591,15 @@ func (c *ImprovedCache) Get(dst *[]byte, k []byte) error {
 	idx := h % BucketsCount
 
 	if !c.buckets[idx].Get(dst, k, h, true) {
-		return errors.NewNotFoundError("key %v not found in cache", k, errors.ErrNotFound)
+		// Return the codebase-wide ErrNotFound sentinel rather than a fresh
+		// formatted error. Profiling showed ~10% of CPU on the cache hot path
+		// went into errors.NewNotFoundError("key %v ...", k, ErrNotFound) —
+		// fmt.Errorf on the byte-slice key plus runtime.Caller stack capture
+		// inside teranode/errors.New — all of which the caller's
+		// errors.Is(err, errors.ErrNotFound) check discards. Reusing the
+		// existing sentinel (treated as immutable across the codebase, like
+		// the other errors.Err* values) avoids allocating a parallel one.
+		return errors.ErrNotFound
 	}
 
 	return nil

--- a/stores/txmetacache/improved_cache_test.go
+++ b/stores/txmetacache/improved_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -259,6 +260,31 @@ func TestImprovedCache_SetAndGet(t *testing.T) {
 			require.Equal(t, tc.value, dst)
 		})
 	}
+}
+
+// TestImprovedCache_GetMissReturnsSentinel pins the cache-miss contract: the
+// returned error must satisfy errors.Is(err, errors.ErrNotFound) and must not
+// allocate per call. The previous formatted error accounted for ~10% of CPU
+// under load via fmt.Errorf + runtime.Caller.
+func TestImprovedCache_GetMissReturnsSentinel(t *testing.T) {
+	cache, err := New(64*1024, Unallocated)
+	require.NoError(t, err)
+	defer cache.Reset()
+
+	var buf []byte
+	err1 := cache.Get(&buf, []byte("absent-key-1"))
+	err2 := cache.Get(&buf, []byte("absent-key-2"))
+
+	require.Error(t, err1)
+	require.Error(t, err2)
+	require.True(t, errors.Is(err1, errors.ErrNotFound), "miss must satisfy errors.Is(err, ErrNotFound)")
+	require.True(t, errors.Is(err2, errors.ErrNotFound))
+
+	key := []byte("absent-key-1")
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = cache.Get(&buf, key)
+	})
+	require.Zero(t, allocs, "cache miss must not allocate; got %.2f allocs/op", allocs)
 }
 
 // TestImprovedCache_Has tests the Has function

--- a/stores/utxo/meta/data.go
+++ b/stores/utxo/meta/data.go
@@ -98,8 +98,9 @@ type Data struct {
 //   - [0:8]   - 8 bytes for Fee (uint64, little-endian)
 //   - [8:16]  - 8 bytes for SizeInBytes (uint64, little-endian)
 //   - [16]    - 1 byte for flags (bit 0: IsCoinbase, bit 1: Frozen, bit 2: Conflicting, bit 3: Locked)
-//   - [17:25] - 8 bytes for number of ParentTxHashes (uint64, little-endian)
-//   - [25+]   - 32 bytes for each ParentTxHash
+//   - [17:21] - 4 bytes for number of ParentTxHashes (uint32, little-endian)
+//   - [21+]   - 32 bytes for each ParentTxHash, then per parent a 4-byte
+//               vout-count followed by 4 bytes per vout (uint32, little-endian)
 //
 // Parameters:
 //   - dataBytes: Pointer to a byte slice containing the serialized metadata
@@ -133,8 +134,9 @@ func NewMetaDataFromBytes(dataBytes []byte, d *Data) (err error) {
 //   - [0:8]   - 8 bytes for Fee (uint64, little-endian)
 //   - [8:16]  - 8 bytes for SizeInBytes (uint64, little-endian)
 //   - [16]    - 1 byte for flags (bit 0: IsCoinbase, bit 1: Frozen, bit 2: Conflicting, bit 3: Locked)
-//   - [17:25] - 8 bytes for number of ParentTxHashes (uint64, little-endian)
-//   - [25+]   - 32 bytes for each ParentTxHash
+//   - [17:21] - 4 bytes for number of ParentTxHashes (uint32, little-endian)
+//   - [21+]   - 32 bytes for each ParentTxHash, then per parent a 4-byte
+//               vout-count followed by 4 bytes per vout (uint32, little-endian)
 //   - [...]   - Variable-length transaction data (full transaction)
 //   - [...]   - Remainder: block IDs as 4-byte integers (uint32, little-endian)
 //
@@ -211,8 +213,9 @@ func NewDataFromBytes(dataBytes []byte) (d *Data, err error) {
 //   - [0:8]   - 8 bytes for Fee (uint64, little-endian)
 //   - [8:16]  - 8 bytes for SizeInBytes (uint64, little-endian)
 //   - [16]    - 1 byte for flags (bit 0: IsCoinbase, bit 1: Frozen, bit 2: Conflicting, bit 3: Locked)
-//   - [17:25] - 8 bytes for number of ParentTxHashes (uint64, little-endian)
-//   - [25+]   - 32 bytes for each ParentTxHash
+//   - [17:21] - 4 bytes for number of ParentTxHashes (uint32, little-endian)
+//   - [21+]   - 32 bytes for each ParentTxHash, then per parent a 4-byte
+//               vout-count followed by 4 bytes per vout (uint32, little-endian)
 //   - [...]   - Variable-length transaction data (full transaction)
 //   - [...]   - Remainder: block IDs as 4-byte integers (uint32, little-endian)
 //
@@ -273,8 +276,9 @@ func (d *Data) Bytes() ([]byte, error) {
 //   - [0:8]   - 8 bytes for Fee (uint64, little-endian)
 //   - [8:16]  - 8 bytes for SizeInBytes (uint64, little-endian)
 //   - [16]    - 1 byte for flags (bit 0: IsCoinbase, bit 1: Frozen, bit 2: Conflicting, bit 3: Locked)
-//   - [17:25] - 8 bytes for number of ParentTxHashes (uint64, little-endian)
-//   - [25+]   - 32 bytes for each ParentTxHash
+//   - [17:21] - 4 bytes for number of ParentTxHashes (uint32, little-endian)
+//   - [21+]   - 32 bytes for each ParentTxHash, then per parent a 4-byte
+//               vout-count followed by 4 bytes per vout (uint32, little-endian)
 //
 // Returns:
 //   - Byte slice containing the serialized metadata (without transaction or block IDs)
@@ -282,7 +286,19 @@ func (d *Data) Bytes() ([]byte, error) {
 // Use this method when you need to efficiently store or transmit just the
 // metadata portion of a transaction record.
 func (d *Data) MetaBytes() ([]byte, error) {
-	buf := make([]byte, 17, 1024) // 8 for Fee, 8 for SizeInBytes, 1 for flags
+	// Serialize the TxInpoints first so we can size the outer buffer exactly.
+	// The previous fixed cap of 1024 over-allocated ~10x for the common case
+	// (single-parent tx) and dominated allocator pressure on hot paths (profile
+	// attributed several TB / 45 s to this function). Calling Serialize up
+	// front also surfaces an inconsistent TxInpoints (e.g.
+	// ErrParentTxHashesMismatch from test fixtures) without us having to walk
+	// the packed vout layout ourselves and risk a bounds-check panic.
+	txInpointsBytes, err := d.TxInpoints.Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 17, 17+len(txInpointsBytes))
 
 	binary.LittleEndian.PutUint64(buf[:8], d.Fee)
 	binary.LittleEndian.PutUint64(buf[8:16], d.SizeInBytes)
@@ -301,11 +317,6 @@ func (d *Data) MetaBytes() ([]byte, error) {
 
 	if d.Locked {
 		buf[16] |= 0b1000
-	}
-
-	txInpointsBytes, err := d.TxInpoints.Serialize()
-	if err != nil {
-		return nil, err
 	}
 
 	buf = append(buf, txInpointsBytes...)


### PR DESCRIPTION
## Summary

Three independent fixes informed by a live CPU + heap profile of `subtree-validator` during 1M-tx subtree processing in the scaling-2 environment. The profile showed ~23 cores saturated, allocation rate ~1 TB/s, and the UTXO store at only ~18% of cumulative CPU — the hot path is the cache layer and the error/allocation machinery around it. One pre-existing test fix is included that surfaced once the build was correct.

| Fix | Where | Effect |
|---|---|---|
| Sentinel error on cache miss | `stores/txmetacache/improved_cache.go` | ~10% CPU, ~3 TB / 45 s allocations removed |
| Right-sized `MetaBytes` buffer | `stores/utxo/meta/data.go` | `Benchmark_MetaBytes`: 1120 → 208 B/op (−81%), 188 → 67 ns/op (−64%) |
| Lazy log-arg evaluation in `Orphanage.Delete` | `services/subtreevalidation/orphanage.go` | >1 TB / 45 s allocations removed |
| Test fix for `TwoPhaseCommitCompletesAfterTxMetaSerializationFailure` | `services/validator/Validator_test.go` | unblocks the `test` CI job |

### #1 — `ImprovedCache.Get` returns `errors.ErrNotFound` on miss

Previously every miss called `errors.NewNotFoundError("key %v not found in cache", k, errors.ErrNotFound)` — `fmt.Errorf` (~49 s CPU), `runtime.Caller` stack capture inside `teranode/errors.New` (~32 s), and `strings.Split` for function-name parsing (~9 s). Callers all use `errors.Is(err, errors.ErrNotFound)`, so the formatted message and stack are thrown away. The fix returns the existing codebase-wide `errors.ErrNotFound` sentinel directly. Same code (`ERR_NOT_FOUND`), so `errors.Is` continues to be true — and no parallel mutable `*Error` is introduced.

### #2 — `MetaBytes` exact-sized buffer

Calls `TxInpoints.Serialize` first and pre-sizes the outer buffer to `17 + len(txInpointsBytes)`. Doing serialise first also surfaces an inconsistent `TxInpoints` (e.g. `ErrParentTxHashesMismatch` from synthetic fixtures) cleanly — walking the v1.4.1 packed vout layout from outside the module would bounds-panic when `ParentTxHashes` outruns `voutIdxs`. Also corrects three stale layout doc comments that claimed an 8-byte `uint64` parent-count field; the wire format has been 4-byte `uint32` since `go-subtree` v1.2.

```
before: 188 ns/op  1120 B/op  2 allocs/op   (main, go-subtree v1.4.1)
after:   67 ns/op   208 B/op  2 allocs/op
```

### #3 — `Orphanage.Delete` Debugf guard

Go evaluates call arguments at every call site regardless of log level, so `txHash.String()` (hex-encodes 32 bytes, allocates ~64 B) ran on every delete even at INFO+. Profile attributed >1 TB of allocations / 45 s to this one line. Added a `LogLevel()` check matching the existing pattern at `services/blockassembly/subtreeprocessor/SubtreeProcessor.go:4221`.

### #4 — Test fix (pre-existing, surfaced during this work)

`TestValidator_TwoPhaseCommitCompletesAfterTxMetaSerializationFailure` was silently broken on `main` after the `go-subtree` v1.4.1 dependency bump:

1. It panicked with a nil-prometheus-histogram dereference whenever it ran before any other Validator test had triggered `initPrometheusMetrics()` (which is gated by a `sync.Once`).
2. Its corruption mechanism — appending a single junk `ParentTxHashes` entry — no longer tripped `TxInpoints.Serialize`'s error path: v1.4.1's check is `len(voutIdxs) < len(ParentTxHashes)`, weaker than v1.3.x's exact equality. The test was named after a failure path it never exercised.

The fix adds `initPrometheusMetrics()` to the test setup (matching the surrounding tests) and appends three corrupt hashes so the mismatch reliably trips under both v1.3.x and v1.4.1.

## Review feedback addressed

- **Copilot (improved_cache.go): shared `*errors.Error` is mutable.** Switched from a freshly-allocated parallel sentinel to returning the existing `errors.ErrNotFound` global. Same risk profile as every other codebase-wide sentinel; no new mutable surface introduced.
- **Copilot (data.go): doc says 8-byte parent count, code computes 4-byte.** The code matches `TxInpoints.Serialize`, which has used a 4-byte `uint32` since v1.2; the docs were stale. Updated the three layout comments in `MetaBytes` / `NewMetaDataFromBytes` / `NewDataFromBytes` to match reality.

## Test plan

- [x] `go vet` clean on all touched packages
- [x] `golangci-lint run` (`--disable gosec --disable prealloc`) — 0 issues
- [x] `go test -race -tags testtxmetacache` (CI flags) on all touched packages: green (`stores/txmetacache`, `stores/utxo/meta`, `services/subtreevalidation`, `services/validator`)
- [x] `TestImprovedCache_GetMissReturnsSentinel` pins the contract: zero allocations on miss, `errors.Is(err, ErrNotFound)` still true
- [x] `TestValidator_TwoPhaseCommitCompletesAfterTxMetaSerializationFailure` now passes and exercises its named path (logs confirm `MetaBytes` returns the mismatch error and 2PC still completes)
- [ ] Re-profile a 1M-tx subtree run after merge to confirm CPU/alloc drop in production

## Out of scope (follow-ups)

- `ImprovedCache.SetMulti` pre-sizes its per-bucket `[][][]byte` and grows them via `append` — heap profile attributes ~3.5 TB / 45 s here. Same family of fix; deferred to keep this PR surgical.