### PR TITLE
perf(subtreeprocessor): skip per-bucket pre-alloc when expected fill is small

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -5060,10 +5060,30 @@ func (stp *SubtreeProcessor) CreateTransactionMap(ctx context.Context, blockSubt
 			// Calculate expected bucket size with better distribution
 			nBuckets := transactionMap.Buckets()
 
-			txHashBuckets := make(map[uint16][]chainhash.Hash, nBuckets)
-			for i := uint16(0); i < nBuckets; i++ {
-				txHashBuckets[i] = make([]chainhash.Hash, 0, 512)
+			// Estimate per-bucket fill from the block-level hint so we only
+			// pre-allocate when the amortized cost is worth paying. The old
+			// unconditional `make([]chainhash.Hash, 0, 512)` per bucket cost
+			// 16 MiB per subtree (1024 buckets × 512 × 32 B) — almost entirely
+			// wasted on early-mainnet legacy catchup where each block has
+			// 1–2 transactions and 99.9% of buckets stay empty.
+			expectedPerBucket := 0
+			if estimatedTxCount > 0 && totalSubtreesInBlock > 0 {
+				expectedPerSubtree := (int(estimatedTxCount) + totalSubtreesInBlock - 1) / totalSubtreesInBlock
+				expectedPerBucket = expectedPerSubtree / int(nBuckets)
 			}
+
+			txHashBuckets := make(map[uint16][]chainhash.Hash, nBuckets)
+			if expectedPerBucket > 4 {
+				// Big-block path: buckets will be meaningfully filled, so
+				// pre-allocate exact size and skip the append-grow doublings.
+				for i := uint16(0); i < nBuckets; i++ {
+					txHashBuckets[i] = make([]chainhash.Hash, 0, expectedPerBucket)
+				}
+			}
+			// else: leave map empty. append-to-nil-slice in the deserializer
+			// handles per-bucket lazy creation. Saves 16 MiB / subtree on
+			// the small-block legacy-catchup hot path; for any block with
+			// >~4k txs the predicate above kicks back in.
 
 			conflictingNodes := make([]chainhash.Hash, 0, 32)
 


### PR DESCRIPTION
## Summary

CreateTransactionMap's per-subtree closure unconditionally pre-allocated 1024 buckets × 512-cap \`[]chainhash.Hash\` slices = **16 MiB of slice backing per subtree**, regardless of actual tx count. For early-mainnet legacy catchup where each block has 1–2 transactions, 99.9% of those buckets stay empty — the pre-alloc is pure waste.

In a live mainnet profile this allocation site was the new top allocator after the go-wire arena lifetime fixes were applied — 71% of cumulative \`alloc_space\`.

### Fix

Derive an expected-per-bucket fill from \`estimatedTxCount / totalSubtreesInBlock / nBuckets\`. If it's ≤4, skip the pre-alloc loop entirely; the deserializer's \`append\`-to-nil-slice handles lazy creation. Above ~4k txs per block the predicate kicks back in and we pre-allocate the exact required size, avoiding both the 512-cap waste AND the append-grow doublings on the hot big-block path.

\`\`\`go
expectedPerBucket := 0
if estimatedTxCount > 0 && totalSubtreesInBlock > 0 {
    expectedPerSubtree := (int(estimatedTxCount) + totalSubtreesInBlock - 1) / totalSubtreesInBlock
    expectedPerBucket = expectedPerSubtree / int(nBuckets)
}

txHashBuckets := make(map[uint16][]chainhash.Hash, nBuckets)
if expectedPerBucket > 4 {
    for i := uint16(0); i < nBuckets; i++ {
        txHashBuckets[i] = make([]chainhash.Hash, 0, expectedPerBucket)
    }
}
\`\`\`

## Measured effect

On mainnet legacy catchup (h≈100k–120k), the \`CreateTransactionMap.func1\` allocation share dropped from **71% → 1.33%** of cumulative \`alloc_space\` (~178× reduction in this site's share). Combined with other GC pressure fixes, total per-block cumulative allocation dropped ~3.3×.

## Test plan

- [x] All 228 subtreeprocessor tests pass
- [ ] CI confirms no regressions