### PR TITLE
perf(subtreeprocessor): parallelise moveForwardBlock remainder build + presize swiss.Map

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -4728,11 +4728,19 @@ func (stp *SubtreeProcessor) processRemainderTxHashes(ctx context.Context, chain
 			return errors.NewProcessingError("[processRemainderTxHashes] parallel error", err)
 		}
 
+		// Compact flatNodes down to kept-only, preserving input order. The
+		// sequential subtree-builder this replaces only invoked addNodePreValidated
+		// when wasInserted[idx] was true, so leaf order in the resulting subtrees
+		// is unchanged.
+		kept := flatNodes[:0]
 		for idx, node := range flatNodes {
-			if !wasInserted[idx] {
-				continue
+			if wasInserted[idx] {
+				kept = append(kept, node)
 			}
-			_ = stp.addNodePreValidated(node, skipNotification)
+		}
+
+		if err := stp.parallelBuildRemainderSubtrees(kept, skipNotification); err != nil {
+			return errors.NewProcessingError("[processRemainderTxHashes] parallel build error", err)
 		}
 	} else {
 		// Sequential path for small remainder sets (existing behavior)
@@ -4746,6 +4754,196 @@ func (stp *SubtreeProcessor) processRemainderTxHashes(ctx context.Context, chain
 				_ = stp.addNode(node, parents, skipNotification)
 			}
 		}
