### PR TITLE
perf(validator): skip BDK script validation for trusted legacy IBD blocks

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -880,6 +880,12 @@ func (sm *SyncManager) PreValidateTransactions(ctx context.Context, txMap *txmap
 					validator.WithSkipPolicyChecks(true),
 					validator.WithSkipTxMetaPublishing(true),
 					validator.WithCreateConflicting(true),
+					// PreValidateTransactions is only reached via the quickValidationMode
+					// path (see prepareSubtrees → ValidateTransactionsLegacyMode), which
+					// runs only when the block height is at or below the highest
+					// hard-coded checkpoint. PoW + checkpoint linkage establish the chain
+					// as canonical, so re-running BDK scripts is pure overhead.
+					validator.WithSkipScriptValidation(true),
 				); validateErr != nil {
 					// ErrTxConflicting is expected during legacy catchup when the UTXO store
 					// has stale spending data. The block is confirmed, so its transactions

--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -151,6 +151,14 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 		}
 	}
 
+	// Legacy catchup below the highest hard-coded checkpoint sets this: PoW +
+	// checkpoint linkage already establish the chain as canonical, so re-running
+	// scripts is pure overhead. The caller is responsible for ensuring the block
+	// is actually trusted (see SyncManager.quickValidationAllowed).
+	if validationOptions.SkipScriptValidation {
+		return nil
+	}
+
 	// SkipPolicyChecks is equivalent to BDK consensus=true.
 	// https://github.com/bsv-blockchain/teranode/issues/2367
 	return tv.bdk.ValidateTransaction(tx, blockHeight, validationOptions.SkipPolicyChecks, utxoHeights)

--- a/services/validator/TxValidator_test.go
+++ b/services/validator/TxValidator_test.go
@@ -119,6 +119,20 @@ func TestTxValidatorCallsBDKValidationOnceInValidateTransaction(t *testing.T) {
 	assert.Equal(t, []uint32{99, 99}, counter.utxoHeights)
 }
 
+func TestTxValidatorSkipsBDKWhenSkipScriptValidationSet(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	counter := &countingBDKValidator{}
+	txValidator := &TxValidator{
+		logger:   ulogger.TestLogger{},
+		settings: tSettings,
+		bdk:      counter,
+	}
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	require.NoError(t, txValidator.ValidateTransaction(aTx, 100, []uint32{99, 99}, validationOptions))
+	assert.Equal(t, 0, counter.calls, "BDK ValidateTransaction must not be called when SkipScriptValidation is set")
+}
+
 // policy settings tests
 func TestMaxTxSizePolicy(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)

--- a/services/validator/options.go
+++ b/services/validator/options.go
@@ -51,6 +51,14 @@ type Options struct {
 	// When true, the validator won't publish transaction metadata to the txmeta Kafka topic
 	// Used during legacy catchup (quickValidationMode) where no consumer needs the data
 	SkipTxMetaPublishing bool
+
+	// SkipScriptValidation determines whether BDK transaction/script validation should be skipped.
+	// When true, the validator skips the BDK ValidateTransaction call (script execution,
+	// sigops, standardness, consensus checks). Intended for legacy catchup
+	// (quickValidationMode) where the block is anchored to a hard-coded checkpoint and
+	// PoW + checkpoint linkage already establish the chain as canonical — re-running
+	// scripts is pure overhead. MUST NOT be set on non-trusted validation paths.
+	SkipScriptValidation bool
 }
 
 // Option defines a function type for setting options
@@ -169,6 +177,14 @@ func WithIgnoreLocked(ignoreLocked bool) Option {
 func WithSkipTxMetaPublishing(skip bool) Option {
 	return func(o *Options) {
 		o.SkipTxMetaPublishing = skip
+	}
+}
+
+// WithSkipScriptValidation creates an option to skip the BDK transaction/script
+// validation step. See Options.SkipScriptValidation for safety constraints.
+func WithSkipScriptValidation(skip bool) Option {
+	return func(o *Options) {
+		o.SkipScriptValidation = skip
 	}
 }
 

--- a/services/validator/options_test.go
+++ b/services/validator/options_test.go
@@ -170,3 +170,29 @@ func TestWithCreateConflicting(t *testing.T) {
 		})
 	}
 }
+
+func TestWithSkipScriptValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		skip     bool
+		expected bool
+	}{
+		{"Skip script validation", true, true},
+		{"Don't skip script validation", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ProcessOptions(WithSkipScriptValidation(tt.skip))
+			if opts.SkipScriptValidation != tt.expected {
+				t.Errorf("SkipScriptValidation = %v, want %v", opts.SkipScriptValidation, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSkipScriptValidationDefault(t *testing.T) {
+	if NewDefaultOptions().SkipScriptValidation {
+		t.Error("Default SkipScriptValidation should be false")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an `Options.SkipScriptValidation` flag and `WithSkipScriptValidation` constructor in `services/validator/options.go`.
- In `TxValidator.ValidateTransaction`, returns immediately before calling the BDK adapter when the flag is set.
- Wires `validator.WithSkipScriptValidation(true)` into the per-tx `Validate` call inside `PreValidateTransactions` (`services/legacy/netsync/handle_block.go`).

## Motivation
`PreValidateTransactions` is only ever reached via the `quickValidationMode` path (`prepareSubtrees` → `ValidateTransactionsLegacyMode`), and that path only runs when the block height is at or below the highest hard-coded checkpoint for the active network (`quickValidationAllowed`). PoW plus checkpoint linkage already establish the chain as canonical, so re-running BDK transaction validation (script execution, sigops, standardness, consensus checks) is pure overhead.

CPU profiling of mainnet IBD showed `gobdk.TxValidator.ValidateTransaction` (the cgo call) accounting for ~22% of teranode's CPU, even though the surrounding code path already trusts the chain via the checkpoint mechanism. This change eliminates that work on the trusted path.

## Safety
- The non-quickValidationMode pre-warm path (`validateTransactions`) deliberately does **not** set the new flag.
- `SkipScriptValidation` is documented as MUST NOT be used on non-trusted paths, and the call-site comment explains why the legacy IBD path can safely set it.
- BIP68 sequence-lock checks in `Validator.validateTransaction` are unaffected — they are gated separately on `SkipPolicyChecks` and CSV activation height (CSV is post-checkpoint on mainnet).

## Test plan
- [x] `go test ./services/validator/... ./services/legacy/netsync/...` — 461 tests pass
- [x] `go vet ./services/validator/... ./services/legacy/netsync/...` — no issues
- [x] New unit tests:
  - `TestWithSkipScriptValidation` — option setter round-trip
  - `TestSkipScriptValidationDefault` — default is false
  - `TestTxValidatorSkipsBDKWhenSkipScriptValidationSet` — counting bdk validator confirms the BDK adapter is not invoked when the flag is set
- [ ] Manual: observe mainnet legacy IBD throughput before/after on a checkpoint-anchored range (e.g. height < 250000)