### PR TITLE
refactor(dashboard): migrate to Svelte 5 runes mode

### DIFF
--- a/.github/workflows/dashboard_pr_smoke.yaml
+++ b/.github/workflows/dashboard_pr_smoke.yaml
@@ -41,10 +41,10 @@ jobs:
       # resolved from package-lock.json above) instead of `npx playwright`,
       # which could in principle fetch a different version on-demand.
       - run: ./node_modules/.bin/playwright install --with-deps chromium
-      # NOTE: `npm run check` is intentionally NOT a CI step. The legacy-mode
-      # baseline carries ~33 svelte-check errors that pre-date this PR and are
-      # cleared by the runes migration in a follow-up PR. Re-add this step
-      # once that PR lands and the baseline is clean.
+      # svelte-check gates type-correctness + Svelte deprecation warnings.
+      # The runes migration cleared the legacy baseline (0 errors); this step
+      # keeps it clean and catches any regression to legacy syntax.
+      - run: npm run check
       - run: npm run test:integration
       - if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/ui/dashboard/package-lock.json
+++ b/ui/dashboard/package-lock.json
@@ -15,7 +15,7 @@
         "echarts": "^5.4.3",
         "i18next": "^23.7.6",
         "polished": "^4.2.2",
-        "svelte-exmarkdown": "^3.0.3",
+        "svelte-exmarkdown": "^5.0.2",
         "svelte-i18next": "^2.2.2",
         "tippy.js": "^6.3.7"
       },
@@ -7472,18 +7472,18 @@
       }
     },
     "node_modules/svelte-exmarkdown": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/svelte-exmarkdown/-/svelte-exmarkdown-3.0.5.tgz",
-      "integrity": "sha512-x0ELw7oTziBaJLFsdGZaoursycGK9HPzxRTRZ/rBi2KmseFG29ryyborJxFmeE0X6ORrEW1pRjoi8q41xpIeRQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/svelte-exmarkdown/-/svelte-exmarkdown-5.0.2.tgz",
+      "integrity": "sha512-/GhWbh0TBd7OPsL6IhQZm4BVuglP5MP4lVwBDnIF8IYfmHfwfY0z/nu78L8FDwJM2pP+DW8045g+jUhM357U1w==",
       "license": "MIT",
       "dependencies": {
-        "remark-gfm": "^4.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.0.0",
-        "unified": "^11.0.0"
+        "remark-rehype": "^11.1.2",
+        "unified": "^11.0.5"
       },
       "peerDependencies": {
-        "svelte": "^3.47.0 || ^4.0.0 || >=5.0.0-next.115"
+        "svelte": "^5.1.3"
       }
     },
     "node_modules/svelte-i18next": {

--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -57,7 +57,7 @@
     "echarts": "^5.4.3",
     "i18next": "^23.7.6",
     "polished": "^4.2.2",
-    "svelte-exmarkdown": "^3.0.3",
+    "svelte-exmarkdown": "^5.0.2",
     "svelte-i18next": "^2.2.2",
     "tippy.js": "^6.3.7"
   },

--- a/ui/dashboard/src/components/LogoutButton.svelte
+++ b/ui/dashboard/src/components/LogoutButton.svelte
@@ -1,12 +1,16 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { goto } from '$app/navigation'
   import { logout } from '$internal/stores/authStore'
 
-  export let buttonText = 'Logout'
-  export let redirectTo = '/login'
-  export let buttonClass = ''
+  let {
+    buttonText = 'Logout',
+    redirectTo = '/login',
+    buttonClass = '',
+  }: { buttonText?: string; redirectTo?: string; buttonClass?: string } = $props()
 
-  let loading = false
+  let loading = $state(false)
 
   async function handleLogout() {
     loading = true
@@ -26,7 +30,7 @@
 
 <button
   class="logout-button {buttonClass}"
-  on:click={handleLogout}
+  onclick={handleLogout}
   disabled={loading}
   aria-label="Logout"
 >

--- a/ui/dashboard/src/internal/api/index.ts
+++ b/ui/dashboard/src/internal/api/index.ts
@@ -594,6 +594,12 @@ export type BUMPLevel = BUMPNode[]
 export interface MerkleProofData {
   blockHeight: number
   path: BUMPLevel[]
+  // Legacy/extended fields populated for subtree-level merkle proofs.
+  // Optional because BUMP (tx-level) responses omit them.
+  subtreeIndex?: number
+  subtreeRoot?: string
+  merkleRoot?: string
+  blockProof?: string[]
 }
 
 // Legacy interface kept for backward compatibility

--- a/ui/dashboard/src/internal/components/action-status-icon/index.svelte
+++ b/ui/dashboard/src/internal/components/action-status-icon/index.svelte
@@ -1,23 +1,35 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onDestroy } from 'svelte'
-  import { createEventDispatcher } from 'svelte'
   import { Icon } from '$lib/components'
 
-  export let size = 18
-  export let icon = ''
-  export let iconSuccess = 'icon-check-line'
-  export let iconFailure = 'icon-close-line'
-  export let statusIndicationPeriod = 2000 // millis
-  export let action: (data: any) => Promise<any>
-  export let actionData: any
+  let {
+    size = 18,
+    icon = '',
+    iconSuccess = 'icon-check-line',
+    iconFailure = 'icon-close-line',
+    statusIndicationPeriod = 2000, // millis
+    action,
+    actionData,
+    status = $bindable(null),
+    onstatus,
+  }: {
+    size?: number
+    icon?: string
+    iconSuccess?: string
+    iconFailure?: string
+    statusIndicationPeriod?: number
+    action: (data: any) => Promise<any>
+    actionData?: any
+    status?: 'success' | 'failure' | null
+    onstatus?: (e: { value: 'success' | 'failure' }) => void
+  } = $props()
 
-  export let status: 'success' | 'failure' | null = null
-  let showingStatus = false
+  let showingStatus = $state(false)
   let statusTimeoutId: any = null
 
-  const dispatch = createEventDispatcher()
-
-  function doSetStatus(value) {
+  function doSetStatus(value: 'success' | 'failure') {
     status = value
     showingStatus = true
 
@@ -29,9 +41,9 @@
     }, statusIndicationPeriod)
   }
 
-  function onStatus(value) {
+  function onStatus(value: 'success' | 'failure') {
     doSetStatus(value)
-    dispatch('status', { value })
+    onstatus?.({ value })
   }
 
   async function onClick() {
@@ -43,23 +55,13 @@
     }
   }
 