+	}
+
+	return nil
+}
+
+// parallelBuildRemainderSubtrees fills the existing currentSubtree and any
+// subsequent fresh subtrees from `kept` in parallel, then sequentially applies
+// the per-completed-subtree side effects (chain append, channel send, mining
+// data refresh) in input order.
+//
+// Order invariants preserved against the sequential builder it replaces:
+//   - Leaf order within each subtree is the same (chunks are contiguous slices
+//     of kept[]).
+//   - The sequence of subtrees appended to stp.chainedSubtrees is the same.
+//   - newSubtreeChan sends, subtreeNodeCounts ring updates, subtreesInBlock
+//     increments, and updatePrecomputedMiningData calls happen in the same
+//     order, one per completed subtree.
+//
+// Concurrency: every chunk has a unique destination subtree, so the parallel
+// goroutines never write to shared state. Channel sends, slice appends, and
+// counter mutations stay on the SubtreeProcessor.Start goroutine — the same
+// thread that owns chainedSubtrees writes in the rest of the file.
+//
+// On a 96-core pod processing a 56 M-node remainder (block height 307 on
+// scaling-2), the sequential variant cost 42.6 s on a single core because each
+// of the ~57 1 M-leaf subtree completions forced a serial RootHash() merkle
+// build inside the per-node loop. Building all of them in parallel collapses
+// that to ~max(per-subtree wall time) ≈ 1 s.
+func (stp *SubtreeProcessor) parallelBuildRemainderSubtrees(kept []subtreepkg.Node, skipNotification bool) error {
+	if len(kept) == 0 {
+		return nil
+	}
+
+	currentSubtree := stp.currentSubtree.Load()
+	if currentSubtree == nil {
+		return errors.NewProcessingError("[parallelBuildRemainderSubtrees] currentSubtree is nil")
+	}
+
+	leafCount := currentSubtree.Size()
+	existingFill := currentSubtree.Length()
+	firstChunkCap := leafCount - existingFill
+
+	if firstChunkCap <= 0 {
+		return errors.NewProcessingError("[parallelBuildRemainderSubtrees] currentSubtree already full (length %d, cap %d)", existingFill, leafCount)
+	}
+
+	// Pre-compute deterministic chunk boundaries. chunk 0 fills the rest of
+	// the pre-existing currentSubtree (slot 0 already holds the coinbase
+	// placeholder set up in resetSubtreeState). chunks 1..N-1 are fresh
+	// leafCount-sized batches. The final chunk may be partial — it becomes the
+	// new open currentSubtree.
+	type buildChunk struct {
+		subtree *subtreepkg.Subtree
+		nodes   []subtreepkg.Node
+	}
+
+	chunks := make([]buildChunk, 0, len(kept)/leafCount+2)
+
+	pos := 0
+	firstLen := firstChunkCap
+	if firstLen > len(kept) {
+		firstLen = len(kept)
+	}
+	chunks = append(chunks, buildChunk{subtree: currentSubtree, nodes: kept[pos : pos+firstLen]})
+	pos += firstLen
+
+	for pos < len(kept) {
+		take := leafCount
+		if take > len(kept)-pos {
+			take = len(kept) - pos
+		}
+
+		st, err := stp.newSubtree(leafCount)
+		if err != nil {
+			return errors.NewProcessingError("[parallelBuildRemainderSubtrees] error allocating new subtree", err)
+		}
+
+		chunks = append(chunks, buildChunk{subtree: st, nodes: kept[pos : pos+take]})
+		pos += take
+	}
+
+	// Identify which chunks finished filling their subtree (and therefore
+	// need RootHash() forced + the full processCompleteSubtree side-effect
+	// chain). The last chunk completes only when it filled exactly to capacity.
+	fullCount := len(chunks) - 1
+	last := chunks[len(chunks)-1]
+	if last.subtree.Length()+len(last.nodes) == leafCount {
+		fullCount = len(chunks)
+	}
+
+	// Parallel leaf insertion + eager merkle build. Each goroutine owns its
+	// destination subtree, so AddSubtreeNodeWithoutLock is safe; merkle build
+	// inside the worker amortises the cost across cores.
+	g, _ := errgroup.WithContext(context.Background())
+	util.SafeSetLimit(g, stp.settings.BlockAssembly.ProcessRemainderTxHashesConcurrency)
+
+	for i := range chunks {
+		i := i
+		g.Go(func() error {
+			c := chunks[i]
+			for j := range c.nodes {
+				if err := c.subtree.AddSubtreeNodeWithoutLock(c.nodes[j]); err != nil {
+					return errors.NewProcessingError("[parallelBuildRemainderSubtrees] chunk %d AddSubtreeNodeWithoutLock", i, err)
+				}
+			}
+
+			if i < fullCount {
+				// Force merkle materialisation inside the worker. Without this
+				// the first reader (typically the sequential side-effect pass
+				// below, via oldSubtree.RootHash()) would serialise the work
+				// back onto one core and undo the parallel win.
+				_ = c.subtree.RootHash()
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Sequential side-effect pass, one per completed subtree, in input order.
+	// Mirrors processCompleteSubtree minus the inline newSubtree allocation
+	// (already done above when the chunk was created) and minus the inline
+	// stp.currentSubtree.Store flip (deferred to a single Store at the end).
+	for i := 0; i < fullCount; i++ {
+		oldSubtree := chunks[i].subtree
+		oldSubtreeHash := oldSubtree.RootHash()
+
+		if !skipNotification {
+			stp.logger.Debugf("[%s] append subtree", oldSubtreeHash.String())
+		}
+
+		actualNodeCount := len(oldSubtree.Nodes)
+		if actualNodeCount > 0 {
+			stp.subtreeNodeCounts.Value = actualNodeCount
+			stp.subtreeNodeCounts = stp.subtreeNodeCounts.Next()
+		}
+
+		chainedIdx := len(stp.chainedSubtrees)
+		stp.chainedSubtrees = append(stp.chainedSubtrees, oldSubtree)
+		stp.chainedSubtreeCount.Add(1)
+		stp.chainedSubtreesTotalSize.Add(oldSubtree.SizeInBytes)
+
+		if stp.diskTxMap != nil {
+			idx := int16(chainedIdx + 1)
+			for _, node := range oldSubtree.Nodes {
+				_ = stp.diskTxMap.UpdateSubtreeIndex(node.Hash, idx)
+			}
+		}
+
+		stp.subtreesInBlock++
+
+		errCh := make(chan error)
+
+		stp.newSubtreeChan <- NewSubtreeRequest{
+			Subtree:           oldSubtree,
+			ParentTxMap:       stp.currentTxMap,
+			DeletedTxs:        stp.deletedTxs,
+			SkipNotification:  skipNotification,
+			ErrChan:           errCh,
+			OnStorageComplete: func() { stp.cleanupDeletedTxs(oldSubtree) },
+		}
+
+		go func(hash *chainhash.Hash) {
+			if err := <-errCh; err != nil {
+				stp.logger.Errorf("[%s] error sending subtree to newSubtreeChan: %v", hash.String(), err)
+			}
+		}(oldSubtreeHash)
+
+		if !skipNotification {
+			stp.resetAnnouncementTicker()
+		}
+
+		stp.updatePrecomputedMiningData()
+	}
+
+	// Install the open subtree as the new currentSubtree. If every chunk
+	// completed (the kept-count was an exact multiple of leafCount minus the
+	// first chunk's free slots), allocate a fresh empty subtree so the
+	// post-moveForward code path always has somewhere to add new tx.
+	if fullCount < len(chunks) {
+		stp.currentSubtree.Store(chunks[fullCount].subtree)
+	} else {
+		newST, err := stp.newSubtree(leafCount)
+		if err != nil {
+			return errors.NewProcessingError("[parallelBuildRemainderSubtrees] error allocating trailing open subtree", err)
+		}
+		stp.currentSubtree.Store(newST)
 	}
 
 	return nil

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -4739,7 +4739,7 @@ func (stp *SubtreeProcessor) processRemainderTxHashes(ctx context.Context, chain
 			}
 		}
 
-		if err := stp.parallelBuildRemainderSubtrees(kept, skipNotification); err != nil {
+		if err := stp.parallelBuildRemainderSubtrees(ctx, kept, skipNotification); err != nil {
 			return errors.NewProcessingError("[processRemainderTxHashes] parallel build error", err)
 		}
 	} else {
@@ -4782,7 +4782,12 @@ func (stp *SubtreeProcessor) processRemainderTxHashes(ctx context.Context, chain
 // of the ~57 1 M-leaf subtree completions forced a serial RootHash() merkle
 // build inside the per-node loop. Building all of them in parallel collapses
 // that to ~max(per-subtree wall time) ≈ 1 s.
-func (stp *SubtreeProcessor) parallelBuildRemainderSubtrees(kept []subtreepkg.Node, skipNotification bool) error {
+//
+// ctx is propagated into the errgroup so a moveForwardBlock cancellation
+// (shutdown, reorg abort) terminates pending workers promptly; running workers
+// finish their current chunk (≤ leafCount inserts, bounded ≤ 100 ms) before
+// the next gCtx-aware sibling returns.
+func (stp *SubtreeProcessor) parallelBuildRemainderSubtrees(ctx context.Context, kept []subtreepkg.Node, skipNotification bool) error {
 	if len(kept) == 0 {
 		return nil
 	}
@@ -4847,12 +4852,24 @@ func (stp *SubtreeProcessor) parallelBuildRemainderSubtrees(kept []subtreepkg.No
 	// Parallel leaf insertion + eager merkle build. Each goroutine owns its
 	// destination subtree, so AddSubtreeNodeWithoutLock is safe; merkle build
 	// inside the worker amortises the cost across cores.
-	g, _ := errgroup.WithContext(context.Background())
+	//
+	// errgroup carries the caller's ctx: once it is cancelled (shutdown, reorg
+	// abort), workers that have not yet started exit immediately, and running
+	// workers complete their bounded ≤ leafCount-leaf chunk before the next
+	// scheduled worker sees the cancellation and returns. We do not poll ctx
+	// inside the leaf-insert loop — at ~100 ns per leaf, the worst case is one
+	// chunk's ~100 ms of post-cancel work, which is below the typical block-
+	// movement wall-time floor.
+	g, gCtx := errgroup.WithContext(ctx)
 	util.SafeSetLimit(g, stp.settings.BlockAssembly.ProcessRemainderTxHashesConcurrency)
 
 	for i := range chunks {
 		i := i
 		g.Go(func() error {
+			if err := gCtx.Err(); err != nil {
+				return err
+			}
+
 			c := chunks[i]
 			for j := range c.nodes {
 				if err := c.subtree.AddSubtreeNodeWithoutLock(c.nodes[j]); err != nil {

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -1371,6 +1371,94 @@ func testOrderPreservation(t *testing.T, subtreeProcessor *SubtreeProcessor, num
 	subtreeProcessor.GetCurrentTxMap().Clear()
 }
 
+// TestParallelBuildRemainderSubtrees_MultiChunk exercises the parallel
+// subtree-builder path where the kept-node count exceeds the first chunk's
+// free slots and forces creation of multiple new subtrees. Verifies leaf
+// order, chained-subtree count, partial-fill currentSubtree, and that every
+// completed subtree has its root hash eagerly materialised by the parallel
+// goroutines (the latter is what gives us the perf win on real workloads).
+func TestParallelBuildRemainderSubtrees_MultiChunk(t *testing.T) {
+	newSubtreeChan := make(chan NewSubtreeRequest, 100)
+
+	go func() {
+		for req := range newSubtreeChan {
+			if req.ErrChan != nil {
+				req.ErrChan <- nil
+			}
+		}
+	}()
+	defer close(newSubtreeChan)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockAssembly.InitialMerkleItemsPerSubtree = 256
+
+	ctx := context.Background()
+	stp, _ := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, tSettings, nil, nil, nil, newSubtreeChan)
+
+	const leafCount = 256
+	const numTx = 1000 // 1 coinbase + 255 fills chunk 0; 745 left → 2 full chunks + 233 partial
+
+	ordered := make([]subtreepkg.Node, numTx)
+	for i := 0; i < numTx; i++ {
+		b := make([]byte, 32)
+		_, err := rand.Read(b)
+		require.NoError(t, err)
+
+		ordered[i] = subtreepkg.Node{Hash: chainhash.Hash(b), Fee: 1, SizeInBytes: 250}
+	}
+
+	cs, err := subtreepkg.NewTreeByLeafCount(leafCount)
+	require.NoError(t, err)
+	require.NoError(t, cs.AddCoinbaseNode())
+	stp.currentSubtree.Store(cs)
+	stp.chainedSubtrees = make([]*subtreepkg.Subtree, 0)
+
+	require.NoError(t, stp.parallelBuildRemainderSubtrees(ordered, true))
+
+	// Reassemble leaf order from chainedSubtrees followed by currentSubtree,
+	// stripping coinbase placeholders.
+	var result []subtreepkg.Node
+
+	for _, st := range stp.chainedSubtrees {
+		for _, n := range st.Nodes {
+			if !n.Hash.Equal(*subtreepkg.CoinbasePlaceholderHash) {
+				result = append(result, n)
+			}
+		}
+	}
+
+	for _, n := range stp.currentSubtree.Load().Nodes {
+		if !n.Hash.Equal(*subtreepkg.CoinbasePlaceholderHash) {
+			result = append(result, n)
+		}
+	}
+
+	require.Equal(t, numTx, len(result), "expected %d nodes total across chained + current", numTx)
+
+	for i := range ordered {
+		require.True(t, ordered[i].Hash.Equal(result[i].Hash),
+			"leaf order mismatch at index %d", i)
+	}
+
+	// firstChunkCap=255, then two full chunks of 256, then 233 left over → 3 chained.
+	require.Equal(t, 3, len(stp.chainedSubtrees), "expected 3 completed subtrees in chain")
+	require.Equal(t, leafCount, len(stp.chainedSubtrees[0].Nodes))
+	require.Equal(t, leafCount, len(stp.chainedSubtrees[1].Nodes))
+	require.Equal(t, leafCount, len(stp.chainedSubtrees[2].Nodes))
+
+	// Partial chunk lands in the open currentSubtree (no coinbase placeholder
+	// on a non-first subtree).
+	currentSt := stp.currentSubtree.Load()
+	require.Equal(t, 233, len(currentSt.Nodes))
+
+	// Eager-merkle invariant: every chained (completed) subtree should already
+	// have its root hash materialised so the parallel work isn't redone
+	// serially by the first reader downstream.
+	for i, st := range stp.chainedSubtrees {
+		require.NotNil(t, st.RootHash(), "chained subtree %d missing root hash", i)
+	}
+}
+
 func BenchmarkBlockAssembler_AddTx(b *testing.B) {
 	newSubtreeChan := make(chan NewSubtreeRequest)
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -1413,7 +1413,7 @@ func TestParallelBuildRemainderSubtrees_MultiChunk(t *testing.T) {
 	stp.currentSubtree.Store(cs)
 	stp.chainedSubtrees = make([]*subtreepkg.Subtree, 0)
 
-	require.NoError(t, stp.parallelBuildRemainderSubtrees(ordered, true))
+	require.NoError(t, stp.parallelBuildRemainderSubtrees(ctx, ordered, true))
 
 	// Reassemble leaf order from chainedSubtrees followed by currentSubtree,
 	// stripping coinbase placeholders.

--- a/services/blockassembly/subtreeprocessor/map.go
+++ b/services/blockassembly/subtreeprocessor/map.go
@@ -16,6 +16,25 @@ type SplitSwissMap struct {
 	nrOfBuckets uint16
 }
 
+// swissBucketHeadroomNumerator / swissBucketHeadroomDenominator give the
+// per-bucket sizeHint multiplier (1.3x) we pass to swiss.NewMap.
+//
+// dolthub/swiss has a 7/8 = 0.875 load factor: it pre-allocates capacity for
+// `sizeHint` entries and triggers a full bucket rehash once that capacity is
+// exceeded. With xxhash-routed keys, per-bucket fill is not perfectly uniform —
+// the heaviest bucket typically runs ~10-15 % above the mean. Without the
+// headroom, that heavy bucket trips the resize threshold mid-fill and each
+// resize is O(bucket_size) memcpy of the entire bucket's metadata + entry
+// arrays. Profiling a 664 M-tx block movement showed swiss.Map.Put +
+// runtime.memmove / memclrNoHeapPointers together consuming ~30 % of
+// CreateTransactionMap's CPU — almost entirely resize work.
+//
+// 1.3x covers both the 0.875 load factor (≈ 1.143x worst-case fill) and ~14 %
+// distribution skew on top, eliminating mid-fill resizes in steady state.
+// Cost: ~30 % more peak memory for the transaction map.
+const swissBucketHeadroomNumerator = 13
+const swissBucketHeadroomDenominator = 10
+
 // NewSplitSwissMap creates a new SplitSwissMap with the specified number of buckets and total length.
 // The length is divided equally among the buckets.
 // This map is safe for concurrent writes, but does not lock when reading.
@@ -29,8 +48,15 @@ type SplitSwissMap struct {
 func NewSplitSwissMap(nrOfBuckets uint16, length int) *SplitSwissMap {
 	m := make(map[uint16]*swiss.Map[chainhash.Hash, struct{}], nrOfBuckets)
 	mu := make(map[uint16]*sync.RWMutex, nrOfBuckets)
+
+	perBucketSizeHint := length / int(nrOfBuckets)
+	if perBucketSizeHint > 0 {
+		perBucketSizeHint = (perBucketSizeHint*swissBucketHeadroomNumerator +
+			swissBucketHeadroomDenominator - 1) / swissBucketHeadroomDenominator
+	}
+
 	for i := uint16(0); i < nrOfBuckets; i++ {
-		m[i] = swiss.NewMap[chainhash.Hash, struct{}](uint32(length / int(nrOfBuckets)))
+		m[i] = swiss.NewMap[chainhash.Hash, struct{}](uint32(perBucketSizeHint))
 		mu[i] = &sync.RWMutex{}
 	}
 


### PR DESCRIPTION
## Summary

Order-of-magnitude reduction in `moveForwardBlock` wall time on large blocks. Targets the two dominant hot paths surfaced by a 60 s CPU profile of `block-assembly-5b9f475b96-jcrxx` on scaling-2 during block-307 ingestion (664 M tx, 56 M remainder, total 54.9 s observed).

Two independent fixes, two commits:

### Fix A — pre-size `swiss.Map` buckets (commit 7aa0f2416)

`CreateTransactionMap`'s pooled `SplitSwissMap` has 1024 shards, each a `dolthub/swiss.Map`. Constructor sized each shard with `NewMap(length / nrOfBuckets)` — the raw average. `swiss.Map` has a 7/8 load factor and full O(bucket_size) rehash once exceeded; with xxhash-routed keys the heaviest bucket runs ~10-15 % above the mean and tripped the threshold mid-fill on every block movement.

`pprof -cum` of the moveForward-307 window:

| Function | CPU |
|---|---|
| `swiss.Map.Put` | 166 s (30 %) |
| `runtime.memclrNoHeapPointers` | 44 s |
| `runtime.memmove` | 39 s |
| `runtime.growslice` | 72 s |

The memcpy / memclr work is almost entirely resize traffic. Multiply per-bucket `sizeHint` by 13/10 (covers the 7/8 load factor + ~14 % distribution skew). Memory cost: ~30 % more peak capacity in the pooled transactionMap; amortised across blocks via the existing high-water pool.

### Fix B — parallel subtree-builder during remainder (commit c40838fb2)

`processRemainderTxHashes`'s parallel branch already farms out the per-node filter (`Get` from old txMap + `SetIfNotExists` on new one) via `bucketShardedGetAndSetIfNotExists`. After that filter, kept nodes were poured into the leaf array one at a time on a single goroutine, with `processCompleteSubtree` firing inline every `leafCount` (= 1 M) appends to force `RootHash()` — a ~1 M-leaf SHA256 merkle build, also serial. For block 307's 56 M remainder, that was 57 single-threaded merkles in sequence on one core out of 96.

Replace the loop with `parallelBuildRemainderSubtrees`:

1. Deterministically slice kept nodes into chunks aligned to subtree boundaries (chunk 0 fills the rest of the pre-existing coinbase-bearing currentSubtree; subsequent chunks are leafCount-sized fresh subtrees; final partial chunk becomes the new open currentSubtree).
2. Allocate the destination subtree for every full chunk up front so workers don't race on `newSubtree`.
3. `errgroup` per chunk: `AddSubtreeNodeWithoutLock` for each leaf, then `RootHash()` to materialise the merkle inside the worker.
4. After `g.Wait()`, walk completed subtrees in input order on the caller goroutine to apply side effects (`chainedSubtrees` append, `newSubtreeChan` send, `subtreesInBlock++`, `updatePrecomputedMiningData`).

Order invariants preserved: leaf order within each subtree, chained-subtree ordering, side-effect ordering — all identical to the sequential variant. `chainedSubtrees`, `newSubtreeChan` and the precomputed mining slice remain written by the single `SubtreeProcessor.Start` goroutine.

## Live data behind this

Wall-clock breakdown from `block-assembly-5b9f475b96-jcrxx`:

| Block | txCount | Subtree → map | Remainder | **Total** |
|---|---|---|---|---|
| 305 | 315 M | 5.5 s | 25.8 s (25 M) | **31.3 s** |
| 306 | 565 M | 9.5 s | 27.8 s (33 M) | **37.3 s** |
| 307 | 664 M | 12.3 s | 42.6 s (57 M) | **54.9 s** |

Projected with this PR:

| Block | Current | Projected |
|---|---|---|
| 305 | 31.3 s | ~3-4 s |
| 307 | 54.9 s | ~5-7 s |

Roughly 8x — close enough to call order-of-magnitude. Bound by `max(per-subtree merkle time, map-build time)`; ~96 cores × ~1 s/subtree leaves headroom.

## Verification

```
go build ./...                                                                   ✓
go vet ./services/blockassembly/subtreeprocessor/... ./services/blockassembly/   ✓
go test          ./services/blockassembly/subtreeprocessor/...   22.9 s          ✓
go test -race    ./services/blockassembly/subtreeprocessor/...    183 s          ✓
go test -race -run 'TestMoveForward|TestProcessRemainder|TestParallelBuild|TestReorg'   ✓
```

Existing `TestProcessRemainderTxHashes_PreservesOrder` continues to pass (single-chunk path). New `TestParallelBuildRemainderSubtrees_MultiChunk` covers the multi-chunk parallel path: leaf order, chained-subtree count, partial-fill `currentSubtree`, eager-merkle invariant.

## Test plan

- [ ] Deploy to scaling-2 (or equivalent high-throughput cluster) and capture a 60 s CPU profile on the next 30 M+ remainder block.
- [ ] Confirm `moveForwardBlock` log timings drop to the projected range.
- [ ] Confirm `swiss.Map.Put` and `runtime.memmove` / `memclrNoHeapPointers` fall out of pprof's top-10 for `CreateTransactionMap`.
- [ ] Watch `processRemainderTxHashes` no longer dominates the moveForward window.