### PR TITLE
perf(blockassembly): pool subtree leaf buffer + DoS-bound the deserializer

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -15,7 +15,6 @@
 package subtreeprocessor
 
 import (
-	"bufio"
 	"container/ring"
 	"context"
 	"encoding/binary"
@@ -5303,7 +5302,13 @@ func (stp *SubtreeProcessor) CreateTransactionMap(ctx context.Context, blockSubt
 			conflictingNodes := make([]chainhash.Hash, 0, 32)
 
 			// read leaves
-			if err = DeserializeHashesFromReaderIntoBuckets(subtreeReader, nBuckets, &txHashBuckets, &conflictingNodes); err != nil {
+			if err = DeserializeHashesFromReaderIntoBuckets(
+				subtreeReader,
+				nBuckets,
+				stp.settings.SubtreeValidation.MaxIncomingSubtreeBytes,
+				&txHashBuckets,
+				&conflictingNodes,
+			); err != nil {
 				return errors.NewProcessingError("error deserializing subtree: %s", st.String(), err)
 			}
 
@@ -5511,66 +5516,157 @@ func (stp *SubtreeProcessor) getBLockIDsMap(ctx context.Context, losingTxHashesM
 	return blockIdsMap, nil
 }
 
-// DeserializeHashesFromReaderIntoBuckets deserializes transaction hashes from a reader into buckets.
+// On-disk subtree layout, replicated here so reads stay independent of the
+// writer's struct definitions:
 //
-// Parameters:
-//   - reader: Source reader containing hash data
-//   - nBuckets: Number of buckets to distribute hashes into
+//	[ 48-byte file header ]
+//	[ 8-byte little-endian leaf count          ]   numLeaves
+//	[ numLeaves * 48-byte leaf records         ]   (32-byte hash + 8B fee + 8B size)
+//	[ 8-byte little-endian conflicting count   ]   numConflicting
+//	[ numConflicting * 32-byte conflicting hashes ]
+const (
+	subtreeHeaderBytes        = 48
+	subtreeLeafBytes          = 48
+	subtreeHashBytes          = 32
+	subtreeCountFieldBytes    = 8
+	subtreeHeaderAndCountSize = subtreeHeaderBytes + subtreeCountFieldBytes
+)
+
+// leafDataPool reuses the leaf-data scratch slice across DeserializeHashes...
+// calls. The pool's New is intentionally nil — first use allocates at the
+// exact size requested (so we don't waste maxLeafDataBytes when subtrees
+// are smaller), and the high-water-mark grows naturally as larger subtrees
+// arrive. Steady-state memory is bounded by
 //
-// Returns:
-//   - map[uint16][][32]byte: Map of bucketed hash arrays
-//   - error: Any error encountered during deserialization
-func DeserializeHashesFromReaderIntoBuckets(reader io.Reader, nBuckets uint16, hashes *map[uint16][]chainhash.Hash, conflictingNodes *[]chainhash.Hash) (err error) {
+//	concurrent_callers * max_observed_subtree_leaf_bytes
+//
+// where the second factor is itself bounded by the caller-supplied DoS cap.
+var leafDataPool sync.Pool
+
+func acquireLeafBuf(size int) []byte {
+	if v := leafDataPool.Get(); v != nil {
+		b := v.([]byte)
+		if cap(b) >= size {
+			return b[:size]
+		}
+		// Pooled buffer is smaller than required for this subtree. Drop it
+		// on the floor — the next Put will replace it with the bigger one we
+		// allocate below, which is the desired high-water-mark behaviour.
+	}
+
+	return make([]byte, size)
+}
+
+func releaseLeafBuf(b []byte) {
+	// Reset to zero length, keep capacity. The next acquirer reslices
+	// via [:size] up to the existing capacity.
+	//nolint:staticcheck // SA6002: slice header copy into Pool is intentional;
+	// using *[]byte would add a pointer indirection in the hot path. The 24-byte
+	// header cost is dominated by the multi-MiB backing array we're reusing.
+	leafDataPool.Put(b[:0])
+}
+
+// DeserializeHashesFromReaderIntoBuckets reads a subtree's leaf hashes from
+// reader, sorts them into nBuckets per-bucket slices keyed by the high bits
+// of the hash, and returns any conflicting-node hashes in the trailer.
+//
+// maxLeafDataBytes bounds the total bytes the function will allocate and
+// read for the leaf-data section. It is intended to be wired from the
+// caller's DoS cap (e.g. settings.SubtreeValidation.MaxIncomingSubtreeBytes)
+// so that a peer claiming an impossibly large numLeaves in the header is
+// rejected before any allocation.
+func DeserializeHashesFromReaderIntoBuckets(
+	reader io.Reader,
+	nBuckets uint16,
+	maxLeafDataBytes int64,
+	hashes *map[uint16][]chainhash.Hash,
+	conflictingNodes *[]chainhash.Hash,
+) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.NewProcessingError("recovered in DeserializeHashesFromReaderIntoBuckets: %v", r)
 		}
 	}()
 
-	// skip headers
-	bytes48 := make([]byte, 48)
-	if _, err = reader.Read(bytes48); err != nil { // skip headers
-		return errors.NewProcessingError("unable to read header", err)
+	// Read the 48-byte header + 8-byte numLeaves in one shot. The header is
+	// not parsed here — readers of this format treat it as opaque — but it
+	// is consumed off the stream so the leaf records align.
+	var hdr [subtreeHeaderAndCountSize]byte
+	if _, err = io.ReadFull(reader, hdr[:]); err != nil {
+		return errors.NewProcessingError("unable to read header+leaf count", err)
 	}
 
-	// read number of leaves
-	bytes8 := make([]byte, 8)
-	if _, err = io.ReadFull(reader, bytes8); err != nil {
-		return errors.NewProcessingError("unable to read number of leaves", err)
+	numLeaves := binary.LittleEndian.Uint64(hdr[subtreeHeaderBytes:])
+
+	// Bound numLeaves against the DoS cap before allocating. The check uses
+	// the supplied cap divided by the per-record size; doing it this way
+	// (instead of computing numLeaves*subtreeLeafBytes first) makes the
+	// comparison overflow-safe regardless of how large numLeaves is.
+	maxLeaves := uint64(maxLeafDataBytes) / uint64(subtreeLeafBytes)
+	if numLeaves > maxLeaves {
+		return errors.NewProcessingError(
+			"subtree header claims %d leaves (%d bytes), exceeds max %d bytes",
+			numLeaves, numLeaves*subtreeLeafBytes, maxLeafDataBytes,
+		)
 	}
 
-	numLeaves := binary.LittleEndian.Uint64(bytes8)
+	leafBytes := int(numLeaves) * subtreeLeafBytes
 
-	buf := bufio.NewReaderSize(reader, int(numLeaves*48))
+	if leafBytes > 0 {
+		// Single-shot read of the entire leaf-data section into a pooled
+		// buffer, then parse from memory. Previously this path wrapped the
+		// reader in a bufio.NewReaderSize of numLeaves*48 bytes — a fresh
+		// ~48 MiB allocation per subtree, multiplied by the concurrency
+		// in CreateTransactionMap. The pool reuses that backing array.
+		buf := acquireLeafBuf(leafBytes)
+		defer releaseLeafBuf(buf)
 
-	var bucket uint16
-
-	for i := uint64(0); i < numLeaves; i++ {
-		// read all the node data in 1 go
-		if _, err = io.ReadFull(buf, bytes48); err != nil {
-			return errors.NewProcessingError("unable to read node", err)
+		if _, err = io.ReadFull(reader, buf); err != nil {
+			return errors.NewProcessingError("unable to read leaves", err)
 		}
 
-		bucket = txmap.Bytes2Uint16Buckets(chainhash.Hash(bytes48[:32]), nBuckets)
-		(*hashes)[bucket] = append((*hashes)[bucket], chainhash.Hash(bytes48[:32]))
+		for i := 0; i < int(numLeaves); i++ {
+			off := i * subtreeLeafBytes
+			// Hash occupies the first 32 bytes of each 48-byte leaf record;
+			// the trailing 16 bytes (fee + size) are not needed for the
+			// transaction-map build and are skipped via the slice index.
+			h := chainhash.Hash(buf[off : off+subtreeHashBytes])
+			bucket := txmap.Bytes2Uint16Buckets(h, nBuckets)
+			(*hashes)[bucket] = append((*hashes)[bucket], h)
+		}
 	}
 
-	// read conflicting txs
-	if _, err = io.ReadFull(buf, bytes8); err != nil {
+	// Conflicting trailer: 8-byte count + count*32-byte hashes. Bounded by
+	// the same DoS cap (divided by per-record size). Typically empty or a
+	// handful, so no pooling here.
+	var cntBuf [subtreeCountFieldBytes]byte
+	if _, err = io.ReadFull(reader, cntBuf[:]); err != nil {
 		return errors.NewProcessingError("unable to read number of conflicting txs", err)
 	}
 
-	numConflicting := binary.LittleEndian.Uint64(bytes8)
+	numConflicting := binary.LittleEndian.Uint64(cntBuf[:])
 
-	// Pre-allocate exact size for conflicting nodes to avoid reallocation
+	maxConflicting := uint64(maxLeafDataBytes) / uint64(subtreeHashBytes)
+	if numConflicting > maxConflicting {
+		return errors.NewProcessingError(
+			"subtree trailer claims %d conflicting txs, exceeds max",
+			numConflicting,
+		)
+	}
+
 	if numConflicting > 0 {
-		bytes32 := make([]byte, 32)
+		if cap(*conflictingNodes) < int(numConflicting) {
+			*conflictingNodes = make([]chainhash.Hash, 0, numConflicting)
+		}
+
+		var node [subtreeHashBytes]byte
+
 		for i := uint64(0); i < numConflicting; i++ {
-			if _, err = io.ReadFull(buf, bytes32); err != nil {
-				return errors.NewProcessingError("unable to read node", err)
+			if _, err = io.ReadFull(reader, node[:]); err != nil {
+				return errors.NewProcessingError("unable to read conflicting node", err)
 			}
 
-			*conflictingNodes = append(*conflictingNodes, chainhash.Hash(bytes32))
+			*conflictingNodes = append(*conflictingNodes, chainhash.Hash(node))
 		}
 	}
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -5570,15 +5570,29 @@ func releaseLeafBuf(b []byte) {
 // reader, sorts them into nBuckets per-bucket slices keyed by the high bits
 // of the hash, and returns any conflicting-node hashes in the trailer.
 //
-// maxLeafDataBytes bounds the total bytes the function will allocate and
-// read for the leaf-data section. It is intended to be wired from the
-// caller's DoS cap (e.g. settings.SubtreeValidation.MaxIncomingSubtreeBytes)
-// so that a peer claiming an impossibly large numLeaves in the header is
-// rejected before any allocation.
+// maxSubtreeBodyBytes bounds the total bytes of the on-disk subtree body —
+// header + leaf-count + leaves + conflicting-count + conflicting-hashes.
+// It is intended to be wired from the caller's DoS cap (e.g.
+// settings.SubtreeValidation.MaxIncomingSubtreeBytes), which is documented
+// as a whole-body cap. The function rejects any combination of numLeaves
+// and numConflicting whose serialized size would exceed it, so a peer
+// cannot pass by claiming `cap` bytes of leaves plus another `cap` bytes
+// of conflicting hashes.
+//
+// A non-positive maxSubtreeBodyBytes is rejected before any read or
+// allocation: the bound must be a real value, not a misconfigured 0 or a
+// negative that would wrap to ~2^63 under unsigned conversion.
+//
+// conflictingNodes precondition: callers should pass either a nil/empty
+// slice or one whose existing contents they are willing to lose. When the
+// trailer count exceeds the slice's capacity, the function reallocates
+// the backing array (length is reset to 0 before appending), which
+// silently drops any prior contents. Both current callers (CreateTransactionMap
+// and the long-test) pass freshly-created empty slices.
 func DeserializeHashesFromReaderIntoBuckets(
 	reader io.Reader,
 	nBuckets uint16,
-	maxLeafDataBytes int64,
+	maxSubtreeBodyBytes int64,
 	hashes *map[uint16][]chainhash.Hash,
 	conflictingNodes *[]chainhash.Hash,
 ) (err error) {
@@ -5587,6 +5601,16 @@ func DeserializeHashesFromReaderIntoBuckets(
 			err = errors.NewProcessingError("recovered in DeserializeHashesFromReaderIntoBuckets: %v", r)
 		}
 	}()
+
+	// Reject misconfigured caps up front. A 0 or negative would wrap into
+	// a huge uint64 below and disable every subsequent bound. This matches
+	// the fail-closed behaviour of the existing io.LimitReader-based path
+	// elsewhere in the subtree fetch surface.
+	if maxSubtreeBodyBytes <= 0 {
+		return errors.NewProcessingError(
+			"invalid maxSubtreeBodyBytes %d: must be positive", maxSubtreeBodyBytes,
+		)
+	}
 
 	// Read the 48-byte header + 8-byte numLeaves in one shot. The header is
 	// not parsed here — readers of this format treat it as opaque — but it
@@ -5598,15 +5622,32 @@ func DeserializeHashesFromReaderIntoBuckets(
 
 	numLeaves := binary.LittleEndian.Uint64(hdr[subtreeHeaderBytes:])
 
-	// Bound numLeaves against the DoS cap before allocating. The check uses
-	// the supplied cap divided by the per-record size; doing it this way
-	// (instead of computing numLeaves*subtreeLeafBytes first) makes the
-	// comparison overflow-safe regardless of how large numLeaves is.
-	maxLeaves := uint64(maxLeafDataBytes) / uint64(subtreeLeafBytes)
+	// Compute the remaining budget for variable-size sections (leaves +
+	// conflicting trailer), excluding what's already been read off the
+	// stream (header + leaf-count) and reserving the conflicting-count
+	// field that follows the leaves. Reserving the trailer-count field
+	// here means an over-large numLeaves can't crowd it out.
+	maxSubtreeBodyBytesU := uint64(maxSubtreeBodyBytes) // safe: > 0 verified above
+	minFixedBytes := uint64(subtreeHeaderAndCountSize + subtreeCountFieldBytes)
+	if maxSubtreeBodyBytesU < minFixedBytes {
+		return errors.NewProcessingError(
+			"maxSubtreeBodyBytes %d too small to hold even an empty subtree (need >= %d)",
+			maxSubtreeBodyBytes, minFixedBytes,
+		)
+	}
+
+	remainingBudget := maxSubtreeBodyBytesU - minFixedBytes
+
+	// Bound numLeaves against the remaining budget before allocating. The
+	// check uses the supplied budget divided by the per-record size;
+	// doing it this way (instead of computing numLeaves*subtreeLeafBytes
+	// first) makes the comparison overflow-safe regardless of how large
+	// numLeaves is.
+	maxLeaves := remainingBudget / uint64(subtreeLeafBytes)
 	if numLeaves > maxLeaves {
 		return errors.NewProcessingError(
-			"subtree header claims %d leaves (%d bytes), exceeds max %d bytes",
-			numLeaves, numLeaves*subtreeLeafBytes, maxLeafDataBytes,
+			"subtree header claims %d leaves (%d bytes), exceeds max body %d bytes",
+			numLeaves, numLeaves*subtreeLeafBytes, maxSubtreeBodyBytes,
 		)
 	}
 
@@ -5637,8 +5678,9 @@ func DeserializeHashesFromReaderIntoBuckets(
 	}
 
 	// Conflicting trailer: 8-byte count + count*32-byte hashes. Bounded by
-	// the same DoS cap (divided by per-record size). Typically empty or a
-	// handful, so no pooling here.
+	// the *remaining* budget after the leaves section, so a subtree cannot
+	// pass by claiming cap bytes of leaves plus another cap bytes of
+	// conflicting hashes.
 	var cntBuf [subtreeCountFieldBytes]byte
 	if _, err = io.ReadFull(reader, cntBuf[:]); err != nil {
 		return errors.NewProcessingError("unable to read number of conflicting txs", err)
@@ -5646,11 +5688,12 @@ func DeserializeHashesFromReaderIntoBuckets(
 
 	numConflicting := binary.LittleEndian.Uint64(cntBuf[:])
 
-	maxConflicting := uint64(maxLeafDataBytes) / uint64(subtreeHashBytes)
+	remainingForConflicting := remainingBudget - uint64(leafBytes)
+	maxConflicting := remainingForConflicting / uint64(subtreeHashBytes)
 	if numConflicting > maxConflicting {
 		return errors.NewProcessingError(
-			"subtree trailer claims %d conflicting txs, exceeds max",
-			numConflicting,
+			"subtree trailer claims %d conflicting txs (%d bytes), exceeds remaining body budget %d bytes",
+			numConflicting, numConflicting*subtreeHashBytes, remainingForConflicting,
 		)
 	}
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_deserialize_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_deserialize_test.go
@@ -217,7 +217,11 @@ func TestDeserializeHashesFromReaderIntoBuckets_PoolReuse(t *testing.T) {
 	// reuse the pool buffer (high-water mark) — we can't observe pool
 	// internals directly but we can verify both calls succeed and the
 	// data parses correctly with no cross-contamination from the first
-	// call's bytes.
+	// call's bytes. ElementsMatch (not just length) locks the invariant
+	// in: a pool-corruption bug that preserved length but altered bytes
+	// would otherwise slip through, because io.ReadFull only overwrites
+	// the requested range and any prior bytes in the pooled backing
+	// array would survive a length-only check.
 	first := []chainhash.Hash{
 		chainhash.HashH([]byte("first-a")),
 		chainhash.HashH([]byte("first-b")),
@@ -247,8 +251,28 @@ func TestDeserializeHashesFromReaderIntoBuckets_PoolReuse(t *testing.T) {
 	}
 
 	got1 := run(first)
-	require.Len(t, got1, len(first))
+	require.ElementsMatch(t, first, got1)
 
 	got2 := run(second)
-	require.Len(t, got2, len(second), "second call must not leak entries from the first")
+	require.ElementsMatch(t, second, got2, "second call must not leak entries from the first")
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_NonPositiveCapRejected(t *testing.T) {
+	// A 0 or negative cap (misconfigured setting) must be rejected before
+	// any read or allocation. Without this check, uint64(int64(-1)) wraps
+	// to ^uint64(0) and disables every subsequent bound.
+	cases := []int64{0, -1, -128 * 1024 * 1024}
+	for _, cap := range cases {
+		buckets := make(map[uint16][]chainhash.Hash, 8)
+		conflictingOut := make([]chainhash.Hash, 0)
+		err := DeserializeHashesFromReaderIntoBuckets(
+			bytes.NewReader(buildSubtreeBytes(nil, nil)),
+			8,
+			cap,
+			&buckets,
+			&conflictingOut,
+		)
+		require.Error(t, err, "cap=%d must be rejected", cap)
+		require.Contains(t, err.Error(), "must be positive")
+	}
 }

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_deserialize_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_deserialize_test.go
@@ -1,0 +1,254 @@
+package subtreeprocessor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSubtreeBytes constructs an on-disk subtree byte stream of the shape
+// DeserializeHashesFromReaderIntoBuckets expects:
+//
+//	[ 48-byte header ]
+//	[ 8-byte numLeaves         ]
+//	[ numLeaves * 48-byte leaves ]
+//	[ 8-byte numConflicting    ]
+//	[ numConflicting * 32-byte conflicting hashes ]
+//
+// Each leaf is 32-byte hash + 8-byte fee + 8-byte size (fee/size are
+// zero-filled here — the deserializer skips them).
+func buildSubtreeBytes(leaves []chainhash.Hash, conflicting []chainhash.Hash) []byte {
+	var buf bytes.Buffer
+
+	// 48-byte header (opaque to the reader)
+	buf.Write(make([]byte, 48))
+
+	// numLeaves
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(leaves)))
+	buf.Write(lenBuf[:])
+
+	// leaves: 32-byte hash + 16 zero bytes
+	zero16 := make([]byte, 16)
+	for _, h := range leaves {
+		buf.Write(h[:])
+		buf.Write(zero16)
+	}
+
+	// numConflicting + hashes
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(conflicting)))
+	buf.Write(lenBuf[:])
+	for _, h := range conflicting {
+		buf.Write(h[:])
+	}
+
+	return buf.Bytes()
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_HappyPath(t *testing.T) {
+	leaves := []chainhash.Hash{
+		chainhash.HashH([]byte("a")),
+		chainhash.HashH([]byte("b")),
+		chainhash.HashH([]byte("c")),
+	}
+	conflicting := []chainhash.Hash{
+		chainhash.HashH([]byte("x")),
+	}
+
+	data := buildSubtreeBytes(leaves, conflicting)
+
+	buckets := make(map[uint16][]chainhash.Hash, 8)
+	conflictingOut := make([]chainhash.Hash, 0)
+
+	err := DeserializeHashesFromReaderIntoBuckets(
+		bytes.NewReader(data),
+		8,
+		128*1024*1024,
+		&buckets,
+		&conflictingOut,
+	)
+	require.NoError(t, err)
+
+	total := 0
+	for _, hs := range buckets {
+		total += len(hs)
+	}
+	require.Equal(t, len(leaves), total, "all leaves should be bucketed")
+	require.Equal(t, conflicting, conflictingOut)
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_EmptySubtree(t *testing.T) {
+	// An empty subtree (zero leaves, zero conflicting) is valid input —
+	// no leaf-data read, no allocation, returns cleanly.
+	data := buildSubtreeBytes(nil, nil)
+
+	buckets := make(map[uint16][]chainhash.Hash, 8)
+	conflictingOut := make([]chainhash.Hash, 0)
+
+	err := DeserializeHashesFromReaderIntoBuckets(
+		bytes.NewReader(data),
+		8,
+		128*1024*1024,
+		&buckets,
+		&conflictingOut,
+	)
+	require.NoError(t, err)
+	require.Empty(t, conflictingOut)
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_NumLeavesExceedsCap(t *testing.T) {
+	// Forge a header that claims a billion leaves. The deserializer must
+	// reject before allocating; if the bounds check is missing it would
+	// either OOM or hang trying to read 48 GiB from the reader.
+	var buf bytes.Buffer
+	buf.Write(make([]byte, 48)) // header
+
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], 1_000_000_000) // 1B leaves → 48GB
+	buf.Write(lenBuf[:])
+
+	buckets := make(map[uint16][]chainhash.Hash, 8)
+	conflictingOut := make([]chainhash.Hash, 0)
+
+	// Cap at 128 MiB — the production default.
+	err := DeserializeHashesFromReaderIntoBuckets(
+		bytes.NewReader(buf.Bytes()),
+		8,
+		128*1024*1024,
+		&buckets,
+		&conflictingOut,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max")
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_NumLeavesOverflowSafe(t *testing.T) {
+	// numLeaves = max uint64 must not panic on the bound check. The check
+	// is overflow-safe by dividing the cap by the per-record size rather
+	// than multiplying numLeaves by it.
+	var buf bytes.Buffer
+	buf.Write(make([]byte, 48))
+
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], ^uint64(0))
+	buf.Write(lenBuf[:])
+
+	buckets := make(map[uint16][]chainhash.Hash, 8)
+	conflictingOut := make([]chainhash.Hash, 0)
+
+	err := DeserializeHashesFromReaderIntoBuckets(
+		bytes.NewReader(buf.Bytes()),
+		8,
+		128*1024*1024,
+		&buckets,
+		&conflictingOut,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max")
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_NumConflictingExceedsCap(t *testing.T) {
+	// Valid leaves section, but the conflicting trailer claims more nodes
+	// than the cap permits. Must reject without allocating.
+	leaves := []chainhash.Hash{chainhash.HashH([]byte("ok"))}
+
+	var buf bytes.Buffer
+	buf.Write(make([]byte, 48))
+
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(leaves)))
+	buf.Write(lenBuf[:])
+	zero16 := make([]byte, 16)
+	for _, h := range leaves {
+		buf.Write(h[:])
+		buf.Write(zero16)
+	}
+
+	// Forged conflicting count: way over cap/32.
+	binary.LittleEndian.PutUint64(lenBuf[:], 1_000_000_000)
+	buf.Write(lenBuf[:])
+
+	buckets := make(map[uint16][]chainhash.Hash, 8)
+	conflictingOut := make([]chainhash.Hash, 0)
+
+	err := DeserializeHashesFromReaderIntoBuckets(
+		bytes.NewReader(buf.Bytes()),
+		8,
+		128*1024*1024,
+		&buckets,
+		&conflictingOut,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicting")
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_TruncatedStream(t *testing.T) {
+	// Header claims more leaves than the stream actually carries. Must
+	// surface a clean read error rather than panic.
+	var buf bytes.Buffer
+	buf.Write(make([]byte, 48))
+
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], 10)
+	buf.Write(lenBuf[:])
+	// Only write 5 leaves' worth (240 bytes) instead of 10 (480 bytes).
+	buf.Write(make([]byte, 5*48))
+
+	buckets := make(map[uint16][]chainhash.Hash, 8)
+	conflictingOut := make([]chainhash.Hash, 0)
+
+	err := DeserializeHashesFromReaderIntoBuckets(
+		bytes.NewReader(buf.Bytes()),
+		8,
+		128*1024*1024,
+		&buckets,
+		&conflictingOut,
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF, "io.ReadFull on short stream should propagate ErrUnexpectedEOF")
+}
+
+func TestDeserializeHashesFromReaderIntoBuckets_PoolReuse(t *testing.T) {
+	// Two back-to-back calls of different sizes. The second call should
+	// reuse the pool buffer (high-water mark) — we can't observe pool
+	// internals directly but we can verify both calls succeed and the
+	// data parses correctly with no cross-contamination from the first
+	// call's bytes.
+	first := []chainhash.Hash{
+		chainhash.HashH([]byte("first-a")),
+		chainhash.HashH([]byte("first-b")),
+	}
+	second := []chainhash.Hash{
+		chainhash.HashH([]byte("second-only")),
+	}
+
+	run := func(leaves []chainhash.Hash) []chainhash.Hash {
+		data := buildSubtreeBytes(leaves, nil)
+		buckets := make(map[uint16][]chainhash.Hash, 8)
+		conflictingOut := make([]chainhash.Hash, 0)
+		err := DeserializeHashesFromReaderIntoBuckets(
+			bytes.NewReader(data),
+			8,
+			128*1024*1024,
+			&buckets,
+			&conflictingOut,
+		)
+		require.NoError(t, err)
+
+		var out []chainhash.Hash
+		for _, hs := range buckets {
+			out = append(out, hs...)
+		}
+		return out
+	}
+
+	got1 := run(first)
+	require.Len(t, got1, len(first))
+
+	got2 := run(second)
+	require.Len(t, got2, len(second), "second call must not leak entries from the first")
+}

--- a/test/longtest/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/test/longtest/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -70,7 +70,9 @@ func Test_DeserializeHashesFromReaderIntoBuckets(t *testing.T) {
 
 	conflictingNodes := make([]chainhash.Hash, 0)
 
-	err := subtreeprocessor.DeserializeHashesFromReaderIntoBuckets(r, 16, &buckets, &conflictingNodes)
+	// 128 MiB matches the default subtreevalidation_max_incoming_subtree_bytes.
+	const maxLeafDataBytes int64 = 128 * 1024 * 1024
+	err := subtreeprocessor.DeserializeHashesFromReaderIntoBuckets(r, 16, maxLeafDataBytes, &buckets, &conflictingNodes)
 	require.NoError(t, err)
 
 	f, _ = os.Create("mem.prof")


### PR DESCRIPTION
## Summary

`DeserializeHashesFromReaderIntoBuckets` previously wrapped the subtree reader in `bufio.NewReaderSize(reader, numLeaves*48)`, allocating a fresh ~48 MiB buffer per call. At `SubtreeProcessorConcurrentReads=375` that is **~18 GiB of transient allocation per `moveForwardBlock` on a receiver**, producing the GC pressure that dominates phase 1 wallclock variance on receivers (we've observed phase 1 swinging between 5 s and 70 s on a 415 M-tx block at scale).

This PR replaces the per-call bufio with a pooled scratch slice, reads the leaf-data section in a single `io.ReadFull`, and adds receive-side bounds against the existing `subtreevalidation_max_incoming_subtree_bytes` DoS cap (independent of local `MaximumMerkleItemsPerSubtree`, per the existing setting's documented contract).

## What changed

- **Pool** (`sync.Pool` of `[]byte`) sized at first use, grows to a high-water mark. Steady-state memory bounded by `concurrency × max-observed-subtree-leaf-bytes`. `New` is intentionally nil so we never waste memory on subtrees smaller than the cap.
- **Single-shot read** of the entire leaf-data section into the pooled buffer; per-leaf parse runs against memory. Removes the per-leaf `io.ReadFull` overhead and the 1 M-call inner loop's bufio dispatch cost.
- **Latent bug fixed**: the original first read of the 48-byte header used `reader.Read` (not `io.ReadFull`); replaced by a single `io.ReadFull` of header+leaf-count (56 bytes) in one shot.
- **DoS bounds** on `numLeaves` and `numConflicting`, overflow-safe via division (`numLeaves > maxLeafDataBytes / subtreeLeafBytes` instead of `numLeaves * subtreeLeafBytes > maxLeafDataBytes`). A peer can no longer claim 2^63 leaves in the header.
- **Variable peer subtree sizes** are handled natively: each call reslices the pooled buffer to the actual `numLeaves*48`. Small subtrees use a small portion of the buffer; larger ones fit as long as they're under the cap.

Signature changed from
```go
func DeserializeHashesFromReaderIntoBuckets(reader io.Reader, nBuckets uint16, hashes *map[uint16][]chainhash.Hash, conflictingNodes *[]chainhash.Hash) error
```
to
```go
func DeserializeHashesFromReaderIntoBuckets(reader io.Reader, nBuckets uint16, maxLeafDataBytes int64, hashes *map[uint16][]chainhash.Hash, conflictingNodes *[]chainhash.Hash) error
```

There are two callers in the repo (`CreateTransactionMap` in production, and one long-running test); both updated to pass `settings.SubtreeValidation.MaxIncomingSubtreeBytes` (default 128 MiB).

## Tests

New file `SubtreeProcessor_deserialize_test.go` with seven focused unit tests:

- `_HappyPath` — round-trip a small leaf set + conflicting-node trailer
- `_EmptySubtree` — zero leaves, zero conflicting; no allocation
- `_NumLeavesExceedsCap` — forged 1 B-leaf header rejected before allocating
- `_NumLeavesOverflowSafe` — `numLeaves = 2^64-1` rejected cleanly, no panic
- `_NumConflictingExceedsCap` — forged trailer count rejected
- `_TruncatedStream` — short stream surfaces `io.ErrUnexpectedEOF`, no panic
- `_PoolReuse` — two back-to-back calls of different sizes, no cross-contamination

## Test plan

- [x] `go build ./...`
- [x] `go vet ./services/blockassembly/subtreeprocessor/... ./test/longtest/services/blockassembly/subtreeprocessor/...`
- [x] `go test -race -count=1 -timeout 300s ./services/blockassembly/subtreeprocessor/` — ok (195s)
- [x] `go test -race -run TestDeserializeHashesFromReaderIntoBuckets ./services/blockassembly/subtreeprocessor/` — 7/7 PASS
- [x] `go test -race -run TestSubtreeProcessor_CreateTransactionMap ./services/blockassembly/subtreeprocessor/` — PASS
- [x] `go test -race -run Test_DeserializeHashesFromReaderIntoBuckets ./test/longtest/services/blockassembly/subtreeprocessor/` — PASS
- [ ] Cluster verification: deploy to one receiver in `scaling-2`/`scaling-3`, watch block-assembly working-set memory across phase 1 (should be flat between blocks, no per-block spike of `concurrency × 48 MiB`).

## Risks / notes

- **Behaviour change on malformed peer subtrees**: previously could allocate up to `numLeaves*48` bytes from the header before failing on read. Now bounded by `maxLeafDataBytes` upfront. Desired hardening; no benign code path produces a header above the cap.
- **Pool worst-case memory**: at `SubtreeProcessorConcurrentReads=375` and 48 MiB subtrees, pool peak is ~18 GiB (vs. 18 GiB transient per block before this change — net memory the same, but no GC churn). If `subtreeProcessorConcurrentReads` is reduced (recommended separately, for Ceph queue-depth reasons), the pool peak drops proportionally — e.g. 64 → ~3 GiB pool peak.
- **`staticcheck SA6002`** (slice header into `sync.Pool`) is suppressed with a rationale comment: using `*[]byte` would cost a pointer indirection in the hot path; the 24-byte slice-header copy is dominated by the multi-MiB backing array being reused.
- Doesn't change the on-disk file format, doesn't change the wire protocol, doesn't change `chainedSubtrees` matching logic. Reverts cleanly.