### PR TITLE
fix(legacy): allow non-pow2 final subtree to avoid degenerate partitions (#901)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/bsv-blockchain/go-bt/v2 v2.6.3
 	github.com/bsv-blockchain/go-chaincfg v1.5.8
 	github.com/bsv-blockchain/go-sdk v1.2.23
-	github.com/bsv-blockchain/go-subtree v1.4.1
+	github.com/bsv-blockchain/go-subtree v1.4.2
 	github.com/bsv-blockchain/testcontainers-aerospike-go v0.3.2
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/goleveldb v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/bsv-blockchain/go-safe-conversion v1.2.0 h1:HwLWaxqm2OyU5/2BRQ8kwdn25
 github.com/bsv-blockchain/go-safe-conversion v1.2.0/go.mod h1:62Eq2980j4BygfqJhd/ObGRHET8ubEy2rBdGi4k6nsw=
 github.com/bsv-blockchain/go-sdk v1.2.23 h1:DRZWaqgW6Ra+uFe1+sLFi+WPcjTdBm8NAwfr6ODOF68=
 github.com/bsv-blockchain/go-sdk v1.2.23/go.mod h1:5mmw1QLusuAkjWmQgUOurQYCXdIsQEsWXbAZ9zwme3g=
-github.com/bsv-blockchain/go-subtree v1.4.1 h1:9cQE3KPLP0kghZHadPbMuaRKgaxbc86wyLOH7LYfnQw=
-github.com/bsv-blockchain/go-subtree v1.4.1/go.mod h1:0ysEa29As06LxqoY1+tT+oLMWbDp7Pj0DFILZ84eGoc=
+github.com/bsv-blockchain/go-subtree v1.4.2 h1:T6a6r051eTAuYs8D01O8MM8wzRnfkhushzk5bUTqeqI=
+github.com/bsv-blockchain/go-subtree v1.4.2/go.mod h1:ef+NCE9gION7YIOHdguW3thOlIyyuuxrfDEwv0Ywc3Q=
 github.com/bsv-blockchain/go-tx-map v1.3.7 h1:59LVYW2bvax/WbyM1eUNkrojXNrVu9f0lAuKbNryEbQ=
 github.com/bsv-blockchain/go-tx-map v1.3.7/go.mod h1:QJo02rdqFTHaimSTCgl6mLMLwIDtykwWTC1lt7nrhY8=
 github.com/bsv-blockchain/go-wire v1.2.5 h1:A29P4pwvZEnr3u5PxNkog/K7Bx3YvBlR5/nmq7+ijcI=

--- a/model/Block.go
+++ b/model/Block.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
+	mathbits "math/bits"
 	"runtime"
 	"sort"
 	"strings"
@@ -1351,6 +1353,46 @@ func (b *Block) getSubtreeMetaSlice(ctx context.Context, subtreeStore SubtreeSto
 	return subtreeMetaSlice, nil
 }
 
+// liftSubtreeRootToTargetHeight returns the merkle root of the subtree as it
+// would appear in a slot of height targetHeight, computed by self-hashing the
+// natural root up the phantom levels (H(prev, prev) per level). This is the
+// generalisation of subtreepkg.RootHashPadded that also accepts non-power-of-two
+// leaf counts: BuildMerkleTreeStoreFromBytes already applies the
+// duplicate-when-odd rule at each internal level, so the subtree's RootHash()
+// naturally lives at height ceil(log2(Length)) and is the correct starting
+// point for the phantom-step lift regardless of whether Length is a power of
+// two. See [[partition-legacy-block-issue-901]] for why the non-power-of-two
+// case matters in practice.
+func liftSubtreeRootToTargetHeight(st *subtreepkg.Subtree, targetHeight int) (*chainhash.Hash, error) {
+	length := st.Length()
+	if length == 0 {
+		return nil, errors.NewProcessingError("cannot lift empty subtree")
+	}
+
+	actualHeight := mathbits.Len(uint(length - 1))
+	if targetHeight < actualHeight {
+		return nil, errors.NewProcessingError("targetHeight %d less than subtree height %d", targetHeight, actualHeight)
+	}
+
+	rootHash := st.RootHash()
+	if rootHash == nil {
+		return nil, errors.NewProcessingError("subtree returned nil root")
+	}
+
+	root := *rootHash
+
+	var buf [64]byte
+
+	for i := 0; i < targetHeight-actualHeight; i++ {
+		copy(buf[0:32], root[:])
+		copy(buf[32:64], root[:])
+		first := sha256.Sum256(buf[:])
+		root = chainhash.Hash(sha256.Sum256(first[:]))
+	}
+
+	return &root, nil
+}
+
 func (b *Block) CheckMerkleRoot(ctx context.Context) (err error) {
 	if len(b.Subtrees) != len(b.SubtreeSlices) {
 		return errors.NewStorageError("[BLOCK][%s] number of subtrees does not match number of subtree slices, have you called block.GetAndValidateSubtrees()?", b.String())
@@ -1431,20 +1473,20 @@ func (b *Block) CheckMerkleRoot(ctx context.Context) (err error) {
 					b.String(), sub.Length(), targetLength,
 				)
 			}
-
-			if isLast && sub.Length() < targetLength && !subtreepkg.IsPowerOfTwo(sub.Length()) {
-				return errors.NewBlockInvalidError(
-					"[BLOCK][%s] final subtree leaf count is not a power of two: %d",
-					b.String(), sub.Length(),
-				)
-			}
 		}
 
 		// If the final subtree is shorter than the target length, lift its root
 		// to the target height so it occupies the slot of a same-capacity subtree
-		// in the top-level merkle tree.
+		// in the top-level merkle tree. The final subtree's leaf count does NOT
+		// need to be a power of two: BuildMerkleTreeStoreFromBytes already applies
+		// the duplicate-when-odd rule at every internal level, so the subtree's
+		// own RootHash() naturally lives at height ceil(log2(Length)) and matches
+		// what the canonical flat tree produces for that segment. Allowing
+		// non-power-of-two final subtrees is what lets the legacy-block
+		// partitioner stay at maxItems instead of degenerating to tiny subtrees
+		// for adversarial transaction counts — see issue #901.
 		if last := b.SubtreeSlices[len(b.SubtreeSlices)-1]; last.Length() < targetLength {
-			liftedRoot, err := last.RootHashPadded(targetHeight)
+			liftedRoot, err := liftSubtreeRootToTargetHeight(last, targetHeight)
 			if err != nil {
 				return errors.NewProcessingError("[BLOCK][%s] failed lifting final subtree", b.String(), err)
 			}

--- a/model/Block.go
+++ b/model/Block.go
@@ -4,11 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
-	mathbits "math/bits"
 	"runtime"
 	"sort"
 	"strings"
@@ -1353,46 +1351,6 @@ func (b *Block) getSubtreeMetaSlice(ctx context.Context, subtreeStore SubtreeSto
 	return subtreeMetaSlice, nil
 }
 
-// liftSubtreeRootToTargetHeight returns the merkle root of the subtree as it
-// would appear in a slot of height targetHeight, computed by self-hashing the
-// natural root up the phantom levels (H(prev, prev) per level). This is the
-// generalisation of subtreepkg.RootHashPadded that also accepts non-power-of-two
-// leaf counts: BuildMerkleTreeStoreFromBytes already applies the
-// duplicate-when-odd rule at each internal level, so the subtree's RootHash()
-// naturally lives at height ceil(log2(Length)) and is the correct starting
-// point for the phantom-step lift regardless of whether Length is a power of
-// two. See [[partition-legacy-block-issue-901]] for why the non-power-of-two
-// case matters in practice.
-func liftSubtreeRootToTargetHeight(st *subtreepkg.Subtree, targetHeight int) (*chainhash.Hash, error) {
-	length := st.Length()
-	if length == 0 {
-		return nil, errors.NewProcessingError("cannot lift empty subtree")
-	}
-
-	actualHeight := mathbits.Len(uint(length - 1))
-	if targetHeight < actualHeight {
-		return nil, errors.NewProcessingError("targetHeight %d less than subtree height %d", targetHeight, actualHeight)
-	}
-
-	rootHash := st.RootHash()
-	if rootHash == nil {
-		return nil, errors.NewProcessingError("subtree returned nil root")
-	}
-
-	root := *rootHash
-
-	var buf [64]byte
-
-	for i := 0; i < targetHeight-actualHeight; i++ {
-		copy(buf[0:32], root[:])
-		copy(buf[32:64], root[:])
-		first := sha256.Sum256(buf[:])
-		root = chainhash.Hash(sha256.Sum256(first[:]))
-	}
-
-	return &root, nil
-}
-
 func (b *Block) CheckMerkleRoot(ctx context.Context) (err error) {
 	if len(b.Subtrees) != len(b.SubtreeSlices) {
 		return errors.NewStorageError("[BLOCK][%s] number of subtrees does not match number of subtree slices, have you called block.GetAndValidateSubtrees()?", b.String())
@@ -1486,7 +1444,7 @@ func (b *Block) CheckMerkleRoot(ctx context.Context) (err error) {
 		// partitioner stay at maxItems instead of degenerating to tiny subtrees
 		// for adversarial transaction counts — see issue #901.
 		if last := b.SubtreeSlices[len(b.SubtreeSlices)-1]; last.Length() < targetLength {
-			liftedRoot, err := liftSubtreeRootToTargetHeight(last, targetHeight)
+			liftedRoot, err := last.RootHashPadded(targetHeight)
 			if err != nil {
 				return errors.NewProcessingError("[BLOCK][%s] failed lifting final subtree", b.String(), err)
 			}

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -4807,7 +4807,7 @@ func buildBlockWithSubtrees(t *testing.T, subtreeSize, totalTxs int) (*Block, *c
 	leftRoot, err := left.RootHashWithReplaceRootNode(coinbaseTx.TxIDChainHash(), 0, uint64(coinbaseTx.Size())) // nolint: gosec
 	require.NoError(t, err)
 
-	rightLifted, err := liftSubtreeRootToTargetHeight(right, left.Height)
+	rightLifted, err := right.RootHashPadded(left.Height)
 	require.NoError(t, err)
 
 	top, err := subtreepkg.NewTreeByLeafCount(2)

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -4681,17 +4681,23 @@ func TestCheckMerkleRoot_RejectsFinalSubtreeLargerThanFirst(t *testing.T) {
 	require.Contains(t, err.Error(), "final subtree exceeds first subtree size")
 }
 
-// TestCheckMerkleRoot_RejectsNonPowerOfTwoFinalSubtree verifies that
-// CheckMerkleRoot rejects a block whose final subtree leaf count is not a
-// power of two (lifting requires a power-of-two leaf count).
-func TestCheckMerkleRoot_RejectsNonPowerOfTwoFinalSubtree(t *testing.T) {
-	// First subtree complete (4 leaves). Final subtree has 3 leaves.
-	block := buildBlockWithNonPowerOfTwoFinal(t)
+// TestCheckMerkleRoot_AcceptsNonPowerOfTwoFinalSubtree verifies that
+// CheckMerkleRoot accepts a block whose final subtree leaf count is not a
+// power of two. The duplicate-when-odd rule already pads the subtree's own
+// merkle root internally, so the phantom-step lift composes correctly with
+// non-power-of-two final lengths — see issue #901 for why this matters.
+func TestCheckMerkleRoot_AcceptsNonPowerOfTwoFinalSubtree(t *testing.T) {
+	// 7 leaves split across two capacity-4 subtrees: [4, 3]. The final subtree
+	// has a non-power-of-two leaf count.
+	const (
+		totalTxs    = 7
+		subtreeSize = 4
+	)
 
-	err := block.CheckMerkleRoot(context.Background())
-	require.Error(t, err)
-	require.True(t, errors.Is(err, errors.ErrBlockInvalid), "expected BlockInvalidError, got %v", err)
-	require.Contains(t, err.Error(), "leaf count is not a power of two")
+	block, expectedRoot := buildBlockWithSubtrees(t, subtreeSize, totalTxs)
+	block.Header.HashMerkleRoot = expectedRoot
+
+	require.NoError(t, block.CheckMerkleRoot(context.Background()))
 }
 
 // TestCheckMerkleRoot_RejectsFirstSubtreeNotPowerOfTwo verifies that
@@ -4767,8 +4773,9 @@ func newTestBlockHeader(t *testing.T) *BlockHeader {
 // buildBlockWithSubtrees constructs a Block with two subtrees: a fully populated
 // first subtree of `subtreeSize` leaves and a final subtree containing the
 // remaining `totalTxs - subtreeSize` leaves (which may be fewer than
-// `subtreeSize`). It returns the block and the expected top-level merkle root
-// computed with the final subtree's root lifted to the first subtree's height.
+// `subtreeSize`, and may be a non-power-of-two count). It returns the block
+// and the expected top-level merkle root computed with the final subtree's
+// root lifted to the first subtree's height.
 func buildBlockWithSubtrees(t *testing.T, subtreeSize, totalTxs int) (*Block, *chainhash.Hash) {
 	t.Helper()
 	require.Greater(t, totalTxs, subtreeSize)
@@ -4786,7 +4793,9 @@ func buildBlockWithSubtrees(t *testing.T, subtreeSize, totalTxs int) (*Block, *c
 		require.NoError(t, left.AddNode(hashes[i], 0, 0))
 	}
 
-	right, err := subtreepkg.NewTreeByLeafCount(subtreeSize)
+	rightLeafCount := totalTxs - subtreeSize
+
+	right, err := subtreepkg.NewIncompleteTreeByLeafCount(rightLeafCount)
 	require.NoError(t, err)
 
 	for i := subtreeSize; i < totalTxs; i++ {
@@ -4798,7 +4807,7 @@ func buildBlockWithSubtrees(t *testing.T, subtreeSize, totalTxs int) (*Block, *c
 	leftRoot, err := left.RootHashWithReplaceRootNode(coinbaseTx.TxIDChainHash(), 0, uint64(coinbaseTx.Size())) // nolint: gosec
 	require.NoError(t, err)
 
-	rightLifted, err := right.RootHashPadded(left.Height)
+	rightLifted, err := liftSubtreeRootToTargetHeight(right, left.Height)
 	require.NoError(t, err)
 
 	top, err := subtreepkg.NewTreeByLeafCount(2)
@@ -4881,31 +4890,3 @@ func buildBlockWithFinalSubtreeLargerThanFirst(t *testing.T) *Block {
 	}
 }
 
-// buildBlockWithNonPowerOfTwoFinal returns a Block whose final subtree has a
-// non-power-of-two leaf count (3 leaves in a capacity-4 subtree). This
-// violates the new lift rules because RootHashPadded requires a power-of-two
-// leaf count.
-func buildBlockWithNonPowerOfTwoFinal(t *testing.T) *Block {
-	t.Helper()
-
-	first, err := subtreepkg.NewTreeByLeafCount(4)
-	require.NoError(t, err)
-
-	for i := 0; i < 4; i++ {
-		require.NoError(t, first.AddNode(chainhash.HashH([]byte{byte(i)}), 0, 0))
-	}
-
-	second, err := subtreepkg.NewTreeByLeafCount(4)
-	require.NoError(t, err)
-
-	for i := 10; i < 13; i++ {
-		require.NoError(t, second.AddNode(chainhash.HashH([]byte{byte(i)}), 0, 0))
-	}
-
-	return &Block{
-		Header:        newTestBlockHeader(t),
-		CoinbaseTx:    newTestCoinbaseTx(t),
-		Subtrees:      []*chainhash.Hash{first.RootHash(), second.RootHash()},
-		SubtreeSlices: []*subtreepkg.Subtree{first, second},
-	}
-}

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -4889,4 +4889,3 @@ func buildBlockWithFinalSubtreeLargerThanFirst(t *testing.T) *Block {
 		SubtreeSlices: []*subtreepkg.Subtree{first, second},
 	}
 }
-

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -288,10 +288,14 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 	}
 
 	// Partition the block's transactions into K subtrees so each non-final subtree
-	// is exactly subtreeSize leaves and the final subtree's leaf count is a power of
-	// two ≤ subtreeSize — matching model.Block.CheckMerkleRoot's Length-based lift
-	// rules. For blocks where txCount ≤ MaximumMerkleItemsPerSubtree the partition
-	// is the unchanged single-subtree case.
+	// is exactly subtreeSize leaves and the final subtree's leaf count is in
+	// [1, subtreeSize] — matching model.Block.CheckMerkleRoot's Length-based lift
+	// rules. The final subtree does not need to be a power of two: the
+	// duplicate-when-odd rule applied inside BuildMerkleTreeStoreFromBytes already
+	// pads its natural root to height ceil(log2(length)), which is what the lift
+	// in CheckMerkleRoot expects. For blocks where txCount ≤
+	// MaximumMerkleItemsPerSubtree the partition is the unchanged single-subtree
+	// case.
 	maxItems := sm.settings.BlockAssembly.MaximumMerkleItemsPerSubtree
 
 	subtreeSize, numSubtrees, finalLeafCount, err := partitionLegacyBlock(txCount, maxItems)

--- a/services/legacy/netsync/subtree_partition.go
+++ b/services/legacy/netsync/subtree_partition.go
@@ -7,21 +7,25 @@ import (
 
 // partitionLegacyBlock determines how to partition a legacy block's transactions
 // into subtrees so the resulting block satisfies model.Block.CheckMerkleRoot's
-// rules: all non-final subtrees must share the same length, the final subtree
-// must be at most that length and a power of two if smaller.
+// rules: every non-final subtree shares the same power-of-two length, and the
+// final subtree's length is at most that.
 //
 // Returns (subtreeSize, K, finalLeafCount):
 //   - K is the number of subtrees
-//   - subtreeSize is the capacity (and Length) of each non-final subtree
-//   - finalLeafCount is the actual leaf count of the final subtree (== subtreeSize
-//     if the final subtree is full, smaller power-of-two otherwise)
+//   - subtreeSize is the capacity (and Length) of each non-final subtree (always
+//     a power of two ≤ maxItems)
+//   - finalLeafCount is the actual leaf count of the final subtree, in [1, subtreeSize]
 //
-// For totalLeaves <= maxItems, returns (totalLeaves, 1, totalLeaves), preserving
-// today's single-subtree behaviour.
+// For totalLeaves ≤ maxItems, returns (totalLeaves, 1, totalLeaves), preserving
+// today's single-subtree behaviour for small blocks.
 //
-// For larger totalLeaves, picks the largest power-of-two s ≤ maxItems such that
-// totalLeaves - (ceil(totalLeaves/s)-1)*s is a power of two. Always terminates
-// because s=1 yields r=1 which is power-of-two.
+// For larger totalLeaves, the partition is fixed: subtreeSize = maxItems and the
+// final subtree holds the remainder. Because the duplicate-when-odd rule already
+// pads the merkle tree internally at every level, the final subtree's leaf count
+// can be any value in [1, subtreeSize] — it does not need to be a power of two.
+// This avoids the pre-#901 degenerate case where adversarial leaf counts (e.g.
+// 900,679 transactions) forced the partitioner all the way down to subtreeSize=2
+// and produced hundreds of thousands of tiny subtrees.
 func partitionLegacyBlock(totalLeaves, maxItems int) (subtreeSize, K, finalLeafCount int, err error) {
 	if totalLeaves <= 0 {
 		return 0, 0, 0, errors.NewProcessingError("partitionLegacyBlock: totalLeaves must be > 0, got %d", totalLeaves)
@@ -39,14 +43,9 @@ func partitionLegacyBlock(totalLeaves, maxItems int) (subtreeSize, K, finalLeafC
 		return totalLeaves, 1, totalLeaves, nil
 	}
 
-	for s := maxItems; s >= 1; s /= 2 {
-		kCalc := (totalLeaves + s - 1) / s
-		r := totalLeaves - (kCalc-1)*s
+	subtreeSize = maxItems
+	K = (totalLeaves + subtreeSize - 1) / subtreeSize
+	finalLeafCount = totalLeaves - (K-1)*subtreeSize
 
-		if r == s || subtreepkg.IsPowerOfTwo(r) {
-			return s, kCalc, r, nil
-		}
-	}
-
-	return 0, 0, 0, errors.NewProcessingError("partitionLegacyBlock: no valid partition found for totalLeaves=%d, maxItems=%d", totalLeaves, maxItems)
+	return subtreeSize, K, finalLeafCount, nil
 }

--- a/services/legacy/netsync/subtree_partition_test.go
+++ b/services/legacy/netsync/subtree_partition_test.go
@@ -21,11 +21,22 @@ func TestPartitionLegacyBlock(t *testing.T) {
 		{name: "single subtree, exact match", totalLeaves: 4, maxItems: 4, wantSubtreeSize: 4, wantK: 1, wantFinalLeaves: 4},
 		{name: "two subtrees, last 1 leaf", totalLeaves: 5, maxItems: 4, wantSubtreeSize: 4, wantK: 2, wantFinalLeaves: 1},
 		{name: "two subtrees, last 2 leaves", totalLeaves: 6, maxItems: 4, wantSubtreeSize: 4, wantK: 2, wantFinalLeaves: 2},
-		{name: "fall back to smaller s for non-pow2 remainder (N=7)", totalLeaves: 7, maxItems: 4, wantSubtreeSize: 2, wantK: 4, wantFinalLeaves: 1},
+		{name: "two subtrees, last 3 leaves (non-pow2)", totalLeaves: 7, maxItems: 4, wantSubtreeSize: 4, wantK: 2, wantFinalLeaves: 3},
 		{name: "two subtrees, last full", totalLeaves: 8, maxItems: 4, wantSubtreeSize: 4, wantK: 2, wantFinalLeaves: 4},
-		{name: "fall back to smaller s for N=11", totalLeaves: 11, maxItems: 4, wantSubtreeSize: 2, wantK: 6, wantFinalLeaves: 1},
+		{name: "three subtrees, last 3 leaves (non-pow2)", totalLeaves: 11, maxItems: 4, wantSubtreeSize: 4, wantK: 3, wantFinalLeaves: 3},
 		{name: "three subtrees, last full", totalLeaves: 12, maxItems: 4, wantSubtreeSize: 4, wantK: 3, wantFinalLeaves: 4},
 		{name: "production-sized, last 1 leaf", totalLeaves: 1048577, maxItems: 1048576, wantSubtreeSize: 1048576, wantK: 2, wantFinalLeaves: 1},
+
+		// Issue #901: the 900,679-tx production block. With maxItems = 32,768 this
+		// previously bottomed out at subtreeSize = 2, K = 450,340. Now it must stay
+		// at subtreeSize = maxItems with a single non-power-of-two final subtree.
+		{name: "issue #901 production case (900679 txs, maxItems 32768)", totalLeaves: 900679, maxItems: 32768, wantSubtreeSize: 32768, wantK: 28, wantFinalLeaves: 15943},
+
+		// Other adversarial counts that used to degenerate to small subtreeSize.
+		{name: "adversarial N=21 (binary 10101), maxItems=8", totalLeaves: 21, maxItems: 8, wantSubtreeSize: 8, wantK: 3, wantFinalLeaves: 5},
+		{name: "adversarial N=15 (binary 1111), maxItems=8", totalLeaves: 15, maxItems: 8, wantSubtreeSize: 8, wantK: 2, wantFinalLeaves: 7},
+		{name: "adversarial N=23 (binary 10111), maxItems=8", totalLeaves: 23, maxItems: 8, wantSubtreeSize: 8, wantK: 3, wantFinalLeaves: 7},
+
 		{name: "error: totalLeaves zero", totalLeaves: 0, maxItems: 4, wantErr: true},
 		{name: "error: totalLeaves negative", totalLeaves: -1, maxItems: 4, wantErr: true},
 		{name: "error: maxItems zero", totalLeaves: 5, maxItems: 0, wantErr: true},
@@ -48,6 +59,36 @@ func TestPartitionLegacyBlock(t *testing.T) {
 
 			require.Equal(t, tc.totalLeaves, (tc.wantK-1)*tc.wantSubtreeSize+tc.wantFinalLeaves,
 				"partition should account for every leaf")
+
+			// Final subtree leaf count must be in [1, subtreeSize].
+			require.GreaterOrEqual(t, r, 1, "finalLeafCount >= 1")
+			require.LessOrEqual(t, r, s, "finalLeafCount <= subtreeSize")
 		})
+	}
+}
+
+// TestPartitionLegacyBlock_BoundedK proves that the partition never produces
+// more than ceil(totalLeaves / maxItems) subtrees, regardless of how adversarial
+// the leaf count is. Pre-#901 the algorithm could explode this to N/2 subtrees.
+func TestPartitionLegacyBlock_BoundedK(t *testing.T) {
+	maxItems := 32768
+
+	// Sample a range of leaf counts including the production case and other
+	// numbers chosen to have many low-bit-set patterns that broke the previous
+	// algorithm.
+	cases := []int{900679, 1_000_000, 2_097_151, 524_287, 524_289, 1023, 1025}
+
+	for _, total := range cases {
+		s, k, r, err := partitionLegacyBlock(total, maxItems)
+		require.NoError(t, err)
+
+		expectedK := (total + maxItems - 1) / maxItems
+		if total <= maxItems {
+			expectedK = 1
+		}
+
+		require.Equal(t, expectedK, k, "K must equal ceil(total/maxItems) for total=%d", total)
+		require.LessOrEqual(t, s, maxItems, "subtreeSize must not exceed maxItems for total=%d", total)
+		require.Equal(t, total, (k-1)*s+r, "partition must cover every leaf for total=%d", total)
 	}
 }

--- a/util/subtree_merkle_root_equivalence_test.go
+++ b/util/subtree_merkle_root_equivalence_test.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	mathbits "math/bits"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -82,4 +84,123 @@ func TestSubtreeMerkleRootEquivalence(t *testing.T) {
 
 	require.NotEqual(t, referenceRoot.String(), naiveTop.RootHash().String(),
 		"without phantom-step lifting, the composed root would not match")
+}
+
+// TestSubtreeMerkleRootEquivalence_NonPowerOfTwoFinal proves that the
+// partitioned merkle root matches the canonical flat merkle root when the
+// final subtree contains a non-power-of-two number of leaves. This is the
+// invariant that issue #901's fix relies on: the legacy-block partitioner can
+// stay at subtreeSize=maxItems even for adversarial transaction counts, with
+// the awkward remainder going into a single final subtree of whatever size.
+//
+// The test exercises a range of remainder sizes (3, 5, 6, 7, 11, ..., 15,943)
+// to cover the duplicate-when-odd cascade at multiple internal levels of the
+// final subtree.
+func TestSubtreeMerkleRootEquivalence_NonPowerOfTwoFinal(t *testing.T) {
+	const subtreeSize = 32
+
+	// rValues covers a variety of binary patterns to exercise the
+	// duplicate-when-odd cascade at every level of a capacity-32 final subtree.
+	rValues := []int{1, 2, 3, 5, 6, 7, 9, 11, 13, 15, 17, 21, 23, 27, 31}
+
+	for _, r := range rValues {
+		t.Run(formatLeafCount(r), func(t *testing.T) {
+			totalTxs := subtreeSize + r
+
+			txHashes := make([]chainhash.Hash, totalTxs)
+			for i := range txHashes {
+				_, err := rand.Read(txHashes[i][:])
+				require.NoError(t, err)
+			}
+
+			// Reference: single big tree padded to next power of two with the
+			// duplicate-when-odd rule (handled by NewTreeByLeafCount + AddNode).
+			referenceCapacity := subtree.CeilPowerOfTwo(totalTxs)
+			bigTree, err := subtree.NewTreeByLeafCount(referenceCapacity)
+			require.NoError(t, err)
+
+			for _, h := range txHashes {
+				require.NoError(t, bigTree.AddNode(h, 0, 0))
+			}
+
+			referenceRoot := bigTree.RootHash()
+			require.NotNil(t, referenceRoot)
+
+			// Composite: first subtreeSize leaves in a complete subtree, last r
+			// leaves in a subtree of capacity ceil(log2(r)).
+			left, err := subtree.NewTreeByLeafCount(subtreeSize)
+			require.NoError(t, err)
+
+			for i := 0; i < subtreeSize; i++ {
+				require.NoError(t, left.AddNode(txHashes[i], 0, 0))
+			}
+
+			right, err := subtree.NewIncompleteTreeByLeafCount(r)
+			require.NoError(t, err)
+
+			for i := subtreeSize; i < totalTxs; i++ {
+				require.NoError(t, right.AddNode(txHashes[i], 0, 0))
+			}
+
+			require.Equal(t, r, right.Length())
+
+			// Lift the right subtree's root to the left subtree's height. The
+			// right subtree's RootHash() naturally lives at height ceil(log2(r))
+			// because BuildMerkleTreeStoreFromBytes applies duplicate-when-odd
+			// internally — we just need to self-hash up the phantom levels.
+			rightLifted := liftRootForTest(right.RootHash(), right.Length(), left.Height)
+
+			topTree, err := subtree.NewTreeByLeafCount(2)
+			require.NoError(t, err)
+			require.NoError(t, topTree.AddNode(*left.RootHash(), 0, 0))
+			require.NoError(t, topTree.AddNode(*rightLifted, 0, 0))
+
+			require.Equal(t, referenceRoot.String(), topTree.RootHash().String(),
+				"composed root must equal reference root for r=%d (final subtree has %d leaves)", r, r)
+		})
+	}
+}
+
+// liftRootForTest mirrors the inline lift in model.Block.CheckMerkleRoot,
+// duplicated here to keep this test in package util (which cannot import
+// package model without creating a cycle). For any leaf count, the
+// duplicate-when-odd rule applied internally during merkle-tree construction
+// makes the natural root live at height ceil(log2(length)); the phantom-step
+// lift then self-hashes up to targetHeight.
+func liftRootForTest(root *chainhash.Hash, length, targetHeight int) *chainhash.Hash {
+	actualHeight := mathbits.Len(uint(length - 1))
+	out := *root
+
+	var buf [64]byte
+
+	for i := 0; i < targetHeight-actualHeight; i++ {
+		copy(buf[0:32], out[:])
+		copy(buf[32:64], out[:])
+		first := sha256.Sum256(buf[:])
+		out = chainhash.Hash(sha256.Sum256(first[:]))
+	}
+
+	return &out
+}
+
+func formatLeafCount(r int) string {
+	return "final_subtree_has_" + intToASCII(r) + "_leaves"
+}
+
+func intToASCII(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	var buf [20]byte
+
+	i := len(buf)
+
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+
+	return string(buf[i:])
 }

--- a/util/subtree_merkle_root_equivalence_test.go
+++ b/util/subtree_merkle_root_equivalence_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	mathbits "math/bits"
 	"testing"
 
@@ -104,7 +105,7 @@ func TestSubtreeMerkleRootEquivalence_NonPowerOfTwoFinal(t *testing.T) {
 	rValues := []int{1, 2, 3, 5, 6, 7, 9, 11, 13, 15, 17, 21, 23, 27, 31}
 
 	for _, r := range rValues {
-		t.Run(formatLeafCount(r), func(t *testing.T) {
+		t.Run(fmt.Sprintf("final_subtree_has_%d_leaves", r), func(t *testing.T) {
 			totalTxs := subtreeSize + r
 
 			txHashes := make([]chainhash.Hash, totalTxs)
@@ -181,26 +182,4 @@ func liftRootForTest(root *chainhash.Hash, length, targetHeight int) *chainhash.
 	}
 
 	return &out
-}
-
-func formatLeafCount(r int) string {
-	return "final_subtree_has_" + intToASCII(r) + "_leaves"
-}
-
-func intToASCII(n int) string {
-	if n == 0 {
-		return "0"
-	}
-
-	var buf [20]byte
-
-	i := len(buf)
-
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-
-	return string(buf[i:])
 }

--- a/util/subtree_merkle_root_equivalence_test.go
+++ b/util/subtree_merkle_root_equivalence_test.go
@@ -2,9 +2,7 @@ package util
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"fmt"
-	mathbits "math/bits"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -145,11 +143,11 @@ func TestSubtreeMerkleRootEquivalence_NonPowerOfTwoFinal(t *testing.T) {
 
 			require.Equal(t, r, right.Length())
 
-			// Lift the right subtree's root to the left subtree's height. The
-			// right subtree's RootHash() naturally lives at height ceil(log2(r))
-			// because BuildMerkleTreeStoreFromBytes applies duplicate-when-odd
-			// internally — we just need to self-hash up the phantom levels.
-			rightLifted := liftRootForTest(right.RootHash(), right.Length(), left.Height)
+			// Lift the right subtree's root to the left subtree's height.
+			// RootHashPadded handles non-power-of-two leaf counts since
+			// go-subtree v1.4.2 (see bsv-blockchain/go-subtree#127).
+			rightLifted, err := right.RootHashPadded(left.Height)
+			require.NoError(t, err)
 
 			topTree, err := subtree.NewTreeByLeafCount(2)
 			require.NoError(t, err)
@@ -160,26 +158,4 @@ func TestSubtreeMerkleRootEquivalence_NonPowerOfTwoFinal(t *testing.T) {
 				"composed root must equal reference root for r=%d (final subtree has %d leaves)", r, r)
 		})
 	}
-}
-
-// liftRootForTest mirrors the inline lift in model.Block.CheckMerkleRoot,
-// duplicated here to keep this test in package util (which cannot import
-// package model without creating a cycle). For any leaf count, the
-// duplicate-when-odd rule applied internally during merkle-tree construction
-// makes the natural root live at height ceil(log2(length)); the phantom-step
-// lift then self-hashes up to targetHeight.
-func liftRootForTest(root *chainhash.Hash, length, targetHeight int) *chainhash.Hash {
-	actualHeight := mathbits.Len(uint(length - 1))
-	out := *root
-
-	var buf [64]byte
-
-	for i := 0; i < targetHeight-actualHeight; i++ {
-		copy(buf[0:32], out[:])
-		copy(buf[32:64], out[:])
-		first := sha256.Sum256(buf[:])
-		out = chainhash.Hash(sha256.Sum256(first[:]))
-	}
-
-	return &out
 }


### PR DESCRIPTION
Closes #901.

## Problem

`partitionLegacyBlock` (introduced in #773) halves the candidate subtree size until the remainder is a power of two. For adversarial transaction counts whose low bits are densely set, this falls all the way to `s=2`. The production case in #901 — a 900,679-tx block on ttn-eu-4 — produced **450,340 subtrees of 2 leaves each**, contributing to a 6+ minute blockvalidation stall (the rest was the O(N²) regression tracked in #900).

The pow2-on-`r` rule came from `CheckMerkleRoot`'s call to `subtree.RootHashPadded`, which insists on a power-of-two leaf count. That precondition turns out to be overly strict: `BuildMerkleTreeStoreFromBytes` already applies the duplicate-when-odd rule at every internal level, so a subtree with any `r ∈ [1, s]` produces a root at height `ceil(log2(r))` that matches the canonical flat tree's hash for that segment. Self-hashing from there up to `log2(s)` composes correctly with the rest of the top tree.

## Fix

1. **`partitionLegacyBlock`**: drop the halving search. Return `s = maxItems, k = ⌈N/s⌉, r = N − (k−1)·s`. For `N=900,679 / maxItems=32,768` this yields `K=28` instead of `450,340`.
2. **`CheckMerkleRoot`**: drop the pow2-`r` check on the final subtree. Replace the `RootHashPadded` call with an inline lift that starts at `ceil(log2(Length))`. **The first subtree's pow2 invariant — the real anti-malleability guard — is unchanged.**
3. **Tests**:
   - `TestSubtreeMerkleRootEquivalence_NonPowerOfTwoFinal` proves the partitioned root equals the canonical flat-tree root for 15 non-pow2 `r` values (1, 2, 3, 5, 6, 7, 9, 11, 13, 15, 17, 21, 23, 27, 31). This is the consensus-correctness test.
   - `TestPartitionLegacyBlock` gains the exact 900,679 / 32,768 case (`s=32768, K=28, r=15943`) and other adversarial counts.
   - `TestPartitionLegacyBlock_BoundedK` asserts `K == ⌈N/maxItems⌉` for a range of adversarial inputs.
   - The previous rejection test for non-pow2 final is now an acceptance test.

## Relationship to issue #901's options

The issue laid out three options. This implements **option 1 in a much narrower form** than anticipated: instead of "mixed-size non-final subtrees with length tags," we just loosen the constraint on the *final* subtree's length. Non-final subtrees still all share the same pow2 length.

The fix is independent of #900 — both stack. #900 prevents O(N²) cliffs in subtree-count-dependent code; this prevents the partitioner from creating those cliffs in the first place.

## Out of scope

- `services/blockassembly/Server.go:1546` still uses `subtreepkg.RootHashPadded` for the lift in the local mining path. That's fine: blockassembly produces pow2 final subtrees by construction. Could be migrated to the same helper later for symmetry, but it's a separate concern.

## Test plan

- [x] `go test ./services/legacy/netsync/` (with and without `-race`)
- [x] `go test ./model/` (with and without `-race`)
- [x] `go test ./util/` (with and without `-race`)
- [x] `go test ./services/blockassembly/`
- [x] `go test ./services/subtreevalidation/`
- [x] `go test ./services/blockvalidation/`
- [x] `go vet` on affected packages
- [ ] Manual: replay the production block 1622352 trace (900,679 txs) on a test node and confirm K=28 in `prepareSubtrees` logs