### PR TITLE
fix(blockassembly): bound state-transition dequeue + close goroutine leaks

### DIFF
--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1847,19 +1847,18 @@ func (ba *BlockAssembly) GetBlockAssemblyState(ctx context.Context, _ *blockasse
 		return nil, errors.NewProcessingError("[GetBlockAssemblyState] error converting subtree count", err)
 	}
 
-	// this will block when the subtree processor is busy with someting else
-	// wait only 1 second for this and continue
-	subtreeHashesChan := make(chan []chainhash.Hash, 1)
-	go func() {
-		subtreeHashesChan <- ba.blockAssembler.subtreeProcessor.GetSubtreeHashes()
-	}()
-
-	var subtreeHashes []chainhash.Hash
-	select {
-	case subtreeHashes = <-subtreeHashesChan:
-		// Successfully retrieved subtree hashes
-	case <-time.After(1 * time.Second):
-		// Timeout occurred, continue with empty slice
+	// Block at most 1s waiting for the SubtreeProcessor main loop to
+	// service the request. GetSubtreeHashes is ctx-aware and uses a
+	// buffered response channel internally so cancellation here cannot
+	// leak a goroutine. Previously this was a `go func` + time.After
+	// pattern that left the spawned goroutine parked on an unbuffered
+	// channel send forever every time the main loop was busy (~224
+	// observed parked on the scaling-2 pod during a moveForwardBlock
+	// stall).
+	subtreeHashesCtx, subtreeHashesCancel := context.WithTimeout(ctx, 1*time.Second)
+	subtreeHashes := ba.blockAssembler.subtreeProcessor.GetSubtreeHashes(subtreeHashesCtx)
+	subtreeHashesCancel()
+	if subtreeHashes == nil {
 		subtreeHashes = []chainhash.Hash{}
 	}
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1667,12 +1667,32 @@ func (stp *SubtreeProcessor) GetChainedSubtrees() []*subtreepkg.Subtree {
 	return <-response
 }
 
-func (stp *SubtreeProcessor) GetSubtreeHashes() []chainhash.Hash {
-	response := make(chan []chainhash.Hash)
+func (stp *SubtreeProcessor) GetSubtreeHashes(ctx context.Context) []chainhash.Hash {
+	// response is buffered size 1 so that even if this function returns
+	// early (because ctx cancelled before the main loop responded), the
+	// main loop's send at line 707 — `getSubtreeHashesChan <- subtreeHashes`
+	// in Start.func1 — never blocks. Combined with the ctx-aware select
+	// on the request send below, this eliminates the goroutine leak that
+	// previously kept ~one parked goroutine per GetBlockAssemblyState RPC
+	// every time the SubtreeProcessor main loop was busy (e.g. inside
+	// moveForwardBlock).
+	response := make(chan []chainhash.Hash, 1)
 
-	stp.getSubtreeHashesChan <- response
+	select {
+	case stp.getSubtreeHashesChan <- response:
+	case <-ctx.Done():
+		return nil
+	}
 
-	return <-response
+	select {
+	case r := <-response:
+		return r
+	case <-ctx.Done():
+		// Main loop will still write into the buffered response channel
+		// when it gets there; the buffer absorbs the write so the main
+		// loop doesn't block. Nothing leaks.
+		return nil
+	}
 }
 
 func (stp *SubtreeProcessor) GetTransactionHashes() []chainhash.Hash {
@@ -4390,20 +4410,39 @@ func (stp *SubtreeProcessor) DrainQueue(dropHashes map[chainhash.Hash]struct{}) 
 // Returns:
 //   - error: Any error encountered during processing
 func (stp *SubtreeProcessor) dequeueDuringBlockMovement(transactionMap *SplitSwissMap, losingTxHashesMap txmap.TxMap, conflictingHashes map[chainhash.Hash]struct{}, skipNotification bool) (err error) {
+	// Bound the drain by two complementary cutoffs:
+	//
+	//  1. Time: validFromMillis = clock.Now() at function entry (or
+	//     clock.Now() - DoubleSpendWindow when that filter is enabled).
+	//     The queue filter at queue.go:96 holds back any batch whose
+	//     enqueue timestamp is >= this value, so we only drain batches
+	//     that existed before this moment. Batches arriving during the
+	//     drain stay queued and roll forward to the next state-transition
+	//     cycle. By design AddTxBatchColumnar (the gRPC ingest path) does
+	//     not backpressure, so this time cap is what stops the loop from
+	//     chasing ingest.
+	//
+	//  2. Items: queueLength snapshotted at entry, compared against items
+	//     drained. Belt-and-braces — if clock granularity ever caused the
+	//     time filter to admit slightly more than expected, this caps
+	//     total work at the snapshot.
+	//
+	// Previous form left validFromMillis=0 when DoubleSpendWindow=0,
+	// which disables the queue filter entirely (queue.go:96 short-circuits
+	// on `validFromMillis > 0`). And the items-bound compared
+	// `nrBatchesProcessed` to `queueLength`, but queue.length() returns
+	// total *items* (queue.go:71 / 75 add len(nodes)), not batches. With
+	// ~1k items/batch and ingest at line-rate, neither bound fired — the
+	// scaling-2 pod sat for 35+ minutes at 558 GB RSS inside this loop.
 	queueLength := stp.queue.length()
 	if queueLength > 0 {
-		nrBatchesProcessed := int64(0)
-		// Match the Start-loop zero-guard at the default-case dequeue
-		// (line 810-813): a zero DoubleSpendWindow disables the queue
-		// filter entirely. Without this guard, the drain computes
-		// Now().UnixMilli() and the queue filter at queue.go:96 holds
-		// back same-millisecond batches under the default config.
-		validFromMillis := int64(0)
+		itemsProcessed := int64(0)
+		validFromMillis := stp.clock.Now().UnixMilli()
 		if stp.settings.BlockAssembly.DoubleSpendWindow > 0 {
 			validFromMillis = stp.clock.Now().Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
 		}
 
-		for {
+		for itemsProcessed < queueLength {
 			batch, found := stp.queue.dequeueBatch(validFromMillis)
 			if !found {
 				break
@@ -4442,12 +4481,8 @@ func (stp *SubtreeProcessor) dequeueDuringBlockMovement(transactionMap *SplitSwi
 				_ = stp.addNode(node, txInpoints, skipNotification)
 			}
 
+			itemsProcessed += int64(len(batch.nodes))
 			prometheusSubtreeProcessorDequeuedTxs.Add(float64(len(batch.nodes)))
-
-			nrBatchesProcessed++
-			if nrBatchesProcessed > queueLength {
-				break
-			}
 		}
 	}
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -4437,9 +4437,15 @@ func (stp *SubtreeProcessor) dequeueDuringBlockMovement(transactionMap *SplitSwi
 	queueLength := stp.queue.length()
 	if queueLength > 0 {
 		itemsProcessed := int64(0)
-		validFromMillis := stp.clock.Now().UnixMilli()
+		// Take a single clock sample so both the zero-window and
+		// non-zero-window branches anchor on the same moment — the
+		// "function entry" semantic the docstring describes. Calling
+		// stp.clock.Now() twice would let the second call admit batches
+		// enqueued in the gap between the two samples.
+		now := stp.clock.Now()
+		validFromMillis := now.UnixMilli()
 		if stp.settings.BlockAssembly.DoubleSpendWindow > 0 {
-			validFromMillis = stp.clock.Now().Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
+			validFromMillis = now.Add(-stp.settings.BlockAssembly.DoubleSpendWindow).UnixMilli()
 		}
 
 		for itemsProcessed < queueLength {

--- a/services/blockassembly/subtreeprocessor/conflicting_queue_race_test.go
+++ b/services/blockassembly/subtreeprocessor/conflicting_queue_race_test.go
@@ -68,14 +68,15 @@ func TestDequeueDuringBlockMovement_RejectsChildOfConflictingParent(t *testing.T
 	otherNode := subtreepkg.Node{Hash: otherHash, Fee: 2, SizeInBytes: 220}
 	otherInpoints := mkInpoints(chainhash.HashH([]byte("unrelated-parent")))
 
-	// Pin both clocks to the same instant so this test is deterministic
-	// (no wall-time waits). With DoubleSpendWindow=0 the queue filter is
-	// disabled at both call sites, so dequeueDuringBlockMovement admits
-	// same-millisecond batches and the test exercises the conflicting-
-	// parent rejection path directly.
-	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
-	stp.clock = fixedClock{t: fixed}
-	stp.queue.clock = fixedClock{t: fixed}
+	// Set the drain clock 1ms ahead of the enqueue clock so the
+	// per-drain cutoff (validFromMillis = drainClock at window=0) admits
+	// the enqueued batch. This is deterministic — no wall-clock waits —
+	// and lets the test exercise the conflicting-parent rejection path
+	// directly.
+	enqueueAt := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	drainAt := enqueueAt.Add(1 * time.Millisecond)
+	stp.queue.clock = fixedClock{t: enqueueAt}
+	stp.clock = fixedClock{t: drainAt}
 
 	stp.queue.enqueueBatch(
 		[]subtreepkg.Node{childNode, otherNode},
@@ -103,24 +104,30 @@ func TestDequeueDuringBlockMovement_RejectsChildOfConflictingParent(t *testing.T
 		"so its own descendants are caught later in the same drain")
 }
 
-// TestDequeueDuringBlockMovement_ZeroWindowAdmitsSameMillisecond pins,
-// at the real call site, that dequeueDuringBlockMovement admits
-// same-millisecond batches when DoubleSpendWindow=0 (the documented
-// default - see settings/blockassembly_settings.go:29). Both the Start
-// loop (SubtreeProcessor.go:807-813) and the drain
-// (SubtreeProcessor.go:3789-3796) zero-guard the calculation, so
-// neither activates the queue filter at queue.go:96 and a batch
-// enqueued in the same millisecond as the drain is included.
+// TestDequeueDuringBlockMovement_DrainCutoffAtClockNow pins, at the real
+// call site, that dequeueDuringBlockMovement holds back batches enqueued
+// in the same millisecond as the drain — even with DoubleSpendWindow=0.
 //
-// The "+1ms" subtest exercises a different scenario where the
-// SubtreeProcessor clock has advanced past the enqueue clock; in
-// that case the drain admits via the (now - window) cutoff rather than
-// via the zero-guard.
-func TestDequeueDuringBlockMovement_ZeroWindowAdmitsSameMillisecond(t *testing.T) {
-	t.Run("same_millisecond_batch_admits", func(t *testing.T) {
+// The drain's validFromMillis is always set (clock.Now() when
+// DoubleSpendWindow=0, clock.Now()-DoubleSpendWindow otherwise) so the
+// queue filter at queue.go:96 (`batch.time >= validFromMillis -> hold`)
+// uses the drain clock as the cutoff. This bounds the drain to batches
+// that already existed before the drain started, preventing the loop
+// from chasing fresh ingest produced by AddTxBatchColumnar — the
+// behaviour that previously stalled the scaling-2 pod inside
+// moveForwardBlock.
+//
+// The Start-loop default-case dequeue still uses its own zero-guard
+// (SubtreeProcessor.go:807-813) and is NOT affected by this test.
+//
+// The "+1ms" subtest exercises the complementary case where the
+// SubtreeProcessor clock has advanced past the enqueue clock; the
+// batch passes the cutoff and drains.
+func TestDequeueDuringBlockMovement_DrainCutoffAtClockNow(t *testing.T) {
+	t.Run("same_millisecond_batch_held_back", func(t *testing.T) {
 		stp := newTestProcessorNoStart(t)
 		require.Zero(t, stp.settings.BlockAssembly.DoubleSpendWindow,
-			"default window is 0; zero-guard parity is the property being asserted")
+			"default window is 0; cutoff-at-now is the property being asserted")
 
 		fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
 		stp.clock = fixedClock{t: fixed}
@@ -135,10 +142,10 @@ func TestDequeueDuringBlockMovement_ZeroWindowAdmitsSameMillisecond(t *testing.T
 
 		require.NoError(t, stp.dequeueDuringBlockMovement(nil, nil, nil, true))
 
-		require.Equal(t, int64(0), stp.queue.length(),
-			"drain must admit same-ms batch at window=0 via zero-guard parity")
-		require.Contains(t, collectSubtreeHashes(stp), txHash,
-			"the admitted batch must appear in chainedSubtrees / currentSubtree")
+		require.Equal(t, int64(1), stp.queue.length(),
+			"same-ms batch must be held back: validFromMillis == batch.time")
+		require.NotContains(t, collectSubtreeHashes(stp), txHash,
+			"held-back batch must not appear in chainedSubtrees / currentSubtree")
 	})
 
 	t.Run("control_one_ms_advance_drains_the_batch", func(t *testing.T) {

--- a/services/blockassembly/subtreeprocessor/interface.go
+++ b/services/blockassembly/subtreeprocessor/interface.go
@@ -242,9 +242,18 @@ type Interface interface {
 	// GetSubtreeHashes returns the hashes of all subtrees currently managed by the processor.
 	// This provides a quick reference to the subtrees without needing to access their full structures.
 	//
+	// Returns nil if ctx is cancelled before the SubtreeProcessor's main
+	// loop services the request. Callers should pass a context with a
+	// timeout so a busy main loop (e.g. in moveForwardBlock) does not park
+	// the caller indefinitely.
+	//
+	// Parameters:
+	//   - ctx: Cancellation context; returning early on cancel never leaks
+	//     a goroutine because the underlying response channel is buffered.
+	//
 	// Returns:
-	//   - []chainhash.Hash: Array of subtree hashes
-	GetSubtreeHashes() []chainhash.Hash
+	//   - []chainhash.Hash: Array of subtree hashes (nil if cancelled)
+	GetSubtreeHashes(ctx context.Context) []chainhash.Hash
 
 	// GetTransactionHashes returns the hashes of all transactions currently being processed.
 	// This provides a complete list of transactions in the processor's queue.

--- a/services/blockassembly/subtreeprocessor/map.go
+++ b/services/blockassembly/subtreeprocessor/map.go
@@ -41,8 +41,21 @@ func NewSplitSwissMap(nrOfBuckets uint16, length int) *SplitSwissMap {
 	}
 }
 
+// Exists reports whether hash is present in its bucket. Holds the per-bucket
+// RLock for the duration of the lookup.
+//
+// The dolthub/swiss.Map underlying each bucket uses open-addressing with
+// in-place control-byte probing — concurrent read while another goroutine is
+// writing (Put or Delete) can land the reader in an inconsistent probe state,
+// in the worst case spinning forever on a corrupted control sequence. Put
+// and PutMultiBucket acquire the per-bucket sync.RWMutex as a write lock;
+// Exists now matches with a read lock. Readers across distinct buckets do
+// not serialise on each other; readers and writers within one bucket do.
 func (s *SplitSwissMap) Exists(hash chainhash.Hash) bool {
-	_, ok := s.m[txmap.Bytes2Uint16Buckets(hash, s.nrOfBuckets)].Get(hash)
+	bucket := txmap.Bytes2Uint16Buckets(hash, s.nrOfBuckets)
+	s.mu[bucket].RLock()
+	_, ok := s.m[bucket].Get(hash)
+	s.mu[bucket].RUnlock()
 	return ok
 }
 

--- a/services/blockassembly/subtreeprocessor/mock.go
+++ b/services/blockassembly/subtreeprocessor/mock.go
@@ -101,8 +101,8 @@ func (m *MockSubtreeProcessor) GetChainedSubtrees() []*subtree.Subtree {
 	return args.Get(0).([]*subtree.Subtree)
 }
 
-func (m *MockSubtreeProcessor) GetSubtreeHashes() []chainhash.Hash {
-	args := m.Called()
+func (m *MockSubtreeProcessor) GetSubtreeHashes(ctx context.Context) []chainhash.Hash {
+	args := m.Called(ctx)
 	if args.Get(0) == nil {
 		return nil
 	}

--- a/services/blockassembly/subtreeprocessor/move_forward_drain_loss_test.go
+++ b/services/blockassembly/subtreeprocessor/move_forward_drain_loss_test.go
@@ -121,11 +121,13 @@ func TestMoveForwardBlockDrainLoss_BatchesLostOnPostDrainError(t *testing.T) {
 	// returns before reaching the drain.
 	stp.currentBlockHeader.Store(model.GenesisBlockHeader)
 
-	// Pin both clocks to the same instant. With DoubleSpendWindow=0 every
-	// enqueued batch admits at drain time.
-	fixed := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
-	stp.clock = fixedClock{t: fixed}
-	stp.queue.clock = fixedClock{t: fixed}
+	// Drain clock 1ms ahead of the enqueue clock so the per-drain cutoff
+	// (validFromMillis = drainClock at window=0) admits the enqueued
+	// batch. Same construction as TestDequeueDuringBlockMovement_*.
+	enqueueAt := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	drainAt := enqueueAt.Add(1 * time.Millisecond)
+	stp.queue.clock = fixedClock{t: enqueueAt}
+	stp.clock = fixedClock{t: drainAt}
 
 	// Enqueue a batch directly into the queue. Using a tx hash that is
 	// NOT in the block we are about to move forward, so the dequeue path

--- a/services/blockassembly/subtreeprocessor/properties_test.go
+++ b/services/blockassembly/subtreeprocessor/properties_test.go
@@ -65,14 +65,18 @@ func Test_propertyDequeueBatchAdmitPredicate(t *testing.T) {
 // Test_propertyDrainAdmitInvariant drives dequeueDuringBlockMovement
 // with random (window, enqueue_clock, drain_clock) and asserts the
 // integration-level outcome matches the expected admit predicate. This
-// catches regressions in either the validFromMillis formula at
-// SubtreeProcessor.go:3789-3796 or the queue filter at queue.go:96.
+// catches regressions in either the validFromMillis formula in
+// dequeueDuringBlockMovement or the queue filter at queue.go:96.
 //
 // The expected predicate composes both call sites:
 //
-//	validFromMillis = 0                                      if window == 0
+//	validFromMillis = drain_clock.UnixMilli()                if window == 0
 //	validFromMillis = (drain_clock - window).UnixMilli()     otherwise
-//	admit iff validFromMillis <= 0 OR batch.time < validFromMillis
+//	admit iff batch.time < validFromMillis
+//
+// (validFromMillis is always non-zero in dequeueDuringBlockMovement so
+// the queue.go:96 zero-guard never triggers from this call site; the
+// zero-guard still applies to the Start-loop default-case dequeue.)
 func Test_propertyDrainAdmitInvariant(outerT *testing.T) {
 	rapid.Check(outerT, func(t *rapid.T) {
 		windowMs := rapid.Int64Range(0, 10_000).Draw(t, "windowMs")
@@ -106,8 +110,10 @@ func Test_propertyDrainAdmitInvariant(outerT *testing.T) {
 		var validFromMillis int64
 		if window > 0 {
 			validFromMillis = drainTime.Add(-window).UnixMilli()
+		} else {
+			validFromMillis = drainTime.UnixMilli()
 		}
-		wantAdmit := validFromMillis <= 0 || enqueueMs < validFromMillis
+		wantAdmit := enqueueMs < validFromMillis
 
 		ctx := fmt.Sprintf("window=%v, enqueueMs=%d, drainMs=%d, validFromMillis=%d",
 			window, enqueueMs, drainTime.UnixMilli(), validFromMillis)

--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -204,7 +204,7 @@ func NewClientWithAddress(ctx context.Context, logger ulogger.Logger, tSettings 
 					}
 
 					for _, s := range c.subscribers {
-						go func(ch chan *blockchain_api.Notification, notification *blockchain_api.Notification) {
+						go func(ch chan *blockchain_api.Notification, notification *blockchain_api.Notification, subscriberSource string) {
 							// Bounded timeout so a slow / unresponsive subscriber
 							// cannot park this fan-out goroutine indefinitely.
 							// Each notification spawns one goroutine per subscriber;
@@ -214,8 +214,15 @@ func NewClientWithAddress(ctx context.Context, logger ulogger.Logger, tSettings 
 							// 30s is long relative to block cadence (~10 min) but
 							// short relative to "forever" — slow subscribers lose
 							// the notification, which is preferable to a leak.
-							_ = util.SafeSend(ch, notification, notificationSendTimeout)
-						}(s.ch, notification)
+							//
+							// SafeSend returns false on timeout. We surface that
+							// at Warn so a wedged subscriber is visible in logs
+							// during diagnosis without flooding the log on every
+							// notification (notifications are infrequent).
+							if !util.SafeSend(ch, notification, notificationSendTimeout) {
+								c.logger.Warnf("[Blockchain] dropping notification for subscriber %s: channel full for %s", subscriberSource, notificationSendTimeout)
+							}
+						}(s.ch, notification, s.source)
 					}
 					c.subscribersMu.Unlock()
 				}
@@ -1178,8 +1185,15 @@ func (c *Client) Subscribe(ctx context.Context, source string) (chan *blockchain
 			// new subscriber's channel is never drained, this goroutine
 			// would otherwise park forever holding a reference to the
 			// notification.
-			_ = util.SafeSend(ch, lastNotification, notificationSendTimeout)
-			c.logger.Debugf("[Blockchain] Sent initial block notification to new subscriber %s", source)
+			//
+			// Only log success when the send actually completed — on
+			// timeout the notification was dropped, which is unexpected
+			// for a brand-new subscriber (its channel should be empty).
+			if util.SafeSend(ch, lastNotification, notificationSendTimeout) {
+				c.logger.Debugf("[Blockchain] Sent initial block notification to new subscriber %s", source)
+			} else {
+				c.logger.Warnf("[Blockchain] dropping initial block notification for new subscriber %s: channel full for %s", source, notificationSendTimeout)
+			}
 		}()
 	}
 	c.subscribersMu.Unlock()

--- a/services/blockchain/Client.go
+++ b/services/blockchain/Client.go
@@ -73,6 +73,11 @@ type FSMStateType = blockchain_api.FSMStateType
 // FSMEventType is an alias for blockchain_api.FSMEventType
 type FSMEventType = blockchain_api.FSMEventType
 
+// notificationSendTimeout bounds how long a fan-out goroutine will wait for
+// a subscriber's channel to accept a block notification. See the two
+// SafeSend call sites in this file for the rationale.
+const notificationSendTimeout = 30 * time.Second
+
 const (
 	FSMStateIDLE           = blockchain_api.FSMStateType_IDLE
 	FSMStateRUNNING        = blockchain_api.FSMStateType_RUNNING
@@ -200,7 +205,16 @@ func NewClientWithAddress(ctx context.Context, logger ulogger.Logger, tSettings 
 
 					for _, s := range c.subscribers {
 						go func(ch chan *blockchain_api.Notification, notification *blockchain_api.Notification) {
-							util.SafeSend(ch, notification)
+							// Bounded timeout so a slow / unresponsive subscriber
+							// cannot park this fan-out goroutine indefinitely.
+							// Each notification spawns one goroutine per subscriber;
+							// without a timeout, a subscriber whose channel never
+							// drains accumulates one parked goroutine per
+							// notification for the lifetime of the process.
+							// 30s is long relative to block cadence (~10 min) but
+							// short relative to "forever" — slow subscribers lose
+							// the notification, which is preferable to a leak.
+							_ = util.SafeSend(ch, notification, notificationSendTimeout)
 						}(s.ch, notification)
 					}
 					c.subscribersMu.Unlock()
@@ -1159,7 +1173,12 @@ func (c *Client) Subscribe(ctx context.Context, source string) (chan *blockchain
 	if c.lastBlockNotification != nil {
 		lastNotification := c.lastBlockNotification
 		go func() {
-			util.SafeSend(ch, lastNotification)
+			// Same bounded-timeout rationale as the fan-out send in
+			// NewClientWithAddress's notification consumer goroutine: if the
+			// new subscriber's channel is never drained, this goroutine
+			// would otherwise park forever holding a reference to the
+			// notification.
+			_ = util.SafeSend(ch, lastNotification, notificationSendTimeout)
 			c.logger.Debugf("[Blockchain] Sent initial block notification to new subscriber %s", source)
 		}()
 	}


### PR DESCRIPTION
## Summary

End-to-end fix for the block-assembly hang observed on `scaling-2` at ~558M-tx workload (`block-assembly-85fb846865-9xqxh`, 554 GiB RSS, stuck 35+ min inside `moveForwardBlock → processRemainderTransactionsAndDequeue → dequeueDuringBlockMovement → addNode`). Live goroutine dump showed the main loop runnable (CPU-bound, not deadlocked) draining a queue that `AddTxBatchColumnar` — by design unbounded — kept refilling. Four issues addressed.

## 1. P0 — `dequeueDuringBlockMovement` was effectively unbounded

`services/blockassembly/subtreeprocessor/SubtreeProcessor.go`

Two coupled bugs:

- **`validFromMillis = 0` when `DoubleSpendWindow=0`** (production default per `settings/blockassembly_settings.go:29`). The queue filter at `queue.go:96` short-circuits on `validFromMillis > 0`, so the time-based cutoff was *disabled* for the whole drain — the loop chased every batch the ingest path enqueued during the drain, indefinitely.
- **Items bound compared `nrBatchesProcessed > queueLength`**, but `queue.length()` returns the total *item* count (queue.go:71/75 add `len(nodes)`), not batches. With ~1k items/batch and ingest at line-rate the inequality could only fire after `~queueLength × items/batch` entries — effectively never.

Fix:

- `validFromMillis` is now **always set**: `clock.Now()` when `DoubleSpendWindow=0`, `clock.Now()-DoubleSpendWindow` otherwise. The queue filter becomes a hard cutoff at function entry — batches enqueued at or after that moment stay queued and roll forward to the next state-transition cycle. `AddTxBatchColumnar` can keep ingesting without stalling the drain and without being stalled by it (as designed — by user request).
- Items bound now compares `itemsProcessed < queueLength` in correct units — belt-and-braces.

Test changes documented inline in the commit message — all green.

## 2. P0 — `GetSubtreeHashes` goroutine leak

`services/blockassembly/Server.go` + `subtreeprocessor/{SubtreeProcessor.go,interface.go,mock.go}`

`GetBlockAssemblyState` spawned a goroutine that called `GetSubtreeHashes()` and used `time.After(1s)` to abandon waiting. When the SubtreeProcessor main loop was busy (e.g. inside `moveForwardBlock`), the spawned goroutine remained parked on an unbuffered channel send forever — **224 leaked on scale-2 across 35 min**, one per state-poll RPC.

Fix:

- `GetSubtreeHashes` now takes a `context.Context`, uses a buffered-size-1 response channel, and selects on `ctx.Done()` for both the request send and the response receive. The buffered response means the SubtreeProcessor main loop's send (`getSubtreeHashesChan <- subtreeHashes`) never blocks even if the caller has abandoned the request.
- `GetBlockAssemblyState` drops the `go func` + `time.After` dance and calls `GetSubtreeHashes` synchronously with a 1s context deadline. Caller-observable behaviour unchanged.

## 3. P1 — `SplitSwissMap.Exists` missing read lock

`services/blockassembly/subtreeprocessor/map.go`

`Put` / `PutMultiBucket` acquire a per-bucket `sync.RWMutex` as a write lock, but `Exists` called `dolthub/swiss.Map.Get` without any lock. dolthub/swiss uses open-addressing with in-place control-byte probing — concurrent read while another goroutine writes can land the reader in an inconsistent probe state, in the worst case spinning forever. `Exists` is now `RLock`-guarded; readers across different buckets still parallelise.

## 4. P2 — blockchain Client notification SafeSend pattern

`services/blockchain/Client.go`

Two `SafeSend` call sites (notification fan-out to subscribers + initial last-block notification for new subscribers) passed no timeout. `SafeSend` without a timeout blocks the goroutine indefinitely when the subscriber channel is full. The live profile showed many leaked goroutines from `blockchain.NewClientWithAddress.func1.1` matching this pattern.

Both call sites now use a 30s timeout — long relative to the ~10-min block cadence so brief subscriber backpressure does not lose notifications, short relative to "forever" so a wedged subscriber cannot park goroutines for the process lifetime.

## Operational notes

- **No new settings.** `DoubleSpendWindow=0` (the production default) is now meaningful at the dequeue cutoff — it no longer disables the cutoff entirely. Existing deploys keep their tx-arrival semantics; the only change is that batches enqueued in the same millisecond as a state transition wait until the next transition instead of being drained in this one. At production block cadence the practical effect is zero.
- **No backpressure added to `AddTxBatchColumnar`.** Per design and confirmed by you: ingest stays unbounded; the drain self-limits.
- **Rollout**: deploy to one subtree-validation pod first; watch RSS + goroutine count via `/debug/pprof/goroutine?debug=1` on port 9091. The leaked-goroutine sources from the scaling-2 capture should drop to zero.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./services/blockassembly/... ./services/blockchain/...` clean
- [x] `go test ./services/blockassembly/subtreeprocessor/...` pass (22.9s, all property/race tests included)
- [x] `go test ./services/blockassembly/...` pass (93.8s)
- [x] `go test ./services/blockchain/...` pass for `TestClient*`
- [ ] Canary one block-assembly pod under production-scale traffic; confirm `RSS` stays bounded and `chan send` goroutine count stays flat across `moveForwardBlock` cycles
- [ ] Confirm `GetBlockAssemblyState` RPC still responds within 1s under load

## Profiles from the diagnosis (still on the laptop)

```
/tmp/blockassembly_live/scale2_goroutines.txt
/tmp/blockassembly_live/scale2_cpu.pb.gz
/tmp/blockassembly_live/scale2_heap.pb.gz
/tmp/blockassembly_live/scale1_*  (healthy comparison pod)
```