### PR TITLE
fix(legacy/netsync): chunk SetMinedMulti in createUtxos (#936)

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -788,7 +788,7 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 		}
 
 		if err = mergeG.Wait(); err != nil {
-			return errors.NewProcessingError("failed to merge blockID into pre-existing txs", err)
+			return errors.NewProcessingError("failed to merge blockID into %d pre-existing txs", len(existingTxHashes), err)
 		}
 	}
 

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -738,15 +738,57 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 	// Merge our blockID into any tx that already existed. Without this, those txs
 	// keep their stale (or empty) BlockIDs and the next block's validOrderAndBlessed
 	// check fails in model/Block.go getParentTxMetaBlockIDs.
+	//
+	// Chunk the merge across a worker pool (#936). A single SetMinedMulti call with
+	// every existing tx in the block overruns the aerospike client connection pool
+	// on fat blocks (e.g. mainnet 755880 = 2.87M txs). Pattern mirrors
+	// stores/utxo/aerospike/longest_chain.go:MarkTransactionsOnLongestChain.
 	if len(existingTxHashes) > 0 {
 		sm.logger.Debugf("[createUtxos] merging blockID %d into %d pre-existing tx(s)", blockID, len(existingTxHashes))
-		if _, err = sm.utxoStore.SetMinedMulti(ctx, existingTxHashes, utxo.MinedBlockInfo{
+
+		batchSize := sm.settings.UtxoStore.MaxMinedBatchSize
+		if batchSize < 1 {
+			batchSize = 1
+		}
+		numChunks := (len(existingTxHashes) + batchSize - 1) / batchSize
+		numWorkers := min(sm.settings.UtxoStore.MaxMinedRoutines, numChunks)
+		if numWorkers < 1 {
+			numWorkers = 1
+		}
+
+		minedBlockInfo := utxo.MinedBlockInfo{
 			BlockID:        blockID,
 			BlockHeight:    blockHeightUint32,
 			SubtreeIdx:     0,
 			OnLongestChain: true,
-		}); err != nil {
-			return errors.NewProcessingError("failed to merge blockID into %d pre-existing txs", len(existingTxHashes), err)
+		}
+
+		rangeSize := (len(existingTxHashes) + numWorkers - 1) / numWorkers
+
+		mergeG, mergeCtx := errgroup.WithContext(ctx)
+
+		for w := 0; w < numWorkers && w*rangeSize < len(existingTxHashes); w++ {
+			workerStart := w * rangeSize
+			workerEnd := min(workerStart+rangeSize, len(existingTxHashes))
+			workerHashes := existingTxHashes[workerStart:workerEnd]
+
+			mergeG.Go(func() error {
+				for i := 0; i < len(workerHashes); i += batchSize {
+					if mergeCtx.Err() != nil {
+						return mergeCtx.Err()
+					}
+					chunkEnd := min(i+batchSize, len(workerHashes))
+					chunk := workerHashes[i:chunkEnd]
+					if _, err := sm.utxoStore.SetMinedMulti(mergeCtx, chunk, minedBlockInfo); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		}
+
+		if err = mergeG.Wait(); err != nil {
+			return errors.NewProcessingError("failed to merge blockID into pre-existing txs", err)
 		}
 	}
 

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -1151,21 +1151,24 @@ func TestSyncManager_createUtxos_MergesBlockIDsForExistingTxs(t *testing.T) {
 		"createUtxos must merge blockID %d into the pre-existing tx", expectedBlockID)
 }
 
-// TestSyncManager_createUtxos_ChunksExistingTxs verifies that when many pre-existing
-// transactions need their blockID merged, createUtxos splits the merge across multiple
-// SetMinedMulti calls bounded by MaxMinedBatchSize, instead of submitting a single
-// monolithic slice that exhausts the aerospike client connection pool. See issue #936.
-func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+// newChunkingTestSetup builds the boilerplate shared by the createUtxos chunking
+// tests: a SyncManager wired to a MockUtxostore that returns ErrTxExists for every
+// Create call (so every tx routes through the merge path), a populated txMap and
+// hashes slice, and a block at height 100. Callers wire up SetMinedMulti
+// expectations on the returned mock to drive the scenario under test.
+func newChunkingTestSetup(t *testing.T, totalTxs, batchSize, routines int) (
+	*SyncManager,
+	*txmap.SyncedMap[chainhash.Hash, *TxMapWrapper],
+	*bsvutil.Block,
+	*utxo.MockUtxostore,
+	[]chainhash.Hash,
+) {
+	t.Helper()
 
 	logger := ulogger.TestLogger{}
 	tSettings := test.CreateBaseTestSettings(t)
-
-	tSettings.UtxoStore.MaxMinedBatchSize = 4
-	tSettings.UtxoStore.MaxMinedRoutines = 2
-
-	const totalTxs = 10 // 2 workers × ceil(5/4) chunks each = 4 chunks of sizes (4, 1, 4, 1)
+	tSettings.UtxoStore.MaxMinedBatchSize = batchSize
+	tSettings.UtxoStore.MaxMinedRoutines = routines
 
 	mockStore := &utxo.MockUtxostore{}
 
@@ -1179,15 +1182,33 @@ func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
 		hashes[i] = *tx.TxIDChainHash()
 	}
 
+	// Every Create returns ErrTxExists so every hash flows into existingTxHashes
+	// and the merge path executes — that's what we're exercising.
 	mockStore.On("Create",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return((*meta.Data)(nil), errors.ErrTxExists)
 
-	var (
-		callMu      sync.Mutex
-		callChunks  [][]chainhash.Hash
-		emptyResult = map[chainhash.Hash][]uint32{}
-	)
+	sm := &SyncManager{
+		settings:  tSettings,
+		logger:    logger,
+		utxoStore: mockStore,
+	}
+
+	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](totalTxs)
+	for i, h := range hashes {
+		txMap.Set(h, &TxMapWrapper{Tx: txs[i]})
+	}
+
+	block := bsvutil.NewBlock(&wire.MsgBlock{Header: wire.BlockHeader{Version: 1}})
+	block.SetHeight(100)
+
+	return sm, txMap, block, mockStore, hashes
+}
+
+// recordChunksOnMock installs a SetMinedMulti expectation that records the hash
+// slice passed on every call into the supplied accumulator (caller owns the mutex).
+// Returns nil error for every call.
+func recordChunksOnMock(mockStore *utxo.MockUtxostore, callMu *sync.Mutex, callChunks *[][]chainhash.Hash) {
 	mockStore.On("SetMinedMulti",
 		mock.Anything, mock.Anything, mock.Anything,
 	).Run(func(args mock.Arguments) {
@@ -1197,23 +1218,43 @@ func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
 			copied[i] = *h
 		}
 		callMu.Lock()
-		callChunks = append(callChunks, copied)
+		*callChunks = append(*callChunks, copied)
 		callMu.Unlock()
-	}).Return(emptyResult, nil)
+	}).Return(map[chainhash.Hash][]uint32{}, nil)
+}
 
