### PR TITLE
feat: add CockroachDB support for SQL-backed UTXO and blockchain stores

### DIFF
--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -92,6 +92,36 @@ jobs:
       #   if: always()
       #   run: npx github-actions-ctrf ctrf-report.json
 
+  cockroach-tests:
+    name: cockroach integration tests
+    runs-on: teranode-runner-8-core
+    steps:
+      - name: Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@f974e0c5942f8f37973c4cc395704165fbe629ba # v2
+        with:
+          theme: "dark"
+          comment_on_pr: "false"
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      # Only login to Docker Hub for internal PRs to avoid rate limits on the
+      # cockroachdb/cockroach image pull. Fork PRs won't have access to secrets
+      # and will skip this step.
+      - name: Login to Docker Hub
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          username: ${{ vars.DOCKER_ORG }}
+          password: ${{ secrets.DOCKER_ORG_TOKEN }}
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Run Cockroach integration tests
+        run: go test -tags cockroach -timeout 15m ./util/usql/... ./stores/utxo/sql/... ./stores/blockchain/sql/...
+
   filename-check-report:
     name: filename check report
     runs-on: ubuntu-latest

--- a/docs/references/sqlEngines.md
+++ b/docs/references/sqlEngines.md
@@ -1,0 +1,78 @@
+# SQL Engine Support
+
+Teranode's SQL-backed UTXO and blockchain stores work transparently against either PostgreSQL or CockroachDB. Engine identity is auto-detected at connection-init time; no configuration flag is required beyond the standard `postgres://` connection URL.
+
+## Engine identity
+
+`util/usql/engine.go` defines:
+
+| Constant | Value |
+|---|---|
+| `usql.EnginePostgres` | `"postgres"` |
+| `usql.EngineCockroach` | `"cockroach"` |
+| `usql.EngineSqlite` | `"sqlite"` |
+| `usql.EngineSqliteMemory` | `"sqlitememory"` |
+
+`util.InitSQLDB` calls `usql.DetectEngine` after every `postgres://` connection. The function runs `SELECT version()` once and matches the result against the `CockroachDB` / `PostgreSQL` prefix. The detected engine is stashed on the `*usql.DB` wrapper and is reachable via `db.Engine()`.
+
+`usql.IsPostgresLike(e)` reports whether the engine speaks the Postgres wire protocol and accepts the PG-compatible SQL subset Teranode uses (batching, CTEs, UNNEST, partial indexes, ON CONFLICT). Use it to gate fast paths that work on both PG and CRDB. Use explicit `e == EngineCockroach` or `e == EnginePostgres` for engine-specific branches (advisory locks, plpgsql DO blocks).
+
+## Cockroach-specific behavior at init
+
+When the detected engine is `EngineCockroach`, the SQL store does three things differently:
+
+1. **Skips `pg_advisory_lock`.** Cockroach does not implement advisory locks. Fresh CRDB installs land in the target schema via `CREATE TABLE IF NOT EXISTS` without serialization; CRDB's transactional DDL keeps concurrent creates safe.
+2. **Skips the `DO $$ ... END $$` plpgsql migration blocks.** Cockroach has partial plpgsql support and its `pg_constraint` / `pg_attribute` system catalogs differ from PostgreSQL's. These blocks are idempotent migrations for existing PG installs; on a fresh CRDB install they are no-ops anyway, because the bare `CREATE TABLE IF NOT EXISTS` definitions above each block already specify the desired final shape.
+3. **Re-opens the connection pool with `SET serial_normalization = 'sql_sequence'`** as an `AfterConnect` hook. Cockroach defaults `BIGSERIAL` columns to `unique_rowid()`, producing 64-bit "snowflake" values that overflow Go's `uint32` fields downstream (e.g. `block.ID`). With `sql_sequence`, `BIGSERIAL` columns get sequence-backed `nextval()` defaults at `CREATE TABLE` time, matching PostgreSQL semantics.
+
+## Schema verification
+
+Both the UTXO and blockchain stores run a `verifyUTXOSchema` / `verifyBlockchainSchema` check after `createPostgresSchema` returns. The check queries `information_schema.columns` (standard, both engines) and asserts the expected post-init column set is present. The verification runs on **both** PostgreSQL and Cockroach so a future migration that drifts the bare `CREATE TABLE` definition (and forgets to mirror the `DO $$` block for Cockroach) fails loud at startup.
+
+## Future migration contract
+
+When adding a new column or constraint:
+
+| Change | What to do |
+|---|---|
+| **New column** | Add to the `CREATE TABLE IF NOT EXISTS` definition AND add an `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` outside the engine gate (CRDB 22.1+ supports it). Update the `expected` map in the relevant `verifyXxxSchema`. |
+| **New FK with `ON DELETE CASCADE`** | Add to the `CREATE TABLE` definition AND add a PG-only `DO $$` block inside `if engine == usql.EnginePostgres { ... }`. |
+| **New table** | Add `CREATE TABLE IF NOT EXISTS` engine-agnostically. Add to the `expected` map. |
+
+## Engine-specific compatibility notes
+
+- **`BIGSERIAL` PKs are sequence-backed on Cockroach** when the connection has `serial_normalization = 'sql_sequence'` set (Teranode installs this hook automatically). Without it, `BIGSERIAL` produces large `unique_rowid()` values that overflow `uint32` callers.
+- **Modifying CTEs require `RETURNING`** on Cockroach. `WITH ins AS (INSERT INTO ...)` without a `RETURNING` clause fails with SQLSTATE 0A000 "WITH clause does not return any columns". PostgreSQL accepts the same pattern. Add `RETURNING 1` (or another minimal expression) to every modifying CTE.
+- **Recursive SQL UDFs are not supported on Cockroach v24.x.** The blockchain store's legacy `reverse_bytes` / `reverse_bytes_iter` functions (now unused, replaced by the `on_main_chain` partial index) are gated to `EnginePostgres` for this reason.
+
+## License caveat
+
+CockroachDB v23.2+ moved to the CockroachDB Community License (CCL) for core enterprise features. **Single-node deployments are under the Business Source License (BSL)** and impose no operational restrictions. Multi-node production deployments require the CCL — verify license terms before recommending Cockroach for any production path.
+
+## Local development
+
+The `teranode-quickstart` repository provides a `cockroach-utxo` compose profile that boots a single-node Cockroach alongside the Teranode services with `utxostore` pointed at it. See that repo for setup instructions.
+
+## CI coverage
+
+`.github/workflows/teranode_pr_tests.yaml` includes a `cockroach-tests` job that runs:
+
+```
+go test -tags cockroach -timeout 15m ./util/usql/... ./stores/utxo/sql/... ./stores/blockchain/sql/...
+```
+
+The build tag (`//go:build cockroach`) keeps the testcontainers-based suite out of the default test run. Local developers can opt in with the same `-tags cockroach` flag.
+
+## Open caveats
+
+- **Multi-node CRDB performance is untested.** The integration suite boots single-node containers only. The spec's `BIGSERIAL` hot-spotting risk on multi-node clusters remains an open item to address via hash-sharded indexes or alternate ID generation if performance work identifies it.
+- **`stores/utxo/postgres/` is unaffected.** The high-performance Postgres store from upstream issue #684 uses `pgx CopyFrom` to staging tables and is not part of this engine-detection path. Its CRDB compatibility needs its own assessment.
+
+## Implementation reference
+
+- Engine detection helper: `util/usql/engine.go`
+- Engine field on `*DB`: `util/usql/db.go`
+- Pool init with engine wiring: `util/sql.go` (`InitPostgresDB`, `InitSQLiteDB`)
+- UTXO schema init + verification: `stores/utxo/sql/sql.go` (`createPostgresSchema`, `verifyUTXOSchema`)
+- Blockchain schema init + verification: `stores/blockchain/sql/sql.go` (`createPostgresSchema`, `verifyBlockchainSchema`)
+- Testcontainer helper: `test/testcontainers/crdb/cockroach.go` (build-tagged)

--- a/internal/banlist/ban_list.go
+++ b/internal/banlist/ban_list.go
@@ -53,7 +53,7 @@ func NewFromSettings(logger ulogger.Logger, tSettings *settings.Settings) (*BanL
 	}
 
 	engine := store.GetDBEngine()
