### PR TITLE
fix(blockvalidation): arena-backed tx decode to eliminate catch-up OOM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/bitcoin-sv/bdk/module/gobdk v1.2.5-0.20260518042519-1ca0c6519af9
-	github.com/bsv-blockchain/go-bt/v2 v2.6.3
+	github.com/bsv-blockchain/go-bt/v2 v2.6.4
 	github.com/bsv-blockchain/go-chaincfg v1.5.8
 	github.com/bsv-blockchain/go-sdk v1.2.23
 	github.com/bsv-blockchain/go-subtree v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/bsv-blockchain/go-bc v1.1.5 h1:G9hioz7yz6ARS5YHYJhA4c0xCU5EnRm6PsjDM8
 github.com/bsv-blockchain/go-bc v1.1.5/go.mod h1:g0ZjqK5pNMvgIQpeN0QXchAKEzl15ro3Fm0LG/8PFyI=
 github.com/bsv-blockchain/go-bn v1.1.4 h1:mEOqX7NwBScGbxq5icxbDI0GOQYtjJBz+xC27xwWQFI=
 github.com/bsv-blockchain/go-bn v1.1.4/go.mod h1:qzHqHkPqXc3uDSoFmHsD8uxgkr/POzU8kpIH4Jm/AcM=
-github.com/bsv-blockchain/go-bt/v2 v2.6.3 h1:LtbJNgXQRFBsI+Iti1X6ccaCRrT43Ps66V5sQRTyrUo=
-github.com/bsv-blockchain/go-bt/v2 v2.6.3/go.mod h1:AkVfArL+yEiA2luWAVdDtwadgzngPsayg45ISwbtvaU=
+github.com/bsv-blockchain/go-bt/v2 v2.6.4 h1:S1PzRP+8uiJLG+bGg/CLQxWP0FZTikN8ri9fVpP7q6M=
+github.com/bsv-blockchain/go-bt/v2 v2.6.4/go.mod h1:iV9HCmK6GEhIWtpeCBb1vvUcI8zjiDZopxXPXCreXMk=
 github.com/bsv-blockchain/go-chaincfg v1.5.8 h1:zhmi42r71mAqPChhSVggzzxaseTvLqC+zipyL2fAN0g=
 github.com/bsv-blockchain/go-chaincfg v1.5.8/go.mod h1:n/Q8aGScTgydZ2Bsjfic7v8ulHBIpgI0WVyqE5mFMxU=
 github.com/bsv-blockchain/go-lockfree-queue v1.0.0 h1:rizOsTImw2Gk/iSTQRHqB+2OcJWBl5qN6pbIHqDWxRw=

--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -102,6 +102,9 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 			return errors.NewProcessingError("[GetLegacyBlockReader] error writing coinbase tx", err)
 		}
 