-	sm := &SyncManager{
-		settings:  tSettings,
-		logger:    logger,
-		utxoStore: mockStore,
+// assertUnionCovers asserts that the union of every recorded chunk exactly equals
+// the supplied hash set (no drops, no duplicates).
+func assertUnionCovers(t *testing.T, callChunks [][]chainhash.Hash, hashes []chainhash.Hash) {
+	t.Helper()
+	seen := make(map[chainhash.Hash]int, len(hashes))
+	for _, chunk := range callChunks {
+		for _, h := range chunk {
+			seen[h]++
+		}
 	}
-
-	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](totalTxs)
-	for i, h := range hashes {
-		txMap.Set(h, &TxMapWrapper{Tx: txs[i]})
+	require.Len(t, seen, len(hashes), "expected %d unique hashes across chunks, got %d", len(hashes), len(seen))
+	for _, h := range hashes {
+		require.Equalf(t, 1, seen[h], "hash %s missing or duplicated across chunks", h)
 	}
+}
 
-	block := bsvutil.NewBlock(&wire.MsgBlock{Header: wire.BlockHeader{Version: 1}})
-	block.SetHeight(100)
+// TestSyncManager_createUtxos_ChunksExistingTxs verifies that when many pre-existing
+// transactions need their blockID merged, createUtxos splits the merge across multiple
+// SetMinedMulti calls bounded by MaxMinedBatchSize, instead of submitting a single
+// monolithic slice that exhausts the aerospike client connection pool. See issue #936.
+func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const totalTxs = 10 // 2 workers × ceil(5/4) chunks each = 4 chunks of sizes (4, 1, 4, 1)
+	sm, txMap, block, mockStore, hashes := newChunkingTestSetup(t, totalTxs, 4, 2)
+
+	var (
+		callMu     sync.Mutex
+		callChunks [][]chainhash.Hash
+	)
+	recordChunksOnMock(mockStore, &callMu, &callChunks)
 
 	require.NoError(t, sm.createUtxos(ctx, txMap, block, 42))
 
@@ -1223,96 +1264,269 @@ func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
 
 	// Assert 2: every chunk respects MaxMinedBatchSize.
 	for i, chunk := range callChunks {
-		require.LessOrEqual(t, len(chunk), tSettings.UtxoStore.MaxMinedBatchSize,
-			"chunk %d size %d exceeds MaxMinedBatchSize=%d", i, len(chunk), tSettings.UtxoStore.MaxMinedBatchSize)
+		require.LessOrEqual(t, len(chunk), sm.settings.UtxoStore.MaxMinedBatchSize,
+			"chunk %d size %d exceeds MaxMinedBatchSize=%d", i, len(chunk), sm.settings.UtxoStore.MaxMinedBatchSize)
 	}
 
 	// Assert 3: union of all chunks equals the input set (no duplicates, no drops).
-	seen := make(map[chainhash.Hash]int, totalTxs)
-	for _, chunk := range callChunks {
-		for _, h := range chunk {
-			seen[h]++
-		}
-	}
-	require.Len(t, seen, totalTxs, "expected %d unique hashes across chunks, got %d", totalTxs, len(seen))
-	for _, h := range hashes {
-		require.Equalf(t, 1, seen[h], "hash %s missing or duplicated across chunks", h)
-	}
+	assertUnionCovers(t, callChunks, hashes)
 }
 
