### PR TITLE
fix(utxopersister): drop double-read of fileformat magic in verifyLastSet

### DIFF
--- a/services/utxopersister/Server.go
+++ b/services/utxopersister/Server.go
@@ -656,15 +656,18 @@ func (s *Server) verifyLastSet(ctx context.Context, hash *chainhash.Hash) error 
 		store:     s.blockStore,
 	}
 
+	// GetUTXOSetReader -> store.GetIoReader already validates the fileformat
+	// header (8-byte magic + matching FileType) before returning the reader,
+	// so a successful open is sufficient evidence that the UTXO set file
+	// exists and has a valid header. Calling fileformat.ReadHeader here
+	// would consume the *next* 8 bytes of the body — which are the first
+	// bytes of the block hash field — and reliably fail with "unknown
+	// magic: [...]", taking the whole core sidecar down via ServiceManager.
 	r, err := us.GetUTXOSetReader(hash)
 	if err != nil {
 		return err
 	}
 	defer r.Close()
-
-	if _, err := fileformat.ReadHeader(r); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/services/utxopersister/Server.go
+++ b/services/utxopersister/Server.go
@@ -628,26 +628,17 @@ func (s *Server) writeLastHeight(ctx context.Context, height uint32) error {
 	)
 }
 
-// verifyLastSet verifies the integrity of the last UTXO set.
-// It checks if the UTXO set for the given hash exists and has valid header and footer.
-// This verification ensures that the UTXO set was completely written and is not corrupted.
-// Returns an error if verification fails.
+// verifyLastSet verifies that a UTXO set file exists and is openable for
+// the given block hash. A successful open via the blob store layer is
+// sufficient evidence that the file is present and (in the file store)
+// has the right fileformat magic + FileType — those checks live in
+// stores/blob/file/file.go validateFileHeader. The memory store advances
+// past the header by size without validating the magic, which is fine
+// because that path is test-only.
 //
