### PR TITLE
ci: PR-feedback quick wins — auto-cancel, drop dead job, restore module cache

### DIFF
--- a/.github/workflows/benchmark-compare.yaml
+++ b/.github/workflows/benchmark-compare.yaml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   bench:
     name: Bench ${{ matrix.group }}

--- a/.github/workflows/benchmark-compare.yaml
+++ b/.github/workflows/benchmark-compare.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bench:
     name: Bench ${{ matrix.group }}

--- a/.github/workflows/dashboard_pr_smoke.yaml
+++ b/.github/workflows/dashboard_pr_smoke.yaml
@@ -7,6 +7,10 @@ on:
       - '.github/workflows/dashboard_pr_smoke.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -17,6 +17,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: sonar-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -36,6 +36,14 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
+      - name: Restore Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            gomod-${{ runner.os }}-
+
       - name: Run Go tests
         run: make test
         continue-on-error: false
@@ -67,6 +75,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
+
+      - name: Restore Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            gomod-${{ runner.os }}-
 
       - name: Run Smoke tests
         run: make smoketest
@@ -101,6 +117,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
+
+      - name: Restore Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            gomod-${{ runner.os }}-
 
       - name: Run Pruner tests
         run: make prunertest
@@ -141,6 +165,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
+
+      - name: Restore Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            gomod-${{ runner.os }}-
 
       # Re-run golangci-lint separately without exiting on errors and generating a report for use in Sonar
       - name: golangci-lint

--- a/.github/workflows/teranode_pr_init.yaml
+++ b/.github/workflows/teranode_pr_init.yaml
@@ -8,6 +8,10 @@ name: Teranode PR init
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/teranode_pr_smoketests.yaml
+++ b/.github/workflows/teranode_pr_smoketests.yaml
@@ -5,6 +5,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -152,34 +156,6 @@ jobs:
         with:
           name: chainintegrity-results
           path: /tmp/teranode-test-results/chainintegrity-results.txt
-          retention-days: 2
-
-  sequential-sqlite:
-    name: sequential-sqlite
-    runs-on: teranode-runner-8-core
-    steps:
-      - name: Login to Docker Hub
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ vars.DOCKER_ORG }}
-          password: ${{ secrets.DOCKER_ORG_TOKEN }}
-
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: "false"
-
-      - name: Upload sequentialtest results
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: sequentialtest-sqlite-results
-          path: /tmp/teranode-test-results/sequentialtest-sqlite-results.txt
           retention-days: 2
 
   sequential-postgres:

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -3,6 +3,10 @@ name: Teranode PR tests
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
@@ -29,6 +33,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            gomod-${{ runner.os }}-
 
       - name: golangci-lint with checkstyle report
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
@@ -63,6 +75,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            gomod-${{ runner.os }}-
 
       - name: Run Go tests
         run: make test


### PR DESCRIPTION
First of three phases from a CI-speed investigation. The PR-feedback gate has drifted up over the last quarter (`pr-smoke` +33% in 9 weeks, `main-build` +19%); these are the low-risk, broad-benefit changes that don't touch test behaviour.

## Changes

**Auto-cancel superseded runs.** Added a `concurrency` group with `cancel-in-progress: true` to the PR-triggered gate workflows (`teranode_pr_tests`, `teranode_pr_smoketests`, `teranode_pr_init`, `dashboard_pr_smoke`) and to `sonar-pr-analyze` (keyed on the originating PR, since it's `workflow_run`-triggered). Pushing a new commit to a PR now cancels the prior in-flight run instead of running both to completion — less runner saturation, less queue time on busy days. Not applied to main/push workflows. `benchmark-compare` is deliberately excluded: cancelling a partial benchmark run would drop comparison results.

**Removed the no-op `sequential-sqlite` job.** It had no run step — it checked out, set up Go, and uploaded a results file that was never produced. Zero coverage behind an always-green check. Confirmed separately that the `--db sqlite` name filter matches zero tests, so it ran nothing regardless. Not a required status check.

**Restored a Go module cache.** `actions/cache` on `~/go/pkg/mod` only (keyed on `go.sum`) for the compile-heavy jobs in `teranode_pr_tests` and `teranode_main_tests`. Deliberately NOT the build cache (`~/.cache/go-build`) — that is what #3352 disabled, for thrashing the 10 GB Actions cache limit with large `-race` build artifacts. The module cache is small and stable, and `setup-go`'s own caching stays off.

## Risk

Low — config only. The module cache reverts cleanly if it regresses. Validated with `actionlint` (only pre-existing custom-runner-label warnings).