-// TestSyncManager_createUtxos_ChunkErrorPropagates verifies that a chunked
-// SetMinedMulti failure short-circuits sibling workers and propagates a wrapped
-// ProcessingError, instead of silently swallowing failures or completing remaining
-// chunks after a fatal store error.
-func TestSyncManager_createUtxos_ChunkErrorPropagates(t *testing.T) {
+// TestSyncManager_createUtxos_ChunkErrorReturnsWrappedProcessingError verifies that
+// a failing chunked SetMinedMulti causes createUtxos to return a wrapped
+// ProcessingError whose message carries the count of pre-existing txs that the
+// merge attempted to mark. Short-circuit semantics are covered separately by
+// TestSyncManager_createUtxos_ChunkFailureCancelsSiblings.
+func TestSyncManager_createUtxos_ChunkErrorReturnsWrappedProcessingError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := ulogger.TestLogger{}
-	tSettings := test.CreateBaseTestSettings(t)
-	tSettings.UtxoStore.MaxMinedBatchSize = 4
-	tSettings.UtxoStore.MaxMinedRoutines = 2
+	const totalTxs = 20
+	sm, txMap, block, mockStore, _ := newChunkingTestSetup(t, totalTxs, 4, 2)
 
-	const totalTxs = 20 // 2 workers × ceil(10/4) chunks each = 6 chunks of sizes (4, 4, 2, 4, 4, 2)
-
-	mockStore := &utxo.MockUtxostore{}
-
-	txs := make([]*bt.Tx, totalTxs)
-	hashes := make([]chainhash.Hash, totalTxs)
-	for i := 0; i < totalTxs; i++ {
-		tx := bt.NewTx()
-		tx.Version = 1
-		require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint64(2000+i)))
-		txs[i] = tx
-		hashes[i] = *tx.TxIDChainHash()
-	}
-
-	mockStore.On("Create",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return((*meta.Data)(nil), errors.ErrTxExists)
-
-	// Second SetMinedMulti call fails; remaining workers should short-circuit on
-	// gCtx.Err(). Track total call count so we can prove some were skipped.
-	var (
-		callMu    sync.Mutex
-		callCount int
-	)
+	// Every SetMinedMulti call fails. We only care that the error round-trips
+	// through createUtxos wrapped as a ProcessingError carrying the tx count.
 	mockStore.On("SetMinedMulti",
 		mock.Anything, mock.Anything, mock.Anything,
-	).Run(func(args mock.Arguments) {
-		callMu.Lock()
-		callCount++
-		callMu.Unlock()
-	}).Return(
+	).Return(
 		map[chainhash.Hash][]uint32{},
 		errors.NewStorageError("synthetic chunk failure"),
 	)
-
-	sm := &SyncManager{
-		settings:  tSettings,
-		logger:    logger,
-		utxoStore: mockStore,
-	}
-
-	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](totalTxs)
-	for i, h := range hashes {
-		txMap.Set(h, &TxMapWrapper{Tx: txs[i]})
-	}
-
-	block := bsvutil.NewBlock(&wire.MsgBlock{Header: wire.BlockHeader{Version: 1}})
-	block.SetHeight(100)
 
 	err := sm.createUtxos(ctx, txMap, block, 42)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to merge blockID into 20 pre-existing txs",
 		"expected wrapped ProcessingError, got: %v", err)
+}
 