-// Parameters:
-// - ctx: Context for controlling the verification operation
-// - hash: Pointer to the block hash for which to verify the UTXO set
-//
-// Returns:
-// - error: Any error encountered during verification, or nil if verification succeeds
-//
-// This method performs several integrity checks on the UTXO set:
-// 1. Verifies that a UTXO set file exists for the given block hash
-// 2. Checks that the header record is valid and matches the expected block hash
-// 3. Ensures that the footer exists and is correctly formatted
-//
-// These checks confirm that the UTXO set for the block was completely written
-// and can be used for subsequent operations. This is crucial for maintaining
-// blockchain state consistency, especially after system restarts.
+// (The previous docstring also promised a footer integrity check that
+// this function never implemented; scope is the existence/openability
+// check only.)
 func (s *Server) verifyLastSet(ctx context.Context, hash *chainhash.Hash) error {
 	us := &UTXOSet{
 		ctx:       ctx,
@@ -656,13 +647,12 @@ func (s *Server) verifyLastSet(ctx context.Context, hash *chainhash.Hash) error 
 		store:     s.blockStore,
 	}
 
-	// GetUTXOSetReader -> store.GetIoReader already validates the fileformat
-	// header (8-byte magic + matching FileType) before returning the reader,
-	// so a successful open is sufficient evidence that the UTXO set file
-	// exists and has a valid header. Calling fileformat.ReadHeader here
-	// would consume the *next* 8 bytes of the body — which are the first
-	// bytes of the block hash field — and reliably fail with "unknown
-	// magic: [...]", taking the whole core sidecar down via ServiceManager.
+	// Do NOT call fileformat.ReadHeader on the returned reader: the store
+	// layer has already advanced past the 8-byte magic. Reading it again
+	// would consume the first 8 bytes of the body, which per the layout
+	// written by CreateUTXOSet are the current block hash field — random
+	// bytes that reliably fail as "unknown magic: [...]" and bring the
+	// whole core sidecar down via ServiceManager.
 	r, err := us.GetUTXOSetReader(hash)
 	if err != nil {
 		return err

--- a/services/utxopersister/Server_test.go
+++ b/services/utxopersister/Server_test.go
@@ -342,7 +342,7 @@ func TestVerifyLastSet_ExistingValidSet(t *testing.T) {
 	// Write a minimal UTXO set body. memory.Set prepends the fileformat
 	// magic for us, so we only supply the post-header bytes.
 	body := make([]byte, 0, 36)
-	body = append(body, testHash[:]...) // 32 bytes block hash
+	body = append(body, testHash[:]...)         // 32 bytes block hash
 	body = append(body, 0x01, 0x00, 0x00, 0x00) // 4 bytes height
 	require.NoError(t, blockStore.Set(ctx, testHash[:], fileformat.FileTypeUtxoSet, body))
 

--- a/services/utxopersister/Server_test.go
+++ b/services/utxopersister/Server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	terrors "github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
@@ -314,6 +315,39 @@ func TestVerifyLastSet_NoUTXOSetExists(t *testing.T) {
 	err := server.verifyLastSet(ctx, &testHash)
 
 	assert.Error(t, err)
+}
+
+// TestVerifyLastSet_ExistingValidSet pins that verifyLastSet does NOT
+// double-read the fileformat magic. The store layer (validateFileHeader
+// inside file.go and the equivalent in memory.go) already validates the
+// 8-byte magic on GetIoReader; consuming another 8 bytes here would
+// read the first bytes of the block hash field that follows the header
+// in the UTXO set file layout, fail with "unknown magic: [<random
+// bytes from hash>]", and bring the whole core sidecar down via
+// ServiceManager.
+//
+// The body bytes used here are intentionally not a valid magic: they
+// match the actual UTXO set layout (32-byte block hash followed by
+// 4-byte height), so without the fix the test fails with exactly the
+// production failure mode.
+func TestVerifyLastSet_ExistingValidSet(t *testing.T) {
+	ctx := context.Background()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+	server := New(ctx, ulogger.TestLogger{}, tSettings, blockStore, nil)
+
+	testHash := createTestHash("test-block")
+
+	// Write a minimal UTXO set body. memory.Set prepends the fileformat
+	// magic for us, so we only supply the post-header bytes.
+	body := make([]byte, 0, 36)
+	body = append(body, testHash[:]...) // 32 bytes block hash
+	body = append(body, 0x01, 0x00, 0x00, 0x00) // 4 bytes height
+	require.NoError(t, blockStore.Set(ctx, testHash[:], fileformat.FileTypeUtxoSet, body))
+
+	err := server.verifyLastSet(ctx, &testHash)
+	require.NoError(t, err, "verifyLastSet must succeed when a valid UTXO set file exists; double-read of the fileformat magic would surface here as \"unknown magic: [...]\"")
 }
 
 // Test trigger - processNextBlock returns not found error

--- a/services/utxopersister/Server_test.go
+++ b/services/utxopersister/Server_test.go
@@ -348,6 +348,11 @@ func TestVerifyLastSet_ExistingValidSet(t *testing.T) {
 
 	err := server.verifyLastSet(ctx, &testHash)
 	require.NoError(t, err, "verifyLastSet must succeed when a valid UTXO set file exists; double-read of the fileformat magic would surface here as \"unknown magic: [...]\"")
+	// Explicit regression intent: future divergent failures should not be
+	// confused with the original double-read bug.
+	if err != nil {
+		require.NotContains(t, err.Error(), "unknown magic", "regression: double-read of fileformat magic must not return")
+	}
 }
 
 // Test trigger - processNextBlock returns not found error

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -614,15 +614,13 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 			return errors.NewStorageError("previous utxo-set block hash mismatch: want %s got %s",
 				c.firstPreviousBlockHash.String(), storedCurrentBlockHash.String())
 		}
-		var (
-			storedBlockHeight       uint32
-			storedPreviousBlockHash chainhash.Hash
-		)
-		if err := binary.Read(previousUTXOSetReader, binary.LittleEndian, &storedBlockHeight); err != nil {
-			return errors.NewStorageError("error reading previous utxo-set block height", err)
-		}
-		if _, err := io.ReadFull(previousUTXOSetReader, storedPreviousBlockHash[:]); err != nil {
-			return errors.NewStorageError("error reading previous utxo-set previous block hash", err)
+		// Skip the remaining 36 bytes of per-file metadata (4-byte height
+		// + 32-byte previous block hash). The new set being written
+		// doesn't natively carry the previous set's stored height /
+		// grandparent hash to compare against, so consuming rather than
+		// parsing avoids dead variables.
+		if _, err := io.CopyN(io.Discard, previousUTXOSetReader, 36); err != nil {
+			return errors.NewStorageError("error skipping previous utxo-set header trailer", err)
 		}
 
 	OUTER:

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -596,13 +596,33 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 
 		defer previousUTXOSetReader.Close()
 
-		previousHeader, err := fileformat.ReadHeader(previousUTXOSetReader)
-		if err != nil {
-			return errors.NewStorageError("error reading previous utxo-set header", err)
+		// store.GetIoReader -> validateFileHeader has already consumed the
+		// 8-byte fileformat magic; reading it again here would consume the
+		// first 8 bytes of the block-hash metadata that follows, then the
+		// OUTER loop's UTXOWrapper reader would be misaligned by 8 bytes.
+		// Consume the per-file header fields written by CreateUTXOSet
+		// (32 bytes current block hash + 4 bytes height + 32 bytes
+		// previous block hash) so the loop below starts at the first
+		// UTXOWrapper record. Validate the stored current-block hash
+		// matches what we expected to open, to catch file/key confusion
+		// loudly rather than silently consolidate the wrong UTXOs.
+		var storedCurrentBlockHash chainhash.Hash
+		if _, err := io.ReadFull(previousUTXOSetReader, storedCurrentBlockHash[:]); err != nil {
+			return errors.NewStorageError("error reading previous utxo-set block hash", err)
 		}
-
-		if previousHeader.FileType() != fileformat.FileTypeUtxoSet {
-			return errors.NewStorageError("previous utxo-set header is not a utxo-set header")
+		if !storedCurrentBlockHash.IsEqual(c.firstPreviousBlockHash) {
+			return errors.NewStorageError("previous utxo-set block hash mismatch: want %s got %s",
+				c.firstPreviousBlockHash.String(), storedCurrentBlockHash.String())
+		}
+		var (
+			storedBlockHeight       uint32
+			storedPreviousBlockHash chainhash.Hash
+		)
+		if err := binary.Read(previousUTXOSetReader, binary.LittleEndian, &storedBlockHeight); err != nil {
+			return errors.NewStorageError("error reading previous utxo-set block height", err)
+		}
+		if _, err := io.ReadFull(previousUTXOSetReader, storedPreviousBlockHash[:]); err != nil {
+			return errors.NewStorageError("error reading previous utxo-set previous block hash", err)
 		}
 
 	OUTER:

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -3,11 +3,13 @@ package utxopersister
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -43,6 +45,102 @@ func TestCreateUTXOSet_NilLastBlockHash(t *testing.T) {
 	err = us.CreateUTXOSet(ctx, c)
 	require.Error(t, err, "CreateUTXOSet must reject a consolidator with nil lastBlockHash instead of dereferencing it")
 	assert.Contains(t, err.Error(), "lastBlockHash", "error message should name the offending field")
+}
+
+// TestCreateUTXOSet_PreviousSetReadDoesNotDoubleReadMagic pins that
+// CreateUTXOSet, when reading the previous block's UTXO set, does NOT
+// call fileformat.ReadHeader on a reader the store layer has already
+// advanced past — and consumes the per-file metadata (current block
+// hash + height + previous block hash) before the wrapper loop. Without
+// the fix, this path either crashed with "unknown magic: [...]" (when
+// the store strips the header, which is the production case) or
+// silently misaligned the wrapper reader by 8 bytes and consolidated
+// the wrong UTXOs.
+//
+// Test scenario: a "previous" UTXO set file for hash P is staged in a
+// memory store, containing just the 68-byte header records (current
+// block hash = P, height, parent hash) and zero wrappers — so the
+// OUTER loop hits a clean io.EOF after the metadata. A consolidator
+// pointing at P as the firstPreviousBlockHash should consolidate
+// successfully and produce a new UTXO set for the current block.
+func TestCreateUTXOSet_PreviousSetReadDoesNotDoubleReadMagic(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	previousBlockHash := chainhash.HashH([]byte("previous-block-hash-for-double-read-test"))
+	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-double-read-test"))
+	grandparentHash := chainhash.HashH([]byte("grandparent-block-hash-for-double-read-test"))
+
+	// Stage the previous UTXO set file with just its 68-byte metadata
+	// (matching the layout CreateUTXOSet writes: current block hash +
+	// 4-byte height + previous block hash). memory.Set prepends the
+	// fileformat magic, so we only provide post-header bytes.
+	var body []byte
+	body = append(body, previousBlockHash[:]...)
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+	body = append(body, heightBuf[:]...)
+	body = append(body, grandparentHash[:]...)
+	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
+
+	// Consolidator: firstPreviousBlockHash = P drives the read of the
+	// staged file; lastBlockHash/height/previousBlockHash drive the
+	// write of the new file CreateUTXOSet produces.
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, &previousBlockHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 43
+	c.previousBlockHash = &previousBlockHash
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.NoError(t, err, "CreateUTXOSet must succeed against a valid previous UTXO set; double-read of the fileformat magic would surface here as \"unknown magic: [...]\" or as misaligned wrapper reads")
+	if err != nil {
+		require.NotContains(t, err.Error(), "unknown magic")
+	}
+}
+
+// TestCreateUTXOSet_PreviousSetWrongBlockHash pins that the post-fix
+// metadata validation rejects a previous UTXO set file whose stored
+// current-block-hash doesn't match what the consolidator expected to
+// open. Catches file/key confusion loudly rather than silently
+// consolidating UTXOs from the wrong ancestor.
+func TestCreateUTXOSet_PreviousSetWrongBlockHash(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	previousBlockHash := chainhash.HashH([]byte("previous-block-mismatch-key"))
+	wrongStoredHash := chainhash.HashH([]byte("wrong-stored-current-hash"))
+	currentBlockHash := chainhash.HashH([]byte("current-block-mismatch-key"))
+	grandparentHash := chainhash.HashH([]byte("grandparent-block-mismatch-key"))
+
+	// File stored under key=previousBlockHash but whose stored
+	// "current block hash" metadata is something else — simulates
+	// corruption or a mis-keyed file.
+	var body []byte
+	body = append(body, wrongStoredHash[:]...)
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+	body = append(body, heightBuf[:]...)
+	body = append(body, grandparentHash[:]...)
+	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
+
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, &previousBlockHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 43
+	c.previousBlockHash = &previousBlockHash
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.Error(t, err, "CreateUTXOSet must reject a previous UTXO set whose stored block hash doesn't match the expected ancestor")
+	assert.Contains(t, err.Error(), "block hash mismatch")
 }
 
 var (

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -77,10 +77,10 @@ func TestCreateUTXOSet_PreviousSetReadDoesNotDoubleReadMagic(t *testing.T) {
 	// (matching the layout CreateUTXOSet writes: current block hash +
 	// 4-byte height + previous block hash). memory.Set prepends the
 	// fileformat magic, so we only provide post-header bytes.
-	var body []byte
-	body = append(body, previousBlockHash[:]...)
 	var heightBuf [4]byte
 	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash))
+	body = append(body, previousBlockHash[:]...)
 	body = append(body, heightBuf[:]...)
 	body = append(body, grandparentHash[:]...)
 	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
@@ -122,10 +122,10 @@ func TestCreateUTXOSet_PreviousSetWrongBlockHash(t *testing.T) {
 	// File stored under key=previousBlockHash but whose stored
 	// "current block hash" metadata is something else — simulates
 	// corruption or a mis-keyed file.
-	var body []byte
-	body = append(body, wrongStoredHash[:]...)
 	var heightBuf [4]byte
 	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+	body := make([]byte, 0, len(wrongStoredHash)+len(heightBuf)+len(grandparentHash))
+	body = append(body, wrongStoredHash[:]...)
 	body = append(body, heightBuf[:]...)
 	body = append(body, grandparentHash[:]...)
 	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))


### PR DESCRIPTION
## Summary

`verifyLastSet` (and `CreateUTXOSet`'s previous-set read path) was calling `fileformat.ReadHeader(r)` on a reader that the store layer had already advanced past the 8-byte fileformat header. The redundant read consumed the next 8 bytes of the UTXO set body — the first bytes of the block hash field — and reliably surfaced as:

```
ERROR | service_manager.go:259 | ServiceManager| Received error: unknown magic: [<8 bytes of block hash>]
```

The unwrapped `fmt.Errorf` from `pkg/fileformat` propagated up through `processNextBlock` to the errgroup, and ServiceManager treated it as fatal — gracefully shutting down the entire `core` sidecar (RPC, alert, blockpersister, utxopersister, pruner, legacy) on a peer that received a freshly-mined block.

## Why "unknown magic: [<random-looking 8 bytes>]"?

UTXO set file layout (per `CreateUTXOSet` in `UTXOSet.go:543-553`):

```
[8 bytes]  fileformat magic   ("US-1.0  ")
[32 bytes] block hash
[4 bytes]  block height
[32 bytes] previous block hash
[N bytes]  UTXO records
```

The store layer's `GetIoReader` advances past the 8-byte magic before returning the reader (and, in the file store, validates magic + FileType — `stores/blob/file/file.go:1011-1023`; the memory store just strips by size — `stores/blob/memory/memory.go:269-271`). The two read sites then called `ReadHeader` *again*, reading the first 8 bytes of the block hash field — essentially random bytes — and rejecting them as an unknown magic.

The bytes from the original crash log (`[202 100 224 254 161 3 101 216]`) match the expected shape of a chainhash prefix.

## When the crash fires

Only when `lastWrittenUTXOSetHash != GenesisHash` (`Server.go:466`) — i.e. once the first non-genesis UTXO set has been written. Before that, `verifyLastSet` is short-circuited, which is why the crash typically manifested a short while into a node's lifetime rather than at boot.

Originally surfaced by the split-mode chaos suite in #958: when a node mined and broadcast a block after a chaos cycle, peers receiving the block hit the second iteration of `processNextBlock`, triggered `verifyLastSet`, and crashed.

## Fix

**`verifyLastSet`:** Drop the redundant `fileformat.ReadHeader` call. A successful `GetUTXOSetReader` is sufficient evidence that the file exists.

**`CreateUTXOSet`'s previous-set read path (UTXOSet.go:592):** Same double-read pattern, with a worse failure mode. The gate at line 567 had prevented this path from ever being reached against a non-genesis previous set, because `verifyLastSet` was crashing first. Just removing the `ReadHeader` here would have unblocked the silent-corruption path (the OUTER `NewUTXOWrapperFromReader` loop misaligned by 8 bytes, consolidating garbage instead of the previous block's UTXOs). The fix:
- Drops `ReadHeader`.
- Consumes the 68 bytes of per-file metadata (current block hash + height + previous block hash) before the wrapper loop.
- **New behaviour (defense in depth):** validates that the stored current-block hash equals `c.firstPreviousBlockHash`. This is a new failure mode — a corrupt or mis-keyed previous set will now fail loudly with a clear `block hash mismatch` error where before it would have silently consolidated UTXOs from the wrong ancestor. Surfaced because the bug fix exposes a code path that had been entirely unreachable in production.

**Docstring / comment cleanup:**
- `verifyLastSet` comment on memory-vs-file-store header behaviour rewritten for precision (the memory store advances past the header by size; only the file store validates the magic + FileType).
- `verifyLastSet` docstring previously promised a footer integrity check that was never implemented; rewritten to describe what the function actually does.

## Regression tests

- **`TestVerifyLastSet_ExistingValidSet`** — happy path; without the fix, fails with the exact production error string. Also asserts `NotContains "unknown magic"` so future divergent failures don't quietly mask this regression.
- **`TestCreateUTXOSet_PreviousSetReadDoesNotDoubleReadMagic`** — happy path against the second site; without the fix fails with the production error chain (`STORAGE_ERROR (69): error reading previous utxo-set header -> UNKNOWN (0): unknown magic: [...]`).
- **`TestCreateUTXOSet_PreviousSetWrongBlockHash`** — pins the new defense-in-depth check.

All three new tests verified to fail with the corresponding fix removed and pass with it restored.

## Test plan

- [x] `go test ./services/utxopersister/...` — full package passes (~60s)
- [x] `go test -race -run 'TestVerifyLastSet|TestCreateUTXOSet' ./services/utxopersister/` — passes under race detector
- [x] Manually verified each new test fails with the corresponding buggy code restored
- [x] `go build ./services/utxopersister/...` clean
- [x] `gci diff` clean

## Out of scope (separate follow-up)

`cmd/utxovalidator/utxo_validator.go:77` has the same double-read pattern against `blockStore.GetIoReader`. It's a CLI tool not on the hot path; deserves its own small PR.

## Companion work

This is the second of the two teranode-side blockers preventing `test/multinode_split/scenario_04_block_assembly_isolation` from running. The first (`fix(utxopersister): nil-guard CreateUTXOSet against empty ConsolidateBlockRange`) is in #969. Once both land, the scenario's `t.Skip` line can be removed.
