### PR TITLE
fix(stores/blob/file): drop racy rmdir-on-empty in Del

### DIFF
--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -1230,19 +1230,20 @@ func (s *File) Del(ctx context.Context, key []byte, fileType fileformat.FileType
 		return errors.NewStorageError("[File][Del] [%s] failed to remove file", fileName, err)
 	}
 
-	// Try to remove the hash prefix directory if now empty (best-effort, ignore errors).
-	// root.Remove on a non-empty directory returns an error, so this is safe. Routing through
-	// the store root keeps the operation inside the os.Root sandbox so it cannot follow a
-	// symlink out of the store, and is consistent with the rest of the path handling in this
-	// file (CodeQL #119).
-	if dir := filepath.Dir(fileName); dir != s.path && len(filepath.Base(dir)) <= 2 {
-		if rel, relErr := s.storeRelPath(dir); relErr == nil {
-			if root, rootErr := s.openStoreRoot(); rootErr == nil {
-				_ = root.Remove(rel)
-				_ = root.Close()
-			}
-		}
-	}
+	// Do NOT attempt to remove the hash prefix directory here. The "remove if
+	// empty" check races with concurrent writes into the same prefix dir:
+	//
+	//   1. Goroutine A (Del):   removes the last file in "44/", then rmdir "44".
+	//   2. Goroutine B (Write): OpenFile("44/.tmp", O_CREATE|O_EXCL) → ENOENT.
+	//
+	// The write path only retries on EEXIST, so ENOENT propagates as a hard
+	// failure. Observed on mainnet legacy catchup where the pruner deletes
+	// expired subtree files concurrently with the next block's subtree-meta
+	// write into the same hex-prefix directory.
+	//
+	// Empty prefix dirs are cheap (one inode each, 256 possible two-char
+	// prefixes) and will get re-populated as soon as another file lands in
+	// that bucket, so leaving them is free.
 
 	s.logger.Debugf("[FILE_DEL] Successfully deleted file: %s", fileName)
 	s.debugf("[File] Del completed key=%s type=%s", keyHex, fileType)


### PR DESCRIPTION
## Summary

The blob \`File.Del\` path tries to rmdir the two-char hex prefix directory after removing the last file in it (\"best-effort\"). This races with concurrent writes into the same prefix dir.

### The race

\`\`\`
1. Goroutine A (Del):   removes the last file in \"44/\", then root.Remove(\"44\")
2. Goroutine B (Write): OpenFile(\"44/.tmp\", O_CREATE|O_EXCL) → ENOENT
\`\`\`

The write path (\`createTempFile\`) only retries on \`EEXIST\`; \`ENOENT\` propagates as a hard \`STORAGE_ERROR\`.

### Observed on mainnet

During a live legacy-peer catchup on a memory-constrained mainnet node, the pruner deleted expired subtree files concurrently with the next block's subtree-meta write into the same hex-prefix directory. The write failure cascaded as repeated \"previous block not found\" errors and stalled catchup for ~3.5 minutes until the peer re-sent the block.

Failing call site:
\`\`\`
ERROR | netsync/handle_block.go:294 | legacy| processing subtree for block height 132831, tx count 96 DONE in 160.164605ms with error: STORAGE_ERROR (69): error writing subtree meta to disk -> STORAGE_ERROR (69): [File][data/subtreestore/44/44e4ee...subtreeMeta] failed to create temporary file -> UNKNOWN (0): openat 44/.44e4ee....subtreeMeta.5192129480656445056.tmp: no such file or directory
\`\`\`

## Fix

Remove the rmdir block at \`stores/blob/file/file.go:1238–1245\`. Empty prefix directories are cheap (one inode each; only 256 possible two-char prefixes in total) and will be re-populated as soon as another file lands in that bucket. The tidiness benefit isn't worth the race.

The previous code is replaced with a comment documenting the race so future readers don't reintroduce the rmdir.

## Alternatives considered

Retry the write on \`ENOENT\` with \`MkdirAll\` + retry. This narrows the race window but doesn't fully close it (another goroutine can rmdir again between MkdirAll and OpenFile). Removing the rmdir entirely is simpler and zero-risk.

## Test plan

- [x] \`go build ./...\` clean
- [x] All 281 \`stores/blob/...\` tests pass
- [ ] CI confirms no regressions