-	// Expect strictly fewer than total chunks (6) to have executed — siblings short-circuited.
-	// Allow up to numWorkers (2) in-flight when the first failure lands, so finalCount <= 4.
-	callMu.Lock()
-	defer callMu.Unlock()
-	require.LessOrEqual(t, callCount, 4,
-		"expected siblings to short-circuit; observed %d/6 chunk calls", callCount)
+// TestSyncManager_createUtxos_ChunkFailureCancelsSiblings proves the mergeCtx.Err()
+// check at the top of each worker's inner loop actually does work: when one chunk
+// fails, errgroup cancels mergeCtx and any surviving sibling worker that is about
+// to enter its next iteration must observe the cancellation and return WITHOUT
+// issuing another SetMinedMulti call.
+//
+// Detecting the check requires careful orchestration. A naive "fail every call
+// after N" only observes 2 post-trigger calls (one per worker — each worker dies
+// on its own first error) and cannot distinguish a working check from a stripped
+// impl. Instead we synchronize the two workers so the failing call lands BEFORE
+// the surviving worker re-enters its loop:
+//
+//  1. totalTxs=16, batchSize=4, routines=2 → numChunks=4, numWorkers=2,
+//     rangeSize=8 — each worker iterates exactly twice (chunks of 4 + 4).
+//  2. Two `Once()` expectations make the first call (whichever worker arrives
+//     first) succeed, and the second call (the other worker's first iteration)
+//     BLOCK until the failure has been triggered, then succeed.
+//  3. A third `Once()` expectation makes the next call FAIL. By construction
+//     that's the originally-first worker's SECOND iteration. errgroup cancels
+//     mergeCtx; the originally-first worker returns the error.
+//  4. The blocked worker is then released and returns success from its first
+//     call. Its loop checks mergeCtx.Err() at the top of iteration 2. With the
+//     short-circuit: returns nil immediately, no further SetMinedMulti call.
+//     Without the short-circuit: it calls SetMinedMulti, hitting expectation 4
+//     (.Maybe) which bumps failureCount.
+//
+// Assertion: failureCount strictly equals 1 (only the triggering call). Removing
+// `if mergeCtx.Err() != nil { return mergeCtx.Err() }` from handle_block.go
+// causes the surviving worker to make its second call → failureCount == 2.
+func TestSyncManager_createUtxos_ChunkFailureCancelsSiblings(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const totalTxs = 16 // 2 workers × 2 chunks each = 4 chunks total
+	sm, txMap, block, mockStore, _ := newChunkingTestSetup(t, totalTxs, 4, 2)
+
+	var (
+		mu            sync.Mutex
+		successCount  int
+		failureCount  int
+		firstArrived  = make(chan struct{}) // closed when first call lands
+		failureLanded = make(chan struct{}) // closed when failing call has run
+	)
+
+	// Expectation 1: first SetMinedMulti call (either worker) returns success
+	// immediately. Signals that workers are running.
+	mockStore.On("SetMinedMulti",
+		mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		mu.Lock()
+		successCount++
+		mu.Unlock()
+		close(firstArrived)
+	}).Return(map[chainhash.Hash][]uint32{}, nil).Once()
+
+	// Expectation 2: second SetMinedMulti call (the other worker's first
+	// iteration) BLOCKS until (a) the failure has been triggered AND (b) the
+	// errgroup has actually cancelled mergeCtx. (a) alone is not enough — we
+	// could otherwise wake the surviving worker before errgroup observes the
+	// returned error and cancels its context, and the surviving worker's
+	// loop-top check would see an uncancelled context and continue. We use
+	// the SetMinedMulti ctx arg (which IS mergeCtx) and wait on its Done.
+	mockStore.On("SetMinedMulti",
+		mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		<-firstArrived
+		<-failureLanded
+		// Wait for the errgroup to propagate the cancellation that the
+		// failing call below will trigger when it returns its error.
+		mergeCtx := args.Get(0).(context.Context)
+		<-mergeCtx.Done()
+		mu.Lock()
+		successCount++
+		mu.Unlock()
+	}).Return(map[chainhash.Hash][]uint32{}, nil).Once()
+
+	// Expectation 3: third SetMinedMulti call FAILS. This is the originally-
+	// first worker's second iteration. The failure triggers errgroup
+	// cancellation. We close failureLanded so the blocked worker can proceed.
+	mockStore.On("SetMinedMulti",
+		mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		<-firstArrived
+		mu.Lock()
+		failureCount++
+		mu.Unlock()
+		close(failureLanded)
+	}).Return(
+		map[chainhash.Hash][]uint32{},
+		errors.NewStorageError("synthetic chunk failure"),
+	).Once()
+
+	// Expectation 4: catch-all for any further SetMinedMulti call. Should NOT
+	// fire when the short-circuit is in place. If it fires, failureCount jumps
+	// to 2 and the assertion fails.
+	mockStore.On("SetMinedMulti",
+		mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		mu.Lock()
+		failureCount++
+		mu.Unlock()
+	}).Return(
+		map[chainhash.Hash][]uint32{},
+		errors.NewStorageError("post short-circuit call (should not happen)"),
+	).Maybe()
+
+	err := sm.createUtxos(ctx, txMap, block, 42)
+	require.Error(t, err, "expected error to propagate from failing chunk")
+
+	mu.Lock()
+	finalFailures := failureCount
+	finalSuccesses := successCount
+	mu.Unlock()
+
+	require.Equal(t, 2, finalSuccesses,
+		"both workers must execute their first iteration successfully; got %d", finalSuccesses)
+	require.Equal(t, 1, finalFailures,
+		"expected mergeCtx short-circuit to suppress the surviving worker's second iteration; got %d failure call(s)", finalFailures)
+}
+
+// TestSyncManager_createUtxos_ExactBatchSize covers n == MaxMinedBatchSize.
+// With totalTxs=4 and batchSize=4: numChunks = ceil(4/4) = 1, numWorkers =
+// min(2, 1) = 1 — one worker performs one SetMinedMulti call of size 4.
+func TestSyncManager_createUtxos_ExactBatchSize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const totalTxs = 4
+	sm, txMap, block, mockStore, hashes := newChunkingTestSetup(t, totalTxs, 4, 2)
+
+	var (
+		callMu     sync.Mutex
+		callChunks [][]chainhash.Hash
+	)
+	recordChunksOnMock(mockStore, &callMu, &callChunks)
+
+	require.NoError(t, sm.createUtxos(ctx, txMap, block, 42))
+
+	require.Len(t, callChunks, 1, "expected exactly 1 chunk for n == batchSize")
+	require.Len(t, callChunks[0], totalTxs, "single chunk must cover all txs")
+	assertUnionCovers(t, callChunks, hashes)
+}
+
+// TestSyncManager_createUtxos_OneOverBatchSize covers n == MaxMinedBatchSize + 1,
+// the off-by-one boundary. With totalTxs=5 and batchSize=4: numChunks =
+// ceil(5/4) = 2, numWorkers = min(2, 2) = 2, rangeSize = ceil(5/2) = 3 — two
+// workers each emit a single chunk, sizes sum to 5. We don't pin the exact split
+// (3,2) so the test is not brittle to range-balancing refactors.
+func TestSyncManager_createUtxos_OneOverBatchSize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const totalTxs = 5
+	sm, txMap, block, mockStore, hashes := newChunkingTestSetup(t, totalTxs, 4, 2)
+
+	var (
+		callMu     sync.Mutex
+		callChunks [][]chainhash.Hash
+	)
+	recordChunksOnMock(mockStore, &callMu, &callChunks)
+
+	require.NoError(t, sm.createUtxos(ctx, txMap, block, 42))
+
+	require.Len(t, callChunks, 2, "expected 2 chunks for n == batchSize+1 with 2 workers")
+	for i, chunk := range callChunks {
+		require.LessOrEqual(t, len(chunk), sm.settings.UtxoStore.MaxMinedBatchSize,
+			"chunk %d size %d exceeds batchSize", i, len(chunk))
+	}
+	assertUnionCovers(t, callChunks, hashes)
+}
+
+// TestSyncManager_createUtxos_BatchSizeZeroClamped exercises the defensive clamp
+// at handle_block.go:749-752. A misconfigured MaxMinedBatchSize=0 must be
+// clamped to 1 — without the clamp the divide-by-zero in
+// (len + batchSize - 1) / batchSize would panic. With clamp: batchSize=1,
+// numChunks=3, numWorkers=min(2,3)=2.
+func TestSyncManager_createUtxos_BatchSizeZeroClamped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const totalTxs = 3
+	sm, txMap, block, mockStore, hashes := newChunkingTestSetup(t, totalTxs, 0, 2)
+
+	var (
+		callMu     sync.Mutex
+		callChunks [][]chainhash.Hash
+	)
+	recordChunksOnMock(mockStore, &callMu, &callChunks)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, sm.createUtxos(ctx, txMap, block, 42))
+	}, "batchSize=0 must be clamped to avoid divide-by-zero")
+
+	require.Len(t, callChunks, totalTxs, "with batchSize clamped to 1, expected one chunk per tx")
+	for i, chunk := range callChunks {
+		require.Len(t, chunk, 1, "chunk %d size: clamped batchSize=1 must produce chunks of size 1", i)
+	}
+	assertUnionCovers(t, callChunks, hashes)
+}
+
+// TestSyncManager_createUtxos_RoutinesZeroClamped exercises the defensive clamp
+// at handle_block.go:754-757. A misconfigured MaxMinedRoutines=0 must be clamped
+// to 1 — without the clamp, the for-loop guarded by `w < numWorkers` would never
+// execute and SetMinedMulti would never be called, silently dropping the merge.
+// With clamp: numWorkers=1, single worker emits ceil(10/4)=3 chunks.
+func TestSyncManager_createUtxos_RoutinesZeroClamped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const totalTxs = 10
+	sm, txMap, block, mockStore, hashes := newChunkingTestSetup(t, totalTxs, 4, 0)
+
+	var (
+		callMu     sync.Mutex
+		callChunks [][]chainhash.Hash
+	)
+	recordChunksOnMock(mockStore, &callMu, &callChunks)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, sm.createUtxos(ctx, txMap, block, 42))
+	}, "numRoutines=0 must be clamped so the merge actually runs")
+
+	require.Len(t, callChunks, 3, "with routines clamped to 1, expected 3 chunks (ceil(10/4))")
+	for i, chunk := range callChunks {
+		require.LessOrEqual(t, len(chunk), sm.settings.UtxoStore.MaxMinedBatchSize,
+			"chunk %d size %d exceeds batchSize", i, len(chunk))
+	}
+	assertUnionCovers(t, callChunks, hashes)
 }
 
 func TestSyncManager_quickValidationAllowed(t *testing.T) {

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -1299,124 +1299,89 @@ func TestSyncManager_createUtxos_ChunkErrorReturnsWrappedProcessingError(t *test
 		"expected wrapped ProcessingError, got: %v", err)
 }
 
