### PR TITLE
fix(legacy/netsync): auto-detect v2 txmeta wire format

### DIFF
--- a/docs/references/kafkaMessageFormat.md
+++ b/docs/references/kafkaMessageFormat.md
@@ -63,16 +63,15 @@ This document provides comprehensive information about the message formats used 
     - [Error Cases](#error-cases)
 - [Transaction Metadata Message Format](#transaction-metadata-message-format)
     - [TxMeta Topic](#txmeta-topic)
-    - [Message Structure](#message-structure)
-    - [Field Specifications](#field-specifications)
-        - [txHash](#txhash)
-        - [action](#action)
-        - [content](#content)
-    - [Transaction Metadata](#transaction-metadata)
-    - [Example](#example)
+    - [Wire Format](#wire-format)
+        - [v1 (legacy)](#v1-legacy)
+        - [v2 (partition-aware)](#v2-partition-aware)
+    - [Wire-Format Detection (Receiver Side)](#wire-format-detection-receiver-side)
+    - [Action Values](#action-values)
+    - [Content Payload](#content-payload)
     - [Code Examples](#code-examples)
-        - [Sending Messages](#sending-messages)
-        - [Receiving Messages](#receiving-messages)
+        - [Producing Messages](#producing-messages)
+        - [Consuming Messages](#consuming-messages)
     - [Error Cases](#error-cases)
 - [Rejected Transaction Message Format](#rejected-transaction-message-format)
     - [Rejected Transaction Topic](#rejected-transaction-topic)
@@ -750,178 +749,137 @@ func handleTxValidationMessage(msg *kafka.Message) error {
 
 `kafka_txmetaConfig` is the Kafka topic used for broadcasting transaction metadata for validated transactions. This topic allows the Validator to either add new transaction metadata or request deletion of previously shared metadata.
 
-### Message Structure
+Unlike the other Teranode Kafka topics, the txmeta topic does **not** use protobuf. Each Kafka record carries a custom, length-prefixed binary batch of many entries so the producer can amortise the per-record overhead at high transaction rates (the throughput target is well into the millions of transactions per second). The wire-format constants are defined once in [`stores/txmetacache/wire.go`](../../stores/txmetacache/wire.go) and imported by the producer (`services/validator`) and every consumer (`services/subtreevalidation`, `services/legacy/netsync`).
 
-The transaction metadata message is defined in protobuf as `KafkaTxMetaTopicMessage`:
+### Wire Format
 
-```protobuf
-enum KafkaTxMetaActionType {
-  ADD = 0;    // Add or update transaction metadata
-  DELETE = 1; // Delete transaction metadata
-}
+Two batch formats coexist on the topic, distinguished at the receiver by a multi-byte signature at the start of the record. The producer chooses the format based on the `validator_txmeta_wireFormat` setting (`v1` by default; `v2` for partition-aligned writes).
 
-message KafkaTxMetaTopicMessage {
-  string txHash = 1;                // Transaction hash (as hex string)
-  KafkaTxMetaActionType action = 2; // Action type (add or delete)
-  bytes content = 3;                // Serialized transaction metadata (only used for ADD)
-}
+#### v1 (legacy)
+
+```text
++--------+-------+--------+----------+---------+
+| count  | hash  | action | contLen  | content |
+| u32 LE | 32 B  | 1 B    | u32 LE   | N B     |
++--------+-------+--------+----------+---------+
+\__hdr__/ \________ per-entry ___________ ... /
 ```
 
-### Field Specifications
+Header (4 bytes): little-endian `uint32` entry count.
+Per entry: 32-byte tx hash · 1-byte action · 4-byte LE content length · `contLen` bytes content (0 bytes for `DELETE`).
 
-#### txHash
+#### v2 (partition-aware)
 
-- Type: string
-- Description: Hexadecimal string representation of the transaction hash
-- Required: Yes
+```text
++-------+--------+----------+--------+--------+-------+--------+---------+---------+
+| magic | versn  | reserved | count  | xxhash | hash  | action | contLen | content |
+| 0xFF  | 0x02   | 2 B = 0  | u32 LE | u64 LE | 32 B  | 1 B    | u32 LE  | N B     |
++-------+--------+----------+--------+--------+-------+--------+---------+---------+
+\__________________ 8-byte header _______________/  \________ per-entry ____________ ... /
+```
 
-#### action
+v2 adds an 8-byte fixed-prefix header followed by entries that carry the pre-computed `xxhash(tx hash)` on the wire. Receivers can use the wire-side xxhash to skip rehashing for cache writes; partition routing is also aligned with the xxhash so that per-partition consumer goroutines touch disjoint cache buckets.
 
-- Type: KafkaTxMetaActionType (enum)
-- Description: Specifies whether to add/update metadata (ADD) or delete metadata (DELETE)
-- Required: Yes
-- Values:
+### Wire-Format Detection (Receiver Side)
 
-    - ADD (0): Add or update transaction metadata
-    - DELETE (1): Delete transaction metadata
+A receiver cannot rely on the magic byte alone: a v1 message with entry count `255`, `511`, `767`, ... has a little-endian low byte of `0xFF`, identical to the v2 magic byte. For count `767` the first four bytes of the v1 message are exactly `[0xFF, 0x02, 0x00, 0x00]`, aliasing the full v2 header signature.
 
-#### content
+To avoid misclassifying these v1 messages, every consumer follows the same detection rule:
 
-- Type: bytes
-- Description: Serialized transaction metadata
-- Required: Only when action is ADD; should be empty when action is DELETE
-- Content: Serialized transaction metadata that includes transaction details, transaction input outpoints (TxInpoints), block IDs, fees, and other relevant information
+1. Verify all four header bytes: `data[0] == 0xFF`, `data[1] == 0x02`, `data[2] == 0`, `data[3] == 0`.
+2. Read the candidate v2 entry count from `data[4:8]`.
+3. Check plausibility: `candidateCount * minV2EntrySize ≤ len(data) - 8` (where `minV2EntrySize = 45` bytes = xxhash + hash + action + contentLen).
+4. **Only if all three pass**, parse as v2.
+5. **Otherwise**, fall through to v1 parsing — the message is *never* dropped just because its first byte happens to be `0xFF`.
 
-### Transaction Metadata
+A symmetric plausibility check on the v1 path (`entries * minV1EntrySize ≤ len(data) - 4`, where `minV1EntrySize = 37`) bounds the receiver's pool-buffer allocation against a malformed wire-side count.
 
-The content field contains serialized transaction metadata, which typically includes:
+### Action Values
 
-- Complete transaction content
-- Transaction input outpoints (TxInpoints) - containing parent transaction hashes and output indices
-- Block heights where the transaction appears
-- Transaction fee
+The 1-byte action enum is defined in `stores/txmetacache/wire.go`:
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `WireActionADD` | `0x00` | Add or replace cached metadata for the given tx hash. `content` carries the serialized `meta.Data`. |
+| `WireActionDELETE` | `0x01` | Remove the entry for the given tx hash from the cache. `contLen` is `0` and no content follows. |
+
+### Content Payload
+
+For `ADD` entries, `content` is the serialized `meta.Data` for the transaction — produced by `(*meta.Data).MetaBytes()` and parsed by `meta.NewMetaDataFromBytes`. It includes:
+
+- Complete transaction bytes (extended format)
+- Transaction input outpoints (parent tx hashes + output indices)
+- Block IDs the transaction has been mined into
+- Transaction fee (satoshis)
 - Size in bytes
-- Flags (e.g., whether it's a coinbase transaction)
+- Coinbase flag
 - Lock time
-
-### Example
-
-Here's a JSON representation of an ADD message (for illustration purposes only; actual messages are protobuf-encoded):
-
-```json
-{
-  "txHash": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
-  "action": 0,  // ADD
-  "content": "<binary data - serialized transaction metadata>"
-}
-```
-
-Here's a JSON representation of a DELETE message:
-
-```json
-{
-  "txHash": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
-  "action": 1,  // DELETE
-  "content": ""  // Empty for DELETE operations
-}
-```
 
 ### Code Examples
 
-#### Sending Messages
+#### Producing Messages
+
+The producer is `services/validator/Validator.go` — see `serializeTxMetaBatch` (v1) and `serializeTxMetaBatchV2` (v2). The wire-format constants come from the shared package:
 
 ```go
-// Example 1: Send ADD transaction metadata message
-txHash := tx.TxID().String() // returns hex string representation
-metadataContent := serializeMetadata(metadata) // serialize transaction metadata
+import "github.com/bsv-blockchain/teranode/stores/txmetacache"
 
-// Create a new protobuf message for adding metadata
-addMessage := &kafkamessage.KafkaTxMetaTopicMessage{
-    TxHash: txHash,
-    Action: kafkamessage.KafkaTxMetaActionType_ADD,
-    Content: metadataContent,
+// v1 entry: hash, action, content length, content
+buf := make([]byte, 4)
+binary.LittleEndian.PutUint32(buf, uint32(len(entries)))
+for _, e := range entries {
+    buf = append(buf, e.hash[:]...)
+    if e.isDelete {
+        buf = append(buf, txmetacache.WireActionDELETE, 0, 0, 0, 0)
+    } else {
+        buf = append(buf, txmetacache.WireActionADD)
+        lenBuf := make([]byte, 4)
+        binary.LittleEndian.PutUint32(lenBuf, uint32(len(e.metaBytes)))
+        buf = append(buf, lenBuf...)
+        buf = append(buf, e.metaBytes...)
+    }
 }
-
-// Serialize to protobuf format
-addData, err := proto.Marshal(addMessage)
-if err != nil {
-    return fmt.Errorf("failed to serialize ADD metadata message: %w", err)
-}
-
-// Send to Kafka
-producer.Publish(&kafka.Message{
-    Value: addData,
-})
-
-// Example 2: Send DELETE transaction metadata message
-txHash := tx.TxID().String() // returns hex string representation
-
-// Create a new protobuf message for deleting metadata
-deleteMessage := &kafkamessage.KafkaTxMetaTopicMessage{
-    TxHash: txHash,
-    Action: kafkamessage.KafkaTxMetaActionType_DELETE,
-    // Content is empty for DELETE operations
-}
-
-// Serialize to protobuf format
-deleteData, err := proto.Marshal(deleteMessage)
-if err != nil {
-    return fmt.Errorf("failed to serialize DELETE metadata message: %w", err)
-}
-
-// Send to Kafka
-producer.Publish(&kafka.Message{
-    Value: deleteData,
-})
 ```
 
-#### Receiving Messages
+#### Consuming Messages
+
+Receivers detect the format and dispatch accordingly. See `services/subtreevalidation/txmetaHandler.go` and `services/legacy/netsync/manager.go` for the canonical implementations:
 
 ```go
-// Handle incoming transaction metadata message
-func handleTxMetaMessage(msg *kafka.Message) error {
-    if msg == nil {
-        return nil
-    }
+import "github.com/bsv-blockchain/teranode/stores/txmetacache"
 
-    // Deserialize from protobuf format
-    txMetaMessage := &kafkamessage.KafkaTxMetaTopicMessage{}
-    if err := proto.Unmarshal(msg.Value, txMetaMessage); err != nil {
-        return fmt.Errorf("failed to deserialize transaction metadata message: %w", err)
-    }
+// Speculative v2 detection — full signature + entry-count plausibility.
+isV2 := false
+var entries uint32
+var offset int
 
-    // Extract transaction hash
-    txHashStr := txMetaMessage.TxHash
-
-    // Convert hex string to chainhash.Hash
-    txHash, err := chainhash.NewHashFromStr(txHashStr)
-    if err != nil {
-        return fmt.Errorf("invalid transaction hash: %w", err)
-    }
-
-    // Process based on action type
-    switch txMetaMessage.Action {
-    case kafkamessage.KafkaTxMetaActionType_ADD:
-        // Handle ADD operation
-        metadata := deserializeMetadata(txMetaMessage.Content)
-        return handleAddMetadata(txHash, metadata)
-
-    case kafkamessage.KafkaTxMetaActionType_DELETE:
-        // Handle DELETE operation
-        return handleDeleteMetadata(txHash)
-
-    default:
-        return fmt.Errorf("unknown action type: %d", txMetaMessage.Action)
+if len(data) >= txmetacache.WireV2HeaderLen &&
+    data[0] == txmetacache.WireV2Magic &&
+    data[1] == txmetacache.WireV2Version &&
+    data[2] == 0 && data[3] == 0 {
+    candidate := binary.LittleEndian.Uint32(data[4:])
+    remaining := uint64(len(data) - txmetacache.WireV2HeaderLen)
+    if uint64(candidate)*uint64(txmetacache.WireV2MinEntrySize) <= remaining {
+        entries, offset, isV2 = candidate, txmetacache.WireV2HeaderLen, true
     }
 }
+
+if !isV2 {
+    entries = binary.LittleEndian.Uint32(data[:4])
+    offset = 4
+}
+
+// ... iterate entries, reading [xxhash (v2 only)][hash][action][contLen][content]
 ```
 
 ### Error Cases
 
-- Invalid message format: Message cannot be unmarshaled to KafkaTxMetaTopicMessage
-- Empty or invalid transaction hash: Hash is not a valid hexadecimal string
-- Unknown action type: Action is not a recognized KafkaTxMetaActionType enum value
-- Missing content for ADD: Content field is empty when Action is ADD
+- **Truncated header**: buffer shorter than the minimum header (4 bytes for v1, 8 bytes for v2). Logged + acked.
+- **Truncated entry**: per-entry header or content runs off the end of the buffer. Logged + acked at the truncation point; preceding entries are still processed.
+- **Implausible entry count**: wire-side count exceeds what the buffer can hold at the minimum entry size. Logged + acked; nothing is dispatched. Protects the pool buffer from oversized pre-allocation.
+- **Unknown action byte** (not `0x00` or `0x01`): the entry is logged and skipped; remaining entries continue to be processed.
+
+In all of the above the message is acknowledged (`return nil`) rather than re-delivered — a single corrupt message must not stall the topic.
 
 ---
 

--- a/services/legacy/netsync/kafka_txmeta_test.go
+++ b/services/legacy/netsync/kafka_txmeta_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bsv-blockchain/go-batcher/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/txmetacache"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func buildTXmetaBatchMessage(t *testing.T, entries []txmetaTestEntry) []byte {
 		// 1-byte action
 		buf = append(buf, entry.action)
 
-		if entry.action == txmetaActionADD {
+		if entry.action == txmetacache.WireActionADD {
 			metaBytes, err := entry.meta.MetaBytes()
 			require.NoError(t, err)
 
@@ -63,8 +64,8 @@ func buildTXmetaBatchMessageV2(t *testing.T, entries []txmetaTestEntry) []byte {
 	t.Helper()
 
 	buf := make([]byte, 8)
-	buf[0] = txmetaWireV2Magic
-	buf[1] = txmetaWireV2Version
+	buf[0] = txmetacache.WireV2Magic
+	buf[1] = txmetacache.WireV2Version
 	// buf[2:4] reserved (zeros)
 	binary.LittleEndian.PutUint32(buf[4:], uint32(len(entries)))
 
@@ -78,7 +79,7 @@ func buildTXmetaBatchMessageV2(t *testing.T, entries []txmetaTestEntry) []byte {
 		// 1-byte action
 		buf = append(buf, entry.action)
 
-		if entry.action == txmetaActionADD {
+		if entry.action == txmetacache.WireActionADD {
 			metaBytes, err := entry.meta.MetaBytes()
 			require.NoError(t, err)
 
@@ -118,7 +119,7 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
 			{
 				hash:   *coinbaseHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         0,
 					SizeInBytes: 100,
@@ -127,7 +128,7 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 			},
 			{
 				hash:   *regularHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         500,
 					SizeInBytes: 250,
@@ -168,7 +169,7 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
 			{
 				hash:   *coinbaseHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         0,
 					SizeInBytes: 100,
@@ -204,7 +205,7 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
 			{
 				hash:   *regularHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         1000,
 					SizeInBytes: 500,
@@ -243,11 +244,11 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		msg := buildTXmetaBatchMessage(t, []txmetaTestEntry{
 			{
 				hash:   *coinbaseHash,
-				action: txmetaActionDELETE,
+				action: txmetacache.WireActionDELETE,
 			},
 			{
 				hash:   *regularHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         750,
 					SizeInBytes: 300,
@@ -296,7 +297,7 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		msg := buildTXmetaBatchMessageV2(t, []txmetaTestEntry{
 			{
 				hash:   *coinbaseHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         0,
 					SizeInBytes: 100,
@@ -305,7 +306,7 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 			},
 			{
 				hash:   *regularHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         500,
 					SizeInBytes: 250,
@@ -344,11 +345,11 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		msg := buildTXmetaBatchMessageV2(t, []txmetaTestEntry{
 			{
 				hash:   *coinbaseHash,
-				action: txmetaActionDELETE,
+				action: txmetacache.WireActionDELETE,
 			},
 			{
 				hash:   *regularHash,
-				action: txmetaActionADD,
+				action: txmetacache.WireActionADD,
 				meta: meta.Data{
 					Fee:         750,
 					SizeInBytes: 300,
@@ -387,6 +388,102 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 
 		err := sm.processTXmetaBatchMessage([]byte{0xFF, 0x02, 0, 0})
 		require.NoError(t, err)
+	})
+
+	// V1 entry counts whose little-endian encoding begins with 0xFF
+	// (255, 511, 767, ...) collide with the v2 magic byte. Naive v2
+	// detection would silently drop or garble these legitimate v1
+	// messages. The cases below pad a real announce-target entry into a
+	// large DELETE-only batch to hit the boundary counts.
+	t.Run("v1 wire format with entry count 255 (0xFF low byte) is parsed as v1", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](1000, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		entries := make([]txmetaTestEntry, 0, 255)
+		entries = append(entries, txmetaTestEntry{
+			hash:   *regularHash,
+			action: txmetacache.WireActionADD,
+			meta: meta.Data{
+				Fee:         123,
+				SizeInBytes: 456,
+				IsCoinbase:  false,
+			},
+		})
+		for i := 0; i < 254; i++ {
+			entries = append(entries, txmetaTestEntry{
+				hash:   *coinbaseHash,
+				action: txmetacache.WireActionDELETE,
+			})
+		}
+		require.Len(t, entries, 255, "entry count must collide with the v2 magic byte")
+
+		msg := buildTXmetaBatchMessage(t, entries)
+		require.Equal(t, byte(0xFF), msg[0], "v1 length-prefix low byte must be 0xFF for this regression")
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
+	})
+
+	t.Run("v1 wire format with entry count 767 (full v2 header alias) is parsed as v1", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](2000, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		entries := make([]txmetaTestEntry, 0, 767)
+		entries = append(entries, txmetaTestEntry{
+			hash:   *regularHash,
+			action: txmetacache.WireActionADD,
+			meta: meta.Data{
+				Fee:         789,
+				SizeInBytes: 321,
+				IsCoinbase:  false,
+			},
+		})
+		for i := 0; i < 766; i++ {
+			entries = append(entries, txmetaTestEntry{
+				hash:   *coinbaseHash,
+				action: txmetacache.WireActionDELETE,
+			})
+		}
+		require.Len(t, entries, 767)
+
+		msg := buildTXmetaBatchMessage(t, entries)
+		// 767 in LE-uint32 = 0xFF 0x02 0x00 0x00 — exactly aliases the v2 header.
+		require.Equal(t, []byte{0xFF, 0x02, 0x00, 0x00}, msg[:4])
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
 	})
 
 	t.Run("message with zero entries is handled gracefully", func(t *testing.T) {

--- a/services/legacy/netsync/kafka_txmeta_test.go
+++ b/services/legacy/netsync/kafka_txmeta_test.go
@@ -55,6 +55,45 @@ type txmetaTestEntry struct {
 	meta   meta.Data
 }
 
+// buildTXmetaBatchMessageV2 constructs a v2 wire-format batch message: an
+// 8-byte header (magic 0xFF, version 0x02, 2 reserved bytes, uint32 LE entry
+// count) followed by per-entry records prefixed with an 8-byte xxhash. The
+// xxhash is filled with zeros — the netsync consumer ignores it.
+func buildTXmetaBatchMessageV2(t *testing.T, entries []txmetaTestEntry) []byte {
+	t.Helper()
+
+	buf := make([]byte, 8)
+	buf[0] = txmetaWireV2Magic
+	buf[1] = txmetaWireV2Version
+	// buf[2:4] reserved (zeros)
+	binary.LittleEndian.PutUint32(buf[4:], uint32(len(entries)))
+
+	for _, entry := range entries {
+		// 8-byte xxhash placeholder
+		buf = append(buf, 0, 0, 0, 0, 0, 0, 0, 0)
+
+		// 32-byte hash
+		buf = append(buf, entry.hash[:]...)
+
+		// 1-byte action
+		buf = append(buf, entry.action)
+
+		if entry.action == txmetaActionADD {
+			metaBytes, err := entry.meta.MetaBytes()
+			require.NoError(t, err)
+
+			lenBuf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(lenBuf, uint32(len(metaBytes)))
+			buf = append(buf, lenBuf...)
+			buf = append(buf, metaBytes...)
+		} else {
+			buf = append(buf, 0, 0, 0, 0)
+		}
+	}
+
+	return buf
+}
+
 func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 	// Set up hashes for test entries
 	coinbaseHash, err := chainhash.NewHashFromStr("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -238,6 +277,115 @@ func TestProcessTXmetaBatchMessage_CoinbaseFiltering(t *testing.T) {
 		require.NoError(t, err)
 
 		err = sm.processTXmetaBatchMessage([]byte{0, 0, 0})
+		require.NoError(t, err)
+	})
+
+	t.Run("v2 wire format: coinbase filtered, regular tx announced", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessageV2(t, []txmetaTestEntry{
+			{
+				hash:   *coinbaseHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         0,
+					SizeInBytes: 100,
+					IsCoinbase:  true,
+				},
+			},
+			{
+				hash:   *regularHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         500,
+					SizeInBytes: 250,
+					IsCoinbase:  false,
+				},
+			},
+		})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
+		require.Equal(t, uint64(500), announced[0].Fee)
+		require.Equal(t, uint64(250), announced[0].Size)
+	})
+
+	t.Run("v2 wire format: DELETE entries are skipped", func(t *testing.T) {
+		var mu sync.Mutex
+		var announced []*TxHashAndFee
+
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+			txAnnounceBatcher: batcher.NewWithDeduplication[TxHashAndFee](100, 50*time.Millisecond, func(batch []*TxHashAndFee) {
+				mu.Lock()
+				announced = append(announced, batch...)
+				mu.Unlock()
+			}, false),
+		}
+
+		msg := buildTXmetaBatchMessageV2(t, []txmetaTestEntry{
+			{
+				hash:   *coinbaseHash,
+				action: txmetaActionDELETE,
+			},
+			{
+				hash:   *regularHash,
+				action: txmetaActionADD,
+				meta: meta.Data{
+					Fee:         750,
+					SizeInBytes: 300,
+					IsCoinbase:  false,
+				},
+			},
+		})
+
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, announced, 1)
+		require.Equal(t, *regularHash, announced[0].TxHash)
+	})
+
+	t.Run("v2 wire format: unknown sub-version is rejected", func(t *testing.T) {
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+		}
+
+		// Magic 0xFF + bogus version 0x99 + 6 padding bytes.
+		msg := []byte{0xFF, 0x99, 0, 0, 0, 0, 0, 0}
+		err := sm.processTXmetaBatchMessage(msg)
+		require.NoError(t, err)
+	})
+
+	t.Run("v2 wire format: truncated header is handled gracefully", func(t *testing.T) {
+		sm := &SyncManager{
+			logger: ulogger.TestLogger{},
+		}
+
+		err := sm.processTXmetaBatchMessage([]byte{0xFF, 0x02, 0, 0})
 		require.NoError(t, err)
 	})
 

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -38,6 +38,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/blob"
+	"github.com/bsv-blockchain/teranode/stores/txmetacache"
 	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
@@ -2538,34 +2539,26 @@ func (sm *SyncManager) kafkaTXmetaListener(ctx context.Context, kafkaURL *url.UR
 	}, &sm.settings.Kafka)
 }
 
-const (
-	txmetaActionADD    = byte(0)
-	txmetaActionDELETE = byte(1)
-
-	// txmetaWireV2Magic marks a v2 txmeta Kafka message. v1 messages start
-	// with the low byte of a uint32 entry count, which can never be 0xFF for
-	// any realistic batch size. Kept in sync with the producer (Validator)
-	// and the subtreevalidation consumer (services/subtreevalidation/txmetaHandler.go).
-	txmetaWireV2Magic = byte(0xFF)
-	// txmetaWireV2Version is the only v2 sub-version defined today.
-	txmetaWireV2Version = byte(0x02)
-)
-
 // processTXmetaBatchMessage processes a binary batch message from the txmeta Kafka topic.
 // It parses the batch format, deserializes metadata for ADD entries, and announces
 // non-coinbase transactions to peers via the txAnnounceBatcher.
 // Coinbase transactions are intentionally skipped to avoid peer bans.
 //
-// Two wire formats are accepted, distinguished by the first byte (mirrors
-// services/subtreevalidation/txmetaHandler.go):
+// Two wire formats are accepted, distinguished by a multi-byte signature at
+// the start of the message (mirrors services/subtreevalidation/txmetaHandler.go):
 //
 //	v1 (legacy)
 //	  [4 bytes] entry count (uint32 LE)
 //	  per entry: [32 hash][1 action][4 contentLen][N content]
 //
 //	v2 (partition-aware)
-//	  [1 byte magic=0xFF][1 byte version=0x02][2 reserved][4 entry count LE]
+//	  [1 byte magic=0xFF][1 byte version=0x02][2 reserved=0][4 entry count LE]
 //	  per entry: [8 xxhash][32 hash][1 action][4 contentLen][N content]
+//
+// v2 detection requires the full 4-byte header signature AND a plausible
+// entry count for the buffer length, otherwise the message is parsed as v1.
+// This avoids misclassifying v1 messages whose entry count happens to begin
+// with 0xFF (counts 255, 511, 767, ...).
 //
 // The xxhash prefix in v2 is read and discarded — netsync only needs the
 // 32-byte tx hash to announce; partition-aligned cache writes are a
@@ -2581,20 +2574,24 @@ func (sm *SyncManager) processTXmetaBatchMessage(data []byte) error {
 		isV2       bool
 	)
 
-	if data[0] == txmetaWireV2Magic {
-		if len(data) < 8 {
-			sm.logger.Errorf("[kafkaTXmetaListener] truncated v2 header (%d bytes)", len(data))
-			return nil
+	// Speculative v2 detection: require the full header signature
+	// (magic + version + reserved bytes) and an entry count that fits in the
+	// remaining buffer at the minimum v2 entry size. Any failure falls
+	// through to v1 — never silently drops a valid v1 message.
+	if len(data) >= txmetacache.WireV2HeaderLen &&
+		data[0] == txmetacache.WireV2Magic &&
+		data[1] == txmetacache.WireV2Version &&
+		data[2] == 0 && data[3] == 0 {
+		candidateCount := binary.LittleEndian.Uint32(data[4:])
+		remaining := uint64(len(data) - txmetacache.WireV2HeaderLen)
+		if uint64(candidateCount)*uint64(txmetacache.WireV2MinEntrySize) <= remaining {
+			entryCount = candidateCount
+			offset = txmetacache.WireV2HeaderLen
+			isV2 = true
 		}
-		if data[1] != txmetaWireV2Version {
-			sm.logger.Errorf("[kafkaTXmetaListener] unknown v2 wire version %d", data[1])
-			return nil
-		}
-		// data[2:4] reserved.
-		entryCount = binary.LittleEndian.Uint32(data[4:])
-		offset = 8
-		isV2 = true
-	} else {
+	}
+
+	if !isV2 {
 		entryCount = binary.LittleEndian.Uint32(data[:4])
 		offset = 4
 	}
@@ -2631,7 +2628,7 @@ func (sm *SyncManager) processTXmetaBatchMessage(data []byte) error {
 		contentLen := binary.LittleEndian.Uint32(data[offset:])
 		offset += 4
 
-		if action == txmetaActionADD {
+		if action == txmetacache.WireActionADD {
 			// Handle ADD
 			if offset+int(contentLen) > len(data) {
 				sm.logger.Errorf("[kafkaTXmetaListener] truncated content at entry %d", i)

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -2541,29 +2541,81 @@ func (sm *SyncManager) kafkaTXmetaListener(ctx context.Context, kafkaURL *url.UR
 const (
 	txmetaActionADD    = byte(0)
 	txmetaActionDELETE = byte(1)
+
+	// txmetaWireV2Magic marks a v2 txmeta Kafka message. v1 messages start
+	// with the low byte of a uint32 entry count, which can never be 0xFF for
+	// any realistic batch size. Kept in sync with the producer (Validator)
+	// and the subtreevalidation consumer (services/subtreevalidation/txmetaHandler.go).
+	txmetaWireV2Magic = byte(0xFF)
+	// txmetaWireV2Version is the only v2 sub-version defined today.
+	txmetaWireV2Version = byte(0x02)
 )
 
 // processTXmetaBatchMessage processes a binary batch message from the txmeta Kafka topic.
 // It parses the batch format, deserializes metadata for ADD entries, and announces
 // non-coinbase transactions to peers via the txAnnounceBatcher.
 // Coinbase transactions are intentionally skipped to avoid peer bans.
+//
+// Two wire formats are accepted, distinguished by the first byte (mirrors
+// services/subtreevalidation/txmetaHandler.go):
+//
+//	v1 (legacy)
+//	  [4 bytes] entry count (uint32 LE)
+//	  per entry: [32 hash][1 action][4 contentLen][N content]
+//
+//	v2 (partition-aware)
+//	  [1 byte magic=0xFF][1 byte version=0x02][2 reserved][4 entry count LE]
+//	  per entry: [8 xxhash][32 hash][1 action][4 contentLen][N content]
+//
+// The xxhash prefix in v2 is read and discarded — netsync only needs the
+// 32-byte tx hash to announce; partition-aligned cache writes are a
+// subtreevalidation concern.
 func (sm *SyncManager) processTXmetaBatchMessage(data []byte) error {
 	if len(data) < 4 {
 		return nil
 	}
 
-	offset := 0
+	var (
+		offset     int
+		entryCount uint32
+		isV2       bool
+	)
 
-	// Read entry count
-	entryCount := binary.LittleEndian.Uint32(data[offset:])
-	offset += 4
+	if data[0] == txmetaWireV2Magic {
+		if len(data) < 8 {
+			sm.logger.Errorf("[kafkaTXmetaListener] truncated v2 header (%d bytes)", len(data))
+			return nil
+		}
+		if data[1] != txmetaWireV2Version {
+			sm.logger.Errorf("[kafkaTXmetaListener] unknown v2 wire version %d", data[1])
+			return nil
+		}
+		// data[2:4] reserved.
+		entryCount = binary.LittleEndian.Uint32(data[4:])
+		offset = 8
+		isV2 = true
+	} else {
+		entryCount = binary.LittleEndian.Uint32(data[:4])
+		offset = 4
+	}
+
+	// Per-entry header size (excluding content): 32-byte hash + 1-byte action
+	// + 4-byte content length, plus 8 bytes of xxhash on the wire in v2.
+	entryHeaderSize := 32 + 1 + 4
+	if isV2 {
+		entryHeaderSize += 8
+	}
 
 	// Process each entry
 	for i := uint32(0); i < entryCount; i++ {
-		// Check minimum bytes for hash + action + length
-		if offset+32+1+4 > len(data) {
+		if offset+entryHeaderSize > len(data) {
 			sm.logger.Errorf("[kafkaTXmetaListener] truncated message at entry %d", i)
 			return nil
+		}
+
+		// v2: skip the 8-byte xxhash prefix; netsync doesn't use it.
+		if isV2 {
+			offset += 8
 		}
 
 		// Read hash (32 bytes)

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -2596,11 +2596,12 @@ func (sm *SyncManager) processTXmetaBatchMessage(data []byte) error {
 		offset = 4
 	}
 
-	// Per-entry header size (excluding content): 32-byte hash + 1-byte action
-	// + 4-byte content length, plus 8 bytes of xxhash on the wire in v2.
-	entryHeaderSize := 32 + 1 + 4
+	// Per-entry header size (excluding content). The shared constants in
+	// stores/txmetacache encode the same numbers; using them here keeps
+	// the producer and the receiver pinned to one source of truth.
+	entryHeaderSize := txmetacache.WireV1MinEntrySize
 	if isV2 {
-		entryHeaderSize += 8
+		entryHeaderSize = txmetacache.WireV2MinEntrySize
 	}
 
 	// Process each entry

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -132,10 +132,28 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 		offset = 4
 	}
 
-	// Per-entry sizes (excluding content).
-	entryHeaderSize := 32 + 1 + 4
+	// Per-entry sizes (excluding content). The shared constants in
+	// stores/txmetacache encode the same numbers; using them here keeps
+	// the producer and the receiver pinned to one source of truth.
+	entryHeaderSize := txmetacache.WireV1MinEntrySize
 	if isV2 {
-		entryHeaderSize += 8
+		entryHeaderSize = txmetacache.WireV2MinEntrySize
+	}
+
+	// Reject implausibly large entry counts before sizing the pool buffers.
+	// The pool pre-allocates `entries * 32` bytes for keysBuf plus `entries`
+	// slice slots, so an unbounded count read straight from the wire is a
+	// DoS surface. The plausibility bound is the same shape as the v2
+	// detection check: each entry needs at least `entryHeaderSize` bytes
+	// excluding content, so a count larger than the remaining buffer can
+	// fit is malformed. The v2 path is already guarded by the detection-
+	// time check above; the guard here matters for the v1 fallback path.
+	remainingForEntries := uint64(len(data) - offset)
+	maxEntries := remainingForEntries / uint64(entryHeaderSize)
+	if uint64(entries) > maxEntries {
+		u.logger.Errorf("[txmetaHandler] entry count %d exceeds buffer capacity (%d max for %d-byte payload)",
+			entries, maxEntries, remainingForEntries)
+		return nil
 	}
 
 	// Pool-backed scratch. Sized to upper bounds derived from the wire:

--- a/services/subtreevalidation/txmetaHandler.go
+++ b/services/subtreevalidation/txmetaHandler.go
@@ -10,24 +10,13 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/txmetacache"
 	"github.com/bsv-blockchain/teranode/util/kafka"
 )
 
-const (
-	// txmetaActionADD represents the ADD action for txmeta batch messages.
-	txmetaActionADD = byte(0)
-	// txmetaActionDELETE represents the DELETE action for txmeta batch messages.
-	txmetaActionDELETE = byte(1)
-
-	// txmetaWireV2Magic marks a v2 txmeta Kafka message. v1 messages start with
-	// the low byte of a uint32 entry count, which can never be 0xFF for any
-	// realistic batch size (it would require >4 billion entries per message).
-	txmetaWireV2Magic = byte(0xFF)
-	// txmetaWireV2Version is the only v2 sub-version defined today. The header
-	// reserves room for additional sub-versions without breaking the magic-byte
-	// detection.
-	txmetaWireV2Version = byte(0x02)
-)
+// Txmeta Kafka wire-format constants live in stores/txmetacache (see wire.go
+// in that package). They are imported here as the single source of truth
+// shared between the producer (services/validator) and all consumers.
 
 // txmetaParseBuffers is the per-Kafka-message scratch space the handler
 // reuses across invocations via txmetaParseBuffersPool. Each parse fills the
@@ -79,27 +68,15 @@ func (u *Server) txmetaMessageHandler(ctx context.Context) func(msg *kafka.Kafka
 
 // txmetaHandler processes a Kafka message of transaction metadata operations.
 //
-// Two wire formats are supported, distinguished by the first byte:
+// Two wire formats are supported, distinguished by a multi-byte signature at
+// the start of the message. See stores/txmetacache/wire.go for the layout
+// definitions and the rationale for the detection rules below.
 //
-//	v1 (legacy)
-//	  [4 bytes]   entry count (uint32 LE)
-//	  per entry:
-//	    [32 bytes] tx hash
-//	    [1 byte]   action (0=ADD, 1=DELETE)
-//	    [4 bytes]  content length (uint32 LE) — 0 for DELETE
-//	    [N bytes]  content
-//
-//	v2 (partition-aware; producer-side rollout pending)
-//	  [1 byte]    magic = 0xFF
-//	  [1 byte]    version = 0x02
-//	  [2 bytes]   reserved
-//	  [4 bytes]   entry count (uint32 LE)
-//	  per entry:
-//	    [8 bytes]  xxhash(tx hash) (uint64 LE)
-//	    [32 bytes] tx hash
-//	    [1 byte]   action
-//	    [4 bytes]  content length
-//	    [N bytes]  content
+// v2 detection requires the full 4-byte header signature (magic + version +
+// 2 reserved zero bytes) AND a plausible entry count for the remaining
+// buffer; otherwise the message is parsed as v1. This avoids
+// misclassifying v1 messages whose entry count happens to begin with 0xFF
+// (counts 255, 511, 767, ...).
 //
 // Dispatch model: all ADDs in the message are collected into one
 // SetCacheMultiSequential call (which is partition-aware — see
@@ -132,20 +109,25 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 		isV2    bool
 	)
 
-	if data[0] == txmetaWireV2Magic {
-		if len(data) < 8 {
-			u.logger.Errorf("[txmetaHandler] truncated v2 header (%d bytes)", len(data))
-			return nil
+	// Speculative v2 detection: require the full header signature
+	// (magic + version + reserved bytes) and an entry count that fits in the
+	// remaining buffer at the minimum v2 entry size. Any failure falls
+	// through to v1 — never silently drops a valid v1 message whose entry
+	// count happens to begin with 0xFF (counts 255, 511, 767, ...).
+	if len(data) >= txmetacache.WireV2HeaderLen &&
+		data[0] == txmetacache.WireV2Magic &&
+		data[1] == txmetacache.WireV2Version &&
+		data[2] == 0 && data[3] == 0 {
+		candidateCount := binary.LittleEndian.Uint32(data[4:])
+		remaining := uint64(len(data) - txmetacache.WireV2HeaderLen)
+		if uint64(candidateCount)*uint64(txmetacache.WireV2MinEntrySize) <= remaining {
+			entries = candidateCount
+			offset = txmetacache.WireV2HeaderLen
+			isV2 = true
 		}
-		if data[1] != txmetaWireV2Version {
-			u.logger.Errorf("[txmetaHandler] unknown v2 wire version %d", data[1])
-			return nil
-		}
-		// data[2:4] reserved.
-		entries = binary.LittleEndian.Uint32(data[4:])
-		offset = 8
-		isV2 = true
-	} else {
+	}
+
+	if !isV2 {
 		entries = binary.LittleEndian.Uint32(data[:4])
 		offset = 4
 	}
@@ -216,7 +198,7 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 		}
 
 		switch action {
-		case txmetaActionADD:
+		case txmetacache.WireActionADD:
 			contentStart := len(bufs.contentBuf)
 			bufs.contentBuf = append(bufs.contentBuf, data[offset:offset+int(contentLen)]...)
 			bufs.keys = append(bufs.keys, bufs.keysBuf[hashStart:hashStart+32])
@@ -224,7 +206,7 @@ func (u *Server) txmetaHandler(ctx context.Context, msg *kafka.KafkaMessage) err
 			if isV2 {
 				bufs.hashes = append(bufs.hashes, entryHash)
 			}
-		case txmetaActionDELETE:
+		case txmetacache.WireActionDELETE:
 			// chainhash.Hash is a value type — copying into deletes[]
 			// captures by value, so the keysBuf arena can be recycled
 			// without worry.

--- a/services/subtreevalidation/txmetaHandler_bench_test.go
+++ b/services/subtreevalidation/txmetaHandler_bench_test.go
@@ -73,7 +73,7 @@ func buildBenchMessage(b *testing.B, entriesPerMessage int, payloadSize int) *ka
 		buf[off+1] = byte(i / 256)
 		off += 32
 
-		buf[off] = txmetaActionADD
+		buf[off] = txmetacache.WireActionADD
 		off++
 
 		binary.LittleEndian.PutUint32(buf[off:], uint32(payloadSize))
@@ -94,8 +94,8 @@ func buildBenchMessageV2(b *testing.B, entriesPerMessage int, payloadSize int) *
 	total := 8 + entriesPerMessage*entrySize
 	buf := make([]byte, total)
 
-	buf[0] = txmetaWireV2Magic
-	buf[1] = txmetaWireV2Version
+	buf[0] = txmetacache.WireV2Magic
+	buf[1] = txmetacache.WireV2Version
 	// buf[2:4] reserved
 	binary.LittleEndian.PutUint32(buf[4:], uint32(entriesPerMessage))
 	off := 8
@@ -113,7 +113,7 @@ func buildBenchMessageV2(b *testing.B, entriesPerMessage int, payloadSize int) *
 		buf[off+1] = byte(i / 256)
 		off += 32
 
-		buf[off] = txmetaActionADD
+		buf[off] = txmetacache.WireActionADD
 		off++
 
 		binary.LittleEndian.PutUint32(buf[off:], uint32(payloadSize))

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -216,9 +216,9 @@ func createKafkaMessage(t *testing.T, delete bool, content []byte) *kafka.KafkaM
 	t.Helper()
 
 	hash := chainhash.Hash{1, 2, 3}
-	action := txmetaActionADD
+	action := txmetacache.WireActionADD
 	if delete {
-		action = txmetaActionDELETE
+		action = txmetacache.WireActionDELETE
 	}
 
 	// Calculate total size: 4 (count) + 32 (hash) + 1 (action) + 4 (length) + len(content)
@@ -260,7 +260,7 @@ func createKafkaMessageForHash(t *testing.T, hash chainhash.Hash, action byte, c
 	t.Helper()
 
 	contentLen := uint32(len(content))
-	if action == txmetaActionDELETE {
+	if action == txmetacache.WireActionDELETE {
 		contentLen = 0
 	}
 
@@ -388,8 +388,8 @@ func TestServer_txmetaHandler_PreservesPerKeyOrdering(t *testing.T) {
 	}
 
 	hash := chainhash.Hash{42}
-	addMessage := createKafkaMessageForHash(t, hash, txmetaActionADD, []byte("payload"))
-	deleteMessage := createKafkaMessageForHash(t, hash, txmetaActionDELETE, nil)
+	addMessage := createKafkaMessageForHash(t, hash, txmetacache.WireActionADD, []byte("payload"))
+	deleteMessage := createKafkaMessageForHash(t, hash, txmetacache.WireActionDELETE, nil)
 
 	err := server.txmetaHandler(context.Background(), addMessage)
 	assert.NoError(t, err)
@@ -423,8 +423,8 @@ func TestServer_txmetaHandler_V2_Parses(t *testing.T) {
 	payload := []byte("test-meta")
 	totalSize := 8 + 8 + 32 + 1 + 4 + len(payload)
 	data := make([]byte, totalSize)
-	data[0] = txmetaWireV2Magic
-	data[1] = txmetaWireV2Version
+	data[0] = txmetacache.WireV2Magic
+	data[1] = txmetacache.WireV2Version
 	binary.LittleEndian.PutUint32(data[4:], 1)
 
 	off := 8
@@ -433,7 +433,7 @@ func TestServer_txmetaHandler_V2_Parses(t *testing.T) {
 	hash := chainhash.Hash{42}
 	copy(data[off:], hash[:])
 	off += 32
-	data[off] = txmetaActionADD
+	data[off] = txmetacache.WireActionADD
 	off++
 	binary.LittleEndian.PutUint32(data[off:], uint32(len(payload)))
 	off += 4
@@ -453,7 +453,7 @@ func TestServer_txmetaHandler_V2_UnknownVersion(t *testing.T) {
 	server := &Server{logger: mLogger}
 
 	data := make([]byte, 8)
-	data[0] = txmetaWireV2Magic
+	data[0] = txmetacache.WireV2Magic
 	data[1] = 0x99
 
 	err := server.txmetaHandler(context.Background(), &kafka.KafkaMessage{Value: data})
@@ -479,7 +479,7 @@ func TestServer_txmetaHandler_V2_MixedAddDelete(t *testing.T) {
 
 	hashes := []chainhash.Hash{{1}, {2}, {3}}
 	payloads := [][]byte{[]byte("a"), nil, []byte("ccc")}
-	actions := []byte{txmetaActionADD, txmetaActionDELETE, txmetaActionADD}
+	actions := []byte{txmetacache.WireActionADD, txmetacache.WireActionDELETE, txmetacache.WireActionADD}
 	pseudoHashes := []uint64{0x11, 0x22, 0x33}
 
 	size := 8 // header
@@ -487,8 +487,8 @@ func TestServer_txmetaHandler_V2_MixedAddDelete(t *testing.T) {
 		size += 8 + 32 + 1 + 4 + len(payloads[i])
 	}
 	data := make([]byte, size)
-	data[0] = txmetaWireV2Magic
-	data[1] = txmetaWireV2Version
+	data[0] = txmetacache.WireV2Magic
+	data[1] = txmetacache.WireV2Version
 	binary.LittleEndian.PutUint32(data[4:], uint32(len(hashes)))
 	off := 8
 
@@ -508,4 +508,85 @@ func TestServer_txmetaHandler_V2_MixedAddDelete(t *testing.T) {
 	err := server.txmetaHandler(context.Background(), &kafka.KafkaMessage{Value: data})
 	assert.NoError(t, err)
 	mCache.AssertExpectations(t)
+}
+
+// buildV1TxmetaMessage builds a v1-format batch message with the requested
+// number of entries: one ADD followed by (count-1) DELETEs. Used to exercise
+// the v1/v2 discriminator collision cases below.
+func buildV1TxmetaMessage(t *testing.T, count int, addHash chainhash.Hash, addPayload []byte) []byte {
+	t.Helper()
+
+	size := 4 + 32 + 1 + 4 + len(addPayload) + (count-1)*(32+1+4)
+	buf := make([]byte, 0, size)
+
+	hdr := make([]byte, 4)
+	binary.LittleEndian.PutUint32(hdr, uint32(count))
+	buf = append(buf, hdr...)
+
+	// ADD entry.
+	buf = append(buf, addHash[:]...)
+	buf = append(buf, txmetacache.WireActionADD)
+	lenBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lenBuf, uint32(len(addPayload)))
+	buf = append(buf, lenBuf...)
+	buf = append(buf, addPayload...)
+
+	// DELETE entries.
+	deleteHash := chainhash.Hash{99}
+	for i := 0; i < count-1; i++ {
+		buf = append(buf, deleteHash[:]...)
+		buf = append(buf, txmetacache.WireActionDELETE)
+		buf = append(buf, 0, 0, 0, 0)
+	}
+
+	return buf
+}
+
+// TestServer_txmetaHandler_V1_CollidesWithV2Magic verifies that v1 messages
+// whose entry count has a low byte of 0xFF (counts 255, 511, 767, ...) are
+// still parsed as v1 instead of being misclassified as v2 and dropped/garbled.
+func TestServer_txmetaHandler_V1_CollidesWithV2Magic(t *testing.T) {
+	cases := []struct {
+		name         string
+		count        int
+		headerPrefix []byte
+	}{
+		{
+			name:         "count 255 (LE low byte 0xFF, version byte 0x00)",
+			count:        255,
+			headerPrefix: []byte{0xFF, 0x00, 0x00, 0x00},
+		},
+		{
+			name:         "count 767 (full v2 header alias 0xFF 0x02 0x00 0x00)",
+			count:        767,
+			headerPrefix: []byte{0xFF, 0x02, 0x00, 0x00},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mLogger := &mockLogger{}
+			mLogger.On("Errorf", mock.Anything, mock.Anything).Maybe().Return()
+			mCache := &mockCache{}
+			// Must take the v1-shaped Set path (no on-wire xxhash).
+			// SetCacheMultiSequential takes (keys, values); WithHashes takes (keys, values, hashes).
+			mCache.On("SetCacheMultiSequential", mock.Anything, mock.Anything).Return(nil)
+			mCache.On("Delete", mock.Anything, mock.AnythingOfType("*chainhash.Hash")).Return(nil).Maybe()
+
+			server := &Server{logger: mLogger, utxoStore: mCache}
+
+			addHash := chainhash.Hash{1, 2, 3}
+			payload := []byte("v1-payload")
+			data := buildV1TxmetaMessage(t, tc.count, addHash, payload)
+			assert.Equal(t, tc.headerPrefix, data[:4],
+				"v1 length-prefix must alias the v2 header bytes for this regression")
+
+			err := server.txmetaHandler(context.Background(), &kafka.KafkaMessage{Value: data})
+			assert.NoError(t, err)
+			mCache.AssertCalled(t, "SetCacheMultiSequential",
+				mock.Anything, mock.Anything)
+			mCache.AssertNotCalled(t, "SetCacheMultiSequentialWithHashes",
+				mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
 }

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -444,13 +444,18 @@ func TestServer_txmetaHandler_V2_Parses(t *testing.T) {
 	mCache.AssertExpectations(t)
 }
 
-// TestServer_txmetaHandler_V2_UnknownVersion confirms that an unknown v2
-// sub-version is logged and acked rather than triggering a redelivery loop.
-func TestServer_txmetaHandler_V2_UnknownVersion(t *testing.T) {
+// TestServer_txmetaHandler_V2Shaped_UnknownVersion_FallsBackToV1 confirms
+// that a v2-shaped message with an unknown sub-version is treated as v1
+// (rather than dropped silently), so a legitimate v1 message with a count
+// whose LE low byte is 0xFF is never misclassified. The 8-byte buffer is
+// too small to hold a single v1 entry, so the v1 path logs a truncation
+// error and acks — but crucially it does NOT call the v2 dispatch path.
+func TestServer_txmetaHandler_V2Shaped_UnknownVersion_FallsBackToV1(t *testing.T) {
 	mLogger := &mockLogger{}
 	mLogger.On("Errorf", mock.Anything, mock.Anything).Return()
+	mCache := &mockCache{}
 
-	server := &Server{logger: mLogger}
+	server := &Server{logger: mLogger, utxoStore: mCache}
 
 	data := make([]byte, 8)
 	data[0] = txmetacache.WireV2Magic
@@ -458,7 +463,10 @@ func TestServer_txmetaHandler_V2_UnknownVersion(t *testing.T) {
 
 	err := server.txmetaHandler(context.Background(), &kafka.KafkaMessage{Value: data})
 	assert.NoError(t, err)
-	mLogger.AssertCalled(t, "Errorf", mock.Anything, mock.Anything)
+	// Must NOT take the v2 dispatch path — the v2-shaped-but-invalid
+	// header must fall through to v1 parsing.
+	mCache.AssertNotCalled(t, "SetCacheMultiSequentialWithHashes",
+		mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestServer_txmetaHandler_V2_MixedAddDelete verifies the receiver handles a
@@ -540,6 +548,36 @@ func buildV1TxmetaMessage(t *testing.T, count int, addHash chainhash.Hash, addPa
 	}
 
 	return buf
+}
+
+// TestServer_txmetaHandler_V1_ImplausibleEntryCount_IsRejected verifies
+// that a v1 message claiming far more entries than the buffer can hold is
+// logged and acked rather than triggering an oversized pre-loop allocation.
+// The wire claims max-uint32 entries (~4B) with only enough buffer for a
+// few; without the plausibility bound, the pool would try to allocate
+// ~128GB for keysBuf alone.
+func TestServer_txmetaHandler_V1_ImplausibleEntryCount_IsRejected(t *testing.T) {
+	mLogger := &mockLogger{}
+	mLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mCache := &mockCache{}
+
+	server := &Server{logger: mLogger, utxoStore: mCache}
+
+	// 4-byte header claiming 0xFFFFFFFE entries (just under max-uint32,
+	// chosen so the first byte is 0xFE — not a v2 magic alias — to force
+	// the v1 detection path), with no entry payload at all.
+	data := make([]byte, 4)
+	binary.LittleEndian.PutUint32(data, 0xFFFFFFFE)
+
+	err := server.txmetaHandler(context.Background(), &kafka.KafkaMessage{Value: data})
+	assert.NoError(t, err)
+	// Neither dispatch path should be reached — the message is rejected
+	// before any entries are parsed.
+	mCache.AssertNotCalled(t, "SetCacheMultiSequential", mock.Anything, mock.Anything)
+	mCache.AssertNotCalled(t, "SetCacheMultiSequentialWithHashes",
+		mock.Anything, mock.Anything, mock.Anything)
+	mLogger.AssertCalled(t, "Errorf",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestServer_txmetaHandler_V1_CollidesWithV2Magic verifies that v1 messages

--- a/services/subtreevalidation/txmeta_e2e_test.go
+++ b/services/subtreevalidation/txmeta_e2e_test.go
@@ -252,8 +252,8 @@ func (h *txmetaE2EHarness) publishV2(t testing.TB, hashes []chainhash.Hash, payl
 			size += 8 + 32 + 1 + 4 + len(it.payload)
 		}
 		buf := make([]byte, size)
-		buf[0] = txmetaWireV2Magic
-		buf[1] = txmetaWireV2Version
+		buf[0] = txmetacache.WireV2Magic
+		buf[1] = txmetacache.WireV2Version
 		putUint32LE(buf[4:], uint32(len(items)))
 		off := 8
 
@@ -262,7 +262,7 @@ func (h *txmetaE2EHarness) publishV2(t testing.TB, hashes []chainhash.Hash, payl
 			off += 8
 			copy(buf[off:], it.hash[:])
 			off += 32
-			buf[off] = txmetaActionADD
+			buf[off] = txmetacache.WireActionADD
 			off++
 			putUint32LE(buf[off:], uint32(len(it.payload)))
 			off += 4
@@ -305,7 +305,7 @@ func serializeV1ForE2E(hashes []chainhash.Hash, payloads [][]byte) []byte {
 	for i := range hashes {
 		copy(buf[off:], hashes[i][:])
 		off += 32
-		buf[off] = txmetaActionADD
+		buf[off] = txmetacache.WireActionADD
 		off++
 		putUint32LE(buf[off:], uint32(len(payloads[i])))
 		off += 4
@@ -329,7 +329,7 @@ func countEntries(data []byte) int {
 	if len(data) < 4 {
 		return 0
 	}
-	if data[0] == txmetaWireV2Magic {
+	if data[0] == txmetacache.WireV2Magic {
 		if len(data) < 8 {
 			return 0
 		}
@@ -545,8 +545,8 @@ func serializeV2Partitioned(hashes []chainhash.Hash, payloads [][]byte, numParti
 		}
 		s.bufs[p] = buf
 
-		buf[0] = txmetaWireV2Magic
-		buf[1] = txmetaWireV2Version
+		buf[0] = txmetacache.WireV2Magic
+		buf[1] = txmetacache.WireV2Version
 		buf[2], buf[3] = 0, 0
 		putUint32LE(buf[4:], uint32(len(g)))
 		off := 8
@@ -555,7 +555,7 @@ func serializeV2Partitioned(hashes []chainhash.Hash, payloads [][]byte, numParti
 			off += 8
 			copy(buf[off:], hashes[it.idx][:])
 			off += 32
-			buf[off] = txmetaActionADD
+			buf[off] = txmetacache.WireActionADD
 			off++
 			putUint32LE(buf[off:], uint32(len(payloads[it.idx])))
 			off += 4

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -62,21 +62,12 @@ const (
 	// not spendable (OP_FALSE OP_RETURN).  This applies to outputs after the
 	// Genesis upgrade.
 	DustLimit = uint64(1)
-
-	// txmetaActionADD represents the ADD action for txmeta batch messages
-	txmetaActionADD = byte(0)
-	// txmetaActionDELETE represents the DELETE action for txmeta batch messages
-	txmetaActionDELETE = byte(1)
-
-	// txmetaWireV2Magic is the first byte of a v2-format txmeta Kafka message.
-	// v1 messages start with the low byte of a uint32 entry count, which can
-	// never be 0xFF for any realistic batch size — see the receiver in
-	// services/subtreevalidation/txmetaHandler.go for the symmetric check.
-	txmetaWireV2Magic = byte(0xFF)
-	// txmetaWireV2Version identifies the v2 sub-version. Bump if the per-entry
-	// or header layout changes; the receiver rejects unknown sub-versions.
-	txmetaWireV2Version = byte(0x02)
 )
+
+// Txmeta Kafka wire-format constants live in stores/txmetacache (see wire.go
+// in that package). They are imported here as the single source of truth
+// shared between the producer (this package) and all consumers
+// (services/subtreevalidation, services/legacy/netsync, ...).
 
 // txmetaBatchItem represents an item to be batched for TxMeta Kafka messages.
 type txmetaBatchItem struct {
@@ -1055,9 +1046,9 @@ func serializeTxMetaBatch(batch []*txmetaBatchItem) []byte {
 
 		// Write action (1 byte)
 		if item.isDelete {
-			buf[offset] = txmetaActionDELETE
+			buf[offset] = txmetacache.WireActionDELETE
 		} else {
-			buf[offset] = txmetaActionADD
+			buf[offset] = txmetacache.WireActionADD
 		}
 		offset++
 
@@ -1114,8 +1105,8 @@ func serializeTxMetaBatchV2(items []txmetaItemWithHash) []byte {
 	}
 
 	buf := make([]byte, size)
-	buf[0] = txmetaWireV2Magic
-	buf[1] = txmetaWireV2Version
+	buf[0] = txmetacache.WireV2Magic
+	buf[1] = txmetacache.WireV2Version
 	binary.LittleEndian.PutUint32(buf[4:], uint32(len(items)))
 	off := 8
 
@@ -1125,12 +1116,12 @@ func serializeTxMetaBatchV2(items []txmetaItemWithHash) []byte {
 		copy(buf[off:], it.item.hash[:])
 		off += 32
 		if it.item.isDelete {
-			buf[off] = txmetaActionDELETE
+			buf[off] = txmetacache.WireActionDELETE
 			off++
 			binary.LittleEndian.PutUint32(buf[off:], 0)
 			off += 4
 		} else {
-			buf[off] = txmetaActionADD
+			buf[off] = txmetacache.WireActionADD
 			off++
 			binary.LittleEndian.PutUint32(buf[off:], uint32(len(it.item.metaBytes)))
 			off += 4

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1351,7 +1351,7 @@ func Test_serializeTxMetaBatch(t *testing.T) {
 				assert.Equal(t, byte(32), hash[31])
 
 				action := data[36]
-				assert.Equal(t, txmetaActionADD, action)
+				assert.Equal(t, txmetacache.WireActionADD, action)
 
 				contentLen := binary.LittleEndian.Uint32(data[37:41])
 				assert.Equal(t, uint32(12), contentLen)
@@ -1376,7 +1376,7 @@ func Test_serializeTxMetaBatch(t *testing.T) {
 				assert.Equal(t, uint32(1), count)
 
 				action := data[36]
-				assert.Equal(t, txmetaActionDELETE, action)
+				assert.Equal(t, txmetacache.WireActionDELETE, action)
 
 				contentLen := binary.LittleEndian.Uint32(data[37:41])
 				assert.Equal(t, uint32(0), contentLen)
@@ -1408,7 +1408,7 @@ func Test_serializeTxMetaBatch(t *testing.T) {
 				// offset 4: hash (32), then action (1), then length (4), then content (3)
 				offset := 4
 				assert.Equal(t, byte(1), data[offset], "first entry hash[0]")
-				assert.Equal(t, txmetaActionADD, data[offset+32], "first entry action")
+				assert.Equal(t, txmetacache.WireActionADD, data[offset+32], "first entry action")
 				len1 := binary.LittleEndian.Uint32(data[offset+33 : offset+37])
 				assert.Equal(t, uint32(3), len1, "first entry content length")
 				assert.Equal(t, "one", string(data[offset+37:offset+40]), "first entry content")
@@ -1416,14 +1416,14 @@ func Test_serializeTxMetaBatch(t *testing.T) {
 				// Second entry: DELETE (starts at offset 4 + 32 + 1 + 4 + 3 = 44)
 				offset = 44
 				assert.Equal(t, byte(2), data[offset], "second entry hash[0]")
-				assert.Equal(t, txmetaActionDELETE, data[offset+32], "second entry action")
+				assert.Equal(t, txmetacache.WireActionDELETE, data[offset+32], "second entry action")
 				len2 := binary.LittleEndian.Uint32(data[offset+33 : offset+37])
 				assert.Equal(t, uint32(0), len2, "second entry content length")
 
 				// Third entry: ADD with "three" (starts at offset 44 + 32 + 1 + 4 + 0 = 81)
 				offset = 81
 				assert.Equal(t, byte(3), data[offset], "third entry hash[0]")
-				assert.Equal(t, txmetaActionADD, data[offset+32], "third entry action")
+				assert.Equal(t, txmetacache.WireActionADD, data[offset+32], "third entry action")
 				len3 := binary.LittleEndian.Uint32(data[offset+33 : offset+37])
 				assert.Equal(t, uint32(5), len3, "third entry content length")
 				assert.Equal(t, "three", string(data[offset+37:offset+42]), "third entry content")
@@ -1483,10 +1483,10 @@ func Test_serializeTxMetaBatch_RoundTrip(t *testing.T) {
 		// Verify against original batch
 		assert.Equal(t, batch[i].hash[:], parsedHash[:], "hash mismatch at entry %d", i)
 		if batch[i].isDelete {
-			assert.Equal(t, txmetaActionDELETE, action, "action mismatch at entry %d", i)
+			assert.Equal(t, txmetacache.WireActionDELETE, action, "action mismatch at entry %d", i)
 			assert.Equal(t, uint32(0), contentLen, "delete should have 0 content length")
 		} else {
-			assert.Equal(t, txmetaActionADD, action, "action mismatch at entry %d", i)
+			assert.Equal(t, txmetacache.WireActionADD, action, "action mismatch at entry %d", i)
 			assert.Equal(t, batch[i].metaBytes, content, "content mismatch at entry %d", i)
 		}
 	}
@@ -1520,7 +1520,7 @@ func Test_serializeTxMetaBatchV2(t *testing.T) {
 	off += 8
 	assert.Equal(t, h1[:], data[off:off+32], "entry 1 hash")
 	off += 32
-	assert.Equal(t, txmetaActionADD, data[off], "entry 1 action")
+	assert.Equal(t, txmetacache.WireActionADD, data[off], "entry 1 action")
 	off++
 	assert.Equal(t, uint32(6), binary.LittleEndian.Uint32(data[off:]), "entry 1 content length")
 	off += 4
@@ -1532,7 +1532,7 @@ func Test_serializeTxMetaBatchV2(t *testing.T) {
 	off += 8
 	assert.Equal(t, h2[:], data[off:off+32], "entry 2 hash")
 	off += 32
-	assert.Equal(t, txmetaActionDELETE, data[off], "entry 2 action")
+	assert.Equal(t, txmetacache.WireActionDELETE, data[off], "entry 2 action")
 	off++
 	assert.Equal(t, uint32(0), binary.LittleEndian.Uint32(data[off:]), "entry 2 content length (DELETE => 0)")
 	off += 4

--- a/stores/txmetacache/wire.go
+++ b/stores/txmetacache/wire.go
@@ -45,4 +45,11 @@ const (
 	// (content length = 0 for a DELETE). Used by detectors to bound the
 	// entry count against buffer size.
 	WireV2MinEntrySize = 8 + 32 + 1 + 4
+
+	// WireV1MinEntrySize is the smallest possible v1 entry on the wire:
+	// 32-byte hash + 1-byte action + 4-byte content length (content length
+	// = 0 for a DELETE). Used to clamp a wire-side entry count against the
+	// remaining buffer so a malformed or malicious count cannot trigger an
+	// oversized pre-loop allocation.
+	WireV1MinEntrySize = 32 + 1 + 4
 )

--- a/stores/txmetacache/wire.go
+++ b/stores/txmetacache/wire.go
@@ -1,0 +1,48 @@
+package txmetacache
+
+// This file defines the wire format used by the txmeta Kafka topic. These
+// constants are the protocol contract between the producer (services/validator)
+// and the consumers (services/subtreevalidation, services/legacy/netsync).
+// New consumers must import these constants instead of redeclaring them so
+// the producer and every consumer stay in lockstep.
+//
+// Two wire formats coexist on the topic, distinguished at the receiver by a
+// multi-byte signature:
+//
+//	v1 (legacy)
+//	  [4 bytes] entry count (uint32 LE)
+//	  per entry: [32 hash][1 action][4 contentLen][N content]
+//
+//	v2 (partition-aware)
+//	  [1 byte magic=0xFF][1 byte version=0x02][2 reserved=0][4 entry count LE]
+//	  per entry: [8 xxhash][32 hash][1 action][4 contentLen][N content]
+//
+// v2 detection cannot rely on the magic byte alone: v1 messages with entry
+// counts 255, 511, 767, ... have a little-endian low byte of 0xFF. Receivers
+// MUST validate the full 4-byte header signature (magic + version + 2
+// reserved zero bytes) AND check that the resulting v2 entry count is
+// plausible for the buffer length; on any failure, fall back to v1 parsing.
+
+const (
+	// WireActionADD signals that the entry's content carries a serialized
+	// txmeta payload for the given tx hash.
+	WireActionADD = byte(0)
+	// WireActionDELETE signals that the entry's hash should be removed from
+	// the cache. Content length is zero for DELETE entries.
+	WireActionDELETE = byte(1)
+
+	// WireV2Magic is the first byte of a v2 batch message. Not a unique
+	// discriminator on its own — see the package comment above.
+	WireV2Magic = byte(0xFF)
+	// WireV2Version is the only v2 sub-version defined today. Bump if the
+	// per-entry or header layout changes; receivers reject unknown sub-versions.
+	WireV2Version = byte(0x02)
+	// WireV2HeaderLen is the fixed-size prefix of a v2 message:
+	// [magic][version][2 reserved=0][uint32 LE entry count].
+	WireV2HeaderLen = 8
+	// WireV2MinEntrySize is the smallest possible v2 entry on the wire:
+	// 8-byte xxhash + 32-byte hash + 1-byte action + 4-byte content length
+	// (content length = 0 for a DELETE). Used by detectors to bound the
+	// entry count against buffer size.
+	WireV2MinEntrySize = 8 + 32 + 1 + 4
+)


### PR DESCRIPTION
## Summary

`processTXmetaBatchMessage` in `services/legacy/netsync/manager.go` read the first 4 bytes as a v1 `uint32` entry count unconditionally. If a future deploy flips `validator_txmeta_wireFormat=v2`, the producer emits messages with a `0xFF` magic byte, an 8-byte header, and an 8-byte xxhash before each entry's tx hash. The legacy consumer would either log "truncated message" and ack silently, or misalign and announce garbled tx hashes to peers.

This mirrors the v2 detection added to `services/subtreevalidation/txmetaHandler.go` in #912:

- Branch on `data[0] == 0xFF` → v2; otherwise v1.
- v2: validate sub-version byte, read entry count from `data[4:8]`, set `offset = 8`.
- v2: per entry, skip the 8-byte xxhash before reading the 32-byte hash.

`netsync` discards the xxhash because it only announces ADDs to peers via `txAnnounceBatcher` — partition-aligned cache writes are a `subtreevalidation` concern.

## Test plan

- [x] `go test -race ./services/legacy/netsync/` — all v1 subtests still pass; 4 new v2 subtests added (happy path, DELETE-skipping, unknown sub-version, truncated header)
- [x] Confirmed red phase: the happy-path and DELETE v2 subtests fail against `main` (current code logs `truncated message at entry N` and announces nothing), proving the regression the fix addresses
- [x] `go vet ./services/legacy/...` clean
- [x] `golangci-lint run ./services/legacy/netsync/...` — 0 issues
- [x] `go build ./...` clean

## Notes

- The constants `txmetaWireV2Magic` (0xFF) / `txmetaWireV2Version` (0x02) are now declared in three places: validator (producer), `subtreevalidation/txmetaHandler.go`, and now `legacy/netsync/manager.go`. Consolidating into a shared `model/` helper is a small follow-up — left out here to keep the diff surgical.
- The v2 magic-byte assumption (v1 messages can't start with `0xFF` because that would require >4.27B entries) is the same one used by the subtreevalidation handler.