### PR TITLE
chore(deps): bump go-wire to v1.2.6 (lazy + sized arena first chunk)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	github.com/bsv-blockchain/go-p2p-message-bus v0.1.17
 	github.com/bsv-blockchain/go-safe-conversion v1.2.0
 	github.com/bsv-blockchain/go-tx-map v1.3.7
-	github.com/bsv-blockchain/go-wire v1.2.5
+	github.com/bsv-blockchain/go-wire v1.2.6
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/bsv-blockchain/go-subtree v1.4.2 h1:T6a6r051eTAuYs8D01O8MM8wzRnfkhush
 github.com/bsv-blockchain/go-subtree v1.4.2/go.mod h1:ef+NCE9gION7YIOHdguW3thOlIyyuuxrfDEwv0Ywc3Q=
 github.com/bsv-blockchain/go-tx-map v1.3.7 h1:59LVYW2bvax/WbyM1eUNkrojXNrVu9f0lAuKbNryEbQ=
 github.com/bsv-blockchain/go-tx-map v1.3.7/go.mod h1:QJo02rdqFTHaimSTCgl6mLMLwIDtykwWTC1lt7nrhY8=
-github.com/bsv-blockchain/go-wire v1.2.5 h1:A29P4pwvZEnr3u5PxNkog/K7Bx3YvBlR5/nmq7+ijcI=
-github.com/bsv-blockchain/go-wire v1.2.5/go.mod h1:iPJctM+SdFfeLYqMGnmoSIAWeKName4dxMWx/FMmYeQ=
+github.com/bsv-blockchain/go-wire v1.2.6 h1:DWMXerY6o9QIYV55blLmdCYOxDq8oRpbNqfiD0jzTfA=
+github.com/bsv-blockchain/go-wire v1.2.6/go.mod h1:iPJctM+SdFfeLYqMGnmoSIAWeKName4dxMWx/FMmYeQ=
 github.com/bsv-blockchain/testcontainers-aerospike-go v0.3.2 h1:wuQkh6oGYkHDEPDFA+MDsgYrXdibzrwZxx277ZBevZ4=
 github.com/bsv-blockchain/testcontainers-aerospike-go v0.3.2/go.mod h1:KlSRfAvk+qsKyCXeF8qEAijNC4H8zhWOnmNkP2wIwQk=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=


### PR DESCRIPTION
## Summary

Bumps \`github.com/bsv-blockchain/go-wire\` from v1.2.5 to v1.2.6, which carries [bsv-blockchain/go-wire#133](https://github.com/bsv-blockchain/go-wire/pull/133).

### What changed in go-wire v1.2.6

The MsgBlock decode arena introduced in #129 (v1.2.5) eagerly allocated a 4 MiB first chunk on every \`newBlockArena()\`, regardless of block size. On mainnet legacy catchup with small early blocks (~500 B at h<100k) this is a ~8000× per-block overhead.

v1.2.6 makes the first chunk:
1. **Lazy** — allocated on the first standard-sized \`Alloc\`, not in the constructor.
2. **Sized** — \`newBlockArenaSized(hint)\` takes a \`txCount\`-derived hint and sizes the first chunk to fit, clamped to \`[4 KiB, 4 MiB]\`. Subsequent chunks remain the standard 4 MiB size, preserving big-block amortization.

\`MsgBlock.Bsvdecode\` passes \`int(txCount) * 256\` as the hint. Tiny blocks pay ~4 KiB; large blocks behave identically to v1.2.5.

### Benchmarks (from go-wire #133)

\`\`\`
TinyCoinbase (1 tx, 175 B scripts)
  v1.2.5: 52,500 ns/op  4,194,656 B/op   9 allocs/op
  v1.2.6:     790 ns/op      4,424 B/op   8 allocs/op
  → 66× faster, 948× less memory

TwoTxLegacy (2 tx, ~270 B scripts; mainnet h≈67k mean)
  v1.2.5: 54,000 ns/op  4,194,856 B/op  13 allocs/op
  v1.2.6:   1,155 ns/op      4,624 B/op  12 allocs/op
  → 47× faster, 907× less memory

100MB / ManySmall / FewLarge benchmarks: within noise (no regression).
\`\`\`

### Why teranode notices

On a memory-constrained mainnet node, combined with #921 (decoupling bt.Tx + queue from the arena), the go-wire v1.2.6 bump took inuse arena memory from ~8 GB (pprof reported) down to where it no longer dominates the live heap. CPU % in \`runtime.gcBgMarkWorker\` dropped from 80% to ~16%.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go mod tidy\` clean
- [ ] CI confirms no regressions