-	if engine != util.Postgres && engine != util.Sqlite && engine != util.SqliteMemory {
+	if !usql.IsPostgresLike(engine) && engine != util.Sqlite && engine != util.SqliteMemory {
 		return nil, errors.NewStorageError("unsupported database engine: %s", engine)
 	}
 
@@ -340,6 +340,9 @@ func (b *BanList) notifySubscribersAsync(event BanEvent) {
 const banlistSchemaLockID int64 = 7_265_726_098 // "tera" + "bl" in ASCII-ish
 
 func (b *BanList) createTables(ctx context.Context) error {
+	// Cockroach doesn't implement pg_advisory_lock and concurrent CREATE TABLE
+	// IF NOT EXISTS is safe under CRDB's transactional DDL — duplicate creates
+	// are no-ops. Only PostgreSQL needs the lock.
 	if b.engine == util.Postgres {
 		return usql.WithAdvisoryLock(ctx, b.db, banlistSchemaLockID, func() error {
 			return b.createTablesUnlocked(ctx)

--- a/stores/blockchain/sql/FindBlocksContainingSubtree.go
+++ b/stores/blockchain/sql/FindBlocksContainingSubtree.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
-	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 )
 
@@ -31,7 +30,7 @@ func (s *SQL) FindBlocksContainingSubtree(ctx context.Context, subtreeHash *chai
 	}
 
 	subtreeSearchClause := "instr(b.subtrees, $1) > 0"
-	if s.engine == util.Postgres {
+	if s.isPostgresLike() {
 		subtreeSearchClause = "position($1 in b.subtrees) > 0"
 	}
 

--- a/stores/blockchain/sql/GetBlockStats.go
+++ b/stores/blockchain/sql/GetBlockStats.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
-	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 )
 
@@ -68,7 +67,7 @@ func (s *SQL) GetBlockStats(ctx context.Context) (*model.BlockStats, error) {
 
 	tweak := "X'00'"
 
-	if s.GetDBEngine() == util.Postgres {
+	if s.isPostgresLike() {
 		tweak = "'\\x00'::bytea"
 	}
 

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -150,7 +150,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		FROM blocks b
 		JOIN ChainBlocks cb ON b.id = cb.id`
 
-		if s.engine == util.Postgres {
+		if s.isPostgresLike() {
 			hashBytes := make(pgtype.FlatArray[[]byte], len(blockLocator))
 			for i, hash := range blockLocator {
 				hashBytes[i] = hash[:]
@@ -199,7 +199,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		WHERE b.on_main_chain = true
 		  AND b.height <= (SELECT height FROM blocks WHERE hash = $1 LIMIT 1)`
 
-		if s.engine == util.Postgres {
+		if s.isPostgresLike() {
 			hashBytes := make(pgtype.FlatArray[[]byte], len(blockLocator))
 			for i, hash := range blockLocator {
 				hashBytes[i] = hash[:]

--- a/stores/blockchain/sql/GetNextBlockID.go
+++ b/stores/blockchain/sql/GetNextBlockID.go
@@ -2,8 +2,6 @@ package sql
 
 import (
 	"context"
-
-	"github.com/bsv-blockchain/teranode/util"
 )
 
 // GetNextBlockID retrieves the next available block ID from the database.
@@ -16,7 +14,7 @@ import (
 //   - uint64: The next available block ID
 //   - error: Error if retrieval fails
 func (s *SQL) GetNextBlockID(ctx context.Context) (uint64, error) {
-	if s.engine == util.Postgres {
+	if s.isPostgresLike() {
 		return s.getNextBlockIdFromPostgres(ctx)
 	}
 

--- a/stores/blockchain/sql/HasBlockBelowHeightContainingSubtree.go
+++ b/stores/blockchain/sql/HasBlockBelowHeightContainingSubtree.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
-	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 )
 
@@ -25,7 +24,7 @@ func (s *SQL) HasBlockBelowHeightContainingSubtree(ctx context.Context, subtreeH
 	}
 
 	subtreeSearchClause := "instr(subtrees, $1) > 0"
-	if s.engine == util.Postgres {
+	if s.isPostgresLike() {
 		subtreeSearchClause = "position($1 in subtrees) > 0"
 	}
 

--- a/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
+++ b/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
@@ -194,7 +194,7 @@ func TestCreatePostgresSchema_FastPathOnSecondCall(t *testing.T) {
 		`SELECT oid FROM pg_class WHERE relname = 'idx_on_main_chain_height'`,
 	).Scan(&oidBefore))
 
-	require.NoError(t, createPostgresSchema(ulogger.TestLogger{}, db, true))
+	require.NoError(t, createPostgresSchema(ulogger.TestLogger{}, db, true, usql.EnginePostgres))
 
 	var oidAfter int64
 	require.NoError(t, db.QueryRow(

--- a/stores/blockchain/sql/SetBlockPersistedAt.go
+++ b/stores/blockchain/sql/SetBlockPersistedAt.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
-	"github.com/bsv-blockchain/teranode/util"
 )
 
 // SetBlockPersistedAt updates the persisted_at timestamp for a block.
@@ -17,7 +16,7 @@ func (s *SQL) SetBlockPersistedAt(ctx context.Context, blockHash *chainhash.Hash
 
 	var q string
 
-	if s.engine == util.Postgres {
+	if s.isPostgresLike() {
 		q = `
 			UPDATE blocks
 			SET persisted_at = CURRENT_TIMESTAMP

--- a/stores/blockchain/sql/SetBlockProcessedAt.go
+++ b/stores/blockchain/sql/SetBlockProcessedAt.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
-	"github.com/bsv-blockchain/teranode/util"
 )
 
 // SetBlockProcessedAt updates the processed_at timestamp for a block.
@@ -24,7 +23,7 @@ func (s *SQL) SetBlockProcessedAt(ctx context.Context, blockHash *chainhash.Hash
 			WHERE hash = $1
 		`
 	} else {
-		if s.engine == util.Postgres {
+		if s.isPostgresLike() {
 			q = `
 				UPDATE blocks
 				SET processed_at = CURRENT_TIMESTAMP

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -20,7 +20,6 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain/work"
 	"github.com/bsv-blockchain/teranode/stores/blockchain/options"
-	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"github.com/bsv-blockchain/teranode/util/usql"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -554,7 +553,7 @@ RETURNING id
 
 	if storeBlockOptions.PersistedAt {
 		now := time.Now()
-		if s.engine == util.Postgres {
+		if s.isPostgresLike() {
 			persistedAt = now
 		} else {
 			// SQLite stores timestamps as TEXT - format as "YYYY-MM-DD HH:MM:SS"

--- a/stores/blockchain/sql/blob_deletion.go
+++ b/stores/blockchain/sql/blob_deletion.go
@@ -98,7 +98,7 @@ func (s *SQL) GetPendingBlobDeletions(ctx context.Context, height uint32, limit 
         LIMIT $2
     `
 
-	if s.engine == "postgres" {
+	if s.isPostgresLike() {
 		query += "\n        FOR UPDATE SKIP LOCKED"
 	}
 
@@ -307,7 +307,7 @@ func (s *SQL) AcquireBlobDeletionBatch(ctx context.Context, height uint32, limit
     `
 
 	// Add locking for PostgreSQL
-	if s.engine == "postgres" {
+	if s.isPostgresLike() {
 		query += "\n        FOR UPDATE SKIP LOCKED"
 	}
 

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -546,7 +546,7 @@ func isBlockchainSchemaCurrent(db *usql.DB, withIndexes bool) (bool, error) {
 // (NOT) EXISTS that both engines accept), but is reserved so future migrations
 // that need to be Postgres-only — e.g. plpgsql DO $$ blocks, which Cockroach
 // does not implement — can branch on it without another signature change.
-func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool, engine usql.Engine)error {
+func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool, engine usql.Engine) error {
 	if _, err := db.Exec(`
       CREATE TABLE IF NOT EXISTS state (
 	    key            VARCHAR(32) PRIMARY KEY
@@ -915,14 +915,14 @@ func verifyBlockchainSchema(ctx context.Context, db *usql.DB, engine usql.Engine
 			WHERE table_name = $1
 		`, table)
 		if err != nil {
-			return fmt.Errorf("verify %s schema (%s): %w", table, engine, err)
+			return errors.NewStorageError("verify %s schema (%s): %w", table, engine, err)
 		}
 		present := map[string]struct{}{}
 		for rows.Next() {
 			var c string
 			if err := rows.Scan(&c); err != nil {
 				_ = rows.Close()
-				return fmt.Errorf("verify %s schema (%s): scan: %w", table, engine, err)
+				return errors.NewStorageError("verify %s schema (%s) scan: %w", table, engine, err)
 			}
 			present[c] = struct{}{}
 		}
@@ -934,7 +934,7 @@ func verifyBlockchainSchema(ctx context.Context, db *usql.DB, engine usql.Engine
 			}
 		}
 		if len(missing) > 0 {
-			return fmt.Errorf("table %s on %s missing columns: %v", table, engine, missing)
+			return errors.NewStorageError("table %s on %s missing columns: %v", table, engine, missing)
 		}
 	}
 	return nil

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -902,42 +902,12 @@ var blockchainSchemaExpectedColumnsByTable = map[string][]string{
 	},
 }
 
-// verifyBlockchainSchema queries information_schema.columns (standard, both PG
-// and Cockroach) and confirms every expected column is present on every
-// expected table. Returns an error listing missing columns; does not check
-// column types. Called from New() after createPostgresSchema completes, only
-// on Postgres-like engines.
+// verifyBlockchainSchema delegates to usql.VerifySchemaColumns with the
+// blockchain-store expected column map. Runs post-init on Postgres-like
+// engines so a future migration that drifts the bare CREATE TABLE definition
+// fails loud.
 func verifyBlockchainSchema(ctx context.Context, db *usql.DB, engine usql.Engine) error {
-	for table, expected := range blockchainSchemaExpectedColumnsByTable {
-		rows, err := db.QueryContext(ctx, `
-			SELECT column_name
-			FROM information_schema.columns
-			WHERE table_name = $1
-		`, table)
-		if err != nil {
-			return errors.NewStorageError("verify %s schema (%s): %w", table, engine, err)
-		}
-		present := map[string]struct{}{}
-		for rows.Next() {
-			var c string
-			if err := rows.Scan(&c); err != nil {
-				_ = rows.Close()
-				return errors.NewStorageError("verify %s schema (%s) scan: %w", table, engine, err)
-			}
-			present[c] = struct{}{}
-		}
-		_ = rows.Close()
-		var missing []string
-		for _, col := range expected {
-			if _, ok := present[col]; !ok {
-				missing = append(missing, col)
-			}
-		}
-		if len(missing) > 0 {
-			return errors.NewStorageError("table %s on %s missing columns: %v", table, engine, missing)
-		}
-	}
-	return nil
+	return usql.VerifySchemaColumns(ctx, db, engine, blockchainSchemaExpectedColumnsByTable)
 }
 
 func createSqliteSchema(db *usql.DB) error {

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -74,8 +74,10 @@ const migrationFullRebuildTimeout = 30 * time.Minute
 type SQL struct {
 	// db is the underlying SQL database connection pool
 	db *usql.DB
-	// engine identifies which SQL engine is being used (PostgreSQL, SQLite, etc.)
-	engine util.SQLEngine
+	// engine identifies which SQL engine is being used (PostgreSQL, SQLite, etc.).
+	// Stored as usql.Engine so callers can use the IsPostgresLike helper to
+	// share code paths between PostgreSQL and CockroachDB.
+	engine usql.Engine
 	// logger provides structured logging capabilities
 	logger ulogger.Logger
 	// responseCache provides a time-based cache for frequently accessed query results
@@ -179,8 +181,18 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		// The 'seeder' query parameter is used to optimize bulk imports by bypassing index creation.
 		// Creating indexes during data insertion can significantly slow down the process, so we skip
 		// index creation when 'seeder=true' is specified in the query parameters.
-		if err = createPostgresSchema(logger, db, storeURL.Query().Get("seeder") != trueStr); err != nil {
+		if err = createPostgresSchema(logger, db, storeURL.Query().Get("seeder") != trueStr, db.Engine()); err != nil {
 			return nil, errors.NewStorageError("failed to create postgres schema", err)
+		}
+
+		// Verify the post-init schema on every Postgres-like engine so a future
+		// migration that diverges Postgres and Cockroach schemas (e.g. forgets
+		// to mirror a DO $$ block) fails loud at startup instead of producing
+		// silently-wrong queries.
+		if usql.IsPostgresLike(db.Engine()) {
+			if err = verifyBlockchainSchema(context.Background(), db, db.Engine()); err != nil {
+				return nil, errors.NewStorageError("blockchain schema verification failed", err)
+			}
 		}
 
 		if storeURL.Query().Get("seeder") == trueStr {
@@ -228,7 +240,7 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 
 	s := &SQL{
 		db:                    db,
-		engine:                util.SQLEngine(storeURL.Scheme),
+		engine:                db.Engine(),
 		logger:                logger,
 		responseCache:         NewGenerationalCache(),
 		cacheTTL:              2 * time.Minute,
@@ -338,6 +350,13 @@ func (s *SQL) GetDBEngine() util.SQLEngine {
 	return s.engine
 }
 
+// isPostgresLike reports whether the store is backed by a Postgres-wire engine
+// (PostgreSQL or CockroachDB). Used to gate fast paths that work on both:
+// CTEs, partial indexes, RETURNING, dollar-quoted placeholders.
+func (s *SQL) isPostgresLike() bool {
+	return usql.IsPostgresLike(s.engine)
+}
+
 func (s *SQL) Close() error {
 	// Signal the background refresh goroutine to stop.
 	if s.backgroundDone != nil {
@@ -359,7 +378,30 @@ func (s *SQL) Close() error {
 // These must be unique per schema-creation context and stable across releases.
 const blockchainSchemaLockID int64 = 7_265_726_101 // "tera" + "bc" in ASCII-ish
 
-func createPostgresSchema(logger ulogger.Logger, db *usql.DB, withIndexes bool) error {
+func createPostgresSchema(logger ulogger.Logger, db *usql.DB, withIndexes bool, engine usql.Engine) error {
+	// Cockroach does not implement pg_advisory_lock. Concurrent CREATE TABLE
+	// IF NOT EXISTS on Cockroach is safe under transactional DDL — duplicate
+	// creates are no-ops — and the column/index migrations below are also
+	// idempotent (IF NOT EXISTS / IF EXISTS guarded). So we skip the advisory
+	// lock dance entirely for Cockroach and run the schema sequence directly.
+	if engine == usql.EngineCockroach {
+		logger.Infof("[blockchain schema] cockroach engine, skipping advisory lock and checking schema")
+		current, err := isBlockchainSchemaCurrent(db, withIndexes)
+		if err != nil {
+			logger.Warnf("[blockchain schema] current-schema probe failed, will run full DDL: %v", err)
+		} else if current {
+			logger.Infof("[blockchain schema] current (withIndexes=%v), skipping DDL", withIndexes)
+			return nil
+		} else {
+			logger.Infof("[blockchain schema] not current (withIndexes=%v), running DDL sequence", withIndexes)
+		}
+		if err := createPostgresSchemaUnlocked(db, withIndexes, engine); err != nil {
+			return err
+		}
+		logger.Infof("[blockchain schema] DDL sequence complete")
+		return nil
+	}
+
 	logger.Infof("[blockchain schema] acquiring advisory lock (id=%d) and checking schema", blockchainSchemaLockID)
 	return usql.WithAdvisoryLock(context.Background(), db, blockchainSchemaLockID, func() error {
 		// Fast path: if the schema is already current, skip the DDL sequence
@@ -387,7 +429,7 @@ func createPostgresSchema(logger ulogger.Logger, db *usql.DB, withIndexes bool) 
 		} else {
 			logger.Infof("[blockchain schema] not current (withIndexes=%v), running DDL sequence", withIndexes)
 		}
-		if err := createPostgresSchemaUnlocked(db, withIndexes); err != nil {
+		if err := createPostgresSchemaUnlocked(db, withIndexes, engine); err != nil {
 			return err
 		}
 		logger.Infof("[blockchain schema] DDL sequence complete")
@@ -497,7 +539,14 @@ func isBlockchainSchemaCurrent(db *usql.DB, withIndexes bool) (bool, error) {
 	return true, nil
 }
 
-func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool) error {
+// createPostgresSchemaUnlocked is the actual DDL sequence — split out from
+// createPostgresSchema so the Postgres path can wrap it in an advisory lock and
+// the Cockroach path can call it directly. The engine parameter is currently
+// unused inside this function (all statements are idempotent CREATE/ALTER IF
+// (NOT) EXISTS that both engines accept), but is reserved so future migrations
+// that need to be Postgres-only — e.g. plpgsql DO $$ blocks, which Cockroach
+// does not implement — can branch on it without another signature change.
+func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool, _ usql.Engine) error {
 	if _, err := db.Exec(`
       CREATE TABLE IF NOT EXISTS state (
 	    key            VARCHAR(32) PRIMARY KEY
@@ -781,6 +830,105 @@ func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool) error {
 		return errors.NewStorageError("could not create idx_scheduled_blob_deletions_height index", err)
 	}
 
+	return nil
+}
+
+// blockchainSchemaExpectedColumnsByTable is the full post-init column set for
+// every table created by createPostgresSchemaUnlocked. verifyBlockchainSchema
+// enforces this on both PostgreSQL and CockroachDB so a future migration that
+// drifts the bare CREATE TABLE definition (and forgets to mirror an ALTER for
+// Cockroach) fails loud at startup instead of producing silently-wrong
+// queries against a half-populated schema.
+//
+// Column names are lowercase to match Postgres' information_schema catalog
+// representation: unquoted identifiers in DDL are folded to lowercase by both
+// PostgreSQL and CockroachDB.
+//
+// Kept in sync with the CREATE TABLE / ADD COLUMN statements in
+// createPostgresSchemaUnlocked above. blockchainSchemaExpectedColumns
+// (declared earlier) covers only the columns added post-CREATE-TABLE for the
+// fast-path probe; this map covers every expected column on every table.
+var blockchainSchemaExpectedColumnsByTable = map[string][]string{
+	"state": {
+		"key",
+		"data",
+		"inserted_at",
+		"updated_at",
+	},
+	"blocks": {
+		"id",
+		"parent_id",
+		"version",
+		"hash",
+		"previous_hash",
+		"merkle_root",
+		"block_time",
+		"n_bits",
+		"nonce",
+		"height",
+		"chain_work",
+		"tx_count",
+		"size_in_bytes",
+		"subtree_count",
+		"subtrees",
+		"coinbase_tx",
+		"invalid",
+		"mined_set",
+		"subtrees_set",
+		"peer_id",
+		"inserted_at",
+		"processed_at",
+		"persisted_at",
+		"median_time_past",
+		"coinbase_bump",
+		"on_main_chain",
+	},
+	"scheduled_blob_deletions": {
+		"id",
+		"blob_key",
+		"file_type",
+		"store_type",
+		"delete_at_height",
+		"retry_count",
+		"last_retry_at",
+	},
+}
+
+// verifyBlockchainSchema queries information_schema.columns (standard, both PG
+// and Cockroach) and confirms every expected column is present on every
+// expected table. Returns an error listing missing columns; does not check
+// column types. Called from New() after createPostgresSchema completes, only
+// on Postgres-like engines.
+func verifyBlockchainSchema(ctx context.Context, db *usql.DB, engine usql.Engine) error {
+	for table, expected := range blockchainSchemaExpectedColumnsByTable {
+		rows, err := db.QueryContext(ctx, `
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_name = $1
+		`, table)
+		if err != nil {
+			return fmt.Errorf("verify %s schema (%s): %w", table, engine, err)
+		}
+		present := map[string]struct{}{}
+		for rows.Next() {
+			var c string
+			if err := rows.Scan(&c); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("verify %s schema (%s): scan: %w", table, engine, err)
+			}
+			present[c] = struct{}{}
+		}
+		_ = rows.Close()
+		var missing []string
+		for _, col := range expected {
+			if _, ok := present[col]; !ok {
+				missing = append(missing, col)
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("table %s on %s missing columns: %v", table, engine, missing)
+		}
+	}
 	return nil
 }
 
@@ -1070,7 +1218,7 @@ func (s *SQL) insertGenesisTransaction(logger ulogger.Logger, params *chaincfg.P
 		// turn off foreign key checks when inserting the genesis block
 		if s.engine == util.Sqlite || s.engine == util.SqliteMemory {
 			_, _ = s.db.Exec("PRAGMA foreign_keys = OFF")
-		} else if s.engine == util.Postgres {
+		} else if s.isPostgresLike() {
 			_, _ = s.db.Exec("SET session_replication_role = 'replica'")
 		}
 
@@ -1084,7 +1232,7 @@ func (s *SQL) insertGenesisTransaction(logger ulogger.Logger, params *chaincfg.P
 		// turn foreign key checks back on
 		if s.engine == util.Sqlite || s.engine == util.SqliteMemory {
 			_, _ = s.db.Exec("PRAGMA foreign_keys = ON")
-		} else if s.engine == util.Postgres {
+		} else if s.isPostgresLike() {
 			_, _ = s.db.Exec("SET session_replication_role = 'origin'")
 		}
 	} else if !bytes.Equal(hash, params.GenesisHash[:]) {

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -546,7 +546,7 @@ func isBlockchainSchemaCurrent(db *usql.DB, withIndexes bool) (bool, error) {
 // (NOT) EXISTS that both engines accept), but is reserved so future migrations
 // that need to be Postgres-only — e.g. plpgsql DO $$ blocks, which Cockroach
 // does not implement — can branch on it without another signature change.
-func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool, _ usql.Engine) error {
+func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool, engine usql.Engine)error {
 	if _, err := db.Exec(`
       CREATE TABLE IF NOT EXISTS state (
 	    key            VARCHAR(32) PRIMARY KEY
@@ -777,32 +777,40 @@ func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool, _ usql.Engine) 
 		}
 	}
 
-	if _, err := db.Exec(`
-		CREATE OR REPLACE FUNCTION reverse_bytes_iter(bytes bytea, length int, midpoint int, index int)
-		RETURNS bytea AS
-		$$
-		  SELECT CASE WHEN index >= midpoint THEN bytes ELSE
-			reverse_bytes_iter(
-			  set_byte(
-				set_byte(bytes, index, get_byte(bytes, length-index)),
-				length-index, get_byte(bytes, index)
-			  ),
-			  length, midpoint, index + 1
-			)
-		  END;
-		$$ LANGUAGE SQL IMMUTABLE;
-   `); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not create block_transactions_map table", err)
-	}
+	// reverse_bytes / reverse_bytes_iter are legacy SQL UDFs left over from an
+	// earlier main-chain-height lookup path. They are unused by current Go code
+	// (the partial index above replaced them). CockroachDB v24.x rejects the
+	// recursive self-reference during planning ("unknown function:
+	// reverse_bytes_iter"), so gate the block to PostgreSQL until the functions
+	// can be removed entirely.
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
+			CREATE OR REPLACE FUNCTION reverse_bytes_iter(bytes bytea, length int, midpoint int, index int)
+			RETURNS bytea AS
+			$$
+			  SELECT CASE WHEN index >= midpoint THEN bytes ELSE
+				reverse_bytes_iter(
+				  set_byte(
+					set_byte(bytes, index, get_byte(bytes, length-index)),
+					length-index, get_byte(bytes, index)
+				  ),
+				  length, midpoint, index + 1
+				)
+			  END;
+			$$ LANGUAGE SQL IMMUTABLE;
+	   `); err != nil {
+			_ = db.Close()
+			return errors.NewStorageError("could not create reverse_bytes_iter function", err)
+		}
 
-	if _, err := db.Exec(`
-		CREATE OR REPLACE FUNCTION reverse_bytes(bytes bytea) RETURNS bytea AS
-		'SELECT reverse_bytes_iter(bytes, octet_length(bytes)-1, octet_length(bytes)/2, 0)'
-		LANGUAGE SQL IMMUTABLE;
-	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not create block_transactions_map table", err)
+		if _, err := db.Exec(`
+			CREATE OR REPLACE FUNCTION reverse_bytes(bytes bytea) RETURNS bytea AS
+			'SELECT reverse_bytes_iter(bytes, octet_length(bytes)-1, octet_length(bytes)/2, 0)'
+			LANGUAGE SQL IMMUTABLE;
+		`); err != nil {
+			_ = db.Close()
+			return errors.NewStorageError("could not create reverse_bytes function", err)
+		}
 	}
 
 	if _, err := db.Exec(`

--- a/stores/blockchain/sql/sql_cockroach_test.go
+++ b/stores/blockchain/sql/sql_cockroach_test.go
@@ -66,4 +66,12 @@ func TestCockroach_BlockchainRoundtrip(t *testing.T) {
 	retrieved, err := store.GetBlockByID(ctx, id)
 	require.NoError(t, err)
 	require.Equal(t, block1.Hash().String(), retrieved.Hash().String())
+
+	// Exercise GetNextBlockID, which queries pg_get_serial_sequence — only
+	// returns a non-NULL sequence on CRDB if serial_normalization='sql_sequence'
+	// was active when the blocks table was created. Guards against future
+	// reordering of the AfterConnect hook relative to schema init.
+	nextID, err := store.GetNextBlockID(ctx)
+	require.NoError(t, err)
+	require.Greater(t, nextID, uint64(0))
 }

--- a/stores/blockchain/sql/sql_cockroach_test.go
+++ b/stores/blockchain/sql/sql_cockroach_test.go
@@ -1,0 +1,69 @@
+//go:build cockroach
+
+package sql
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	tctc "github.com/bsv-blockchain/teranode/test/testcontainers/crdb"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/usql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCockroach_BlockchainSchemaInit verifies that the blockchain SQL store
+// boots cleanly against a real CockroachDB instance: engine detection
+// identifies CRDB, the Postgres schema-init path runs, and the post-init
+// verifyBlockchainSchema (Task 8) accepts every expected column on the bare
+// CREATE TABLE definitions emitted on Cockroach.
+func TestCockroach_BlockchainSchemaInit(t *testing.T) {
+	ctx := context.Background()
+	connURL := tctc.StartCockroach(t, ctx, "teranode_blockchain_test")
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	parsed, err := url.Parse(connURL)
+	require.NoError(t, err)
+
+	db, err := util.InitSQLDB(logger, parsed, tSettings)
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Equal(t, usql.EngineCockroach, db.Engine(), "expected Cockroach engine detection")
+
+	store, err := New(logger, parsed, tSettings)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	defer store.Close()
+}
+
+// TestCockroach_BlockchainRoundtrip exercises the Postgres-like store/fetch
+// paths end-to-end against CRDB: StoreBlock writes block1, then GetBlockByID
+// reads it back and confirms the hash matches. This proves the Postgres
+// branches of StoreBlock + GetBlockByID work on Cockroach.
+func TestCockroach_BlockchainRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	connURL := tctc.StartCockroach(t, ctx, "teranode_blockchain_rt_test")
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	parsed, err := url.Parse(connURL)
+	require.NoError(t, err)
+
+	store, err := New(logger, parsed, tSettings)
+	require.NoError(t, err)
+	defer store.Close()
+
+	id, height, err := store.StoreBlock(ctx, block1, "")
+	require.NoError(t, err)
+	require.Greater(t, id, uint64(0))
+	require.Equal(t, uint32(1), height)
+
+	retrieved, err := store.GetBlockByID(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, block1.Hash().String(), retrieved.Hash().String())
+}

--- a/stores/utxo/sql/create_postgres_schema_test.go
+++ b/stores/utxo/sql/create_postgres_schema_test.go
@@ -240,18 +240,21 @@ func TestCreatePostgresSchema_ErrorAtUnspentByParentIndex(t *testing.T) {
 // The ACTUAL solution to get coverage: Create a testable interface version
 // and temporarily modify the original function to be testable
 
-// Helper function that calls the ACTUAL extracted implementation
+// Helper function that calls the ACTUAL extracted implementation.
+// Engine is hard-coded to Postgres so the DO $$ migration blocks execute and
+// all mock expectations are satisfied.
 func createPostgresSchemaWithMockDB(_ *usql.DB, mockDB *MockDB) error {
 	// Now we can call the actual implementation function with our mock!
-	return createPostgresSchemaImpl(mockDB)
+	return createPostgresSchemaImpl(mockDB, usql.EnginePostgres)
 }
 
 // createPostgresSchemaTestWrapper delegates to the real implementation.
+// Engine is hard-coded to Postgres so the DO $$ migration blocks execute.
 func createPostgresSchemaTestWrapper(db interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Close() error
 }) error {
-	return createPostgresSchemaImpl(db)
+	return createPostgresSchemaImpl(db, usql.EnginePostgres)
 }
 
 // Direct test of our wrapper function to show coverage

--- a/stores/utxo/sql/create_postgres_schema_test.go
+++ b/stores/utxo/sql/create_postgres_schema_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -252,6 +253,7 @@ func createPostgresSchemaWithMockDB(_ *usql.DB, mockDB *MockDB) error {
 // Engine is hard-coded to Postgres so the DO $$ migration blocks execute.
 func createPostgresSchemaTestWrapper(db interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	Close() error
 }) error {
 	return createPostgresSchemaImpl(db, usql.EnginePostgres)

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -4865,14 +4865,14 @@ func verifyUTXOSchema(ctx context.Context, db DBExecutor, engine usql.Engine) er
 			WHERE table_name = $1
 		`, table)
 		if err != nil {
-			return fmt.Errorf("verify %s schema (%s): %w", table, engine, err)
+			return errors.NewStorageError("verify %s schema (%s): %w", table, engine, err)
 		}
 		present := map[string]struct{}{}
 		for rows.Next() {
 			var c string
 			if err := rows.Scan(&c); err != nil {
 				_ = rows.Close()
-				return fmt.Errorf("verify %s schema (%s): scan: %w", table, engine, err)
+				return errors.NewStorageError("verify %s schema (%s) scan: %w", table, engine, err)
 			}
 			present[c] = struct{}{}
 		}
@@ -4884,7 +4884,7 @@ func verifyUTXOSchema(ctx context.Context, db DBExecutor, engine usql.Engine) er
 			}
 		}
 		if len(missing) > 0 {
-			return fmt.Errorf("table %s on %s missing columns: %v", table, engine, missing)
+			return errors.NewStorageError("table %s on %s missing columns: %v", table, engine, missing)
 		}
 	}
 	return nil

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -4854,40 +4854,11 @@ var utxoSchemaExpectedColumns = map[string][]string{
 	},
 }
 
-// verifyUTXOSchema queries information_schema.columns (standard, both PG and
-// Cockroach) and confirms every expected column is present on every expected
-// table. Returns an error listing missing columns; does not check column types.
-func verifyUTXOSchema(ctx context.Context, db DBExecutor, engine usql.Engine) error {
-	for table, expected := range utxoSchemaExpectedColumns {
-		rows, err := db.QueryContext(ctx, `
-			SELECT column_name
-			FROM information_schema.columns
-			WHERE table_name = $1
-		`, table)
-		if err != nil {
-			return errors.NewStorageError("verify %s schema (%s): %w", table, engine, err)
-		}
-		present := map[string]struct{}{}
-		for rows.Next() {
-			var c string
-			if err := rows.Scan(&c); err != nil {
-				_ = rows.Close()
-				return errors.NewStorageError("verify %s schema (%s) scan: %w", table, engine, err)
-			}
-			present[c] = struct{}{}
-		}
-		_ = rows.Close()
-		var missing []string
-		for _, col := range expected {
-			if _, ok := present[col]; !ok {
-				missing = append(missing, col)
-			}
-		}
-		if len(missing) > 0 {
-			return errors.NewStorageError("table %s on %s missing columns: %v", table, engine, missing)
-		}
-	}
-	return nil
+// verifyUTXOSchema delegates to usql.VerifySchemaColumns with the UTXO-store
+// expected column map. Runs post-init on Postgres-like engines so a future
+// migration that drifts the bare CREATE TABLE definition fails loud.
+func verifyUTXOSchema(ctx context.Context, db usql.SchemaQuerier, engine usql.Engine) error {
+	return usql.VerifySchemaColumns(ctx, db, engine, utxoSchemaExpectedColumns)
 }
 
 func createSqliteSchema(db *usql.DB) error {

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -179,6 +179,12 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 			return nil, errors.NewStorageError("failed to create postgres schema", err)
 		}
 
+		if usql.IsPostgresLike(db.Engine()) {
+			if err = verifyUTXOSchema(ctx, db, db.Engine()); err != nil {
+				return nil, errors.NewServiceError("utxo schema verification failed", err)
+			}
+		}
+
 	case "sqlite", "sqlitememory":
 		if err = createSqliteSchema(db); err != nil {
 			return nil, errors.NewStorageError("failed to create sqlite schema", err)
@@ -4526,8 +4532,11 @@ func (s *Store) MarkTransactionsOnLongestChain(ctx context.Context, txHashes []c
 }
 
 // DBExecutor interface for database operations needed by schema creation
+// and verification. Both createPostgresSchemaImpl and verifyUTXOSchema rely
+// on this minimal surface so tests can substitute fakes.
 type DBExecutor interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	Close() error
 }
 
@@ -4781,6 +4790,100 @@ func createPostgresSchemaImpl(db DBExecutor, engine usql.Engine) error {
 		return errors.NewStorageError("could not create px_outputs_unspent_by_parent index - [%+v]", err)
 	}
 
+	return nil
+}
+
+// utxoSchemaExpectedColumns is the post-init column set for each UTXO store
+// table. verifyUTXOSchema enforces this on both PostgreSQL and Cockroach so a
+// future migration that drifts the bare CREATE TABLE definition (and forgets
+// to mirror the DO $$ block for Cockroach) fails loud at startup.
+//
+// Column names are stored lowercase to match Postgres' information_schema
+// catalog representation: unquoted identifiers in DDL (e.g. spendableIn) are
+// folded to lowercase by both PostgreSQL and CockroachDB.
+var utxoSchemaExpectedColumns = map[string][]string{
+	"transactions": {
+		"id",
+		"hash",
+		"version",
+		"lock_time",
+		"fee",
+		"size_in_bytes",
+		"coinbase",
+		"frozen",
+		"conflicting",
+		"locked",
+		"delete_at_height",
+		"unmined_since",
+		"preserve_until",
+		"inserted_at",
+	},
+	"inputs": {
+		"transaction_id",
+		"idx",
+		"previous_transaction_hash",
+		"previous_tx_idx",
+		"previous_tx_satoshis",
+		"previous_tx_script",
+		"unlocking_script",
+		"sequence_number",
+	},
+	"outputs": {
+		"transaction_id",
+		"idx",
+		"locking_script",
+		"satoshis",
+		"coinbase_spending_height",
+		"utxo_hash",
+		"spending_data",
+		"frozen",
+		"spendablein",
+	},
+	"block_ids": {
+		"transaction_id",
+		"block_id",
+		"block_height",
+		"subtree_idx",
+	},
+	"conflicting_children": {
+		"transaction_id",
+		"child_transaction_id",
+	},
+}
+
+// verifyUTXOSchema queries information_schema.columns (standard, both PG and
+// Cockroach) and confirms every expected column is present on every expected
+// table. Returns an error listing missing columns; does not check column types.
+func verifyUTXOSchema(ctx context.Context, db DBExecutor, engine usql.Engine) error {
+	for table, expected := range utxoSchemaExpectedColumns {
+		rows, err := db.QueryContext(ctx, `
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_name = $1
+		`, table)
+		if err != nil {
+			return fmt.Errorf("verify %s schema (%s): %w", table, engine, err)
+		}
+		present := map[string]struct{}{}
+		for rows.Next() {
+			var c string
+			if err := rows.Scan(&c); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("verify %s schema (%s): scan: %w", table, engine, err)
+			}
+			present[c] = struct{}{}
+		}
+		_ = rows.Close()
+		var missing []string
+		for _, col := range expected {
+			if _, ok := present[col]; !ok {
+				missing = append(missing, col)
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("table %s on %s missing columns: %v", table, engine, missing)
+		}
+	}
 	return nil
 }
 

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -175,7 +175,7 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 
 	switch storeURL.Scheme {
 	case "postgres":
-		if err = createPostgresSchema(db); err != nil {
+		if err = createPostgresSchema(db, db.Engine()); err != nil {
 			return nil, errors.NewStorageError("failed to create postgres schema", err)
 		}
 
@@ -4534,14 +4534,21 @@ type DBExecutor interface {
 // Advisory lock ID for UTXO schema creation serialization across pods.
 const utxoSchemaLockID int64 = 7_265_726_117 // "tera" + "ux" in ASCII-ish
 
-func createPostgresSchema(db *usql.DB) error {
+func createPostgresSchema(db *usql.DB, engine usql.Engine) error {
+	// Cockroach does not implement pg_advisory_lock. Concurrent CREATE TABLE
+	// IF NOT EXISTS on Cockroach is safe under transactional DDL — duplicate
+	// creates are no-ops. There is no migration block to serialize on a fresh
+	// Cockroach install because we skip the DO $$ blocks below.
+	if engine == usql.EngineCockroach {
+		return createPostgresSchemaImpl(db, engine)
+	}
 	return usql.WithAdvisoryLock(context.Background(), db, utxoSchemaLockID, func() error {
-		return createPostgresSchemaImpl(db)
+		return createPostgresSchemaImpl(db, engine)
 	})
 }
 
 // createPostgresSchemaImpl contains the actual implementation, now testable
-func createPostgresSchemaImpl(db DBExecutor) error {
+func createPostgresSchemaImpl(db DBExecutor, engine usql.Engine) error {
 	if _, err := db.Exec(`
       CREATE TABLE IF NOT EXISTS transactions (
          id               BIGSERIAL PRIMARY KEY
@@ -4597,8 +4604,11 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 		return errors.NewStorageError("could not create inputs table - [%+v]", err)
 	}
 
-	// Ensure inputs FK has ON DELETE CASCADE — only drop+recreate if it exists without CASCADE
-	if _, err := db.Exec(`
+	// Ensure inputs FK has ON DELETE CASCADE — only drop+recreate if it exists without CASCADE.
+	// Postgres-only: Cockroach does not implement plpgsql DO blocks and does not need the
+	// migration (fresh installs land with the CASCADE FK from CREATE TABLE above).
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
 		DO $$
 		BEGIN
 			IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'inputs_transaction_id_fkey' AND contype = 'f' AND confdeltype != 'c') THEN
@@ -4609,8 +4619,9 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 			END IF;
 		END $$;
 	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not ensure CASCADE foreign key on inputs table - [%+v]", err)
+			_ = db.Close()
+			return errors.NewStorageError("could not ensure CASCADE foreign key on inputs table - [%+v]", err)
+		}
 	}
 
 	// All fields are NOT NULL except for the spending_data which is NULL for unspent outputs.
@@ -4634,8 +4645,11 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 		return errors.NewStorageError("could not create outputs table - [%+v]", err)
 	}
 
-	// Ensure outputs FK has ON DELETE CASCADE — only drop+recreate if it exists without CASCADE
-	if _, err := db.Exec(`
+	// Ensure outputs FK has ON DELETE CASCADE — only drop+recreate if it exists without CASCADE.
+	// Postgres-only: Cockroach does not implement plpgsql DO blocks and does not need the
+	// migration (fresh installs land with the CASCADE FK from CREATE TABLE above).
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
 		DO $$
 		BEGIN
 			IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'outputs_transaction_id_fkey' AND contype = 'f' AND confdeltype != 'c') THEN
@@ -4646,8 +4660,9 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 			END IF;
 		END $$;
 	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not ensure CASCADE foreign key on outputs table - [%+v]", err)
+			_ = db.Close()
+			return errors.NewStorageError("could not ensure CASCADE foreign key on outputs table - [%+v]", err)
+		}
 	}
 
 	if _, err := db.Exec(`
@@ -4663,8 +4678,11 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 		return errors.NewStorageError("could not create block_ids table - [%+v]", err)
 	}
 
-	// Add new columns to block_ids table if they don't exist
-	if _, err := db.Exec(`
+	// Add new columns to block_ids table if they don't exist.
+	// Postgres-only: Cockroach does not implement plpgsql DO blocks and does not need the
+	// migration (fresh installs already have these columns from CREATE TABLE above).
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
 		DO $$
 		BEGIN
 			IF NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'block_ids'::regclass AND attname = 'block_height' AND NOT attisdropped) THEN
@@ -4676,12 +4694,16 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 			END IF;
 		END $$;
 	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not add new columns to block_ids table - [%+v]", err)
+			_ = db.Close()
+			return errors.NewStorageError("could not add new columns to block_ids table - [%+v]", err)
+		}
 	}
 
-	// Add unmined_since column to transactions table if it doesn't exist
-	if _, err := db.Exec(`
+	// Add unmined_since column to transactions table if it doesn't exist.
+	// Postgres-only: Cockroach does not implement plpgsql DO blocks and does not need the
+	// migration (fresh installs already have the column from CREATE TABLE above).
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
 		DO $$
 		BEGIN
 			IF NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'transactions'::regclass AND attname = 'unmined_since' AND NOT attisdropped) THEN
@@ -4689,12 +4711,16 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 			END IF;
 		END $$;
 	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not add unmined_since column to transactions table - [%+v]", err)
+			_ = db.Close()
+			return errors.NewStorageError("could not add unmined_since column to transactions table - [%+v]", err)
+		}
 	}
 
-	// Add preserve_until column to transactions table if it doesn't exist
-	if _, err := db.Exec(`
+	// Add preserve_until column to transactions table if it doesn't exist.
+	// Postgres-only: Cockroach does not implement plpgsql DO blocks and does not need the
+	// migration (fresh installs already have the column from CREATE TABLE above).
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
 		DO $$
 		BEGIN
 			IF NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'transactions'::regclass AND attname = 'preserve_until' AND NOT attisdropped) THEN
@@ -4702,12 +4728,16 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 			END IF;
 		END $$;
 	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not add preserve_until column to transactions table - [%+v]", err)
+			_ = db.Close()
+			return errors.NewStorageError("could not add preserve_until column to transactions table - [%+v]", err)
+		}
 	}
 
-	// Ensure block_ids FK has ON DELETE CASCADE — only drop+recreate if it exists without CASCADE
-	if _, err := db.Exec(`
+	// Ensure block_ids FK has ON DELETE CASCADE — only drop+recreate if it exists without CASCADE.
+	// Postgres-only: Cockroach does not implement plpgsql DO blocks and does not need the
+	// migration (fresh installs land with the CASCADE FK from CREATE TABLE above).
+	if engine == usql.EnginePostgres {
+		if _, err := db.Exec(`
 		DO $$
 		BEGIN
 			IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'block_ids_transaction_id_fkey' AND contype = 'f' AND confdeltype != 'c') THEN
@@ -4718,8 +4748,9 @@ func createPostgresSchemaImpl(db DBExecutor) error {
 			END IF;
 		END $$;
 	`); err != nil {
-		_ = db.Close()
-		return errors.NewStorageError("could not ensure CASCADE foreign key on block_ids table - [%+v]", err)
+			_ = db.Close()
+			return errors.NewStorageError("could not ensure CASCADE foreign key on block_ids table - [%+v]", err)
+		}
 	}
 
 	if _, err := db.Exec(`

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -663,16 +663,19 @@ WITH new_tx AS (
 	SELECT new_tx.id, u.idx, u.prev_hash, u.prev_idx, u.prev_satoshis, u.prev_script, u.unlock_script, u.seq_num
 	FROM new_tx, UNNEST($11::int[],$12::bytea[],$13::int[],$14::bigint[],$15::bytea[],$16::bytea[],$17::bigint[])
 		AS u(idx, prev_hash, prev_idx, prev_satoshis, prev_script, unlock_script, seq_num)
+	RETURNING 1
 ), ins_outputs AS (
 	INSERT INTO outputs (transaction_id,idx,locking_script,satoshis,coinbase_spending_height,utxo_hash,spending_data)
 	SELECT new_tx.id, u.idx, u.locking_script, u.satoshis, u.csh, u.utxo_hash, NULL
 	FROM new_tx, UNNEST($18::int[],$19::bytea[],$20::bigint[],$21::int[],$22::bytea[])
 		AS u(idx, locking_script, satoshis, csh, utxo_hash)
+	RETURNING 1
 ), ins_block_ids AS (
 	INSERT INTO block_ids (transaction_id,block_id,block_height,subtree_idx)
 	SELECT new_tx.id, u.block_id, u.block_height, u.subtree_idx
 	FROM new_tx, UNNEST($23::int[],$24::int[],$25::int[])
 		AS u(block_id, block_height, subtree_idx)
+	RETURNING 1
 )
 SELECT id FROM new_tx
 `

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -98,7 +98,7 @@ type Store struct {
 	settings        *settings.Settings
 	db              *usql.DB
 	storeURL        *url.URL
-	engine          string
+	engine          usql.Engine
 	blockHeight     atomic.Uint32
 	medianBlockTime atomic.Uint32
 	ctx             context.Context
@@ -106,6 +106,13 @@ type Store struct {
 	getBatcher      *batcher.Batcher[batchGetItem]
 	createBatcher   *batcher.Batcher[batchCreateItem]
 	unlockBatcher   *batcher.Batcher[batchUnlockItem]
+}
+
+// isPostgresLike reports whether the store is backed by a Postgres-wire engine
+// (PostgreSQL or CockroachDB). Used to gate fast paths that work on both:
+// pgx batching, CTEs, UNNEST, partial indexes, ON CONFLICT.
+func (s *Store) isPostgresLike() bool {
+	return usql.IsPostgresLike(s.engine)
 }
 
 // batchUnlockItem represents a single SetLocked(false) request.
@@ -186,7 +193,7 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 		settings:        tSettings,
 		db:              db,
 		storeURL:        storeURL,
-		engine:          storeURL.Scheme,
+		engine:          db.Engine(),
 		blockHeight:     atomic.Uint32{},
 		medianBlockTime: atomic.Uint32{},
 		ctx:             ctx,
@@ -397,7 +404,7 @@ func (s *Store) createWithRetry(ctx context.Context, tx *bt.Tx, blockHeight uint
 	}
 
 	// Postgres with batching: single-CTE with UNNEST arrays — one round-trip, auto-atomic
-	if s.settings.UtxoStore.BatchSQLOperations && s.engine == "postgres" {
+	if s.settings.UtxoStore.BatchSQLOperations && s.isPostgresLike() {
 		return s.createCTE(ctx, tx, blockHeight, options, txHash, txMeta, isCoinbase, unminedSince)
 	}
 
@@ -1932,7 +1939,7 @@ func (s *Store) sendSpendBatch(batch []*batchSpend) {
 // Returns false if the batch completed (success or non-retryable error) and results
 // have been sent to all item errCh channels.
 func (s *Store) trySendSpendBatch(batch []*batchSpend) (retryable bool) {
-	if s.settings.UtxoStore.BatchSQLOperations && s.engine == "postgres" {
+	if s.settings.UtxoStore.BatchSQLOperations && s.isPostgresLike() {
 		return s.trySendSpendBatchBulk(batch)
 	}
 	return s.trySendSpendBatchPerRow(batch)
@@ -3913,7 +3920,7 @@ func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) 
 	//   - Postgres caps at 65535; fewer, larger queries win because the planner
 	//     fuses the IN list and we save round-trips. 4000 pairs = 8000 params.
 	chunkSize := maxINClauseSize
-	if s.engine == string(util.Postgres) {
+	if s.isPostgresLike() {
 		chunkSize = postgresBatchDecorateChunkSize
 	}
 	if batchDecorateChunkSizeOverride > 0 {
@@ -4203,7 +4210,7 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 
 	if setValue {
 		// Postgres: pipeline all lock UPDATEs in a single network flush
-		if s.engine == "postgres" {
+		if s.isPostgresLike() {
 			return s.setLockedPipelined(ctx, txHashes)
 		}
 		// SQLite: sequential updates
@@ -4237,7 +4244,7 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 	}
 
 	// Postgres: bulk unlock + DAH in chunked UPDATE statements
-	if s.engine == "postgres" {
+	if s.isPostgresLike() {
 		return s.setUnlockedBulk(ctx, txHashes)
 	}
 
@@ -5235,13 +5242,13 @@ type outpointPair struct {
 // parent. The VALUES-join form forces a per-pair composite-PK lookup
 // (`transaction_id = t.id AND idx = v.i`), an ~90× cost reduction on 3-pair
 // cases and a much larger reduction when parent txs have many outputs.
-func buildCompositeValuesPairs(pairs []outpointPair, startIdx int, engine string) (string, []interface{}) {
+func buildCompositeValuesPairs(pairs []outpointPair, startIdx int, engine usql.Engine) (string, []interface{}) {
 	if len(pairs) == 0 {
 		return "", nil
 	}
 	groups := make([]string, len(pairs))
 	args := make([]interface{}, 0, len(pairs)*2)
-	postgres := engine == string(util.Postgres)
+	postgres := usql.IsPostgresLike(engine)
 	for i, p := range pairs {
 		a := startIdx + (2 * i)
 		b := a + 1

--- a/stores/utxo/sql/sql_cockroach_test.go
+++ b/stores/utxo/sql/sql_cockroach_test.go
@@ -1,0 +1,137 @@
+//go:build cockroach
+
+package sql
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
+	tctc "github.com/bsv-blockchain/teranode/test/testcontainers/crdb"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/usql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCockroach_SchemaInit verifies that the UTXO store boots cleanly against
+// a real CockroachDB instance: engine detection identifies CRDB, the Postgres
+// schema-init path runs without the pg_advisory_lock / DO $$ statements, and
+// post-init verifyUTXOSchema accepts every expected column.
+func TestCockroach_SchemaInit(t *testing.T) {
+	ctx := context.Background()
+	connURL := tctc.StartCockroach(t, ctx, "teranode_utxo_test")
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	parsed, err := url.Parse(connURL)
+	require.NoError(t, err)
+
+	db, err := util.InitSQLDB(logger, parsed, tSettings)
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Equal(t, usql.EngineCockroach, db.Engine(), "expected Cockroach engine detection")
+
+	store, err := New(ctx, logger, tSettings, parsed)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+// TestCockroach_VerifySchemaCatchesMissingColumn pre-creates a deliberately
+// incomplete transactions table, then calls verifyUTXOSchema directly. The
+// verification must report the missing columns rather than silently passing.
+// This guards against schema drift where a future migration forgets to mirror
+// a column add on CockroachDB's bare CREATE TABLE definition.
+func TestCockroach_VerifySchemaCatchesMissingColumn(t *testing.T) {
+	ctx := context.Background()
+	connURL := tctc.StartCockroach(t, ctx, "teranode_utxo_verify_test")
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	parsed, err := url.Parse(connURL)
+	require.NoError(t, err)
+
+	db, err := util.InitSQLDB(logger, parsed, tSettings)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Pre-create a deliberately incomplete `transactions` table to simulate
+	// drift. The store's New() is intentionally not called here — we want
+	// verifyUTXOSchema to see this stub table, not the full schema.
+	_, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS transactions (id BIGSERIAL PRIMARY KEY)")
+	require.NoError(t, err)
+
+	err = verifyUTXOSchema(ctx, db, usql.EngineCockroach)
+	require.Error(t, err, "expected verification to fail when columns are missing")
+}
+
+// TestCockroach_SpendRoundtrip exercises the Postgres-like fast paths
+// (isPostgresLike branches) end-to-end against CRDB: Create a parent tx,
+// Create a child tx that references the parent, Spend one of the child's
+// outputs, then read back the outputs row to confirm spending_data is set.
+func TestCockroach_SpendRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	connURL := tctc.StartCockroach(t, ctx, "teranode_utxo_spend_test")
+
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	// The "batched SQL" Create path uses a single CTE
+	// (WITH ins_inputs AS (INSERT...)) with no RETURNING. Postgres accepts
+	// this; CockroachDB v24.1 rejects it with SQLSTATE 0A000 ("WITH clause
+	// does not return any columns"). The fast-path is currently gated on
+	// isPostgresLike, which is overreaching — CRDB needs a separate path.
+	// That gate fix is an isPostgresLike (Task 6) follow-up. To keep this
+	// integration test focused on the engine-detection + non-batched Create
+	// + Spend roundtrip, disable the CTE batch path here.
+	tSettings.UtxoStore.BatchSQLOperations = false
+	tSettings.UtxoStore.StoreBatcherSize = 1
+
+	parsed, err := url.Parse(connURL)
+	require.NoError(t, err)
+
+	store, err := New(ctx, logger, tSettings, parsed)
+	require.NoError(t, err)
+
+	err = store.SetBlockHeight(1000)
+	require.NoError(t, err)
+
+	// Parent first — tests.Tx references tests.ParentTx as input.
+	_, err = store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.ParentTx.TxIDChainHash()) }()
+
+	_, err = store.Create(ctx, tests.Tx, 1000)
+	require.NoError(t, err)
+	defer func() { _ = store.Delete(ctx, tests.Tx.TxIDChainHash()) }()
+
+	txHash := *tests.Tx.TxIDChainHash()
+
+	// Build a spend tx that consumes output 0 of tests.Tx.
+	spendTx := bt.NewTx()
+	require.NoError(t, spendTx.From(
+		txHash.String(), 0,
+		tests.Tx.Outputs[0].LockingScript.String(),
+		tests.Tx.Outputs[0].Satoshis,
+	))
+	require.NoError(t, spendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
+
+	_, err = store.Spend(ctx, spendTx, 1001)
+	require.NoError(t, err)
+
+	// Verify the output row is marked spent. We don't decode spending_data —
+	// non-NULL is sufficient to confirm the Postgres-like UPDATE path ran on
+	// Cockroach.
+	var spendingData []byte
+	err = store.db.QueryRowContext(ctx,
+		`SELECT spending_data FROM outputs o
+		 JOIN transactions t ON o.transaction_id = t.id
+		 WHERE t.hash = $1 AND o.idx = 0`,
+		txHash[:]).Scan(&spendingData)
+	require.NoError(t, err)
+	require.NotNil(t, spendingData, "outputs.spending_data should be set after Spend")
+	require.NotEmpty(t, spendingData, "outputs.spending_data should be non-empty after Spend")
+}

--- a/stores/utxo/sql/sql_cockroach_test.go
+++ b/stores/utxo/sql/sql_cockroach_test.go
@@ -79,16 +79,6 @@ func TestCockroach_SpendRoundtrip(t *testing.T) {
 
 	logger := ulogger.TestLogger{}
 	tSettings := test.CreateBaseTestSettings(t)
-	// The "batched SQL" Create path uses a single CTE
-	// (WITH ins_inputs AS (INSERT...)) with no RETURNING. Postgres accepts
-	// this; CockroachDB v24.1 rejects it with SQLSTATE 0A000 ("WITH clause
-	// does not return any columns"). The fast-path is currently gated on
-	// isPostgresLike, which is overreaching — CRDB needs a separate path.
-	// That gate fix is an isPostgresLike (Task 6) follow-up. To keep this
-	// integration test focused on the engine-detection + non-batched Create
-	// + Spend roundtrip, disable the CTE batch path here.
-	tSettings.UtxoStore.BatchSQLOperations = false
-	tSettings.UtxoStore.StoreBatcherSize = 1
 
 	parsed, err := url.Parse(connURL)
 	require.NoError(t, err)

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -1349,8 +1349,9 @@ func TestCreatePostgresSchema(t *testing.T) {
 	// Setup successful mock expectations for all DDL operations
 	SetupCreatePostgresSchemaSuccessMocks(mockDB)
 
-	// Call the function under test using the mock
-	err := createPostgresSchemaImpl(mockDB)
+	// Call the function under test using the mock. Pass EnginePostgres so the
+	// DO $$ migration blocks execute and the mock expectations all fire.
+	err := createPostgresSchemaImpl(mockDB, usql.EnginePostgres)
 
 	// Verify success
 	assert.NoError(t, err)

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/usql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1495,7 +1496,7 @@ func TestCreateSqliteSchemaDirectly(t *testing.T) {
 	store, err := New(ctx, logger, tSettings, utxoStoreURL)
 	require.NoError(t, err)
 	require.NotNil(t, store)
-	assert.Equal(t, "sqlitememory", store.engine)
+	assert.Equal(t, usql.EngineSqliteMemory, store.engine)
 
 	// Verify all expected tables were created
 	expectedTables := []string{"transactions", "inputs", "outputs", "block_ids", "conflicting_children"}

--- a/test/testcontainers/cockroach.go
+++ b/test/testcontainers/cockroach.go
@@ -1,0 +1,67 @@
+//go:build cockroach
+
+package testcontainers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// StartCockroach boots a single-node insecure CockroachDB container, creates
+// a fresh test database, and returns a postgres-wire connection URL. The
+// container is automatically torn down via t.Cleanup.
+//
+// Pinned to v24.1 to keep the test stable across CRDB releases. Update
+// deliberately when validating against a newer version.
+func StartCockroach(t *testing.T, ctx context.Context, dbName string) (url string) {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "cockroachdb/cockroach:v24.1.13",
+		ExposedPorts: []string{"26257/tcp"},
+		Cmd:          []string{"start-single-node", "--insecure", "--listen-addr=0.0.0.0:26257"},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort("26257/tcp"),
+			wait.ForLog("nodeID:"),
+		),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = container.Terminate(ctx)
+	})
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "26257")
+	require.NoError(t, err)
+
+	rootURL := fmt.Sprintf("postgres://root@%s:%s/defaultdb?sslmode=disable", host, port.Port())
+
+	// Create the test database from the default connection.
+	createDB(t, ctx, rootURL, dbName)
+
+	return fmt.Sprintf("postgres://root@%s:%s/%s?sslmode=disable", host, port.Port(), dbName)
+}
+
+func createDB(t *testing.T, ctx context.Context, rootURL, dbName string) {
+	t.Helper()
+	// Open a one-shot connection via database/sql + pgx stdlib driver.
+	// Avoid importing usql to keep this helper self-contained.
+	db, err := sql.Open("pgx", rootURL)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName))
+	require.NoError(t, err)
+}

--- a/test/testcontainers/crdb/cockroach.go
+++ b/test/testcontainers/crdb/cockroach.go
@@ -1,6 +1,11 @@
 //go:build cockroach
 
-package testcontainers
+// Package crdb provides a build-tagged CockroachDB testcontainer helper.
+// It lives in a sub-package (separate from test/testcontainers) so that
+// stores can import it without dragging in the daemon dependency that the
+// parent package carries — daemon → stores/utxo/factory → stores/utxo/sql
+// would create an import cycle otherwise.
+package crdb
 
 import (
 	"context"
@@ -26,7 +31,17 @@ func StartCockroach(t *testing.T, ctx context.Context, dbName string) (url strin
 	req := testcontainers.ContainerRequest{
 		Image:        "cockroachdb/cockroach:v24.1.13",
 		ExposedPorts: []string{"26257/tcp"},
-		Cmd:          []string{"start-single-node", "--insecure", "--listen-addr=0.0.0.0:26257"},
+		// CRDB v24.1 rejects "--listen-addr=0.0.0.0:..." with: hostname of
+		// listen_addr must be "127.0.0.1" or "localhost". An empty hostname
+		// (":26257") binds all interfaces and is what CRDB itself recommends
+		// for containerised single-node test setups; --advertise-addr makes
+		// the node usable from outside the container via the mapped port.
+		Cmd: []string{
+			"start-single-node",
+			"--insecure",
+			"--listen-addr=:26257",
+			"--advertise-addr=localhost:26257",
+		},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("26257/tcp"),
 			wait.ForLog("nodeID:"),

--- a/util/sql.go
+++ b/util/sql.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -17,12 +18,16 @@ import (
 	"github.com/labstack/gommon/random"
 )
 
-type SQLEngine string
+// SQLEngine is preserved as an alias to usql.Engine for backwards
+// compatibility with existing call sites. New code should use usql.Engine
+// directly. The aliases below let existing references to util.Postgres etc.
+// keep compiling during the migration to a single canonical type.
+type SQLEngine = usql.Engine
 
 const (
-	Postgres     SQLEngine = "postgres"
-	Sqlite       SQLEngine = "sqlite"
-	SqliteMemory SQLEngine = "sqlitememory"
+	Postgres     = usql.EnginePostgres
+	Sqlite       = usql.EngineSqlite
+	SqliteMemory = usql.EngineSqliteMemory
 )
 
 // InitSQLDB initializes a SQL database connection based on the provided URL scheme.
@@ -87,6 +92,17 @@ func InitPostgresDB(logger ulogger.Logger, storeURL *url.URL, tSettings *setting
 
 	sqlDB := stdlib.OpenDB(*connConfig)
 	db := usql.WrapDB(sqlDB)
+
+	// Identify the engine (Postgres vs Cockroach) via a single SELECT version().
+	// Cockroach speaks the PG wire protocol so the connection succeeds either way;
+	// engine identity gates the schema-init code paths downstream.
+	engine, err := usql.DetectEngine(context.Background(), db)
+	if err != nil {
+		_ = db.Close()
+		return nil, errors.NewServiceError("failed to detect postgres engine", err)
+	}
+	db.SetEngine(engine)
+	logger.Infof("Detected SQL engine: %s", engine)
 
 	logger.Infof("Using postgres DB: %s@%s:%d/%s", dbUser, dbHost, dbPort, dbName)
 
@@ -244,6 +260,12 @@ func InitSQLiteDB(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.
 	db, err = usql.Open("sqlite", filename)
 	if err != nil {
 		return nil, errors.NewServiceError("failed to open sqlite DB", err)
+	}
+
+	if storeURL.Scheme == "sqlitememory" {
+		db.SetEngine(usql.EngineSqliteMemory)
+	} else {
+		db.SetEngine(usql.EngineSqlite)
 	}
 
 	// foreign_keys is set per-connection via the `_pragma=foreign_keys=on`

--- a/util/sql.go
+++ b/util/sql.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/url"
 	"os"
@@ -100,6 +101,24 @@ func InitPostgresDB(logger ulogger.Logger, storeURL *url.URL, tSettings *setting
 	if err != nil {
 		_ = db.Close()
 		return nil, errors.NewServiceError("failed to detect postgres engine", err)
+	}
+
+	if engine == usql.EngineCockroach {
+		// CockroachDB's BIGSERIAL default is unique_rowid() — globally unique but
+		// 64-bit "snowflake" values that overflow Go's uint32 fields downstream
+		// (e.g. block.ID). Switching to sql_sequence makes BIGSERIAL emit a
+		// monotonic small-integer sequence at CREATE TABLE time, matching
+		// PostgreSQL semantics. The DEFAULT clause is captured at column-creation
+		// time, so the setting only needs to be active when DDL runs — but we
+		// install it on every connection for safety in case of future schema
+		// extensions added at runtime.
+		_ = db.Close()
+		connector := stdlib.GetConnector(*connConfig, stdlib.OptionAfterConnect(func(ctx context.Context, conn *pgx.Conn) error {
+			_, err := conn.Exec(ctx, "SET serial_normalization = 'sql_sequence'")
+			return err
+		}))
+		sqlDB = sql.OpenDB(connector)
+		db = usql.WrapDB(sqlDB)
 	}
 	db.SetEngine(engine)
 	logger.Infof("Detected SQL engine: %s", engine)

--- a/util/sql_test.go
+++ b/util/sql_test.go
@@ -54,9 +54,12 @@ func TestInitSQLDB(t *testing.T) {
 		errType string
 	}{
 		{
-			name:    "valid postgres scheme",
-			url:     "postgres://user:pass@localhost:5432/testdb",
-			wantErr: false, // sql.Open doesn't actually connect, just validates driver
+			name: "valid postgres scheme",
+			url:  "postgres://user:pass@localhost:5432/testdb",
+			// InitPostgresDB now runs DetectEngine (SELECT version()) at init.
+			// Without a reachable Postgres on localhost:5432 the call must fail.
+			wantErr: true,
+			errType: "service error",
 		},
 		{
 			name:    "valid sqlite scheme",
@@ -148,13 +151,14 @@ func TestInitPostgresDB(t *testing.T) {
 
 			db, err := util.InitPostgresDB(logger, storeURL, testSettings, nil)
 
-			// sql.Open doesn't actually connect, it just validates the driver.
-			// Connection only happens on first query/ping.
-			assert.NoError(t, err)
-			assert.NotNil(t, db)
-			if db != nil {
-				db.Close()
-			}
+			// InitPostgresDB now calls DetectEngine which forces a real connection
+			// via SELECT version(). Without a reachable Postgres on localhost:5432
+			// this fails — the error path also closes the underlying *sql.DB, so
+			// db must be nil. The error message confirms config parsing succeeded
+			// and we reached the engine-detection step.
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to detect postgres engine")
+			assert.Nil(t, db)
 		})
 	}
 }
@@ -500,16 +504,16 @@ func TestInitPostgresDB_PoolSettings(t *testing.T) {
 			// we'll test the helper function that determines pool settings
 			// by creating a mock that captures what would be set
 
-			// Test the merging logic by calling InitPostgresDB
-			// It will fail to connect, but we can verify the error is about connection, not settings
+			// Test that the call gets past config parsing and reaches engine
+			// detection (which fails because no PG is listening on localhost:5432).
+			// Pool-setting merging happens after DetectEngine, so this test no
+			// longer exercises that path — see TestPostgresPoolSettingsMerging
+			// for the unit-test coverage of the merge logic itself.
 			db, err := util.InitPostgresDB(logger, storeURL, tt.globalSettings, tt.servicePoolSettings)
 
-			// We expect a connection error, not a configuration error
-			if err != nil {
-				// Verify it's a connection error, not a settings error
-				assert.Contains(t, err.Error(), "failed to open postgres DB")
-				assert.Nil(t, db)
-			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to detect postgres engine")
+			assert.Nil(t, db)
 
 			// To actually verify the pool settings were applied correctly,
 			// we would need a real PostgreSQL connection. For unit tests,
@@ -626,8 +630,11 @@ func TestInitSQLDB_WithServicePoolSettings(t *testing.T) {
 			name:                "postgres with nil service settings",
 			url:                 "postgres://user:pass@localhost:5432/testdb",
 			servicePoolSettings: nil,
-			wantErr:             false,
-			description:         "Should use global defaults when service settings are nil",
+			// InitPostgresDB now runs DetectEngine; without a reachable PG on
+			// localhost:5432 the call fails. The merge-logic coverage lives in
+			// TestPostgresPoolSettingsMerging.
+			wantErr:     true,
+			description: "Postgres path fails at engine detection when no DB is reachable",
 		},
 		{
 			name: "postgres with service settings",
@@ -635,8 +642,8 @@ func TestInitSQLDB_WithServicePoolSettings(t *testing.T) {
 			servicePoolSettings: &settings.PostgresSettings{
 				MaxOpenConns: 80,
 			},
-			wantErr:     false,
-			description: "Should merge service settings with global defaults",
+			wantErr:     true,
+			description: "Postgres path fails at engine detection when no DB is reachable",
 		},
 		{
 			name:                "sqlite ignores service pool settings",

--- a/util/usql/db.go
+++ b/util/usql/db.go
@@ -18,6 +18,7 @@ type DB struct {
 	*sql.DB
 	retryConfig    RetryConfig
 	circuitBreaker *CircuitBreaker
+	engine         Engine
 }
 
 func Open(driverName, dataSourceName string) (*DB, error) {
@@ -194,4 +195,18 @@ func (db *DB) recordCircuitBreakerResult(err error) {
 		db.circuitBreaker.RecordSuccess()
 	}
 	// Non-retriable errors (business logic errors) are ignored by the circuit breaker
+}
+
+// Engine returns the SQL engine identity for this connection. Set once at
+// init via SetEngine (typically by util.InitSQLDB after DetectEngine). The
+// zero value is the empty Engine; callers must not assume any particular
+// engine before SetEngine has been invoked.
+func (db *DB) Engine() Engine {
+	return db.engine
+}
+
+// SetEngine stashes the engine identity on the wrapper. Idempotent; the
+// expected pattern is one call at init time.
+func (db *DB) SetEngine(e Engine) {
+	db.engine = e
 }

--- a/util/usql/db_test.go
+++ b/util/usql/db_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -733,4 +734,19 @@ func BenchmarkExec(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestDB_EngineField(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	wrapped := WrapDB(db)
+	require.Equal(t, Engine(""), wrapped.Engine(), "default engine is empty until set")
+
+	wrapped.SetEngine(EnginePostgres)
+	require.Equal(t, EnginePostgres, wrapped.Engine())
+
+	wrapped.SetEngine(EngineCockroach)
+	require.Equal(t, EngineCockroach, wrapped.Engine())
 }

--- a/util/usql/engine.go
+++ b/util/usql/engine.go
@@ -2,8 +2,9 @@ package usql
 
 import (
 	"context"
-	"fmt"
 	"strings"
+
+	"github.com/bsv-blockchain/teranode/errors"
 )
 
 // Engine identifies the SQL engine behind a *usql.DB connection.
@@ -37,7 +38,7 @@ func IsPostgresLike(e Engine) bool {
 func DetectEngine(ctx context.Context, db *DB) (Engine, error) {
 	var v string
 	if err := db.DB.QueryRowContext(ctx, "SELECT version()").Scan(&v); err != nil {
-		return "", fmt.Errorf("detect engine: %w", err)
+		return "", errors.New(errors.ERR_ERROR, "detect engine: %w", err)
 	}
 	switch {
 	case strings.Contains(v, "CockroachDB"):
@@ -45,6 +46,6 @@ func DetectEngine(ctx context.Context, db *DB) (Engine, error) {
 	case strings.Contains(v, "PostgreSQL"):
 		return EnginePostgres, nil
 	default:
-		return "", fmt.Errorf("unrecognized engine: %q", v)
+		return "", errors.New(errors.ERR_ERROR, "unrecognized engine: %q", v)
 	}
 }

--- a/util/usql/engine.go
+++ b/util/usql/engine.go
@@ -1,0 +1,22 @@
+package usql
+
+// Engine identifies the SQL engine behind a *usql.DB connection.
+// PostgreSQL and CockroachDB both speak the Postgres wire protocol but
+// diverge on a few features (advisory locks, plpgsql DO blocks); call
+// sites use IsPostgresLike for shared fast paths and explicit equality
+// checks for engine-specific branches.
+type Engine string
+
+const (
+	EnginePostgres     Engine = "postgres"
+	EngineCockroach    Engine = "cockroach"
+	EngineSqlite       Engine = "sqlite"
+	EngineSqliteMemory Engine = "sqlitememory"
+)
+
+// IsPostgresLike reports whether the engine speaks the Postgres wire
+// protocol and accepts the PG-compatible SQL subset used by Teranode
+// (batching, CTEs, UNNEST, partial indexes, ON CONFLICT).
+func IsPostgresLike(e Engine) bool {
+	return e == EnginePostgres || e == EngineCockroach
+}

--- a/util/usql/engine.go
+++ b/util/usql/engine.go
@@ -2,10 +2,75 @@ package usql
 
 import (
 	"context"
+	"database/sql"
+	"sort"
 	"strings"
 
 	"github.com/bsv-blockchain/teranode/errors"
 )
+
+// SchemaQuerier is the minimal surface VerifySchemaColumns needs. Both *usql.DB
+// and the store packages' DBExecutor interfaces satisfy it.
+type SchemaQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
+
+// VerifySchemaColumns checks that every column listed in expected is present
+// on the corresponding table in the database's public schema. Designed to run
+// post-init on PostgreSQL-like engines; catches drift where a future migration
+// added a column to one engine's path but not the other.
+//
+// Returns a single error per call listing every (table, missing-columns)
+// finding so operators see the full delta instead of a leaky one-at-a-time
+// view. Iteration over the expected map is sorted by table name so error
+// messages are deterministic across runs.
+func VerifySchemaColumns(ctx context.Context, db SchemaQuerier, engine Engine, expected map[string][]string) error {
+	tables := make([]string, 0, len(expected))
+	for table := range expected {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+
+	var findings []string
+	for _, table := range tables {
+		rows, err := db.QueryContext(ctx, `
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_schema = 'public' AND table_name = $1
+		`, table)
+		if err != nil {
+			return errors.NewStorageError("verify %s schema (%s)", table, engine, err)
+		}
+		present := map[string]struct{}{}
+		for rows.Next() {
+			var c string
+			if err := rows.Scan(&c); err != nil {
+				_ = rows.Close()
+				return errors.NewStorageError("verify %s schema (%s) scan", table, engine, err)
+			}
+			present[c] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return errors.NewStorageError("verify %s schema (%s) iter", table, engine, err)
+		}
+		_ = rows.Close()
+
+		var missing []string
+		for _, col := range expected[table] {
+			if _, ok := present[col]; !ok {
+				missing = append(missing, col)
+			}
+		}
+		if len(missing) > 0 {
+			findings = append(findings, table+": "+strings.Join(missing, ","))
+		}
+	}
+	if len(findings) > 0 {
+		return errors.NewStorageError("missing columns on %s: %s", engine, strings.Join(findings, "; "))
+	}
+	return nil
+}
 
 // Engine identifies the SQL engine behind a *usql.DB connection.
 // PostgreSQL and CockroachDB both speak the Postgres wire protocol but
@@ -38,7 +103,7 @@ func IsPostgresLike(e Engine) bool {
 func DetectEngine(ctx context.Context, db *DB) (Engine, error) {
 	var v string
 	if err := db.DB.QueryRowContext(ctx, "SELECT version()").Scan(&v); err != nil {
-		return "", errors.New(errors.ERR_ERROR, "detect engine: %w", err)
+		return "", errors.New(errors.ERR_ERROR, "detect engine", err)
 	}
 	switch {
 	case strings.Contains(v, "CockroachDB"):

--- a/util/usql/engine.go
+++ b/util/usql/engine.go
@@ -1,5 +1,11 @@
 package usql
 
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
 // Engine identifies the SQL engine behind a *usql.DB connection.
 // PostgreSQL and CockroachDB both speak the Postgres wire protocol but
 // diverge on a few features (advisory locks, plpgsql DO blocks); call
@@ -19,4 +25,26 @@ const (
 // (batching, CTEs, UNNEST, partial indexes, ON CONFLICT).
 func IsPostgresLike(e Engine) bool {
 	return e == EnginePostgres || e == EngineCockroach
+}
+
+// DetectEngine probes the connected database and returns its engine identity.
+// Safe to call once per *DB at init; the result is stable for the connection's
+// lifetime. Runs a single SELECT version() query against an arbitrary connection
+// from the pool — version() is a session-independent constant.
+//
+// Returns an error if the version string matches neither known engine. Loud
+// failure is preferred over silently falling back to a wrong engine assumption.
+func DetectEngine(ctx context.Context, db *DB) (Engine, error) {
+	var v string
+	if err := db.DB.QueryRowContext(ctx, "SELECT version()").Scan(&v); err != nil {
+		return "", fmt.Errorf("detect engine: %w", err)
+	}
+	switch {
+	case strings.Contains(v, "CockroachDB"):
+		return EngineCockroach, nil
+	case strings.Contains(v, "PostgreSQL"):
+		return EnginePostgres, nil
+	default:
+		return "", fmt.Errorf("unrecognized engine: %q", v)
+	}
 }

--- a/util/usql/engine_test.go
+++ b/util/usql/engine_test.go
@@ -1,0 +1,24 @@
+package usql
+
+import "testing"
+
+func TestIsPostgresLike(t *testing.T) {
+	cases := []struct {
+		engine Engine
+		want   bool
+	}{
+		{EnginePostgres, true},
+		{EngineCockroach, true},
+		{EngineSqlite, false},
+		{EngineSqliteMemory, false},
+		{Engine(""), false},
+		{Engine("mysql"), false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.engine), func(t *testing.T) {
+			if got := IsPostgresLike(tc.engine); got != tc.want {
+				t.Fatalf("IsPostgresLike(%q) = %v, want %v", tc.engine, got, tc.want)
+			}
+		})
+	}
+}

--- a/util/usql/engine_test.go
+++ b/util/usql/engine_test.go
@@ -75,3 +75,67 @@ func TestDetectEngine_QueryError(t *testing.T) {
 	_, err = DetectEngine(context.Background(), WrapDB(db))
 	require.Error(t, err)
 }
+
+func TestVerifySchemaColumns(t *testing.T) {
+	expected := map[string][]string{
+		"transactions": {"id", "hash", "version"},
+		"outputs":      {"transaction_id", "idx"},
+	}
+
+	t.Run("all present", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery("SELECT column_name").WithArgs("outputs").
+			WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("transaction_id").AddRow("idx"))
+		mock.ExpectQuery("SELECT column_name").WithArgs("transactions").
+			WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("id").AddRow("hash").AddRow("version"))
+
+		err = VerifySchemaColumns(context.Background(), db, EngineCockroach, expected)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("missing column reported", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery("SELECT column_name").WithArgs("outputs").
+			WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("transaction_id").AddRow("idx"))
+		mock.ExpectQuery("SELECT column_name").WithArgs("transactions").
+			WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("id").AddRow("hash"))
+
+		err = VerifySchemaColumns(context.Background(), db, EngineCockroach, expected)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "transactions: version")
+	})
+
+	t.Run("query error propagated", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery("SELECT column_name").WithArgs("outputs").WillReturnError(context.DeadlineExceeded)
+
+		err = VerifySchemaColumns(context.Background(), db, EngineCockroach, expected)
+		require.Error(t, err)
+	})
+
+	t.Run("multi-table drift in one error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectQuery("SELECT column_name").WithArgs("outputs").
+			WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("transaction_id"))
+		mock.ExpectQuery("SELECT column_name").WithArgs("transactions").
+			WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("id"))
+
+		err = VerifySchemaColumns(context.Background(), db, EngineCockroach, expected)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outputs: idx")
+		require.Contains(t, err.Error(), "transactions: hash,version")
+	})
+}

--- a/util/usql/engine_test.go
+++ b/util/usql/engine_test.go
@@ -1,6 +1,12 @@
 package usql
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
 
 func TestIsPostgresLike(t *testing.T) {
 	cases := []struct {
@@ -21,4 +27,51 @@ func TestIsPostgresLike(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDetectEngine(t *testing.T) {
+	cases := []struct {
+		name      string
+		version   string
+		want      Engine
+		wantError bool
+	}{
+		{"postgres 15", "PostgreSQL 15.5 on x86_64-pc-linux-gnu, compiled by gcc", EnginePostgres, false},
+		{"postgres 13", "PostgreSQL 13.10 (Debian 13.10-1.pgdg110+1)", EnginePostgres, false},
+		{"cockroach 24.1 ccl", "CockroachDB CCL v24.1.0 (x86_64-pc-linux-gnu, built 2024/05/20)", EngineCockroach, false},
+		{"cockroach 23.2", "CockroachDB CCL v23.2.5", EngineCockroach, false},
+		{"unknown engine", "MariaDB 11.2.0", "", true},
+		{"empty version", "", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			mock.ExpectQuery("SELECT version\\(\\)").
+				WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(tc.version))
+
+			got, err := DetectEngine(context.Background(), WrapDB(db))
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestDetectEngine_QueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT version\\(\\)").WillReturnError(context.DeadlineExceeded)
+
+	_, err = DetectEngine(context.Background(), WrapDB(db))
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Add transparent CockroachDB support to the SQL UTXO and blockchain stores. Engine identity is detected at connection init via `SELECT version()`; no configuration flag is required beyond the standard `postgres://` URL. The existing PostgreSQL path is functionally unchanged.

## Scope

- New `usql.Engine` type with `DetectEngine` helper and `IsPostgresLike` predicate.
- Engine identity stashed on `*usql.DB` via new `SetEngine`/`Engine()` methods.
- `pg_advisory_lock` and `DO $$` migration blocks are engine-gated; Cockroach skips both (fresh installs land in the right shape via `CREATE TABLE IF NOT EXISTS`).
- Shared `usql.VerifySchemaColumns` helper runs post-init on both PostgreSQL and Cockroach via `information_schema.columns`. Catches future-migration drift; deterministic multi-table error reports.
- `serial_normalization = sql_sequence` AfterConnect hook installed on Cockroach connections so `BIGSERIAL` produces sequence-backed small integers (Postgres semantics) instead of `unique_rowid()` values that overflow `uint32` callers.
- Banlist `NewFromSettings` allowlist updated to accept Cockroach (was silently disabling the ban list on CRDB-backed deployments).
- Testcontainers CRDB integration tests behind a `cockroach` build tag.
- CI job `cockroach-tests` runs both standard and `-tags cockroach` suites.

## Production fixes surfaced while validating

- `createCTE` in `stores/utxo/sql/sql.go` had three modifying CTEs (`ins_inputs`, `ins_outputs`, `ins_block_ids`) without `RETURNING`. PostgreSQL accepts; Cockroach rejects with SQLSTATE 0A000. Added `RETURNING 1` to each — portable across both engines.
- `reverse_bytes` / `reverse_bytes_iter` SQL UDFs in `stores/blockchain/sql/sql.go` are dead code (zero callers, superseded by the `on_main_chain` partial index above them) and CRDB's planner rejects the recursive self-reference. Engine-gated to `EnginePostgres`. Also fixed a misleading `"could not create block_transactions_map table"` error wrapper that mislabeled the failing DDL — these were SQL function creates, not table creates.

## Out of scope (deferred to follow-up)

- `stores/utxo/postgres/` (the high-perf store from #684 with `CopyFrom` to staging tables) — needs its own assessment.
- Multi-region 3-node Cockroach performance comparison — manual perf testing post-merge.
- Quickstart compose changes live in the separate `teranode-quickstart` repo.

## Risk

- CockroachDB CCL license caveat applies to multi-node production deployments. Single-node is under BSL. Mentioned in `docs/references/sqlEngines.md`.
- Every new migration in the SQL stores must be mirrored in the engine-gated path or extended into `usql.VerifySchemaColumns` expected-column maps. The verification check fails loud on drift, so the cost of missing this is "broken install on CRDB," not "silent wrong behavior."

## Test plan

- [x] `go test ./...` — 8579 pass on baseline + this branch.
- [x] `go test -tags cockroach ./util/usql/... ./stores/utxo/sql/... ./stores/blockchain/sql/...` — green against `cockroachdb/cockroach:v24.1.13`.
- [x] `go vet ./...`, `golangci-lint run`, `staticcheck ./...` clean on touched packages.
- [x] `go test -race` clean on touched packages.
- [ ] Manual smoke: Teranode catches up to Testnet tip via the `cockroach-utxo` profile in `teranode-quickstart`. (Separate PR there.)

Draft for discussion. Open to scope changes / split / fork as the maintainers prefer.