### PR TITLE
perf(txmetacache): raise smallSetMultiBatchThreshold 32 -> 256

### DIFF
--- a/stores/txmetacache/improved_cache.go
+++ b/stores/txmetacache/improved_cache.go
@@ -89,7 +89,11 @@ const (
 	minSlabBytesPerMmap = minSlabChunks * ChunkSize // keep in sync with minSlabChunks
 )
 
-const smallSetMultiBatchThreshold = 32
+// smallSetMultiBatchThreshold gates SetMulti's two paths: at or below this
+// size, keys are written sequentially via per-key Set on the caller's
+// goroutine. Above it, keys are bucketed and dispatched to one goroutine
+// per non-empty bucket.
+const smallSetMultiBatchThreshold = 256
 
 func mapCapacityPerBucket() int {
 	return max(1, MapInitialCapacity/BucketsCount)


### PR DESCRIPTION
## Summary

One-line tuning constant in `ImprovedCache.SetMulti`. Keeps small/mid-sized `SetMulti` calls on the sequential per-key `Set` path — avoiding per-call `errgroup` goroutine spawn — for the call shape produced by the txmeta Kafka handler after #906.

## Why

`ImprovedCache.SetMulti` has two paths:
- `len(keys) <= threshold`: write all keys sequentially via per-key `Set` on the caller's goroutine. No goroutine spawn, no `errgroup` overhead.
- `len(keys) > threshold`: bucket the keys and fan out via `errgroup` — one fresh goroutine per non-empty bucket per call.

The old `threshold = 32` made sense when the txmeta handler dispatched single entries through 256 hash-byte shard workers. With #906 the handler now dispatches **per-shard batches** sized roughly `batch_size / 256` — for a 10K-entry Kafka message, ~40 entries per shard. At the old threshold, every shard worker call would tip into bucket fan-out, multiplying goroutine creation 256× (once per shard). Raising the threshold to 256 keeps those calls on the cheap per-key path.

Direct callers issuing genuinely large `SetMulti` (e.g. `BatchDecorate` write-backs at 1000+ keys) still cross 256 and get the bucket fan-out as before — only the small-mid range moved.

## Bench

Apple M3 Max, handler + real `ImprovedCache` (Unallocated bucket):

| Batch | Payload | threshold=32 tx/s | **threshold=256 tx/s** | Δ |
|---|---|---|---|---|
| 1,000 | 32 B | 3.42M | **9.11M** | **+2.66×** |
| 1,000 | 64 B | 3.35M | **5.26M** | **+1.57×** |
| 1,000 | 128 B | 3.29M | **8.19M** | **+2.49×** |
| 10,000 | 64 B | 2.65M | **7.41M** | **+2.80×** |

(Bench in #906 — `BenchmarkTxmetaHandler_RealCache_*` for repro.)

## Risk

Cache-side change affecting **every** `SetMulti` caller, not only the txmeta handler. The fast path is sequential, so callers issuing batches in the 33–256 range now lose the per-bucket parallelism they previously got. Direct calls with hundreds of keys to genuinely-distinct buckets will see a small regression; calls with sub-256 keys against a hot working set will see a win.

Stacks cleanly on top of #906 — neither PR depends on the other landing first.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./stores/txmetacache/...` clean
- [ ] Existing `stores/txmetacache` test suite passes in CI
- [ ] In-cluster measurement on scaling-2 (before/after) once both PRs land