-// TestSyncManager_createUtxos_ChunkFailureCancelsSiblings proves the mergeCtx.Err()
-// check at the top of each worker's inner loop actually does work: when one chunk
-// fails, errgroup cancels mergeCtx and any surviving sibling worker that is about
-// to enter its next iteration must observe the cancellation and return WITHOUT
-// issuing another SetMinedMulti call.
+// TestSyncManager_createUtxos_ChunkFailureCancelsSiblings proves the
+// `if mergeCtx.Err() != nil { return mergeCtx.Err() }` short-circuit at the top
+// of each worker's inner loop actually suppresses sibling iterations after a
+// chunk fails.
 //
-// Detecting the check requires careful orchestration. A naive "fail every call
-// after N" only observes 2 post-trigger calls (one per worker — each worker dies
-// on its own first error) and cannot distinguish a working check from a stripped
-// impl. Instead we synchronize the two workers so the failing call lands BEFORE
-// the surviving worker re-enters its loop:
+// Why this design (vs orchestrating worker identity): worker A vs worker B
+// identity at runtime is not predictable from the input hash array — the
+// `existingTxHashes` slice is appended by parallel Create() goroutines in
+// arbitrary scheduler order, so subsequent worker ranges are scheduler-derived.
+// We avoid that by not trying to pin which worker calls which expectation.
 //
-//  1. totalTxs=16, batchSize=4, routines=2 → numChunks=4, numWorkers=2,
-//     rangeSize=8 — each worker iterates exactly twice (chunks of 4 + 4).
-//  2. Two `Once()` expectations make the first call (whichever worker arrives
-//     first) succeed, and the second call (the other worker's first iteration)
-//     BLOCK until the failure has been triggered, then succeed.
-//  3. A third `Once()` expectation makes the next call FAIL. By construction
-//     that's the originally-first worker's SECOND iteration. errgroup cancels
-//     mergeCtx; the originally-first worker returns the error.
-//  4. The blocked worker is then released and returns success from its first
-//     call. Its loop checks mergeCtx.Err() at the top of iteration 2. With the
-//     short-circuit: returns nil immediately, no further SetMinedMulti call.
-//     Without the short-circuit: it calls SetMinedMulti, hitting expectation 4
-//     (.Maybe) which bumps failureCount.
+// Instead: pick a worker/chunk topology where the surviving worker has many
+// remaining iterations after the trigger, so the mutation's effect dominates
+// any in-flight noise.
 //
-// Assertion: failureCount strictly equals 1 (only the triggering call). Removing
-// `if mergeCtx.Err() != nil { return mergeCtx.Err() }` from handle_block.go
-// causes the surviving worker to make its second call → failureCount == 2.
+//	totalTxs=32, batchSize=4, routines=2 → 8 chunks, 4 per worker.
+//	exp1 .Times(2) — first 2 calls succeed.
+//	exp2 .Once()   — 3rd call fails, cancels mergeCtx.
+//	exp3 .Maybe()  — catch-all, increments postTriggerCount.
+//
+// Across every interleaving the surviving worker has at least 3 remaining
+// iterations after the trigger:
+//   - W_A blasts iter1+iter2 success, iter3 fails → W_B has all 4 iters remaining.
+//   - W_A.iter1 + W_B.iter1 → W_A.iter2 fails → W_B has 3 iters remaining.
+//   - W_B.iter1 + W_B.iter2 → W_B.iter3 fails → W_A has all 4 iters remaining.
+//
+// With the check intact, the surviving worker's for-loop top observes the
+// cancelled mergeCtx on every remaining iteration and bails without a Called.
+// Post-trigger count = 0 normally, or 1 if the sibling's next call was already
+// in flight when cancellation propagated.
+//
+// With the check removed, the surviving worker calls SetMinedMulti for each
+// remaining iteration → exp3 fires ≥ 2 times → postTriggerCount ≥ 2.
+//
+// Assertion: postTriggerCount ≤ 1. Mutation produces 2-4 across interleavings,
+// so the bound reliably distinguishes the two cases.
 func TestSyncManager_createUtxos_ChunkFailureCancelsSiblings(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	const totalTxs = 16 // 2 workers × 2 chunks each = 4 chunks total
+	const totalTxs = 32 // 2 workers × 4 chunks each = 8 chunks total
 	sm, txMap, block, mockStore, _ := newChunkingTestSetup(t, totalTxs, 4, 2)
 
 	var (
-		mu            sync.Mutex
-		successCount  int
-		failureCount  int
-		firstArrived  = make(chan struct{}) // closed when first call lands
-		failureLanded = make(chan struct{}) // closed when failing call has run
+		postTriggerMu    sync.Mutex
+		postTriggerCount int
 	)
 
-	// Expectation 1: first SetMinedMulti call (either worker) returns success
-	// immediately. Signals that workers are running.
 	mockStore.On("SetMinedMulti",
 		mock.Anything, mock.Anything, mock.Anything,
-	).Run(func(args mock.Arguments) {
-		mu.Lock()
-		successCount++
-		mu.Unlock()
-		close(firstArrived)
-	}).Return(map[chainhash.Hash][]uint32{}, nil).Once()
+	).Return(map[chainhash.Hash][]uint32{}, nil).Times(2)
 
