### PR TITLE
fix(stores/utxo/aerospike): align frozen UTXO checks with SQL and bitcoin-sv

### DIFF
--- a/stores/utxo/aerospike/metrics.go
+++ b/stores/utxo/aerospike/metrics.go
@@ -69,10 +69,12 @@ var (
 	prometheusUtxoMapDelete prometheus.Counter
 	prometheusUtxoMapErrors *prometheus.CounterVec
 
-	prometheusUtxoCreateBatch     prometheus.Histogram
-	prometheusUtxoCreateBatchSize prometheus.Histogram
-	prometheusUtxoSpendBatch      prometheus.Histogram
-	prometheusUtxoSpendBatchSize  prometheus.Histogram
+	prometheusUtxoCreateBatch              prometheus.Histogram
+	prometheusUtxoCreateBatchSize          prometheus.Histogram
+	prometheusUtxoSpendBatch               prometheus.Histogram
+	prometheusUtxoSpendBatchSize           prometheus.Histogram
+	prometheusUtxoSpendExpressionLuaRetry  prometheus.Counter
+	prometheusUtxoSpendExpressionLuaRetryN prometheus.Counter
 
 	prometheusTxMetaAerospikeMapGet                   prometheus.Counter
 	prometheusUtxostoreCreate                         prometheus.Counter
@@ -296,6 +298,24 @@ func _initPrometheusMetrics() {
 			Name:      "utxo_spend_batch_size",
 			Help:      "Size of utxo spend batch",
 			Buckets:   util.MetricsBucketsSizeSmall,
+		},
+	)
+
+	prometheusUtxoSpendExpressionLuaRetry = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "aerospike",
+			Name:      "utxo_spend_expression_lua_retry",
+			Help:      "Number of expression spend batches that triggered a retry through Lua because at least one record was filtered out (typically by the conservative utxoSpendableIn guard).",
+		},
+	)
+
+	prometheusUtxoSpendExpressionLuaRetryN = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "aerospike",
+			Name:      "utxo_spend_expression_lua_retry_records",
+			Help:      "Number of individual records re-dispatched through Lua after being FILTERED_OUT by the expression path.",
 		},
 	)
 

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -520,6 +520,19 @@ func (s *Store) sendSpendBatchLua(batch []*batchSpend) {
 		return
 	}
 
