### PR TITLE
perf(legacy/netsync): decouple bt.Tx + orphan goroutine + queue cap from MsgBlock arena

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1325,8 +1325,13 @@ func (sm *SyncManager) createTxMap(ctx context.Context, block *bsvutil.Block, tx
 
 		// don't add the coinbase to the txMap, we cannot process it anyway
 		if !tx.IsCoinbase() {
-			tx.SetTxHash(wireTx.Hash())
-			txMap.Set(*tx.TxIDChainHash(), &TxMapWrapper{Tx: tx})
+			// Copy the hash value out of the bsvutil.Tx wrapper. bt.Tx.SetTxHash
+			// stores the pointer, so passing wireTx.Hash() directly would keep
+			// the wrapping wire.MsgTx (and its decode arena) alive through this
+			// bt.Tx and the TxMapWrapper it lands in.
+			hashCopy := *wireTx.Hash()
+			tx.SetTxHash(&hashCopy)
+			txMap.Set(hashCopy, &TxMapWrapper{Tx: tx})
 		}
 	}
 

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -182,15 +182,28 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	}
 
 	// process any orphan transactions that are now valid in background
-	// this will also remove the transactions from the orphan pool
+	// this will also remove the transactions from the orphan pool.
+	//
+	// Pre-extract the tx hashes here, before launching the goroutine, so the
+	// background work does not keep `block` (and therefore the wire.MsgBlock
+	// + its decode arena) reachable for the lifetime of orphan processing.
+	// Copy the hash *values* (not the *chainhash.Hash pointers returned by
+	// tx.Hash(), which alias into the bsvutil.Tx wrapper and would pin it).
+	wireTxs := block.Transactions()
+	txHashes := make([]chainhash.Hash, len(wireTxs))
+	for i, tx := range wireTxs {
+		txHashes[i] = *tx.Hash()
+	}
+	blockHashStr := block.Hash().String()
+
 	go func() {
 		acceptedTxs := make([]*TxHashAndFee, 0)
-		for _, tx := range block.Transactions() {
-			sm.processOrphanTransactions(ctx, tx.Hash(), &acceptedTxs)
+		for i := range txHashes {
+			sm.processOrphanTransactions(ctx, &txHashes[i], &acceptedTxs)
 		}
 
 		if len(acceptedTxs) > 0 {
-			sm.logger.Infof("[HandleBlockDirect][%s %d] accepted %d orphan transactions", block.Hash().String(), blockHeight, len(acceptedTxs))
+			sm.logger.Infof("[HandleBlockDirect][%s %d] accepted %d orphan transactions", blockHashStr, blockHeight, len(acceptedTxs))
 			sm.peerNotifier.AnnounceNewTransactions(acceptedTxs)
 		}
 	}()
@@ -1483,8 +1496,16 @@ func (sm *SyncManager) ExtendTransaction(ctx context.Context, tx *bt.Tx, txMap *
 	return nil
 }
 
-// WireTxToGoBtTx converts a wire.Tx to a bt.Tx
-// This does not use the bytes methods, but directly uses the fields of the wire.Tx
+// WireTxToGoBtTx converts a wire.Tx to a bt.Tx.
+//
+// Script bytes are *copied* (not aliased) so the resulting bt.Tx is fully
+// independent of the source wire.MsgBlock's decode arena. This is the
+// load-bearing fix for legacy-sync GC pressure: aliasing kept the arena's
+// 4 MiB chunks reachable for the entire downstream pipeline lifetime
+// (subtree prep, validation, persistence, the orphan goroutine below), so
+// arenas piled up across all in-flight blocks and dominated the live heap.
+// Copying lets the arena and its containing MsgBlock be reclaimed as soon
+// as this function (and any other consumers in HandleBlockDirect) returns.
 func WireTxToGoBtTx(wireTx *bsvutil.Tx, tx *bt.Tx) error {
 	wTx := wireTx.MsgTx()
 
@@ -1499,7 +1520,7 @@ func WireTxToGoBtTx(wireTx *bsvutil.Tx, tx *bt.Tx) error {
 			SequenceNumber:     in.Sequence,
 		}
 		_ = tx.Inputs[i].PreviousTxIDAdd(&in.PreviousOutPoint.Hash)
-		*tx.Inputs[i].UnlockingScript = in.SignatureScript
+		*tx.Inputs[i].UnlockingScript = bytes.Clone(in.SignatureScript)
 	}
 
 	tx.Outputs = make([]*bt.Output, len(wTx.TxOut))
@@ -1508,7 +1529,7 @@ func WireTxToGoBtTx(wireTx *bsvutil.Tx, tx *bt.Tx) error {
 			Satoshis:      uint64(out.Value),
 			LockingScript: &bscript.Script{},
 		}
-		*tx.Outputs[i].LockingScript = out.PkScript
+		*tx.Outputs[i].LockingScript = bytes.Clone(out.PkScript)
 	}
 
 	return nil

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -1932,8 +1932,17 @@ func (sm *SyncManager) blockHandler() {
 	ticker := time.NewTicker(syncPeerTickerInterval)
 	defer ticker.Stop()
 
-	// TODO make this configurable
-	maxBlockQueue := 10_000
+	// TODO make this configurable.
+	//
+	// This buffer pins one *wire.MsgBlock per slot. Each MsgBlock carries
+	// its go-wire decode arena (≥4 MiB per block today), so the previous
+	// 10_000-deep queue could pin ~40 GiB of arena memory ahead of the
+	// sequential processor. On a memory-constrained box that turns into
+	// the dominant live-heap source and starves the GC. Cap at a small
+	// value: enough to absorb processor-stall jitter, far below anything
+	// that would meaningfully pin memory. The downloader naturally
+	// back-pressures via TCP when the queue is full.
+	maxBlockQueue := 100
 
 	// create a block queue to handle block messages in a separate goroutine, in order
 	blockQueue := make(chan *blockQueueMsg, maxBlockQueue)


### PR DESCRIPTION
## Summary

Legacy peer block decode allocates a go-wire blockArena per MsgBlock. Several aliasing paths kept those arenas reachable for the entire downstream pipeline, piling up tens of GB of live arena memory during mainnet catchup on memory-constrained nodes and dominating GC work. This change decouples the downstream pipeline from the arena along three independent paths.

### 1. WireTxToGoBtTx copies script bytes (was aliasing)

`WireTxToGoBtTx` aliased `SignatureScript` / `PkScript` directly into the constructed `bt.Tx`. Every `bt.Tx` flowing through subtree prep, validation and persistence anchored the source MsgBlock's arena chunks. Concurrent in-flight blocks meant concurrent live arenas. `bytes.Clone()` on both scripts makes each `bt.Tx` independent of the arena — GC can reclaim the MsgBlock and arena as soon as `WireTxToGoBtTx` returns.

### 2. Orphan goroutine no longer captures `block`

The background orphan-processing goroutine in `HandleBlockDirect` captured `block` only to extract each tx hash. The closure kept `wire.MsgBlock` alive for the full duration of orphan processing — long after `HandleBlockDirect` returned. Pre-extract the hash *values* (not the pointers returned by `tx.Hash()`, which alias into the `bsvutil.Tx` wrapper and would pin it) into locals before launching the goroutine.

### 3. createTxMap copies hash value before SetTxHash

`bt.Tx.SetTxHash` atomically stores the pointer it's given. Passing `wireTx.Hash()` directly meant every `bt.Tx` in the txMap kept its corresponding `bsvutil.Tx` (and through it the wire.MsgTx and arena) reachable. Copy the hash value into an independent `chainhash.Hash` before storing.

### 4. blockHandler queue cap reduced from 10_000 to 100

`blockQueue` holds `*wire.MsgBlock` per slot. With the default 10_000-deep queue, a fast downloader feeding a sequential processor could accumulate thousands of decoded MsgBlocks ahead, each pinning its arena (≥4 MiB pre-go-wire-v1.2.6). Cap at 100 — enough to absorb processor-stall jitter, bounds worst-case in-flight arena memory. TCP back-pressure handles the producer side naturally.

## Trade-offs

This re-introduces a per-script copy in the legacy conversion path, undoing part of the go-wire #888 / #129 optimization on that hot path. On a GC-constrained box this is the right trade — short-lived, bt.Tx-scoped script allocations beat long-lived arena chunks held across the whole pipeline.

## Measured effect

On a memory-constrained mainnet node:
- Catchup throughput improved 4–5× (~37 b/s → ~200 b/s during the small-block phase)
- Swap usage collapsed from 1.4 GiB to 158 MiB
- Combined with the go-wire arena-size fix (bsv-blockchain/go-wire#133, v1.2.6) and a smaller maximum_merkle_items_per_subtree config, GC % dropped from 80% to under 20%.

## Test plan

- [ ] All 85 services/legacy/netsync tests pass
- [ ] go build ./... and go vet ./... clean
- [ ] Confirmed on a live mainnet legacy catchup that arena live-heap drops and throughput improves