### PR TITLE
perf(subtreevalidation): batch txmeta dispatch per shard, call SetCacheMulti

### DIFF
--- a/services/subtreevalidation/Server.go
+++ b/services/subtreevalidation/Server.go
@@ -137,7 +137,7 @@ type Server struct {
 	// txmeta worker pool state.
 	txmetaWorkerInitOnce sync.Once
 	txmetaWorkerCancel   context.CancelFunc
-	txmetaWorkerQueues   []chan txmetaWorkItem
+	txmetaWorkerQueues   []chan *txmetaShardBatch
 	txmetaWorkerWg       sync.WaitGroup
 	// txmetaCaughtUp is a one-way latch. While false, the txmeta handler blocks on
 	// the shard worker queues so backfill cannot drop messages. The latch flips

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -169,16 +169,10 @@ func (u *Server) SetTxMetaCacheFromBytes(_ context.Context, key, txMetaBytes []b
 	return nil
 }
 
-// SetTxMetaCacheMulti stores multiple transaction metadata entries in the cache in a single call.
-//
-// Reserved for a future batched fan-out optimisation of the Kafka txmeta handler: the
-// intent is that a single Kafka message containing N ADD entries can be applied as one
-// SetCacheMulti call, letting the underlying cache acquire each touched per-bucket lock
-// once per call instead of once per entry. The current txmetaHandler is sharded across
-// 256 hash-byte worker goroutines and applies entries one at a time via
-// SetTxMetaCacheFromBytes — it does NOT call this method yet. Kept on the interface so
-// alternative cache implementations can implement the fan-out today and the handler can
-// be migrated later without an interface change.
+// SetTxMetaCacheMulti stores multiple transaction metadata entries in the cache in a single
+// call. The txmeta Kafka handler invokes this once per shard-batch, so the underlying cache
+// acquires each touched per-bucket lock once per shard-batch instead of once per entry.
+// Returns nil if the underlying store does not implement txMetaCacheOps.
 func (u *Server) SetTxMetaCacheMulti(_ context.Context, keys [][]byte, values [][]byte) error {
 	if len(keys) == 0 {
 		return nil

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -21,16 +21,28 @@ const (
 
 	// txmetaWorkerShardCount shards work by hash byte to preserve per-key ordering.
 	txmetaWorkerShardCount = 256
-	// txmetaWorkerQueueSize bounds in-flight work per shard to avoid unbounded goroutine growth.
+	// txmetaWorkerQueueSize bounds the per-shard channel depth. Each slot holds
+	// a whole shard batch (potentially thousands of entries), so this is
+	// "Kafka messages per shard worth of headroom" rather than "individual
+	// records".
 	txmetaWorkerQueueSize = 256
 )
 
-type txmetaWorkItem struct {
+// txmetaShardBatch is the unit dispatched to a per-shard worker: all entries
+// from a single Kafka message that hashed to the same shard. Batching at the
+// Kafka-message boundary (instead of one channel send per entry) collapses
+// N channel hops into 1 and lets the worker bulk-write ADDs via
+// SetCacheMulti, which takes the cache bucket lock once for the whole batch.
+type txmetaShardBatch struct {
 	ctx        context.Context
-	hash       chainhash.Hash
-	action     byte
-	content    []byte
+	adds       []txmetaAdd
+	deletes    []chainhash.Hash
 	enqueuedAt time.Time
+}
+
+type txmetaAdd struct {
+	hash    chainhash.Hash
+	content []byte // copied out of msg.Value at parse time
 }
 
 // txmetaMessageHandler returns a Kafka message handler for transaction metadata operations.
@@ -52,15 +64,14 @@ func (u *Server) txmetaMessageHandler(ctx context.Context) func(msg *kafka.Kafka
 //	[4 bytes]  - content length (uint32, little-endian) - 0 for DELETE
 //	[N bytes]  - content (metaBytes) - only for ADD
 //
-// Entries are sharded by the first byte of the tx hash across
-// txmetaWorkerShardCount (256) worker goroutines, each draining its own
-// bounded channel (txmetaWorkerQueueSize). Sharding by hash byte preserves
-// per-key ordering: every operation for the same hash lands in the same
-// shard and is therefore applied in arrival order. Per-shard parallelism
-// gives us 256-way concurrency without the per-entry-goroutine cost that
-// an earlier design suffered (89K goroutine queue depth at ~1.1M
-// entries/sec, p50 enqueue→complete ~80 ms; spawn+queue dominated the
-// microsecond-scale cache writes).
+// Dispatch model: parse all entries into per-shard batches keyed by hash[0],
+// then dispatch one batch per non-empty shard to its worker. Workers bulk-
+// write ADDs via SetCacheMulti, which takes the cache bucket lock once per
+// shard-batch instead of once per entry.
+//
+// Sharding by hash byte preserves per-key ordering: every operation for the
+// same hash lands in the same shard and is therefore applied in arrival
+// order. Per-shard parallelism gives 256-way concurrency.
 //
 // On full shard queues:
 //
@@ -71,12 +82,12 @@ func (u *Server) txmetaMessageHandler(ctx context.Context) func(msg *kafka.Kafka
 //   - Once caught up (any partition reaches its tail) the enqueue is
 //     drop-on-full and the remainder of the current Kafka batch is
 //     abandoned. The cache will be repopulated from Kafka on the next
-//     restart; live ADDs that are dropped fall through to the UTXO store
-//     on the next BatchDecorate. enqueueTxmetaWorkItem logs a Warn.
+//     restart; live ADDs that are dropped fall through to the UTXO store on
+//     the next BatchDecorate. enqueueTxmetaShardBatch logs a Warn.
 //
-// Memory: ADD content is COPIED out of msg.Value because the worker may
-// run after the puller has advanced past this Kafka record. DELETE entries
-// store only the 32-byte chainhash.Hash by value (no allocation).
+// Memory: ADD content is COPIED out of msg.Value because the worker may run
+// after the puller has advanced past this Kafka record. DELETE entries store
+// only the 32-byte chainhash.Hash by value (no allocation).
 //
 // Errors:
 //
@@ -98,66 +109,80 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 	data := msg.Value
 	offset := 0
 
-	// Read entry count
 	entryCount := binary.LittleEndian.Uint32(data[offset:])
 	offset += 4
 
+	// Per-shard batches built up while walking the Kafka message. Nil slot
+	// means no entries for that shard in this Kafka message — for small
+	// Kafka messages most of the array stays nil, which keeps the dispatch
+	// loop cheap.
+	var shardBatches [txmetaWorkerShardCount]*txmetaShardBatch
+	enqueuedAt := time.Now()
+
 	var hash chainhash.Hash
 
-	// Parse and dispatch each entry to a bounded shard worker queue.
 	for i := uint32(0); i < entryCount; i++ {
-		// Check minimum bytes for hash + action + length
 		if offset+32+1+4 > len(data) {
 			u.logger.Errorf("[txmetaHandler] truncated message at entry %d", i)
-			return nil
+			break
 		}
 
-		// Read hash (32 bytes)
 		copy(hash[:], data[offset:offset+32])
 		offset += 32
 
-		// Read action (1 byte)
 		action := data[offset]
 		offset++
 
-		// Read content length (4 bytes)
 		contentLen := binary.LittleEndian.Uint32(data[offset:])
 		offset += 4
 
 		if offset+int(contentLen) > len(data) {
 			u.logger.Errorf("[txmetaHandler] truncated content at entry %d", i)
-			return nil
+			break
 		}
 
-		var content []byte
-		if action == txmetaActionADD {
-			content = make([]byte, contentLen)
+		shard := int(hash[0]) % txmetaWorkerShardCount
+		b := shardBatches[shard]
+		if b == nil {
+			b = &txmetaShardBatch{ctx: ctx, enqueuedAt: enqueuedAt}
+			shardBatches[shard] = b
+		}
+
+		switch action {
+		case txmetaActionADD:
+			content := make([]byte, contentLen)
 			copy(content, data[offset:offset+int(contentLen)])
+			b.adds = append(b.adds, txmetaAdd{hash: hash, content: content})
+		case txmetaActionDELETE:
+			b.deletes = append(b.deletes, hash)
+		default:
+			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+			u.logger.Errorf("[txmetaHandler][%s] unknown txmeta action: %d", hash, action)
 		}
 		offset += int(contentLen)
+	}
 
-		workItem := txmetaWorkItem{
-			ctx:        ctx,
-			hash:       hash,
-			action:     action,
-			content:    content,
-			enqueuedAt: time.Now(),
+	// Dispatch each non-empty shard batch. enqueueTxmetaShardBatch enforces
+	// the two-mode (startup-block / caught-up-drop) contract per shard.
+	for shard, b := range shardBatches {
+		if b == nil {
+			continue
 		}
-		ok, err := u.enqueueTxmetaWorkItem(ctx, workItem)
+		ok, err := u.enqueueTxmetaShardBatch(ctx, shard, b)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			// Caught-up (normal) mode: shard queue is full. The remainder of
-			// the batch is abandoned; the cache will be repopulated from Kafka
-			// on the next restart (best-effort by design).
-			// enqueueTxmetaWorkItem has already emitted the Warn log.
+			// Caught-up mode + full queue: abandon the remaining shard
+			// batches in this Kafka message. enqueueTxmetaShardBatch
+			// already emitted the Warn log.
 			return nil
 		}
 	}
 
-	// Latch from startup (blocking) to caught-up (drop-on-full) mode the first
-	// time we observe a message at the partition's tail. One-way: never reverts.
+	// Latch from startup (blocking) to caught-up (drop-on-full) mode the
+	// first time we observe a message at the partition's tail. One-way:
+	// never reverts.
 	u.maybeMarkTxmetaCaughtUp(msg)
 
 	return nil
@@ -202,9 +227,9 @@ func (u *Server) ensureTxmetaWorkers(ctx context.Context) error {
 		workerCtx, cancel := context.WithCancel(ctx)
 		u.txmetaWorkerCancel = cancel
 
-		u.txmetaWorkerQueues = make([]chan txmetaWorkItem, txmetaWorkerShardCount)
+		u.txmetaWorkerQueues = make([]chan *txmetaShardBatch, txmetaWorkerShardCount)
 		for shard := 0; shard < txmetaWorkerShardCount; shard++ {
-			ch := make(chan txmetaWorkItem, txmetaWorkerQueueSize)
+			ch := make(chan *txmetaShardBatch, txmetaWorkerQueueSize)
 			u.txmetaWorkerQueues[shard] = ch
 			u.txmetaWorkerWg.Add(1)
 			go u.runTxmetaWorker(workerCtx, ch)
@@ -218,7 +243,7 @@ func (u *Server) ensureTxmetaWorkers(ctx context.Context) error {
 	return nil
 }
 
-func (u *Server) runTxmetaWorker(ctx context.Context, workQueue <-chan txmetaWorkItem) {
+func (u *Server) runTxmetaWorker(ctx context.Context, workQueue <-chan *txmetaShardBatch) {
 	defer u.txmetaWorkerWg.Done()
 
 	// Workers exit immediately on context cancellation without draining remaining
@@ -228,33 +253,49 @@ func (u *Server) runTxmetaWorker(ctx context.Context, workQueue <-chan txmetaWor
 		select {
 		case <-ctx.Done():
 			return
-		case workItem := <-workQueue:
-			u.processTxmetaWorkItem(workItem)
+		case batch := <-workQueue:
+			u.processTxmetaShardBatch(batch)
 		}
 	}
 }
 
-func (u *Server) processTxmetaWorkItem(workItem txmetaWorkItem) {
-	switch workItem.action {
-	case txmetaActionDELETE:
-		if err := u.DelTxMetaCache(workItem.ctx, &workItem.hash); err != nil {
+func (u *Server) processTxmetaShardBatch(b *txmetaShardBatch) {
+	// DELETEs are processed one-at-a-time: they're rare relative to ADDs
+	// and the cache exposes no batch-delete API today.
+	for i := range b.deletes {
+		if err := u.DelTxMetaCache(b.ctx, &b.deletes[i]); err != nil {
 			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-			u.logger.Errorf("[txmetaHandler][%s] failed to delete tx meta data: %v", workItem.hash, err)
+			u.logger.Errorf("[txmetaHandler][%s] failed to delete tx meta data: %v", b.deletes[i], err)
 		}
-		prometheusSubtreeValidationDelTXMetaCacheKafka.Observe(float64(time.Since(workItem.enqueuedAt).Microseconds()) / 1_000_000)
-	case txmetaActionADD:
-		if err := u.SetTxMetaCacheFromBytes(workItem.ctx, workItem.hash[:], workItem.content); err != nil {
-			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-			u.logger.Debugf("[txmetaHandler][%s] failed to set tx meta data: %v", workItem.hash, err)
-		}
-		prometheusSubtreeValidationSetTXMetaCacheKafka.Observe(float64(time.Since(workItem.enqueuedAt).Microseconds()) / 1_000_000)
-	default:
+		prometheusSubtreeValidationDelTXMetaCacheKafka.Observe(float64(time.Since(b.enqueuedAt).Microseconds()) / 1_000_000)
+	}
+
+	if len(b.adds) == 0 {
+		return
+	}
+
+	// Single SetCacheMulti call for the whole shard batch: the cache
+	// bucket mutex is taken once instead of len(b.adds) times.
+	keys := make([][]byte, len(b.adds))
+	values := make([][]byte, len(b.adds))
+	for i := range b.adds {
+		keys[i] = b.adds[i].hash[:]
+		values[i] = b.adds[i].content
+	}
+
+	if err := u.SetTxMetaCacheMulti(b.ctx, keys, values); err != nil {
 		prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-		u.logger.Errorf("[txmetaHandler][%s] unknown txmeta action: %d", workItem.hash, workItem.action)
+		u.logger.Debugf("[txmetaHandler] failed to set tx meta data batch (%d items): %v", len(keys), err)
 	}
+
+	// Per-batch metric observation; histogram now records per-shard-batch
+	// latency rather than per-item. Downstream dashboards that assumed one
+	// observation == one record need adjustment.
+	elapsed := float64(time.Since(b.enqueuedAt).Microseconds()) / 1_000_000
+	prometheusSubtreeValidationSetTXMetaCacheKafka.Observe(elapsed)
 }
 
-// enqueueTxmetaWorkItem dispatches a work item to the shard worker queue. Two
+// enqueueTxmetaShardBatch dispatches a shard batch to its worker queue. Two
 // modes:
 //
 //   - Startup mode (txmetaCaughtUp == false): block on send until the worker
@@ -267,16 +308,15 @@ func (u *Server) processTxmetaWorkItem(workItem txmetaWorkItem) {
 //     remainder of the batch. Live-traffic backpressure is by design
 //     best-effort (the cache repopulates from Kafka on restart).
 //
-// Returns (true, nil) on successful enqueue, (false, nil) when an item was
+// Returns (true, nil) on successful enqueue, (false, nil) when the batch was
 // dropped in caught-up mode, and (false, ctx.Err()) when ctx is cancelled
 // during a startup-mode blocking send.
-func (u *Server) enqueueTxmetaWorkItem(ctx context.Context, workItem txmetaWorkItem) (bool, error) {
-	shard := int(workItem.hash[0]) % len(u.txmetaWorkerQueues)
+func (u *Server) enqueueTxmetaShardBatch(ctx context.Context, shard int, b *txmetaShardBatch) (bool, error) {
 	ch := u.txmetaWorkerQueues[shard]
 
 	if u.txmetaCaughtUp.Load() {
 		select {
-		case ch <- workItem:
+		case ch <- b:
 			return true, nil
 		default:
 			u.logger.Warnf("[txmetaHandler] txmeta worker queue full for shard %d, dropping remainder of batch", shard)
@@ -285,7 +325,7 @@ func (u *Server) enqueueTxmetaWorkItem(ctx context.Context, workItem txmetaWorkI
 	}
 
 	select {
-	case ch <- workItem:
+	case ch <- b:
 		return true, nil
 	case <-ctx.Done():
 		return false, ctx.Err()

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -32,17 +32,23 @@ const (
 // from a single Kafka message that hashed to the same shard. Batching at the
 // Kafka-message boundary (instead of one channel send per entry) collapses
 // N channel hops into 1 and lets the worker bulk-write ADDs via
-// SetCacheMulti, which takes the cache bucket lock once for the whole batch.
+// SetCacheMulti, which takes the cache bucket lock once per ADD run.
+//
+// Ops are kept in arrival order so per-key ordering is preserved when ADDs
+// and DELETEs for the same hash appear in the same Kafka message. The
+// worker flushes any buffered ADDs before each DELETE.
 type txmetaShardBatch struct {
 	ctx        context.Context
-	adds       []txmetaAdd
-	deletes    []chainhash.Hash
+	ops        []txmetaOp
 	enqueuedAt time.Time
 }
 
-type txmetaAdd struct {
+// txmetaOp is a single parsed entry. content is non-nil for ADD (copied out
+// of msg.Value at parse time) and nil for DELETE.
+type txmetaOp struct {
 	hash    chainhash.Hash
-	content []byte // copied out of msg.Value at parse time
+	content []byte
+	action  byte
 }
 
 // txmetaMessageHandler returns a Kafka message handler for transaction metadata operations.
@@ -91,8 +97,10 @@ func (u *Server) txmetaMessageHandler(ctx context.Context) func(msg *kafka.Kafka
 //
 // Errors:
 //
-//   - Truncated message: logged and acked (return nil) to avoid infinite
-//     retry loops on corrupt input.
+//   - Truncated message: logged, error counter incremented, and acked
+//     (return nil) to avoid infinite retry loops on corrupt input. Any
+//     partial shard batches built before the truncation are discarded
+//     and the caught-up latch is NOT advanced on the malformed message.
 //
 //   - Enqueue error (shard channel send fails for a reason other than
 //     full): returned, so the Kafka offset stays uncommitted and the
@@ -120,10 +128,12 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 	enqueuedAt := time.Now()
 
 	var hash chainhash.Hash
+	parseError := false
 
 	for i := uint32(0); i < entryCount; i++ {
 		if offset+32+1+4 > len(data) {
 			u.logger.Errorf("[txmetaHandler] truncated message at entry %d", i)
+			parseError = true
 			break
 		}
 
@@ -138,6 +148,7 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 
 		if offset+int(contentLen) > len(data) {
 			u.logger.Errorf("[txmetaHandler] truncated content at entry %d", i)
+			parseError = true
 			break
 		}
 
@@ -152,9 +163,9 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 		case txmetaActionADD:
 			content := make([]byte, contentLen)
 			copy(content, data[offset:offset+int(contentLen)])
-			b.adds = append(b.adds, txmetaAdd{hash: hash, content: content})
+			b.ops = append(b.ops, txmetaOp{hash: hash, content: content, action: txmetaActionADD})
 		case txmetaActionDELETE:
-			b.deletes = append(b.deletes, hash)
+			b.ops = append(b.ops, txmetaOp{hash: hash, action: txmetaActionDELETE})
 		default:
 			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
 			u.logger.Errorf("[txmetaHandler][%s] unknown txmeta action: %d", hash, action)
@@ -162,8 +173,24 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 		offset += int(contentLen)
 	}
 
+	if parseError {
+		// Discard any partial shard batches built before the truncation
+		// and do NOT flip the caught-up latch — a malformed message must
+		// not advance the startup-to-live mode transition.
+		prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+		return nil
+	}
+
 	// Dispatch each non-empty shard batch. enqueueTxmetaShardBatch enforces
 	// the two-mode (startup-block / caught-up-drop) contract per shard.
+	//
+	// NOTE: in caught-up mode, an early bail-out on a full queue abandons
+	// any shard batches we haven't dispatched yet — earlier shards in
+	// this iteration have already been enqueued and will still be
+	// processed. The Kafka offset is committed (we return nil), so the
+	// abandoned shards are not retried; the cache will catch up either
+	// from the next ADD touching the same keys or from a Kafka replay on
+	// restart.
 	for shard, b := range shardBatches {
 		if b == nil {
 			continue
@@ -173,9 +200,6 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 			return err
 		}
 		if !ok {
-			// Caught-up mode + full queue: abandon the remaining shard
-			// batches in this Kafka message. enqueueTxmetaShardBatch
-			// already emitted the Warn log.
 			return nil
 		}
 	}
@@ -260,39 +284,52 @@ func (u *Server) runTxmetaWorker(ctx context.Context, workQueue <-chan *txmetaSh
 }
 
 func (u *Server) processTxmetaShardBatch(b *txmetaShardBatch) {
-	// DELETEs are processed one-at-a-time: they're rare relative to ADDs
-	// and the cache exposes no batch-delete API today.
-	for i := range b.deletes {
-		if err := u.DelTxMetaCache(b.ctx, &b.deletes[i]); err != nil {
-			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-			u.logger.Errorf("[txmetaHandler][%s] failed to delete tx meta data: %v", b.deletes[i], err)
+	// Walk ops in arrival order. Accumulate consecutive ADDs and flush
+	// via SetCacheMulti before each DELETE (and at the end) so per-key
+	// ordering is preserved when a single Kafka message contains an
+	// ADD/DELETE pair for the same hash. For ADD-only shard batches
+	// (the common case under current producers) this still yields a
+	// single SetCacheMulti call.
+	//
+	// keys[i] = op.hash[:] aliases the hash field inside the op struct;
+	// the underlying txmetaShardBatch is not pooled/reused, so the
+	// alias is stable for the lifetime of the SetCacheMulti call. If
+	// batch pooling is added later, that aliasing has to be revisited.
+	addKeys := make([][]byte, 0, len(b.ops))
+	addValues := make([][]byte, 0, len(b.ops))
+
+	flushAdds := func() {
+		if len(addKeys) == 0 {
+			return
 		}
-		prometheusSubtreeValidationDelTXMetaCacheKafka.Observe(float64(time.Since(b.enqueuedAt).Microseconds()) / 1_000_000)
+		if err := u.SetTxMetaCacheMulti(b.ctx, addKeys, addValues); err != nil {
+			prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+			u.logger.Debugf("[txmetaHandler] failed to set tx meta data batch (%d items): %v", len(addKeys), err)
+		}
+		// One observation per SetCacheMulti call. DELETE is observed
+		// per-item below; the asymmetry is intentional because each
+		// observation maps to one underlying cache API call.
+		prometheusSubtreeValidationSetTXMetaCacheKafka.Observe(float64(time.Since(b.enqueuedAt).Microseconds()) / 1_000_000)
+		addKeys = addKeys[:0]
+		addValues = addValues[:0]
 	}
 
-	if len(b.adds) == 0 {
-		return
+	for i := range b.ops {
+		op := &b.ops[i]
+		switch op.action {
+		case txmetaActionADD:
+			addKeys = append(addKeys, op.hash[:])
+			addValues = append(addValues, op.content)
+		case txmetaActionDELETE:
+			flushAdds()
+			if err := u.DelTxMetaCache(b.ctx, &op.hash); err != nil {
+				prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
+				u.logger.Errorf("[txmetaHandler][%s] failed to delete tx meta data: %v", op.hash, err)
+			}
+			prometheusSubtreeValidationDelTXMetaCacheKafka.Observe(float64(time.Since(b.enqueuedAt).Microseconds()) / 1_000_000)
+		}
 	}
-
-	// Single SetCacheMulti call for the whole shard batch: the cache
-	// bucket mutex is taken once instead of len(b.adds) times.
-	keys := make([][]byte, len(b.adds))
-	values := make([][]byte, len(b.adds))
-	for i := range b.adds {
-		keys[i] = b.adds[i].hash[:]
-		values[i] = b.adds[i].content
-	}
-
-	if err := u.SetTxMetaCacheMulti(b.ctx, keys, values); err != nil {
-		prometheusSubtreeValidationSetTXMetaCacheKafkaErrors.Inc()
-		u.logger.Debugf("[txmetaHandler] failed to set tx meta data batch (%d items): %v", len(keys), err)
-	}
-
-	// Per-batch metric observation; histogram now records per-shard-batch
-	// latency rather than per-item. Downstream dashboards that assumed one
-	// observation == one record need adjustment.
-	elapsed := float64(time.Since(b.enqueuedAt).Microseconds()) / 1_000_000
-	prometheusSubtreeValidationSetTXMetaCacheKafka.Observe(elapsed)
+	flushAdds()
 }
 
 // enqueueTxmetaShardBatch dispatches a shard batch to its worker queue. Two

--- a/services/subtreevalidation/txmetaHandler_bench_test.go
+++ b/services/subtreevalidation/txmetaHandler_bench_test.go
@@ -125,7 +125,10 @@ func benchmarkTxmetaHandlerThroughput(b *testing.B, entriesPerMessage, payloadSi
 	}
 
 	expected := uint64(b.N) * uint64(entriesPerMessage)
+	// Match the warm-up loop above: a tiny sleep keeps this from busy-spinning
+	// on a core (which both burns CPU and skews the throughput measurement).
 	for cache.adds.Load() < expected {
+		time.Sleep(time.Microsecond)
 	}
 	elapsed := time.Since(start)
 	b.StopTimer()

--- a/services/subtreevalidation/txmetaHandler_bench_test.go
+++ b/services/subtreevalidation/txmetaHandler_bench_test.go
@@ -1,0 +1,164 @@
+package subtreevalidation
+
+import (
+	"context"
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/txmetacache"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/kafka"
+)
+
+// benchCache is a minimal txMetaCacheOps implementation that counts entries
+// instead of writing them, isolating the handler + worker dispatch cost from
+// the real cache's bucket-locking cost.
+//
+// The embedded txmetacache.TxMetaCache zero value satisfies the broader
+// utxo.Store surface that the Server holds; only the three methods overridden
+// below are ever called on the bench path.
+type benchCache struct {
+	txmetacache.TxMetaCache
+	adds    atomic.Uint64
+	deletes atomic.Uint64
+}
+
+func (c *benchCache) Delete(_ context.Context, _ *chainhash.Hash) error {
+	c.deletes.Add(1)
+	return nil
+}
+
+func (c *benchCache) SetCacheFromBytes(_, _ []byte) error {
+	c.adds.Add(1)
+	return nil
+}
+
+func (c *benchCache) SetCacheMulti(keys, _ [][]byte) error {
+	c.adds.Add(uint64(len(keys)))
+	return nil
+}
+
+// buildBenchMessage encodes a synthetic Kafka batch message in the binary
+// format documented on txmetaHandler. Hashes are spread across all 256
+// shards (h[0] = i % 256) so dispatch hits every worker.
+func buildBenchMessage(b *testing.B, entriesPerMessage int, payloadSize int) *kafka.KafkaMessage {
+	b.Helper()
+
+	entrySize := 32 + 1 + 4 + payloadSize
+	total := 4 + entriesPerMessage*entrySize
+	buf := make([]byte, total)
+	off := 0
+
+	binary.LittleEndian.PutUint32(buf[off:], uint32(entriesPerMessage))
+	off += 4
+
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	for i := 0; i < entriesPerMessage; i++ {
+		buf[off+0] = byte(i % 256)
+		buf[off+1] = byte(i / 256)
+		off += 32
+
+		buf[off] = txmetaActionADD
+		off++
+
+		binary.LittleEndian.PutUint32(buf[off:], uint32(payloadSize))
+		off += 4
+
+		copy(buf[off:], payload)
+		off += payloadSize
+	}
+
+	return &kafka.KafkaMessage{Value: buf}
+}
+
+// benchmarkTxmetaHandlerThroughput drives the full Kafka-handler →
+// per-shard channel → worker → cache pipeline with a counting cache and
+// reports entries/sec. The handler dispatch is blocking (startup mode)
+// throughout the bench window, so a slow worker would surface as the
+// benchmark stalling — measured throughput is bottlenecked by whichever
+// stage is actually slow.
+func benchmarkTxmetaHandlerThroughput(b *testing.B, entriesPerMessage, payloadSize int) {
+	cache := &benchCache{}
+
+	server := &Server{
+		logger:    ulogger.TestLogger{},
+		utxoStore: cache,
+	}
+
+	msg := buildBenchMessage(b, entriesPerMessage, payloadSize)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		if server.txmetaWorkerCancel != nil {
+			server.txmetaWorkerCancel()
+		}
+		server.txmetaWorkerWg.Wait()
+	}()
+
+	const warmIters = 4
+	for i := 0; i < warmIters; i++ {
+		if err := server.txmetaHandler(ctx, msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+	expectedWarm := uint64(warmIters * entriesPerMessage)
+	for cache.adds.Load() < expectedWarm {
+		time.Sleep(time.Microsecond)
+	}
+	cache.adds.Store(0)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	start := time.Now()
+	for i := 0; i < b.N; i++ {
+		if err := server.txmetaHandler(ctx, msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	expected := uint64(b.N) * uint64(entriesPerMessage)
+	for cache.adds.Load() < expected {
+	}
+	elapsed := time.Since(start)
+	b.StopTimer()
+
+	entries := float64(expected)
+	b.ReportMetric(entries/elapsed.Seconds(), "tx/s")
+	b.ReportMetric(elapsed.Seconds()*1e9/entries, "ns/tx")
+}
+
+// Matrix brackets realistic Kafka batch sizes for the txmeta topic
+// (low-thousands of entries per message) and payload sizes for serialised
+// meta.Data (tens of bytes).
+
+func BenchmarkTxmetaHandler_Batch1_Payload64(b *testing.B) {
+	benchmarkTxmetaHandlerThroughput(b, 1, 64)
+}
+
+func BenchmarkTxmetaHandler_Batch100_Payload64(b *testing.B) {
+	benchmarkTxmetaHandlerThroughput(b, 100, 64)
+}
+
+func BenchmarkTxmetaHandler_Batch1000_Payload64(b *testing.B) {
+	benchmarkTxmetaHandlerThroughput(b, 1000, 64)
+}
+
+func BenchmarkTxmetaHandler_Batch10000_Payload64(b *testing.B) {
+	benchmarkTxmetaHandlerThroughput(b, 10000, 64)
+}
+
+func BenchmarkTxmetaHandler_Batch1000_Payload32(b *testing.B) {
+	benchmarkTxmetaHandlerThroughput(b, 1000, 32)
+}
+
+func BenchmarkTxmetaHandler_Batch1000_Payload128(b *testing.B) {
+	benchmarkTxmetaHandlerThroughput(b, 1000, 128)
+}

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -281,50 +282,67 @@ func createKafkaMessageForHash(t *testing.T, hash chainhash.Hash, action byte, c
 func TestServer_txmetaHandler(t *testing.T) {
 	// Note: The handler dispatches work to bounded shard workers and may return an error if a queue is full.
 	// Tests verify proper parsing of the binary batch format.
+	// setupMocks takes a `bumpDone` callback that the mock's Run hook invokes
+	// once per cache operation. Driving sync off a goroutine-safe atomic is
+	// race-free, unlike polling mockCache.Calls (testify's internal mutex
+	// is unexported).
 	tests := []struct {
-		name       string
-		setupMocks func(*mockLogger, *mockCache)
-		input      *kafka.KafkaMessage
+		name               string
+		setupMocks         func(l *mockLogger, c *mockCache, bumpDone func())
+		input              *kafka.KafkaMessage
+		expectedCacheCalls int
 	}{
 		{
 			name:       "nil message",
-			setupMocks: func(l *mockLogger, c *mockCache) {},
+			setupMocks: func(_ *mockLogger, _ *mockCache, _ func()) {},
 			input:      nil,
 		},
 		{
 			name:       "message too short for entry count",
-			setupMocks: func(l *mockLogger, c *mockCache) {},
+			setupMocks: func(_ *mockLogger, _ *mockCache, _ func()) {},
 			input:      &kafka.KafkaMessage{Value: make([]byte, 3)},
 		},
 		{
 			name: "successful delete operation",
-			setupMocks: func(l *mockLogger, c *mockCache) {
-				c.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).Return(nil)
+			setupMocks: func(_ *mockLogger, c *mockCache, bumpDone func()) {
+				c.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).
+					Return(nil).
+					Run(func(_ mock.Arguments) { bumpDone() })
 			},
-			input: createKafkaMessage(t, true, []byte{}),
+			input:              createKafkaMessage(t, true, []byte{}),
+			expectedCacheCalls: 1,
 		},
 		{
 			name: "failed delete operation logs error",
-			setupMocks: func(l *mockLogger, c *mockCache) {
-				c.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).Return(errors.ErrProcessing)
+			setupMocks: func(l *mockLogger, c *mockCache, bumpDone func()) {
+				c.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).
+					Return(errors.ErrProcessing).
+					Run(func(_ mock.Arguments) { bumpDone() })
 				l.On("Errorf", mock.Anything, mock.Anything).Return()
 			},
-			input: createKafkaMessage(t, true, []byte{}),
+			input:              createKafkaMessage(t, true, []byte{}),
+			expectedCacheCalls: 1,
 		},
 		{
 			name: "successful set operation",
-			setupMocks: func(l *mockLogger, c *mockCache) {
-				c.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil)
+			setupMocks: func(_ *mockLogger, c *mockCache, bumpDone func()) {
+				c.On("SetCacheMulti", mock.Anything, mock.Anything).
+					Return(nil).
+					Run(func(_ mock.Arguments) { bumpDone() })
 			},
-			input: createKafkaMessage(t, false, []byte("test data")),
+			input:              createKafkaMessage(t, false, []byte("test data")),
+			expectedCacheCalls: 1,
 		},
 		{
 			name: "failed set operation logs debug",
-			setupMocks: func(l *mockLogger, c *mockCache) {
-				c.On("SetCacheMulti", mock.Anything, mock.Anything).Return(errors.ErrProcessing)
+			setupMocks: func(l *mockLogger, c *mockCache, bumpDone func()) {
+				c.On("SetCacheMulti", mock.Anything, mock.Anything).
+					Return(errors.ErrProcessing).
+					Run(func(_ mock.Arguments) { bumpDone() })
 				l.On("Debugf", mock.Anything, mock.Anything).Return()
 			},
-			input: createKafkaMessage(t, false, []byte("test data")),
+			input:              createKafkaMessage(t, false, []byte("test data")),
+			expectedCacheCalls: 1,
 		},
 	}
 
@@ -332,7 +350,8 @@ func TestServer_txmetaHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockLogger := &mockLogger{}
 			mockCache := &mockCache{}
-			tt.setupMocks(mockLogger, mockCache)
+			var done atomic.Int32
+			tt.setupMocks(mockLogger, mockCache, func() { done.Add(1) })
 
 			server := &Server{
 				logger:    mockLogger,
@@ -341,11 +360,15 @@ func TestServer_txmetaHandler(t *testing.T) {
 
 			// The handler always returns nil (async processing)
 			err := server.txmetaHandler(context.Background(), tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			// Wait briefly for async goroutine to complete
-			// This is a bit awkward but necessary since processing is async
-			<-time.After(10 * time.Millisecond)
+			// Sync on the atomic counter (race-free) instead of a fixed
+			// time.After sleep, so the test is robust on loaded CI.
+			if tt.expectedCacheCalls > 0 {
+				require.Eventually(t, func() bool {
+					return int(done.Load()) >= tt.expectedCacheCalls
+				}, 2*time.Second, time.Millisecond, "expected at least %d mock cache calls", tt.expectedCacheCalls)
+			}
 
 			mockCache.AssertExpectations(t)
 		})
@@ -539,6 +562,193 @@ func TestServer_txmetaHandler_LatchIgnoredWhenHighWaterMarkUnset(t *testing.T) {
 	// Give the worker a moment in case the latch were going to flip async.
 	time.Sleep(20 * time.Millisecond)
 	assert.False(t, server.txmetaCaughtUp.Load(), "latch must not flip when HWM is unset")
+}
+
+// buildMultiOpKafkaMessage encodes N entries into a single Kafka message in
+// the txmetaHandler binary format. Used by the bucketing and ordering tests
+// that need more than one entry per message.
+func buildMultiOpKafkaMessage(t *testing.T, entries []struct {
+	hash    chainhash.Hash
+	action  byte
+	content []byte
+},
+) *kafka.KafkaMessage {
+	t.Helper()
+
+	size := 4
+	for _, e := range entries {
+		size += 32 + 1 + 4
+		if e.action == txmetaActionADD {
+			size += len(e.content)
+		}
+	}
+	buf := make([]byte, size)
+	off := 0
+
+	binary.LittleEndian.PutUint32(buf[off:], uint32(len(entries)))
+	off += 4
+
+	for _, e := range entries {
+		copy(buf[off:], e.hash[:])
+		off += 32
+		buf[off] = e.action
+		off++
+		if e.action == txmetaActionADD {
+			binary.LittleEndian.PutUint32(buf[off:], uint32(len(e.content)))
+			off += 4
+			copy(buf[off:], e.content)
+			off += len(e.content)
+		} else {
+			binary.LittleEndian.PutUint32(buf[off:], 0)
+			off += 4
+		}
+	}
+
+	return &kafka.KafkaMessage{Value: buf}
+}
+
+// TestServer_txmetaHandler_ShardBucketingByHashByte verifies the central
+// invariant of the per-shard dispatch model: entries from a single Kafka
+// message are bucketed across shards by hash[0], and each shard batch
+// contains only entries whose hash[0] matches its shard index.
+func TestServer_txmetaHandler_ShardBucketingByHashByte(t *testing.T) {
+	server := &Server{logger: ulogger.TestLogger{}}
+	// Caught-up mode so the dispatch is non-blocking and we don't need a
+	// reader on every channel.
+	server.txmetaCaughtUp.Store(true)
+
+	// Pre-create all shard channels and skip starting real workers; we
+	// inspect what landed in each queue directly.
+	server.txmetaWorkerInitOnce.Do(func() {})
+	queues := make([]chan *txmetaShardBatch, txmetaWorkerShardCount)
+	for i := range queues {
+		queues[i] = make(chan *txmetaShardBatch, 1)
+	}
+	server.txmetaWorkerQueues = queues
+
+	// Two entries per shard: one ADD and one DELETE, with hash[0] = shard
+	// and hash[1] = 0 or 1 to keep entries distinct.
+	type entry = struct {
+		hash    chainhash.Hash
+		action  byte
+		content []byte
+	}
+	entries := make([]entry, 0, 2*txmetaWorkerShardCount)
+	for shard := 0; shard < txmetaWorkerShardCount; shard++ {
+		var h1, h2 chainhash.Hash
+		h1[0] = byte(shard)
+		h1[1] = 0
+		h2[0] = byte(shard)
+		h2[1] = 1
+		entries = append(entries,
+			entry{hash: h1, action: txmetaActionADD, content: []byte{byte(shard)}},
+			entry{hash: h2, action: txmetaActionDELETE},
+		)
+	}
+
+	msg := buildMultiOpKafkaMessage(t, entries)
+	require.NoError(t, server.txmetaHandler(context.Background(), msg))
+
+	for shard := 0; shard < txmetaWorkerShardCount; shard++ {
+		select {
+		case b := <-queues[shard]:
+			require.Len(t, b.ops, 2, "shard %d should have 2 ops", shard)
+			for _, op := range b.ops {
+				require.Equal(t, byte(shard), op.hash[0], "shard %d received op for hash[0]=%d", shard, op.hash[0])
+			}
+		default:
+			t.Fatalf("shard %d received no batch", shard)
+		}
+	}
+}
+
+// TestServer_txmetaHandler_PreservesOrderWithinKafkaMessage verifies that when
+// a single Kafka message contains interleaved ADD/DELETE ops for the same hash
+// (and therefore the same shard), the worker applies them in arrival order:
+// ADD → DELETE → ADD must result in the cache holding the second ADD's value,
+// not the first.
+func TestServer_txmetaHandler_PreservesOrderWithinKafkaMessage(t *testing.T) {
+	mockLogger := &mockLogger{}
+	mockCache := &mockCache{}
+
+	var (
+		mu  sync.Mutex
+		ops []string
+	)
+	mockCache.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		mu.Lock()
+		defer mu.Unlock()
+		ops = append(ops, "add")
+	})
+	mockCache.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).Return(nil).Run(func(args mock.Arguments) {
+		mu.Lock()
+		defer mu.Unlock()
+		ops = append(ops, "delete")
+	})
+
+	server := &Server{
+		logger:    mockLogger,
+		utxoStore: mockCache,
+	}
+
+	hash := chainhash.Hash{42}
+	msg := buildMultiOpKafkaMessage(t, []struct {
+		hash    chainhash.Hash
+		action  byte
+		content []byte
+	}{
+		{hash: hash, action: txmetaActionADD, content: []byte("v1")},
+		{hash: hash, action: txmetaActionDELETE},
+		{hash: hash, action: txmetaActionADD, content: []byte("v2")},
+	})
+
+	require.NoError(t, server.txmetaHandler(context.Background(), msg))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(ops) == 3
+	}, 2*time.Second, time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"add", "delete", "add"}, ops)
+}
+
+// TestServer_txmetaHandler_TruncatedMessageDoesNotLatch verifies that a
+// truncated Kafka message neither dispatches partial work nor flips the
+// caught-up latch even when the message claims to be at the partition's tail.
+func TestServer_txmetaHandler_TruncatedMessageDoesNotLatch(t *testing.T) {
+	mockLogger := &mockLogger{}
+	mockCache := &mockCache{}
+	mockLogger.On("Errorf", mock.Anything, mock.Anything).Return()
+
+	server := &Server{
+		logger:    mockLogger,
+		utxoStore: mockCache,
+	}
+
+	// Claim 2 entries but only encode header for 1 entry's worth of bytes
+	// (no content); the second entry's header trips the truncation check.
+	buf := make([]byte, 4+32+1+4)
+	binary.LittleEndian.PutUint32(buf, 2)
+	// Leave the rest zeroed; entry-1 header is read, then the loop's next
+	// iteration sees offset+32+1+4 > len(buf) and bails.
+
+	msg := &kafka.KafkaMessage{
+		Value:         buf,
+		Offset:        99,
+		HighWaterMark: 100, // would normally flip the latch
+	}
+
+	require.NoError(t, server.txmetaHandler(context.Background(), msg))
+
+	// Give the async worker plenty of time to NOT do anything.
+	time.Sleep(20 * time.Millisecond)
+
+	require.False(t, server.txmetaCaughtUp.Load(), "latch must not flip on truncated message")
+	mockCache.AssertNotCalled(t, "SetCacheMulti", mock.Anything, mock.Anything)
+	mockCache.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
 }
 
 // TestServer_txmetaHandler_LatchIsOneWay verifies that once the latch is set,

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -86,6 +86,11 @@ func (m *mockCache) SetCacheFromBytes(key, txMetaBytes []byte) error {
 	return args.Error(0)
 }
 
+func (m *mockCache) SetCacheMulti(keys, values [][]byte) error {
+	args := m.Called(keys, values)
+	return args.Error(0)
+}
+
 func (m *mockCache) BatchDecorate(ctx context.Context, txs []*utxo.UnresolvedMetaData, fields ...fields.FieldName) error {
 	args := m.Called(ctx, txs, fields)
 	return args.Error(0)
@@ -309,14 +314,14 @@ func TestServer_txmetaHandler(t *testing.T) {
 		{
 			name: "successful set operation",
 			setupMocks: func(l *mockLogger, c *mockCache) {
-				c.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+				c.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil)
 			},
 			input: createKafkaMessage(t, false, []byte("test data")),
 		},
 		{
 			name: "failed set operation logs debug",
 			setupMocks: func(l *mockLogger, c *mockCache) {
-				c.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(errors.ErrProcessing)
+				c.On("SetCacheMulti", mock.Anything, mock.Anything).Return(errors.ErrProcessing)
 				l.On("Debugf", mock.Anything, mock.Anything).Return()
 			},
 			input: createKafkaMessage(t, false, []byte("test data")),
@@ -356,7 +361,7 @@ func TestServer_txmetaHandler_PreservesPerKeyOrdering(t *testing.T) {
 		operations  []string
 	)
 
-	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+	mockCache.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		operationMu.Lock()
 		defer operationMu.Unlock()
 		operations = append(operations, "add")
@@ -407,8 +412,8 @@ func TestServer_txmetaHandler_CaughtUpModeDropsOnFullQueue(t *testing.T) {
 	// Pretend workers are already initialized; an unbuffered channel with no
 	// reader is always "full" for a non-blocking send.
 	server.txmetaWorkerInitOnce.Do(func() {})
-	server.txmetaWorkerQueues = []chan txmetaWorkItem{
-		make(chan txmetaWorkItem),
+	server.txmetaWorkerQueues = []chan *txmetaShardBatch{
+		make(chan *txmetaShardBatch),
 	}
 
 	hash := chainhash.Hash{0}
@@ -428,11 +433,11 @@ func TestServer_txmetaHandler_StartupModeBlocksUntilDrained(t *testing.T) {
 	// Latch defaults to false (startup mode).
 
 	server.txmetaWorkerInitOnce.Do(func() {})
-	ch := make(chan txmetaWorkItem, 1)
-	server.txmetaWorkerQueues = []chan txmetaWorkItem{ch}
+	ch := make(chan *txmetaShardBatch, 1)
+	server.txmetaWorkerQueues = []chan *txmetaShardBatch{ch}
 
 	// Pre-fill the queue. Any further send blocks until a reader appears.
-	ch <- txmetaWorkItem{}
+	ch <- &txmetaShardBatch{}
 
 	// Drain a single item after a short delay; this should unblock the handler.
 	go func() {
@@ -462,8 +467,8 @@ func TestServer_txmetaHandler_StartupModeUnblocksOnContextCancel(t *testing.T) {
 	}
 
 	server.txmetaWorkerInitOnce.Do(func() {})
-	ch := make(chan txmetaWorkItem) // unbuffered, no reader -> always blocks
-	server.txmetaWorkerQueues = []chan txmetaWorkItem{ch}
+	ch := make(chan *txmetaShardBatch) // unbuffered, no reader -> always blocks
+	server.txmetaWorkerQueues = []chan *txmetaShardBatch{ch}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -485,7 +490,7 @@ func TestServer_txmetaHandler_StartupModeUnblocksOnContextCancel(t *testing.T) {
 func TestServer_txmetaHandler_LatchFlipsAtHighWaterMark(t *testing.T) {
 	mockLogger := &mockLogger{}
 	mockCache := &mockCache{}
-	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+	mockCache.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil)
 	mockLogger.On("Infof", mock.Anything, mock.Anything).Return()
 
 	server := &Server{
@@ -516,7 +521,7 @@ func TestServer_txmetaHandler_LatchFlipsAtHighWaterMark(t *testing.T) {
 func TestServer_txmetaHandler_LatchIgnoredWhenHighWaterMarkUnset(t *testing.T) {
 	mockLogger := &mockLogger{}
 	mockCache := &mockCache{}
-	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+	mockCache.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil)
 
 	server := &Server{
 		logger:    mockLogger,
@@ -542,7 +547,7 @@ func TestServer_txmetaHandler_LatchIgnoredWhenHighWaterMarkUnset(t *testing.T) {
 func TestServer_txmetaHandler_LatchIsOneWay(t *testing.T) {
 	mockLogger := &mockLogger{}
 	mockCache := &mockCache{}
-	mockCache.On("SetCacheFromBytes", mock.Anything, mock.Anything).Return(nil)
+	mockCache.On("SetCacheMulti", mock.Anything, mock.Anything).Return(nil)
 	mockLogger.On("Infof", mock.Anything, mock.Anything).Return()
 
 	server := &Server{


### PR DESCRIPTION
## Summary

Replaces per-entry shard-worker dispatch with per-shard-batch dispatch in the txmeta Kafka handler. The worker now calls `SetTxMetaCacheMulti` once per shard-batch instead of `SetTxMetaCacheFromBytes` once per entry — exercising the `SetCacheMulti` API that #891 pre-positioned on the interface.

## What changes

- For each Kafka message, entries are bucketed into per-shard slices in a single parse pass and sent as one `*txmetaShardBatch` per non-empty shard.
- Worker processes the whole batch: DELETEs one-at-a-time (rare), ADDs in one `SetCacheMulti` call.
- Preserves the two-mode (startup-block / caught-up-drop) enqueue contract from #891. The "abandon remainder of batch" semantic is now per-shard-batch rather than per-entry.
- Hash-byte sharding still provides per-key ordering; 256-way parallelism is unchanged.
- ADD content is still copied out of `msg.Value` at parse time.
- Per-batch metric observation replaces per-item observation — dashboards interpreting one `Observe()` as one record need adjustment.

## Why

Two throughput wins on the hot path:

1. **Channel hops** drop from N entries to up-to-256 shards per Kafka message — eliminates per-entry channel send/recv on the dispatch path.
2. **Bucket-lock acquisitions** drop similarly: the cache acquires each touched bucket lock once per shard-batch instead of once per entry. Larger batches stay on the existing `smallSetMultiBatchThreshold` fast-path in `ImprovedCache.SetMulti` (no per-call bucket-fanout goroutines).

## Bench

Apple M3 Max, counting `txMetaCacheOps` to isolate dispatch cost:

| Batch size | tx/s | ns/tx | allocs/op |
|---|---|---|---|
| 1 | 2.5M | 395 | 5 |
| 100 | 1.5M | 649 | 500 |
| 1000 | 4.0M | 249 | 2,536 |
| 10000 | 11.8M | 84 | 12,565 |

Production Kafka batch sizes sit in the low thousands; per-pod ceiling is ~4M tx/s on the dispatch path alone, well above the per-cluster txmeta volume that triggers the cache-fill drops in the field.

A separate small PR will follow that raises `smallSetMultiBatchThreshold` in `stores/txmetacache/improved_cache.go` — that's a cache-tuning concern independent of this handler change.

## Test plan

- [x] Existing `TestServer_txmetaHandler*` suite passes (mocks updated to expect `SetCacheMulti`; queue-full / startup-block / latch tests rewritten for the new channel element type)
- [x] New `txmetaHandler_bench_test.go` keeps throughput measurement reproducible
- [x] `go build ./...` clean, `go vet ./services/subtreevalidation/...` clean
- [ ] CI green