+	s.executeLuaSpendBatch(batch)
+}
+
+// executeLuaSpendBatch runs the Lua UDF spend pipeline for the provided batch. It is the
+// shared backend used by sendSpendBatchLua's Lua route and by the expression path's
+// retry-through-Lua handler. Callers MUST have already run any duplicate-claim
+// filtering, since this method does not re-run it and assumes every item still expects
+// exactly one response on its errCh.
+func (s *Store) executeLuaSpendBatch(batch []*batchSpend) {
+	if len(batch) == 0 {
+		return
+	}
+
 	start := time.Now()
 	stat := gocore.NewStat("sendSpendBatchLua")
 
@@ -536,7 +549,6 @@ func (s *Store) sendSpendBatchLua(batch []*batchSpend) {
 	batchID := s.batchID.Add(1)
 	s.logSpendBatchStart(batchID, len(batch))
 
-	// Prepare and execute batch
 	batchesByKey, err := s.prepareSpendBatches(batch, batchID)
 	if err != nil {
 		return
@@ -548,7 +560,6 @@ func (s *Store) sendSpendBatchLua(batch []*batchSpend) {
 		return
 	}
 
-	// Process results
 	s.processSpendBatchResults(ctx, batchRecords, batchRecordKeys, batchesByKey, batch, batchID)
 	stat.NewStat("postBatchOperate").AddTime(start)
 }

--- a/stores/utxo/aerospike/spend_expressions.go
+++ b/stores/utxo/aerospike/spend_expressions.go
@@ -167,12 +167,17 @@ func (s *Store) buildSpendFilterExpression(
 		),
 	)
 
-	// Check spendableIn for this specific offset
-	// Note: Aerospike expressions have limited map access capabilities.
-	// We check if the spendableIn bin exists but cannot easily check specific map values.
-	// The actual spendableIn validation will be done at the Lua level or by reading the map.
-	// For the expression-based approach, we accept that this check is less strict than Lua.
-	// Alternative: Skip the operation if spendableIn exists (conservative approach)
+	// Conservative guard: filter out any record that has UtxoSpendableIn set.
+	//
+	// Aerospike filter expressions cannot inspect specific map values, so we cannot
+	// compare currentBlockHeight against spendableIn[offset] here — only check
+	// whether the map exists at all. This is strictly stricter than the SQL store
+	// and the Lua UDF, both of which compare per-offset.
+	//
+	// The guard stays in place as defense-in-depth: a record that needs the
+	// per-offset comparison must never reach ListSetOp through the expression
+	// path. Filter-outs caused by this guard are retried through the Lua UDF in
+	// processSpendBatchResultsExpressions, which evaluates the boundary correctly.
 	filterConditions = append(filterConditions,
 		aerospike.ExpNot(aerospike.ExpBinExists(fields.UtxoSpendableIn.String())),
 	)
@@ -341,6 +346,14 @@ func (s *Store) SpendMultiWithExpressions(ctx context.Context, batch []*batchSpe
 }
 
 // processSpendBatchResultsExpressions processes the results from expression-based spend operations.
+//
+// FILTERED_OUT records are not failed in place. The expression filter contains a
+// conservative guard that rejects every record with UtxoSpendableIn set, regardless
+// of the per-offset spendable-height value. SQL and the Lua UDF compare per-offset
+// (the freeze window is closed at start, open at stop), so the expression path is
+// strictly stricter and would otherwise reject valid spends. To restore parity we
+// collect FILTERED_OUT records and re-issue them through the Lua UDF, which can
+// inspect the map value and apply the correct boundary check.
 func (s *Store) processSpendBatchResultsExpressions(
 	ctx context.Context,
 	batchRecords []aerospike.BatchRecordIfc,
@@ -363,6 +376,10 @@ func (s *Store) processSpendBatchResultsExpressions(
 		DAH  uint32
 	}, 0)
 
+	// Records filtered out by the expression — retried through Lua before sending
+	// any response on their errCh, so each caller still sees exactly one result.
+	var retryThroughLua []*batchSpend
+
 	for idx, batchRecord := range batchRecords {
 		bItem, ok := spendIndex[idx]
 		if !ok {
@@ -382,10 +399,13 @@ func (s *Store) processSpendBatchResultsExpressions(
 				}
 
 				if aErr.ResultCode == types.FILTERED_OUT {
-					// Spend was filtered out - could be already spent, conflicting, locked, etc.
-					// Return a generic error since we can't distinguish the exact reason
-					bItem.errCh <- errors.NewUtxoError("spend validation failed for %s:%d", bItem.spend.TxID.String(), bItem.spend.Vout)
-					errCount++
+					// The expression can't disambiguate which filter clause rejected
+					// the record. Retry every FILTERED_OUT through Lua so spends
+					// blocked solely by the conservative UtxoSpendableIn guard get
+					// a correct decision, while genuine rejections (already-spent,
+					// conflicting, locked, frozen-until-X) still surface the right
+					// classified error from the Lua UDF.
+					retryThroughLua = append(retryThroughLua, bItem)
 					continue
 				}
 			}
@@ -488,7 +508,15 @@ func (s *Store) processSpendBatchResultsExpressions(
 	}
 
 	if s.settings.UtxoStore.VerboseDebug {
-		s.logger.Debugf("[SPEND_BATCH_EXP] batch %d of %d spends completed in %v (ok=%d, err=%d)",
-			batchID, len(spendIndex), time.Since(start), okCount, errCount)
+		s.logger.Debugf("[SPEND_BATCH_EXP] batch %d of %d spends (ok=%d, err=%d, lua_retry=%d) completed in %v",
+			batchID, len(spendIndex), okCount, errCount, len(retryThroughLua), time.Since(start))
+	}
+
+	// Dispatch FILTERED_OUT records to the Lua UDF for a correct decision. The Lua
+	// path checks UtxoSpendableIn per-offset and returns the precise rejection
+	// reason for records that genuinely cannot be spent. Each item still has a
+	// pending errCh receive — Lua sends exactly one response on it.
+	if len(retryThroughLua) > 0 {
+		s.executeLuaSpendBatch(retryThroughLua)
 	}
 }

--- a/stores/utxo/aerospike/spend_expressions.go
+++ b/stores/utxo/aerospike/spend_expressions.go
@@ -516,7 +516,14 @@ func (s *Store) processSpendBatchResultsExpressions(
 	// path checks UtxoSpendableIn per-offset and returns the precise rejection
 	// reason for records that genuinely cannot be spent. Each item still has a
 	// pending errCh receive — Lua sends exactly one response on it.
+	//
+	// This is a single additional batched Lua call per expression batch — its
+	// cost is independent of how many records were filtered out, but it is only
+	// paid when at least one record needed re-evaluation.
 	if len(retryThroughLua) > 0 {
+		prometheusUtxoSpendExpressionLuaRetry.Inc()
+		prometheusUtxoSpendExpressionLuaRetryN.Add(float64(len(retryThroughLua)))
+
 		s.executeLuaSpendBatch(retryThroughLua)
 	}
 }

--- a/stores/utxo/aerospike/spend_spendable_in_boundary_test.go
+++ b/stores/utxo/aerospike/spend_spendable_in_boundary_test.go
@@ -1,0 +1,211 @@
+package aerospike_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/settings"
+	teranode_aerospike "github.com/bsv-blockchain/teranode/stores/utxo/aerospike"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/uaerospike"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStore_SpendableInBoundary verifies the freeze-window boundary across the
+// Aerospike Lua and expression spend paths.
+//
+// Reference behaviour: the freeze window is closed at start, open at stop —
+// i.e. a UTXO becomes spendable AT spendableHeight. The SQL store enforces this
+// with `item.blockHeight < *r.spendableIn` (strict <), and svnode's
+// CFrozenTXOCheck enforces `nHeight < i.stop`.
+//
+// Pre-fix:
+//   - Lua used `>=` (off-by-one — rejected at the boundary).
+//   - Expression rejected ANY record with utxoSpendableIn set (over-strict).
+//
+// Post-fix:
+//   - Lua uses `>` (matches SQL/svnode).
+//   - Expression keeps the conservative bin-exists guard for safety, but the
+//     result handler retries FILTERED_OUT records through Lua so the boundary
+//     check is applied correctly.
+func TestStore_SpendableInBoundary(t *testing.T) {
+	cases := []struct {
+		name              string
+		enableExpressions bool
+	}{
+		{name: "lua", enableExpressions: false},
+		{name: "expressions", enableExpressions: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger := ulogger.NewErrorTestLogger(t)
+			tSettings := test.CreateBaseTestSettings(t)
+			tSettings.UtxoStore.UtxoBatchSize = 1
+			tSettings.UtxoStore.SpendBatcherSize = 1
+			tSettings.UtxoStore.SpendBatcherDurationMillis = 5
+			tSettings.UtxoStore.SpendWaitTimeout = 10 * time.Second
+			tSettings.Aerospike.EnableSpendFilterExpressions = c.enableExpressions
+
+			client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+			t.Cleanup(deferFn)
+
+			const spendableHeight uint32 = 200
+
+			boundary := []struct {
+				name             string
+				currentHeight    uint32
+				wantSpendSuccess bool
+			}{
+				{name: "below_boundary_rejects", currentHeight: spendableHeight - 1, wantSpendSuccess: false},
+				{name: "at_boundary_accepts", currentHeight: spendableHeight, wantSpendSuccess: true},
+				{name: "above_boundary_accepts", currentHeight: spendableHeight + 1, wantSpendSuccess: true},
+			}
+
+			for _, tc := range boundary {
+				t.Run(tc.name, func(t *testing.T) {
+					cleanDB(t, client)
+
+					_, err := store.Create(ctx, tx, 101)
+					require.NoError(t, err)
+
+					injectSpendableIn(t, client, tSettings, store, 0, spendableHeight)
+
+					spends, err := store.Spend(ctx, spendTx, tc.currentHeight)
+					if tc.wantSpendSuccess {
+						require.NoError(t, err)
+						require.Len(t, spends, 1)
+						require.NoError(t, spends[0].Err)
+						return
+					}
+
+					require.Error(t, err)
+					require.Len(t, spends, 1)
+					require.Error(t, spends[0].Err)
+					require.ErrorIs(t, spends[0].Err, errors.ErrFrozen,
+						"expected ErrFrozen at currentHeight=%d (spendableHeight=%d)", tc.currentHeight, spendableHeight)
+				})
+			}
+		})
+	}
+}
+
+// TestStore_SpendableInExpressionParity_PastValueAccepted exercises the property
+// called out in the issue's acceptance criteria: a record with utxoSpendableIn
+// set whose values are all past must be spendable through BOTH Aerospike paths.
+//
+// Pre-fix the expression path would reject this spend (it cannot inspect map
+// values, only the bin's existence). Post-fix the FILTERED_OUT result is
+// retried through Lua, which compares per-offset and accepts the spend.
+func TestStore_SpendableInExpressionParity_PastValueAccepted(t *testing.T) {
+	cases := []struct {
+		name              string
+		enableExpressions bool
+	}{
+		{name: "lua", enableExpressions: false},
+		{name: "expressions", enableExpressions: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger := ulogger.NewErrorTestLogger(t)
+			tSettings := test.CreateBaseTestSettings(t)
+			tSettings.UtxoStore.UtxoBatchSize = 1
+			tSettings.UtxoStore.SpendBatcherSize = 1
+			tSettings.UtxoStore.SpendBatcherDurationMillis = 5
+			tSettings.UtxoStore.SpendWaitTimeout = 10 * time.Second
+			tSettings.Aerospike.EnableSpendFilterExpressions = c.enableExpressions
+
+			client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+			t.Cleanup(deferFn)
+
+			cleanDB(t, client)
+
+			_, err := store.Create(ctx, tx, 101)
+			require.NoError(t, err)
+
+			// spendableHeight far in the past — currentHeight (300) is well above.
+			injectSpendableIn(t, client, tSettings, store, 0, 50)
+
+			spends, err := store.Spend(ctx, spendTx, 300)
+			require.NoError(t, err, "spend at currentHeight=300 with spendableHeight=50 must succeed on both paths")
+			require.Len(t, spends, 1)
+			require.NoError(t, spends[0].Err)
+		})
+	}
+}
+
+// TestStore_SpendableInExpressionParity_FutureValueRejected confirms the safety
+// property the conservative guard enforces: a record with utxoSpendableIn[offset]
+// strictly greater than currentBlockHeight must NEVER be spent through either
+// path. After the T25 retry, the expression path still rejects (via Lua) with
+// ErrFrozen, matching SQL and svnode behaviour.
+func TestStore_SpendableInExpressionParity_FutureValueRejected(t *testing.T) {
+	cases := []struct {
+		name              string
+		enableExpressions bool
+	}{
+		{name: "lua", enableExpressions: false},
+		{name: "expressions", enableExpressions: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger := ulogger.NewErrorTestLogger(t)
+			tSettings := test.CreateBaseTestSettings(t)
+			tSettings.UtxoStore.UtxoBatchSize = 1
+			tSettings.UtxoStore.SpendBatcherSize = 1
+			tSettings.UtxoStore.SpendBatcherDurationMillis = 5
+			tSettings.UtxoStore.SpendWaitTimeout = 10 * time.Second
+			tSettings.Aerospike.EnableSpendFilterExpressions = c.enableExpressions
+
+			client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+			t.Cleanup(deferFn)
+
+			cleanDB(t, client)
+
+			_, err := store.Create(ctx, tx, 101)
+			require.NoError(t, err)
+
+			injectSpendableIn(t, client, tSettings, store, 0, 500)
+
+			spends, err := store.Spend(ctx, spendTx, 100)
+			require.Error(t, err, "spend at currentHeight=100 with spendableHeight=500 must fail on both paths")
+			require.Len(t, spends, 1)
+			require.Error(t, spends[0].Err)
+			require.ErrorIs(t, spends[0].Err, errors.ErrFrozen)
+		})
+	}
+}
+
+// injectSpendableIn writes a single-offset utxoSpendableIn map onto the
+// Aerospike record that holds the UTXO at the package-level test tx's given
+// vout. It uses UPDATE so the rest of the record created by store.Create stays
+// intact.
+func injectSpendableIn(t *testing.T, client *uaerospike.Client, tSettings *settings.Settings, store *teranode_aerospike.Store, vout uint32, spendableHeight uint32) {
+	t.Helper()
+
+	batchSize := store.GetUtxoBatchSize()
+	keySource := uaerospike.CalculateKeySource(tx.TxIDChainHash(), vout, batchSize)
+	key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), keySource)
+	require.NoError(t, err)
+
+	// Offset within the per-batch record. For utxoBatchSize=1 this is always 0.
+	offset := int(vout % uint32(batchSize)) // nolint:gosec
+
+	writePolicy := util.GetAerospikeWritePolicy(tSettings, 0)
+	writePolicy.RecordExistsAction = aerospike.UPDATE
+
+	bins := aerospike.BinMap{
+		fields.UtxoSpendableIn.String(): map[any]any{
+			offset: int(spendableHeight),
+		},
+	}
+	err = client.Put(writePolicy, key, bins)
+	require.NoError(t, err)
+}