-	// Expectation 2: second SetMinedMulti call (the other worker's first
-	// iteration) BLOCKS until (a) the failure has been triggered AND (b) the
-	// errgroup has actually cancelled mergeCtx. (a) alone is not enough — we
-	// could otherwise wake the surviving worker before errgroup observes the
-	// returned error and cancels its context, and the surviving worker's
-	// loop-top check would see an uncancelled context and continue. We use
-	// the SetMinedMulti ctx arg (which IS mergeCtx) and wait on its Done.
 	mockStore.On("SetMinedMulti",
 		mock.Anything, mock.Anything, mock.Anything,
-	).Run(func(args mock.Arguments) {
-		<-firstArrived
-		<-failureLanded
-		// Wait for the errgroup to propagate the cancellation that the
-		// failing call below will trigger when it returns its error.
-		mergeCtx := args.Get(0).(context.Context)
-		<-mergeCtx.Done()
-		mu.Lock()
-		successCount++
-		mu.Unlock()
-	}).Return(map[chainhash.Hash][]uint32{}, nil).Once()
-
-	// Expectation 3: third SetMinedMulti call FAILS. This is the originally-
-	// first worker's second iteration. The failure triggers errgroup
-	// cancellation. We close failureLanded so the blocked worker can proceed.
-	mockStore.On("SetMinedMulti",
-		mock.Anything, mock.Anything, mock.Anything,
-	).Run(func(args mock.Arguments) {
-		<-firstArrived
-		mu.Lock()
-		failureCount++
-		mu.Unlock()
-		close(failureLanded)
-	}).Return(
+	).Return(
 		map[chainhash.Hash][]uint32{},
 		errors.NewStorageError("synthetic chunk failure"),
 	).Once()
 
-	// Expectation 4: catch-all for any further SetMinedMulti call. Should NOT
-	// fire when the short-circuit is in place. If it fires, failureCount jumps
-	// to 2 and the assertion fails.
+	// Catch-all returns nil so the surviving worker keeps iterating under
+	// mutation — if it returned an error, the worker would bail on its first
+	// post-trigger call (postTriggerCount=1) and the mutation would slip past
+	// the `<= 1` assertion. With nil returns, the surviving worker drains all
+	// its remaining iterations and postTriggerCount ≥ 3.
 	mockStore.On("SetMinedMulti",
 		mock.Anything, mock.Anything, mock.Anything,
 	).Run(func(args mock.Arguments) {
-		mu.Lock()
-		failureCount++
-		mu.Unlock()
-	}).Return(
-		map[chainhash.Hash][]uint32{},
-		errors.NewStorageError("post short-circuit call (should not happen)"),
-	).Maybe()
+		postTriggerMu.Lock()
+		postTriggerCount++
+		postTriggerMu.Unlock()
+	}).Return(map[chainhash.Hash][]uint32{}, nil).Maybe()
 
 	err := sm.createUtxos(ctx, txMap, block, 42)
 	require.Error(t, err, "expected error to propagate from failing chunk")
 
-	mu.Lock()
-	finalFailures := failureCount
-	finalSuccesses := successCount
-	mu.Unlock()
+	postTriggerMu.Lock()
+	finalCount := postTriggerCount
+	postTriggerMu.Unlock()
 
-	require.Equal(t, 2, finalSuccesses,
-		"both workers must execute their first iteration successfully; got %d", finalSuccesses)
-	require.Equal(t, 1, finalFailures,
-		"expected mergeCtx short-circuit to suppress the surviving worker's second iteration; got %d failure call(s)", finalFailures)
+	require.LessOrEqual(t, finalCount, 1,
+		"mergeCtx short-circuit should suppress sibling iterations after a chunk fails; "+
+			"observed %d post-trigger call(s). Removing the short-circuit produces ≥ 2.",
+		finalCount)
 }
 
 // TestSyncManager_createUtxos_ExactBatchSize covers n == MaxMinedBatchSize.

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -1162,16 +1162,13 @@ func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
 	logger := ulogger.TestLogger{}
 	tSettings := test.CreateBaseTestSettings(t)
 
-	// Force small chunks so the test is cheap but still exercises the >1 chunk path.
 	tSettings.UtxoStore.MaxMinedBatchSize = 4
 	tSettings.UtxoStore.MaxMinedRoutines = 2
 
-	const totalTxs = 10 // 10 / 4 = 3 chunks (4, 4, 2)
+	const totalTxs = 10 // 2 workers × ceil(5/4) chunks each = 4 chunks of sizes (4, 1, 4, 1)
 
 	mockStore := &utxo.MockUtxostore{}
 
