### PR TITLE
fix(utxovalidator): consume fileformat magic at the reader source, not twice in validate

### DIFF
--- a/cmd/utxovalidator/utxo_validator.go
+++ b/cmd/utxovalidator/utxo_validator.go
@@ -68,20 +68,18 @@ func ValidateUTXOFile(ctx context.Context, path string, logger ulogger.Logger, s
 }
 
 // validateUTXOSet reads a UTXO set from the reader and validates the total satoshi amount.
+//
+// The reader is expected to be positioned past the 8-byte fileformat magic.
+// Both supported sources satisfy that contract: getLocalFileReader consumes
+// and validates the magic before returning, and blockStore.GetIoReader does
+// so internally via the store layer (stores/blob/file/file.go's
+// validateFileHeader). Calling fileformat.ReadHeader here would re-consume
+// 8 bytes of the body — the first bytes of the block hash field — and fail
+// with "unknown magic: [<random hash bytes>]".
 func validateUTXOSet(ctx context.Context, r io.Reader, verbose bool) (*UTXOValidationResult, error) {
 	result := &UTXOValidationResult{}
 
 	br := bufio.NewReaderSize(r, 64*1024) // 64KB buffer - sufficient for CLI tool validation
-
-	// Read file header to verify this is a UTXO set file
-	header, err := fileformat.ReadHeader(br)
-	if err != nil {
-		return nil, errors.NewProcessingError("error reading file header", err)
-	}
-
-	if header.FileType() != fileformat.FileTypeUtxoSet {
-		return nil, errors.NewProcessingError("file is not a UTXO set file, got: %s", header.FileType())
-	}
 
 	// Read current block hash (32 bytes) - this matches what filereader calls "previous block hash"
 	// but it's actually the current block hash based on the filereader output
@@ -179,11 +177,26 @@ func getUTXOFileReader(path string, logger ulogger.Logger, settings *settings.Se
 	return getLocalFileReader(path)
 }
 
-// getLocalFileReader returns a reader for a local file.
+// getLocalFileReader opens a local file, consumes and validates the
+// fileformat magic, and returns a reader positioned at the start of
+// the UTXO set body. This mirrors the contract of
+// blockStore.GetIoReader so validateUTXOSet can stay agnostic about
+// which source it's reading from.
 func getLocalFileReader(path string) (io.ReadCloser, error) {
 	fileReader, err := os.Open(path)
 	if err != nil {
 		return nil, errors.NewProcessingError("error opening file", err)
+	}
+
+	header, err := fileformat.ReadHeader(fileReader)
+	if err != nil {
+		_ = fileReader.Close()
+		return nil, errors.NewProcessingError("error reading file header", err)
+	}
+
+	if header.FileType() != fileformat.FileTypeUtxoSet {
+		_ = fileReader.Close()
+		return nil, errors.NewProcessingError("file is not a UTXO set file, got: %s", header.FileType())
 	}
 
 	return fileReader, nil

--- a/cmd/utxovalidator/utxo_validator_test.go
+++ b/cmd/utxovalidator/utxo_validator_test.go
@@ -77,11 +77,6 @@ func TestValidateUTXOFile_LocalDoesNotDoubleReadMagic(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 	result, err := ValidateUTXOFile(ctx, path, ulogger.TestLogger{}, tSettings, false)
 	require.NoError(t, err, "ValidateUTXOFile must not double-read the fileformat magic; a regression here would surface as \"unknown magic: [...]\"")
-	// Explicit regression intent — future divergent failures should
-	// not be confused with the original double-read bug.
-	if err != nil {
-		assert.NotContains(t, err.Error(), "unknown magic")
-	}
 	assert.Equal(t, blockHash.String(), result.BlockHash.String(), "BlockHash parsed from body must match what we wrote")
 	assert.Equal(t, uint32(42), result.BlockHeight)
 	assert.Equal(t, prevHash.String(), result.PreviousHash.String(), "PreviousHash parsed from body must match what we wrote")

--- a/cmd/utxovalidator/utxo_validator_test.go
+++ b/cmd/utxovalidator/utxo_validator_test.go
@@ -1,10 +1,17 @@
 package utxovalidator
 
 import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,4 +32,81 @@ func TestValidateUTXOFile(t *testing.T) {
 	t.Logf("Expected Satoshis: %d", result.ExpectedSatoshis)
 	t.Logf("Is Valid: %t", result.IsValid)
 	t.Logf("UTXO Count: %d", result.UTXOCount)
+}
+
+// TestValidateUTXOFile_LocalDoesNotDoubleReadMagic pins that the
+// local-file path through ValidateUTXOFile consumes the fileformat
+// magic exactly once. Previously, getLocalFileReader returned a raw
+// os.File and validateUTXOSet called fileformat.ReadHeader on it
+// — which worked for local files but mirrored a bug in
+// utxopersister where the same call was made on a reader the blob
+// store had already advanced past. The fix moved the
+// read-and-validate-magic step into getLocalFileReader so both
+// reader sources (local file, blob store) hand validateUTXOSet a
+// body-only reader; the function no longer calls ReadHeader.
+//
+// Without that fix, removing ReadHeader from validateUTXOSet would
+// have silently misread the first 8 bytes of the block hash field
+// as a magic and rejected every local file as "unknown magic"; with
+// the fix, both source paths converge on a single body-reading
+// contract.
+func TestValidateUTXOFile_LocalDoesNotDoubleReadMagic(t *testing.T) {
+	ctx := context.Background()
+
+	blockHash := chainhash.HashH([]byte("utxovalidator-double-read-current-block"))
+	prevHash := chainhash.HashH([]byte("utxovalidator-double-read-previous-block"))
+
+	// Build a minimal UTXO set file: 8-byte fileformat magic + 32-byte
+	// current block hash + 4-byte height + 32-byte previous block hash
+	// + zero UTXO wrappers. The OUTER wrapper loop in validateUTXOSet
+	// breaks on either io.EOF or "failed to read txid", so a body that
+	// ends after the metadata exercises the read path cleanly.
+	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
+	body := make([]byte, 0, 8+32+4+32)
+	body = append(body, header.Bytes()...)
+	body = append(body, blockHash[:]...)
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+	body = append(body, heightBuf[:]...)
+	body = append(body, prevHash[:]...)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.utxo-set")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+
+	tSettings := test.CreateBaseTestSettings(t)
+	result, err := ValidateUTXOFile(ctx, path, ulogger.TestLogger{}, tSettings, false)
+	require.NoError(t, err, "ValidateUTXOFile must not double-read the fileformat magic; a regression here would surface as \"unknown magic: [...]\"")
+	// Explicit regression intent — future divergent failures should
+	// not be confused with the original double-read bug.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "unknown magic")
+	}
+	assert.Equal(t, blockHash.String(), result.BlockHash.String(), "BlockHash parsed from body must match what we wrote")
+	assert.Equal(t, uint32(42), result.BlockHeight)
+	assert.Equal(t, prevHash.String(), result.PreviousHash.String(), "PreviousHash parsed from body must match what we wrote")
+}
+
+// TestValidateUTXOFile_LocalRejectsWrongFileType pins that the
+// magic + FileType validation moved into getLocalFileReader still
+// rejects files of the wrong type (the check used to live in
+// validateUTXOSet). A subtree file with subtree magic should fail
+// with a clear "not a UTXO set file" error.
+func TestValidateUTXOFile_LocalRejectsWrongFileType(t *testing.T) {
+	ctx := context.Background()
+
+	// Build a body with subtree magic — a recognised file type, but
+	// not FileTypeUtxoSet, so getLocalFileReader should reject it.
+	header := fileformat.NewHeader(fileformat.FileTypeSubtree)
+	body := append([]byte(nil), header.Bytes()...)
+	body = append(body, []byte("some-arbitrary-content")...)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.subtree")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+
+	tSettings := test.CreateBaseTestSettings(t)
+	_, err := ValidateUTXOFile(ctx, path, ulogger.TestLogger{}, tSettings, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a UTXO set file")
 }


### PR DESCRIPTION
## Summary

Same double-read anti-pattern as #971, this time in the `utxovalidator` CLI tool. Flagged in #971's review as a separate follow-up because this isn't on a hot path.

`ValidateUTXOFile` accepts a path and produces an `io.ReadCloser` from one of two sources:

```
getLocalFileReader  -> os.Open(path)
getBlobStoreReader  -> blockStore.GetIoReader(...)
```

Only the second consumes the 8-byte fileformat magic before returning (via the file store's `validateFileHeader` or the memory store's strip-by-size). `validateUTXOSet` then unconditionally called `fileformat.ReadHeader(br)`, which:

- **Worked for local-file callers** — the file still has the magic at offset 0.
- **Crashed for blob-store callers** — the next 8 bytes of the body are the first bytes of the block hash field, so the read failed with `unknown magic: [<random hash bytes>]`.

The blob-store path is reachable when the CLI tool is pointed at a 64-char block hash instead of a file path (`utxo_validator.go:170-176`).

## Fix

Uniformise the two readers so both hand `validateUTXOSet` a body-only reader:

- `getLocalFileReader` now consumes and validates the magic itself (returns a reader positioned past the magic — same shape as `GetIoReader`).
- `validateUTXOSet` drops the `ReadHeader` call entirely.
- The `FileType == FileTypeUtxoSet` assertion moves into `getLocalFileReader`. The blob-store path keeps its existing FileType check via the file store's `validateFileHeader`.

## Regression tests

- `TestValidateUTXOFile_LocalDoesNotDoubleReadMagic` — writes a minimal valid UTXO set file to a tempdir and verifies `ValidateUTXOFile` parses the block hash / height / previous hash correctly. Without the fix, restoring the `ReadHeader` call in `validateUTXOSet` causes this test to fail with the exact production error chain (`PROCESSING (4): error reading file header -> UNKNOWN (0): unknown magic: [...]`).
- `TestValidateUTXOFile_LocalRejectsWrongFileType` — writes a file with subtree magic and verifies the FileType check that moved into `getLocalFileReader` still rejects mistyped files with a clear error.

## Test plan

- [x] `go test ./cmd/utxovalidator/...` clean
- [x] `go test -race -run TestValidateUTXOFile_Local ./cmd/utxovalidator/` clean
- [x] `go build ./cmd/utxovalidator/...` clean
- [x] `gci diff` clean
- [x] Manually verified each new test fails with the buggy `ReadHeader` line restored

## Related

Same anti-pattern, different site as #971 (`fix(utxopersister): drop double-read of fileformat magic in verifyLastSet`). Reviewer in #971 explicitly asked to land this as a separate small PR.