--- a/stores/utxo/aerospike/teranode.lua
+++ b/stores/utxo/aerospike/teranode.lua
@@ -370,7 +370,7 @@ function spendMulti(rec, spends, ignoreConflicting, ignoreLocked, currentBlockHe
 
         if spendableIn then
             local spendableHeight = spendableIn[offset]
-            if spendableHeight and spendableHeight >= currentBlockHeight then
+            if spendableHeight and spendableHeight > currentBlockHeight then
                 local error = map()
 
                 error[FIELD_ERROR_CODE] = ERROR_CODE_FROZEN_UNTIL


### PR DESCRIPTION
## Summary

The Aerospike UTXO store's two spend paths (Lua and expression-based) diverged from the SQL store and bitcoin-sv at the freeze-expiry boundary. An Aerospike-backed node was strictly stricter than the rest of the network: it refused to mine or accept transactions that SQL/svnode considered valid.

Reference behaviour comes from svnode's `CFrozenTXOCheck` (`bitcoin-sv/src/frozentxo_db.h`): `enforceAtHeight` intervals are evaluated half-open with `nHeight < i.stop` — the freeze window is closed at start, open at stop. A UTXO becomes spendable AT `stop`.

Two related fixes ship together so all three storage paths (SQL, Aerospike Lua, Aerospike expression) make identical accept/reject decisions.

## Fix 1 — Aerospike Lua boundary off-by-one (T5a)

`stores/utxo/aerospike/teranode.lua:373` used `>=` which kept the UTXO frozen at `currentBlockHeight == spendableIn`. The SQL store uses strict `<` in all three call sites (`sql.go:2071, 2557, 3346`). Flipped to `>` so the UTXO becomes spendable AT `spendableIn`, matching SQL/svnode.

## Fix 2 — Aerospike expression-path strictness (T25)

`stores/utxo/aerospike/spend_expressions.go` rejected ANY record with `utxoSpendableIn` set, regardless of the per-offset value, because Aerospike filter expressions cannot inspect map values — only check bin existence.

Picked Option B2a from the issue (over-retry through Lua):

- Kept the conservative `ExpNot(ExpBinExists(UtxoSpendableIn))` guard as defense in depth — a record needing per-offset comparison must never reach `ListSetOp` through the expression path.
- Added retry-through-Lua: `processSpendBatchResultsExpressions` now collects `FILTERED_OUT` records and re-dispatches them via a **single batched Lua call**, which compares per-offset and produces the correct accept/reject decision with the precise rejection reason (`ErrFrozen`, `ErrSpent`, `ErrTxConflicting`, etc.) — rather than the previous generic "spend validation failed".
- Extracted the Lua execution from `sendSpendBatchLua` into `executeLuaSpendBatch` so both the primary Lua route and the expression retry share the same implementation.

**Cost:** one additional batched Lua call per expression batch that has *any* `FILTERED_OUT` records. The cost is independent of how many records were filtered out — they all go through in the same batch — and is only paid when at least one record needed re-evaluation. In steady state most spends pass the expression filter, so this is paid only on already-failing records. The conservative guard means the safety property holds even if the retry logic has a bug.

## Observability

Two new Prometheus counters give operators visibility into how often the expression path is falling back to Lua — the only quantitative signal that the conservative `utxoSpendableIn` guard is hot:

- `teranode_aerospike_utxo_spend_expression_lua_retry` — counter incremented per expression batch that triggered a retry (rate divided by `utxo_spend_batch` gives the batch-level retry fraction).
- `teranode_aerospike_utxo_spend_expression_lua_retry_records` — counter incremented per record re-dispatched through Lua (rate divided by `utxo_spend` gives the per-record retry fraction).

## Test plan

New tests in `stores/utxo/aerospike/spend_spendable_in_boundary_test.go`, all run against a real Aerospike container via testcontainers-go:

- [x] `TestStore_SpendableInBoundary` — boundary at `spendableHeight - 1` (reject), `== spendableHeight` (accept after fix), `+ 1` (accept). Runs against both Lua and expression paths.
- [x] `TestStore_SpendableInExpressionParity_PastValueAccepted` — record with `utxoSpendableIn` set to a long-past value is spendable through both paths.
- [x] `TestStore_SpendableInExpressionParity_FutureValueRejected` — record with `utxoSpendableIn` strictly in the future is rejected through both paths with `ErrFrozen` (the safety property the guard enforces).
- [x] Full `go test ./stores/utxo/aerospike/...` suite passes (178s with containers).
- [x] No regression in `go test ./stores/utxo/sql/...`.
- [x] No regression in `go test -tags testtxmetacache ./services/validator/...`.

## Acceptance criteria (from bitcoin-sv/teranode#4640)

- [x] At `blockHeight == spendableIn`, all three store paths accept the spend.
- [x] At `blockHeight == spendableIn - 1`, all three reject.
- [x] A record with `UtxoSpendableIn` set whose values are all past is spendable through both Aerospike paths.
- [x] The Aerospike expression path never spends a record whose `UtxoSpendableIn` map contains a value `> currentBlockHeight` for the output being spent.
- [x] No regression in SQL or validator tests.

Closes bitcoin-sv/teranode#4640