### PR TITLE
ci(deps): add dependency-review PR gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,5 +26,10 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+          # spdx.satisfiesAny matching does not normalise deprecated SPDX IDs and
+          # silently buckets unresolved ones — so list deprecated + both explicit variants.
+          deny-licenses: >-
+            GPL-2.0, GPL-2.0-only, GPL-2.0-or-later,
+            GPL-3.0, GPL-3.0-only, GPL-3.0-or-later,
+            AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+name: Dependency Review
+
+# Blocking PR gate. Diff-scoped: only evaluates dependencies a PR adds/changes,
+# so it never trips on the existing backlog. Native Dependabot alerts notify but
+# do not block merges — this enforces. Make it a required status check on main.
+
+on:
+  pull_request:
+
+# Read-only default token; the job below elevates only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # for comment-summary-in-pr
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## What

Adds one blocking CI gate: `dependency-review` on every PR. Fails a PR that adds a dependency with a ≥ high-severity CVE or a disallowed licence (GPL-2.0/3.0, AGPL-3.0). Diff-scoped — only the PR's added/changed deps, so it never trips on the existing backlog.

Native Dependabot alerts notify on vulnerable deps but **don't block merges** — this enforces. That's the one gap in teranode's enterprise security stack.

## Why just this

teranode's enterprise policy already provides, zero-config:
- Dependabot alerts (known CVEs) + Dependabot **malware** (catalogued malicious packages)
- Code scanning (first-party vulns) + secret scanning

Evaluated and dropped as redundant / low-value:
- **OSV-Scanner** — same known-CVE coverage as Dependabot alerts.
- **govulncheck** — only adds reachability triage over Dependabot's Go alerts; no new detection.
- **guarddog** — native Dependabot malware covers catalogued malware; its Go typosquatting heuristic false-positives on Go `/vN` module paths (validated against this repo's deps).
- **AI reviewer / Socket.dev** — deferred (residual gap: novel uncatalogued malware).

## Action needed after merge

Add **`dependency-review`** as a required status check in branch protection for `main` (Settings ▸ Branches) — that's what makes it enforce.

## Notes

`dependency-review-action` pinned by commit SHA. The clean-PR run passes; blocking on a bad dep follows the action's standard behaviour (not exercised in this PR).