+		arena := getAssetArena()
+		defer putAssetArena(arena)
+
 		for subtreeIdx, subtreeHash := range block.Subtrees {
 			subtreeDataExists, err = repo.SubtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtreeData)
 			if err == nil && subtreeDataExists {
@@ -121,8 +124,7 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 				for {
 					tx := &bt.Tx{}
 
-					// this will read the transaction into the tx object
-					if _, err = tx.ReadFrom(bufferedReader); err != nil {
+					if _, err = tx.ReadFromWithArena(bufferedReader, arena); err != nil {
 						if err == io.EOF {
 							break
 						}
@@ -133,6 +135,8 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 					// Skip if this is the coinbase transaction
 					// Include the subtreeIdx check to avoid needing to do string comparison every iteration
 					if subtreeIdx == 0 && tx.IsCoinbase() {
+						// Reset the arena so a coinbase-only iteration doesn't leak slab space.
+						arena.Reset()
 						continue
 					}
 
@@ -143,6 +147,11 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 
 						return errors.NewProcessingError("error writing transaction to writer: %s", err)
 					}
+
+					// tx.WriteTo finished serialising the tx to w; the arena-backed scripts
+					// are no longer needed. Reset rewinds the cursor so the next tx reuses
+					// the same slab.
+					arena.Reset()
 				}
 
 				// close the subtree data reader after processing all transactions

--- a/services/asset/repository/arena_pool.go
+++ b/services/asset/repository/arena_pool.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"sync"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+const (
+	assetArenaInitialCap = 4 << 20  // 4 MiB
+	assetArenaShrinkCap  = 64 << 20 // 64 MiB
+)
+
+// assetArenaPool holds bt.Arena instances reused across legacy-block
+// reconstruction streams. The caller Gets an arena once per block and Puts
+// it on goroutine exit; the per-tx arena.Reset between WriteTo calls
+// bounds peak memory by the largest single tx.
+var assetArenaPool = sync.Pool{
+	New: func() any { return bt.NewArena(assetArenaInitialCap) },
+}
+
+func getAssetArena() *bt.Arena {
+	return assetArenaPool.Get().(*bt.Arena)
+}
+
+func putAssetArena(a *bt.Arena) {
+	a.ResetAndShrink(assetArenaShrinkCap)
+	assetArenaPool.Put(a)
+}

--- a/services/blockpersister/arena_pool.go
+++ b/services/blockpersister/arena_pool.go
@@ -1,0 +1,29 @@
+package blockpersister
+
+import (
+	"sync"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+const (
+	blockpersisterArenaInitialCap = 2 << 20  // 2 MiB
+	blockpersisterArenaShrinkCap  = 64 << 20 // 64 MiB
+)
+
+// blockpersisterArenaPool holds bt.Arena instances reused across subtree
+// UTXO streaming. The contract: callers Get an arena before the decode
+// loop, Put it back when the loop returns. Put runs ResetAndShrink so a
+// one-off oversized decode doesn't bloat the pool's idle footprint.
+var blockpersisterArenaPool = sync.Pool{
+	New: func() any { return bt.NewArena(blockpersisterArenaInitialCap) },
+}
+
+func getBlockpersisterArena() *bt.Arena {
+	return blockpersisterArenaPool.Get().(*bt.Arena)
+}
+
+func putBlockpersisterArena(a *bt.Arena) {
+	a.ResetAndShrink(blockpersisterArenaShrinkCap)
+	blockpersisterArenaPool.Put(a)
+}

--- a/services/blockpersister/streaming_process_subtree.go
+++ b/services/blockpersister/streaming_process_subtree.go
@@ -273,6 +273,13 @@ func (u *Server) ProcessSubtreeUTXOStreaming(ctx context.Context, subtreeHash ch
 	// 3. Stream through transactions and process UTXO changes
 	subtreeLen := subtree.Length()
 
+	// Arena-backed tx decode is safe here because utxoDiff is
+	// *utxopersister.UTXOSet (NOT services/blockpersister/utxoset/model.UTXODiff,
+	// which retains script slices in an in-memory map). UTXOSet.ProcessTx
+	// serialises via UTXOWrapper.Bytes -> UTXO.Bytes, which does
+	// `append(b, u.Script...)` — a heap copy — and then writes through a
+	// bufio.Writer (which copies into its internal buffer). No arena-backed
+	// slice survives this function frame.
 	arena := getBlockpersisterArena()
 	defer putBlockpersisterArena(arena)
 	var hashScratch []byte

--- a/services/blockpersister/streaming_process_subtree.go
+++ b/services/blockpersister/streaming_process_subtree.go
@@ -273,11 +273,14 @@ func (u *Server) ProcessSubtreeUTXOStreaming(ctx context.Context, subtreeHash ch
 	// 3. Stream through transactions and process UTXO changes
 	subtreeLen := subtree.Length()
 
+	arena := getBlockpersisterArena()
+	defer putBlockpersisterArena(arena)
+	var hashScratch []byte
+
 	for i := 0; i < subtreeLen; i++ {
 		tx := &bt.Tx{}
 
-		// Read transaction from buffered reader
-		if _, err = tx.ReadFrom(bufferedReader); err != nil {
+		if _, err = tx.ReadFromWithArena(bufferedReader, arena); err != nil {
 			return errors.NewProcessingError("[BlockPersister] error reading transaction at index %d from subtree %s", i, subtreeHash.String(), err)
 		}
 
@@ -295,7 +298,8 @@ func (u *Server) ProcessSubtreeUTXOStreaming(ctx context.Context, subtreeHash ch
 
 		// check the tx hash matches the expected hash (from subtree), except for coinbase
 		if !tx.IsCoinbase() {
-			txHash := tx.TxIDChainHash()
+			var txHash chainhash.Hash
+			txHash, hashScratch = tx.HashTxIDInto(hashScratch)
 			if !txHash.Equal(subtree.Nodes[i].Hash) {
 				return errors.NewProcessingError("[BlockPersister] transaction hash mismatch at index %d: expected %s, got %s", i, subtree.Nodes[i].Hash.String(), txHash.String())
 			}

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -144,6 +144,12 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 		return errors.NewProcessingError("failed to serialize coinbase", err)
 	}
 
+	// Single coinbase decode per block, retained into the teranodeBlock model
+	// for downstream use; stays on the standard heap path. The arena variant
+	// would require Put before return, at which point coinbaseTx's scripts
+	// would alias soon-to-be-reused memory. Per-block tx loops in legacy
+	// ingestion live in bsvutil/subtree-assembly, which works with
+	// bsvutil.Tx (not bt.Tx) and never round-trips through go-bt decode.
 	coinbaseTx, err := bt.NewTxFromBytes(coinbase.Bytes())
 	if err != nil {
 		return errors.NewProcessingError("failed to create bt.Tx for coinbase", err)

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -929,6 +929,9 @@ func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
 	buf := bytes.NewBuffer(make([]byte, 0, tmsg.tx.MsgTx().SerializeSize()))
 	_ = tmsg.tx.MsgTx().Serialize(buf)
 
+	// Single inbound tx per call, passed downstream to the validator. Stays
+	// on the standard heap path — no arena amortisation possible for a
+	// one-shot decode where the tx must outlive this function frame.
 	btTx, err := bt.NewTxFromBytes(buf.Bytes())
 	if err != nil {
 		sm.logger.Errorf("Failed to create transaction from bytes: %v", err)

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -344,6 +344,13 @@ func (u *Server) getMissingTransactionsBatch(ctx context.Context, subtreeHash ch
 // readTxFromReader reads and validates a single transaction from an io.ReadCloser.
 // It includes panic recovery for handling potential runtime errors from the go-bt library.
 //
+// Stays on the standard tx.ReadFrom path (no arena). The returned *bt.Tx is
+// consumed by the caller after this function returns, so script bytes must be
+// heap-owned — an arena allocated here would have to be Put before return, at
+// which point the script slices would alias soon-to-be-reused arena memory.
+// The arena variant is reserved for the bulk subtree-stream decode where the
+// entire batch of txs is consumed before the arena is returned to the pool.
+//
 // Parameters:
 //   - body: ReadCloser containing the transaction data
 //

--- a/services/subtreevalidation/arena_pool.go
+++ b/services/subtreevalidation/arena_pool.go
@@ -1,0 +1,36 @@
+package subtreevalidation
+
+import (
+	"sync"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+const (
+	subtreeArenaInitialCap = 2 << 20  // 2 MiB
+	subtreeArenaShrinkCap  = 64 << 20 // 64 MiB
+)
+
+// subtreeArenaPool holds bt.Arena instances reused across subtree decode
+// operations. The contract: callers Get an arena before decoding a subtree,
+// Put it back when the decoded txs are fully consumed (validation +
+// metadata emission complete). Put runs ResetAndShrink(subtreeArenaShrinkCap)
+// so a one-off oversized decode doesn't bloat the pool's idle footprint.
+var subtreeArenaPool = sync.Pool{
+	New: func() any { return bt.NewArena(subtreeArenaInitialCap) },
+}
+
+// getSubtreeArena returns an arena ready for use. The arena's cursor is at
+// zero on entry.
+func getSubtreeArena() *bt.Arena {
+	return subtreeArenaPool.Get().(*bt.Arena)
+}
+
+// putSubtreeArena returns the arena to the pool after Reset+Shrink. The
+// caller must release all *bt.Tx pointers obtained from arena-backed
+// decode calls before invoking putSubtreeArena — script bytes will be
+// reused or freed by subsequent pool consumers.
+func putSubtreeArena(a *bt.Arena) {
+	a.ResetAndShrink(subtreeArenaShrinkCap)
+	subtreeArenaPool.Put(a)
+}

--- a/services/subtreevalidation/arena_pool_test.go
+++ b/services/subtreevalidation/arena_pool_test.go
@@ -1,0 +1,37 @@
+package subtreevalidation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArenaPool_GetPutLifecycle(t *testing.T) {
+	a := getSubtreeArena()
+	require.NotNil(t, a)
+	require.Equal(t, 0, a.Used())
+
+	_ = a.Alloc(1024)
+	require.Equal(t, 1024, a.Used())
+
+	putSubtreeArena(a)
+	// After Put, the arena should have been Reset. Get an arena and verify.
+	a2 := getSubtreeArena()
+	require.Equal(t, 0, a2.Used())
+	putSubtreeArena(a2)
+}
+
+func TestArenaPool_ShrinkAfterLargeUse(t *testing.T) {
+	a := getSubtreeArena()
+	_ = a.Alloc(128 << 20) // 128 MiB
+	require.GreaterOrEqual(t, a.Cap(), 128<<20)
+
+	putSubtreeArena(a) // ResetAndShrink(64 MiB) — slab dropped
+
+	// sync.Pool does not guarantee returning the same arena, but if it does,
+	// its capacity should be 0 (or significantly less than 128 MiB). Either
+	// way, the pool should not be retaining a 128 MiB slab indefinitely.
+	a2 := getSubtreeArena()
+	require.Less(t, a2.Cap(), 128<<20, "oversized slab should have been dropped on Put")
+	putSubtreeArena(a2)
+}

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -172,6 +172,7 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 
 		// Load transactions for this batch of subtrees in parallel
 		subtreeTxs := make([][]*bt.Tx, len(batchSubtrees))
+		batchArenas := make([]*bt.Arena, len(batchSubtrees))
 		g, gCtx := errgroup.WithContext(ctx)
 		util.SafeSetLimit(g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
 
@@ -278,6 +279,12 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 				// PHASE 2: Exact pre-allocation
 				subtreeTxs[subtreeIdx] = make([]*bt.Tx, 0, subtreeToCheck.Length())
 
+				// Allocate a per-subtree arena for zero-copy script decoding.
+				// The arena is stored in batchArenas[subtreeIdx] so it can be released
+				// after processTransactionsInLevels consumes the batch's txs.
+				arena := getSubtreeArena()
+				batchArenas[subtreeIdx] = arena
+
 				subtreeDataExists, err := u.subtreeStore.Exists(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeData)
 				if err != nil {
 					return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to check if subtree data exists in store", subtreeHash.String(), err)
@@ -302,7 +309,7 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 					}
 
 					// Process transactions directly from the stream while storing to disk
-					err = u.processSubtreeDataStream(gCtx, subtreeToCheck, countingBody, &subtreeTxs[subtreeIdx], dah)
+					err = u.processSubtreeDataStream(gCtx, subtreeToCheck, countingBody, &subtreeTxs[subtreeIdx], dah, arena)
 					_ = countingBody.Close()
 
 					// Track bytes downloaded from peer after stream is consumed
@@ -320,7 +327,7 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 					}
 				} else {
 					// SubtreeData exists, extract transactions from stored file
-					err = u.extractAndCollectTransactions(gCtx, subtreeToCheck, &subtreeTxs[subtreeIdx])
+					err = u.extractAndCollectTransactions(gCtx, subtreeToCheck, &subtreeTxs[subtreeIdx], arena)
 					if err != nil {
 						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to extract transactions", subtreeHash.String(), err)
 					}
@@ -331,6 +338,12 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 		}
 
 		if err = g.Wait(); err != nil {
+			// Release arenas allocated by goroutines that completed before the error.
+			for i := range batchArenas {
+				if batchArenas[i] != nil {
+					putSubtreeArena(batchArenas[i])
+				}
+			}
 			return nil, errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to get subtree tx hashes for batch %d", batchNum, err)
 		}
 
@@ -358,6 +371,12 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 		// Process transactions for this batch
 		if batchTxCount > 0 {
 			if err = u.processTransactionsInLevels(ctx, allTransactions, *block.Hash(), chainhash.Hash{}, block.Height, blockIds); err != nil {
+				// Release arenas before returning — txs won't be consumed further.
+				for i := range batchArenas {
+					if batchArenas[i] != nil {
+						putSubtreeArena(batchArenas[i])
+					}
+				}
 				return nil, errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to process transactions in batch %d", batchNum, err)
 			}
 			totalProcessedTxs += batchTxCount
@@ -366,6 +385,17 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 			// Transactions are now in UTXO store and validator cache, original slice no longer needed
 			allTransactions = nil //nolint:ineffassign // Intentional early GC hint
 		}
+
+		// Release per-subtree arenas: all *bt.Tx pointers were consumed by
+		// processTransactionsInLevels above, so the arena-backed script slices
+		// are no longer referenced and the arenas can be returned to the pool.
+		for i := range batchArenas {
+			if batchArenas[i] != nil {
+				putSubtreeArena(batchArenas[i])
+				batchArenas[i] = nil
+			}
+		}
+		batchArenas = nil //nolint:ineffassign // Intentional early GC hint
 
 		batchSubtrees = nil //nolint:ineffassign // Intentional early GC hint for batch slice view
 		u.logger.Debugf("[CheckBlockSubtrees] Batch %d/%d complete for block %s (%d txs processed, %d total), memory reclaimed", batchNum, totalBatches, block.Hash().String(), batchTxCount, totalProcessedTxs)
@@ -504,8 +534,9 @@ func (u *Server) validateMissingSubtreesWithOrderedRetry(
 }
 
 // extractAndCollectTransactions extracts all transactions from a subtree's data file
-// and adds them to the shared collection for block-wide processing
-func (u *Server) extractAndCollectTransactions(ctx context.Context, subtree *subtreepkg.Subtree, subtreeTransactions *[]*bt.Tx) error {
+// and adds them to the shared collection for block-wide processing.
+// When arena is non-nil, script bytes are arena-allocated (caller owns arena lifetime).
+func (u *Server) extractAndCollectTransactions(ctx context.Context, subtree *subtreepkg.Subtree, subtreeTransactions *[]*bt.Tx, arena *bt.Arena) error {
 	ctx, _, deferFn := tracing.Tracer("subtreevalidation").Start(ctx, "extractAndCollectTransactions",
 		tracing.WithParentStat(u.stats),
 		tracing.WithDebugLogMessage(u.logger, "[extractAndCollectTransactions] called for subtree %s", subtree.RootHash().String()),
@@ -528,7 +559,7 @@ func (u *Server) extractAndCollectTransactions(ctx context.Context, subtree *sub
 	}()
 
 	// Read transactions directly into the shared collection
-	txCount, err := u.readTransactionsFromSubtreeDataStream(subtree, bufferedReader, subtreeTransactions)
+	txCount, err := u.readTransactionsFromSubtreeDataStream(subtree, bufferedReader, subtreeTransactions, arena)
 	if err != nil {
 		return errors.NewProcessingError("[extractAndCollectTransactions] failed to read transactions from subtreeData", err)
 	}
@@ -544,8 +575,9 @@ func (u *Server) extractAndCollectTransactions(ctx context.Context, subtree *sub
 
 // processSubtreeDataStream downloads subtreeData and simultaneously stores to disk while parsing transactions.
 // PHASE 1: Concurrent streaming - eliminates storage read-back by writing to disk while parsing.
+// When arena is non-nil, script bytes are arena-allocated (caller owns arena lifetime).
 func (u *Server) processSubtreeDataStream(ctx context.Context, subtree *subtreepkg.Subtree,
-	body io.ReadCloser, allTransactions *[]*bt.Tx, dah uint32) error {
+	body io.ReadCloser, allTransactions *[]*bt.Tx, dah uint32, arena *bt.Arena) error {
 	ctx, _, deferFn := tracing.Tracer("subtreevalidation").Start(ctx, "processSubtreeDataStream",
 		tracing.WithParentStat(u.stats),
 		tracing.WithDebugLogMessage(u.logger, "[processSubtreeDataStream] called for subtree %s", subtree.RootHash().String()),
@@ -581,7 +613,7 @@ func (u *Server) processSubtreeDataStream(ctx context.Context, subtree *subtreep
 	}()
 
 	// Parse transactions while writing to storage
-	txCount, parseErr := u.readTransactionsFromSubtreeDataStream(subtree, bufferedReader, allTransactions)
+	txCount, parseErr := u.readTransactionsFromSubtreeDataStream(subtree, bufferedReader, allTransactions, arena)
 
 	// Close the pipe writer to signal completion to storage goroutine
 	// Use CloseWithError if parsing failed to properly signal the storage goroutine
@@ -614,19 +646,24 @@ func (u *Server) processSubtreeDataStream(ctx context.Context, subtree *subtreep
 	return nil
 }
 
-// readTransactionsFromSubtreeDataStream reads transactions directly from subtreeData stream
-// This follows the same pattern as go-subtree's serializeFromReader but appends directly to the shared collection
-func (u *Server) readTransactionsFromSubtreeDataStream(subtree *subtreepkg.Subtree, reader io.Reader, subtreeTransactions *[]*bt.Tx) (int, error) {
+// readTransactionsFromSubtreeDataStream reads transactions directly from subtreeData stream.
+// When arena is non-nil, per-script byte slices are drawn from the arena (caller must keep
+// the arena alive for as long as the returned *bt.Tx values are in use, and call
+// putSubtreeArena only after the txs are fully consumed). When arena is nil, scripts are
+// heap-allocated via the standard tx.ReadFrom path.
+func (u *Server) readTransactionsFromSubtreeDataStream(subtree *subtreepkg.Subtree, reader io.Reader, subtreeTransactions *[]*bt.Tx, arena *bt.Arena) (int, error) {
 	txIndex := 0
 
 	if len(subtree.Nodes) > 0 && subtree.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
 		txIndex = 1
 	}
 
+	var hashScratch []byte
+
 	for {
 		tx := &bt.Tx{}
 
-		_, err := tx.ReadFrom(reader)
+		_, err := tx.ReadFromWithArena(reader, arena)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				// End of stream reached
@@ -641,7 +678,9 @@ func (u *Server) readTransactionsFromSubtreeDataStream(subtree *subtreepkg.Subtr
 			txIndex = 0
 		}
 
-		tx.SetTxHash(tx.TxIDChainHash()) // Cache the transaction hash to avoid recomputing it
+		var h chainhash.Hash
+		h, hashScratch = tx.HashTxIDInto(hashScratch)
+		tx.SetTxHash(&h)
 
 		// Basic sanity check: ensure the transaction hash matches the expected hash from the subtree
 		if txIndex < subtree.Length() {

--- a/services/subtreevalidation/check_block_subtrees_memory_test.go
+++ b/services/subtreevalidation/check_block_subtrees_memory_test.go
@@ -1,0 +1,104 @@
+package subtreevalidation
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadTransactionsFromSubtreeDataStream_MemoryBoundWithArena builds a
+// synthetic 1000-tx stream where each tx carries a 100 KB OP_RETURN output
+// (total ≈ 100 MiB on the wire) and decodes it via the arena path. Asserts
+// that the post-decode HeapInuse delta is well under what a non-arena decode
+// would produce (which would scale 1:1 with the stream size since every
+// script slice would be heap-allocated and held by the returned []*bt.Tx).
+//
+// Skipped under -short because it allocates ~100 MiB during the build phase.
+func TestReadTransactionsFromSubtreeDataStream_MemoryBoundWithArena(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	const (
+		txCount    = 1000
+		scriptSize = 100 * 1024
+	)
+
+	// Build a canonical large tx with a single OP_RETURN payload.
+	bigScript := make([]byte, scriptSize)
+	bigScript[0] = 0x6a // OP_RETURN
+
+	template := bt.NewTx()
+	template.AddOutput(&bt.Output{
+		Satoshis:      0,
+		LockingScript: bscript.NewFromBytes(bigScript),
+	})
+	raw := template.Bytes()
+
+	stream := make([]byte, 0, len(raw)*txCount)
+	for i := 0; i < txCount; i++ {
+		stream = append(stream, raw...)
+	}
+
+	// Build a matching subtree skeleton. The hash-check inside the stream
+	// reader compares decoded txid vs subtree.Nodes[i].Hash, so populate
+	// each node with the template's txid.
+	expectedHash := *template.TxIDChainHash()
+	subtree, err := subtreepkg.NewIncompleteTreeByLeafCount(txCount)
+	require.NoError(t, err)
+	for i := 0; i < txCount; i++ {
+		require.NoError(t, subtree.AddNode(expectedHash, 0, 0))
+	}
+
+	server := &Server{}
+
+	// Warm the pool with a small decode so the first benchmark iteration
+	// doesn't pay the pool's New cost.
+	{
+		warmArena := getSubtreeArena()
+		putSubtreeArena(warmArena)
+	}
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	arena := getSubtreeArena()
+	subtreeTxs := make([]*bt.Tx, 0, txCount)
+	count, err := server.readTransactionsFromSubtreeDataStream(subtree, bytes.NewReader(stream), &subtreeTxs, arena)
+	require.NoError(t, err)
+	require.Equal(t, txCount, count)
+	require.Len(t, subtreeTxs, txCount)
+
+	runtime.GC()
+	var afterDecode runtime.MemStats
+	runtime.ReadMemStats(&afterDecode)
+
+	decodeDelta := int64(afterDecode.HeapInuse) - int64(before.HeapInuse)
+	streamSizeMiB := int64(len(stream)) >> 20
+	t.Logf("stream size: %d MiB, post-decode HeapInuse delta: %d MiB",
+		streamSizeMiB, decodeDelta>>20)
+
+	// With per-script make() (non-arena), the decoded []*bt.Tx would retain
+	// every locking-script payload independently — heap delta ~ stream size.
+	// With the arena, every tx's LockingScript points into a single slab
+	// (the arena's), so the holding cost is one slab + the *bt.Tx slice +
+	// per-tx struct overhead. Cap the assertion well below the wire size:
+	// allow up to 1.5x the slab cap as a safety margin for the *bt.Tx +
+	// chainhash.Hash + slice overheads.
+	maxAllowed := int64(subtreeArenaShrinkCap) + int64(80<<20)
+	require.Less(t, decodeDelta, maxAllowed,
+		"arena-backed decode of a %d MiB stream should hold ≤ %d MiB live, got %d MiB",
+		streamSizeMiB, maxAllowed>>20, decodeDelta>>20)
+
+	// Release the tx slice + arena so the test process doesn't keep the
+	// pool warm with a large slab for downstream tests.
+	subtreeTxs = nil //nolint:ineffassign // explicit GC hint
+	putSubtreeArena(arena)
+	_ = subtreeTxs
+}

--- a/services/subtreevalidation/check_block_subtrees_test.go
+++ b/services/subtreevalidation/check_block_subtrees_test.go
@@ -877,7 +877,7 @@ func TestExtractAndCollectTransactions(t *testing.T) {
 		// Test extraction
 		var allTransactions []*bt.Tx
 
-		err = server.extractAndCollectTransactions(context.Background(), subtree, &allTransactions)
+		err = server.extractAndCollectTransactions(context.Background(), subtree, &allTransactions, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, allTransactions, 2)
@@ -903,7 +903,7 @@ func TestExtractAndCollectTransactions(t *testing.T) {
 
 		var allTransactions []*bt.Tx
 
-		err = server.extractAndCollectTransactions(context.Background(), subtree, &allTransactions)
+		err = server.extractAndCollectTransactions(context.Background(), subtree, &allTransactions, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get subtreeData from store")
 	})
@@ -927,7 +927,7 @@ func TestExtractAndCollectTransactions(t *testing.T) {
 
 		var allTransactions []*bt.Tx
 
-		err = server.extractAndCollectTransactions(context.Background(), subtree, &allTransactions)
+		err = server.extractAndCollectTransactions(context.Background(), subtree, &allTransactions, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read transactions from subtreeData")
 	})
@@ -963,7 +963,7 @@ func TestProcessSubtreeDataStream(t *testing.T) {
 
 		var allTransactions []*bt.Tx
 
-		err = server.processSubtreeDataStream(context.Background(), subtree, body, &allTransactions, 100)
+		err = server.processSubtreeDataStream(context.Background(), subtree, body, &allTransactions, 100, nil)
 		require.NoError(t, err)
 
 		// Verify transactions were collected
@@ -1007,7 +1007,7 @@ func TestProcessSubtreeDataStream(t *testing.T) {
 
 		var allTransactions []*bt.Tx
 
-		err = server.processSubtreeDataStream(context.Background(), subtree, body, &allTransactions, 100)
+		err = server.processSubtreeDataStream(context.Background(), subtree, body, &allTransactions, 100, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to store subtree data")
 		// With streaming approach, if storage fails, no transactions are collected
@@ -1035,7 +1035,7 @@ func TestProcessSubtreeDataStream(t *testing.T) {
 
 		var allTransactions []*bt.Tx
 
-		err = server.processSubtreeDataStream(context.Background(), subtree, body, &allTransactions, 100)
+		err = server.processSubtreeDataStream(context.Background(), subtree, body, &allTransactions, 100, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error reading transaction")
 	})
@@ -1067,7 +1067,7 @@ func TestReadTransactionsFromSubtreeDataStream(t *testing.T) {
 
 		var allTransactions []*bt.Tx
 
-		count, err := server.readTransactionsFromSubtreeDataStream(subtree, &subtreeData, &allTransactions)
+		count, err := server.readTransactionsFromSubtreeDataStream(subtree, &subtreeData, &allTransactions, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, 3, count)         // includes coinbase in the count
@@ -1087,7 +1087,7 @@ func TestReadTransactionsFromSubtreeDataStream(t *testing.T) {
 		// Don't add any nodes - this means 0 transactions expected
 		var allTransactions []*bt.Tx
 
-		count, err := server.readTransactionsFromSubtreeDataStream(subtree, &emptyBuffer, &allTransactions)
+		count, err := server.readTransactionsFromSubtreeDataStream(subtree, &emptyBuffer, &allTransactions, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, count)
@@ -1133,7 +1133,7 @@ func TestReadTransactionsFromSubtreeDataStream(t *testing.T) {
 		subtreeData.Write(tx1.Bytes())
 
 		var allTransactions []*bt.Tx
-		count, err := server.readTransactionsFromSubtreeDataStream(subtree, &subtreeData, &allTransactions)
+		count, err := server.readTransactionsFromSubtreeDataStream(subtree, &subtreeData, &allTransactions, nil)
 		require.NoError(t, err)
 
 		// Should succeed — the coinbase placeholder at index 0 is allowed when the tx is coinbase
@@ -1164,7 +1164,7 @@ func TestReadTransactionsFromSubtreeDataStream(t *testing.T) {
 		subtreeData.Write(tx2.Bytes())
 
 		var allTransactions []*bt.Tx
-		_, err = server.readTransactionsFromSubtreeDataStream(subtree, &subtreeData, &allTransactions)
+		_, err = server.readTransactionsFromSubtreeDataStream(subtree, &subtreeData, &allTransactions, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "transaction hash mismatch")
 	})
@@ -2008,13 +2008,13 @@ func TestExtractAndCollectTransactions_ConcurrentAccess(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		err := server.extractAndCollectTransactions(context.Background(), subtree1, &transactions1)
+		err := server.extractAndCollectTransactions(context.Background(), subtree1, &transactions1, nil)
 		assert.NoError(t, err)
 	}()
 
 	go func() {
 		defer wg.Done()
-		err := server.extractAndCollectTransactions(context.Background(), subtree2, &transactions2)
+		err := server.extractAndCollectTransactions(context.Background(), subtree2, &transactions2, nil)
 		assert.NoError(t, err)
 	}()
 


### PR DESCRIPTION
## Summary

Closes #920. Eliminates the per-script `make([]byte, l)` allocation hotspot in `go-bt` tx decode that was responsible for ~70% of the heap during testnet catch-up sync (causing OOM at ~13 GiB RSS around block ~5000).

Uses the new `bt.Arena` + `Tx.ReadFromWithArena` + `Tx.HashTxIDInto` APIs landed in go-bt v2.6.4 (bsv-blockchain/go-bt#146).

## What's in this PR

- Bumps `go-bt` to `v2.6.4` (introduces `bt.Arena`, `*.ReadFromWithArena`, `Tx.HashTxIDInto`, and a 1 GiB script-length cap on existing `ReadFrom` paths).
- New per-service `sync.Pool` of `bt.Arena` in `subtreevalidation`, `blockpersister`, `asset/repository`. Get on decode start, Put on completion via `ResetAndShrink(64 MiB)` so a one-off large decode doesn't bloat idle pool footprint.
- Migrated hot decode paths:
  - `subtreevalidation/check_block_subtrees.go`: `readTransactionsFromSubtreeDataStream` is the catch-up critical loop. Per-subtree arena allocated in each parallel goroutine, kept alive in a `batchArenas` slice, returned to the pool only after `processTransactionsInLevels` consumes the batch's txs.
  - `blockpersister/streaming_process_subtree.go`: per-subtree arena around `ProcessSubtreeUTXOStreaming`'s decode loop.
  - `asset/repository/GetLegacyBlock.go`: per-block arena around the streaming-reconstruction loop, with `arena.Reset()` between successful `tx.WriteTo` calls — peak bounded by the largest single tx, not the cumulative block size.
- Hashing migrated to `tx.HashTxIDInto` (reusable scratch buffer) in the bulk-stream sites — eliminates the `tx.Bytes()` per-call allocation that contributed 524 MB to the original heap profile.
- Single-tx call sites that retain `*bt.Tx` past the function frame (`subtreevalidation.readTxFromReader`, `legacy/netsync/handle_block.go` coinbase decode, `legacy/netsync/manager.go` inbound tx decode) intentionally stay on the standard `bt.NewTxFromBytes` / `tx.ReadFrom` path with an inline comment explaining why.

## Performance

`TestReadTransactionsFromSubtreeDataStream_MemoryBoundWithArena` (synthetic, `-short` skipped):

- Wire size: 97 MiB (1000 txs × 100 KB OP_RETURN each)
- Post-decode HeapInuse delta: **28 MiB** (held in arena slab + tx struct overhead)
- Without arena, the delta would scale 1:1 with wire size

Concrete heap-bound: `arena_pool` uses `ResetAndShrink(64 MiB)`. With up to 8 concurrent catch-up workers (per #911), idle pool baseline ≤ 512 MiB; peak ≤ N × max-subtree-script-bytes + struct overhead.

## Backwards compatibility

- `go-bt v2.6.4` is additive — no breaking changes for any consumer.
- Migrated functions in teranode: `processSubtreeDataStream` and `extractAndCollectTransactions` gained a `*bt.Arena` parameter; all internal callers updated. Test files pass `nil` to preserve the heap-allocating path.
- All public method signatures on `*Server` remain stable.

## Verification

- [x] `go vet ./...` on touched packages — clean
- [x] `go test -count=1 -tags testtxmetacache ./...` on touched packages — pass
- [x] `go test -count=1 -race -tags testtxmetacache ./services/subtreevalidation/... ./services/blockpersister/...` — pass
- [x] `TestArenaPool_GetPutLifecycle`, `TestArenaPool_ShrinkAfterLargeUse` — verify pool contract
- [x] `TestReadTransactionsFromSubtreeDataStream_MemoryBoundWithArena` — 28 MiB delta on 97 MiB stream
- [ ] Manual: deploy to `bsva-ovh-teranode-ttn-eu-3`, restart fresh, catch up past block ~5000, confirm RSS < 8 GiB sustained and `go-bt.(*Output).ReadFrom` no longer in heap top-10 inuse.

## Upstream

go-bt PR: bsv-blockchain/go-bt#146 (merged + released as v2.6.4)