-	// Build N distinct synthetic txs. They never need to be valid on-chain — Create
-	// returns ErrTxExists immediately so we never inspect them.
 	txs := make([]*bt.Tx, totalTxs)
 	hashes := make([]chainhash.Hash, totalTxs)
 	for i := 0; i < totalTxs; i++ {
@@ -1182,12 +1179,10 @@ func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
 		hashes[i] = *tx.TxIDChainHash()
 	}
 
-	// Every Create returns ErrTxExists, forcing all txs into the existing path.
 	mockStore.On("Create",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return((*meta.Data)(nil), errors.ErrTxExists)
 
-	// Capture every chunk passed to SetMinedMulti.
 	var (
 		callMu      sync.Mutex
 		callChunks  [][]chainhash.Hash
@@ -1309,7 +1304,7 @@ func TestSyncManager_createUtxos_ChunkErrorPropagates(t *testing.T) {
 
 	err := sm.createUtxos(ctx, txMap, block, 42)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to merge blockID into pre-existing txs",
+	require.Contains(t, err.Error(), "failed to merge blockID into 20 pre-existing txs",
 		"expected wrapped ProcessingError, got: %v", err)
 
 	// Expect strictly fewer than total chunks (5) to have executed — siblings short-circuited.

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/legacy/testdata"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/nullstore"
@@ -1148,6 +1149,175 @@ func TestSyncManager_createUtxos_MergesBlockIDsForExistingTxs(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, post.BlockIDs, expectedBlockID,
 		"createUtxos must merge blockID %d into the pre-existing tx", expectedBlockID)
+}
+
+// TestSyncManager_createUtxos_ChunksExistingTxs verifies that when many pre-existing
+// transactions need their blockID merged, createUtxos splits the merge across multiple
+// SetMinedMulti calls bounded by MaxMinedBatchSize, instead of submitting a single
+// monolithic slice that exhausts the aerospike client connection pool. See issue #936.
+func TestSyncManager_createUtxos_ChunksExistingTxs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	// Force small chunks so the test is cheap but still exercises the >1 chunk path.
+	tSettings.UtxoStore.MaxMinedBatchSize = 4
+	tSettings.UtxoStore.MaxMinedRoutines = 2
+
+	const totalTxs = 10 // 10 / 4 = 3 chunks (4, 4, 2)
+
+	mockStore := &utxo.MockUtxostore{}
+
+	// Build N distinct synthetic txs. They never need to be valid on-chain — Create
+	// returns ErrTxExists immediately so we never inspect them.
+	txs := make([]*bt.Tx, totalTxs)
+	hashes := make([]chainhash.Hash, totalTxs)
+	for i := 0; i < totalTxs; i++ {
+		tx := bt.NewTx()
+		tx.Version = 1
+		require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint64(1000+i)))
+		txs[i] = tx
+		hashes[i] = *tx.TxIDChainHash()
+	}
+
+	// Every Create returns ErrTxExists, forcing all txs into the existing path.
+	mockStore.On("Create",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return((*meta.Data)(nil), errors.ErrTxExists)
+
+	// Capture every chunk passed to SetMinedMulti.
+	var (
+		callMu      sync.Mutex
+		callChunks  [][]chainhash.Hash
+		emptyResult = map[chainhash.Hash][]uint32{}
+	)
+	mockStore.On("SetMinedMulti",
+		mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		chunk := args.Get(1).([]*chainhash.Hash)
+		copied := make([]chainhash.Hash, len(chunk))
+		for i, h := range chunk {
+			copied[i] = *h
+		}
+		callMu.Lock()
+		callChunks = append(callChunks, copied)
+		callMu.Unlock()
+	}).Return(emptyResult, nil)
+
+	sm := &SyncManager{
+		settings:  tSettings,
+		logger:    logger,
+		utxoStore: mockStore,
+	}
+
+	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](totalTxs)
+	for i, h := range hashes {
+		txMap.Set(h, &TxMapWrapper{Tx: txs[i]})
+	}
+
+	block := bsvutil.NewBlock(&wire.MsgBlock{Header: wire.BlockHeader{Version: 1}})
+	block.SetHeight(100)
+
+	require.NoError(t, sm.createUtxos(ctx, txMap, block, 42))
+
+	// Assert 1: at least 2 calls (proves chunking happens).
+	require.GreaterOrEqual(t, len(callChunks), 2,
+		"expected multiple SetMinedMulti calls; got %d (monolithic call regression)", len(callChunks))
+
+	// Assert 2: every chunk respects MaxMinedBatchSize.
+	for i, chunk := range callChunks {
+		require.LessOrEqual(t, len(chunk), tSettings.UtxoStore.MaxMinedBatchSize,
+			"chunk %d size %d exceeds MaxMinedBatchSize=%d", i, len(chunk), tSettings.UtxoStore.MaxMinedBatchSize)
+	}
+
+	// Assert 3: union of all chunks equals the input set (no duplicates, no drops).
+	seen := make(map[chainhash.Hash]int, totalTxs)
+	for _, chunk := range callChunks {
+		for _, h := range chunk {
+			seen[h]++
+		}
+	}
+	require.Len(t, seen, totalTxs, "expected %d unique hashes across chunks, got %d", totalTxs, len(seen))
+	for _, h := range hashes {
+		require.Equalf(t, 1, seen[h], "hash %s missing or duplicated across chunks", h)
+	}
+}
+
+// TestSyncManager_createUtxos_ChunkErrorPropagates verifies that a chunked
+// SetMinedMulti failure short-circuits sibling workers and propagates a wrapped
+// ProcessingError, instead of silently swallowing failures or completing remaining
+// chunks after a fatal store error.
+func TestSyncManager_createUtxos_ChunkErrorPropagates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.UtxoStore.MaxMinedBatchSize = 4
+	tSettings.UtxoStore.MaxMinedRoutines = 2
+
+	const totalTxs = 20 // 20 / 4 = 5 chunks — plenty of room for short-circuit
+
+	mockStore := &utxo.MockUtxostore{}
+
+	txs := make([]*bt.Tx, totalTxs)
+	hashes := make([]chainhash.Hash, totalTxs)
+	for i := 0; i < totalTxs; i++ {
+		tx := bt.NewTx()
+		tx.Version = 1
+		require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", uint64(2000+i)))
+		txs[i] = tx
+		hashes[i] = *tx.TxIDChainHash()
+	}
+
+	mockStore.On("Create",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return((*meta.Data)(nil), errors.ErrTxExists)
+
+	// Second SetMinedMulti call fails; remaining workers should short-circuit on
+	// gCtx.Err(). Track total call count so we can prove some were skipped.
+	var (
+		callMu    sync.Mutex
+		callCount int
+	)
+	mockStore.On("SetMinedMulti",
+		mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		callMu.Lock()
+		callCount++
+		callMu.Unlock()
+	}).Return(
+		map[chainhash.Hash][]uint32{},
+		errors.NewStorageError("synthetic chunk failure"),
+	)
+
+	sm := &SyncManager{
+		settings:  tSettings,
+		logger:    logger,
+		utxoStore: mockStore,
+	}
+
+	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](totalTxs)
+	for i, h := range hashes {
+		txMap.Set(h, &TxMapWrapper{Tx: txs[i]})
+	}
+
+	block := bsvutil.NewBlock(&wire.MsgBlock{Header: wire.BlockHeader{Version: 1}})
+	block.SetHeight(100)
+
+	err := sm.createUtxos(ctx, txMap, block, 42)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to merge blockID into pre-existing txs",
+		"expected wrapped ProcessingError, got: %v", err)
+
+	// Expect strictly fewer than total chunks (5) to have executed — siblings short-circuited.
+	// Allow up to numWorkers (2) in-flight when the first failure lands, so finalCount <= 4.
+	callMu.Lock()
+	defer callMu.Unlock()
+	require.LessOrEqual(t, callCount, 4,
+		"expected siblings to short-circuit; observed %d/%d chunk calls", callCount, 5)
 }
 
 func TestSyncManager_quickValidationAllowed(t *testing.T) {

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -1253,7 +1253,7 @@ func TestSyncManager_createUtxos_ChunkErrorPropagates(t *testing.T) {
 	tSettings.UtxoStore.MaxMinedBatchSize = 4
 	tSettings.UtxoStore.MaxMinedRoutines = 2
 
-	const totalTxs = 20 // 20 / 4 = 5 chunks — plenty of room for short-circuit
+	const totalTxs = 20 // 2 workers × ceil(10/4) chunks each = 6 chunks of sizes (4, 4, 2, 4, 4, 2)
 
 	mockStore := &utxo.MockUtxostore{}
 
@@ -1307,12 +1307,12 @@ func TestSyncManager_createUtxos_ChunkErrorPropagates(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to merge blockID into 20 pre-existing txs",
 		"expected wrapped ProcessingError, got: %v", err)
 
-	// Expect strictly fewer than total chunks (5) to have executed — siblings short-circuited.
+	// Expect strictly fewer than total chunks (6) to have executed — siblings short-circuited.
 	// Allow up to numWorkers (2) in-flight when the first failure lands, so finalCount <= 4.
 	callMu.Lock()
 	defer callMu.Unlock()
 	require.LessOrEqual(t, callCount, 4,
-		"expected siblings to short-circuit; observed %d/%d chunk calls", callCount, 5)
+		"expected siblings to short-circuit; observed %d/6 chunk calls", callCount)
 }
 
 func TestSyncManager_quickValidationAllowed(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace the unbounded `SetMinedMulti` call at the tail of `createUtxos` with a caller-side worker pool: divide `existingTxHashes` into `UtxoStore.MaxMinedRoutines` ranges, each worker iterates its range in `UtxoStore.MaxMinedBatchSize` chunks. Pattern mirrors `stores/utxo/aerospike/longest_chain.go:MarkTransactionsOnLongestChain`.
- Fail-fast `errgroup.WithContext` semantics — matches the existing `Create()` loop already in `createUtxos`. First chunk failure cancels siblings via `gCtx`; wrapped `ProcessingError` propagated up.
- Regression introduced by #854 (`fix(legacy): merge blockID into pre-existing tx in createUtxos`) which moved the per-block merge into the synchronous critical path without chunking. On block 755880 (2.87M txs, almost all pre-existing via propagation) the monolithic 2.87M-record `BatchOperate` exhausts the aerospike client connection pool (`ConnectionQueueSize=16` on `.docker.m`), hits `MAX_RETRIES_EXCEEDED` / `NETWORK_ERROR` / `connection reset by peer`, and stalls mainnet sync in an infinite retry loop.

Fixes #936.

## Test plan

- [x] `go test -race ./services/legacy/netsync/...` passes (88/88).
- [x] `go vet ./services/legacy/netsync/...` clean.
- [x] `golangci-lint run ./services/legacy/netsync/...` clean.
- [x] New `TestSyncManager_createUtxos_ChunksExistingTxs` asserts call count, per-chunk size bound, and union coverage with `MaxMinedBatchSize=4` / `MaxMinedRoutines=2` / 10 txs.
- [x] New `TestSyncManager_createUtxos_ChunkErrorPropagates` asserts wrapped `ProcessingError` and sibling short-circuit on first chunk failure.
- [x] Pre-existing sqlitememory-backed `TestSyncManager_createUtxos_MergesBlockIDsForExistingTxs` left untouched and still green (1-tx case flows through new path as 1 worker × 1 chunk).
- [x] Resume mainnet sync on `bsva-ovh-teranode-eu-3` at block 755880; expect `[createUtxos] merging blockID … into 2867287 pre-existing tx(s)` followed by completion within the existing `HandleBlockDirect` deadline (post-merge field validation).