-  let showIcon = icon
-
-  $: {
-    showIcon = icon
-
+  const showIcon = $derived.by(() => {
     if (showingStatus) {
-      switch (status) {
-        case 'success':
-          showIcon = iconSuccess
-          break
-        case 'failure':
-          showIcon = iconFailure
-          break
-        default:
-      }
+      if (status === 'success') return iconSuccess
+      if (status === 'failure') return iconFailure
     }
-  }
+    return icon
+  })
 
   onDestroy(() => {
     if (statusTimeoutId) {
@@ -68,7 +70,7 @@
   })
 </script>
 
-<button class="action-status-icon" on:click={onClick} style:--size={size} type="button">
+<button class="action-status-icon" onclick={onClick} style:--size={size} type="button">
   <Icon name={showIcon} {size} />
 </button>
 

--- a/ui/dashboard/src/internal/components/anim-menu-icon/index.svelte
+++ b/ui/dashboard/src/internal/components/anim-menu-icon/index.svelte
@@ -1,10 +1,12 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   // TODO component is a mess, redo later
 
-  export let open = false
-  let size = 24
+  let { open = false }: { open?: boolean } = $props()
+  const size = 24
 
-  $: scaleLocal = (18 / 60) * (size / 24)
+  const scaleLocal = $derived((18 / 60) * (size / 24))
 </script>
 
 <div class="anim-menu-icon" style:--scale={scaleLocal} style:--size={`${size}px`}>

--- a/ui/dashboard/src/internal/components/banner/index.svelte
+++ b/ui/dashboard/src/internal/components/banner/index.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let text = ''
+  let { text = '' }: { text?: string } = $props()
 </script>
 
 <div class="tui-banner">

--- a/ui/dashboard/src/internal/components/block-assembly-modal/index.svelte
+++ b/ui/dashboard/src/internal/components/block-assembly-modal/index.svelte
@@ -1,27 +1,31 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { Modal } from '$lib/components'
   import { blockAssemblyModalStore } from '../../stores/blockAssemblyModalStore'
   import { formatNum } from '$lib/utils/format'
   import { onMount, onDestroy } from 'svelte'
 
-  let isOpen = false
-  let nodeId = ''
-  let nodeUrl = ''
-  let blockAssembly: any = null
-  
+  let isOpen = $state(false)
+  let nodeId = $state('')
+  let nodeUrl = $state('')
+  let blockAssembly: any = $state(null)
+
   // Subtree pagination state
-  let subtreesExpanded = false
-  let subtreesPage = 1
-  let subtreesPerPage = 10
-  
-  $: totalSubtrees = blockAssembly?.subtrees?.length || 0
-  $: totalPages = Math.ceil(totalSubtrees / subtreesPerPage)
-  $: paginatedSubtrees = blockAssembly?.subtrees?.slice(
-    (subtreesPage - 1) * subtreesPerPage,
-    subtreesPage * subtreesPerPage
-  ) || []
-  $: startIndex = (subtreesPage - 1) * subtreesPerPage + 1
-  $: endIndex = Math.min(subtreesPage * subtreesPerPage, totalSubtrees)
+  let subtreesExpanded = $state(false)
+  let subtreesPage = $state(1)
+  let subtreesPerPage = $state(10)
+
+  const totalSubtrees = $derived(blockAssembly?.subtrees?.length || 0)
+  const totalPages = $derived(Math.ceil(totalSubtrees / subtreesPerPage))
+  const paginatedSubtrees = $derived(
+    blockAssembly?.subtrees?.slice(
+      (subtreesPage - 1) * subtreesPerPage,
+      subtreesPage * subtreesPerPage
+    ) || []
+  )
+  const startIndex = $derived((subtreesPage - 1) * subtreesPerPage + 1)
+  const endIndex = $derived(Math.min(subtreesPage * subtreesPerPage, totalSubtrees))
 
   const unsubscribe = blockAssemblyModalStore.subscribe((state) => {
     isOpen = state.isOpen
@@ -78,7 +82,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h2>Block Assembly Details</h2>
-        <button class="close-btn" on:click={handleClose}>×</button>
+        <button class="close-btn" onclick={handleClose}>×</button>
       </div>
       
       <div class="node-info">
@@ -126,7 +130,7 @@
         {#if blockAssembly.subtrees && blockAssembly.subtrees.length > 0}
           <div class="detail-item full-width">
             <div class="subtrees-header">
-              <button class="expand-btn" on:click={toggleSubtrees}>
+              <button class="expand-btn" onclick={toggleSubtrees}>
                 <span class="expand-icon">{subtreesExpanded ? '▼' : '▶'}</span>
                 <span class="label">Subtrees ({formatNum(blockAssembly.subtrees.length)})</span>
               </button>
@@ -153,8 +157,8 @@
                 {#if totalPages > 1}
                   <div class="pagination">
                     <button 
-                      class="page-btn" 
-                      on:click={() => goToPage(subtreesPage - 1)}
+                      class="page-btn"
+                      onclick={() => goToPage(subtreesPage - 1)}
                       disabled={subtreesPage === 1}
                     >
                       ←
@@ -166,8 +170,8 @@
                     </span>
                     
                     <button 
-                      class="page-btn" 
-                      on:click={() => goToPage(subtreesPage + 1)}
+                      class="page-btn"
+                      onclick={() => goToPage(subtreesPage + 1)}
                       disabled={subtreesPage === totalPages}
                     >
                       →

--- a/ui/dashboard/src/internal/components/breadcrumbs/index.svelte
+++ b/ui/dashboard/src/internal/components/breadcrumbs/index.svelte
@@ -1,21 +1,20 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { beforeUpdate } from 'svelte'
   import { page } from '$app/stores'
   import { getDetailsUrl } from '$internal/utils/urls'
   import i18n from '../../i18n'
 
-  export let showOnRoot = false
+  let { showOnRoot = false }: { showOnRoot?: boolean } = $props()
 
   const baseKey = 'comp.breadcrumbs.page'
 
-  let ready = false
-  beforeUpdate(() => {
+  let ready = $state(false)
+  $effect.pre(() => {
     ready = true
   })
 
-  let data: any[] = []
-
-  $: {
+  const data = $derived.by(() => {
     const tmp: any[] = []
     const pathname = ready ? $page.url.pathname : ''
 
@@ -49,8 +48,8 @@
       }
     }
 
-    data = [...tmp]
-  }
+    return [...tmp]
+  })
 </script>
 
 {#if showOnRoot || data.length > 1}

--- a/ui/dashboard/src/internal/components/card/index.svelte
+++ b/ui/dashboard/src/internal/components/card/index.svelte
@@ -1,11 +1,37 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let title = ''
-  export let headerPadding = '20px 24px 32px 24px'
-  export let contentPadding = '0 24px'
-  export let footerPadding = $$slots.footer ? '20px 24px' : '0 24px 20px 24px'
-  export let stretch = true
-  export let showFooter = true
-  export let wrapHeader = false
+  import type { Snippet } from 'svelte'
+
+  let {
+    title = '',
+    headerPadding = '20px 24px 32px 24px',
+    contentPadding = '0 24px',
+    footerPadding,
+    stretch = true,
+    showFooter = true,
+    wrapHeader = false,
+    subtitle,
+    headerTools,
+    footer,
+    children,
+  }: {
+    title?: string | Snippet
+    headerPadding?: string
+    contentPadding?: string
+    footerPadding?: string
+    stretch?: boolean
+    showFooter?: boolean
+    wrapHeader?: boolean
+    subtitle?: Snippet
+    headerTools?: Snippet
+    footer?: Snippet
+    children?: Snippet
+  } = $props()
+
+  const effectiveFooterPadding = $derived(
+    footerPadding ?? (footer ? '20px 24px' : '0 24px 20px 24px'),
+  )
 </script>
 
 <div
@@ -13,31 +39,31 @@
   class:stretch
   style:--header-padding={headerPadding}
   style:--content-padding={contentPadding}
-  style:--footer-padding={footerPadding}
+  style:--footer-padding={effectiveFooterPadding}
 >
   <div class="header" class:wrapHeader>
     <div class="title-container">
       <div class="title">
-        {#if $$slots.title}
-          <slot name="title"></slot>
+        {#if typeof title === 'function'}
+          {@render title()}
         {:else}
           {title}
         {/if}
       </div>
       <div class="subtitle">
-        <slot name="subtitle"></slot>
+        {@render subtitle?.()}
       </div>
     </div>
     <div class="header-tools">
-      <slot name="header-tools"></slot>
+      {@render headerTools?.()}
     </div>
   </div>
   <div class="content">
-    <slot></slot>
+    {@render children?.()}
   </div>
   {#if showFooter}
     <div class="footer">
-      <slot name="footer"></slot>
+      {@render footer?.()}
     </div>
   {/if}
 </div>

--- a/ui/dashboard/src/internal/components/footer/index.svelte
+++ b/ui/dashboard/src/internal/components/footer/index.svelte
@@ -1,23 +1,26 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import Typo from '../typo/index.svelte'
   import i18n from '../../i18n'
 
-  $: t = $i18n.t
+  let { testId = null }: { testId?: string | undefined | null } = $props()
+
+  const t = $derived($i18n.t)
   const tKey = 'comp.footer'
 
-  $: gutterW =
+  const gutterW = $derived(
     $mediaSize <= MediaSize.lg
       ? $mediaSize <= MediaSize.sm
         ? $mediaSize <= MediaSize.xs
           ? 16
           : 20
         : 32
-      : 90
+      : 90,
+  )
 
-  export let testId: string | undefined | null = null
-
-  let year = new Date().getFullYear()
+  const year = new Date().getFullYear()
 </script>
 
 <div class="tui-footer" data-test-id={testId} style:--padding={`0px ${gutterW}px`}>

--- a/ui/dashboard/src/internal/components/item-renderers/link-hash-copy/index.svelte
+++ b/ui/dashboard/src/internal/components/item-renderers/link-hash-copy/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { tippy } from '$lib/stores/media'
 
@@ -5,39 +7,47 @@
   import ActionStatusIcon from '$internal/components/action-status-icon/index.svelte'
   import { getLinkPrefix } from '$lib/utils/url'
 
-  export let href = ''
-  export let text: string | null = null
-  export let className = ''
-  export let external = true
+  let {
+    href = '',
+    text = null,
+    className = '',
+    external = true,
+    iconValue = null,
+    icon = 'icon-duplicate-line',
+    iconSize = 15,
+    iconPadding = '2px 0 0 0',
+    tooltip = '',
+  }: {
+    href?: string
+    text?: string | null
+    className?: string
+    external?: boolean
+    iconValue?: any
+    icon?: string
+    iconSize?: number
+    iconPadding?: string
+    tooltip?: string
+  } = $props()
 
-  export let iconValue: any = null
-  export let icon = 'icon-duplicate-line'
-  export let iconSize = 15
-  export let iconPadding = '2px 0 0 0'
-  export let tooltip = ''
-
-  let props: any = {}
-  let hrefWithPrefix = ''
-  let value = ''
-
-  $: {
-    props = external ? { target: '_blank', rel: 'noopener noreferrer' } : {}
+  const linkProps = $derived.by(() => {
+    const p: any = external ? { target: '_blank', rel: 'noopener noreferrer' } : {}
 
     if (className) {
-      props.class = className
+      p.class = className
     }
 
-    const prefix = getLinkPrefix(href, external)
-    hrefWithPrefix = prefix + href
+    return p
+  })
 
-    value = text || href
-  }
+  const hrefWithPrefix = $derived(getLinkPrefix(href, external) + href)
+
+  const value = $derived(text || href)
 </script>
 
 {#if value}
   {#if icon && iconValue}
     <div class="link" style:--icon-padding={iconPadding}>
-      <a href={hrefWithPrefix} {...props}>{value}</a>
+      <a href={hrefWithPrefix} {...linkProps}>{value}</a>
       <div class="icon" use:$tippy={{ content: tooltip }}>
         <ActionStatusIcon
           {icon}
@@ -48,7 +58,7 @@
       </div>
     </div>
   {:else}
-    <a href={hrefWithPrefix} {...props}>{value}</a>
+    <a href={hrefWithPrefix} {...linkProps}>{value}</a>
   {/if}
 {:else}
   ''

--- a/ui/dashboard/src/internal/components/item-renderers/link-with-icon/index.svelte
+++ b/ui/dashboard/src/internal/components/item-renderers/link-with-icon/index.svelte
@@ -49,7 +49,7 @@
     <div class="link" style:--icon-padding={iconPadding}>
       <a href={hrefWithPrefix} {...props}>{value}</a>
       <div class="icon" use:$tippy={{ content: tooltip }}>
-        <Icon name={icon} size={iconSize} on:click={onIconLocal} />
+        <Icon name={icon} size={iconSize} onclick={onIconLocal} />
       </div>
     </div>
   {:else}

--- a/ui/dashboard/src/internal/components/item-renderers/link-with-icon/index.svelte
+++ b/ui/dashboard/src/internal/components/item-renderers/link-with-icon/index.svelte
@@ -1,59 +1,67 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { tippy } from '$lib/stores/media'
 
   import { Icon } from '$lib/components'
   import { getLinkPrefix } from '$lib/utils/url'
 
-  const dispatch = createEventDispatcher()
+  let {
+    href = '',
+    text = null,
+    className = '',
+    external = true,
+    iconValue = null,
+    icon = '',
+    iconSize = 18,
+    iconPadding = '2px 0 0 0',
+    tooltip = '',
+    onIcon = (_value: any) => {},
+    onselect,
+  }: {
+    href?: string
+    text?: string | null
+    className?: string
+    external?: boolean
+    iconValue?: any
+    icon?: string
+    iconSize?: number
+    iconPadding?: string
+    tooltip?: string
+    onIcon?: (value: any) => void
+    onselect?: (detail: { value: any }) => void
+  } = $props()
 
-  export let href = ''
-  export let text: string | null = null
-  export let className = ''
-  export let external = true
-
-  export let iconValue: any = null
-  export let icon = ''
-  export let iconSize = 18
-  export let iconPadding = '2px 0 0 0'
-  export let tooltip = ''
-  export let onIcon = (any) => {}
-
-  let props: any = {}
-  let hrefWithPrefix = ''
-  let value = ''
-
-  $: {
-    props = external ? { target: '_blank', rel: 'noopener noreferrer' } : {}
-
+  const attrs = $derived.by(() => {
+    const a: any = external ? { target: '_blank', rel: 'noopener noreferrer' } : {}
     if (className) {
-      props.class = className
+      a.class = className
     }
+    return a
+  })
 
-    const prefix = getLinkPrefix(href, external)
-    hrefWithPrefix = prefix + href
+  const hrefWithPrefix = $derived(getLinkPrefix(href, external) + href)
 
-    value = text || href
-  }
+  const value = $derived(text || href)
 
   function onIconLocal() {
     if (onIcon) {
       onIcon(iconValue)
     }
-    dispatch('select', { value: iconValue })
+    onselect?.({ value: iconValue })
   }
 </script>
 
 {#if value}
   {#if icon && iconValue}
     <div class="link" style:--icon-padding={iconPadding}>
-      <a href={hrefWithPrefix} {...props}>{value}</a>
+      <a href={hrefWithPrefix} {...attrs}>{value}</a>
       <div class="icon" use:$tippy={{ content: tooltip }}>
         <Icon name={icon} size={iconSize} onclick={onIconLocal} />
       </div>
     </div>
   {:else}
-    <a href={hrefWithPrefix} {...props}>{value}</a>
+    <a href={hrefWithPrefix} {...attrs}>{value}</a>
   {/if}
 {:else}
   ''

--- a/ui/dashboard/src/internal/components/json-tree/index.svelte
+++ b/ui/dashboard/src/internal/components/json-tree/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import { copyTextToClipboardVanilla } from '$lib/utils/clipboard'
@@ -7,27 +9,41 @@
   import { valueSet } from '$lib/utils/types'
 
   import ActionStatusIcon from '$internal/components/action-status-icon/index.svelte'
+  import Self from './index.svelte'
 
   import i18n from '$internal/i18n'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  // internal, don't set manually
-  export let level = 0 // used internally to set recursive level
-  export let id = 'exp'
-  export let isLastChild = false
-  export let expandState = {} // mapping from "expand" block id's to boolean indicating whether the block should be collapsed
-  let expIds: string[] = []
+  let {
+    // internal, don't set manually
+    level = 0, // used internally to set recursive level
+    id = 'exp',
+    isLastChild = false,
+    expandState = $bindable({}), // mapping from "expand" block id's to boolean indicating whether the block should be collapsed
+    // options
+    inlineArr = true,
+    inlineObj = true,
+    showCommas = true,
+    showFinalComma = false,
+    data = {},
+    parentKey = '',
+    blockHash = '',
+  }: {
+    level?: number
+    id?: string
+    isLastChild?: boolean
+    expandState?: Record<string, boolean>
+    inlineArr?: boolean
+    inlineObj?: boolean
+    showCommas?: boolean
+    showFinalComma?: boolean
+    data?: any
+    parentKey?: string
+    blockHash?: string
+  } = $props()
 
-  // options
-  export let inlineArr = true
-  export let inlineObj = true
-  export let showCommas = true
-  export let showFinalComma = false
-
-  export let data = {}
-  export let parentKey = ''
-  export let blockHash = ''
+  let expIds: string[] = $state([])
 
   function getType(value: any) {
     if (Array.isArray(value)) return 'array'
@@ -38,13 +54,13 @@
     return value as any[]
   }
 
-  $: entries = typeof data === 'object' ? Object.entries(data) : []
+  const entries = $derived<[string, any][]>(typeof data === 'object' ? Object.entries(data) : [])
 
   function onExpClick(e) {
-    const id = e.srcElement.id
+    const elId = e.srcElement.id
     expandState = {
       ...expandState,
-      [id]: valueSet(expandState[id]) ? !expandState[id] : false,
+      [elId]: valueSet(expandState[elId]) ? !expandState[elId] : false,
     }
   }
 
@@ -98,7 +114,7 @@
           class="expand"
           class:closed={expandState[id]}
           {id}
-          on:click={onExpClick}
+          onclick={onExpClick}
           type="button"
         >
           <div class="exp_icon"><Icon name="icon-chevron-down-line" size={11} /></div>
@@ -116,7 +132,7 @@
                     class:closed={expandState[id + '_' + i]}
                     id={id + '_' + i}
                     style="padding-left:3px;"
-                    on:click={onExpClick}
+                    onclick={onExpClick}
                     type="button"
                   >
                     <div class="exp_icon"><Icon name="icon-chevron-down-line" size={11} /></div>
@@ -138,7 +154,7 @@
 
               {#if getType(value) === 'object' && value !== null}
                 {#if !expandState[id + '_' + i] || !inlineObj}
-                  <svelte:self
+                  <Self
                     data={value}
                     {blockHash}
                     level={level + 1}
@@ -156,7 +172,7 @@
                       class:closed={expandState[id + '_' + i + '_']}
                       id={id + '_' + i + '_'}
                       style="margin-left:-15px;"
-                      on:click={onExpClick}
+                      onclick={onExpClick}
                       type="button"
                     >
                       <div class="exp_icon"><Icon name="icon-chevron-down-line" size={11} /></div>
@@ -168,7 +184,7 @@
                     <ul>
                       {#each value as item, j (item)}
                         <li>
-                          <svelte:self
+                          <Self
                             data={item}
                             parentKey={key}
                             {blockHash}

--- a/ui/dashboard/src/internal/components/json-tree/index.svelte
+++ b/ui/dashboard/src/internal/components/json-tree/index.svelte
@@ -75,10 +75,10 @@
   {#if level === 0}
     <div class="tools">
       <div class="icon" use:$tippy={{ content: t('tooltip.collapse-all') }}>
-        <Icon name="icon-chevron-right-line" size={15} on:click={() => onBulkClose(true)} />
+        <Icon name="icon-chevron-right-line" size={15} onclick={() => onBulkClose(true)} />
       </div>
       <div class="icon" use:$tippy={{ content: t('tooltip.expand-all') }}>
-        <Icon name="icon-chevron-down-line" size={15} on:click={() => onBulkClose(false)} />
+        <Icon name="icon-chevron-down-line" size={15} onclick={() => onBulkClose(false)} />
       </div>
       <div class="icon" use:$tippy={{ content: t('tooltip.copy-json-to-clipboard') }}>
         <ActionStatusIcon

--- a/ui/dashboard/src/internal/components/msgbox/index.svelte
+++ b/ui/dashboard/src/internal/components/msgbox/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import { humanTime } from '$internal/utils/format'
@@ -6,17 +8,25 @@
   import type { Message, P2PMessage, StatusMessage, MessageSource, MsgDisplayField } from './types'
   import i18n from '../../i18n'
 
-  export let source: MessageSource = 'p2p'
-  export let message: Message
-  export let collapse = false
-  export let titleMinW = '120px'
-  export let hidePeer = false
-  export let rawMode = false
+  let {
+    source = 'p2p',
+    message,
+    collapse = false,
+    titleMinW = '120px',
+    hidePeer = false,
+    rawMode = false,
+  }: {
+    source?: MessageSource
+    message: Message
+    collapse?: boolean
+    titleMinW?: string
+    hidePeer?: boolean
+    rawMode?: boolean
+  } = $props()
 
-  let age = ''
+  let age = $state('')
   let fields: MsgDisplayField[] = []
-  let title = ''
-  
+
   // Format JSON with syntax highlighting
   function formatJSON(obj: any): string {
     try {
@@ -67,10 +77,10 @@
     return () => clearInterval(interval)
   })
 
-  $: updatedFields = getMessageFields(source, message, `${age} ago`, hidePeer)
-  $: baseKey = `comp.msgbox.${message.type.toLowerCase()}`
+  const updatedFields = $derived(getMessageFields(source, message, `${age} ago`, hidePeer))
+  const baseKey = $derived(`comp.msgbox.${message.type.toLowerCase()}`)
 
-  $: {
+  const title = $derived.by(() => {
     const translationKey =
       source === 'status' && (message as StatusMessage).source === 'status'
         ? `comp.msgbox.status.type.${message.type.toLowerCase()}.title`
@@ -78,11 +88,10 @@
 
     // Check if translation exists, if not provide a fallback
     const translation = $i18n.t(translationKey)
-    title =
-      translation === translationKey
-        ? `${message.type.charAt(0).toUpperCase()}${message.type.slice(1).toLowerCase().replace(/_/g, ' ')}`
-        : translation
-  }
+    return translation === translationKey
+      ? `${message.type.charAt(0).toUpperCase()}${message.type.slice(1).toLowerCase().replace(/_/g, ' ')}`
+      : translation
+  })
 </script>
 
 <div

--- a/ui/dashboard/src/internal/components/page/content/menu/index.svelte
+++ b/ui/dashboard/src/internal/components/page/content/menu/index.svelte
@@ -1,14 +1,20 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { mediaSize, MediaSize } from '$lib/stores/media'
 
-  $: gutterW =
+  let { children }: { children?: Snippet } = $props()
+
+  const gutterW = $derived(
     $mediaSize <= MediaSize.lg
       ? $mediaSize <= MediaSize.sm
         ? $mediaSize <= MediaSize.xs
           ? 16
           : 20
         : 32
-      : 90
+      : 90,
+  )
 
   const marginTop = 15
   const marginBottom = 36
@@ -21,7 +27,7 @@
   style:--margin-bottom={marginBottom + 'px'}
   style:--min-height-local="calc(100% - {marginTop + marginBottom}px - var(--footer-height, 0px))"
 >
-  <slot></slot>
+  {@render children?.()}
 </div>
 
 <style>

--- a/ui/dashboard/src/internal/components/page/home/home-stats-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/home/home-stats-card/index.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <Card title={t(`${baseKey}.title`)} showFooter={false} headerPadding="20px 24px 10px 24px">
-  <svelte:fragment slot="header-tools">
+  {#snippet headerTools()}
     <div class="live">
       <div class="live-icon" class:connected>
         <Icon name="icon-status-light-glow-solid" size={14} />
@@ -56,7 +56,7 @@
       tooltip={t('tooltip.refresh')}
       onclick={onRefresh}
     />
-  </svelte:fragment>
+  {/snippet}
   <div class="content" style:--grid-template-columns={`repeat(${colCount}, 1fr)`}>
     {#if loading}
       <div class="block">

--- a/ui/dashboard/src/internal/components/page/home/home-stats-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/home/home-stats-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import { addNumCommas } from '$lib/utils/format'
@@ -6,16 +8,22 @@
   import i18n from '$internal/i18n'
   import { sock as p2pSock } from '$internal/stores/p2pStore'
 
-  export let loading = true
-  export let data: any = {}
-  export let onRefresh = () => {}
+  let {
+    loading = true,
+    data = {},
+    onRefresh = () => {},
+  }: {
+    loading?: boolean
+    data?: any
+    onRefresh?: () => void
+  } = $props()
 
   const baseKey = 'page.home.stats'
   const fieldKey = `${baseKey}.fields`
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  $: connected = $p2pSock !== null
+  const connected = $derived($p2pSock !== null)
 
   const colsLg = [
     'txns_per_second',
@@ -37,8 +45,10 @@
     'chain_work',
   ]
 
-  $: cols = $mediaSize <= MediaSize.md ? colsMd : colsLg
-  $: colCount = $mediaSize <= MediaSize.md ? ($mediaSize <= MediaSize.xs ? 1 : 2) : 4
+  const cols = $derived($mediaSize <= MediaSize.md ? colsMd : colsLg)
+  const colCount = $derived(
+    $mediaSize <= MediaSize.md ? ($mediaSize <= MediaSize.xs ? 1 : 2) : 4
+  )
 </script>
 
 <Card title={t(`${baseKey}.title`)} showFooter={false} headerPadding="20px 24px 10px 24px">

--- a/ui/dashboard/src/internal/components/page/home/home-stats-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/home/home-stats-card/index.svelte
@@ -54,7 +54,7 @@
       ico={true}
       icon="icon-refresh-line"
       tooltip={t('tooltip.refresh')}
-      on:click={onRefresh}
+      onclick={onRefresh}
     />
   </svelte:fragment>
   <div class="content" style:--grid-template-columns={`repeat(${colCount}, 1fr)`}>

--- a/ui/dashboard/src/internal/components/page/home/home-stats-graph/index.svelte
+++ b/ui/dashboard/src/internal/components/page/home/home-stats-graph/index.svelte
@@ -48,7 +48,7 @@
   wrapHeader={true}
 >
   {#snippet headerTools()}
-    <RangeToggle value={period} on:change={(e) => onChangePeriod(e.detail.value)} />
+    <RangeToggle value={period} onchange={(e) => onChangePeriod(e.value)} />
   {/snippet}
 
   <ChartContainer bind:renderKey height="530px">

--- a/ui/dashboard/src/internal/components/page/home/home-stats-graph/index.svelte
+++ b/ui/dashboard/src/internal/components/page/home/home-stats-graph/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import { Chart, ChartContainer } from '$lib/components/chart'
@@ -6,17 +8,23 @@
   import i18n from '$internal/i18n'
   import { getGraphObj } from './graph'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
   const baseKey = 'page.home.txs'
 
-  export let data: any = []
-  export let period
-  export let onChangePeriod
+  let {
+    data = [],
+    period,
+    onChangePeriod,
+  }: {
+    data?: any
+    period?: string
+    onChangePeriod?: (value: string) => void
+  } = $props()
 
-  let renderKey = ''
-  let graphObj
-  let tmpGraphObj
+  let renderKey = $state('')
+  let graphObj = $state<any>(null)
+  let tmpGraphObj: any
   let delayId
 
   function doDelay() {
@@ -28,11 +36,13 @@
     }, 20)
   }
 
-  $: if (data) {
-    tmpGraphObj = getGraphObj(t, data, period)
-    graphObj = null
-    doDelay()
-  }
+  $effect(() => {
+    if (data) {
+      tmpGraphObj = getGraphObj(t, data, period)
+      graphObj = null
+      doDelay()
+    }
+  })
 
   onDestroy(() => {
     if (delayId) {
@@ -48,7 +58,7 @@
   wrapHeader={true}
 >
   {#snippet headerTools()}
-    <RangeToggle value={period} onchange={(e) => onChangePeriod(e.value)} />
+    <RangeToggle value={period} onchange={(e) => onChangePeriod?.(e.value)} />
   {/snippet}
 
   <ChartContainer bind:renderKey height="530px">

--- a/ui/dashboard/src/internal/components/page/home/home-stats-graph/index.svelte
+++ b/ui/dashboard/src/internal/components/page/home/home-stats-graph/index.svelte
@@ -47,9 +47,9 @@
   headerPadding="20px 24px 10px 24px"
   wrapHeader={true}
 >
-  <svelte:fragment slot="header-tools">
+  {#snippet headerTools()}
     <RangeToggle value={period} on:change={(e) => onChangePeriod(e.detail.value)} />
-  </svelte:fragment>
+  {/snippet}
 
   <ChartContainer bind:renderKey height="530px">
     {#if graphObj?.graphOptions}

--- a/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
@@ -55,7 +55,7 @@
 
   let variant = 'dynamic'
   function onToggle(e) {
-    const value = e.detail.value
+    const value = e.value
     variant = $tableVariant = value
   }
 </script>
@@ -81,7 +81,7 @@
       hasBoundaryRight={true}
       on:change={onPage}
     />
-    <TableToggle value={variant} on:change={onToggle} />
+    <TableToggle value={variant} onchange={onToggle} />
     {#if hasSorting}
       <button class="clear-sort-btn" on:click={clearSort} title="Clear sorting">
         <Icon name="icon-close-line" size={16} />

--- a/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
@@ -61,10 +61,12 @@
 </script>
 
 <Card contentPadding="0" showFooter={showTableFooter}>
-  <div class="title" slot="title">
-    <Typo variant="title" size="h4" value={t(`${pageKey}.title`)} />
-  </div>
-  <svelte:fragment slot="header-tools">
+  {#snippet title()}
+    <div class="title">
+      <Typo variant="title" size="h4" value={t(`${pageKey}.title`)} />
+    </div>
+  {/snippet}
+  {#snippet headerTools()}
     <Pager
       i18n={i18nLocal}
       expandUp={true}
@@ -91,7 +93,7 @@
       </div>
       <div class="live-label">{t(`page.network.live`)}</div>
     </div>
-  </svelte:fragment>
+  {/snippet}
   <Table
     name="nodes"
     {variant}
@@ -117,22 +119,24 @@
     on:action={() => {}}
     on:sort={onSort}
   />
-  <div slot="footer">
-    <Pager
-      i18n={i18nLocal}
-      expandUp={true}
-      totalItems={allData?.length}
-      showPageSize={showPagerSize}
-      showQuickNav={showPagerNav}
-      showNav={showPagerNav}
-      value={{
-        page,
-        pageSize,
-      }}
-      hasBoundaryRight={true}
-      on:change={onPage}
-    />
-  </div>
+  {#snippet footer()}
+    <div>
+      <Pager
+        i18n={i18nLocal}
+        expandUp={true}
+        totalItems={allData?.length}
+        showPageSize={showPagerSize}
+        showQuickNav={showPagerNav}
+        showNav={showPagerNav}
+        value={{
+          page,
+          pageSize,
+        }}
+        hasBoundaryRight={true}
+        on:change={onPage}
+      />
+    </div>
+  {/snippet}
 </Card>
 
 <BlockAssemblyModal />

--- a/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import Table from '$lib/components/table/index.svelte'
   import Pager from '$internal/components/pager/index.svelte'
   import Icon from '$lib/components/icon/index.svelte'
@@ -12,48 +13,60 @@
   import { getColDefs, renderCells, getRenderProps } from './data'
 
   const pageKey = 'page.network.nodes'
-  const dispatch = createEventDispatcher()
 
-  $: t = $i18n.t
-  $: i18nLocal = { t, baseKey: 'comp.pager' }
+  let {
+    data = [], // Paginated data
+    allData = [], // Full dataset for pagination calculation
+    connected = false,
+    page = 1,
+    pageSize = 10,
+    sortColumn = '',
+    sortOrder = '',
+    onpagechange,
+    onsort,
+  }: {
+    data?: any[]
+    allData?: any[]
+    connected?: boolean
+    page?: number
+    pageSize?: number
+    sortColumn?: string
+    sortOrder?: string
+    onpagechange?: (e: any) => void
+    onsort?: (e: any) => void
+  } = $props()
 
-  let colDefs: any[] = []
-  $: colDefs = getColDefs(t) || []
+  const t = $derived($i18n.t)
+  const i18nLocal = $derived({ t, baseKey: 'comp.pager' })
 
-  export let data: any[] = [] // Paginated data
-  export let allData: any[] = [] // Full dataset for pagination calculation
-  export let connected = false
-  export let page = 1
-  export let pageSize = 10
-  export let sortColumn = ''
-  export let sortOrder = ''
+  const colDefs = $derived(getColDefs(t) || [])
 
   function onPage(e) {
     // Forward pagination changes to parent component
-    dispatch('pagechange', e)
+    onpagechange?.(e)
   }
 
   function onSort(e) {
     // Forward sort changes to parent component
-    dispatch('sort', e)
+    onsort?.(e)
   }
 
   function clearSort() {
     // Dispatch a sort event with empty values to clear sorting
-    dispatch('sort', {
+    onsort?.({
       colId: '',
       value: ''
     })
   }
 
-  $: hasSorting = sortColumn && sortOrder
+  const hasSorting = $derived(sortColumn && sortOrder)
 
-  $: totalPages = Math.max(1, Math.ceil((allData?.length || 0) / pageSize))
-  $: showPagerNav = totalPages > 1
-  $: showPagerSize = showPagerNav || (totalPages === 1 && allData.length > 5)
-  $: showTableFooter = showPagerSize
+  const totalPages = $derived(Math.max(1, Math.ceil((allData?.length || 0) / pageSize)))
+  const showPagerNav = $derived(totalPages > 1)
+  const showPagerSize = $derived(showPagerNav || (totalPages === 1 && allData.length > 5))
+  const showTableFooter = $derived(showPagerSize)
 
-  let variant = 'dynamic'
+  let variant = $state('dynamic')
   function onToggle(e) {
     const value = e.value
     variant = $tableVariant = value
@@ -83,7 +96,7 @@
     />
     <TableToggle value={variant} onchange={onToggle} />
     {#if hasSorting}
-      <button class="clear-sort-btn" on:click={clearSort} title="Clear sorting">
+      <button class="clear-sort-btn" onclick={clearSort} title="Clear sorting">
         <Icon name="icon-close-line" size={16} />
       </button>
     {/if}

--- a/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/network/connected-nodes-card/index.svelte
@@ -30,12 +30,12 @@
 
   function onPage(e) {
     // Forward pagination changes to parent component
-    dispatch('pagechange', e.detail)
+    dispatch('pagechange', e)
   }
 
   function onSort(e) {
     // Forward sort changes to parent component
-    dispatch('sort', e.detail)
+    dispatch('sort', e)
   }
 
   function clearSort() {
@@ -79,7 +79,7 @@
         pageSize,
       }}
       hasBoundaryRight={true}
-      on:change={onPage}
+      onchange={onPage}
     />
     <TableToggle value={variant} onchange={onToggle} />
     {#if hasSorting}
@@ -116,8 +116,8 @@
     {renderCells}
     {getRenderProps}
     getRowIconActions={null}
-    on:action={() => {}}
-    on:sort={onSort}
+    onaction={() => {}}
+    onsort={onSort}
   />
   {#snippet footer()}
     <div>
@@ -133,7 +133,7 @@
           pageSize,
         }}
         hasBoundaryRight={true}
-        on:change={onPage}
+        onchange={onPage}
       />
     </div>
   {/snippet}

--- a/ui/dashboard/src/internal/components/page/template/menu/index.svelte
+++ b/ui/dashboard/src/internal/components/page/template/menu/index.svelte
@@ -24,8 +24,8 @@
     goto('/')
   }
 
-  function onMenuItem(e) {
-    const { item, type } = e.detail
+  function onMenuItem(detail) {
+    const { item, type } = detail
 
     if (type === 'page-links') {
       goto(item.path)
@@ -52,9 +52,7 @@
     showMenu = !showMenu
   }
 
-  function onDrawerMetrics(e) {
-    const detail = e.detail
-
+  function onDrawerMetrics(detail) {
     if (!showMobileNavbar) {
       if (detail.position === 'left') {
         $contentLeft = detail.width
@@ -66,7 +64,7 @@
 
   $: showDrawer = (showMobileNavbar && showMenu) || !showMobileNavbar
 
-  function onDrawerClose(e) {
+  function onDrawerClose() {
     showMenu = false
   }
 
@@ -118,22 +116,24 @@
     showCover={showMobileNavbar}
     showHeader={!showMobileNavbar}
     coverColor="var(--app-cover-bg-color)"
-    on:metrics={onDrawerMetrics}
-    on:close={onDrawerClose}
-    on:header-select={onLogo}
+    onmetrics={onDrawerMetrics}
+    onclose={onDrawerClose}
+    onheaderSelect={onLogo}
   >
-    <div slot="header" class="logo-container">
-      <Logo name="teranode" height={28} />
-      {#if expanded}
-        <Logo name="teranode-text" height={14} />
-      {/if}
-    </div>
+    {#snippet header()}
+      <div class="logo-container">
+        <Logo name="teranode" height={28} />
+        {#if expanded}
+          <Logo name="teranode-text" height={14} />
+        {/if}
+      </div>
+    {/snippet}
     {#key menuKey}
       <Menu
         collapsed={!expanded}
         idField="path"
         data={$pageLinks.items}
-        on:select={(e) => onMenuItem({ detail: { item: e.detail.item, type: 'page-links' } })}
+        onselect={(e) => onMenuItem({ item: e.item, type: 'page-links' })}
       />
     {/key}
   </Drawer>

--- a/ui/dashboard/src/internal/components/page/template/menu/index.svelte
+++ b/ui/dashboard/src/internal/components/page/template/menu/index.svelte
@@ -1,4 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { goto } from '$app/navigation'
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import { pageLinks, contentLeft } from '../../../../stores/nav'
@@ -11,14 +14,21 @@
   // import Banner from '$internal/components/banner/index.svelte'
   import AnimMenuIcon from '$internal/components/anim-menu-icon/index.svelte'
   import ContentMenu from '../../content/menu/index.svelte'
-
-  export let testId: string | undefined | null = null
-  export let showGlobalToolbar = true
-  export let showTools = true
-
   import i18n from '$internal/i18n'
 
-  $: t = $i18n.t
+  let {
+    testId = null,
+    showGlobalToolbar = true,
+    showTools = true,
+    children,
+  }: {
+    testId?: string | undefined | null
+    showGlobalToolbar?: boolean
+    showTools?: boolean
+    children?: Snippet
+  } = $props()
+
+  const t = $derived($i18n.t)
 
   function onLogo() {
     goto('/')
@@ -38,15 +48,15 @@
     }
   }
 
-  let showMenu = true
-  let showMobileNavbar = false
-  $: {
+  let showMenu = $state(true)
+  let showMobileNavbar = $state(false)
+  $effect(() => {
     let newShowMobileNavbar = $mediaSize <= MediaSize.sm
     if (showMobileNavbar !== newShowMobileNavbar) {
       showMenu = false
     }
     showMobileNavbar = newShowMobileNavbar
-  }
+  })
 
   function onToggleMenu() {
     showMenu = !showMenu
@@ -60,25 +70,25 @@
     }
   }
 
-  $: expanded = showMobileNavbar || $contentLeft > 60
+  const expanded = $derived(showMobileNavbar || $contentLeft > 60)
 
-  $: showDrawer = (showMobileNavbar && showMenu) || !showMobileNavbar
+  const showDrawer = $derived((showMobileNavbar && showMenu) || !showMobileNavbar)
 
   function onDrawerClose() {
     showMenu = false
   }
 
-  $: menuKey = JSON.stringify($pageLinks.items)
+  const menuKey = $derived(JSON.stringify($pageLinks.items))
 </script>
 
 {#if showMobileNavbar}
   <MobileNavbar offsetTop={'var(--banner-height, 0px)'}>
     <div class="navbar-content">
-      <button class="logo-container" on:click={onLogo} type="button">
+      <button class="logo-container" onclick={onLogo} type="button">
         <Logo name="teranode" height={28} />
         <Logo name="teranode-text" height={14} />
       </button>
-      <button class="icon" on:click={(e) => onToggleMenu()} type="button">
+      <button class="icon" onclick={(e) => onToggleMenu()} type="button">
         <AnimMenuIcon open={showDrawer} />
       </button>
     </div>
@@ -99,7 +109,7 @@
     {#if showGlobalToolbar}
       <Toolbar style="padding-bottom: 13px;" {showTools} />
     {/if}
-    <slot></slot>
+    {@render children?.()}
   </ContentMenu>
 
   <Footer />

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-coinbase-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-coinbase-card/index.svelte
@@ -30,18 +30,20 @@
 
 {#if coinbaseTx}
   <Card title={t(`${baseKey}.title`)} headerPadding="20px 24px 16px 24px">
-    <div class="copy-link" slot="subtitle">
-      <a href={getDetailsUrl(DetailType.tx, coinbaseTx.txid)} class="hash-link">{coinbaseTx.txid}</a
-      >
-      <div class="icon" use:$tippy={{ content: t('tooltip.copy-hash-to-clipboard') }}>
-        <ActionStatusIcon
-          icon="icon-duplicate-line"
-          action={copyTextToClipboardVanilla}
-          actionData={coinbaseTx.txid}
-          size={15}
-        />
+    {#snippet subtitle()}
+      <div class="copy-link">
+        <a href={getDetailsUrl(DetailType.tx, coinbaseTx.txid)} class="hash-link">{coinbaseTx.txid}</a
+        >
+        <div class="icon" use:$tippy={{ content: t('tooltip.copy-hash-to-clipboard') }}>
+          <ActionStatusIcon
+            icon="icon-duplicate-line"
+            action={copyTextToClipboardVanilla}
+            actionData={coinbaseTx.txid}
+            size={15}
+          />
+        </div>
       </div>
-    </div>
+    {/snippet}
     <div class="content">
       <div class="fields" class:collapse>
         <div>

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-coinbase-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-coinbase-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { formatSatoshi } from '$lib/utils/format'
   import { getDetailsUrl, DetailType } from '$internal/utils/urls'
@@ -11,21 +13,20 @@
   const baseKey = 'page.viewer-block.coinbase'
   const fieldKey = `${baseKey}.fields`
 
-  $: t = $i18n.t
-  $: collapse = $mediaSize < MediaSize.sm
+  const t = $derived($i18n.t)
+  const collapse = $derived($mediaSize < MediaSize.sm)
 
-  export let data: any = {}
+  let { data = {} }: { data?: any } = $props()
 
-  $: coinbaseTx = data?.coinbase_tx
-  $: blockHeight = data?.expandedHeader?.height
-  $: hasOutputs = coinbaseTx?.outputs?.length > 0
+  const coinbaseTx = $derived(data?.coinbase_tx)
 
   // Calculate total block reward from coinbase outputs
-  $: totalReward =
-    coinbaseTx?.outputs?.reduce((sum, output) => sum + (output.satoshis || 0), 0) || 0
+  const totalReward = $derived(
+    coinbaseTx?.outputs?.reduce((sum, output) => sum + (output.satoshis || 0), 0) || 0,
+  )
 
   // Calculate transaction size from hex
-  $: txSize = coinbaseTx?.hex ? coinbaseTx.hex.length / 2 : 0
+  const txSize = $derived(coinbaseTx?.hex ? coinbaseTx.hex.length / 2 : 0)
 </script>
 
 {#if coinbaseTx}

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
@@ -46,7 +46,9 @@
         // Keep cache size manageable (same limit as in p2pStore)
         if (map.size > 1000) {
           const firstKey = map.keys().next().value
-          map.delete(firstKey)
+          if (firstKey !== undefined) {
+            map.delete(firstKey)
+          }
         }
         return map
       })

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
@@ -99,7 +99,7 @@
       ico={true}
       disabled={!expandedHeader.previousblockhash}
       tooltip={expandedHeader.previousblockhash ? t('tooltip.previous-block') : ''}
-      on:click={() => navToBlock(expandedHeader.previousblockhash)}
+      onclick={() => navToBlock(expandedHeader.previousblockhash)}
     />
     <Button
       size="small"
@@ -107,7 +107,7 @@
       ico={true}
       disabled={!data?.nextblock}
       tooltip={data?.nextblock ? t('tooltip.next-block') : ''}
-      on:click={() => navToBlock(data?.nextblock)}
+      onclick={() => navToBlock(data?.nextblock)}
     />
   </div>
   <div class="content">
@@ -117,14 +117,14 @@
         hasFocusRect={false}
         selected={isOverview}
         variant={isOverview ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('overview')}>{t(`${baseKey}.tab.overview`)}</Button
+        onclick={() => onDisplay('overview')}>{t(`${baseKey}.tab.overview`)}</Button
       >
       <Button
         size="medium"
         hasFocusRect={false}
         selected={isJson}
         variant={isJson ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
+        onclick={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
       >
     </div>
     {#if isOverview}

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
@@ -63,7 +63,8 @@
 </script>
 
 <Card title={t(`${baseKey}.title`, { height: expandedHeader.height })}>
-  <div class="copy-link" slot="subtitle">
+  {#snippet subtitle()}
+  <div class="copy-link">
     <div class="hash">{expandedHeader.hash}</div>
     <div class="icon" use:$tippy={{ content: t('tooltip.copy-hash-to-clipboard') }}>
       <ActionStatusIcon
@@ -92,7 +93,9 @@
     &nbsp;&nbsp;&nbsp;
     <a href="/forks/?hash={expandedHeader.hash}">forks</a>
   </div>
-  <div class="btns" slot="header-tools">
+  {/snippet}
+  {#snippet headerTools()}
+  <div class="btns">
     <Button
       size="small"
       icon="icon-chevron-left-line"
@@ -110,6 +113,7 @@
       onclick={() => navToBlock(data?.nextblock)}
     />
   </div>
+  {/snippet}
   <div class="content">
     <div class="tabs">
       <Button

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-details-card/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { goto } from '$app/navigation'
   import { tippy } from '$lib/stores/media'
   import { mediaSize, MediaSize } from '$lib/stores/media'
@@ -16,37 +17,44 @@
   import { getItemApiUrl, ItemType } from '$internal/api'
   import { blockHashToMiner } from '$internal/stores/p2pStore'
 
-  const dispatch = createEventDispatcher()
-
   const baseKey = 'page.viewer-block.details'
   const fieldKey = `${baseKey}.fields`
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  $: collapse = $mediaSize < MediaSize.sm
+  const collapse = $derived($mediaSize < MediaSize.sm)
 
-  export let data: any = {}
-  export let display: DetailTab = DetailTab.overview
+  let {
+    data = {},
+    display = DetailTab.overview,
+    ondisplay,
+  }: {
+    data?: any
+    display?: DetailTab
+    ondisplay?: (detail: { value: string }) => void
+  } = $props()
 
-  $: expandedHeader = data?.expandedHeader
-  $: isOverview = display === DetailTab.overview
-  $: isJson = display === DetailTab.json
-  
+  const expandedHeader = $derived(data?.expandedHeader)
+  const isOverview = $derived(display === DetailTab.overview)
+  const isJson = $derived(display === DetailTab.json)
+
   // Populate the block hash -> miner cache when block data is loaded
-  $: if (expandedHeader?.hash && expandedHeader?.miner) {
-    blockHashToMiner.update(map => {
-      map.set(expandedHeader.hash, expandedHeader.miner)
-      // Keep cache size manageable (same limit as in p2pStore)
-      if (map.size > 1000) {
-        const firstKey = map.keys().next().value
-        map.delete(firstKey)
-      }
-      return map
-    })
-  }
+  $effect(() => {
+    if (expandedHeader?.hash && expandedHeader?.miner) {
+      blockHashToMiner.update(map => {
+        map.set(expandedHeader.hash, expandedHeader.miner)
+        // Keep cache size manageable (same limit as in p2pStore)
+        if (map.size > 1000) {
+          const firstKey = map.keys().next().value
+          map.delete(firstKey)
+        }
+        return map
+      })
+    }
+  })
 
   function onDisplay(value) {
-    dispatch('display', { value })
+    ondisplay?.({ value })
   }
 
   function onReverseHash(hash) {
@@ -59,7 +67,7 @@
     }
   }
 
-  $: difficultyDisplay = formatNumberExpStr(getDifficultyFromBits(expandedHeader.bits))
+  const difficultyDisplay = $derived(formatNumberExpStr(getDifficultyFromBits(expandedHeader.bits)))
 </script>
 
 <Card title={t(`${baseKey}.title`, { height: expandedHeader.height })}>
@@ -84,7 +92,7 @@
     </div>
     <button
       class="icon"
-      on:click={() => onReverseHash(expandedHeader.hash)}
+      onclick={() => onReverseHash(expandedHeader.hash)}
       use:$tippy={{ content: t('tooltip.reverse-hash') }}
       type="button"
     >

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import Table from '$lib/components/table/index.svelte'
   import Pager from '$internal/components/pager/index.svelte'
@@ -11,21 +13,20 @@
 
   const baseKey = 'page.viewer-block.subtrees'
 
-  export let block: any
+  let { block }: { block?: any } = $props()
 
-  let data: any[] = []
+  let data: any[] = $state([])
 
-  $: t = $i18n.t
-  $: i18nLocal = { t, baseKey: 'comp.pager' }
+  const t = $derived($i18n.t)
+  const i18nLocal = $derived({ t, baseKey: 'comp.pager' })
 
-  let colDefs: any[] = []
-  $: colDefs = getColDefs(t) || []
+  const colDefs = $derived(getColDefs(t) || [])
 
-  $: renderCells = getRenderCells(t, block?.expandedHeader?.hash) || {}
+  const renderCells = $derived(getRenderCells(t, block?.expandedHeader?.hash) || {})
 
-  let page = 1
-  let pageSize = 10
-  let totalItems = 0
+  let page = $state(1)
+  let pageSize = $state(10)
+  let totalItems = $state(0)
 
   function onPage(e) {
     const data = e
@@ -33,12 +34,12 @@
     pageSize = data.value.pageSize
   }
 
-  $: totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
-  $: showPagerNav = totalPages > 1
-  $: showPagerSize = showPagerNav || (totalPages === 1 && data.length > 5)
-  $: showTableFooter = showPagerSize
+  const totalPages = $derived(Math.max(1, Math.ceil(totalItems / pageSize)))
+  const showPagerNav = $derived(totalPages > 1)
+  const showPagerSize = $derived(showPagerNav || (totalPages === 1 && data.length > 5))
+  const showTableFooter = $derived(showPagerSize)
 
-  let variant = 'dynamic'
+  let variant = $state('dynamic')
   function onToggle(e) {
     const value = e.value
     variant = $tableVariant = value
@@ -61,9 +62,11 @@
     }
   }
 
-  $: if (block) {
-    fetchData(block.expandedHeader.hash, page, pageSize)
-  }
+  $effect(() => {
+    if (block) {
+      fetchData(block.expandedHeader.hash, page, pageSize)
+    }
+  })
 </script>
 
 <Card

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
@@ -28,7 +28,7 @@
   let totalItems = 0
 
   function onPage(e) {
-    const data = e.detail
+    const data = e
     page = data.value.page
     pageSize = data.value.pageSize
   }
@@ -96,7 +96,7 @@
         pageSize,
       }}
       hasBoundaryRight={true}
-      on:change={onPage}
+      onchange={onPage}
     />
     <TableToggle value={variant} onchange={onToggle} />
   {/snippet}
@@ -118,7 +118,7 @@
     {renderCells}
     getRenderProps={null}
     getRowIconActions={null}
-    on:action={() => {}}
+    onaction={() => {}}
   />
   {#snippet footer()}
     <div>
@@ -134,7 +134,7 @@
           pageSize,
         }}
         hasBoundaryRight={true}
-        on:change={onPage}
+        onchange={onPage}
       />
     </div>
   {/snippet}

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
@@ -72,16 +72,18 @@
   contentPadding="0"
   showFooter={showTableFooter}
 >
-  <div slot="subtitle">
-    {#if totalItems > pageSize}
-      Viewing subtrees {((page - 1) * pageSize) + 1}-{Math.min(page * pageSize, totalItems)} of {totalItems} subtrees
-    {:else if totalItems === 1}
-      {t(`${baseKey}.subtitle_singular`, { count: totalItems || 0 })}
-    {:else}
-      {t(`${baseKey}.subtitle`, { count: totalItems || 0 })}
-    {/if}
-  </div>
-  <svelte:fragment slot="header-tools">
+  {#snippet subtitle()}
+    <div>
+      {#if totalItems > pageSize}
+        Viewing subtrees {((page - 1) * pageSize) + 1}-{Math.min(page * pageSize, totalItems)} of {totalItems} subtrees
+      {:else if totalItems === 1}
+        {t(`${baseKey}.subtitle_singular`, { count: totalItems || 0 })}
+      {:else}
+        {t(`${baseKey}.subtitle`, { count: totalItems || 0 })}
+      {/if}
+    </div>
+  {/snippet}
+  {#snippet headerTools()}
     <Pager
       i18n={i18nLocal}
       expandUp={true}
@@ -97,7 +99,7 @@
       on:change={onPage}
     />
     <TableToggle value={variant} on:change={onToggle} />
-  </svelte:fragment>
+  {/snippet}
   <Table
     name="subtrees"
     {variant}
@@ -118,20 +120,22 @@
     getRowIconActions={null}
     on:action={() => {}}
   />
-  <div slot="footer">
-    <Pager
-      i18n={i18nLocal}
-      expandUp={true}
-      {totalItems}
-      showPageSize={showPagerSize}
-      showQuickNav={showPagerNav}
-      showNav={showPagerNav}
-      value={{
-        page,
-        pageSize,
-      }}
-      hasBoundaryRight={true}
-      on:change={onPage}
-    />
-  </div>
+  {#snippet footer()}
+    <div>
+      <Pager
+        i18n={i18nLocal}
+        expandUp={true}
+        {totalItems}
+        showPageSize={showPagerSize}
+        showQuickNav={showPagerNav}
+        showNav={showPagerNav}
+        value={{
+          page,
+          pageSize,
+        }}
+        hasBoundaryRight={true}
+        on:change={onPage}
+      />
+    </div>
+  {/snippet}
 </Card>

--- a/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/block-subtrees-card/index.svelte
@@ -40,7 +40,7 @@
 
   let variant = 'dynamic'
   function onToggle(e) {
-    const value = e.detail.value
+    const value = e.value
     variant = $tableVariant = value
   }
 
@@ -98,7 +98,7 @@
       hasBoundaryRight={true}
       on:change={onPage}
     />
-    <TableToggle value={variant} on:change={onToggle} />
+    <TableToggle value={variant} onchange={onToggle} />
   {/snippet}
   <Table
     name="subtrees"

--- a/ui/dashboard/src/internal/components/page/viewer/block/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/block/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { beforeUpdate } from 'svelte'
   import { page } from '$app/stores'
   import BlockDetailsCard from './block-details-card/index.svelte'
   import BlockCoinbaseCard from './block-coinbase-card/index.svelte'
@@ -12,30 +13,32 @@
   import { failure } from '$lib/utils/notifications'
   import * as api from '$internal/api'
 
-  let ready = false
-  beforeUpdate(() => {
+  let ready = $state(false)
+  $effect(() => {
     ready = true
   })
 
   const type = DetailType.block
 
-  export let hash = ''
+  let { hash = '' }: { hash?: string } = $props()
 
-  let display: DetailTab
+  let display: DetailTab = $state(DetailTab.overview)
 
-  $: tab = ready ? $page.url.searchParams.get('tab') ?? '' : ''
-  $: display = tab === DetailTab.json ? DetailTab.json : DetailTab.overview
+  const tab = $derived(ready ? $page.url.searchParams.get('tab') ?? '' : '')
+  $effect(() => {
+    display = tab === DetailTab.json ? DetailTab.json : DetailTab.overview
+  })
 
-  let result: any = null
+  let result: any = $state(null)
 
-  $: {
+  $effect(() => {
     if ($assetHTTPAddress && type && hash && hash.length === 64) {
       fetchData()
     }
-  }
+  })
 
   function onDisplay(e) {
-    display = e.detail.value
+    display = e.value
     setQueryParam('tab', display)
   }
 
@@ -89,7 +92,7 @@
 </script>
 
 {#if result}
-  <BlockDetailsCard data={result} {display} on:display={onDisplay} />
+  <BlockDetailsCard data={result} {display} ondisplay={onDisplay} />
   {#if display === DetailTab.overview}
     <div style="height: 20px"></div>
     <BlockCoinbaseCard data={result} />

--- a/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
@@ -65,7 +65,7 @@
   }
 
   function onPage(e) {
-    const data = e.detail
+    const data = e
     page = data.value.page
     pageSize = data.value.pageSize
     updateURL(page, pageSize)
@@ -168,7 +168,7 @@
         pageSize,
       }}
       hasBoundaryRight={true}
-      on:change={onPage}
+      onchange={onPage}
     />
     <div style="height: 24px; width: 12px;"></div>
     <TableToggle value={variant} onchange={onToggle} />
@@ -198,7 +198,7 @@
     {renderCells}
     getRenderProps={null}
     getRowIconActions={null}
-    on:action={() => {}}
+    onaction={() => {}}
   />
   {#snippet footer()}
     <div>
@@ -214,7 +214,7 @@
           pageSize,
         }}
         hasBoundaryRight={true}
-        on:change={onPage}
+        onchange={onPage}
       />
     </div>
   {/snippet}

--- a/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
@@ -78,7 +78,7 @@
 
   let variant = 'dynamic'
   function onToggle(e) {
-    const value = e.detail.value
+    const value = e.value
     variant = $tableVariant = value
   }
 
@@ -171,7 +171,7 @@
       on:change={onPage}
     />
     <div style="height: 24px; width: 12px;"></div>
-    <TableToggle value={variant} on:change={onToggle} />
+    <TableToggle value={variant} onchange={onToggle} />
     <Button
       size="small"
       ico={true}

--- a/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
@@ -175,7 +175,7 @@
       ico={true}
       icon="icon-refresh-line"
       tooltip={t('tooltip.refresh')}
-      on:click={() => fetchData(page, pageSize)}
+      onclick={() => fetchData(page, pageSize)}
     />
   </svelte:fragment>
   <Table

--- a/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import Button from '$lib/components/button/index.svelte'
   import Table from '$lib/components/table/index.svelte'
@@ -18,24 +20,23 @@
 
   const baseKey = 'page.viewer'
 
-  $: t = $i18n.t
-  $: i18nLocal = { t, baseKey: 'comp.pager' }
+  const t = $derived($i18n.t)
+  const i18nLocal = $derived({ t, baseKey: 'comp.pager' })
 
-  let colDefs: any[] = []
-  $: colDefs = getColDefs(t) || []
+  const colDefs = $derived(getColDefs(t) || [])
 
-  $: renderCells = getRenderCells(t) || {}
+  const renderCells = $derived(getRenderCells(t) || {})
 
-  let data: any[] = []
+  let data: any[] = $state([])
 
-  $: hasData = data && data.length > 0
+  const hasData = $derived(data && data.length > 0)
 
-  let page = 1
-  let pageSize = 20
-  let totalItems = 0
+  let page = $state(1)
+  let pageSize = $state(20)
+  let totalItems = $state(0)
 
   // Get pagination from URL (read-only, no writing in reactive block)
-  $: {
+  $effect(() => {
     const urlPageSize = $pageStore.url.searchParams.get('pageSize')
     if (urlPageSize) {
       const parsed = parseInt(urlPageSize, 10)
@@ -55,7 +56,7 @@
     } else if (page !== 1) {
       page = 1 // Always reset to page 1 if not in URL
     }
-  }
+  })
 
   function updateURL(page: number, pageSize: number) {
     const url = new URL($pageStore.url)
@@ -71,12 +72,12 @@
     updateURL(page, pageSize)
   }
 
-  $: totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
-  $: showPagerNav = totalPages > 1
-  $: showPagerSize = showPagerNav || (totalPages === 1 && data.length > 5)
-  $: showTableFooter = showPagerSize
+  const totalPages = $derived(Math.max(1, Math.ceil(totalItems / pageSize)))
+  const showPagerNav = $derived(totalPages > 1)
+  const showPagerSize = $derived(showPagerNav || (totalPages === 1 && data.length > 5))
+  const showTableFooter = $derived(showPagerSize)
 
-  let variant = 'dynamic'
+  let variant = $state('dynamic')
   function onToggle(e) {
     const value = e.value
     variant = $tableVariant = value
@@ -132,9 +133,11 @@
   }
 
   // Fetch data when the selected node changes or pagination params change
-  $: if ($assetHTTPAddress) {
-    fetchData(page, pageSize)
-  }
+  $effect(() => {
+    if ($assetHTTPAddress) {
+      fetchData(page, pageSize)
+    }
+  })
 
   function onKeyDown(e) {
     if (!e) e = window.event
@@ -220,4 +223,4 @@
   {/snippet}
 </Card>
 
-<svelte:window on:keydown={onKeyDown} />
+<svelte:window onkeydown={onKeyDown} />

--- a/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/blocks/blocks-table-card/index.svelte
@@ -146,14 +146,16 @@
 </script>
 
 <Card title={t(`${baseKey}.title`)} contentPadding="0" showFooter={showTableFooter}>
-  <div slot="subtitle">
-    {t(`${baseKey}.subtitle`, {
-      fromHeight: hasData ? addNumCommas(data[data.length - 1].height) : 'N/A',
-      toHeight: hasData ? addNumCommas(data[0].height) : 'N/A',
-    })}
-  </div>
+  {#snippet subtitle()}
+    <div>
+      {t(`${baseKey}.subtitle`, {
+        fromHeight: hasData ? addNumCommas(data[data.length - 1].height) : 'N/A',
+        toHeight: hasData ? addNumCommas(data[0].height) : 'N/A',
+      })}
+    </div>
+  {/snippet}
 
-  <svelte:fragment slot="header-tools">
+  {#snippet headerTools()}
     <Pager
       i18n={i18nLocal}
       expandUp={true}
@@ -177,7 +179,7 @@
       tooltip={t('tooltip.refresh')}
       onclick={() => fetchData(page, pageSize)}
     />
-  </svelte:fragment>
+  {/snippet}
   <Table
     name="blocks"
     {variant}
@@ -198,22 +200,24 @@
     getRowIconActions={null}
     on:action={() => {}}
   />
-  <div slot="footer">
-    <Pager
-      i18n={i18nLocal}
-      expandUp={true}
-      {totalItems}
-      showPageSize={showPagerSize}
-      showQuickNav={showPagerNav}
-      showNav={showPagerNav}
-      value={{
-        page,
-        pageSize,
-      }}
-      hasBoundaryRight={true}
-      on:change={onPage}
-    />
-  </div>
+  {#snippet footer()}
+    <div>
+      <Pager
+        i18n={i18nLocal}
+        expandUp={true}
+        {totalItems}
+        showPageSize={showPagerSize}
+        showQuickNav={showPagerNav}
+        showNav={showPagerNav}
+        value={{
+          page,
+          pageSize,
+        }}
+        hasBoundaryRight={true}
+        on:change={onPage}
+      />
+    </div>
+  {/snippet}
 </Card>
 
 <svelte:window on:keydown={onKeyDown} />

--- a/ui/dashboard/src/internal/components/page/viewer/no-data-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/no-data-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import Button from '$lib/components/button/index.svelte'
   import Logo from '$lib/components/logo/index.svelte'
@@ -7,10 +9,15 @@
 
   const fieldKey = 'comp.no-data'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  export let hash = ''
-  export let maxWidth = 400
+  let {
+    hash = '',
+    maxWidth = 400,
+  }: {
+    hash?: string
+    maxWidth?: number
+  } = $props()
 
   function onReverseHash() {
     reverseHashParam(hash)

--- a/ui/dashboard/src/internal/components/page/viewer/no-data-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/no-data-card/index.svelte
@@ -38,7 +38,7 @@
     />
   </div>
   <div class="btn">
-    <Button variant="tertiary" icon="icon-reeverse-line" width={100} on:click={onReverseHash}
+    <Button variant="tertiary" icon="icon-reeverse-line" width={100} onclick={onReverseHash}
       >{t(`${fieldKey}.reverse`)}</Button
     >
   </div>

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { beforeUpdate } from 'svelte'
   import { page } from '$app/stores'
   import SubtreeDetailsCard from './subtree-details-card/index.svelte'
   import SubtreeTxsCard from './subtree-txs-card/index.svelte'
@@ -12,43 +13,47 @@
   import { failure } from '$lib/utils/notifications'
   import * as api from '$internal/api'
 
-  let ready = false
-  beforeUpdate(() => {
+  let ready = $state(false)
+  $effect(() => {
     ready = true
   })
 
   const type = DetailType.subtree
 
-  export let hash = ''
+  let { hash = '' }: { hash?: string } = $props()
 
-  $: blockHash = ready ? $page.url.searchParams.get('blockHash') ?? '' : ''
+  const blockHash = $derived(ready ? $page.url.searchParams.get('blockHash') ?? '' : '')
 
-  let display: DetailTab
+  let display: DetailTab = $state(DetailTab.overview)
 
-  $: tab = ready ? $page.url.searchParams.get('tab') ?? '' : ''
-  $: display = tab === DetailTab.json ? DetailTab.json :
+  const tab = $derived(ready ? $page.url.searchParams.get('tab') ?? '' : '')
+  $effect(() => {
+    display = tab === DetailTab.json ? DetailTab.json :
               tab === DetailTab.merkleproof ? DetailTab.merkleproof :
               DetailTab.overview
+  })
 
-  let result: any = null
+  let result: any = $state(null)
 
   // Track previous values to prevent unnecessary fetches
   let lastFetchParams = { assetHTTPAddress: '', hash: '', blockHash: '' }
 
-  $: if ($assetHTTPAddress && type && hash && hash.length === 64) {
-    // Only fetch if parameters actually changed
-    if (
-      lastFetchParams.assetHTTPAddress !== $assetHTTPAddress ||
-      lastFetchParams.hash !== hash ||
-      lastFetchParams.blockHash !== blockHash
-    ) {
-      lastFetchParams = { assetHTTPAddress: $assetHTTPAddress, hash, blockHash }
-      fetchData()
+  $effect(() => {
+    if ($assetHTTPAddress && type && hash && hash.length === 64) {
+      // Only fetch if parameters actually changed
+      if (
+        lastFetchParams.assetHTTPAddress !== $assetHTTPAddress ||
+        lastFetchParams.hash !== hash ||
+        lastFetchParams.blockHash !== blockHash
+      ) {
+        lastFetchParams = { assetHTTPAddress: $assetHTTPAddress, hash, blockHash }
+        fetchData()
+      }
     }
-  }
+  })
 
   function onDisplay(e) {
-    display = e.detail.value
+    display = e.value
     setQueryParam('tab', display)
   }
 
@@ -109,7 +114,7 @@
 </script>
 
 {#if result}
-  <SubtreeDetailsCard data={result} {display} {blockHash} on:display={onDisplay} />
+  <SubtreeDetailsCard data={result} {display} {blockHash} ondisplay={onDisplay} />
   {#if display === DetailTab.overview}
     <div style="height: 20px"></div>
     <SubtreeTxsCard subtree={result} {blockHash} />

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
@@ -83,7 +83,8 @@
 </script>
 
 <Card title={t(`${baseKey}.title`, { height: expandedData.height })}>
-  <div class="copy-link" slot="subtitle">
+  {#snippet subtitle()}
+  <div class="copy-link">
     <div class="hash">{expandedData.hash}</div>
     <div class="icon" use:$tippy={{ content: t('tooltip.copy-hash-to-clipboard') }}>
       <ActionStatusIcon
@@ -110,6 +111,7 @@
       <Icon name="icon-reeverse-line" size={15} />
     </button>
   </div>
+  {/snippet}
   <div class="content">
     <div class="tabs">
       <Button

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
@@ -117,21 +117,21 @@
         hasFocusRect={false}
         selected={isOverview}
         variant={isOverview ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('overview')}>{t(`${baseKey}.tab.overview`)}</Button
+        onclick={() => onDisplay('overview')}>{t(`${baseKey}.tab.overview`)}</Button
       >
       <Button
         size="medium"
         hasFocusRect={false}
         selected={isJson}
         variant={isJson ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
+        onclick={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
       >
       <Button
         size="medium"
         hasFocusRect={false}
         selected={isMerkleProof}
         variant={isMerkleProof ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('merkleproof')}>{t(`${baseKey}.tab.merkleproof`)}</Button
+        onclick={() => onDisplay('merkleproof')}>{t(`${baseKey}.tab.merkleproof`)}</Button
       >
     </div>
     {#if isOverview}

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { tippy } from '$lib/stores/media'
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import { copyTextToClipboardVanilla } from '$lib/utils/clipboard'
@@ -18,36 +19,42 @@
   import * as api from '$internal/api'
   import { failure } from '$lib/utils/notifications'
 
-  const dispatch = createEventDispatcher()
-
   const baseKey = 'page.viewer-subtree.details'
   const fieldKey = `${baseKey}.fields`
 
-  $: t = $i18n.t
-  $: i18nLocal = { t, baseKey: 'comp.pager' }
+  const t = $derived($i18n.t)
+  const i18nLocal = $derived({ t, baseKey: 'comp.pager' })
 
-  $: collapse = $mediaSize < MediaSize.sm
+  const collapse = $derived($mediaSize < MediaSize.sm)
 
-  export let data: any = {}
-  export let display: DetailTab = DetailTab.overview
-  export let blockHash = ''
+  let {
+    data = {},
+    display = DetailTab.overview,
+    blockHash = '',
+    ondisplay,
+  }: {
+    data?: any
+    display?: DetailTab
+    blockHash?: string
+    ondisplay?: (detail: { value: string }) => void
+  } = $props()
 
-  $: expandedData = data?.expandedData
-  $: isOverview = display === DetailTab.overview
-  $: isJson = display === DetailTab.json
-  $: isMerkleProof = display === DetailTab.merkleproof
+  const expandedData = $derived(data?.expandedData)
+  const isOverview = $derived(display === DetailTab.overview)
+  const isJson = $derived(display === DetailTab.json)
+  const isMerkleProof = $derived(display === DetailTab.merkleproof)
 
-  let paginatedData: any = null
-  let page = 1
-  let pageSize = 20
-  let totalItems = 0
+  let paginatedData: any = $state(null)
+  let page = $state(1)
+  let pageSize = $state(20)
+  let totalItems = $state(0)
 
-  $: totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
-  $: showPagerNav = totalPages > 1
-  $: showPagerSize = showPagerNav || (totalPages === 1 && paginatedData?.Nodes?.length > 5)
+  const totalPages = $derived(Math.max(1, Math.ceil(totalItems / pageSize)))
+  const showPagerNav = $derived(totalPages > 1)
+  const showPagerSize = $derived(showPagerNav || (totalPages === 1 && paginatedData?.Nodes?.length > 5))
 
   function onDisplay(value) {
-    dispatch('display', { value })
+    ondisplay?.({ value })
   }
 
   function onReverseHash(hash) {
@@ -77,9 +84,11 @@
     }
   }
 
-  $: if (isJson && expandedData?.hash) {
-    fetchPaginatedData(expandedData.hash, page, pageSize)
-  }
+  $effect(() => {
+    if (isJson && expandedData?.hash) {
+      fetchPaginatedData(expandedData.hash, page, pageSize)
+    }
+  })
 </script>
 
 <Card title={t(`${baseKey}.title`, { height: expandedData.height })}>
@@ -104,7 +113,7 @@
     </div>
     <button
       class="icon"
-      on:click={() => onReverseHash(expandedData.hash)}
+      onclick={() => onReverseHash(expandedData.hash)}
       use:$tippy={{ content: t('tooltip.reverse-hash') }}
       type="button"
     >

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-details-card/index.svelte
@@ -55,7 +55,7 @@
   }
 
   function onPage(e) {
-    const pageData = e.detail
+    const pageData = e
     page = pageData.value.page
     pageSize = pageData.value.pageSize
   }
@@ -211,7 +211,7 @@
             pageSize,
           }}
           hasBoundaryRight={true}
-          on:change={onPage}
+          onchange={onPage}
         />
       </div>
       <div class="json">
@@ -235,7 +235,7 @@
               pageSize,
             }}
             hasBoundaryRight={true}
-            on:change={onPage}
+            onchange={onPage}
           />
         </div>
       {/if}

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-merkle-visualizer/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-merkle-visualizer/index.svelte
@@ -154,10 +154,10 @@
     nodes = []
     links = []
 
-    const subtreeIndex = merkleProof.subtreeIndex
-    const blockProof = merkleProof.blockProof
-    const subtreeRoot = merkleProof.subtreeRoot
-    const merkleRoot = merkleProof.merkleRoot
+    const subtreeIndex = merkleProof.subtreeIndex ?? 0
+    const blockProof = merkleProof.blockProof ?? []
+    const subtreeRoot = merkleProof.subtreeRoot ?? ''
+    const merkleRoot = merkleProof.merkleRoot ?? ''
     
     // Build complete block-level binary tree structure
     const blockLevels = blockProof.length + 1 // +1 for the subtree root level
@@ -572,11 +572,11 @@
         </div>
         <div class="info-item">
           <span class="label">Subtree Index:</span>
-          <span class="value">{merkleProof.subtreeIndex}</span>
+          <span class="value">{merkleProof.subtreeIndex ?? 0}</span>
         </div>
         <div class="info-item">
           <span class="label">Block Proof:</span>
-          <span class="value">{merkleProof.blockProof.length} levels</span>
+          <span class="value">{merkleProof.blockProof?.length ?? 0} levels</span>
         </div>
       </div>
       

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-merkle-visualizer/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-merkle-visualizer/index.svelte
@@ -1,26 +1,33 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import * as d3 from 'd3'
   import type { MerkleProofData } from '$internal/api'
   import * as api from '$internal/api'
 
-  export let subtreeHash: string = ''
-  export let blockHash: string = ''
+  let {
+    subtreeHash = '',
+    blockHash = '',
+  }: {
+    subtreeHash?: string
+    blockHash?: string
+  } = $props()
 
-  let container: HTMLDivElement
+  let container: HTMLDivElement | undefined = $state()
   let svg: d3.Selection<SVGSVGElement, unknown, null, undefined>
   let svgGroup: d3.Selection<SVGGElement, unknown, null, undefined>
   let zoomBehavior: d3.ZoomBehavior<SVGSVGElement, unknown>
-  let mounted = false
-  
+  let mounted = $state(false)
+
   // Navigation state
   let currentTransform = d3.zoomIdentity
   let showNavigationHelp = false
 
   // Data state
-  let merkleProof: MerkleProofData | null = null
-  let loading = false
-  let error: string | null = null
+  let merkleProof: MerkleProofData | null = $state(null)
+  let loading = $state(false)
+  let error: string | null = $state(null)
 
   // Tree visualization constants
   const NODE_WIDTH = 160
@@ -106,9 +113,11 @@
   })
 
   // Fetch merkle proof when subtree hash changes
-  $: if (subtreeHash && blockHash) {
-    fetchSubtreeMerkleProof()
-  }
+  $effect(() => {
+    if (subtreeHash && blockHash) {
+      fetchSubtreeMerkleProof()
+    }
+  })
 
   async function fetchSubtreeMerkleProof() {
     loading = true
@@ -129,13 +138,15 @@
     }
   }
 
-  $: if (mounted && merkleProof && container) {
-    // Wait for container to be properly sized
-    setTimeout(async () => {
-      await buildBlockTree()
-      renderVisualization()
-    }, 50)
-  }
+  $effect(() => {
+    if (mounted && merkleProof && container) {
+      // Wait for container to be properly sized
+      setTimeout(async () => {
+        await buildBlockTree()
+        renderVisualization()
+      }, 50)
+    }
+  })
 
   async function buildBlockTree() {
     if (!merkleProof) return
@@ -498,7 +509,7 @@
   }
 
   function zoomToFit() {
-    if (!svg || !svgGroup || !zoomBehavior || nodes.length === 0) return
+    if (!svg || !svgGroup || !zoomBehavior || nodes.length === 0 || !container) return
 
     const bounds = svgGroup.node()?.getBBox()
     if (!bounds) return
@@ -532,7 +543,7 @@
   }
 </script>
 
-<svelte:window on:resize={handleResize} />
+<svelte:window onresize={handleResize} />
 
 <div class="subtree-merkle-visualizer">
   {#if loading}
@@ -585,8 +596,8 @@
       </div>
       
       <div class="navigation-controls">
-        <button class="nav-button" on:click={zoomToFit} title="Zoom to Fit">🔍</button>
-        <button class="nav-button" on:click={resetZoom} title="Reset Zoom">🏠</button>
+        <button class="nav-button" onclick={zoomToFit} title="Zoom to Fit">🔍</button>
+        <button class="nav-button" onclick={resetZoom} title="Reset Zoom">🏠</button>
       </div>
     </div>
 

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
@@ -44,7 +44,7 @@
 
   let variant = 'dynamic'
   function onToggle(e) {
-    const value = e.detail.value
+    const value = e.value
     variant = $tableVariant = value
   }
 
@@ -129,7 +129,7 @@
       hasBoundaryRight={true}
       on:change={onPage}
     />
-    <TableToggle value={variant} on:change={onToggle} />
+    <TableToggle value={variant} onchange={onToggle} />
   {/snippet}
   <Table
     name="txss"

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import Table from '$lib/components/table/index.svelte'
   import Pager from '$internal/components/pager/index.svelte'
@@ -11,25 +13,29 @@
 
   const baseKey = 'page.viewer-subtree.txs'
 
-  $: t = $i18n.t
-  $: i18nLocal = { t, baseKey: 'comp.pager' }
+  const t = $derived($i18n.t)
+  const i18nLocal = $derived({ t, baseKey: 'comp.pager' })
 
-  let colDefs: any[] = []
-  $: colDefs = getColDefs(t) || []
+  const colDefs = $derived(getColDefs(t) || [])
 
-  export let subtree: any
-  export let blockHash = ''
+  let {
+    subtree,
+    blockHash = '',
+  }: {
+    subtree: any
+    blockHash?: string
+  } = $props()
 
-  let data: any[] = []
-  let coinbaseTxId = ''
+  let data: any[] = $state([])
+  let coinbaseTxId = $state('')
   let fetchingCoinbase = false
   let fetchedBlockHashes = new Set()
 
-  $: renderCells = getRenderCells(t, blockHash, coinbaseTxId) || {}
+  const renderCells = $derived(getRenderCells(t, blockHash, coinbaseTxId) || {})
 
-  let page = 1
-  let pageSize = 10
-  let totalItems = 0
+  let page = $state(1)
+  let pageSize = $state(10)
+  let totalItems = $state(0)
 
   function onPage(e) {
     const data = e
@@ -37,12 +43,12 @@
     pageSize = data.value.pageSize
   }
 
-  $: totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
-  $: showPagerNav = totalPages > 1
-  $: showPagerSize = showPagerNav || (totalPages === 1 && data.length > 5)
-  $: showTableFooter = showPagerSize
+  const totalPages = $derived(Math.max(1, Math.ceil(totalItems / pageSize)))
+  const showPagerNav = $derived(totalPages > 1)
+  const showPagerSize = $derived(showPagerNav || (totalPages === 1 && data.length > 5))
+  const showTableFooter = $derived(showPagerSize)
 
-  let variant = 'dynamic'
+  let variant = $state('dynamic')
   function onToggle(e) {
     const value = e.value
     variant = $tableVariant = value
@@ -65,23 +71,29 @@
     }
   }
 
-  $: if (subtree) {
-    fetchData(subtree.expandedData.hash, page, pageSize)
-  }
+  $effect(() => {
+    if (subtree) {
+      fetchData(subtree.expandedData.hash, page, pageSize)
+    }
+  })
 
   // Reset coinbaseTxId when blockHash changes
-  $: if (blockHash) {
-    coinbaseTxId = ''
-  }
+  $effect(() => {
+    if (blockHash) {
+      coinbaseTxId = ''
+    }
+  })
 
-  $: if (
-    blockHash &&
-    blockHash.length === 64 &&
-    !coinbaseTxId &&
-    !fetchedBlockHashes.has(blockHash)
-  ) {
-    fetchCoinbaseId(blockHash)
-  }
+  $effect(() => {
+    if (
+      blockHash &&
+      blockHash.length === 64 &&
+      !coinbaseTxId &&
+      !fetchedBlockHashes.has(blockHash)
+    ) {
+      fetchCoinbaseId(blockHash)
+    }
+  })
 
   async function fetchCoinbaseId(hash) {
     if (fetchingCoinbase || fetchedBlockHashes.has(hash)) return

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
@@ -107,12 +107,14 @@
   contentPadding="0"
   showFooter={showTableFooter}
 >
-  <div slot="subtitle">
-    {data?.length === 1
-      ? t(`${baseKey}.subtitle_singular`, { count: data?.length || 0 })
-      : t(`${baseKey}.subtitle`, { count: data?.length || 0 })}
-  </div>
-  <svelte:fragment slot="header-tools">
+  {#snippet subtitle()}
+    <div>
+      {data?.length === 1
+        ? t(`${baseKey}.subtitle_singular`, { count: data?.length || 0 })
+        : t(`${baseKey}.subtitle`, { count: data?.length || 0 })}
+    </div>
+  {/snippet}
+  {#snippet headerTools()}
     <Pager
       i18n={i18nLocal}
       expandUp={true}
@@ -128,7 +130,7 @@
       on:change={onPage}
     />
     <TableToggle value={variant} on:change={onToggle} />
-  </svelte:fragment>
+  {/snippet}
   <Table
     name="txss"
     {variant}
@@ -149,20 +151,22 @@
     getRowIconActions={null}
     on:action={() => {}}
   />
-  <div slot="footer">
-    <Pager
-      i18n={i18nLocal}
-      expandUp={true}
-      {totalItems}
-      showPageSize={showPagerSize}
-      showQuickNav={showPagerNav}
-      showNav={showPagerNav}
-      value={{
-        page,
-        pageSize,
-      }}
-      hasBoundaryRight={true}
-      on:change={onPage}
-    />
-  </div>
+  {#snippet footer()}
+    <div>
+      <Pager
+        i18n={i18nLocal}
+        expandUp={true}
+        {totalItems}
+        showPageSize={showPagerSize}
+        showQuickNav={showPagerNav}
+        showNav={showPagerNav}
+        value={{
+          page,
+          pageSize,
+        }}
+        hasBoundaryRight={true}
+        on:change={onPage}
+      />
+    </div>
+  {/snippet}
 </Card>

--- a/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/subtree/subtree-txs-card/index.svelte
@@ -32,7 +32,7 @@
   let totalItems = 0
 
   function onPage(e) {
-    const data = e.detail
+    const data = e
     page = data.value.page
     pageSize = data.value.pageSize
   }
@@ -127,7 +127,7 @@
         pageSize,
       }}
       hasBoundaryRight={true}
-      on:change={onPage}
+      onchange={onPage}
     />
     <TableToggle value={variant} onchange={onToggle} />
   {/snippet}
@@ -149,7 +149,7 @@
     {renderCells}
     getRenderProps={null}
     getRowIconActions={null}
-    on:action={() => {}}
+    onaction={() => {}}
   />
   {#snippet footer()}
     <div>
@@ -165,7 +165,7 @@
           pageSize,
         }}
         hasBoundaryRight={true}
-        on:change={onPage}
+        onchange={onPage}
       />
     </div>
   {/snippet}

--- a/ui/dashboard/src/internal/components/page/viewer/tx/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { beforeUpdate } from 'svelte'
   import { page } from '$app/stores'
   import TxDetailsCard from './tx-details-card/index.svelte'
   import TxIoCard from './tx-io-card/index.svelte'
@@ -13,38 +14,40 @@
   import * as api from '$internal/api'
   import type { MerkleProofData } from '$internal/api'
 
-  let ready = false
-  beforeUpdate(() => {
+  let ready = $state(false)
+  $effect(() => {
     ready = true
   })
 
   const type = DetailType.tx
 
-  export let hash = ''
+  let { hash = '' }: { hash?: string } = $props()
 
-  let display: DetailTab
+  let display: DetailTab = $state(DetailTab.overview)
 
-  $: tab = ready ? $page.url.searchParams.get('tab') ?? '' : ''
-  $: display = tab === DetailTab.json ? DetailTab.json : 
+  const tab = $derived(ready ? $page.url.searchParams.get('tab') ?? '' : '')
+  $effect(() => {
+    display = tab === DetailTab.json ? DetailTab.json :
               tab === DetailTab.merkleproof ? DetailTab.merkleproof : DetailTab.overview
+  })
 
-  let result: any = null
-  let merkleProof: MerkleProofData | null = null
-  let merkleProofLoading: boolean = false
-  let merkleProofError: string | null = null
+  let result: any = $state(null)
+  let merkleProof: MerkleProofData | null = $state(null)
+  let merkleProofLoading: boolean = $state(false)
+  let merkleProofError: string | null = $state(null)
 
-  $: {
+  $effect(() => {
     if ($assetHTTPAddress && type && hash && hash.length === 64) {
       fetchData()
     }
-  }
+  })
 
   function onDisplay(e) {
-    display = e.detail.value
+    display = e.value
     setQueryParam('tab', display)
-    
+
     // Fetch merkle proof data when switching to merkle proof tab
-    if (display === DetailTab.merkleproof && !merkleProof && 
+    if (display === DetailTab.merkleproof && !merkleProof &&
         (result?.blockHashes?.length > 0 || result?.blockIDs?.length > 0)) {
       fetchMerkleProof()
     }
@@ -115,14 +118,13 @@
 </script>
 
 {#if result}
-  <TxDetailsCard data={result} {display} on:display={onDisplay}>
-    <svelte:fragment slot="merkle-proof">
-      <MerkleProofVisualizer 
-        merkleProof={merkleProof} 
-        loading={merkleProofLoading} 
-        error={merkleProofError} />
-    </svelte:fragment>
-  </TxDetailsCard>
+  <TxDetailsCard data={result} {display} ondisplay={onDisplay} merkleProof={merkleProofSnippet} />
+  {#snippet merkleProofSnippet()}
+    <MerkleProofVisualizer
+      merkleProof={merkleProof}
+      loading={merkleProofLoading}
+      error={merkleProofError} />
+  {/snippet}
   {#if display === DetailTab.overview}
     <div style="height: 20px"></div>
     <TxIoCard data={result} />

--- a/ui/dashboard/src/internal/components/page/viewer/tx/merkle-proof-visualizer/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/merkle-proof-visualizer/index.svelte
@@ -1,21 +1,29 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import * as d3 from 'd3'
   import type { MerkleProofData } from '$internal/api'
 
-  export let merkleProof: MerkleProofData | null = null
-  export let loading: boolean = false
-  export let error: string | null = null
+  let {
+    merkleProof = null,
+    loading = false,
+    error = null,
+  }: {
+    merkleProof?: MerkleProofData | null
+    loading?: boolean
+    error?: string | null
+  } = $props()
 
-  let container: HTMLDivElement
+  let container: HTMLDivElement | undefined = $state()
   let svg: d3.Selection<SVGSVGElement, unknown, null, undefined>
   let svgGroup: d3.Selection<SVGGElement, unknown, null, undefined>
   let zoomBehavior: d3.ZoomBehavior<SVGSVGElement, unknown>
-  let mounted = false
-  
+  let mounted = $state(false)
+
   // Navigation state
   let currentTransform = d3.zoomIdentity
-  let showNavigationHelp = false
+  let showNavigationHelp = $state(false)
 
   // Tree visualization constants
   const NODE_WIDTH = 160
@@ -144,13 +152,15 @@
     }
   })
 
-  $: if (mounted && merkleProof && container) {
-    // Wait for container to be properly sized
-    setTimeout(async () => {
-      await buildTree()
-      renderVisualization()
-    }, 50)
-  }
+  $effect(() => {
+    if (mounted && merkleProof && container) {
+      // Wait for container to be properly sized
+      setTimeout(async () => {
+        await buildTree()
+        renderVisualization()
+      }, 50)
+    }
+  })
 
   // Helper function to extract visualization data from BUMP format
   function extractVisualizationData(bumpData: MerkleProofData) {
@@ -782,7 +792,7 @@
   }
 
   function zoomToFit() {
-    if (!svg || !svgGroup || !zoomBehavior || nodes.length === 0) return
+    if (!svg || !svgGroup || !zoomBehavior || nodes.length === 0 || !container) return
 
     const bounds = svgGroup.node()?.getBBox()
     if (!bounds) return
@@ -808,7 +818,7 @@
   }
 
   function focusOnTransaction() {
-    if (!svg || !zoomBehavior || !merkleProof) return
+    if (!svg || !zoomBehavior || !merkleProof || !container) return
 
     const txNode = nodes.find(n => n.type === 'transaction')
     if (!txNode) return
@@ -835,7 +845,7 @@
   }
 </script>
 
-<svelte:window on:resize={handleResize} />
+<svelte:window onresize={handleResize} />
 
 <div class="merkle-visualizer">
   {#if loading}
@@ -885,10 +895,10 @@
       </div>
       
       <div class="navigation-controls">
-        <button class="nav-button" on:click={focusOnTransaction} title="Focus on Transaction">🎯</button>
-        <button class="nav-button" on:click={zoomToFit} title="Zoom to Fit">🔍</button>
-        <button class="nav-button" on:click={resetZoom} title="Reset Zoom">🏠</button>
-        <button class="nav-button help-button" on:click={() => showNavigationHelp = !showNavigationHelp} title="Navigation Help">❓</button>
+        <button class="nav-button" onclick={focusOnTransaction} title="Focus on Transaction">🎯</button>
+        <button class="nav-button" onclick={zoomToFit} title="Zoom to Fit">🔍</button>
+        <button class="nav-button" onclick={resetZoom} title="Reset Zoom">🏠</button>
+        <button class="nav-button help-button" onclick={() => showNavigationHelp = !showNavigationHelp} title="Navigation Help">❓</button>
       </div>
     </div>
 

--- a/ui/dashboard/src/internal/components/page/viewer/tx/merkle-proof-visualizer/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/merkle-proof-visualizer/index.svelte
@@ -93,7 +93,7 @@
   }
 
   // SHA256 double hash function for computing intermediate hashes
-  async function sha256Double(bytes: Uint8Array): Promise<string> {
+  async function sha256Double(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
     // Validate input
     if (!(bytes instanceof Uint8Array)) {
       throw new Error('sha256Double requires a Uint8Array input')

--- a/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
@@ -38,7 +38,8 @@
 </script>
 
 <Card title={t(`${baseKey}.title`, { height: data?.height })}>
-  <div class="copy-link" slot="subtitle">
+  {#snippet subtitle()}
+  <div class="copy-link">
     <div class="hash">{data?.txid}</div>
     <div class="icon" use:$tippy={{ content: t('tooltip.copy-hash-to-clipboard') }}>
       <ActionStatusIcon
@@ -65,6 +66,7 @@
       <Icon name="icon-reeverse-line" size={15} />
     </button>
   </div>
+  {/snippet}
   <div class="content">
     <div class="tabs">
       <Button

--- a/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
@@ -72,14 +72,14 @@
         hasFocusRect={false}
         selected={isOverview}
         variant={isOverview ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('overview')}>{t(`${baseKey}.tab.overview`)}</Button
+        onclick={() => onDisplay('overview')}>{t(`${baseKey}.tab.overview`)}</Button
       >
       <Button
         size="medium"
         hasFocusRect={false}
         selected={isJson}
         variant={isJson ? 'tertiary' : 'primary'}
-        on:click={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
+        onclick={() => onDisplay('json')}>{t(`${baseKey}.tab.json`)}</Button
       >
       {#if (data?.blockHashes && data?.blockHashes.length > 0) || (data?.blockIDs && data?.blockIDs.length > 0)}
         <Button
@@ -87,7 +87,7 @@
           hasFocusRect={false}
           selected={isMerkleProof}
           variant={isMerkleProof ? 'tertiary' : 'primary'}
-          on:click={() => onDisplay('merkleproof')}>Merkle Proof</Button
+          onclick={() => onDisplay('merkleproof')}>Merkle Proof</Button
         >
       {/if}
     </div>

--- a/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/tx-details-card/index.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import type { Snippet } from 'svelte'
   import { tippy } from '$lib/stores/media'
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import { addNumCommas, dataSize } from '$lib/utils/format'
@@ -12,24 +14,31 @@
   import i18n from '$internal/i18n'
   import { getItemApiUrl, ItemType } from '$internal/api'
 
-  const dispatch = createEventDispatcher()
-
   const baseKey = 'page.viewer-tx.details'
   const fieldKey = `${baseKey}.fields`
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  $: collapse = $mediaSize < MediaSize.sm
+  const collapse = $derived($mediaSize < MediaSize.sm)
 
-  export let data: any = {}
-  export let display: DetailTab = DetailTab.overview
+  let {
+    data = {},
+    display = DetailTab.overview,
+    ondisplay,
+    merkleProof,
+  }: {
+    data?: any
+    display?: DetailTab
+    ondisplay?: (detail: { value: string }) => void
+    merkleProof?: Snippet
+  } = $props()
 
-  $: isOverview = display === DetailTab.overview
-  $: isJson = display === DetailTab.json
-  $: isMerkleProof = display === DetailTab.merkleproof
+  const isOverview = $derived(display === DetailTab.overview)
+  const isJson = $derived(display === DetailTab.json)
+  const isMerkleProof = $derived(display === DetailTab.merkleproof)
 
   function onDisplay(value) {
-    dispatch('display', { value })
+    ondisplay?.({ value })
   }
 
   function onReverseHash(hash) {
@@ -59,7 +68,7 @@
     </div>
     <button
       class="icon"
-      on:click={() => onReverseHash(data?.txid)}
+      onclick={() => onReverseHash(data?.txid)}
       use:$tippy={{ content: t('tooltip.reverse-hash') }}
       type="button"
     >
@@ -218,7 +227,7 @@
       </div>
     {:else if isMerkleProof}
       <div class="merkle-proof">
-        <slot name="merkle-proof"></slot>
+        {@render merkleProof?.()}
       </div>
     {/if}
   </div>

--- a/ui/dashboard/src/internal/components/page/viewer/tx/tx-io-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/tx/tx-io-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import { formatSatoshi } from '$lib/utils/format'
@@ -11,16 +13,16 @@
 
   const baseKey = 'page.viewer-tx.txs'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  $: collapse = $mediaSize < MediaSize.sm
+  const collapse = $derived($mediaSize < MediaSize.sm)
 
-  export let data: any = []
+  let { data = [] }: { data?: any } = $props()
 
-  let sliceCount = 10
-  let outputViewModes: { [key: number]: 'default' | 'asm' | 'hex' } = {}
-  let inputViewModes: { [key: number]: 'default' | 'hex' } = {}
-  let outputAddresses: { [key: number]: string | null } = {}
+  let sliceCount = $state(10)
+  let outputViewModes: { [key: number]: 'default' | 'asm' | 'hex' } = $state({})
+  let inputViewModes: { [key: number]: 'default' | 'hex' } = $state({})
+  let outputAddresses: { [key: number]: string | null } = $state({})
 
   let legacyPubKeyHashAddrID = 0x00
   let legacyScriptHashAddrID = 0x05
@@ -43,20 +45,20 @@
     inputViewModes = { ...inputViewModes } // Trigger reactivity
   }
 
-  $: inputSlice = data.inputs.slice(0, sliceCount)
-  $: outputSlice = data.outputs.slice(0, sliceCount)
+  const inputSlice = $derived(data.inputs.slice(0, sliceCount))
+  const outputSlice = $derived(data.outputs.slice(0, sliceCount))
 
   // Track which outputs we've already processed to avoid re-processing
   let processedOutputsHash = ''
 
   // Extract addresses for outputs when data changes
-  $: {
+  $effect(() => {
     const currentHash = data.outputs ? JSON.stringify(data.outputs.map(o => o.lockingScript)) : ''
     if (currentHash && currentHash !== processedOutputsHash) {
       processedOutputsHash = currentHash
       extractOutputAddresses()
     }
-  }
+  })
 
   onMount(async () => {
     const resp: any = await api.getChainParams()
@@ -131,9 +133,9 @@
               >{`${input.previousTxSatoshis ? formatSatoshi(input.previousTxSatoshis) : '-'} BSV`}</span
             >
             {#if input.unlockingScript}
-              <button 
+              <button
                 class="view-toggle"
-                on:click={() => toggleInputView(i)}
+                onclick={() => toggleInputView(i)}
                 type="button"
               >
                 {inputViewModes[i] === 'hex' ? 'Show Default' : 'Show Hex'}
@@ -147,7 +149,7 @@
       {/each}
     </div>
     {#if data.inputs.length > inputSlice.length}
-      <button class="load-more" on:click={increaseSlize} type="button"
+      <button class="load-more" onclick={increaseSlize} type="button"
         >{t(`${baseKey}.load-more`)}</button
       >
     {/if}
@@ -182,9 +184,9 @@
             {/if}
             <span class="amount">{`${formatSatoshi(output.satoshis)} BSV`}</span>
             
-            <button 
+            <button
               class="view-toggle"
-              on:click={() => toggleOutputView(i)}
+              onclick={() => toggleOutputView(i)}
               type="button"
             >
               {viewMode === 'default' ? 'Show Script' : viewMode === 'asm' ? 'Show Hex' : 'Show Default'}
@@ -207,7 +209,7 @@
       {/each}
     </div>
     {#if data.outputs.length > outputSlice.length}
-      <button class="load-more" on:click={increaseSlize} type="button"
+      <button class="load-more" onclick={increaseSlize} type="button"
         >{t(`${baseKey}.load-more`)}</button
       >
     {/if}

--- a/ui/dashboard/src/internal/components/page/viewer/utxo/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/utxo/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { beforeUpdate } from 'svelte'
   // import { page } from '$app/stores'
   import UtxoDetailsCard from './utxo-details-card/index.svelte'
 
@@ -8,22 +9,17 @@
   import { spinCount } from '$internal/stores/nav'
   import { assetHTTPAddress } from '$internal/stores/nodeStore'
 
-  let ready = false
-  beforeUpdate(() => {
-    ready = true
-  })
-
   const type = DetailType.utxo
 
-  export let hash = ''
+  let { hash = '' }: { hash?: string } = $props()
 
-  let result: any = null
+  let result: any = $state(null)
 
-  $: {
+  $effect(() => {
     if ($assetHTTPAddress && type && hash && hash.length === 64) {
       fetchData()
     }
-  }
+  })
 
   async function fetchData() {
     result = { hash }

--- a/ui/dashboard/src/internal/components/page/viewer/utxo/utxo-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/utxo/utxo-details-card/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { tippy } from '$lib/stores/media'
   import { copyTextToClipboardVanilla } from '$lib/utils/clipboard'
@@ -13,9 +15,9 @@
 
   const baseKey = 'page.viewer-utxo.details'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  export let data: any = {}
+  let { data = {} }: { data?: any } = $props()
 
   function onReverseHash(hash) {
     reverseHashParam(hash)
@@ -44,7 +46,7 @@
     </div>
     <button
       class="icon"
-      on:click={() => onReverseHash(data?.hash)}
+      onclick={() => onReverseHash(data?.hash)}
       use:$tippy={{ content: t('tooltip.reverse-hash') }}
       type="button"
     >

--- a/ui/dashboard/src/internal/components/page/viewer/utxo/utxo-details-card/index.svelte
+++ b/ui/dashboard/src/internal/components/page/viewer/utxo/utxo-details-card/index.svelte
@@ -23,7 +23,8 @@
 </script>
 
 <Card title={t(`${baseKey}.title`)}>
-  <div class="copy-link" slot="subtitle">
+  {#snippet subtitle()}
+  <div class="copy-link">
     <div class="hash">{data?.hash}</div>
     <div class="icon" use:$tippy={{ content: t('tooltip.copy-hash-to-clipboard') }}>
       <ActionStatusIcon
@@ -50,6 +51,7 @@
       <Icon name="icon-reeverse-line" size={15} />
     </button>
   </div>
+  {/snippet}
 
   <div class="json">
     <div><JSONTree {data} /></div>

--- a/ui/dashboard/src/internal/components/pager/index.svelte
+++ b/ui/dashboard/src/internal/components/pager/index.svelte
@@ -1,59 +1,71 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { Tab, Dropdown, TextInput } from '$lib/components'
   import Typo from '../typo/index.svelte'
   import { getBtnData, getPageSizeOptions } from './utils'
   import type { I18n } from '$lib/types'
 
-  const dispatch = createEventDispatcher()
-
-  export let testId: string | undefined | null = null
-
   let type = 'page'
 
-  export let name = ''
-  export let value
-  export let totalItems = 0
-  export let siblingCount = 0
-  export let boundaryCount = 1
-  export let hasBoundaryRight = true
-  export let dataSize = 5
-  export let i18n: I18n | null | undefined
-  export let expandUp = false
-  export let stretch = true
-  export let showPageSize = true
-  export let showQuickNav = true
-  export let showNav = true
+  let {
+    testId = null,
+    name = '',
+    value = $bindable(),
+    totalItems = 0,
+    siblingCount = 0,
+    boundaryCount = 1,
+    hasBoundaryRight = true,
+    dataSize = 5,
+    i18n,
+    expandUp = false,
+    stretch = true,
+    showPageSize = true,
+    showQuickNav = true,
+    showNav = true,
+    onchange,
+  }: {
+    testId?: string | undefined | null
+    name?: string
+    value?: { page?: number; pageSize?: number }
+    totalItems?: number
+    siblingCount?: number
+    boundaryCount?: number
+    hasBoundaryRight?: boolean
+    dataSize?: number
+    i18n?: I18n | null | undefined
+    expandUp?: boolean
+    stretch?: boolean
+    showPageSize?: boolean
+    showQuickNav?: boolean
+    showNav?: boolean
+    onchange?: (e: { name: string; type: string; value: any }) => void
+  } = $props()
 
-  $: i18nLocal = {
+  const i18nLocal = $derived({
     t: i18n?.t,
     baseKey: i18n?.baseKey || 'comp.pager',
-  }
-  $: t = i18nLocal?.t || function () {}
-  $: baseKey = i18nLocal?.baseKey
-  $: pageSizeOptions = getPageSizeOptions(i18nLocal)
+  })
+  const t = $derived(i18nLocal?.t || function () {})
+  const baseKey = $derived(i18nLocal?.baseKey)
+  const pageSizeOptions = $derived(getPageSizeOptions(i18nLocal))
 
-  $: page = value?.page || 1
-  $: pageSize = value?.pageSize || 10
-  $: pageInput = `${page}`
+  const page = $derived(value?.page || 1)
+  const pageSize = $derived(value?.pageSize || 10)
 
-  let totalPages = 1
-  let isLastPage = false
-  let btnData: { type: 'page' | 'range'; page?: number; range?: number[] }[] = []
+  // pageInput is derived from `page` but also reassigned imperatively by the
+  // input-change handler, so it cannot be a plain $derived. Keep it as $state
+  // and re-sync it whenever `page` changes.
+  let pageInput = $state(`${value?.page || 1}`)
+  $effect(() => {
+    pageInput = `${page}`
+  })
 
-  $: {
-    totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
-    isLastPage = dataSize < pageSize
-
-    btnData = getBtnData(
-      totalPages,
-      page,
-      isLastPage,
-      hasBoundaryRight,
-      boundaryCount,
-      siblingCount,
-    )
-  }
+  const totalPages = $derived(Math.max(1, Math.ceil(totalItems / pageSize)))
+  const isLastPage = $derived(dataSize < pageSize)
+  const btnData: { type: 'page' | 'range'; page?: number; range?: number[] }[] = $derived(
+    getBtnData(totalPages, page, isLastPage, hasBoundaryRight, boundaryCount, siblingCount),
+  )
 
   function isSelected(btn) {
     return btn.type === 'page' && btn.page === page
@@ -61,7 +73,7 @@
 
   function callChange(page, pageSize) {
     value = { page, pageSize }
-    dispatch('change', { name, type, value })
+    onchange?.({ name, type, value })
   }
 
   function onSelect(btn) {
@@ -108,17 +120,13 @@
     }
   }
 
-  let quickNavDisabled = false
-  let onCurrentPage = false
-
-  $: {
+  const quickNavDisabled = $derived.by(() => {
     const pageNum = parseInt(pageInput)
-
-    quickNavDisabled =
+    return (
       !pageInput || isNaN(pageNum) || pageNum === page || pageNum < 1 || pageNum > totalPages
-
-    onCurrentPage = pageNum === page
-  }
+    )
+  })
+  const onCurrentPage = $derived(parseInt(pageInput) === page)
 
   function onQuickNavKeyDown(e) {
     const keyCode = e.code || e.key

--- a/ui/dashboard/src/internal/components/pager/index.svelte
+++ b/ui/dashboard/src/internal/components/pager/index.svelte
@@ -89,8 +89,8 @@
   }
 
   const onInputChange = (e) => {
-    const name = e.detail.name
-    const val = parseInt(e.detail.value)
+    const name = e.name
+    const val = parseInt(e.value)
 
     switch (name) {
       case 'page':
@@ -121,7 +121,7 @@
   }
 
   function onQuickNavKeyDown(e) {
-    const keyCode = e.detail.code || e.detail.key
+    const keyCode = e.code || e.key
     if (!quickNavDisabled && keyCode === 'Enter') {
       onNav('nav', parseInt(pageInput))
       return false
@@ -139,7 +139,7 @@
         items={pageSizeOptions}
         size="small"
         {expandUp}
-        on:change={onInputChange}
+        onchange={onInputChange}
       />
     </div>
   {/if}
@@ -156,8 +156,8 @@
           stretch={true}
           value={pageInput}
           valid={!quickNavDisabled || onCurrentPage}
-          on:change={onInputChange}
-          on:keydown={onQuickNavKeyDown}
+          onchange={onInputChange}
+          onkeydown={onQuickNavKeyDown}
         />
       </div>
       <Typo
@@ -176,14 +176,14 @@
         icon="icon-chevron-left-line"
         size="small"
         disabled={page === 1}
-        on:click={() => onNav('prev')}
+        onclick={() => onNav('prev')}
       />
       {#each btnData as btn}
         <Tab
           variant="primary"
           size="small"
           selected={isSelected(btn)}
-          on:click={() => onSelect(btn)}
+          onclick={() => onSelect(btn)}
         >
           {btn.type === 'page' ? btn.page : '...'}
         </Tab>
@@ -193,7 +193,7 @@
         iconAfter="icon-chevron-right-line"
         size="small"
         disabled={page === totalPages}
-        on:click={() => onNav('next')}
+        onclick={() => onNav('next')}
       />
     </div>
   {/if}

--- a/ui/dashboard/src/internal/components/range-toggle/index.svelte
+++ b/ui/dashboard/src/internal/components/range-toggle/index.svelte
@@ -57,9 +57,9 @@
   const dispatch = createEventDispatcher()
 
   function onSelect(e) {
-    value = e.detail.value
-    dispatch('change', e.detail)
+    value = e.value
+    dispatch('change', e)
   }
 </script>
 
-<Toggle name="range-toggle" size="medium" {items} bind:value on:change={onSelect} />
+<Toggle name="range-toggle" size="medium" {items} bind:value onchange={onSelect} />

--- a/ui/dashboard/src/internal/components/range-toggle/index.svelte
+++ b/ui/dashboard/src/internal/components/range-toggle/index.svelte
@@ -1,64 +1,71 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import Toggle from '$lib/components/toggle/index.svelte'
   import i18n from '../../i18n'
 
   const baseKey = 'comp.range-toggle'
 
-  $: t = $i18n.t
+  let {
+    value = $bindable('24h'),
+    onchange,
+  }: {
+    value?: string
+    onchange?: (e: { name: string; type: string; value: any }) => void
+  } = $props()
 
-  $: items = t
-    ? [
-        {
-          label: t(`${baseKey}.2h.label`),
-          tooltip: t(`${baseKey}.2h.tooltip`),
-          value: '2h',
-        },
-        {
-          label: t(`${baseKey}.6h.label`),
-          tooltip: t(`${baseKey}.6h.tooltip`),
-          value: '6h',
-        },
-        {
-          label: t(`${baseKey}.12h.label`),
-          tooltip: t(`${baseKey}.12h.tooltip`),
-          value: '12h',
-        },
-        {
-          label: t(`${baseKey}.24h.label`),
-          tooltip: t(`${baseKey}.24h.tooltip`),
-          value: '24h',
-        },
-        {
-          label: t(`${baseKey}.1w.label`),
-          tooltip: t(`${baseKey}.1w.tooltip`),
-          value: '1w',
-        },
-        {
-          label: t(`${baseKey}.1m.label`),
-          tooltip: t(`${baseKey}.1m.tooltip`),
-          value: '1m',
-        },
-        {
-          label: t(`${baseKey}.3m.label`),
-          tooltip: t(`${baseKey}.3m.tooltip`),
-          value: '3m',
-        },
-        {
-          label: t(`${baseKey}.all.label`),
-          tooltip: t(`${baseKey}.all.tooltip`),
-          value: 'all',
-        },
-      ]
-    : []
+  let t = $derived($i18n.t)
 
-  export let value = '24h'
+  let items = $derived(
+    t
+      ? [
+          {
+            label: t(`${baseKey}.2h.label`),
+            tooltip: t(`${baseKey}.2h.tooltip`),
+            value: '2h',
+          },
+          {
+            label: t(`${baseKey}.6h.label`),
+            tooltip: t(`${baseKey}.6h.tooltip`),
+            value: '6h',
+          },
+          {
+            label: t(`${baseKey}.12h.label`),
+            tooltip: t(`${baseKey}.12h.tooltip`),
+            value: '12h',
+          },
+          {
+            label: t(`${baseKey}.24h.label`),
+            tooltip: t(`${baseKey}.24h.tooltip`),
+            value: '24h',
+          },
+          {
+            label: t(`${baseKey}.1w.label`),
+            tooltip: t(`${baseKey}.1w.tooltip`),
+            value: '1w',
+          },
+          {
+            label: t(`${baseKey}.1m.label`),
+            tooltip: t(`${baseKey}.1m.tooltip`),
+            value: '1m',
+          },
+          {
+            label: t(`${baseKey}.3m.label`),
+            tooltip: t(`${baseKey}.3m.tooltip`),
+            value: '3m',
+          },
+          {
+            label: t(`${baseKey}.all.label`),
+            tooltip: t(`${baseKey}.all.tooltip`),
+            value: 'all',
+          },
+        ]
+      : [],
+  )
 
-  const dispatch = createEventDispatcher()
-
-  function onSelect(e) {
+  function onSelect(e: { name: string; type: string; value: any }) {
     value = e.value
-    dispatch('change', e)
+    onchange?.(e)
   }
 </script>
 

--- a/ui/dashboard/src/internal/components/table-toggle/index.svelte
+++ b/ui/dashboard/src/internal/components/table-toggle/index.svelte
@@ -1,28 +1,32 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import Toggle from '$lib/components/toggle/index.svelte'
   import i18n from '$internal/i18n'
 
   const baseKey = 'comp.table-toggle'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  export let value
+  let {
+    value = $bindable(),
+    onchange,
+  }: {
+    value?: any
+    onchange?: (e: { name: string; type: string; value: any }) => void
+  } = $props()
 
-  let useValue
-  $: {
-    useValue = value
+  const useValue = $derived.by(() => {
     if (value === 'dynamic') {
-      useValue = $mediaSize <= MediaSize.sm ? 'div' : 'standard'
+      return $mediaSize <= MediaSize.sm ? 'div' : 'standard'
     }
-  }
+    return value
+  })
 
-  const dispatch = createEventDispatcher()
-
-  function onSelect(e) {
-    value = e.detail.value
-    dispatch('change', e.detail)
+  function onSelect(e: { name: string; type: string; value: any }) {
+    value = e.value
+    onchange?.(e)
   }
 </script>
 
@@ -34,5 +38,5 @@
     { icon: 'icon-card-line', value: 'div', tooltip: t(`${baseKey}.tooltip.div`) },
   ]}
   value={useValue}
-  on:change={onSelect}
+  onchange={onSelect}
 />

--- a/ui/dashboard/src/internal/components/toolbar/index.svelte
+++ b/ui/dashboard/src/internal/components/toolbar/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { goto } from '$app/navigation'
   import { mediaSize, MediaSize, theme } from '$lib/stores/media'
@@ -10,13 +12,16 @@
   import i18n from '$internal/i18n'
   import * as api from '$internal/api'
 
-  $: t = $i18n.t
+  let {
+    style = '',
+    showTools = true,
+  }: {
+    style?: string
+    showTools?: boolean
+  } = $props()
 
-  export let style = ''
-  export let showTools = true
-
-  let searchValue = ''
-  let lastSearchCalled = ''
+  let searchValue = $state('')
+  let lastSearchCalled = $state('')
 
   async function onSearchKeyDown(e) {
     if (!e) e = window.event
@@ -39,9 +44,9 @@
     }
   }
 
-  let w
+  let w = $state(0)
 
-  $: focusWidth = $mediaSize <= MediaSize.xs ? w - 60 : 570
+  const focusWidth = $derived($mediaSize <= MediaSize.xs ? w - 60 : 570)
 
   function toggleTheme() {
     $theme = $theme === 'dark' ? 'light' : 'dark'
@@ -58,7 +63,7 @@
     <div class="right">
       <button
         class="theme-toggle"
-        on:click={toggleTheme}
+        onclick={toggleTheme}
         type="button"
         title={$theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
         aria-label={$theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}

--- a/ui/dashboard/src/internal/components/toolbar/index.svelte
+++ b/ui/dashboard/src/internal/components/toolbar/index.svelte
@@ -20,7 +20,7 @@
 
   async function onSearchKeyDown(e) {
     if (!e) e = window.event
-    const keyCode = e.detail.code || e.detail.key
+    const keyCode = e.code || e.key
 
     if (keyCode === 'Enter') {
       lastSearchCalled = searchValue
@@ -78,7 +78,7 @@
           ? 'icon-search-line'
           : 'icon-search-solid'}
         placeholder={$i18n.t('comp.toolbar.placeholder')}
-        on:keydown={onSearchKeyDown}
+        onkeydown={onSearchKeyDown}
       />
     </div>
   </div>

--- a/ui/dashboard/src/internal/components/typo/index.svelte
+++ b/ui/dashboard/src/internal/components/typo/index.svelte
@@ -1,41 +1,50 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { TypoVariant } from './types'
   import type { TypoVariantType } from './types'
   import { title, text, getTypoProps } from '$internal/styles/themes/dark/constants/typography'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    variant = TypoVariant.text,
+    size = 'sm',
+    color = null,
+    hoverColor = null,
+    html = false,
+    value = '',
+    wrap = true,
+    overflow = false,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    variant?: TypoVariantType
+    size?: string
+    color?: string | null
+    hoverColor?: string | null
+    html?: boolean
+    value?: any
+    wrap?: boolean
+    overflow?: boolean
+  } = $props()
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const typoObj = $derived(variant === TypoVariant.text ? text : title)
 
-  export let style = ''
+  const typoProps = $derived(getTypoProps(typoObj, size))
 
-  export let variant: TypoVariantType = TypoVariant.text
-  export let size = 'sm'
-  export let color: string | null = null
-  export let hoverColor: string | null = null
-  export let html = false
-  export let value: any = ''
-  export let wrap = true
-  export let overflow = false
-
-  $: typoObj = variant === TypoVariant.text ? text : title
-
-  $: typoProps = getTypoProps(typoObj, size)
-
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--color:${color ? color : typoProps.color}`,
-      `--color-hover:${hoverColor ? hoverColor : color ? color : typoProps.color}`,
-      `--font-family:${typoProps.font.family}`,
-      `--font-weight:${typoProps.font.weight}`,
-      `--font-size:${typoProps.font.size}`,
-      `--line-height:${typoProps.line.height}`,
-      `--wrap:${wrap ? 'normal' : 'nowrap'}`,
-      `--margin:0`,
-    ]
-  }
+  const cssVars: string[] = $derived([
+    `--color:${color ? color : typoProps.color}`,
+    `--color-hover:${hoverColor ? hoverColor : color ? color : typoProps.color}`,
+    `--font-family:${typoProps.font.family}`,
+    `--font-weight:${typoProps.font.weight}`,
+    `--font-size:${typoProps.font.size}`,
+    `--line-height:${typoProps.line.height}`,
+    `--wrap:${wrap ? 'normal' : 'nowrap'}`,
+    `--margin:0`,
+  ])
 </script>
 
 <span

--- a/ui/dashboard/src/internal/stores/p2pStore.ts
+++ b/ui/dashboard/src/internal/stores/p2pStore.ts
@@ -3,7 +3,7 @@ import type { Writable } from 'svelte/store'
 //import * as api from '$internal/api'
 
 export const messages: Writable<any[]> = writable([])
-export const miningNodes: any = writable({})
+export const miningNodes: Writable<Record<string, any>> = writable({})
 export const wsUrl: Writable<URL | string> = writable('')
 export const error: Writable<any> = writable(null)
 export const sock: Writable<any> = writable(null)
@@ -202,7 +202,9 @@ export async function connectToP2PServer() {
                   // Keep cache size manageable
                   if (map.size > MAX_BLOCK_HASH_CACHE) {
                     const firstKey = map.keys().next().value
-                    map.delete(firstKey)
+                    if (firstKey !== undefined) {
+                      map.delete(firstKey)
+                    }
                   }
                   return map
                 })
@@ -249,7 +251,9 @@ export async function connectToP2PServer() {
                   // Keep cache size manageable
                   if (map.size > MAX_BLOCK_HASH_CACHE) {
                     const firstKey = map.keys().next().value
-                    map.delete(firstKey)
+                    if (firstKey !== undefined) {
+                      map.delete(firstKey)
+                    }
                   }
                   return map
                 })

--- a/ui/dashboard/src/lib/components/button/index.svelte
+++ b/ui/dashboard/src/lib/components/button/index.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import type { Snippet } from 'svelte'
   import { FocusRect, Icon } from '$lib/components'
   import { tippy } from '$lib/stores/media'
   import {
@@ -8,61 +10,78 @@
     ComponentVariant,
     type ComponentVariantType,
     FlexDirection,
-    type FlexDirectionType,
     getStyleSizeFromComponentSize,
   } from '$lib/styles/types'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    variant = ComponentVariant.primary,
+    icon = null,
+    iconColor = 'currentColor',
+    iconAfter = null,
+    tabindex = -99,
+    hasFocusRect = true,
+    emulateHover = false,
+    tooltip = '',
+    disabled = false,
+    selected = false,
+    toggle = false,
+    width = -1,
+    round = false,
+    ico = false,
+    stretch = false,
+    uppercase = false,
+    size = ComponentSize.medium,
+    onclick,
+    onfocus,
+    onblur,
+    onkeydown,
+    children,
+  }: {
+    testId?: string | null
+    class?: string | null
+    style?: string
+    variant?: ComponentVariantType
+    icon?: string | null
+    iconColor?: string
+    iconAfter?: string | null
+    tabindex?: number
+    hasFocusRect?: boolean
+    emulateHover?: boolean
+    tooltip?: string
+    disabled?: boolean
+    selected?: boolean
+    toggle?: boolean
+    width?: number
+    round?: boolean
+    ico?: boolean
+    stretch?: boolean
+    uppercase?: boolean
+    size?: ComponentSizeType
+    onclick?: (e: MouseEvent) => void
+    onfocus?: () => void
+    onblur?: () => void
+    onkeydown?: (e: KeyboardEvent) => void
+    children?: Snippet
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const hasIcon = $derived(Boolean(icon) || Boolean(iconAfter))
+  const direction = $derived(
+    hasIcon ? (icon ? FlexDirection.row : FlexDirection.rowReverse) : FlexDirection.row,
+  )
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let style = ''
+  const compVarStr = $derived(`--comp-${variant}`)
+  const buttonVarStr = $derived(`--button-${variant}`)
+  const compSizeStr = $derived(`--comp-size-${styleSize}`)
+  const buttonSizeStr = $derived(`--button-size-${styleSize}`)
 
-  export let variant: ComponentVariantType = ComponentVariant.primary
-  export let icon: string | undefined | null = null
-  export let iconColor = 'currentColor'
-  export let iconAfter: string | undefined | null = null
-  // export let iconAfterColor = 'currentColor'
-  export let tabindex = -99
-  export let hasFocusRect = true
-  export let emulateHover = false
-  export let tooltip = ''
-
-  let hasIcon = false
-  let direction: FlexDirectionType = FlexDirection.row
-
-  $: {
-    hasIcon = Boolean(icon) || Boolean(iconAfter)
-
-    if (hasIcon) {
-      direction = icon ? FlexDirection.row : FlexDirection.rowReverse
-    }
-  }
-
-  export let disabled = false
-  export let selected = false
-  export let toggle = false
-  export let width = -1
-  export let round = false
-  export let ico = false
-  export let stretch = false
-  export let uppercase = false
-
-  export let size: ComponentSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: compVarStr = `--comp-${variant}`
-  $: buttonVarStr = `--button-${variant}`
-  $: compSizeStr = `--comp-size-${styleSize}`
-  $: buttonSizeStr = `--button-size-${styleSize}`
-
-  let cssVars: string[] = []
-  $: {
-    let states = ['enabled', 'hover', 'active', 'focus', 'disabled']
-    cssVars = [
+  const cssVars = $derived.by(() => {
+    const states = ['enabled', 'hover', 'active', 'focus', 'disabled']
+    return [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -91,11 +110,11 @@
       `--border-width:var(--button-border-width, var(--comp-border-width))`,
       `--gap:var(--button-icon-gap, 6px)`,
     ]
-  }
+  })
 
   let focused = false
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
@@ -104,17 +123,18 @@
         focused = true
         break
     }
-    dispatch(eventName)
+    if (eventName === 'focus') onfocus?.()
+    else if (eventName === 'blur') onblur?.()
   }
 
-  function onKeyDown(e) {
-    if (!e) e = window.event
+  function onKeyDown(e: KeyboardEvent) {
+    if (!e) e = window.event as KeyboardEvent
     const keyCode = e.code || e.key
     if (keyCode === 'Enter') {
-      dispatch('click', e)
+      onclick?.(e as unknown as MouseEvent)
       return false
     }
-    dispatch('keydown', e)
+    onkeydown?.(e)
   }
 </script>
 
@@ -126,8 +146,8 @@
     : `var(${buttonSizeStr}-border-radius, var(${compSizeStr}-border-radius))`}
   {stretch}
 >
-  <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
     role="button"
     data-test-id={testId}
@@ -142,10 +162,10 @@
     style:--direction={direction}
     style:--width={width === -1 ? 'auto' : `${width}px`}
     tabindex={tabindex === -99 ? 0 : tabindex}
-    on:click
-    on:focus={() => onFocusAction('focus')}
-    on:blur={() => onFocusAction('blur')}
-    on:keydown={onKeyDown}
+    onclick={onclick}
+    onfocus={() => onFocusAction('focus')}
+    onblur={() => onFocusAction('blur')}
+    onkeydown={onKeyDown}
     use:$tippy={{ content: tooltip }}
   >
     {#if hasIcon}
@@ -157,8 +177,8 @@
         />
       </div>
     {/if}
-    {#if $$slots.default && $$slots.default != ''}
-      <div class="label"><slot></slot></div>
+    {#if children}
+      <div class="label">{@render children()}</div>
     {/if}
   </div>
 </FocusRect>

--- a/ui/dashboard/src/lib/components/chart/Chart.svelte
+++ b/ui/dashboard/src/lib/components/chart/Chart.svelte
@@ -1,4 +1,6 @@
-<script lang="ts" context="module">
+<svelte:options runes={true} />
+
+<script lang="ts" module>
   import * as echarts from 'echarts/core'
 
   export type EChartsOptions = any //echarts.EChartsOption
@@ -51,9 +53,17 @@
 </script>
 
 <script lang="ts">
-  export let options: EChartsOptions //echarts.EChartsOption
-  export let { theme, renderer } = DEFAULT_OPTIONS
-  export let renderKey = ''
+  let {
+    options,
+    theme = DEFAULT_OPTIONS.theme,
+    renderer = DEFAULT_OPTIONS.renderer,
+    renderKey = '',
+  }: {
+    options: EChartsOptions //echarts.EChartsOption
+    theme?: EChartsTheme
+    renderer?: EChartsRenderer
+    renderKey?: string
+  } = $props()
 </script>
 
 <div class="chart" use:chartable={{ renderer, theme, options, renderKey }}></div>

--- a/ui/dashboard/src/lib/components/chart/ChartContainer.svelte
+++ b/ui/dashboard/src/lib/components/chart/ChartContainer.svelte
@@ -1,12 +1,22 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { onMount } from 'svelte'
 
-  export let renderKey = ''
+  let {
+    renderKey = $bindable(''),
+    width = '100%',
+    height = '500px',
+    children,
+  }: {
+    renderKey?: string
+    width?: string
+    height?: string
+    children?: Snippet
+  } = $props()
 
-  export let width = '100%'
-  export let height = '500px'
-
-  let containerRef
+  let containerRef = $state<HTMLDivElement>()
 
   onMount(() => {
     const resizeObserver = new ResizeObserver((entries) => {
@@ -16,8 +26,14 @@
         renderKey = `${contentRect.width}_${contentRect.height}`
       }
     })
-    resizeObserver.observe(containerRef)
-    return () => resizeObserver.unobserve(containerRef)
+    if (containerRef) {
+      resizeObserver.observe(containerRef)
+    }
+    return () => {
+      if (containerRef) {
+        resizeObserver.unobserve(containerRef)
+      }
+    }
   })
 </script>
 
@@ -27,7 +43,7 @@
   style:--height={height}
   style:--width={width}
 >
-  <slot></slot>
+  {@render children?.()}
 </div>
 
 <style>

--- a/ui/dashboard/src/lib/components/checkbox/index.svelte
+++ b/ui/dashboard/src/lib/components/checkbox/index.svelte
@@ -116,7 +116,6 @@
 
 <FootnoteContainer {footnote} {error} {disabled} stretch={false}>
   <LabelContainer
-    variant="body"
     {name}
     {size}
     {disabled}
@@ -127,7 +126,7 @@
     stretch={false}
     margin="-2px 0 0 0"
     interactive
-    on:click={disabled ? null : onInputParentClick}
+    onclick={disabled ? null : onInputParentClick}
   >
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div

--- a/ui/dashboard/src/lib/components/checkbox/index.svelte
+++ b/ui/dashboard/src/lib/components/checkbox/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { FocusRect, FootnoteContainer, Icon, LabelContainer } from '$lib/components'
   import {
     ComponentSize,
@@ -10,39 +11,54 @@
   import type { LabelAlignmentType, LabelPlacementType } from '$lib/styles/types'
   import type { InputSizeType } from '$lib/styles/types/input'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    label = '',
+    footnote = '',
+    required = false,
+    name = '',
+    checked = $bindable(false),
+    disabled = false,
+    valid = true,
+    error = '',
+    labelPlacement = LabelPlacement.right,
+    labelAlignment = LabelAlignment.center,
+    size = ComponentSize.medium,
+    onchange,
+    onfocus,
+    onblur,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    label?: any
+    footnote?: any
+    required?: boolean
+    name?: string
+    checked?: boolean
+    disabled?: boolean
+    valid?: boolean
+    error?: string
+    labelPlacement?: LabelPlacementType
+    labelAlignment?: LabelAlignmentType
+    size?: InputSizeType
+    onchange?: (e: { name: string; type: string; checked: boolean }) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const type = 'checkbox'
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let style = ''
+  const cbVarStr = $derived(`--checkbox-default`)
+  const cbSizeStr = $derived(`--checkbox-size-${styleSize}`)
 
-  export let label: any = ''
-  export let footnote: any = ''
-  export let required = false
-  export let name = ''
-  export let checked = false
-  export let disabled = false
-  export let valid = true
-  export let error = ''
-
-  let type = 'checkbox'
-
-  export let labelPlacement: LabelPlacementType = LabelPlacement.right
-  export let labelAlignment: LabelAlignmentType = LabelAlignment.center
-
-  export let size: InputSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: cbVarStr = `--checkbox-default`
-  $: cbSizeStr = `--checkbox-size-${styleSize}`
-
-  let cssVars: string[] = []
-  $: {
-    let states = ['enabled', 'hover', 'focused', 'checked', 'disabled']
-    cssVars = [
+  const cssVars = $derived.by(() => {
+    const states = ['enabled', 'hover', 'focused', 'checked', 'disabled']
+    return [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -58,35 +74,33 @@
       `--border-radius:var(--checkbox-border-radius)`,
       `--icon-size:var(${cbSizeStr}-icon-size)`,
     ]
-  }
+  })
 
   // TODO: fix check icon, this is a tmp workaround
-  let iconMarginTop = '0'
-  $: {
+  const iconMarginTop = $derived.by(() => {
     switch (size) {
       case ComponentSize.small:
-        iconMarginTop = '-7px'
-        break
+        return '-7px'
       case ComponentSize.medium:
-        iconMarginTop = '-3px'
-        break
+        return '-3px'
       case ComponentSize.large:
-        iconMarginTop = '0'
-        break
+        return '0'
+      default:
+        return '0'
     }
-  }
+  })
 
-  let focused = false
+  let focused = $state(false)
 
-  let inputRef
+  let inputRef = $state<HTMLInputElement>()
 
   function onInputParentClick() {
-    inputRef.focus()
+    inputRef?.focus()
     checked = !checked
-    dispatch('change', { name, type, checked })
+    onchange?.({ name, type, checked })
   }
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
@@ -95,7 +109,8 @@
         focused = true
         break
     }
-    dispatch(eventName)
+    if (eventName === 'focus') onfocus?.()
+    else if (eventName === 'blur') onblur?.()
   }
 </script>
 
@@ -114,7 +129,7 @@
     interactive
     on:click={disabled ? null : onInputParentClick}
   >
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
       data-test-id={testId}
       class={`tui-checkbox${clazz ? ' ' + clazz : ''}`}
@@ -130,8 +145,8 @@
             {type}
             {name}
             {checked}
-            on:focus={() => onFocusAction('focus')}
-            on:blur={() => onFocusAction('blur')}
+            onfocus={() => onFocusAction('focus')}
+            onblur={() => onFocusAction('blur')}
             aria-labelledby={`${name}_label`}
           />
           <Icon

--- a/ui/dashboard/src/lib/components/dropdown/index.svelte
+++ b/ui/dashboard/src/lib/components/dropdown/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { fade, slide } from 'svelte/transition'
   import { clickOutside } from '../../actions'
   import { FootnoteContainer, Icon, LabelContainer, FocusRect } from '$lib/components'
@@ -12,46 +13,66 @@
   import type { LabelAlignmentType, LabelPlacementType } from '$lib/styles/types'
   import type { InputSizeType } from '$lib/styles/types/input'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    label = '',
+    footnote = '',
+    required = false,
+    name = '',
+    value = $bindable(undefined),
+    multiple = false,
+    items = [],
+    disabled = false,
+    valid = true,
+    error = '',
+    maxVisibleListItems = -1,
+    expandUp = false,
+    stretch = false,
+    labelPlacement = LabelPlacement.top,
+    labelAlignment = LabelAlignment.start,
+    size = ComponentSize.medium,
+    onchange,
+    onfocus,
+    onblur,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    label?: any
+    footnote?: any
+    required?: boolean
+    name?: string
+    value?: any
+    multiple?: boolean
+    items?: { value: any; label: string }[]
+    disabled?: boolean
+    valid?: boolean
+    error?: string
+    maxVisibleListItems?: number
+    expandUp?: boolean
+    stretch?: boolean
+    labelPlacement?: LabelPlacementType
+    labelAlignment?: LabelAlignmentType
+    size?: InputSizeType
+    onchange?: (e: { name: string; type: string; value: any }) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const type = 'select'
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  let open = $state(false)
 
-  export let style = ''
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let label: any = ''
-  export let footnote: any = ''
-  export let required = false
-  export let name = ''
-  export let value: any = undefined
-  export let multiple = false
-  export let items: { value: any; label: string }[] = []
-  export let disabled = false
-  export let valid = true
-  export let error = ''
-  export let maxVisibleListItems = -1
-  export let expandUp = false
-  export let stretch = false
+  const inputVarStr = `--input-default`
+  const inputSizeStr = $derived(`--input-size-${styleSize}`)
 
-  let type = 'select'
-
-  let open = false
-
-  export let labelPlacement: LabelPlacementType = LabelPlacement.top
-  export let labelAlignment: LabelAlignmentType = LabelAlignment.start
-
-  export let size: InputSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: inputVarStr = `--input-default`
-  $: inputSizeStr = `--input-size-${styleSize}`
-
-  let cssVars: string[] = []
-  $: {
-    let states = ['enabled', 'hover', 'active', 'focus', 'disabled']
-    cssVars = [
+  const cssVars = $derived.by(() => {
+    const states = ['enabled', 'hover', 'active', 'focus', 'disabled']
+    const vars = [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -85,20 +106,21 @@
       `--list-top:${expandUp ? `auto` : '0'}`,
     ]
     if (maxVisibleListItems === -1) {
-      cssVars.push(`--list-height:calc(${items.length} * var(${inputSizeStr}-height))`)
+      vars.push(`--list-height:calc(${items.length} * var(${inputSizeStr}-height))`)
     } else {
-      cssVars.push(
+      vars.push(
         `--list-height:calc(min(calc(${items.length} * var(${inputSizeStr}-height)), calc(${maxVisibleListItems} * var(${inputSizeStr}-height))))`,
       )
     }
-  }
+    return vars
+  })
 
-  let focused = false
+  let focused = $state(false)
 
-  let selectRef
+  let selectRef = $state<HTMLSelectElement>()
 
   function onSelectParentClick() {
-    selectRef.focus()
+    selectRef?.focus()
     open = !open
     if (open) {
       const result = items.filter((item) => item.value === value)
@@ -110,29 +132,30 @@
     }
   }
 
-  function onSelectChange(e) {
+  function onSelectChange(e: Event) {
     arrowFocusIndex = -1
-    value = items[e.srcElement.selectedIndex].value
-    dispatch('change', { name, type, value })
-    selectRef.focus()
+    const target = e.target as HTMLSelectElement
+    value = items[target.selectedIndex].value
+    onchange?.({ name, type, value })
+    selectRef?.focus()
   }
 
   function onClose() {
     open = false
   }
 
-  function onItemSelect(val) {
+  function onItemSelect(val: any) {
     value = val
     open = false
     arrowFocusIndex = -1
-    dispatch('change', { name, type, value })
-    selectRef.focus()
+    onchange?.({ name, type, value })
+    selectRef?.focus()
   }
 
-  let arrowFocusIndex = -1
+  let arrowFocusIndex = $state(-1)
 
-  function onKeyDown(e) {
-    if (!e) e = window.event
+  function onKeyDown(e: KeyboardEvent) {
+    if (!e) e = window.event as KeyboardEvent
     const keyCode = e.code || e.key
     switch (keyCode) {
       case 'Space':
@@ -160,7 +183,7 @@
     }
   }
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
@@ -169,7 +192,8 @@
         focused = true
         break
     }
-    dispatch(eventName)
+    if (eventName === 'focus') onfocus?.()
+    else if (eventName === 'blur') onblur?.()
   }
 </script>
 
@@ -192,11 +216,11 @@
       class:expandUp
       class:stretch
       use:clickOutside
-      on:outclick={onClose}
-      on:focus={(e) => (focused = true)}
+      {...{ onoutclick: onClose }}
+      onfocus={() => (focused = true)}
     >
       <FocusRect {disabled} style={`--comp-focus-rect-border-radius:var(--border-radius)`}>
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
           role="button"
           tabindex="-1"
@@ -204,8 +228,8 @@
           class:disabled
           class:error={!valid || error !== ''}
           class:focused
-          on:click={disabled ? null : onSelectParentClick}
-          on:keydown={(e) => {
+          onclick={disabled ? null : onSelectParentClick}
+          onkeydown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()
               !disabled && onSelectParentClick()
@@ -218,10 +242,10 @@
             {disabled}
             {name}
             {value}
-            on:change={onSelectChange}
-            on:focus={() => onFocusAction('focus')}
-            on:blur={() => onFocusAction('blur')}
-            on:keydown={onKeyDown}
+            onchange={onSelectChange}
+            onfocus={() => onFocusAction('focus')}
+            onblur={() => onFocusAction('blur')}
+            onkeydown={onKeyDown}
             aria-labelledby={`${name}_label`}
           >
             {#each items as item (item.value)}
@@ -248,7 +272,7 @@
             >
               <div class="options-container">
                 {#each items as item, i (item.value)}
-                  <!-- svelte-ignore a11y-click-events-have-key-events -->
+                  <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <div
                     role="option"
                     tabindex="-1"
@@ -256,8 +280,8 @@
                     class="list-item"
                     class:selected={item.value === value}
                     class:arrowFocused={arrowFocusIndex === i}
-                    on:click={() => onItemSelect(item.value)}
-                    on:keydown={(e) => {
+                    onclick={() => onItemSelect(item.value)}
+                    onkeydown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault()
                         onItemSelect(item.value)

--- a/ui/dashboard/src/lib/components/focus-rect/index.svelte
+++ b/ui/dashboard/src/lib/components/focus-rect/index.svelte
@@ -1,14 +1,26 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let style = ''
+  import type { Snippet } from 'svelte'
 
-  export let disabled = false
-  export let show = true
-  export let borderRadius = ''
-  export let stretch = true
+  let {
+    style = '',
+    disabled = false,
+    show = true,
+    borderRadius = '',
+    stretch = true,
+    children,
+  }: {
+    style?: string
+    disabled?: boolean
+    show?: boolean
+    borderRadius?: string
+    stretch?: boolean
+    children?: Snippet
+  } = $props()
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
+  const cssVars = $derived.by(() => {
+    return [
       `--focus-rect-color:${disabled ? 'transparent' : `var(--comp-focus-rect-color)`}`,
       `--focus-rect-width:var(--comp-focus-rect-width)`,
       `--focus-rect-border-radius:${
@@ -17,7 +29,7 @@
       `--focus-rect-padding:var(--comp-focus-rect-padding)`,
       `--focus-rect-bg-color:var(--comp-focus-rect-bg-color)`,
     ]
-  }
+  })
 </script>
 
 {#if show}
@@ -26,10 +38,10 @@
     class:stretch
     style={`${cssVars.join(';')}${style ? `;${style}` : ''}`}
   >
-    <div class="halo"><slot></slot></div>
+    <div class="halo">{@render children?.()}</div>
   </div>
 {:else}
-  <slot></slot>
+  {@render children?.()}
 {/if}
 
 <style>

--- a/ui/dashboard/src/lib/components/footnote-container/index.svelte
+++ b/ui/dashboard/src/lib/components/footnote-container/index.svelte
@@ -1,56 +1,63 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { Typo } from '$lib/components'
   import { LabelAlignment } from '$lib/styles/types'
   import type { LabelAlignmentType } from '$lib/styles/types'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    disabled = false,
+    size = -1,
+    footnote = '',
+    error = '',
+    stretch = true,
+    html = false,
+    footnoteAlignment = LabelAlignment.start,
+    children,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    disabled?: boolean
+    size?: number
+    footnote?: any
+    error?: any
+    stretch?: boolean
+    html?: boolean
+    footnoteAlignment?: LabelAlignmentType
+    children?: Snippet
+  } = $props()
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const direction = 'column'
+  const justify = 'flex-start'
 
-  export let style = ''
-
-  export let disabled = false
-  export let size = -1
-  export let footnote: any = ''
-  export let error: any = ''
-  export let stretch = true
-  export let html = false
-
-  export let footnoteAlignment: LabelAlignmentType = LabelAlignment.start
-
-  let direction = 'column'
-  let justify = 'flex-start'
-
-  let footnoteAlign = 'center'
-
-  $: {
+  const footnoteAlign = $derived.by(() => {
     switch (footnoteAlignment) {
       case 'start':
-        footnoteAlign = 'flex-start'
-        break
+        return 'flex-start'
       case 'center':
-        footnoteAlign = 'center'
-        break
+        return 'center'
       case 'end':
-        footnoteAlign = 'flex-end'
-        break
+        return 'flex-end'
+      default:
+        return 'center'
     }
-  }
+  })
 
-  $: bodyTextSize = size !== -1 ? size : 4
+  const bodyTextSize = $derived(size !== -1 ? size : 4)
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--direction:${direction}`,
-      `--justify:${justify}`,
-      `--footnote-align:${footnoteAlign}`,
-      `--gap:var(--comp-footnote-gap, 8px)`,
-      `--flex:${stretch ? 1 : 0}`,
-      `--content-with:${stretch ? '100%' : 'auto'}`,
-    ]
-  }
+  const cssVars = $derived([
+    `--direction:${direction}`,
+    `--justify:${justify}`,
+    `--footnote-align:${footnoteAlign}`,
+    `--gap:var(--comp-footnote-gap, 8px)`,
+    `--flex:${stretch ? 1 : 0}`,
+    `--content-with:${stretch ? '100%' : 'auto'}`,
+  ])
 </script>
 
 <div
@@ -60,7 +67,7 @@
   tabindex="-1"
 >
   <div class="content">
-    <slot></slot>
+    {@render children?.()}
   </div>
   {#if footnote}
     <Typo

--- a/ui/dashboard/src/lib/components/heading/index.svelte
+++ b/ui/dashboard/src/lib/components/heading/index.svelte
@@ -1,32 +1,35 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { mediaSize, MediaSize } from '../../stores/media'
   import { Typo } from '$lib/components'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    size = 1,
+    html = false,
+    value = '',
+  }: {
+    testId?: string | undefined | null
+    size?: number
+    html?: boolean
+    value?: any
+  } = $props()
 
-  export let size = 1
-  export let html = false
-  export let value: any = ''
+  const mediaSmall = $derived($mediaSize <= MediaSize.sm)
 
-  $: mediaSmall = $mediaSize <= MediaSize.sm
-
-  let responsiveSize = size
-
-  $: {
+  const responsiveSize = $derived.by(() => {
     switch (size) {
       case 1:
-        responsiveSize = mediaSmall ? 2 : 1
-        break
+        return mediaSmall ? 2 : 1
       case 2:
-        responsiveSize = mediaSmall ? 3 : 2
-        break
+        return mediaSmall ? 3 : 2
       case 3:
-        responsiveSize = mediaSmall ? 4 : 3
-        break
+        return mediaSmall ? 4 : 3
       default:
-        responsiveSize = size
+        return size
     }
-  }
+  })
 </script>
 
 <Typo variant="heading" size={responsiveSize} {value} {html} {testId} />

--- a/ui/dashboard/src/lib/components/icon/index.svelte
+++ b/ui/dashboard/src/lib/components/icon/index.svelte
@@ -1,30 +1,40 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Component } from 'svelte'
   import { toUnit } from '$lib/styles/utils/css'
   import { iconNameOverrides, useLibIcons } from '$lib/stores/media'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    name = null,
+    size = 24,
+    opacity = 1,
+    color = 'currentColor',
+    iconSvg = null,
+    onclick,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    name?: string | null | undefined
+    size?: number
+    opacity?: number
+    color?: string
+    iconSvg?: string | null
+    onclick?: (e: MouseEvent) => void
+  } = $props()
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
-
-  export let style = ''
-
-  export let name: string | null | undefined = null
-  export let size = 24
-  export let opacity = 1
-  export let color = 'currentColor'
-  export let iconSvg = null
-
-  let finalName = name
-  $: {
-    finalName = name
-
+  const finalName = $derived.by(() => {
     if (name && $iconNameOverrides[name]) {
-      finalName = $iconNameOverrides[name]
+      return $iconNameOverrides[name]
     }
-  }
+    return name
+  })
 
-  let SvgIcon
+  let SvgIcon = $state<Component | null>(null)
 
   async function loadSvgComp(name) {
     SvgIcon = null
@@ -49,33 +59,30 @@
     }
   }
 
-  $: {
+  $effect(() => {
     if (finalName) {
       loadSvgComp(finalName)
     }
-  }
+  })
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--width:${toUnit(size)}`,
-      `--height:${toUnit(size)}`,
-      `--opacity:${opacity}`,
-      `--color:${color}`,
-      `--margin:0`,
-    ]
-  }
+  const cssVars = $derived([
+    `--width:${toUnit(size)}`,
+    `--height:${toUnit(size)}`,
+    `--opacity:${opacity}`,
+    `--color:${color}`,
+    `--margin:0`,
+  ])
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   role="button"
   tabindex="0"
   data-test-id={testId}
   class={`tui-icon${clazz ? ' ' + clazz : ''}`}
   style={`${cssVars.join(';')}${style ? `;${style}` : ''}`}
-  on:click
-  on:keydown={(e) => {
+  {onclick}
+  onkeydown={(e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       e.currentTarget.click()
@@ -84,7 +91,7 @@
 >
   {#if finalName && SvgIcon}
     {#key finalName}
-      <svelte:component this={SvgIcon} />
+      <SvgIcon />
     {/key}
   {:else if iconSvg}
     {@html iconSvg}

--- a/ui/dashboard/src/lib/components/label-container/index.svelte
+++ b/ui/dashboard/src/lib/components/label-container/index.svelte
@@ -1,4 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   // import { Typo } from '$lib/components'
   import {
     ComponentSize,
@@ -7,67 +10,76 @@
     getStyleSizeFromComponentSize,
   } from '$lib/styles/types'
   import type { ComponentSizeType, LabelAlignmentType, LabelPlacementType } from '$lib/styles/types'
-  import type { TypoVariantType } from '../typo/types'
+  // import type { TypoVariantType } from '../typo/types'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    name = '',
+    disabled = false,
+    required = false,
+    label = '',
+    // variant = 'heading',
+    interactive = false,
+    margin = '0',
+    stretch = true,
+    labelPlacement = LabelPlacement.top,
+    labelAlignment = LabelAlignment.start,
+    size = ComponentSize.medium,
+    onclick,
+    children,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    name?: string
+    disabled?: boolean
+    required?: boolean
+    label?: any
+    interactive?: boolean
+    margin?: string
+    stretch?: boolean
+    labelPlacement?: LabelPlacementType
+    labelAlignment?: LabelAlignmentType
+    size?: ComponentSizeType
+    onclick?: ((e: MouseEvent) => void) | null
+    children?: Snippet
+  } = $props()
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let style = ''
-
-  export let name = ''
-  export let disabled = false
-  export let required = false
-  export let label: any = ''
-  // export let variant: TypoVariantType = 'heading'
-  export let interactive = false
-  export let margin = '0'
-  export let stretch = true
-
-  export let labelPlacement: LabelPlacementType = LabelPlacement.top
-  export let labelAlignment: LabelAlignmentType = LabelAlignment.start
-
-  export let size: ComponentSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  let direction = 'row'
-  let justify = 'flex-start'
-
-  $: {
+  const direction = $derived.by(() => {
     switch (labelPlacement) {
       case 'top':
-        direction = 'column'
-        break
+        return 'column'
       case 'bottom':
-        direction = 'column-reverse'
-        justify = 'flex-end'
-        break
+        return 'column-reverse'
       case 'left':
-        direction = 'row'
-        break
+        return 'row'
       case 'right':
-        direction = 'row-reverse'
-        justify = 'flex-end'
-        break
+        return 'row-reverse'
+      default:
+        return 'row'
     }
-  }
+  })
 
-  let labelAlign = 'center'
+  const justify = $derived(
+    labelPlacement === 'bottom' || labelPlacement === 'right' ? 'flex-end' : 'flex-start',
+  )
 
-  $: {
+  const labelAlign = $derived.by(() => {
     switch (labelAlignment) {
       case 'start':
-        labelAlign = 'flex-start'
-        break
+        return 'flex-start'
       case 'center':
-        labelAlign = 'center'
-        break
+        return 'center'
       case 'end':
-        labelAlign = 'flex-end'
-        break
+        return 'flex-end'
+      default:
+        return 'center'
     }
-  }
+  })
 
   // TODO: handle sizes differently
   // let typoSize = 1
@@ -92,35 +104,31 @@
   //   }
   // }
 
-  $: compSizeStr = `--comp-size-${styleSize}`
-  // $: labelSizeStr = `--label-size-${styleSize}`
+  const compSizeStr = $derived(`--comp-size-${styleSize}`)
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--direction:${direction}`,
-      `--justify:${justify}`,
-      `--label-align:${labelAlign}`,
-      `--gap:var(--comp-label-gap, 8px)`,
-      `--flex:${stretch ? 1 : 0}`,
-      `--content-with:${stretch ? '100%' : 'auto'}`,
-      `--font-family:var(--label-font-family, var(--comp-font-family))`,
-      `--font-size:var(${compSizeStr}-font-size)`,
-      `--color:${disabled ? 'var(--comp-label-disabled-color)' : 'var(--comp-label-color)'}`,
-      `--margin:${margin}`,
-    ]
-  }
+  const cssVars = $derived([
+    `--direction:${direction}`,
+    `--justify:${justify}`,
+    `--label-align:${labelAlign}`,
+    `--gap:var(--comp-label-gap, 8px)`,
+    `--flex:${stretch ? 1 : 0}`,
+    `--content-with:${stretch ? '100%' : 'auto'}`,
+    `--font-family:var(--label-font-family, var(--comp-font-family))`,
+    `--font-size:var(${compSizeStr}-font-size)`,
+    `--color:${disabled ? 'var(--comp-label-disabled-color)' : 'var(--comp-label-color)'}`,
+    `--margin:${margin}`,
+  ])
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   role={interactive && !disabled ? 'button' : null}
   data-test-id={testId}
   class={`tui-label-container${clazz ? ' ' + clazz : ''}`}
   class:interactive={interactive && !disabled}
   style={`${cssVars.join(';')}${style ? `;${style}` : ''}`}
-  on:click
-  on:keydown={(e) => {
+  {onclick}
+  onkeydown={(e) => {
     if (interactive && !disabled && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault()
       e.currentTarget.click()
@@ -143,7 +151,7 @@
     </label>
   {/if}
   <div class="content">
-    <slot></slot>
+    {@render children?.()}
   </div>
 </div>
 

--- a/ui/dashboard/src/lib/components/logo/index.svelte
+++ b/ui/dashboard/src/lib/components/logo/index.svelte
@@ -1,39 +1,43 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import logos from './svg'
   import { injectedLogos } from '$lib/stores/media'
   import { toUnit } from '$lib/styles/utils/css'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    name = null,
+    width = -1,
+    height = -1,
+    opacity = 1,
+    logoSvg = null,
+    onclick,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    name?: string | undefined | null
+    width?: number
+    height?: number
+    opacity?: number
+    logoSvg?: string | null
+    onclick?: (e: MouseEvent) => void
+  } = $props()
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  let hasNoSize = $derived(width === -1 && height === -1)
 
-  export let style = ''
-
-  export let name: string | undefined | null = null
-  export let width = -1
-  export let height = -1
-  export let opacity = 1
-  export let logoSvg = null
-
-  let hasNoSize = true
-
-  $: {
-    hasNoSize = width === -1 && height === -1
-  }
-
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--width:${toUnit(width)}`,
-      `--height:${hasNoSize ? toUnit(64) : toUnit(height)}`,
-      `--opacity:${opacity}`,
-      `--margin:0`,
-    ]
-  }
+  let cssVars: string[] = $derived([
+    `--width:${toUnit(width)}`,
+    `--height:${hasNoSize ? toUnit(64) : toUnit(height)}`,
+    `--opacity:${opacity}`,
+    `--margin:0`,
+  ])
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   role="button"
   tabindex="0"
@@ -43,8 +47,8 @@
   class:o={opacity !== 1}
   class:w={width !== -1}
   class:h={height !== -1 || hasNoSize}
-  on:click
-  on:keydown={(e) => {
+  {onclick}
+  onkeydown={(e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       e.currentTarget.click()
@@ -53,9 +57,9 @@
 >
   {#if logoSvg}
     {@html logoSvg}
-  {:else if $injectedLogos[name]}
+  {:else if name && $injectedLogos[name]}
     {@html $injectedLogos[name]}
-  {:else if logos[name]}
+  {:else if name && logos[name]}
     {@html logos[name]}
   {/if}
 </div>

--- a/ui/dashboard/src/lib/components/modal/index.svelte
+++ b/ui/dashboard/src/lib/components/modal/index.svelte
@@ -1,13 +1,25 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { fade, fly } from 'svelte/transition'
 
-  export let coverCol = 'rgba(40, 41, 51, 0.7)'
-  export let maxContentW = '900px'
-  export let fadeCoverDuration = 200
-  export let flyContent = true
+  let {
+    coverCol = 'rgba(40, 41, 51, 0.7)',
+    maxContentW = '900px',
+    fadeCoverDuration = 200,
+    flyContent = true,
+    children,
+  }: {
+    coverCol?: string
+    maxContentW?: string
+    fadeCoverDuration?: number
+    flyContent?: boolean
+    children?: Snippet
+  } = $props()
 
-  let w
-  let h
+  let w = $state<number>()
+  let h = $state<number>()
 </script>
 
 <div
@@ -25,7 +37,7 @@
   style:--height-local="{h}px"
   style:--max-content-width={maxContentW}
 >
-  <slot></slot>
+  {@render children?.()}
 </div>
 
 <style>

--- a/ui/dashboard/src/lib/components/navigation/drawer/index.svelte
+++ b/ui/dashboard/src/lib/components/navigation/drawer/index.svelte
@@ -1,71 +1,86 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { onDestroy } from 'svelte'
-  import { createEventDispatcher } from 'svelte'
+  import type { Snippet } from 'svelte'
   import { fade } from 'svelte/transition'
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import Icon from '../../icon/index.svelte'
 
-  export let testId: string | undefined | null = null
-  export let position = 'left' // left | right
-  export let minWidth = 60
-  export let maxWidth = 212
-  export let offsetTop = ''
-  export let snapBelowHeader = true
-  export let coverColor = 'rgba(40, 41, 51, 0.7)'
-  export let showCover = false
-  export let showHeader = false
-  export let showFooter = false
+  let {
+    testId = null,
+    position = 'left', // left | right
+    minWidth = 60,
+    maxWidth = 212,
+    offsetTop = '',
+    snapBelowHeader = true,
+    coverColor = 'rgba(40, 41, 51, 0.7)',
+    showCover = false,
+    showHeader = false,
+    showFooter = false,
+    enableCollapse = true,
+    collapsed = true,
+    onmetrics,
+    onclose,
+    onheaderSelect,
+    header,
+    footer,
+    children,
+  }: {
+    testId?: string | undefined | null
+    position?: string
+    minWidth?: number
+    maxWidth?: number
+    offsetTop?: string
+    snapBelowHeader?: boolean
+    coverColor?: string
+    showCover?: boolean
+    showHeader?: boolean
+    showFooter?: boolean
+    enableCollapse?: boolean
+    collapsed?: boolean
+    onmetrics?: (detail: { position: string; width: number }) => void
+    onclose?: () => void
+    onheaderSelect?: () => void
+    header?: Snippet
+    footer?: Snippet
+    children?: Snippet
+  } = $props()
 
-  export let enableCollapse = true
-  export let collapsed = true
-
-  const dispatch = createEventDispatcher()
-
-  let collapse = collapsed
-  $: {
+  let collapse = $state(collapsed)
+  $effect(() => {
     collapse = collapsed
-  }
+  })
+
   function onCollapseClick() {
     collapse = !collapse
   }
 
-  let timeoutId: any = null
-  let calcW = collapse ? minWidth : maxWidth
-  $: {
-    calcW = collapse ? minWidth : maxWidth
-
-    timeoutId = setTimeout(() => {
-      dispatch('metrics', { position, width: calcW })
+  const calcW = $derived(collapse ? minWidth : maxWidth)
+  $effect(() => {
+    const timeoutId = setTimeout(() => {
+      onmetrics?.({ position, width: calcW })
     }, 0)
-  }
+    return () => clearTimeout(timeoutId)
+  })
 
-  $: hasHeader = showHeader && $$slots.header
-  $: hasFooter = showFooter && $$slots.footer
+  const hasHeader = $derived(showHeader && !!header)
+  const hasFooter = $derived(showFooter && !!footer)
 
   function onClose() {
-    dispatch('close', {})
+    onclose?.()
   }
 
   function onHeader() {
-    dispatch('header-select', {})
+    onheaderSelect?.()
   }
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--width:${$mediaSize <= MediaSize.xs ? '100%' : `${calcW}px`}`,
-      `--top:${snapBelowHeader ? `calc(var(--header-height)${offsetTop ? ` + ${offsetTop}` : '0'} )` : `${offsetTop}`}`,
-      `--content-top:${hasHeader ? 'var(--header-height)' : '0'}`,
-      `--content-bottom:${hasFooter ? 'var(--drawer-footer-height)' : '0'}`,
-      `--cover-color:${coverColor}`,
-    ]
-  }
-
-  onDestroy(() => {
-    if (timeoutId) {
-      clearTimeout(timeoutId)
-    }
-  })
+  const cssVars = $derived([
+    `--width:${$mediaSize <= MediaSize.xs ? '100%' : `${calcW}px`}`,
+    `--top:${snapBelowHeader ? `calc(var(--header-height)${offsetTop ? ` + ${offsetTop}` : '0'} )` : `${offsetTop}`}`,
+    `--content-top:${hasHeader ? 'var(--header-height)' : '0'}`,
+    `--content-bottom:${hasFooter ? 'var(--drawer-footer-height)' : '0'}`,
+    `--cover-color:${coverColor}`,
+  ])
 </script>
 
 {#if showCover}
@@ -74,10 +89,13 @@
     role="button"
     tabindex="-1"
     in:fade
-    on:mousedown|preventDefault={onClose}
-    on:keydown={(e) => e.key === 'Escape' && onClose()}
+    onmousedown={(e) => {
+      e.preventDefault()
+      onClose()
+    }}
+    onkeydown={(e) => e.key === 'Escape' && onClose()}
     style={`${cssVars.join(';')}`}
-  />
+  ></div>
 {/if}
 
 <div
@@ -88,7 +106,7 @@
   {#if enableCollapse}
     <button
       class="collapse-icon"
-      on:click={onCollapseClick}
+      onclick={onCollapseClick}
       type="button"
       aria-label="Toggle drawer"
     >
@@ -99,19 +117,19 @@
   <div class="container">
     {#key collapsed}
       {#if hasHeader}
-        <button class="header" on:click={onHeader} type="button">
-          <slot name="header"></slot>
+        <button class="header" onclick={onHeader} type="button">
+          {@render header?.()}
         </button>
       {/if}
     {/key}
 
     <div class="content">
-      <slot></slot>
+      {@render children?.()}
     </div>
 
     {#if hasFooter}
-      <button class="footer" on:click={onHeader} type="button">
-        <slot name="footer"></slot>
+      <button class="footer" onclick={onHeader} type="button">
+        {@render footer?.()}
       </button>
     {/if}
   </div>

--- a/ui/dashboard/src/lib/components/navigation/menu-item/index.svelte
+++ b/ui/dashboard/src/lib/components/navigation/menu-item/index.svelte
@@ -1,35 +1,49 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { tippy } from '$lib/stores/media'
   import Icon from '../../icon/index.svelte'
 
-  export let selected = false
-  export let collapsed = false
-  export let icon
-  export let iconSelected
-  export let label
+  let {
+    selected = false,
+    collapsed = false,
+    icon,
+    iconSelected,
+    label,
+    onclick,
+    onfocus,
+    onblur,
+  }: {
+    selected?: boolean
+    collapsed?: boolean
+    icon?: any
+    iconSelected?: any
+    label?: any
+    onclick?: (detail?: any) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  const dispatch = createEventDispatcher()
+  let focused = $state(false)
 
-  let focused = false
-
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
+        onblur?.()
         break
       case 'focus':
         focused = true
+        onfocus?.()
         break
     }
-    dispatch(eventName)
   }
 
-  function dispatchClick(e) {
-    dispatch('click', e.detail)
+  function dispatchClick(e: any) {
+    onclick?.(e?.detail)
   }
 
-  function onKeyDown(e) {
+  function onKeyDown(e: any) {
     if (!e) e = window.event
     const keyCode = e.code || e.key
     switch (keyCode) {
@@ -42,9 +56,9 @@
     }
   }
 
-  let active = false
+  let active = $state(false)
 
-  $: currentIcon = selected || active || focused ? iconSelected : icon
+  const currentIcon = $derived(selected || active || focused ? iconSelected : icon)
 </script>
 
 {#key collapsed}
@@ -52,12 +66,12 @@
     role="menuitem"
     class={`tui-menu-item${selected ? ' selected' : ''}${collapsed ? ' collapsed' : ''}`}
     tabindex="0"
-    on:click={dispatchClick}
-    on:keydown={onKeyDown}
-    on:focus={() => onFocusAction('focus')}
-    on:blur={() => onFocusAction('blur')}
-    on:mouseenter={() => (active = true)}
-    on:mouseleave={() => (active = false)}
+    onclick={dispatchClick}
+    onkeydown={onKeyDown}
+    onfocus={() => onFocusAction('focus')}
+    onblur={() => onFocusAction('blur')}
+    onmouseenter={() => (active = true)}
+    onmouseleave={() => (active = false)}
     use:$tippy={{ content: collapsed ? label : null, offset: [0, 0] }}
   >
     {#if icon}

--- a/ui/dashboard/src/lib/components/navigation/menu/index.svelte
+++ b/ui/dashboard/src/lib/components/navigation/menu/index.svelte
@@ -1,15 +1,22 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import MenuItem from '../menu-item/index.svelte'
 
-  const dispatch = createEventDispatcher()
-
-  export let data: any[] = []
-  export let collapsed = false
-  export let idField = 'id'
+  let {
+    data = [],
+    collapsed = false,
+    idField = 'id',
+    onselect,
+  }: {
+    data?: any[]
+    collapsed?: boolean
+    idField?: string
+    onselect?: (detail: { item: any }) => void
+  } = $props()
 
   function onMenuItem(item: any) {
-    dispatch('select', { item })
+    onselect?.({ item })
   }
 </script>
 
@@ -21,7 +28,7 @@
       label={item.label}
       selected={item.selected}
       {collapsed}
-      onclick={(e) => onMenuItem(item)}
+      onclick={() => onMenuItem(item)}
     />
   {/each}
 </div>

--- a/ui/dashboard/src/lib/components/navigation/menu/index.svelte
+++ b/ui/dashboard/src/lib/components/navigation/menu/index.svelte
@@ -21,7 +21,7 @@
       label={item.label}
       selected={item.selected}
       {collapsed}
-      on:click={(e) => onMenuItem(item)}
+      onclick={(e) => onMenuItem(item)}
     />
   {/each}
 </div>

--- a/ui/dashboard/src/lib/components/navigation/mobile-navbar/index.svelte
+++ b/ui/dashboard/src/lib/components/navigation/mobile-navbar/index.svelte
@@ -1,9 +1,19 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let offsetTop = ''
+  import type { Snippet } from 'svelte'
+
+  let {
+    offsetTop = '',
+    children,
+  }: {
+    offsetTop?: string
+    children?: Snippet
+  } = $props()
 </script>
 
 <div class="tui-mobile-navbar" style:--offset-top={offsetTop}>
-  <slot></slot>
+  {@render children?.()}
 </div>
 
 <style>

--- a/ui/dashboard/src/lib/components/pager/index.svelte
+++ b/ui/dashboard/src/lib/components/pager/index.svelte
@@ -1,54 +1,62 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
-  import { Button, Dropdown, Tab, TextInput, Typo } from '$lib/components'
+  import { Dropdown, Tab, TextInput, Typo } from '$lib/components'
   import { getBtnData, getPageSizeOptions } from './utils'
   import type { I18n } from '$lib/types'
 
-  const dispatch = createEventDispatcher()
-
-  export let testId: string | undefined | null = null
-
   let type = 'page'
 
-  export let name = ''
-  export let value
-  export let totalItems = 0
-  export let siblingCount = 1
-  export let boundaryCount = 1
-  export let hasBoundaryRight = true
-  export let dataSize = 5
-  export let i18n: I18n | null | undefined
-  export let expandUp = false
+  let {
+    testId = null,
+    name = '',
+    value = $bindable(),
+    totalItems = 0,
+    siblingCount = 1,
+    boundaryCount = 1,
+    hasBoundaryRight = true,
+    dataSize = 5,
+    i18n,
+    expandUp = false,
+    onchange,
+  }: {
+    testId?: string | undefined | null
+    name?: string
+    value?: { page?: number; pageSize?: number }
+    totalItems?: number
+    siblingCount?: number
+    boundaryCount?: number
+    hasBoundaryRight?: boolean
+    dataSize?: number
+    i18n?: I18n | null | undefined
+    expandUp?: boolean
+    onchange?: (e: { name: string; type: string; value: any }) => void
+  } = $props()
 
-  $: i18nLocal = {
+  const i18nLocal = $derived({
     t: i18n?.t,
     baseKey: i18n?.baseKey || 'comp.pager',
-  }
-  $: t = i18nLocal?.t || function () {}
-  $: baseKey = i18nLocal?.baseKey
-  $: pageSizeOptions = getPageSizeOptions(i18nLocal)
+  })
+  const t = $derived(i18nLocal?.t || function () {})
+  const baseKey = $derived(i18nLocal?.baseKey)
+  const pageSizeOptions = $derived(getPageSizeOptions(i18nLocal))
 
-  $: page = value?.page || 1
-  $: pageSize = value?.pageSize || 10
-  $: pageInput = `${page}`
+  const page = $derived(value?.page || 1)
+  const pageSize = $derived(value?.pageSize || 10)
 
-  let totalPages = 1
-  let isLastPage = false
-  let btnData: { type: 'page' | 'range'; page?: number; range?: number[] }[] = []
+  // pageInput is derived from `page` but also reassigned imperatively by the
+  // input-change handler, so it cannot be a plain $derived. Keep it as $state
+  // and re-sync it whenever `page` changes.
+  let pageInput = $state(`${value?.page || 1}`)
+  $effect(() => {
+    pageInput = `${page}`
+  })
 
-  $: {
-    totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
-    isLastPage = dataSize < pageSize
-
-    btnData = getBtnData(
-      totalPages,
-      page,
-      isLastPage,
-      hasBoundaryRight,
-      boundaryCount,
-      siblingCount,
-    )
-  }
+  const totalPages = $derived(Math.max(1, Math.ceil(totalItems / pageSize)))
+  const isLastPage = $derived(dataSize < pageSize)
+  const btnData: { type: 'page' | 'range'; page?: number; range?: number[] }[] = $derived(
+    getBtnData(totalPages, page, isLastPage, hasBoundaryRight, boundaryCount, siblingCount),
+  )
 
   function isSelected(btn) {
     return btn.type === 'page' && btn.page === page
@@ -56,7 +64,7 @@
 
   function callChange(page, pageSize) {
     value = { page, pageSize }
-    dispatch('change', { name, type, value })
+    onchange?.({ name, type, value })
   }
 
   function onSelect(btn) {
@@ -103,17 +111,13 @@
     }
   }
 
-  let quickNavDisabled = false
-  let onCurrentPage = false
-
-  $: {
+  const quickNavDisabled = $derived.by(() => {
     const pageNum = parseInt(pageInput)
-
-    quickNavDisabled =
+    return (
       !pageInput || isNaN(pageNum) || pageNum === page || pageNum < 1 || pageNum > totalPages
-
-    onCurrentPage = pageNum === page
-  }
+    )
+  })
+  const onCurrentPage = $derived(parseInt(pageInput) === page)
 
   function onQuickNavKeyDown(e) {
     const keyCode = e.detail.code || e.detail.key

--- a/ui/dashboard/src/lib/components/pager/index.svelte
+++ b/ui/dashboard/src/lib/components/pager/index.svelte
@@ -92,8 +92,8 @@
   }
 
   const onInputChange = (e) => {
-    const name = e.detail.name
-    const val = parseInt(e.detail.value)
+    const name = e.name
+    const val = parseInt(e.value)
 
     switch (name) {
       case 'page':
@@ -120,7 +120,7 @@
   const onCurrentPage = $derived(parseInt(pageInput) === page)
 
   function onQuickNavKeyDown(e) {
-    const keyCode = e.detail.code || e.detail.key
+    const keyCode = e.code || e.key
     if (!quickNavDisabled && keyCode === 'Enter') {
       onNav('nav', parseInt(pageInput))
       return false
@@ -137,7 +137,7 @@
       border={false}
       disabled={page === 1}
       style={`--font-weight:var(--typo-body-font-weight);--font-size:var(--typo-body-3-font-size);--line-height:var(--typo-body-3-line-height);`}
-      on:click={() => onNav('prev')}
+      onclick={() => onNav('prev')}
     >
       {t(`${baseKey}.prev`)}
     </Tab>
@@ -148,7 +148,7 @@
         border={false}
         selected={isSelected(btn)}
         style={`--font-weight:var(--typo-body-font-weight);--font-size:var(--typo-body-3-font-size);--line-height:var(--typo-body-3-line-height);`}
-        on:click={() => onSelect(btn)}
+        onclick={() => onSelect(btn)}
       >
         {btn.type === 'page' ? btn.page : '...'}
       </Tab>
@@ -160,7 +160,7 @@
       border={false}
       disabled={page === totalPages}
       style={`--font-weight:var(--typo-body-font-weight);--font-size:var(--typo-body-3-font-size);--line-height:var(--typo-body-3-line-height);`}
-      on:click={() => onNav('next')}
+      onclick={() => onNav('next')}
     >
       {t(`${baseKey}.next`)}
     </Tab>
@@ -175,8 +175,8 @@
       size="small"
       value={pageInput}
       valid={!quickNavDisabled || onCurrentPage}
-      on:change={onInputChange}
-      on:keydown={onQuickNavKeyDown}
+      onchange={onInputChange}
+      onkeydown={onQuickNavKeyDown}
     />
     <Typo
       variant="body"
@@ -193,7 +193,7 @@
       items={pageSizeOptions}
       size="small"
       {expandUp}
-      on:change={onInputChange}
+      onchange={onInputChange}
     />
     <Typo variant="body" size={3} value={t(`${baseKey}.rows_per_page`)} wrap={false} />
   </div>

--- a/ui/dashboard/src/lib/components/radio/index.svelte
+++ b/ui/dashboard/src/lib/components/radio/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { FocusRect, FootnoteContainer, LabelContainer } from '$lib/components'
   import {
     ComponentSize,
@@ -10,42 +11,59 @@
   import type { LabelAlignmentType, LabelPlacementType } from '$lib/styles/types'
   import type { InputSizeType } from '$lib/styles/types/input'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    label = 'Lalala',
+    footnote = '',
+    required = false,
+    name = '',
+    group = '',
+    checked = $bindable(false),
+    disabled = false,
+    valid = true,
+    error = '',
+    allowToggle = false,
+    labelPlacement = LabelPlacement.right,
+    labelAlignment = LabelAlignment.center,
+    size = ComponentSize.large,
+    onchange,
+    onfocus,
+    onblur,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    label?: any
+    footnote?: any
+    required?: boolean
+    name?: string
+    group?: string
+    checked?: boolean
+    disabled?: boolean
+    valid?: boolean
+    error?: string
+    allowToggle?: boolean
+    labelPlacement?: LabelPlacementType
+    labelAlignment?: LabelAlignmentType
+    size?: InputSizeType
+    onchange?: (detail: { name: string; group: string; type: string; checked: boolean }) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const type = 'radio'
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  let styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let style = ''
+  let cbVarStr = $derived(`--checkbox-default`)
+  let cbSizeStr = $derived(`--checkbox-size-${styleSize}`)
+  let radioSizeStr = $derived(`--radio-size-${styleSize}`)
 
-  export let label: any = 'Lalala'
-  export let footnote: any = ''
-  export let required = false
-  export let name = ''
-  export let group = ''
-  export let checked = false
-  export let disabled = false
-  export let valid = true
-  export let error = ''
-  export let allowToggle = false
-
-  let type = 'radio'
-
-  export let labelPlacement: LabelPlacementType = LabelPlacement.right
-  export let labelAlignment: LabelAlignmentType = LabelAlignment.center
-
-  export let size: InputSizeType = ComponentSize.large
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: cbVarStr = `--checkbox-default`
-  $: cbSizeStr = `--checkbox-size-${styleSize}`
-  $: radioSizeStr = `--radio-size-${styleSize}`
-
-  let cssVars: string[] = []
-  $: {
+  let cssVars: string[] = $derived.by(() => {
     let states = ['enabled', 'hover', 'focused', 'checked', 'disabled']
-    cssVars = [
+    return [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -62,33 +80,34 @@
       `--icon-size:var(${radioSizeStr}-icon-size)`,
       `--focus-rect-size:calc(var(${cbSizeStr}-size) / 2)`,
     ]
-  }
+  })
 
-  $: blockInteraction = disabled || (checked && !allowToggle)
+  let blockInteraction = $derived(disabled || (checked && !allowToggle))
 
-  let focused = false
+  let focused = $state(false)
 
-  let inputRef
+  let inputRef: HTMLInputElement | undefined = $state()
 
   function onInputParentClick() {
     if (blockInteraction) {
       return
     }
-    inputRef.focus()
+    inputRef?.focus()
     checked = !checked
-    dispatch('change', { name, group, type, checked })
+    onchange?.({ name, group, type, checked })
   }
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: string) {
     switch (eventName) {
       case 'blur':
         focused = false
+        onblur?.()
         break
       case 'focus':
         focused = true
+        onfocus?.()
         break
     }
-    dispatch(eventName)
   }
 </script>
 
@@ -105,7 +124,7 @@
     interactive={!disabled && !blockInteraction}
     onclick={disabled || blockInteraction ? null : onInputParentClick}
   >
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
       data-test-id={testId}
       class={`tui-radio${clazz ? ' ' + clazz : ''}`}
@@ -121,8 +140,8 @@
             {type}
             {name}
             {checked}
-            on:focus={() => onFocusAction('focus')}
-            on:blur={() => onFocusAction('blur')}
+            onfocus={() => onFocusAction('focus')}
+            onblur={() => onFocusAction('blur')}
             aria-labelledby={`${name}_label`}
           />
           <div

--- a/ui/dashboard/src/lib/components/radio/index.svelte
+++ b/ui/dashboard/src/lib/components/radio/index.svelte
@@ -103,7 +103,7 @@
     {required}
     margin="-2px 0 0 0"
     interactive={!disabled && !blockInteraction}
-    on:click={disabled || blockInteraction ? null : onInputParentClick}
+    onclick={disabled || blockInteraction ? null : onInputParentClick}
   >
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div

--- a/ui/dashboard/src/lib/components/spinner/index.svelte
+++ b/ui/dashboard/src/lib/components/spinner/index.svelte
@@ -1,37 +1,45 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { Modal } from '$lib/components'
 
-  export let size = 75
-  export let speed = 550
-  export let color = '#232d7c'
-  export let coverColor = 'rgba(255, 255, 255, 0.7)'
-  export let thickness = 1
-  export let gap = 25
-  export let radius = 10
-  export let offsetX = 0
+  let {
+    size = 75,
+    speed = 550,
+    color = '#232d7c',
+    coverColor = 'rgba(255, 255, 255, 0.7)',
+    thickness = 1,
+    gap = 25,
+    radius = 10,
+    offsetX = 0,
+  }: {
+    size?: number | 'small'
+    speed?: number
+    color?: string
+    coverColor?: string
+    thickness?: number
+    gap?: number
+    radius?: number
+    offsetX?: number
+  } = $props()
 
   // Handle predefined sizes
-  if (size === 'small') {
-    size = 16
-    thickness = 2
-    radius = 6
-    gap = 20
-  }
+  const isSmall = $derived(size === 'small')
+  const effectiveSize = $derived(isSmall ? 16 : (size as number))
+  const effectiveThickness = $derived(isSmall ? 2 : thickness)
+  const effectiveRadius = $derived(isSmall ? 6 : radius)
+  const effectiveGap = $derived(isSmall ? 20 : gap)
 
-  let dash
-  let marginLeft = 0
-  $: {
-    dash = (2 * Math.PI * radius * (100 - gap)) / 100
-    marginLeft = offsetX
-  }
+  const dash = $derived((2 * Math.PI * effectiveRadius * (100 - effectiveGap)) / 100)
+  const marginLeft = $derived(offsetX)
 </script>
 
 <Modal flyContent={false} coverCol={coverColor}>
   <svg
-    height={size}
-    width={size}
+    height={effectiveSize}
+    width={effectiveSize}
     style="animation-duration:{speed}ms;"
-    class="svelte-spinner {size === 16 ? 'spinner-small' : ''}"
+    class="svelte-spinner {effectiveSize === 16 ? 'spinner-small' : ''}"
     viewBox="0 0 32 32"
     style:--margin-left={marginLeft + 'px'}
   >
@@ -39,10 +47,10 @@
       role="presentation"
       cx="16"
       cy="16"
-      r={radius}
+      r={effectiveRadius}
       stroke={color}
       fill="none"
-      stroke-width={thickness}
+      stroke-width={effectiveThickness}
       stroke-dasharray="{dash},100"
       stroke-linecap="round"
     />

--- a/ui/dashboard/src/lib/components/switch/index.svelte
+++ b/ui/dashboard/src/lib/components/switch/index.svelte
@@ -106,7 +106,7 @@
     {required}
     margin="-4px 0 0 0"
     interactive
-    on:click={disabled ? null : onInputParentClick}
+    onclick={disabled ? null : onInputParentClick}
   >
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div

--- a/ui/dashboard/src/lib/components/switch/index.svelte
+++ b/ui/dashboard/src/lib/components/switch/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { FocusRect, FootnoteContainer, LabelContainer } from '$lib/components'
   import {
     ComponentSize,
@@ -10,37 +11,52 @@
   import type { LabelAlignmentType, LabelPlacementType } from '$lib/styles/types'
   import type { InputSizeType } from '$lib/styles/types/input'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    label = 'Lalala',
+    footnote = '',
+    required = false,
+    name = '',
+    checked = $bindable(false),
+    disabled = false,
+    valid = true,
+    error = '',
+    labelPlacement = LabelPlacement.right,
+    labelAlignment = LabelAlignment.center,
+    size = ComponentSize.large,
+    onchange,
+    onfocus,
+    onblur,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    label?: any
+    footnote?: any
+    required?: boolean
+    name?: string
+    checked?: boolean
+    disabled?: boolean
+    valid?: boolean
+    error?: string
+    labelPlacement?: LabelPlacementType
+    labelAlignment?: LabelAlignmentType
+    size?: InputSizeType
+    onchange?: (detail: { name: string; type: string; checked: boolean }) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const type = 'checkbox'
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  let styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let style = ''
+  let cbVarStr = $derived(`--switch-default`)
+  let switchSizeStr = $derived(`--switch-size-${styleSize}`)
 
-  export let label: any = 'Lalala'
-  export let footnote: any = ''
-  export let required = false
-  export let name = ''
-  export let checked = false
-  export let disabled = false
-  export let valid = true
-  export let error = ''
-
-  let type = 'checkbox'
-
-  export let labelPlacement: LabelPlacementType = LabelPlacement.right
-  export let labelAlignment: LabelAlignmentType = LabelAlignment.center
-
-  export let size: InputSizeType = ComponentSize.large
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: cbVarStr = `--switch-default`
-  $: switchSizeStr = `--switch-size-${styleSize}`
-
-  let cssVars: string[] = []
-  $: {
+  let cssVars: string[] = $derived.by(() => {
     let states = [
       'enabled',
       'enabled-checked',
@@ -51,7 +67,7 @@
       'disabled',
       'disabled-checked',
     ]
-    cssVars = [
+    return [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -70,28 +86,29 @@
       `--focus-rect-width:var(${switchSizeStr}-focus-rect-width, var(--comp-focus-rect-width))`,
       `--focus-rect-padding:var(${switchSizeStr}-focus-rect-padding, var(--comp-focus-rect-padding))`,
     ]
-  }
+  })
 
-  let focused = false
+  let focused = $state(false)
 
-  let inputRef
+  let inputRef: HTMLInputElement | undefined = $state()
 
   function onInputParentClick() {
-    inputRef.focus()
+    inputRef?.focus()
     checked = !checked
-    dispatch('change', { name, type, checked })
+    onchange?.({ name, type, checked })
   }
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: string) {
     switch (eventName) {
       case 'blur':
         focused = false
+        onblur?.()
         break
       case 'focus':
         focused = true
+        onfocus?.()
         break
     }
-    dispatch(eventName)
   }
 </script>
 
@@ -108,7 +125,7 @@
     interactive
     onclick={disabled ? null : onInputParentClick}
   >
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
       data-test-id={testId}
       class={`tui-switch${clazz ? ' ' + clazz : ''}`}
@@ -124,8 +141,8 @@
             {type}
             {name}
             {checked}
-            on:focus={() => onFocusAction('focus')}
-            on:blur={() => onFocusAction('blur')}
+            onfocus={() => onFocusAction('focus')}
+            onblur={() => onFocusAction('blur')}
             aria-labelledby={`${name}_label`}
           />
           <div

--- a/ui/dashboard/src/lib/components/tab/index.svelte
+++ b/ui/dashboard/src/lib/components/tab/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import type { Snippet } from 'svelte'
   import { FocusRect, Icon } from '$lib/components'
   import {
     ComponentSize,
@@ -13,51 +13,65 @@
     FlexDirectionType,
   } from '$lib/styles/types'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    variant = ComponentVariant.primary,
+    icon = null,
+    iconAfter = null,
+    border = true,
+    disabled = false,
+    selected = false,
+    toggle = false,
+    width = -1,
+    round = false,
+    hasFocusRect = true,
+    stretch = false,
+    size = ComponentSize.medium,
+    children,
+    onclick,
+    onkeydown,
+    onfocus,
+    onblur,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    variant?: ComponentVariantType
+    icon?: string | undefined | null
+    iconAfter?: string | undefined | null
+    border?: boolean
+    disabled?: boolean
+    selected?: boolean
+    toggle?: boolean
+    width?: number
+    round?: boolean
+    hasFocusRect?: boolean
+    stretch?: boolean
+    size?: ComponentSizeType
+    children?: Snippet
+    onclick?: (e: MouseEvent | KeyboardEvent) => void
+    onkeydown?: (e: KeyboardEvent) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const hasIcon = $derived(Boolean(icon) || Boolean(iconAfter))
+  const direction: FlexDirectionType = $derived(
+    hasIcon ? (icon ? FlexDirection.row : FlexDirection.rowReverse) : FlexDirection.row,
+  )
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  export let style = ''
+  const compVarStr = $derived(`--comp-${variant}`)
+  const tabVarStr = `--tab-default`
+  const compSizeStr = $derived(`--comp-size-${styleSize}`)
+  const tabSizeStr = $derived(`--tab-size-${styleSize}`)
 
-  export let variant: ComponentVariantType = ComponentVariant.primary
-  export let icon: string | undefined | null = null
-  export let iconAfter: string | undefined | null = null
-  export let border = true
-
-  let hasIcon = false
-  let direction: FlexDirectionType = FlexDirection.row
-
-  $: {
-    hasIcon = Boolean(icon) || Boolean(iconAfter)
-
-    if (hasIcon) {
-      direction = icon ? FlexDirection.row : FlexDirection.rowReverse
-    }
-  }
-
-  export let disabled = false
-  export let selected = false
-  export let toggle = false
-  export let width = -1
-  export let round = false
-  export let hasFocusRect = true
-  export let stretch = false
-
-  export let size: ComponentSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: compVarStr = `--comp-${variant}`
-  $: tabVarStr = `--tab-default`
-  $: compSizeStr = `--comp-size-${styleSize}`
-  $: tabSizeStr = `--tab-size-${styleSize}`
-
-  let cssVars: string[] = []
-  $: {
-    let states = ['enabled', 'hover', 'selected', 'focus', 'disabled']
-    cssVars = [
+  const cssVars = $derived.by(() => {
+    const states = ['enabled', 'hover', 'selected', 'focus', 'disabled']
+    return [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -82,11 +96,11 @@
       `--gap:var(--button-icon-gap, 6px)`,
       `--min-width:var(${tabSizeStr}-height, var(${compSizeStr}-height))`,
     ]
-  }
+  })
 
   let focused = false
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
@@ -95,17 +109,18 @@
         focused = true
         break
     }
-    dispatch(eventName)
+    if (eventName === 'focus') onfocus?.()
+    else if (eventName === 'blur') onblur?.()
   }
 
-  function onKeyDown(e) {
-    if (!e) e = window.event
+  function onKeyDown(e: KeyboardEvent) {
+    if (!e) e = window.event as KeyboardEvent
     const keyCode = e.code || e.key
     if (keyCode === 'Enter') {
-      dispatch('click', e)
+      onclick?.(e)
       return false
     }
-    dispatch('keydown', e)
+    onkeydown?.(e)
   }
 </script>
 
@@ -118,8 +133,8 @@
   {stretch}
   style="--focus-rect-bg-color:transparent;"
 >
-  <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
     role="tab"
     aria-selected={selected}
@@ -133,10 +148,10 @@
     style:--direction={direction}
     style:--width={width === -1 ? 'auto' : `${width}px`}
     tabindex="0"
-    on:click
-    on:focus={() => onFocusAction('focus')}
-    on:blur={() => onFocusAction('blur')}
-    on:keydown={onKeyDown}
+    {onclick}
+    onfocus={() => onFocusAction('focus')}
+    onblur={() => onFocusAction('blur')}
+    onkeydown={onKeyDown}
   >
     {#if hasIcon}
       <Icon
@@ -144,8 +159,8 @@
         style={`--width:var(${tabSizeStr}-icon-size, var(${compSizeStr}-icon-size));--height:var(${tabSizeStr}-icon-size, var(${compSizeStr}-icon-size))`}
       />
     {/if}
-    {#if $$slots.default}
-      <div class="label"><slot></slot></div>
+    {#if children}
+      <div class="label">{@render children()}</div>
     {/if}
   </div>
 </FocusRect>

--- a/ui/dashboard/src/lib/components/tab/index.svelte
+++ b/ui/dashboard/src/lib/components/tab/index.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import type { Snippet } from 'svelte'
   import { FocusRect, Icon } from '$lib/components'

--- a/ui/dashboard/src/lib/components/table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/index.svelte
@@ -1,94 +1,127 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import { untrack } from 'svelte'
   import { mediaSize, MediaSize } from '$lib/stores/media'
   import { SortOrder } from './utils'
   import { filterData, sortData, paginateData } from './hooks'
   import type { I18n } from '$lib/types'
-  import { TableVariant, type ColDef, type TableVariantType } from './types'
+  import { TableVariant, type ColDef } from './types'
 
-  const dispatch = createEventDispatcher()
-
-  export let testId: string | undefined | null = null
-
-  //   export let selectable = false
-  //   export let i18n = {}
-  //   export let selectedRowIds = []
-  //   export let onRowSelect
-  //   export let getRowClassName
-  //
-  //
-
-  // core
-  export let variant: string = TableVariant.dynamic
-  export let name
-  export let colDefs: ColDef[] = []
-  export let data: any[] = []
-  export let idField = 'id'
-  export let renderCells = {}
-  export let renderTypes = {}
-  export let disabled = false
-  export let expandUp = false
-  export let wrapTitles = true
-
-  // i18n
-  export let i18n: I18n | null | undefined
-
-  // cosmetics - legacy
-  export let maxHeight = -1
-  export let fullWidth = true
-  export let bgColorTable = null // = '#FCFCFF'
-  export let bgColorHead = null // = '#FFFFFF'
-  // more legacy
-  export let selectable = false
-  export let selectedRowIds = []
-  export let getRowIconActions
-  export let getRenderProps
-  // export let getRowClassName
-
-  // filters
-  export let filters = {}
-  export let filtersEnabled = true
-  export let useServerFilters = false
-  // sort
-  export let sort: { sortColumn?: string; sortOrder?: string } = {}
-  export let sortEnabled = true
-  export let useServerSort = false
-  export let sortByTypeFunctions = {}
-  // paginate
-  export let pagination = { page: 1, pageSize: 10 }
-  export let paginationEnabled = true
-  export let useServerPagination = false
-  export let hasBoundaryRight = true
-  export let pager = true // show pager?
-  export let alignPager = 'center'
-
-  // use server catch-all
-  export let useServerAll = false
+  let {
+    testId = null,
+    // core
+    variant = TableVariant.dynamic,
+    name,
+    colDefs = [],
+    data = [],
+    idField = 'id',
+    renderCells = {},
+    renderTypes = {},
+    disabled = false,
+    expandUp = false,
+    wrapTitles = true,
+    // i18n
+    i18n,
+    // cosmetics - legacy
+    maxHeight = -1,
+    fullWidth = true,
+    bgColorTable = null, // = '#FCFCFF'
+    bgColorHead = null, // = '#FFFFFF'
+    // more legacy
+    selectable = false,
+    selectedRowIds = [],
+    getRowIconActions,
+    getRenderProps,
+    // filters
+    filters = {},
+    filtersEnabled = true,
+    useServerFilters = false,
+    // sort
+    sort = {},
+    sortEnabled = true,
+    useServerSort = false,
+    sortByTypeFunctions = {},
+    // paginate
+    pagination = $bindable({ page: 1, pageSize: 10 }),
+    paginationEnabled = true,
+    useServerPagination = false,
+    hasBoundaryRight = true,
+    pager = true, // show pager?
+    alignPager = 'center',
+    // use server catch-all
+    useServerAll = false,
+    onfilter,
+    onsort,
+    onpaginate,
+    onaction,
+  }: {
+    testId?: string | undefined | null
+    variant?: string
+    name?: any
+    colDefs?: ColDef[]
+    data?: any[]
+    idField?: string
+    renderCells?: any
+    renderTypes?: any
+    disabled?: boolean
+    expandUp?: boolean
+    wrapTitles?: boolean
+    i18n?: I18n | null | undefined
+    maxHeight?: number
+    fullWidth?: boolean
+    bgColorTable?: any
+    bgColorHead?: any
+    selectable?: boolean
+    selectedRowIds?: any[]
+    getRowIconActions?: any
+    getRenderProps?: any
+    filters?: any
+    filtersEnabled?: boolean
+    useServerFilters?: boolean
+    sort?: { sortColumn?: string; sortOrder?: string }
+    sortEnabled?: boolean
+    useServerSort?: boolean
+    sortByTypeFunctions?: any
+    pagination?: { page: number; pageSize: number }
+    paginationEnabled?: boolean
+    useServerPagination?: boolean
+    hasBoundaryRight?: boolean
+    pager?: boolean
+    alignPager?: string
+    useServerAll?: boolean
+    onfilter?: (e: { name: any; filters: any }) => void
+    onsort?: (e: { name: any; colId: any; value: any }) => void
+    onpaginate?: (e: any) => void
+    onaction?: (e: { name: any; type: any; value: any }) => void
+  } = $props()
 
   // define preferences for server interaction
-  let serverPagination = false
-  let serverSort = false
-  let serverFilters = false
-
-  $: {
-    serverPagination = useServerAll || useServerPagination
-    serverSort = useServerAll || useServerSort
-    serverFilters = useServerAll || useServerFilters
-  }
+  const serverPagination = $derived(useServerAll || useServerPagination)
+  const serverSort = $derived(useServerAll || useServerSort)
+  const serverFilters = $derived(useServerAll || useServerFilters)
 
   // filter
-  let filteredData: any[] = data ? [...data] : []
-  $: filtersState = { ...filters }
+  // filtersState is derived from the `filters` prop but is also reassigned
+  // imperatively by updateFilters(), so keep it as $state synced via $effect.
+  // untrack() in the initializer makes the intentional initial-value capture
+  // explicit (avoids the state_referenced_locally warning).
+  let filtersState = $state(untrack(() => ({ ...filters })))
+  $effect(() => {
+    filtersState = { ...filters }
+  })
 
-  $: {
-    filteredData = filterData(data, filtersEnabled, serverFilters, filtersState)
-  }
+  const filteredData: any[] = $derived(
+    filterData(data, filtersEnabled, serverFilters, filtersState),
+  )
 
   // if either data changes or our filters change the number of data items, we need to reset
   // page to 1, to avoid pointing to out-of-bounds pages
-  $: if (filteredData) {
-    pagination.page = 1
-  }
+  $effect(() => {
+    if (filteredData) {
+      pagination.page = 1
+    }
+  })
 
   function updateFilters(key, filter) {
     if (!filtersEnabled) {
@@ -101,23 +134,19 @@
         ...filter,
       },
     }
-    dispatch('filter', { name, filters: { ...filtersState } })
+    onfilter?.({ name, filters: { ...filtersState } })
   }
 
   // sort
-  let sortedData = [...filteredData]
-  $: sortState = { ...sort }
+  // sortState mirrors the `sort` prop but is also reassigned by toggleSort().
+  let sortState = $state(untrack(() => ({ ...sort })))
+  $effect(() => {
+    sortState = { ...sort }
+  })
 
-  $: {
-    sortedData = sortData(
-      filteredData,
-      sortEnabled,
-      serverSort,
-      sortState,
-      colDefs,
-      sortByTypeFunctions,
-    )
-  }
+  const sortedData = $derived(
+    sortData(filteredData, sortEnabled, serverSort, sortState, colDefs, sortByTypeFunctions),
+  )
 
   function toggleSort(colId) {
     if (!sortEnabled) {
@@ -130,23 +159,27 @@
       value = SortOrder.desc
     }
     sortState = { sortColumn: colId, sortOrder: value }
-    dispatch('sort', { name, colId, value })
+    onsort?.({ name, colId, value })
   }
 
   // paginate
-  let pageData = [...sortedData]
-  $: paginationState = { ...pagination }
+  // paginationState mirrors the `pagination` prop but is also reassigned by
+  // updatePagination().
+  let paginationState = $state(untrack(() => ({ ...pagination })))
+  $effect(() => {
+    paginationState = { ...pagination }
+  })
 
-  $: {
-    pageData = paginateData(sortedData, paginationEnabled, serverPagination, paginationState)
-  }
+  const pageData = $derived(
+    paginateData(sortedData, paginationEnabled, serverPagination, paginationState),
+  )
 
   function updatePagination(state) {
     paginationState = { ...state }
-    dispatch('paginate', { name, ...paginationState })
+    onpaginate?.({ name, ...paginationState })
   }
 
-  let renderComp: any = null
+  let renderComp: any = $state(null)
 
   async function setRenderComp(variant: string) {
     try {
@@ -159,78 +192,73 @@
       console.error('Error loading table variant:', e)
     }
   }
-  $: {
+  $effect(() => {
     let useVariant = variant
     if (variant === TableVariant.dynamic) {
       useVariant = $mediaSize <= MediaSize.sm ? TableVariant.div : TableVariant.standard
     }
     setRenderComp(useVariant)
-  }
+  })
 
-  let renderProps = {}
-  $: {
-    renderProps = {
-      name,
-      colDefs,
-      data: pageData,
-      idField,
-      renderCells,
-      renderTypes,
-      disabled,
-      expandUp,
-      wrapTitles,
-      i18n,
-      maxHeight,
-      fullWidth,
-      bgColorTable,
-      bgColorHead,
-      selectable,
-      selectedRowIds,
-      filtersEnabled,
-      filtersState,
-      sortEnabled,
-      sortState,
-      paginationEnabled,
-      paginationState,
-      totalItems: sortedData.length,
-      hasBoundaryRight,
-      pager,
-      alignPager,
-      getRowIconActions,
-      getRenderProps,
-      // getRowClassName,
-    }
-  }
+  const renderProps = $derived({
+    name,
+    colDefs,
+    data: pageData,
+    idField,
+    renderCells,
+    renderTypes,
+    disabled,
+    expandUp,
+    wrapTitles,
+    i18n,
+    maxHeight,
+    fullWidth,
+    bgColorTable,
+    bgColorHead,
+    selectable,
+    selectedRowIds,
+    filtersEnabled,
+    filtersState,
+    sortEnabled,
+    sortState,
+    paginationEnabled,
+    paginationState,
+    totalItems: sortedData.length,
+    hasBoundaryRight,
+    pager,
+    alignPager,
+    getRowIconActions,
+    getRenderProps,
+  })
 
   function onFilterClick(e) {
-    const colId = e.detail.colId
+    const colId = e.colId
     console.log('onFilterClick: colId =', colId)
   }
 
   function onHeaderClick(e) {
-    toggleSort(e.detail.colId)
+    toggleSort(e.colId)
   }
 
   function onPaginate(e) {
-    updatePagination(e.detail.value)
+    updatePagination(e.value)
   }
 
   function onAction(e) {
-    const { type, value } = e.detail
-    dispatch('action', { name, type, value })
+    const { type, value } = e
+    onaction?.({ name, type, value })
   }
 </script>
 
 <div class="tui-table" data-test-id={testId}>
   {#if renderComp}
-    <!-- ts-lint-ignore -->
-    <svelte:component
-      this={renderComp}
+    {@const RenderComp = renderComp}
+    <RenderComp
       {...renderProps}
-      on:filter={onFilterClick}
-      on:header={onHeaderClick}
-      on:paginate={onPaginate}
-      on:action={onAction} />
+      onfilter={onFilterClick}
+      onheader={onHeaderClick}
+      onpaginate={onPaginate}
+      onaction={onAction} />
   {:else}
     <div>Unknown table variant.</div>
   {/if}

--- a/ui/dashboard/src/lib/components/table/renderers/render-clickable-span/index.svelte
+++ b/ui/dashboard/src/lib/components/table/renderers/render-clickable-span/index.svelte
@@ -1,13 +1,17 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let text: string = ''
-  export let onClick: () => void = () => {}
-  export let className: string = ''
+  let {
+    text = '',
+    onClick = () => {},
+    className = '',
+  }: { text?: string; onClick?: () => void; className?: string } = $props()
 </script>
 
-<span 
-  class="clickable-span {className}" 
-  on:click={onClick}
-  on:keydown={(e) => e.key === 'Enter' && onClick()}
+<span
+  class="clickable-span {className}"
+  onclick={onClick}
+  onkeydown={(e) => e.key === 'Enter' && onClick()}
   role="button"
   tabindex="0"
 >

--- a/ui/dashboard/src/lib/components/table/renderers/render-hash-with-miner/index.svelte
+++ b/ui/dashboard/src/lib/components/table/renderers/render-hash-with-miner/index.svelte
@@ -1,16 +1,29 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { tippy } from '$lib/stores/media'
   import { copyTextToClipboardVanilla } from '$lib/utils/clipboard'
   import ActionStatusIcon from '$internal/components/action-status-icon/index.svelte'
-  
-  export let hash = ''
-  export let hashUrl = ''
-  export let shortHash = ''
-  export let miner = ''
-  export let className = ''
-  export let tooltip = ''
-  export let showCopyButton = false
-  export let copyTooltip = 'Copy hash'
+
+  let {
+    hash = '',
+    hashUrl = '',
+    shortHash = '',
+    miner = '',
+    className = '',
+    tooltip = '',
+    showCopyButton = false,
+    copyTooltip = 'Copy hash',
+  }: {
+    hash?: string
+    hashUrl?: string
+    shortHash?: string
+    miner?: string
+    className?: string
+    tooltip?: string
+    showCopyButton?: boolean
+    copyTooltip?: string
+  } = $props()
 </script>
 
 <div class="hash-miner-container {className}">

--- a/ui/dashboard/src/lib/components/table/renderers/render-link/index.svelte
+++ b/ui/dashboard/src/lib/components/table/renderers/render-link/index.svelte
@@ -1,31 +1,29 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { getLinkPrefix } from '../../../../utils/url'
 
-  export let href = ''
-  export let text = null
-  export let className = ''
-  export let external = true
+  let {
+    href = '',
+    text = null,
+    className = '',
+    external = true,
+  }: { href?: string; text?: any; className?: string; external?: boolean } = $props()
 
-  let props: any = {}
-  let hrefWithPrefix = ''
-  let value = ''
-
-  $: {
-    props = external ? { target: '_blank', rel: 'noopener noreferrer' } : {}
-
+  const linkProps = $derived.by(() => {
+    const p: any = external ? { target: '_blank', rel: 'noopener noreferrer' } : {}
     if (className) {
-      props.class = className
+      p.class = className
     }
+    return p
+  })
 
-    const prefix = getLinkPrefix(href, external)
-    hrefWithPrefix = prefix + href
-
-    value = text || href
-  }
+  const hrefWithPrefix = $derived(getLinkPrefix(href, external) + href)
+  const value = $derived(text || href)
 </script>
 
 {#if value}
-  <a href={hrefWithPrefix} {...props}>{value}</a>
+  <a href={hrefWithPrefix} {...linkProps}>{value}</a>
 {:else}
   ''
 {/if}

--- a/ui/dashboard/src/lib/components/table/renderers/render-span-with-tooltip/index.svelte
+++ b/ui/dashboard/src/lib/components/table/renderers/render-span-with-tooltip/index.svelte
@@ -1,23 +1,27 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { tippy } from '$lib/stores/media'
-  
-  export let value = ''
-  export let className = ''
-  export let tooltip = ''
-  
-  let props: any = {}
-  
-  $: {
+
+  let {
+    value = '',
+    className = '',
+    tooltip = '',
+  }: { value?: any; className?: string; tooltip?: string } = $props()
+
+  const spanProps = $derived.by(() => {
+    const p: any = {}
     if (className) {
-      props.class = className
+      p.class = className
     }
-  }
+    return p
+  })
 </script>
 
 {#if value || value === 0}
   {#if tooltip && $tippy}
-    <span {...props} use:$tippy={{ content: tooltip }}>{value}</span>
+    <span {...spanProps} use:$tippy={{ content: tooltip }}>{value}</span>
   {:else}
-    <span {...props}>{value}</span>
+    <span {...spanProps}>{value}</span>
   {/if}
 {/if}

--- a/ui/dashboard/src/lib/components/table/renderers/render-span/index.svelte
+++ b/ui/dashboard/src/lib/components/table/renderers/render-span/index.svelte
@@ -1,16 +1,17 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let value = ''
-  export let className = ''
+  let { value = '', className = '' }: { value?: any; className?: string } = $props()
 
-  let props: any = {}
-
-  $: {
+  const spanProps = $derived.by(() => {
+    const p: any = {}
     if (className) {
-      props.class = className
+      p.class = className
     }
-  }
+    return p
+  })
 </script>
 
 {#if value || value === 0}
-  <span {...props}>{value}</span>
+  <span {...spanProps}>{value}</span>
 {/if}

--- a/ui/dashboard/src/lib/components/table/renderers/render-status-text/index.svelte
+++ b/ui/dashboard/src/lib/components/table/renderers/render-status-text/index.svelte
@@ -1,6 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  export let value = ''
-  export let statusColor = '#54adff'
+  let { value = '', statusColor = '#54adff' }: { value?: string; statusColor?: string } = $props()
 </script>
 
 {#if value}

--- a/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
@@ -173,7 +173,7 @@
                   {/if}
                   {#if filtersEnabled && filtersState[colDef.id]}
                     <div class="header-icon">
-                      <Icon name="filters" size={18} on:click={() => onFilterClick(colDef.id)} />
+                      <Icon name="filters" size={18} onclick={() => onFilterClick(colDef.id)} />
                     </div>
                   {/if}
                 </div>
@@ -240,7 +240,7 @@
                               <Icon
                                 name="filters"
                                 size={18}
-                                on:click={() => onFilterClick(colDef.id)}
+                                onclick={() => onFilterClick(colDef.id)}
                               />
                             </div>
                           {/if}

--- a/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
@@ -193,7 +193,7 @@
                 <Checkbox
                   name={item[idField]}
                   checked={selectedRowIds.includes(item[idField])}
-                  on:change={() => onRowSelect(item[idField])}
+                  onchange={() => onRowSelect(item[idField])}
                 />
               </div>
             {/if}

--- a/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
@@ -1,68 +1,104 @@
-<script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+<svelte:options runes={true} />
 
+<script lang="ts">
   import { mediaSize, MediaSize } from '../../../../stores/media'
   import { Button, Checkbox, Icon, Pager } from '$lib/components'
   import { getDisplay, SortOrder } from '../../utils'
   import type { ColDef } from '../../types'
 
-  const dispatch = createEventDispatcher()
-
-  export let name
-  export let colDefs: ColDef[] = []
-  export let data = []
-  export let idField
-  export let renderCells = {}
-  export let renderTypes = {}
-  export let disabled = false
-  export let expandUp = false
-  export let i18n
-  export let maxHeight = -1
-  export let fullWidth
-  export let bgColorTable
-  export let bgColorHead
-  export let selectable
-  export let selectedRowIds = []
-  export let filtersEnabled
-  export let filtersState
-  export let sortEnabled
-  export let sortState
-  export let paginationEnabled
-  export let paginationState
-  export let totalItems = -1
-  export let hasBoundaryRight = true
-  export let pager = true
-  export let alignPager = 'center'
-  export let getRowIconActions
-  export let getRenderProps
-  // export let getRowClassName
-  export let wrapTitles = true
+  let {
+    name,
+    colDefs = [],
+    data = [],
+    idField,
+    renderCells = {},
+    renderTypes = {},
+    disabled = false,
+    expandUp = false,
+    i18n,
+    maxHeight = -1,
+    fullWidth,
+    bgColorTable,
+    bgColorHead,
+    selectable,
+    selectedRowIds = [],
+    filtersEnabled,
+    filtersState,
+    sortEnabled,
+    sortState,
+    paginationEnabled,
+    paginationState,
+    totalItems = -1,
+    hasBoundaryRight = true,
+    pager = true,
+    alignPager = 'center',
+    getRowIconActions,
+    getRenderProps,
+    wrapTitles = true,
+    onfilter,
+    onheader,
+    onselect,
+    onpaginate,
+    onaction,
+  }: {
+    name?: any
+    colDefs?: ColDef[]
+    data?: any[]
+    idField?: any
+    renderCells?: any
+    renderTypes?: any
+    disabled?: boolean
+    expandUp?: boolean
+    i18n?: any
+    maxHeight?: number
+    fullWidth?: any
+    bgColorTable?: any
+    bgColorHead?: any
+    selectable?: any
+    selectedRowIds?: any[]
+    filtersEnabled?: any
+    filtersState?: any
+    sortEnabled?: any
+    sortState?: any
+    paginationEnabled?: any
+    paginationState?: any
+    totalItems?: number
+    hasBoundaryRight?: boolean
+    pager?: boolean
+    alignPager?: string
+    getRowIconActions?: any
+    getRenderProps?: any
+    wrapTitles?: boolean
+    onfilter?: (e: { colId: string }) => void
+    onheader?: (e: { colId: string }) => void
+    onselect?: (e: { id: any }) => void
+    onpaginate?: (e: any) => void
+    onaction?: (e: { name: any; type: any; value: any }) => void
+  } = $props()
 
   function onFilterClick(colId) {
-    dispatch('filter', { colId })
+    onfilter?.({ colId })
   }
 
   function onHeaderClick(colId) {
-    dispatch('header', { colId })
+    onheader?.({ colId })
   }
 
   function onRowSelect(id) {
-    dispatch('select', { id })
+    onselect?.({ id })
   }
 
   function onPage(e) {
-    dispatch('paginate', { ...e.detail })
+    onpaginate?.({ ...e })
   }
 
   function onActionIcon(type, value) {
-    dispatch('action', { name, type, value })
+    onaction?.({ name, type, value })
   }
 
-  let gutter = 32
-  let iconsW = 0
+  let gridGap = 0
 
-  $: {
-    iconsW = 0
+  const iconsW = $derived.by(() => {
     let maxIconsW = 0
     data.forEach((item) => {
       const icons = getRowIconActions ? getRowIconActions(name, item, idField) || [] : []
@@ -72,15 +108,14 @@
       }
     })
     // table cell has padding-left of 15px
-    iconsW = maxIconsW === 0 ? 0 : $mediaSize <= MediaSize.sm ? 56 : maxIconsW + 48
-  }
+    return maxIconsW === 0 ? 0 : $mediaSize <= MediaSize.sm ? 56 : maxIconsW + 48
+  })
 
-  let gridGap = 0
-  $: fixedWidth =
-    iconsW + (selectable ? 32 : 0) + (colDefs.length > 0 ? (colDefs.length - 1) * gridGap : 0)
-  let grid = ''
+  const fixedWidth = $derived(
+    iconsW + (selectable ? 32 : 0) + (colDefs.length > 0 ? (colDefs.length - 1) * gridGap : 0),
+  )
 
-  $: {
+  const grid = $derived.by(() => {
     let gridItems = selectable ? ['32px'] : []
     if ($mediaSize <= MediaSize.sm) {
       gridItems.push(`calc(100% - ${selectable ? '80px' : iconsW > 0 ? '48px' : '0'})`)
@@ -99,8 +134,8 @@
         gridItems.push(`${iconsW}px`)
       }
     }
-    grid = gridItems.join(' ')
-  }
+    return gridItems.join(' ')
+  })
 
   function getStyleProps(colDef) {
     if (colDef?.props?.style) {
@@ -113,24 +148,21 @@
     return {}
   }
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--max-height-local:${maxHeight + 'px'}`,
-      `--bg-col-head-local:${
-        bgColorHead
-          ? bgColorHead
-          : bgColorTable
-            ? bgColorTable
-            : 'var(--table-th-bg-color, #ffffff)'
-      }`,
-      `--row-col-local:${bgColorTable ? bgColorTable : 'var(--table-bg-color, none)'}`,
-      `--align-pager-local:${alignPager}`,
-      `--grid-local:${grid}`,
-      `--grid-gap-local:${gridGap + 'px'}`,
-      `--header-wrap-titles:${wrapTitles ? 'wrap' : 'nowrap'}`,
-    ]
-  }
+  const cssVars: string[] = $derived([
+    `--max-height-local:${maxHeight + 'px'}`,
+    `--bg-col-head-local:${
+      bgColorHead
+        ? bgColorHead
+        : bgColorTable
+          ? bgColorTable
+          : 'var(--table-th-bg-color, #ffffff)'
+    }`,
+    `--row-col-local:${bgColorTable ? bgColorTable : 'var(--table-bg-color, none)'}`,
+    `--align-pager-local:${alignPager}`,
+    `--grid-local:${grid}`,
+    `--grid-gap-local:${gridGap + 'px'}`,
+    `--header-wrap-titles:${wrapTitles ? 'wrap' : 'nowrap'}`,
+  ])
 </script>
 
 <div class="table-and-tools" style={`${cssVars.join(';')}`}>
@@ -154,10 +186,10 @@
               <div class="th"></div>
             {/if}
             {#each colDefs as colDef, i (colDef.id)}
-              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
               <button
                 class="th"
-                on:click={() => onHeaderClick(colDef.id)}
+                onclick={() => onHeaderClick(colDef.id)}
                 class:right={i > 0 && colDef?.type === 'number'}
                 type="button"
               >
@@ -199,16 +231,17 @@
             {/if}
             {#if $mediaSize > MediaSize.sm}
               {#each colDefs as colDef, i (colDef.id)}
+                {@const display = getDisplay(renderCells, renderTypes, colDef, idField, item)}
                 <div class="td" class:left={i === 0}>
-                  {#if getDisplay(renderCells, renderTypes, colDef, idField, item).component}
-                    <svelte:component
-                      this={getDisplay(renderCells, renderTypes, colDef, idField, item).component}
+                  {#if display.component}
+                    {@const CellComponent = display.component}
+                    <CellComponent
                       {...{
-                        ...getDisplay(renderCells, renderTypes, colDef, idField, item).props,
+                        ...display.props,
                         ...(getRenderProps ? getRenderProps(name, colDef, idField, item) : {}),
                       }} />
                   {:else}
-                    {getDisplay(renderCells, renderTypes, colDef, idField, item).value}
+                    {display.value}
                   {/if}
                 </div>
               {/each}
@@ -216,11 +249,12 @@
               <div class="td">
                 <div class="inner-grid">
                   {#each colDefs as colDef (colDef.id)}
+                    {@const display = getDisplay(renderCells, renderTypes, colDef, idField, item)}
                     <div class="inner-grid-item" {...getStyleProps(colDef)}>
-                      <!-- svelte-ignore a11y-click-events-have-key-events -->
+                      <!-- svelte-ignore a11y_click_events_have_key_events -->
                       <button
                         class="inner-grid-item-label"
-                        on:click={() => onHeaderClick(colDef.id)}
+                        onclick={() => onHeaderClick(colDef.id)}
                         type="button"
                       >
                         <div class="table-cell-row">
@@ -247,18 +281,17 @@
                         </div>
                       </button>
                       <div class="inner-grid-item-value">
-                        {#if getDisplay(renderCells, renderTypes, colDef, idField, item).component}
-                          <svelte:component
-                            this={getDisplay(renderCells, renderTypes, colDef, idField, item)
-                              .component}
+                        {#if display.component}
+                          {@const CellComponent = display.component}
+                          <CellComponent
                             {...{
-                              ...getDisplay(renderCells, renderTypes, colDef, idField, item).props,
+                              ...display.props,
                               ...(getRenderProps
                                 ? getRenderProps(name, colDef, idField, item)
                                 : {}),
                             }} />
                         {:else}
-                          {getDisplay(renderCells, renderTypes, colDef, idField, item).value}
+                          {display.value}
                         {/if}
                       </div>
                     </div>
@@ -271,11 +304,11 @@
                 {#if !disabled}
                   <div class="table-cell-row">
                     {#each getRowIconActions(name, item, idField) || [] as actionItem (actionItem.icon)}
-                      <!-- svelte-ignore a11y-click-events-have-key-events -->
+                      <!-- svelte-ignore a11y_click_events_have_key_events -->
                       <button
                         class="action"
                         class:disabled={actionItem.disabled}
-                        on:click={actionItem.disabled
+                        onclick={actionItem.disabled
                           ? null
                           : () => onActionIcon(actionItem.type, item)}
                         disabled={actionItem.disabled}

--- a/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/div-table/index.svelte
@@ -315,7 +315,7 @@
         {totalItems}
         value={paginationState}
         {hasBoundaryRight}
-        on:change={onPage}
+        onchange={onPage}
       />
     </div>
   {/if}

--- a/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
@@ -1,77 +1,113 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { Button, Checkbox, Icon, Pager } from '$lib/components'
   import { getDisplay, SortOrder } from '../../utils'
   import type { ColDef } from '../../types'
 
-  const dispatch = createEventDispatcher()
-
-  export let name
-  export let colDefs: ColDef[] = []
-  export let data = []
-  export let idField
-  export let renderCells = {}
-  export let renderTypes = {}
-  export let disabled = false
-  export let expandUp = false
-  export let i18n
-  export let maxHeight = -1
-  export let fullWidth
-  export let bgColorTable
-  export let bgColorHead
-  export let selectable
-  export let selectedRowIds = []
-  export let filtersEnabled
-  export let filtersState
-  export let sortEnabled
-  export let sortState
-  export let paginationEnabled
-  export let paginationState
-  export let totalItems = -1
-  export let hasBoundaryRight = true
-  export let pager = true
-  export let alignPager = 'center'
-  export let getRowIconActions
-  export let getRenderProps
-  // export let getRowClassName
-  export let wrapTitles = true
+  let {
+    name,
+    colDefs = [],
+    data = [],
+    idField,
+    renderCells = {},
+    renderTypes = {},
+    disabled = false,
+    expandUp = false,
+    i18n,
+    maxHeight = -1,
+    fullWidth,
+    bgColorTable,
+    bgColorHead,
+    selectable,
+    selectedRowIds = [],
+    filtersEnabled,
+    filtersState,
+    sortEnabled,
+    sortState,
+    paginationEnabled,
+    paginationState,
+    totalItems = -1,
+    hasBoundaryRight = true,
+    pager = true,
+    alignPager = 'center',
+    getRowIconActions,
+    getRenderProps,
+    wrapTitles = true,
+    onfilter,
+    onheader,
+    onselect,
+    onpaginate,
+    onaction,
+  }: {
+    name?: any
+    colDefs?: ColDef[]
+    data?: any[]
+    idField?: any
+    renderCells?: any
+    renderTypes?: any
+    disabled?: boolean
+    expandUp?: boolean
+    i18n?: any
+    maxHeight?: number
+    fullWidth?: any
+    bgColorTable?: any
+    bgColorHead?: any
+    selectable?: any
+    selectedRowIds?: any[]
+    filtersEnabled?: any
+    filtersState?: any
+    sortEnabled?: any
+    sortState?: any
+    paginationEnabled?: any
+    paginationState?: any
+    totalItems?: number
+    hasBoundaryRight?: boolean
+    pager?: boolean
+    alignPager?: string
+    getRowIconActions?: any
+    getRenderProps?: any
+    wrapTitles?: boolean
+    onfilter?: (e: { colId: string }) => void
+    onheader?: (e: { colId: string }) => void
+    onselect?: (e: { id: any }) => void
+    onpaginate?: (e: { page: any }) => void
+    onaction?: (e: { name: any; type: any; value: any }) => void
+  } = $props()
 
   function onFilterClick(colId) {
-    dispatch('filter', { colId })
+    onfilter?.({ colId })
   }
 
   function onHeaderClick(colId) {
-    dispatch('header', { colId })
+    onheader?.({ colId })
   }
 
   function onRowSelect(id) {
-    dispatch('select', { id })
+    onselect?.({ id })
   }
 
   function onPage(e) {
-    dispatch('paginate', { page: e.detail.value })
+    onpaginate?.({ page: e.value })
   }
 
   function onActionIcon(type, value) {
-    dispatch('action', { name, type, value })
+    onaction?.({ name, type, value })
   }
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--max-height-local:${maxHeight + 'px'}`,
-      `--bg-col-head-local:${
-        bgColorHead
-          ? bgColorHead
-          : bgColorTable
-            ? bgColorTable
-            : 'var(--table-th-bg-color, #ffffff)'
-      }`,
-      `--row-col-local:${bgColorTable ? bgColorTable : 'var(--table-bg-color, none)'}`,
-      `--align-pager-local:${alignPager}`,
-      `--header-wrap-titles:${wrapTitles ? 'wrap' : 'nowrap'}`,
-    ]
-  }
+  const cssVars: string[] = $derived([
+    `--max-height-local:${maxHeight + 'px'}`,
+    `--bg-col-head-local:${
+      bgColorHead
+        ? bgColorHead
+        : bgColorTable
+          ? bgColorTable
+          : 'var(--table-th-bg-color, #ffffff)'
+    }`,
+    `--row-col-local:${bgColorTable ? bgColorTable : 'var(--table-bg-color, none)'}`,
+    `--align-pager-local:${alignPager}`,
+    `--header-wrap-titles:${wrapTitles ? 'wrap' : 'nowrap'}`,
+  ])
 </script>
 
 <div class="table-and-tools" style={`${cssVars.join(';')}`}>
@@ -100,7 +136,7 @@
           {/if}
           {#each colDefs as colDef, i (colDef.id)}
             <th
-              on:click={() => onHeaderClick(colDef.id)}
+              onclick={() => onHeaderClick(colDef.id)}
               class:right={i > 0 && colDef?.type === 'number'}
             >
               <div class="table-cell-row">
@@ -139,16 +175,17 @@
               </td>
             {/if}
             {#each colDefs as colDef, i (colDef.id)}
+              {@const display = getDisplay(renderCells, renderTypes, colDef, idField, item)}
               <td class:left={i === 0}>
-                {#if getDisplay(renderCells, renderTypes, colDef, idField, item).component}
-                  <svelte:component
-                    this={getDisplay(renderCells, renderTypes, colDef, idField, item).component}
+                {#if display.component}
+                  {@const CellComponent = display.component}
+                  <CellComponent
                     {...{
-                      ...getDisplay(renderCells, renderTypes, colDef, idField, item).props,
+                      ...display.props,
                       ...(getRenderProps ? getRenderProps(name, colDef, idField, item) : {}),
                     }} />
                 {:else}
-                  {getDisplay(renderCells, renderTypes, colDef, idField, item).value}
+                  {display.value}
                 {/if}
               </td>
             {/each}
@@ -157,11 +194,11 @@
                 {#if !disabled}
                   <div class="table-cell-row">
                     {#each getRowIconActions(name, item, idField) || [] as actionItem (actionItem.icon)}
-                      <!-- svelte-ignore a11y-click-events-have-key-events -->
+                      <!-- svelte-ignore a11y_click_events_have_key_events -->
                       <button
                         class="action"
                         class:disabled={actionItem.disabled}
-                        on:click={actionItem.disabled
+                        onclick={actionItem.disabled
                           ? null
                           : () => onActionIcon(actionItem.type, item)}
                         disabled={actionItem.disabled}

--- a/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
@@ -134,7 +134,7 @@
                 <Checkbox
                   name={item[idField]}
                   checked={selectedRowIds.includes(item[idField])}
-                  on:change={() => onRowSelect(item[idField])}
+                  onchange={() => onRowSelect(item[idField])}
                 />
               </td>
             {/if}

--- a/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
@@ -115,7 +115,7 @@
                 {/if}
                 {#if filtersEnabled && filtersState[colDef.id]}
                   <div class="header-icon">
-                    <Icon name="filters" size={18} on:click={() => onFilterClick(colDef.id)} />
+                    <Icon name="filters" size={18} onclick={() => onFilterClick(colDef.id)} />
                   </div>
                 {/if}
               </div>

--- a/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
+++ b/ui/dashboard/src/lib/components/table/variant/standard-table/index.svelte
@@ -201,7 +201,7 @@
         {totalItems}
         value={paginationState}
         {hasBoundaryRight}
-        on:change={onPage}
+        onchange={onPage}
       />
     </div>
   {/if}

--- a/ui/dashboard/src/lib/components/textinput/index.svelte
+++ b/ui/dashboard/src/lib/components/textinput/index.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import { FootnoteContainer, Icon, LabelContainer, FocusRect } from '$lib/components'
   import {
     ComponentSize,
@@ -11,51 +13,92 @@
   import type { InputSizeType } from '$lib/styles/types/input'
   import { valueSet } from '$lib/utils'
 
-  const dispatch = createEventDispatcher()
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    type = 'text',
+    min = null,
+    max = null,
+    label = '',
+    footnote = '',
+    footnoteHtml = true,
+    required = false,
+    name = '',
+    value = $bindable(''),
+    placeholder = null,
+    disabled = false,
+    valid = true,
+    error = '',
+    autocomplete = 'off',
+    stretch = false,
+    width = -1,
+    focusWidth = -1,
+    icon = null,
+    iconAfter = null,
+    labelPlacement = LabelPlacement.top,
+    labelAlignment = LabelAlignment.start,
+    size = ComponentSize.medium,
+    confirm = false,
+    onchange,
+    onmount,
+    onconfirm,
+    onkeydown,
+    onfocus,
+    onblur,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    type?: 'text' | 'number'
+    min?: number | null
+    max?: number | null
+    label?: any
+    footnote?: any
+    footnoteHtml?: boolean
+    required?: boolean
+    name?: string
+    value?: string
+    placeholder?: any
+    disabled?: boolean
+    valid?: boolean
+    error?: string
+    autocomplete?: string | undefined | null
+    stretch?: boolean
+    width?: number
+    focusWidth?: number
+    icon?: string | undefined | null
+    iconAfter?: string | undefined | null
+    labelPlacement?: LabelPlacementType
+    labelAlignment?: LabelAlignmentType
+    size?: InputSizeType
+    confirm?: boolean
+    onchange?: (e: { name: string; type: string; value: string }) => void
+    onmount?: (e: { inputRef: HTMLInputElement | undefined }) => void
+    onconfirm?: (e: { name: string; type: string; value: string }) => void
+    onkeydown?: (e: KeyboardEvent) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  export let testId: string | undefined | null = null
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
+  const inputVarStr = `--input-default`
+  const inputSizeStr = $derived(`--input-size-${styleSize}`)
 
-  export let style = ''
+  // in confirm mode, changes are local until confirm is clicked,
+  // or alternatively changes can be reset to previous non-local value
+  let localValue = $state(value)
 
-  export let type: 'text' | 'number' = 'text'
-  export let min: number | null = null
-  export let max: number | null = null
+  $effect(() => {
+    localValue = value
+  })
 
-  export let label: any = ''
-  export let footnote: any = ''
-  export let footnoteHtml = true
-  export let required = false
-  export let name = ''
-  export let value = ''
-  export let placeholder: any = null
-  export let disabled = false
-  export let valid = true
-  export let error = ''
-  export let autocomplete: string | undefined | null = 'off'
-  export let stretch = false
-  export let width = -1
-  export let focusWidth = -1
-  export let icon: string | undefined | null = null
-  export let iconAfter: string | undefined | null = null
+  const placeholderActive = $derived(placeholder && !localValue)
 
-  export let labelPlacement: LabelPlacementType = LabelPlacement.top
-  export let labelAlignment: LabelAlignmentType = LabelAlignment.start
-
-  export let size: InputSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
-
-  $: inputVarStr = `--input-default`
-  $: inputSizeStr = `--input-size-${styleSize}`
-
-  $: placeholderActive = placeholder && !localValue
-
-  let cssVars: string[] = []
-  $: {
-    let states = ['enabled', 'hover', 'active', 'focus', 'disabled']
-    cssVars = [
+  const cssVars = $derived.by(() => {
+    const states = ['enabled', 'hover', 'active', 'focus', 'disabled']
+    return [
       ...states.reduce(
         (acc, state) => [
           ...acc,
@@ -83,71 +126,63 @@
       `--width:${width}px`,
       `--focus-width:${focusWidth}px`,
     ]
-  }
+  })
 
-  // in confirm mode, changes are local until confirm is clicked,
-  // or alternatively changes can be reset to previous non-local value
-  export let confirm = false
-  let localValue = value
-
-  $: {
-    localValue = value
-  }
-
-  let inputOpts: any = {}
-
-  $: {
-    inputOpts = {}
+  const inputOpts = $derived.by(() => {
+    const opts: any = {}
 
     if (autocomplete) {
-      inputOpts.autocomplete = autocomplete
+      opts.autocomplete = autocomplete
     }
     if (placeholder) {
-      inputOpts.placeholder = placeholder
+      opts.placeholder = placeholder
     }
     if (type === 'number') {
       if (valueSet(min)) {
-        inputOpts.min = min
+        opts.min = min
       }
       if (valueSet(max)) {
-        inputOpts.max = max
+        opts.max = max
       }
     }
-  }
 
-  let focused = false
+    return opts
+  })
 
-  let inputRef
+  let focused = $state(false)
+
+  let inputRef = $state<HTMLInputElement>()
 
   function onInputParentClick() {
-    inputRef.focus()
+    inputRef?.focus()
   }
 
-  function onInputChange(e) {
+  function onInputChange(e: Event) {
+    const target = e.target as HTMLInputElement
     if (confirm) {
-      localValue = e.srcElement.value
+      localValue = target.value
     } else {
-      value = e.srcElement.value
+      value = target.value
     }
     // we always pass through the raw value here to aid validators, etc
-    dispatch('change', { name, type, value: e.srcElement.value })
+    onchange?.({ name, type, value: target.value })
   }
 
   onMount(() => {
-    dispatch('mount', { inputRef })
+    onmount?.({ inputRef })
   })
 
   function doConfirm() {
     value = localValue
-    dispatch('confirm', { name, type, value })
+    onconfirm?.({ name, type, value })
   }
 
   function doReset() {
     localValue = value
   }
 
-  function onKeyDown(e) {
-    if (!e) e = window.event
+  function onInputKeyDown(e: KeyboardEvent) {
+    if (!e) e = window.event as KeyboardEvent
     const keyCode = e.code || e.key
     if (confirm) {
       if (keyCode === 'Enter') {
@@ -158,10 +193,10 @@
         return false
       }
     }
-    dispatch('keydown', e)
+    onkeydown?.(e)
   }
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
@@ -170,7 +205,8 @@
         focused = true
         break
     }
-    dispatch(eventName)
+    if (eventName === 'focus') onfocus?.()
+    else if (eventName === 'blur') onblur?.()
   }
 </script>
 
@@ -188,7 +224,7 @@
   {stretch}
 >
   <FootnoteContainer {footnote} {error} {disabled} html={footnoteHtml}>
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <FocusRect {disabled} style={`--comp-focus-rect-border-radius:var(--border-radius)`}>
       <div
         role="button"
@@ -200,8 +236,8 @@
         class:focusWidth={focusWidth !== -1}
         class:width={width !== -1}
         class:placeholder={placeholder && !localValue}
-        on:click={onInputParentClick}
-        on:keydown={(e) => {
+        onclick={onInputParentClick}
+        onkeydown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             onInputParentClick()
@@ -221,10 +257,10 @@
           value={confirm ? localValue : value}
           {disabled}
           {...inputOpts}
-          on:input={onInputChange}
-          on:focus={() => onFocusAction('focus')}
-          on:blur={() => onFocusAction('blur')}
-          on:keydown={onKeyDown}
+          oninput={onInputChange}
+          onfocus={() => onFocusAction('focus')}
+          onblur={() => onFocusAction('blur')}
+          onkeydown={onInputKeyDown}
           aria-labelledby={`${name}_label`}
         />
         {#if iconAfter}
@@ -235,7 +271,7 @@
             <button
               class="confirm-icon"
               style="color: #6EC492; width: 20px; height: 20px;"
-              on:click={doConfirm}
+              onclick={doConfirm}
               type="button"
               aria-label="Confirm"
             >
@@ -244,7 +280,7 @@
             <button
               class="confirm-icon"
               style="color: #FF344C; width: 17px; height: 17px;"
-              on:click={doReset}
+              onclick={doReset}
               type="button"
               aria-label="Cancel"
             >

--- a/ui/dashboard/src/lib/components/toast/index.svelte
+++ b/ui/dashboard/src/lib/components/toast/index.svelte
@@ -1,47 +1,47 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { Icon, Typo } from '$lib/components'
   import { ToastStatus } from './types'
   import type { ToastStatusType } from './types'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    status = ToastStatus.success,
+    title = '',
+    message = '',
+  }: {
+    testId?: string | undefined | null
+    status?: ToastStatusType
+    title?: string
+    message?: string
+  } = $props()
 
-  export let status: ToastStatusType = ToastStatus.success
-  export let title = ''
-  export let message = ''
-
-  let icon = ''
-
-  $: {
+  const icon = $derived.by(() => {
     switch (status) {
       case ToastStatus.success:
-        icon = 'check-circle'
-        break
+        return 'check-circle'
       case ToastStatus.failure:
-        icon = 'exclamation-circle'
-        break
+        return 'exclamation-circle'
       case ToastStatus.warn:
-        icon = 'exclamation'
-        break
+        return 'exclamation'
       case ToastStatus.info:
-        icon = 'information-circle'
-        break
+        return 'information-circle'
     }
-  }
+    return ''
+  })
 
-  $: toastVarStr = `--toast`
+  const toastVarStr = `--toast`
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--width:var(${toastVarStr}-width)`,
-      `--padding:var(${toastVarStr}-padding)`,
-      `--border-radius:var(${toastVarStr}-border-radius)`,
-      `--border-width:var(${toastVarStr}-border-width)`,
-      `--border-style:var(${toastVarStr}-border-style)`,
-      `--bg-color:var(${toastVarStr}-${status}-bg-color)`,
-      `--border-color:var(${toastVarStr}-${status}-border-color)`,
-    ]
-  }
+  const cssVars = $derived([
+    `--width:var(${toastVarStr}-width)`,
+    `--padding:var(${toastVarStr}-padding)`,
+    `--border-radius:var(${toastVarStr}-border-radius)`,
+    `--border-width:var(${toastVarStr}-border-width)`,
+    `--border-style:var(${toastVarStr}-border-style)`,
+    `--bg-color:var(${toastVarStr}-${status}-bg-color)`,
+    `--border-color:var(${toastVarStr}-${status}-border-color)`,
+  ])
 </script>
 
 <div class="tui-toast" data-test-id={testId} style={`${cssVars.join(';')}`}>

--- a/ui/dashboard/src/lib/components/toggle/index.svelte
+++ b/ui/dashboard/src/lib/components/toggle/index.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
   import { tippy } from '$lib/stores/media'
 
   import {
@@ -7,63 +8,73 @@
     type ComponentSizeType,
     ComponentVariant,
     type ComponentVariantType,
-    FlexDirection,
-    type FlexDirectionType,
     getStyleSizeFromComponentSize,
     getComponentSizeDown,
   } from '$lib/styles/types'
 
   import { FocusRect, Button } from '$lib/components'
 
-  export let name = ''
-  export let items: any = []
-  export let value: any = null
-  export let tabindex = -99
-  export let disabled = false
-  export let hasFocusRect = true
-  export let round = false
-  export let stretch = false
+  let {
+    name = '',
+    items = [],
+    value = $bindable(null),
+    tabindex = -99,
+    disabled = false,
+    hasFocusRect = true,
+    round = false,
+    stretch = false,
+    testId = null,
+    class: clazz = null,
+    style = '',
+    size = ComponentSize.medium,
+    onchange,
+    onfocus,
+    onblur,
+  }: {
+    name?: string
+    items?: any
+    value?: any
+    tabindex?: number
+    disabled?: boolean
+    hasFocusRect?: boolean
+    round?: boolean
+    stretch?: boolean
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    size?: ComponentSizeType
+    onchange?: (e: { name: string; type: string; value: any }) => void
+    onfocus?: () => void
+    onblur?: () => void
+  } = $props()
 
-  let variant: ComponentVariantType = ComponentVariant.tool
-
-  const dispatch = createEventDispatcher()
-
-  export let testId: string | undefined | null = null
-
-  let clazz: string | undefined | null = null
-  export { clazz as class }
-
-  export let style = ''
+  const variant: ComponentVariantType = ComponentVariant.tool
 
   const type = 'toggle'
 
-  export let size: ComponentSizeType = ComponentSize.medium
-  $: styleSize = getStyleSizeFromComponentSize(size)
+  const styleSize = $derived(getStyleSizeFromComponentSize(size))
 
-  $: buttonComponentSize = getComponentSizeDown(size as ComponentSize)
-  $: buttonStyleSize = getStyleSizeFromComponentSize(buttonComponentSize)
+  const buttonComponentSize = $derived(getComponentSizeDown(size as ComponentSize))
+  const buttonStyleSize = $derived(getStyleSizeFromComponentSize(buttonComponentSize))
 
-  $: compVarStr = `--comp-${variant}`
-  $: toggleVarStr = `--toggle-${variant}`
-  $: compSizeStr = `--comp-size-${styleSize}`
-  $: toggleSizeStr = `--toggle-size-${styleSize}`
+  const compVarStr = $derived(`--comp-${variant}`)
+  const toggleVarStr = $derived(`--toggle-${variant}`)
+  const compSizeStr = $derived(`--comp-size-${styleSize}`)
+  const toggleSizeStr = $derived(`--toggle-size-${styleSize}`)
 
-  let cssVars: string[] = []
-  $: {
-    cssVars = [
-      `--border-radius:${round ? '9999px' : `var(--toggle-border-radius, 6px)`}`,
-      `--gap:var(--toggle-gap, 4px)`,
-      `--padding-x:var(--toggle-padding-x, 3px)`,
-      `--padding-y:var(--toggle-padding-y, 2px)`,
-      `--icon-tab-border-radius:${round ? '9999px' : `var(--toggle-tab-border-radius, 4px)`}`,
-      `--icon-size:var(--toggle-icon-size, 16px)`,
-      `--height:var(${toggleSizeStr}-height, var(${compSizeStr}-height))`,
-    ]
-  }
+  const cssVars = $derived.by(() => [
+    `--border-radius:${round ? '9999px' : `var(--toggle-border-radius, 6px)`}`,
+    `--gap:var(--toggle-gap, 4px)`,
+    `--padding-x:var(--toggle-padding-x, 3px)`,
+    `--padding-y:var(--toggle-padding-y, 2px)`,
+    `--icon-tab-border-radius:${round ? '9999px' : `var(--toggle-tab-border-radius, 4px)`}`,
+    `--icon-size:var(--toggle-icon-size, 16px)`,
+    `--height:var(${toggleSizeStr}-height, var(${compSizeStr}-height))`,
+  ])
 
   let focused = false
 
-  function onFocusAction(eventName) {
+  function onFocusAction(eventName: 'focus' | 'blur') {
     switch (eventName) {
       case 'blur':
         focused = false
@@ -72,31 +83,32 @@
         focused = true
         break
     }
-    dispatch(eventName)
+    if (eventName === 'focus') onfocus?.()
+    else if (eventName === 'blur') onblur?.()
   }
 
-  let toggleRef
+  let toggleRef = $state<HTMLElement>()
 
-  let arrowFocusIndex = -1
+  let arrowFocusIndex = $state(-1)
 
-  $: {
+  $effect(() => {
     for (let i = 0; i < items.length; i++) {
       if (items[i].value === value) {
         arrowFocusIndex = i
         break
       }
     }
-  }
+  })
 
-  function onSelect(val, index) {
+  function onSelect(val: any, index: number) {
     value = val
     arrowFocusIndex = index
-    dispatch('change', { name, type, value })
-    toggleRef.focus()
+    onchange?.({ name, type, value })
+    toggleRef?.focus()
   }
 
-  function onKeyDown(e) {
-    if (!e) e = window.event
+  function onKeyDown(e: KeyboardEvent) {
+    if (!e) e = window.event as KeyboardEvent
     const keyCode = e.code || e.key
     switch (keyCode) {
       case 'ArrowLeft':
@@ -115,7 +127,7 @@
       case 'Space':
         e.preventDefault()
         if (arrowFocusIndex !== -1) {
-          ;(toggleRef.querySelectorAll('.tab')[arrowFocusIndex] as any).click()
+          ;(toggleRef?.querySelectorAll('.tab')[arrowFocusIndex] as any).click()
         }
         return false
     }
@@ -133,9 +145,9 @@
     class={`tui-toggle${clazz ? ' ' + clazz : ''}`}
     style={`${cssVars.join(';')}${style ? `;${style}` : ''}`}
     bind:this={toggleRef}
-    on:focus={() => onFocusAction('focus')}
-    on:blur={() => onFocusAction('blur')}
-    on:keydown={onKeyDown}
+    onfocus={() => onFocusAction('focus')}
+    onblur={() => onFocusAction('blur')}
+    onkeydown={onKeyDown}
     role="listbox"
     tabindex={tabindex === -99 ? 0 : tabindex}
     aria-label={name}
@@ -145,8 +157,8 @@
         class="tab"
         class:selected={item.value === value}
         class:arrowFocused={arrowFocusIndex === i}
-        on:click={() => onSelect(item.value, i)}
-        on:keydown={() => {}}
+        onclick={() => onSelect(item.value, i)}
+        onkeydown={() => {}}
         use:$tippy={{ content: item.tooltip }}
         role="option"
         aria-selected={item.value === value}

--- a/ui/dashboard/src/lib/components/typo/index.svelte
+++ b/ui/dashboard/src/lib/components/typo/index.svelte
@@ -1,26 +1,35 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { TypoVariant } from './types'
   import type { TypoVariantType } from './types'
 
-  export let testId: string | undefined | null = null
+  let {
+    testId = null,
+    class: clazz = null,
+    style = '',
+    variant = TypoVariant.heading,
+    size = 1,
+    color = null,
+    html = false,
+    value = '',
+    wrap = true,
+  }: {
+    testId?: string | undefined | null
+    class?: string | undefined | null
+    style?: string
+    variant?: TypoVariantType
+    size?: number
+    color?: string | null
+    html?: boolean
+    value?: any
+    wrap?: boolean
+  } = $props()
 
-  let clazz: string | undefined | null = null
-  export { clazz as class }
-
-  export let style = ''
-
-  export let variant: TypoVariantType = TypoVariant.heading
-  export let size = 1
-  export let color: string | null = null
-  export let html = false
-  export let value: any = ''
-  export let wrap = true
-
-  let cssVars: string[] = []
-  $: {
-    let varStr = `--typo-${variant}`
-    let sizeStr = `${varStr}-${size}`
-    cssVars = [
+  const cssVars: string[] = $derived.by(() => {
+    const varStr = `--typo-${variant}`
+    const sizeStr = `${varStr}-${size}`
+    return [
       `--color:${color ? color : `var(${varStr}-color)`}`,
       `--font-family:var(${varStr}-font-family)`,
       `--font-weight:var(${varStr}-font-weight)`,
@@ -29,7 +38,7 @@
       `--wrap:${wrap ? 'normal' : 'nowrap'}`,
       `--margin:0`,
     ]
-  }
+  })
 </script>
 
 <span

--- a/ui/dashboard/src/lib/styles/GlobalStyle.svelte
+++ b/ui/dashboard/src/lib/styles/GlobalStyle.svelte
@@ -1,4 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { theme as themeStore } from '$lib/stores/media'
   import deepmerge from 'deepmerge'
 
@@ -10,19 +13,25 @@
   // web fonts
   import './css/inter.css'
 
-  export let theme
-  export let themeNs
-  export let customThemeProps: any = {}
+  let {
+    theme,
+    themeNs,
+    customThemeProps = {},
+    children,
+  }: {
+    theme: any
+    themeNs: any
+    customThemeProps?: any
+    children?: Snippet
+  } = $props()
 
   const themes = {
     dark: darkTheme,
     light: lightTheme,
   }
 
-  let themeProps = {}
-
-  $: {
-    themeProps = themes[theme] ?? lightTheme
+  $effect(() => {
+    let themeProps = themes[theme] ?? lightTheme
 
     if (theme !== null) {
       themeProps = deepmerge(themeProps, customThemeProps)
@@ -34,10 +43,10 @@
     if (typeof document !== 'undefined' && (theme === 'light' || theme === 'dark')) {
       document.documentElement.setAttribute('data-theme', theme)
     }
-  }
+  })
 </script>
 
-<slot></slot>
+{@render children?.()}
 
 <style>
   :global(:root) {

--- a/ui/dashboard/src/routes/+error.svelte
+++ b/ui/dashboard/src/routes/+error.svelte
@@ -56,7 +56,7 @@
     <Typo variant="text" size="md" value={body} color="var(--comp-label-color)" />
   </div>
   <div class="btn">
-    <Button variant="tertiary" width={140} on:click={onHome}>{btnLabel}</Button>
+    <Button variant="tertiary" width={140} onclick={onHome}>{btnLabel}</Button>
   </div>
 </div>
 

--- a/ui/dashboard/src/routes/+error.svelte
+++ b/ui/dashboard/src/routes/+error.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { page } from '$app/stores'
   import { goto } from '$app/navigation'
@@ -9,36 +11,37 @@
 
   const fieldKey = 'comp.error'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
   const maxWidth = 500
 
-  $: is404 = $page.status === 404
-  $: isFatal = $page.status >= 500 && $page.status < 600
+  const is404 = $derived($page.status === 404)
+  const isFatal = $derived($page.status >= 500 && $page.status < 600)
 
-  let logoName = ''
-  let title = ''
-  let body = ''
-  let btnLabel = ''
-
-  $: {
+  const display = $derived.by(() => {
     if (is404) {
-      logoName = 'error-404'
-      title = t(`${fieldKey}.404.title`)
-      body = t(`${fieldKey}.404.body`, { url: $page.url })
-      btnLabel = t(`${fieldKey}.404.home`)
+      return {
+        logoName: 'error-404',
+        title: t(`${fieldKey}.404.title`),
+        body: t(`${fieldKey}.404.body`, { url: $page.url }),
+        btnLabel: t(`${fieldKey}.404.home`),
+      }
     } else if (isFatal) {
-      logoName = 'error-fatal'
-      title = t(`${fieldKey}.fatal.title`)
-      body = $page?.error?.message || ''
-      btnLabel = t(`${fieldKey}.fatal.home`)
+      return {
+        logoName: 'error-fatal',
+        title: t(`${fieldKey}.fatal.title`),
+        body: $page?.error?.message || '',
+        btnLabel: t(`${fieldKey}.fatal.home`),
+      }
     } else {
-      logoName = 'error-x'
-      title = t(`${fieldKey}.x.title`, { status: $page.status })
-      body = $page?.error?.message || ''
-      btnLabel = t(`${fieldKey}.x.home`)
+      return {
+        logoName: 'error-x',
+        title: t(`${fieldKey}.x.title`, { status: $page.status }),
+        body: $page?.error?.message || '',
+        btnLabel: t(`${fieldKey}.x.home`),
+      }
     }
-  }
+  })
 
   function onHome() {
     goto('/')
@@ -47,16 +50,16 @@
 
 <div class="error" style:--max-width={maxWidth}>
   <div class="logo">
-    <Logo name={logoName} width={162} />
+    <Logo name={display.logoName} width={162} />
   </div>
   <div class="title">
-    <Typo variant="title" size="h5" value={title} color="var(--app-color)" />
+    <Typo variant="title" size="h5" value={display.title} color="var(--app-color)" />
   </div>
   <div class="body">
-    <Typo variant="text" size="md" value={body} color="var(--comp-label-color)" />
+    <Typo variant="text" size="md" value={display.body} color="var(--comp-label-color)" />
   </div>
   <div class="btn">
-    <Button variant="tertiary" width={140} onclick={onHome}>{btnLabel}</Button>
+    <Button variant="tertiary" width={140} onclick={onHome}>{display.btnLabel}</Button>
   </div>
 </div>
 

--- a/ui/dashboard/src/routes/+layout.svelte
+++ b/ui/dashboard/src/routes/+layout.svelte
@@ -1,5 +1,9 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, untrack } from 'svelte'
+  import type { Snippet } from 'svelte'
+  import { get } from 'svelte/store'
   import { page } from '$app/stores'
   import { SvelteToast } from '@zerodevx/svelte-toast'
   import { createTippy } from '$lib/actions/tooltip'
@@ -23,6 +27,8 @@
 
   import { connectToP2PServer } from '$internal/stores/p2pStore'
 
+  let { children }: { children?: Snippet } = $props()
+
   onMount(() => {
     connectToP2PServer()
   })
@@ -44,12 +50,12 @@
     appendTo: () => document.body,
   })
 
-  $: {
+  $effect(() => {
     $i18nStore = {
       t: $i18n.t,
       baseKey: '',
     }
-  }
+  })
 
   // inject assets
   initLib({
@@ -123,29 +129,31 @@
     ],
   }
 
-  $: {
+  $effect(() => {
+    // Only depend on pathname; reading/writing $pageLinks here would self-trigger the effect.
     const pathname = $page.url.pathname
 
-    let items: any[] = []
+    untrack(() => {
+      const links = get(pageLinks)
+      if (links) {
+        const items = links.items.map((route) => ({
+          ...route,
+          selected:
+            (pathname === '/' && route.path == '/') ||
+            pathname === route.path ||
+            pathname.indexOf(`${route.path}/`) === 0,
+        }))
+        $pageLinks = { ...links, items }
+      }
+    })
+  })
 
-    if ($pageLinks) {
-      items = $pageLinks.items.map((route) => ({
-        ...route,
-        selected:
-          (pathname === '/' && route.path == '/') ||
-          pathname === route.path ||
-          pathname.indexOf(`${route.path}/`) === 0,
-      }))
-      $pageLinks.items = items
-    }
-  }
+  const queryXl = query(xl)
+  const queryLg = query(lg)
+  const queryMd = query(md)
+  const querySm = query(sm)
 
-  $: queryXl = query(xl)
-  $: queryLg = query(lg)
-  $: queryMd = query(md)
-  $: querySm = query(sm)
-
-  $: {
+  $effect(() => {
     if ($queryXl) {
       $mediaSize = MediaSize.xl
     } else if ($queryLg) {
@@ -157,7 +165,7 @@
     } else {
       $mediaSize = MediaSize.xs
     }
-  }
+  })
 
   const toastOptions = {
     duration: 3000, // duration of progress bar tween to the `next` value
@@ -169,7 +177,7 @@
 </script>
 
 <GlobalStyle theme={$theme} themeNs={$themeNs}>
-  <slot></slot>
+  {@render children?.()}
 </GlobalStyle>
 
 {#if $spinCount > 0}

--- a/ui/dashboard/src/routes/+page.svelte
+++ b/ui/dashboard/src/routes/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script>
   import Home from './home/+page.svelte'
 </script>

--- a/ui/dashboard/src/routes/admin/+page.svelte
+++ b/ui/dashboard/src/routes/admin/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import PageWithMenu from '$internal/components/page/template/menu/index.svelte'
   import { onMount, onDestroy } from 'svelte'
@@ -12,41 +14,41 @@
   import RenderHashWithMiner from '$lib/components/table/renderers/render-hash-with-miner/index.svelte'
 
   // FSM State Management
-  let fsmState: FSMState | null = null
-  let fsmEvents: FSMEvent[] = []
-  let fsmStates: string[] = []
-  let fsmLoading = true
-  let fsmError: string | null = null
-  let apiBaseUrl = ''
+  let fsmState: FSMState | null = $state(null)
+  let fsmEvents: FSMEvent[] = $state([])
+  let fsmStates: string[] = $state([])
+  let fsmLoading = $state(true)
+  let fsmError: string | null = $state(null)
+  let apiBaseUrl = $state('')
   let pollingInterval: any = null
-  let selectedEvent: string | null = null
+  let selectedEvent: string | null = $state(null)
   const POLLING_INTERVAL_MS = 5000 // 5 seconds
 
   // Block invalidation
-  let blockHash = ''
-  let blockActionLoading = false
-  let blockActionResult: { success: boolean; message: string } | null = null
+  let blockHash = $state('')
+  let blockActionLoading = $state(false)
+  let blockActionResult: { success: boolean; message: string } | null = $state(null)
   // Create regex pattern for hash validation
   const hashRegex = /^[0-9a-fA-F]{64}$/
 
   // Invalid blocks list
-  let invalidBlocks: any[] = []
-  let invalidBlocksLoading = false
-  let invalidBlocksError: string | null = null
-  let lastInvalidBlocksRefresh: Date | null = null
-  let invalidBlocksOffset = 0
+  let invalidBlocks: any[] = $state([])
+  let invalidBlocksLoading = $state(false)
+  let invalidBlocksError: string | null = $state(null)
+  let lastInvalidBlocksRefresh: Date | null = $state(null)
+  let invalidBlocksOffset = $state(0)
   const INVALID_BLOCKS_PAGE_SIZE = 5
-  let invalidBlocksHasMore = false
+  let invalidBlocksHasMore = $state(false)
 
-  $: invalidBlocksShowingFrom = invalidBlocks.length > 0 ? invalidBlocksOffset + 1 : 0
-  $: invalidBlocksShowingTo = invalidBlocksOffset + invalidBlocks.length
+  const invalidBlocksShowingFrom = $derived(invalidBlocks.length > 0 ? invalidBlocksOffset + 1 : 0)
+  const invalidBlocksShowingTo = $derived(invalidBlocksOffset + invalidBlocks.length)
 
   // Re-validate block state
-  let revalidatingBlock = false
-  let revalidatingBlockHash = ''
+  let revalidatingBlock = $state(false)
+  let revalidatingBlockHash = $state('')
 
   // Reset peer reputations
-  let resettingReputations = false
+  let resettingReputations = $state(false)
 
   // Subscribe to the API base URL
   const unsubscribe = api.assetHTTPAddress.subscribe((value) => {
@@ -654,7 +656,7 @@
               <div class="error-message">
                 <p><i class="fas fa-exclamation-triangle"></i> {fsmError}</p>
               </div>
-              <button class="btn btn-primary" on:click={handleRefreshClick}>
+              <button class="btn btn-primary" onclick={handleRefreshClick}>
                 <i class="fas fa-sync-alt"></i> Retry
               </button>
             </div>
@@ -680,7 +682,7 @@
                       {#if event && event.name}
                         {@const allowed = isEventAllowedForState(fsmState?.state, event.name)}
                         <button
-                          on:click={() => sendFSMEvent(event.name)}
+                          onclick={() => sendFSMEvent(event.name)}
                           disabled={fsmLoading || !allowed}
                           class="action-button"
                           data-event={event.name.toLowerCase()}
@@ -703,7 +705,7 @@
           {:else}
             <div class="no-state">
               <p>No state information available.</p>
-              <button class="btn btn-primary" on:click={handleRefreshClick}>
+              <button class="btn btn-primary" onclick={handleRefreshClick}>
                 <i class="fas fa-sync-alt"></i> Refresh
               </button>
             </div>
@@ -751,7 +753,7 @@
           <div class="block-actions">
             <button
               class="block-action-button"
-              on:click={() => performBlockAction(api.invalidateBlock, 'invalidate')}
+              onclick={() => performBlockAction(api.invalidateBlock, 'invalidate')}
               disabled={!hashRegex.test(blockHash) || blockActionLoading}
             >
               <i class="fas fa-ban"></i> Invalidate Block
@@ -759,7 +761,7 @@
 
             <button
               class="block-action-button"
-              on:click={() => performBlockAction(api.revalidateBlock, 'revalidate')}
+              onclick={() => performBlockAction(api.revalidateBlock, 'revalidate')}
               disabled={!hashRegex.test(blockHash) || blockActionLoading}
             >
               <i class="fas fa-check-circle"></i> Revalidate Block
@@ -782,7 +784,7 @@
         <div class="refresh-container">
           <button
             class="icon-button with-text"
-            on:click={goToPrevInvalidBlocksPage}
+            onclick={goToPrevInvalidBlocksPage}
             disabled={invalidBlocksLoading || invalidBlocksOffset === 0}
             title="Previous page"
           >
@@ -793,7 +795,7 @@
           </span>
           <button
             class="icon-button with-text"
-            on:click={goToNextInvalidBlocksPage}
+            onclick={goToNextInvalidBlocksPage}
             disabled={invalidBlocksLoading || !invalidBlocksHasMore}
             title="Next page"
           >
@@ -806,7 +808,7 @@
           {/if}
           <button
             class="icon-button"
-            on:click={() => fetchInvalidBlocks()}
+            onclick={() => fetchInvalidBlocks()}
             disabled={invalidBlocksLoading}
             title="Refresh invalidated blocks list"
           >
@@ -832,7 +834,7 @@
               <i class="fas fa-exclamation-circle"></i>
               <p>Error loading invalidated blocks</p>
               <p class="error-message">{invalidBlocksError}</p>
-              <button class="icon-button with-text" on:click={() => fetchInvalidBlocks()}>
+              <button class="icon-button with-text" onclick={() => fetchInvalidBlocks()}>
                 <Icon name="icon-refresh-line" size={16} />
                 <span>Try again</span>
               </button>
@@ -874,7 +876,7 @@
                       <td class="actions-cell">
                         <button
                           class="revalidate-button"
-                          on:click={() => revalidateBlock(block.hash)}
+                          onclick={() => revalidateBlock(block.hash)}
                           disabled={revalidatingBlock}
                         >
                           {#if revalidatingBlock && revalidatingBlockHash === block.hash}
@@ -908,7 +910,7 @@
         <div class="action-buttons">
           <button
             class="action-button neutral"
-            on:click={resetPeerReputations}
+            onclick={resetPeerReputations}
             disabled={resettingReputations}
           >
             {#if resettingReputations}

--- a/ui/dashboard/src/routes/ancestors/+page.svelte
+++ b/ui/dashboard/src/routes/ancestors/+page.svelte
@@ -416,17 +416,6 @@
         value: '',
       }
     },
-    best_height: (idField, item, colId) => {
-      const value = item[colId]
-      return {
-        component: RenderSpan,
-        props: {
-          value: value ? value.toLocaleString() : '-',
-          className: 'num',
-        },
-        value: '',
-      }
-    },
     best_block_hash: (idField, item, colId) => {
       const value = item[colId]
       const shortHash = value ? (value.length > 16 ? `${value.slice(0, 8)}...${value.slice(-8)}` : value) : ''

--- a/ui/dashboard/src/routes/ancestors/+page.svelte
+++ b/ui/dashboard/src/routes/ancestors/+page.svelte
@@ -593,10 +593,12 @@
 
 <PageWithMenu testId="page-root">
   <Card contentPadding="0">
-    <div class="title" slot="title">
-      <Typo variant="title" size="h4" value={t(`${pageKey}.title`, { defaultValue: 'Common Ancestors' })} />
-    </div>
-    <svelte:fragment slot="header-tools">
+    {#snippet title()}
+      <div class="title">
+        <Typo variant="title" size="h4" value={t(`${pageKey}.title`, { defaultValue: 'Common Ancestors' })} />
+      </div>
+    {/snippet}
+    {#snippet headerTools()}
       {#if data.length > 0}
         <Button
           size="small"
@@ -612,7 +614,7 @@
         </div>
         <div class="live-label">{t(`page.network.live`)}</div>
       </div>
-    </svelte:fragment>
+    {/snippet}
     {#if !connected}
       <div class="no-data">
         <Icon name="icon-status-light-glow-solid" size={48} color="var(--comp-label-color)" />

--- a/ui/dashboard/src/routes/ancestors/+page.svelte
+++ b/ui/dashboard/src/routes/ancestors/+page.svelte
@@ -600,7 +600,7 @@
       {#if data.length > 0}
         <Button
           size="small"
-          on:click={refreshAll}
+          onclick={refreshAll}
           disabled={findingAncestors || isLoadingLocator}
         >
           {findingAncestors || isLoadingLocator ? 'Refreshing...' : 'Refresh'}

--- a/ui/dashboard/src/routes/ancestors/+page.svelte
+++ b/ui/dashboard/src/routes/ancestors/+page.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, untrack } from 'svelte'
   import { dev } from '$app/environment'
   import PageWithMenu from '$internal/components/page/template/menu/index.svelte'
   import Card from '$internal/components/card/index.svelte'
@@ -14,22 +16,22 @@
   import RenderSpanWithTooltip from '$lib/components/table/renderers/render-span-with-tooltip/index.svelte'
   import RenderHashWithMiner from '$lib/components/table/renderers/render-hash-with-miner/index.svelte'
   import { get } from 'svelte/store'
-  
-  $: t = $i18n.t
-  
+
+  const t = $derived($i18n.t)
+
   const pageKey = 'page.ancestors'
   const fieldKey = `${pageKey}.fields`
-  
-  let blockLocator: string[] = []
-  let isLoadingLocator = false
-  let data: any[] = []
-  let findingAncestors = false
+
+  let blockLocator: string[] = $state([])
+  let isLoadingLocator = $state(false)
+  let data: any[] = $state([])
+  let findingAncestors = $state(false)
   let ancestorErrors: Map<string, string> = new Map()
   let ancestorData: Map<string, {hash: string, height: number | null, miner?: string}> = new Map()
   let hasInitiallyFetchedAncestors = false
   let fetchedPeers: Set<string> = new Set()
-  
-  $: connected = $sock !== null
+
+  const connected = $derived($sock !== null)
   
   // Update table data
   function updateData() {
@@ -391,8 +393,8 @@
     ]
   }
   
-  $: colDefs = getColDefs()
-  
+  const colDefs = $derived(getColDefs())
+
   // Custom render functions using RenderSpan component
   const renderCells = {
     client_name: (idField, item, colId) => {
@@ -560,30 +562,39 @@
     },
   }
   
-  // React to p2pStore changes - table stays reactive
-  $: {
-    if ($miningNodes) {
-      updateData()
+  // React to p2pStore changes - table stays reactive.
+  // updateData() reads $miningNodes and writes `data`; tracking only the store
+  // (untracking the read/write of `data` inside) avoids a runes update loop.
+  $effect(() => {
+    const nodes = $miningNodes
+    if (nodes) {
+      untrack(() => updateData())
     }
-  }
-  
-  // Fetch ancestors for any peers that haven't been fetched yet
-  $: {
-    if (blockLocator.length > 0 && data.length > 0) {
-      data.forEach((peer, index) => {
-        // If we haven't fetched ancestor for this peer yet, do it now
-        if (!fetchedPeers.has(peer.peer_id) && !peer.isCurrentNode) {
-          fetchAncestorForPeer(peer, index)
+  })
+
+  // Fetch ancestors for any peers that haven't been fetched yet.
+  // Triggered by blockLocator/data changes; fetchAncestorForPeer writes `data`,
+  // so the per-peer loop runs untracked to avoid re-triggering this effect.
+  $effect(() => {
+    const locatorLen = blockLocator.length
+    const currentData = data
+    if (locatorLen > 0 && currentData.length > 0) {
+      untrack(() => {
+        currentData.forEach((peer, index) => {
+          // If we haven't fetched ancestor for this peer yet, do it now
+          if (!fetchedPeers.has(peer.peer_id) && !peer.isCurrentNode) {
+            fetchAncestorForPeer(peer, index)
+          }
+        })
+
+        // Mark that we've done initial fetching
+        if (!hasInitiallyFetchedAncestors) {
+          hasInitiallyFetchedAncestors = true
         }
       })
-      
-      // Mark that we've done initial fetching
-      if (!hasInitiallyFetchedAncestors) {
-        hasInitiallyFetchedAncestors = true
-      }
     }
-  }
-  
+  })
+
   onMount(async () => {
     updateData()
     // Fetch the block locator on mount

--- a/ui/dashboard/src/routes/ancestors/+page.svelte
+++ b/ui/dashboard/src/routes/ancestors/+page.svelte
@@ -643,7 +643,7 @@
         expandUp={true}
         {renderCells}
         getRowIconActions={null}
-        on:action={() => {}}
+        onaction={() => {}}
       />
     {/if}
   </Card>

--- a/ui/dashboard/src/routes/forks/+page.svelte
+++ b/ui/dashboard/src/routes/forks/+page.svelte
@@ -98,7 +98,7 @@
       <Button
         size="small"
         disabled={!nearestForks?.prev_fork}
-        on:click={() => nearestForks?.prev_fork && goToFork(nearestForks.prev_fork.parent_hash)}
+        onclick={() => nearestForks?.prev_fork && goToFork(nearestForks.prev_fork.parent_hash)}
       >
         &larr; Prev fork{nearestForks?.prev_fork ? ` (h: ${nearestForks.prev_fork.height})` : ''}
       </Button>
@@ -112,7 +112,7 @@
       <Button
         size="small"
         disabled={!nearestForks?.next_fork}
-        on:click={() => nearestForks?.next_fork && goToFork(nearestForks.next_fork.parent_hash)}
+        onclick={() => nearestForks?.next_fork && goToFork(nearestForks.next_fork.parent_hash)}
       >
         Next fork{nearestForks?.next_fork ? ` (h: ${nearestForks.next_fork.height})` : ''} &rarr;
       </Button>

--- a/ui/dashboard/src/routes/forks/+page.svelte
+++ b/ui/dashboard/src/routes/forks/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import PageWithMenu from '$internal/components/page/template/menu/index.svelte'
   import { onMount } from 'svelte'
@@ -8,24 +10,26 @@
   import { goto } from '$app/navigation'
   import { Button } from '$lib/components'
 
-  let vis: HTMLDivElement
-  let tree: any
-  let pageSize = 20
-  let mounted = false
-  let lastLoadedHash = ''
+  let vis = $state<HTMLDivElement | undefined>(undefined)
+  let tree: any = $state(null)
+  const pageSize = 20
+  let mounted = $state(false)
+  let lastLoadedHash = $state('')
 
   let nearestForks: {
     current_height: number
     prev_fork: { height: number; parent_hash: string } | null
     next_fork: { height: number; parent_hash: string } | null
-  } | null = null
+  } | null = $state(null)
 
-  $: hash = $page.url.searchParams.get('hash') || ''
-  $: orientation = $page.url.searchParams.get('orientation') || checkOrientation()
+  const hash = $derived($page.url.searchParams.get('hash') || '')
+  const orientation = $derived($page.url.searchParams.get('orientation') || checkOrientation())
 
-  $: if (mounted && hash && hash !== lastLoadedHash) {
-    loadData(hash)
-  }
+  $effect(() => {
+    if (mounted && hash && hash !== lastLoadedHash) {
+      loadData(hash)
+    }
+  })
 
   function checkOrientation() {
     let orientation = 'left-to-right'

--- a/ui/dashboard/src/routes/home/+page.svelte
+++ b/ui/dashboard/src/routes/home/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import HomeStatsCard from '$internal/components/page/home/home-stats-card/index.svelte'
@@ -5,11 +7,11 @@
   import * as api from '$internal/api'
   import { failure } from '$lib/utils/notifications'
 
-  let isMounted = false
+  let isMounted = $state(false)
 
   // stats
-  let statsLoading = true
-  let statsData = {}
+  let statsLoading = $state(true)
+  let statsData = $state({})
 
   async function getStatsData() {
     try {
@@ -83,7 +85,7 @@
   }
 
   // graph
-  export let blockGraphData: any = []
+  let blockGraphData: any = $state([])
 
   async function getBlockGraphData(period: string) {
     const res: any = await api.getBlockGraphData({ period })
@@ -94,17 +96,19 @@
     }
   }
 
-  let period
+  let period = $state<string | undefined>(undefined)
 
-  $: if (isMounted && period) {
-    getBlockGraphData(period)
-  }
+  $effect(() => {
+    if (isMounted && period) {
+      getBlockGraphData(period)
+    }
+  })
 
   function onChangePeriod(value: string) {
     period = value
   }
 
-  let Graph
+  let Graph = $state<any>(undefined)
   onMount(() => {
     // stats
     getStatsData()
@@ -133,12 +137,12 @@
   <div class="content">
     <HomeStatsCard loading={statsLoading} data={statsData} onRefresh={getStatsData} />
     {#if Graph}
-      <svelte:component this={Graph} data={blockGraphData} {period} {onChangePeriod} />
+      <Graph data={blockGraphData} {period} {onChangePeriod} />
     {/if}
   </div>
 </PageWithMenu>
 
-<svelte:window on:keydown={onKeyDown} />
+<svelte:window onkeydown={onKeyDown} />
 
 <style>
   .content {

--- a/ui/dashboard/src/routes/login/+page.svelte
+++ b/ui/dashboard/src/routes/login/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
@@ -9,18 +11,19 @@
   import i18n from '$internal/i18n'
 
   // Form fields
-  let username = ''
-  let password = ''
-  let showPassword = false
-  let loading = false
-  let errorMessage = ''
-  let csrfToken = ''
+  let username = $state('')
+  let password = $state('')
+  let showPassword = $state(false)
+  let loading = $state(false)
+  let errorMessage = $state('')
+  let csrfToken = $state('')
   let passwordTimeout: ReturnType<typeof setTimeout>
-  let passwordStrength = 0
 
   // Subscribe to the auth error store
-  $: errorMessage = $authError
-  $: t = $i18n.t
+  $effect(() => {
+    errorMessage = $authError
+  })
+  const t = $derived($i18n.t)
 
   // Get the redirect URL from the query parameter
   let redirectUrl = '/admin'
@@ -71,15 +74,16 @@
   }
 
   // Update password strength when password changes
-  $: passwordStrength = checkPasswordStrength(password)
+  const passwordStrength = $derived(checkPasswordStrength(password))
 
   // Get strength color based on score
-  $: strengthColor =
+  const strengthColor = $derived(
     passwordStrength < 30
       ? 'var(--color-error)'
       : passwordStrength < 60
         ? 'var(--color-warning)'
-        : 'var(--color-success)'
+        : 'var(--color-success)',
+  )
 
   // Handle form submission
   async function handleSubmit() {
@@ -160,7 +164,10 @@
       {/if}
 
       <form
-        on:submit|preventDefault={handleSubmit}
+        onsubmit={(e) => {
+          e.preventDefault()
+          handleSubmit()
+        }}
         id="login-form"
         name="login-form"
         autocomplete="on"
@@ -192,7 +199,7 @@
             <button
               type="button"
               class="password-toggle password-toggle-left"
-              on:click={togglePasswordVisibility}
+              onclick={togglePasswordVisibility}
               disabled={loading}
               aria-label={showPassword ? 'Hide password' : 'Show password'}
               tabindex="-1"
@@ -292,7 +299,14 @@
       </form>
 
       <div class="back-link-container">
-        <a href="/" class="back-link" on:click|preventDefault={goToDashboard}>
+        <a
+          href="/"
+          class="back-link"
+          onclick={(e) => {
+            e.preventDefault()
+            goToDashboard()
+          }}
+        >
           {t('login.back_to_dashboard', 'Back to Dashboard')}
         </a>
       </div>

--- a/ui/dashboard/src/routes/network/+page.svelte
+++ b/ui/dashboard/src/routes/network/+page.svelte
@@ -238,7 +238,9 @@
       // Keep cache size manageable (only last 10 states)
       if (chainworkCache.size > 10) {
         const firstKey = chainworkCache.keys().next().value
-        chainworkCache.delete(firstKey)
+        if (firstKey !== undefined) {
+          chainworkCache.delete(firstKey)
+        }
       }
     }
     

--- a/ui/dashboard/src/routes/network/+page.svelte
+++ b/ui/dashboard/src/routes/network/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import { page } from '$app/stores'
@@ -11,22 +13,22 @@
   import { miningNodes, sock, currentNodePeerID } from '$internal/stores/p2pStore'
   import i18n from '$internal/i18n'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  $: connected = $sock !== null
+  const connected = $derived($sock !== null)
 
   let nodes: any[] = []
-  let allNodes: any[] = [] // Full dataset
-  let paginatedNodes: any[] = [] // Sliced data for current page
-  
+  let allNodes: any[] = $state([]) // Full dataset
+  let paginatedNodes: any[] = $state([]) // Sliced data for current page
+
   // Persistent pagination state that survives data updates
-  let currentPage = 1
-  let currentPageSize = 10
-  
+  let currentPage = $state(1)
+  let currentPageSize = $state(10)
+
   // Persistent sort state
-  let sortColumn = ''
-  let sortOrder = ''
-  
+  let sortColumn = $state('')
+  let sortOrder = $state('')
+
   // Load sort from localStorage on mount
   if (browser) {
     const savedSort = loadSortFromStorage()
@@ -35,15 +37,17 @@
       sortOrder = savedSort.sortOrder
     }
   }
-  
+
   // Cache for chainwork calculations to avoid recalculation
-  let chainworkCache = new Map<string, Map<string, number>>()
-  
+  const chainworkCache = new Map<string, Map<string, number>>()
+
   // Force update of paginatedNodes when tick changes to update relative time displays
-  $: if (tickCounter >= 0 && allNodes.length > 0) {
-    updatePaginatedNodes()
-  }
-  
+  $effect(() => {
+    if (tickCounter >= 0 && allNodes.length > 0) {
+      updatePaginatedNodes()
+    }
+  })
+
   // Local storage keys for persistence
   const NETWORK_PAGE_SIZE_KEY = 'teranode-network-pagesize'
   const NETWORK_SORT_KEY = 'teranode-network-sort'
@@ -104,7 +108,7 @@
   }
 
   // Get pagination from URL and localStorage with priority: URL > localStorage > Default
-  $: {
+  $effect(() => {
     // First, try to get pageSize from URL (highest priority)
     const urlPageSize = $page.url.searchParams.get('pageSize')
     if (urlPageSize) {
@@ -116,7 +120,7 @@
       // If no URL parameter, use localStorage default
       currentPageSize = loadPageSizeFromStorage()
     }
-    
+
     // Get page from URL
     const urlPage = $page.url.searchParams.get('page')
     if (urlPage) {
@@ -127,10 +131,10 @@
     } else {
       currentPage = 1 // Always reset to page 1 if not in URL
     }
-    
+
     // Update paginated data when URL changes
     updatePaginatedNodes()
-  }
+  })
 
   // Update URL when pagination changes
   function updateURL(newPage: number, newPageSize: number) {
@@ -299,18 +303,22 @@
   }
 
   // Subscribe to miningNodes changes from WebSocket
-  $: if ($miningNodes) {
-    updateData()
-  }
-  
+  $effect(() => {
+    if ($miningNodes) {
+      updateData()
+    }
+  })
+
   // Also subscribe to currentNodePeerID changes to update isCurrentNode flags
-  $: if ($currentNodePeerID) {
-    updateData()
-  }
-  
+  $effect(() => {
+    if ($currentNodePeerID) {
+      updateData()
+    }
+  })
+
   // Add a ticker ONLY for re-rendering the relative time display
   // This doesn't recalculate data, just forces component updates
-  let tickCounter = 0
+  let tickCounter = $state(0)
   onMount(() => {
     const ticker = setInterval(() => {
       tickCounter++

--- a/ui/dashboard/src/routes/network/+page.svelte
+++ b/ui/dashboard/src/routes/network/+page.svelte
@@ -146,7 +146,7 @@
   }
 
   function onPageChange(e) {
-    const data = e.detail
+    const data = e
     const newPage = data.value.page
     const newPageSize = data.value.pageSize
     
@@ -162,7 +162,7 @@
   }
   
   function onSort(e) {
-    const { colId, value } = e.detail
+    const { colId, value } = e
     sortColumn = colId
     sortOrder = value
 
@@ -329,7 +329,7 @@
     pageSize={currentPageSize}
     {sortColumn}
     {sortOrder}
-    on:pagechange={onPageChange}
-    on:sort={onSort}
+    onpagechange={onPageChange}
+    onsort={onSort}
   />
 </PageWithMenu>

--- a/ui/dashboard/src/routes/p2p/+page.svelte
+++ b/ui/dashboard/src/routes/p2p/+page.svelte
@@ -241,7 +241,7 @@
           icon="icon-status-light-glow-solid"
           iconColor={connected ? '#15B241' : '#CE1722'}
           uppercase={true}
-          on:click={onLive}
+          onclick={onLive}
         >
           {usingLiveData ? t(`${pageKey}.live`) : t(`${pageKey}.paused`)}
         </Button>

--- a/ui/dashboard/src/routes/p2p/+page.svelte
+++ b/ui/dashboard/src/routes/p2p/+page.svelte
@@ -1,6 +1,7 @@
-<script lang="ts">
-  import { afterUpdate } from 'svelte'
+<svelte:options runes={true} />
 
+<script lang="ts">
+  import { untrack } from 'svelte'
   import PageWithMenu from '$internal/components/page/template/menu/index.svelte'
   import MessageBox from '$internal/components/msgbox/index.svelte'
   import Typo from '$internal/components/typo/index.svelte'
@@ -11,13 +12,13 @@
   import { messages, sock, connectionAttempts, currentNodePeerID } from '$internal/stores/p2pStore'
   import i18n from '$internal/i18n'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
-  $: connected = $sock !== null
+  const connected = $derived($sock !== null)
 
   const pageKey = 'page.p2p'
 
-  let innerWidth = 0
+  let innerWidth = $state(0)
 
   function scrollToTop() {
     if (!import.meta.env.SSR && window && window.scrollTo) {
@@ -30,29 +31,25 @@
     }
   }
 
-  afterUpdate(() => {
-    scrollToTop()
-  })
+  let collapseMsgContent = $state(false)
 
-  let collapseMsgContent = false
+  let byPeer = $state(false)
+  let rawMode = $state(false) // Toggle for showing raw JSON
+  let filter = $state('')
+  let showLocalMessages = $state(false) // Toggle for showing local messages (off by default)
+  let groupedMessages: any = $state({})
+  let filteredMessages: any[] = $state([])
+  let peers: string[] = $state([])
+  let peerClientNames: { [key: string]: string } = $state({}) // Map peer IDs to client names
 
   // In by-peer mode, always collapse messages for compact view
-  $: actualCollapseState = byPeer ? true : collapseMsgContent
-
-  let byPeer = false
-  let rawMode = false // Toggle for showing raw JSON
-  let filter = ''
-  let showLocalMessages = false // Toggle for showing local messages (off by default)
-  let groupedMessages: any = {}
-  let filteredMessages: any[] = []
-  let peers: string[] = []
-  let peerClientNames: { [key: string]: string } = {} // Map peer IDs to client names
+  const actualCollapseState = $derived(byPeer ? true : collapseMsgContent)
 
   // Message type filter
-  let messageTypeSet = new Set(['All'])
-  let messageTypeOptions: string[] = ['All']
-  let selectedMessageType = 'All'
-  let reverseFilter = false
+  const messageTypeSet = new Set(['All'])
+  let messageTypeOptions: string[] = $state(['All'])
+  let selectedMessageType = $state('All')
+  let reverseFilter = $state(false)
 
   // Function to process message types
   function processMessageType(messageType: string) {
@@ -68,7 +65,7 @@
     }
   }
 
-  let dataSnapshot: any = null
+  let dataSnapshot: any = $state(null)
 
   function onLive() {
     if (dataSnapshot) {
@@ -78,101 +75,129 @@
     }
   }
 
-  $: usingLiveData = dataSnapshot === null
+  const usingLiveData = $derived(dataSnapshot === null)
 
-  $: data = dataSnapshot ? dataSnapshot : $messages
+  const data = $derived(dataSnapshot ? dataSnapshot : $messages)
 
-  $: {
-    // Transform types to be lower case, as they have been changing case in the BE
-    // Filter messages based on the showLocalMessages toggle
-    filteredMessages = data
-      .filter((item) => {
-        // Only filter out local messages if showLocalMessages is false
-        if (!showLocalMessages && $currentNodePeerID) {
-          // Check if the message is from the current node using peer_id
-          const messagePeerId = item.peer_id || item.peerID || item.peer
-          return messagePeerId !== $currentNodePeerID // Keep message if it's NOT from current node
-        }
-        return true
-      })
-      .map((item) => {
-        // Process message type for dropdown
-        const lowerType = item.type?.toLowerCase()
-        processMessageType(lowerType)
-        return { ...item, type: lowerType }
-      })
+  $effect(() => {
+    // Read all genuine reactive inputs up front so the effect re-runs when they
+    // change. The body then runs untracked, so writing to (and re-reading)
+    // filteredMessages / groupedMessages / peers does not self-trigger the effect.
+    const inData = data
+    const inShowLocal = showLocalMessages
+    const inCurrentPeer = $currentNodePeerID
+    const inSelectedType = selectedMessageType
+    const inReverse = reverseFilter
+    const inFilter = filter
+    const inByPeer = byPeer
+    const inInnerWidth = innerWidth
+    const inContentLeft = $contentLeft
 
-    // Apply message type filter
-    if (selectedMessageType !== 'All') {
-      if (reverseFilter) {
-        filteredMessages = filteredMessages.filter((msg) => msg.type !== selectedMessageType)
-      } else {
-        filteredMessages = filteredMessages.filter((msg) => msg.type === selectedMessageType)
-      }
-    }
-
-    if (filter.length > 0) {
-      const f = filter.toLowerCase()
-
-      filteredMessages = filteredMessages.filter((message) => {
-        // More targeted search - check specific fields instead of entire JSON
-        return (
-          message.type?.toLowerCase().includes(f) ||
-          message.hash?.toLowerCase().includes(f) ||
-          message.base_url?.toLowerCase().includes(f) ||
-          message.miner?.toLowerCase().includes(f) ||
-          message.miner_name?.toLowerCase().includes(f) ||
-          message.client_name?.toLowerCase().includes(f) ||
-          message.peer_id?.toLowerCase().includes(f) ||
-          message.peerID?.toLowerCase().includes(f) ||
-          message.peer?.toLowerCase().includes(f) ||
-          message.fsm_state?.toLowerCase().includes(f) ||
-          message.version?.toLowerCase().includes(f)
-        )
-      })
-    }
-
-    if (byPeer) {
-      let newGroupedMessages: any = {}
-      let newPeerClientNames: { [key: string]: string } = {}
-
-      filteredMessages.forEach((message, index) => {
-        // Compare with lowercase since we convert types to lowercase
-        if (message.type !== MessageType.ping.toLowerCase()) {
-          // Check for peer_id, peerID, or peer field
-          const peerId = message.peer_id || message.peerID || message.peer || 'unknown'
-
-          if (!newGroupedMessages[peerId]) {
-            newGroupedMessages[peerId] = []
+    untrack(() => {
+      // Transform types to be lower case, as they have been changing case in the BE
+      // Filter messages based on the showLocalMessages toggle
+      let newFiltered = inData
+        .filter((item) => {
+          // Only filter out local messages if showLocalMessages is false
+          if (!inShowLocal && inCurrentPeer) {
+            // Check if the message is from the current node using peer_id
+            const messagePeerId = item.peer_id || item.peerID || item.peer
+            return messagePeerId !== inCurrentPeer // Keep message if it's NOT from current node
           }
-          newGroupedMessages[peerId].push(message)
-
-          // Extract client name if available and not already stored
-          if (!newPeerClientNames[peerId] && message.client_name) {
-            newPeerClientNames[peerId] = message.client_name
-          }
-        } else {
-        }
-      })
-
-      // Sort messages in descending order by receivedAt timestamp
-      Object.keys(newGroupedMessages).forEach((peer_id) => {
-        newGroupedMessages[peer_id].sort((a: any, b: any) => {
-          // Sort by receivedAt in descending order (newest first)
-          return new Date(b.receivedAt).getTime() - new Date(a.receivedAt).getTime()
+          return true
         })
-      })
+        .map((item) => {
+          // Process message type for dropdown
+          const lowerType = item.type?.toLowerCase()
+          processMessageType(lowerType)
+          return { ...item, type: lowerType }
+        })
 
-      groupedMessages = newGroupedMessages
-      peerClientNames = newPeerClientNames
-    }
+      // Apply message type filter
+      if (inSelectedType !== 'All') {
+        if (inReverse) {
+          newFiltered = newFiltered.filter((msg) => msg.type !== inSelectedType)
+        } else {
+          newFiltered = newFiltered.filter((msg) => msg.type === inSelectedType)
+        }
+      }
 
-    peers = Object.keys(groupedMessages).length > 0 ? Object.keys(groupedMessages) : []
-    peers = peers.sort()
+      if (inFilter.length > 0) {
+        const f = inFilter.toLowerCase()
 
-    const msgboxW = byPeer ? (innerWidth - $contentLeft) / peers.length : innerWidth - $contentLeft
-    collapseMsgContent = msgboxW < 500
-  }
+        newFiltered = newFiltered.filter((message) => {
+          // More targeted search - check specific fields instead of entire JSON
+          return (
+            message.type?.toLowerCase().includes(f) ||
+            message.hash?.toLowerCase().includes(f) ||
+            message.base_url?.toLowerCase().includes(f) ||
+            message.miner?.toLowerCase().includes(f) ||
+            message.miner_name?.toLowerCase().includes(f) ||
+            message.client_name?.toLowerCase().includes(f) ||
+            message.peer_id?.toLowerCase().includes(f) ||
+            message.peerID?.toLowerCase().includes(f) ||
+            message.peer?.toLowerCase().includes(f) ||
+            message.fsm_state?.toLowerCase().includes(f) ||
+            message.version?.toLowerCase().includes(f)
+          )
+        })
+      }
+
+      filteredMessages = newFiltered
+
+      if (inByPeer) {
+        let newGroupedMessages: any = {}
+        let newPeerClientNames: { [key: string]: string } = {}
+
+        newFiltered.forEach((message) => {
+          // Compare with lowercase since we convert types to lowercase
+          if (message.type !== MessageType.ping.toLowerCase()) {
+            // Check for peer_id, peerID, or peer field
+            const peerId = message.peer_id || message.peerID || message.peer || 'unknown'
+
+            if (!newGroupedMessages[peerId]) {
+              newGroupedMessages[peerId] = []
+            }
+            newGroupedMessages[peerId].push(message)
+
+            // Extract client name if available and not already stored
+            if (!newPeerClientNames[peerId] && message.client_name) {
+              newPeerClientNames[peerId] = message.client_name
+            }
+          }
+        })
+
+        // Sort messages in descending order by receivedAt timestamp
+        Object.keys(newGroupedMessages).forEach((peer_id) => {
+          newGroupedMessages[peer_id].sort((a: any, b: any) => {
+            // Sort by receivedAt in descending order (newest first)
+            return new Date(b.receivedAt).getTime() - new Date(a.receivedAt).getTime()
+          })
+        })
+
+        groupedMessages = newGroupedMessages
+        peerClientNames = newPeerClientNames
+      }
+
+      const newPeers =
+        Object.keys(groupedMessages).length > 0 ? Object.keys(groupedMessages).sort() : []
+      peers = newPeers
+
+      const msgboxW = inByPeer
+        ? (inInnerWidth - inContentLeft) / newPeers.length
+        : inInnerWidth - inContentLeft
+      collapseMsgContent = msgboxW < 500
+    })
+  })
+
+  // Scroll to top after the message list re-renders (replaces afterUpdate)
+  $effect(() => {
+    // Touch the reactive values that drive a re-render so this fires after them
+    void filteredMessages
+    void groupedMessages
+    void byPeer
+    scrollToTop()
+  })
 </script>
 
 <svelte:window bind:innerWidth />

--- a/ui/dashboard/src/routes/peers/+page.svelte
+++ b/ui/dashboard/src/routes/peers/+page.svelte
@@ -800,7 +800,7 @@
         on:total={onTotal}
       />
       {#if allData.length > 0}
-        <Button size="small" on:click={fetchPeers} disabled={isLoading}>
+        <Button size="small" onclick={fetchPeers} disabled={isLoading}>
           {isLoading ? 'Refreshing...' : 'Refresh'}
         </Button>
       {/if}
@@ -821,7 +821,7 @@
         <Icon name="icon-status-light-glow-solid" size={48} color="#ff6b6b" />
         <p>Failed to load peer data</p>
         <p class="sub">{error}</p>
-        <Button size="small" on:click={fetchPeers} disabled={isLoading}>
+        <Button size="small" onclick={fetchPeers} disabled={isLoading}>
           Retry
         </Button>
       </div>

--- a/ui/dashboard/src/routes/peers/+page.svelte
+++ b/ui/dashboard/src/routes/peers/+page.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte'
+  import { onMount, onDestroy, untrack } from 'svelte'
   import { page } from '$app/stores'
   import { goto } from '$app/navigation'
   import { browser } from '$app/environment'
@@ -15,7 +17,7 @@
   import RenderSpanWithTooltip from '$lib/components/table/renderers/render-span-with-tooltip/index.svelte'
   import RenderLink from '$lib/components/table/renderers/render-link/index.svelte'
 
-  $: t = $i18n.t
+  const t = $derived($i18n.t)
 
   const pageKey = 'page.peers'
 
@@ -78,28 +80,28 @@
     previous_attempt?: PreviousAttemptData
   }
 
-  let allData: PeerData[] = []  // Full dataset
-  let data: PeerData[] = []      // Paginated data for display
-  let catchupStatus: CatchupStatusData | null = null
-  let isLoading = false
-  let error: string | null = null
+  let allData: PeerData[] = $state([])  // Full dataset
+  let data: PeerData[] = $state([])      // Paginated data for display
+  let catchupStatus: CatchupStatusData | null = $state(null)
+  let isLoading = $state(false)
+  let error: string | null = $state(null)
   let refreshInterval: number | null = null
   let catchupRefreshInterval: number | null = null
 
   // Modal state
-  let showCatchupModal = false
-  let selectedPeer: PeerData | null = null
+  let showCatchupModal = $state(false)
+  let selectedPeer: PeerData | null = $state(null)
 
   // Persistent pagination state
-  let currentPage = 1
-  let currentPageSize = 25
+  let currentPage = $state(1)
+  let currentPageSize = $state(25)
 
   // Persistent sort state
-  let sortColumn = ''
-  let sortOrder = ''
+  let sortColumn = $state('')
+  let sortOrder = $state('')
 
   // Memoized sorted data
-  let sortedData: PeerData[] = []
+  let sortedData: PeerData[] = $state([])
 
   // Local storage keys for persistence
   const PEERS_PAGE_SIZE_KEY = 'teranode-peers-pagesize'
@@ -178,34 +180,40 @@
     }
   }
 
-  // Get pagination from URL and localStorage
-  $: {
-    // First, try to get pageSize from URL (highest priority)
-    const urlPageSize = $page.url.searchParams.get('pageSize')
-    if (urlPageSize) {
-      const parsed = parseInt(urlPageSize, 10)
-      if (parsed > 0 && parsed <= 100) {
-        currentPageSize = parsed
+  // Get pagination from URL and localStorage.
+  // Tracks the page store (URL changes); the body both reads and writes
+  // currentPage/currentPageSize via updatePaginatedData, so it runs untracked
+  // to avoid a runes update loop.
+  $effect(() => {
+    const url = $page.url
+    untrack(() => {
+      // First, try to get pageSize from URL (highest priority)
+      const urlPageSize = url.searchParams.get('pageSize')
+      if (urlPageSize) {
+        const parsed = parseInt(urlPageSize, 10)
+        if (parsed > 0 && parsed <= 100) {
+          currentPageSize = parsed
+        }
+      } else {
+        // If no URL parameter, use localStorage default
+        currentPageSize = loadPageSizeFromStorage()
       }
-    } else {
-      // If no URL parameter, use localStorage default
-      currentPageSize = loadPageSizeFromStorage()
-    }
 
-    // Get page from URL
-    const urlPage = $page.url.searchParams.get('page')
-    if (urlPage) {
-      const parsed = parseInt(urlPage, 10)
-      if (parsed > 0) {
-        currentPage = parsed
+      // Get page from URL
+      const urlPage = url.searchParams.get('page')
+      if (urlPage) {
+        const parsed = parseInt(urlPage, 10)
+        if (parsed > 0) {
+          currentPage = parsed
+        }
+      } else {
+        currentPage = 1 // Always reset to page 1 if not in URL
       }
-    } else {
-      currentPage = 1 // Always reset to page 1 if not in URL
-    }
 
-    // Update paginated data when URL changes
-    updatePaginatedData()
-  }
+      // Update paginated data when URL changes
+      updatePaginatedData()
+    })
+  })
 
   // Update URL when pagination changes
   function updateURL(newPage: number, newPageSize: number) {
@@ -402,18 +410,18 @@
     console.log('Table action:', event)
   }
 
-  $: hasSorting = sortColumn && sortOrder
+  const hasSorting = $derived(sortColumn && sortOrder)
 
   // The internal Pager does not emit a "total" event, so totalPages is never
   // updated from it and stays at its initial value (behaviour unchanged from
   // the previous dead on:total listener).
-  let totalPages = 0
+  const totalPages: number = 0
 
-  $: showPagerNav = totalPages > 1
-  $: showPagerSize = showPagerNav || (totalPages === 1 && allData.length > 5)
-  $: showTableFooter = showPagerSize
+  const showPagerNav = $derived(totalPages > 1)
+  const showPagerSize = $derived(showPagerNav || (totalPages === 1 && allData.length > 5))
+  const showTableFooter = $derived(showPagerSize)
 
-  $: i18nLocal = { t, baseKey: 'comp.pager' }
+  const i18nLocal = $derived({ t, baseKey: 'comp.pager' })
 
   // Format error type to human-readable string
   function formatErrorType(errorType: string): string {
@@ -484,7 +492,7 @@
     ]
   }
 
-  $: colDefs = getColDefs()
+  const colDefs = $derived(getColDefs())
 
   // Custom render functions
   const renderCells = {
@@ -806,7 +814,7 @@
         </Button>
       {/if}
       {#if hasSorting}
-        <button class="clear-sort-btn" on:click={clearSort} title="Clear sorting">
+        <button class="clear-sort-btn" onclick={clearSort} title="Clear sorting">
           <Icon name="icon-close-line" size={16} />
         </button>
       {/if}
@@ -887,33 +895,33 @@
 </PageWithMenu>
 
 {#if showCatchupModal && selectedPeer}
-  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="modal-overlay"
     role="presentation"
-    on:click={() => {
+    onclick={() => {
       showCatchupModal = false
       selectedPeer = null
     }}
-    on:keydown={(e) => {
+    onkeydown={(e) => {
       if (e.key === 'Escape') {
         showCatchupModal = false
         selectedPeer = null
       }
     }}
   >
-    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
       class="modal-content"
       role="dialog"
       aria-modal="true"
       aria-labelledby="modal-title"
-      on:click|stopPropagation
-      on:keydown|stopPropagation
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
     >
       <div class="modal-header">
         <h2 id="modal-title" class="modal-title">Catchup Details - {selectedPeer.client_name || selectedPeer.id}</h2>
-        <button class="modal-close" on:click={() => {
+        <button class="modal-close" onclick={() => {
           showCatchupModal = false
           selectedPeer = null
         }}>×</button>

--- a/ui/dashboard/src/routes/peers/+page.svelte
+++ b/ui/dashboard/src/routes/peers/+page.svelte
@@ -857,7 +857,7 @@
           sortOrder,
         }}
         sortEnabled={true}
-        serverSort={true}
+        useServerSort={true}
         pagination={{
           page: 1,
           pageSize: -1,

--- a/ui/dashboard/src/routes/peers/+page.svelte
+++ b/ui/dashboard/src/routes/peers/+page.svelte
@@ -352,7 +352,7 @@
 
   // Handle pagination changes
   function onPageChange(e) {
-    const data = e.detail
+    const data = e
     const newPage = data.value.page
     const newPageSize = data.value.pageSize
 
@@ -369,7 +369,7 @@
 
   // Handle sort changes
   function onSort(e) {
-    const { colId, value } = e.detail
+    const { colId, value } = e
     sortColumn = colId || ''
     sortOrder = value || ''
 
@@ -393,21 +393,21 @@
 
   // Clear sort
   function clearSort() {
-    onSort({ detail: { colId: '', value: '' } })
+    onSort({ colId: '', value: '' })
   }
 
   // Handle table actions
   function handleAction(event) {
     // Handle any table actions if needed
-    console.log('Table action:', event.detail)
+    console.log('Table action:', event)
   }
 
   $: hasSorting = sortColumn && sortOrder
 
+  // The internal Pager does not emit a "total" event, so totalPages is never
+  // updated from it and stays at its initial value (behaviour unchanged from
+  // the previous dead on:total listener).
   let totalPages = 0
-  const onTotal = (e) => {
-    totalPages = e.detail.total
-  }
 
   $: showPagerNav = totalPages > 1
   $: showPagerSize = showPagerNav || (totalPages === 1 && allData.length > 5)
@@ -798,8 +798,7 @@
           pageSize: currentPageSize,
         }}
         hasBoundaryRight={true}
-        on:change={onPageChange}
-        on:total={onTotal}
+        onchange={onPageChange}
       />
       {#if allData.length > 0}
         <Button size="small" onclick={fetchPeers} disabled={isLoading}>
@@ -862,8 +861,8 @@
         {renderCells}
         getRenderProps={null}
         getRowIconActions={null}
-        on:sort={onSort}
-        on:action={handleAction}
+        onsort={onSort}
+        onaction={handleAction}
       />
     {/if}
     {#snippet footer()}
@@ -880,7 +879,7 @@
             pageSize: currentPageSize,
           }}
           hasBoundaryRight={true}
-          on:change={onPageChange}
+          onchange={onPageChange}
         />
       </div>
     {/snippet}

--- a/ui/dashboard/src/routes/peers/+page.svelte
+++ b/ui/dashboard/src/routes/peers/+page.svelte
@@ -762,10 +762,12 @@
   {/if}
 
   <Card contentPadding="0" showFooter={showTableFooter}>
-    <div class="title" slot="title">
-      <Typo variant="title" size="h4" value={t(`${pageKey}.title`, { defaultValue: 'Peer Registry' })} />
-    </div>
-    <svelte:fragment slot="header-tools">
+    {#snippet title()}
+      <div class="title">
+        <Typo variant="title" size="h4" value={t(`${pageKey}.title`, { defaultValue: 'Peer Registry' })} />
+      </div>
+    {/snippet}
+    {#snippet headerTools()}
       <div class="stats">
         <span class="stat-item">
           <span class="stat-label">Total:</span>
@@ -815,7 +817,7 @@
         </div>
         <div class="live-label">{t(`page.network.live`)}</div>
       </div>
-    </svelte:fragment>
+    {/snippet}
     {#if error}
       <div class="no-data">
         <Icon name="icon-status-light-glow-solid" size={48} color="#ff6b6b" />
@@ -864,22 +866,24 @@
         on:action={handleAction}
       />
     {/if}
-    <div slot="footer">
-      <Pager
-        i18n={i18nLocal}
-        expandUp={true}
-        totalItems={allData?.length}
-        showPageSize={showPagerSize}
-        showQuickNav={showPagerNav}
-        showNav={showPagerNav}
-        value={{
-          page: currentPage,
-          pageSize: currentPageSize,
-        }}
-        hasBoundaryRight={true}
-        on:change={onPageChange}
-      />
-    </div>
+    {#snippet footer()}
+      <div>
+        <Pager
+          i18n={i18nLocal}
+          expandUp={true}
+          totalItems={allData?.length}
+          showPageSize={showPagerSize}
+          showQuickNav={showPagerNav}
+          showNav={showPagerNav}
+          value={{
+            page: currentPage,
+            pageSize: currentPageSize,
+          }}
+          hasBoundaryRight={true}
+          on:change={onPageChange}
+        />
+      </div>
+    {/snippet}
   </Card>
 </PageWithMenu>
 

--- a/ui/dashboard/src/routes/settings/+page.svelte
+++ b/ui/dashboard/src/routes/settings/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import PageWithMenu from '$internal/components/page/template/menu/index.svelte'
@@ -7,21 +9,21 @@
   import Markdown from 'svelte-exmarkdown'
   import { gfmPlugin } from 'svelte-exmarkdown/gfm'
 
-  let settings: SettingMetadata[] = []
-  let categories: string[] = []
-  let loading = true
-  let error: string | null = null
-  let version = ''
-  let commit = ''
-  let total = 0
-  let filtered = 0
+  let settings = $state<SettingMetadata[]>([])
+  let categories = $state<string[]>([])
+  let loading = $state(true)
+  let error = $state<string | null>(null)
+  let version = $state('')
+  let commit = $state('')
+  let total = $state(0)
+  let filtered = $state(0)
 
   // Filter state
-  let selectedCategory = ''
-  let searchQuery = ''
+  let selectedCategory = $state('')
+  let searchQuery = $state('')
   let searchTimeout: ReturnType<typeof setTimeout> | null = null
   // Use an object for reactivity instead of Set
-  let expandedKeys: Record<string, boolean> = {}
+  let expandedKeys = $state<Record<string, boolean>>({})
 
   // Column resizing state
   const COLUMN_WIDTHS_STORAGE_KEY = 'settings-table-column-widths'
@@ -33,7 +35,7 @@
     description: 46
   }
 
-  let columnWidths = { ...defaultColumnWidths }
+  let columnWidths = $state({ ...defaultColumnWidths })
   let resizingColumn: string | null = null
   let resizeStartX = 0
   let resizeStartWidth = 0
@@ -141,7 +143,6 @@
 
   function toggleExpanded(key: string) {
     expandedKeys[key] = !expandedKeys[key]
-    expandedKeys = expandedKeys // Trigger reactivity
   }
 
   function formatValue(value: string, type: string): string {
@@ -256,18 +257,18 @@
           <input
             type="text"
             placeholder={t('page.settings.search-placeholder', 'Search settings...')}
-            on:input={handleSearchInput}
+            oninput={handleSearchInput}
             bind:value={searchQuery}
             class="search-input"
           />
           {#if searchQuery}
-            <button class="clear-search" on:click={() => { searchQuery = ''; fetchSettings(); }}>
+            <button class="clear-search" onclick={() => { searchQuery = ''; fetchSettings(); }}>
               <Icon name="icon-close-line" size={16} />
             </button>
           {/if}
         </div>
 
-        <button class="reset-columns-btn" on:click={resetColumnWidths} title="Reset column widths to default">
+        <button class="reset-columns-btn" onclick={resetColumnWidths} title="Reset column widths to default">
           <Icon name="icon-layout-column-line" size={16} />
           <span>Reset Columns</span>
         </button>
@@ -277,7 +278,7 @@
         <button
           class="category-btn"
           class:active={selectedCategory === ''}
-          on:click={() => handleCategoryChange('')}
+          onclick={() => handleCategoryChange('')}
         >
           {t('page.settings.all-categories', 'All Categories')}
         </button>
@@ -285,7 +286,7 @@
           <button
             class="category-btn"
             class:active={selectedCategory === category}
-            on:click={() => handleCategoryChange(category)}
+            onclick={() => handleCategoryChange(category)}
           >
             {category}
           </button>
@@ -302,7 +303,7 @@
       <div class="error-container">
         <Icon name="icon-warning-line" size={48} />
         <p class="error-message">{error}</p>
-        <button class="retry-btn" on:click={fetchSettings}>
+        <button class="retry-btn" onclick={fetchSettings}>
           <Icon name="icon-refresh-line" size={18} />
           <span>Retry</span>
         </button>
@@ -311,7 +312,7 @@
       <div class="empty-container">
         <Icon name="icon-search-line" size={48} />
         <p>No settings found matching your criteria</p>
-        <button class="clear-btn" on:click={clearFilters}>
+        <button class="clear-btn" onclick={clearFilters}>
           Clear filters
         </button>
       </div>
@@ -323,25 +324,25 @@
               <th class="col-key" style="width: {columnWidths.key}%">
                 <div class="th-content">
                   {t('page.settings.col-key', 'Config Key')}
-                  <div class="resize-handle" on:mousedown={(e) => startResize('key', e)}></div>
+                  <div class="resize-handle" onmousedown={(e) => startResize('key', e)}></div>
                 </div>
               </th>
               <th class="col-type" style="width: {columnWidths.type}%">
                 <div class="th-content">
                   Type
-                  <div class="resize-handle" on:mousedown={(e) => startResize('type', e)}></div>
+                  <div class="resize-handle" onmousedown={(e) => startResize('type', e)}></div>
                 </div>
               </th>
               <th class="col-default" style="width: {columnWidths.default}%">
                 <div class="th-content">
                   {t('page.settings.col-default', 'Default')}
-                  <div class="resize-handle" on:mousedown={(e) => startResize('default', e)}></div>
+                  <div class="resize-handle" onmousedown={(e) => startResize('default', e)}></div>
                 </div>
               </th>
               <th class="col-current" style="width: {columnWidths.current}%">
                 <div class="th-content">
                   {t('page.settings.col-current', 'Current')}
-                  <div class="resize-handle" on:mousedown={(e) => startResize('current', e)}></div>
+                  <div class="resize-handle" onmousedown={(e) => startResize('current', e)}></div>
                 </div>
               </th>
               <th class="col-description" style="width: {columnWidths.description}%">
@@ -363,7 +364,7 @@
                     {#if setting.longDescription}
                       <button
                         class="expand-btn"
-                        on:click={() => toggleExpanded(uniqueKey)}
+                        onclick={() => toggleExpanded(uniqueKey)}
                         aria-expanded={expandedKeys[uniqueKey] || false}
                       >
                         <Icon name={expandedKeys[uniqueKey] ? 'icon-arrow-up-s-line' : 'icon-arrow-down-s-line'} size={16} />

--- a/ui/dashboard/src/routes/viewer/+page.svelte
+++ b/ui/dashboard/src/routes/viewer/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import BlocksTableCard from '$internal/components/page/viewer/blocks/blocks-table-card/index.svelte'
 

--- a/ui/dashboard/src/routes/viewer/[type]/+page.svelte
+++ b/ui/dashboard/src/routes/viewer/[type]/+page.svelte
@@ -1,5 +1,6 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { beforeUpdate } from 'svelte'
   import { page } from '$app/stores'
 
   import BlockDetails from '$internal/components/page/viewer/block/index.svelte'
@@ -9,13 +10,8 @@
   import PageWithMenu from '$internal/components/page/template/menu/index.svelte'
   import { DetailType } from '$internal/utils/urls'
 
-  let ready = false
-  beforeUpdate(() => {
-    ready = true
-  })
-
-  $: type = $page.params.type
-  $: hash = ready ? $page.url.searchParams.get('hash') ?? '' : ''
+  const type = $derived($page.params.type)
+  const hash = $derived($page.url.searchParams.get('hash') ?? '')
 </script>
 
 <PageWithMenu testId="page-root">

--- a/ui/dashboard/src/routes/wstest/+page.svelte
+++ b/ui/dashboard/src/routes/wstest/+page.svelte
@@ -1,15 +1,17 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import { Button, TextInput } from '$lib/components'
   import Card from '$internal/components/card/index.svelte'
   import Typo from '$internal/components/typo/index.svelte'
 
-  let wsUrl = 'ws://localhost:9906/p2p-ws'
+  let wsUrl = $state('ws://localhost:9906/p2p-ws')
   let socket: WebSocket | null = null
-  let connected = false
-  let messages: any[] = []
-  let firstNodeStatus: any = null
-  let connectionLog: string[] = []
+  let connected = $state(false)
+  let messages: any[] = $state([])
+  let firstNodeStatus: any = $state(null)
+  let connectionLog: string[] = $state([])
 
   function addLog(msg: string) {
     connectionLog = [...connectionLog, `[${new Date().toISOString()}] ${msg}`]

--- a/ui/dashboard/src/routes/wstest/+page.svelte
+++ b/ui/dashboard/src/routes/wstest/+page.svelte
@@ -142,7 +142,7 @@
       {#if !connected}
         <Button onclick={connect} variant="primary">Connect</Button>
       {:else}
-        <Button onclick={disconnect} variant="danger">Disconnect</Button>
+        <Button onclick={disconnect} variant="destructive">Disconnect</Button>
       {/if}
 
       <div class="status">

--- a/ui/dashboard/src/routes/wstest/+page.svelte
+++ b/ui/dashboard/src/routes/wstest/+page.svelte
@@ -136,9 +136,9 @@
       />
 
       {#if !connected}
-        <Button on:click={connect} variant="primary">Connect</Button>
+        <Button onclick={connect} variant="primary">Connect</Button>
       {:else}
-        <Button on:click={disconnect} variant="danger">Disconnect</Button>
+        <Button onclick={disconnect} variant="danger">Disconnect</Button>
       {/if}
 
       <div class="status">

--- a/ui/dashboard/src/routes/wstest/+page.svelte
+++ b/ui/dashboard/src/routes/wstest/+page.svelte
@@ -123,9 +123,11 @@
 
 <div class="container" data-test-id="page-root">
   <Card>
-    <div slot="title">
-      <Typo variant="title" size="h4" value="WebSocket Test Tool" />
-    </div>
+    {#snippet title()}
+      <div>
+        <Typo variant="title" size="h4" value="WebSocket Test Tool" />
+      </div>
+    {/snippet}
 
     <div class="controls">
       <TextInput


### PR DESCRIPTION
## Summary
Migrates all of `ui/dashboard` from Svelte 5 legacy/compat mode to **runes mode**, completing the deferred cleanup from #968. Closes #977.

Every `.svelte` component (~86 files) now opts into runes (`<svelte:options runes={true} />`) with `$props`/`$state`/`$derived`/`$effect`, snippet-based slots, and callback-prop events. The Playwright smoke harness from #981 stayed green at every step.

## Approach: per-component opt-in (not a global flag)
The global `compilerOptions.runes: true` flag is **not** usable here: it applies to third-party `.svelte` deps too, and `@zerodevx/svelte-toast` ships legacy `export let` with no runes-native release at any version, so a global flag breaks `vite build` (and the carve-out is unreachable under `sveltekit()`). Instead each component opts in individually — #977 explicitly sanctions this. Third-party deps stay legacy (correct; not our code).

Work proceeded **bottom-up by dependency** (shared children before parents): leaf renderers → Icon/Button/Card/Pager/form inputs → nav/table/shell → viewer cards → route pages. Each shared component's conversion flips its callers' event tokens (`on:x`→`onx`) and slot usage (`<div slot="x">`→`{#snippet x()}`) in the same commit, for reviewable history.

## Conversions applied
- `export let` → `$props()`; mutated/`bind:`-ed props → `$bindable`; `bind:this` → `$state`
- `$:` → `$derived` (values) / `$derived.by` (blocks) / `$effect` (side effects); reassigned markup-read locals → `$state`
- `createEventDispatcher` → callback props (`dispatch('x', d)` → `onx?.(d)`; consumers' `e.detail.x` → `e.x`)
- legacy event forwarding (bare `on:click`) → `onclick` callback prop
- `<slot>` / `<slot name="x">` / `$$slots` → `{@render children?.()}` / `{@render x?.()}` snippet props
- `<svelte:component this={X}>` → `<X />`; `<svelte:self>` → self-import; `<script context="module">` → `<script module>`; hyphenated `svelte-ignore a11y-*` → underscore form
- several legacy `$:` read-then-write blocks that would `effect_update_depth_exceeded` under runes → restructured with `untrack`

## Dependency hygiene
- **`svelte-exmarkdown` 3.0.3 → 5.0.2**: v3's peer range was `svelte ^3 || ^4` — a real peer-dep conflict under Svelte 5. v5.0.2 is runes-native (`svelte ^5.1.3`); the `<Markdown md plugins>` API is unchanged. `npm ls` is now conflict-free.
- `@zerodevx/svelte-toast` left as-is (no runes release; legacy third-party works fine from runes parents).

## Also cleaned up
Fixed the 17 pre-existing `svelte-check` TYPE errors that `svelte-check 4` (from the #968 v5 bump) surfaced — unrelated to runes but cleared here so the baseline is green: `MerkleProofData` missing fields (added as optional), a `Uint8Array`/`BufferSource` narrowing, `node: unknown` store typing, `string | undefined` guards, a duplicate `best_height` `renderCells` key, a stray `serverSort` prop (→ `useServerSort`), and an invalid Button `variant="danger"` (→ `destructive`). All behavior-preserving.

## Verification
- `npm run check` — **0 errors, 0 Svelte deprecation warnings** (the #977 acceptance criterion). Re-added as a CI gate in `dashboard_pr_smoke.yaml` (it was held out during the smoke-harness PR while the legacy baseline was dirty). 14 cosmetic a11y/CSS warnings remain (svelte-check exits 0 on those).
- `npm run build` — succeeds.
- `npm run test:integration` — **16/16 smoke tests green** (route shells + `/viewer` block-detail click-through + subtree/tx/utxo detail). Green after every commit.

Closes #977.
