### PR TITLE
fix(utxopersister): nil-guard CreateUTXOSet against empty ConsolidateBlockRange

### DIFF
--- a/services/utxopersister/Server.go
+++ b/services/utxopersister/Server.go
@@ -475,9 +475,22 @@ func (s *Server) processNextBlock(ctx context.Context) (time.Duration, error) {
 	s.logger.Infof("Rolling up data from block height %d to %d", s.lastHeight+1, maxHeight)
 
 	if err := c.ConsolidateBlockRange(ctx, s.lastHeight+1, maxHeight); err != nil {
-		if !errors.Is(err, errors.ErrNotFound) {
-			return 0, nil
+		if errors.Is(err, errors.ErrNotFound) {
+			// BlockPersister hasn't yet written the per-block UTXO files
+			// for this range. Wait for the next trigger; caller treats
+			// ErrNotFound as "no new block to process".
+			return 0, err
 		}
+		return 0, err
+	}
+
+	if c.lastBlockHash == nil {
+		// ConsolidateBlockRange returned successfully but didn't advance
+		// past genesis (range was empty, or contained only the genesis
+		// block which the loop skips). Nothing new to persist; signal
+		// "no new block" so the caller waits for the next trigger
+		// rather than spinning on an empty iteration.
+		return 0, errors.ErrNotFound
 	}
 
 	// At the end of this, we have a rollup of deletions and additions.  Add these to the last UTXOSet

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -524,6 +524,13 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 		return errors.NewStorageError("settings is nil")
 	}
 
+	// Defensive: the caller in Server.processNextBlock now gates on
+	// nil-lastBlockHash, but reject it here too so any future caller
+	// gets a clear error instead of a SIGSEGV from c.lastBlockHash[:].
+	if c.lastBlockHash == nil {
+		return errors.NewStorageError("consolidator has no lastBlockHash (block range was empty or only genesis)")
+	}
+
 	storer, err := filestorer.NewFileStorer(ctx, us.logger, us.settings, us.store, c.lastBlockHash[:], fileformat.FileTypeUtxoSet)
 	if err != nil {
 		return errors.NewStorageError("error creating utxo-set file", err)

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -15,6 +15,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestCreateUTXOSet_NilLastBlockHash pins the defensive check at the entry
+// of CreateUTXOSet: if the consolidator never set lastBlockHash (its loop
+// body bailed early on per-block ErrNotFound from a UTXO file
+// BlockPersister hasn't written yet, or the range contained only the
+// genesis block which the loop skips with `continue`), the previous
+// implementation crashed at `c.lastBlockHash[:]` with SIGSEGV. The
+// function must surface a clear error instead.
+func TestCreateUTXOSet_NilLastBlockHash(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	// blockHash here is only used to initialise the UTXOSet handle;
+	// the bug is in dereferencing c.lastBlockHash, not us.blockHash.
+	someHash := chainhash.HashH([]byte("test-utxoset-blockhash"))
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &someHash)
+	require.NoError(t, err)
+
+	// Construct a consolidator with lastBlockHash == nil — exactly the
+	// state ConsolidateBlockRange leaves it in when no non-genesis
+	// block was successfully processed.
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, nil)
+	require.Nil(t, c.lastBlockHash, "test precondition: consolidator must have nil lastBlockHash")
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.Error(t, err, "CreateUTXOSet must reject a consolidator with nil lastBlockHash instead of dereferencing it")
+	assert.Contains(t, err.Error(), "lastBlockHash", "error message should name the offending field")
+}
+
 var (
 	hash1 = chainhash.HashH([]byte{0x00, 0x01, 0x02, 0x03, 0x04})
 	// hash2 = chainhash.HashH([]byte{0x05, 0x06, 0x07, 0x08, 0x09})


### PR DESCRIPTION
## Summary

`utxopersister.processNextBlock` could crash with a nil-pointer SIGSEGV at `UTXOSet.go:527` (`c.lastBlockHash[:]`) during a startup race between `BlockPersister` and `UTXOPersister`. The fix propagates errors correctly and gates downstream code on a valid `lastBlockHash`; a defensive check at the `CreateUTXOSet` entry covers any future caller.

## Crash signature

```
ERROR: Processing block <nil> height 0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=...]

goroutine 627 [running]:
github.com/bsv-blockchain/teranode/services/utxopersister.(*UTXOSet).CreateUTXOSet(...)
	github.com/bsv-blockchain/teranode/services/utxopersister/UTXOSet.go:527 +0x29d
github.com/bsv-blockchain/teranode/services/utxopersister.(*Server).processNextBlock(...)
	github.com/bsv-blockchain/teranode/services/utxopersister/Server.go:499 +0x84d
```

Reproduces during 3-node split-mode bring-up: the height-1 probe block triggers `processNextBlock` on each node's `core` sidecar before `BlockPersister` has written the per-block UTXO additions file. The whole `core` process panics, taking RPC + ancillary services down with it.

## Root cause

`consolidator.ConsolidateBlockRange` only assigns `c.lastBlockHash` at the **bottom** of its loop body (`consolidator.go:234`). The loop:

- `continue`s over the genesis block (`consolidator.go:205`)
- `return err`s on per-block errors before line 234 — including `errors.ErrNotFound` from `GetUTXOAdditionsReader` when BlockPersister hasn't written that block's additions file yet.

`processNextBlock` had two issues compounding this:

1. **Swallowed real errors:** `if !errors.Is(err, errors.ErrNotFound) { return 0, nil }` — non-NotFound errors were dropped, returning success.
2. **Fell through on ErrNotFound:** code below assumed the consolidator was populated even when the loop bailed early, so `CreateUTXOSet` got a nil `lastBlockHash` and dereferenced it.

## Fix

`services/utxopersister/Server.go` (`processNextBlock`):
- Propagate non-ErrNotFound errors instead of swallowing them.
- After ConsolidateBlockRange (either success or ErrNotFound), bail with `errors.ErrNotFound` if `c.lastBlockHash` is nil — caller treats that as 'no new block, wait for next trigger' (matches the existing `if errors.Is(err, errors.ErrNotFound)` branch at the call site).

`services/utxopersister/UTXOSet.go` (`CreateUTXOSet`):
- Defensive nil-check alongside the other entry-guards. Future callers get a clear error instead of a SIGSEGV.

## Test plan

- [x] `go test ./services/utxopersister/...` — full package suite passes
- [x] `go test -race -run TestCreateUTXOSet_NilLastBlockHash ./services/utxopersister/` — new regression test passes under the race detector
- [x] `go vet ./services/utxopersister/...` clean
- [x] Code-review: the `processNextBlock` change is a small, mechanical error-propagation tightening; verifiable by inspection

The full integration repro lives in `test/multinode_split/scenario_04_block_assembly_isolation`, which is currently `t.Skip`-ed pending one other teranode robustness fix (legacy `unknown magic` parser). Once that lands, deleting the `t.Skip` line re-enables end-to-end coverage of this fix path.