### PR TITLE
Fix merkle proof calculation with proper coinbase replacement

### DIFF
--- a/util/bump/coinbase_placeholder_crosscheck_test.go
+++ b/util/bump/coinbase_placeholder_crosscheck_test.go
@@ -1,0 +1,204 @@
+package bump_test
+
+import (
+	"testing"
+
+	bc "github.com/bsv-blockchain/go-bc"
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/util/bump"
+	"github.com/bsv-blockchain/teranode/util/merkleproof"
+	"github.com/stretchr/testify/require"
+)
+
+const testCoinbaseHex = "02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff03510101ffffffff0100f2052a01000000232103656065e6886ca1e947de3471c9e723673ab6ba34724476417fa9fcef8bafa604ac00000000"
+
+// mockConstructor implements merkleproof.MerkleProofConstructor for a single in-memory block.
+type mockConstructor struct {
+	txMeta      *merkleproof.TxMetaData
+	block       *model.Block
+	blockHeader *model.BlockHeader
+	subtrees    map[string]*subtreepkg.Subtree
+}
+
+func (m *mockConstructor) GetTxMeta(*chainhash.Hash) (*merkleproof.TxMetaData, error) {
+	return m.txMeta, nil
+}
+func (m *mockConstructor) GetBlockByID(uint64) (*model.Block, error) { return m.block, nil }
+func (m *mockConstructor) GetBlockHeader(*chainhash.Hash) (*model.BlockHeader, error) {
+	return m.blockHeader, nil
+}
+func (m *mockConstructor) GetSubtree(h *chainhash.Hash) (*subtreepkg.Subtree, error) {
+	return m.subtrees[h.String()], nil
+}
+func (m *mockConstructor) FindBlocksContainingSubtree(*chainhash.Hash) ([]uint32, []uint32, []int, error) {
+	return []uint32{1}, []uint32{100}, []int{0}, nil
+}
+
+// canonicalRoot mirrors model.Block.CheckMerkleRoot: coinbase replacement for subtree 0 and padding
+// for an incomplete final subtree, then a top-level merkle tree over the resulting roots.
+func canonicalRoot(t *testing.T, subtrees []*subtreepkg.Subtree, coinbaseTx *bt.Tx) *chainhash.Hash {
+	t.Helper()
+
+	targetLength := subtrees[0].Length()
+	targetHeight := subtrees[0].Height
+	roots := make([]subtreepkg.Node, len(subtrees))
+
+	for i, st := range subtrees {
+		switch {
+		case i == 0:
+			r, err := st.RootHashWithReplaceRootNode(coinbaseTx.TxIDChainHash(), 0, uint64(coinbaseTx.Size()))
+			require.NoError(t, err)
+			roots[i] = subtreepkg.Node{Hash: *r}
+		case i == len(subtrees)-1 && st.Length() < targetLength:
+			r, err := st.RootHashPadded(targetHeight)
+			require.NoError(t, err)
+			roots[i] = subtreepkg.Node{Hash: *r}
+		default:
+			roots[i] = subtreepkg.Node{Hash: *st.RootHash()}
+		}
+	}
+
+	if len(roots) == 1 {
+		return &roots[0].Hash
+	}
+
+	store, err := subtreepkg.BuildMerkleTreeStoreFromBytes(roots)
+	require.NoError(t, err)
+	root := (*store)[len(*store)-1]
+
+	return &root
+}
+
+func placeholderSubtree(t *testing.T, txs ...*chainhash.Hash) *subtreepkg.Subtree {
+	t.Helper()
+	st, err := subtreepkg.NewTreeByLeafCount(len(txs) + 1)
+	require.NoError(t, err)
+	require.NoError(t, st.AddCoinbaseNode())
+	for _, h := range txs {
+		require.NoError(t, st.AddNode(*h, 1, 1))
+	}
+	return st
+}
+
+func regularSubtree(t *testing.T, txs ...*chainhash.Hash) *subtreepkg.Subtree {
+	t.Helper()
+	st, err := subtreepkg.NewTreeByLeafCount(len(txs))
+	require.NoError(t, err)
+	for _, h := range txs {
+		require.NoError(t, st.AddNode(*h, 1, 1))
+	}
+	return st
+}
+
+func newMock(t *testing.T, subtrees []*subtreepkg.Subtree, coinbaseTx *bt.Tx, subtreeIdx int) *mockConstructor {
+	t.Helper()
+
+	merkleRoot := canonicalRoot(t, subtrees, coinbaseTx)
+	hashes := make([]*chainhash.Hash, len(subtrees))
+	stMap := make(map[string]*subtreepkg.Subtree, len(subtrees))
+
+	for i, st := range subtrees {
+		h := st.RootHash()
+		hashes[i] = h
+		stMap[h.String()] = st
+	}
+
+	prev, _ := chainhash.NewHashFromStr("0000000000000000000000000000000000000000000000000000000000000000")
+	header := &model.BlockHeader{Version: 1, HashPrevBlock: prev, HashMerkleRoot: merkleRoot, Timestamp: 1, Nonce: 1}
+
+	return &mockConstructor{
+		txMeta:      &merkleproof.TxMetaData{BlockIDs: []uint32{1}, BlockHeights: []uint32{100}, SubtreeIdxs: []int{subtreeIdx}},
+		block:       &model.Block{Header: header, CoinbaseTx: coinbaseTx, Subtrees: hashes},
+		blockHeader: header,
+		subtrees:    stMap,
+	}
+}
+
+// verifyViaGoBC encodes the proof to a BUMP, parses it with go-bc, and asserts that
+// CalculateRootGivenTxid for the proven txid reproduces the block header merkle root.
+func verifyViaGoBC(t *testing.T, proof *merkleproof.MerkleProof) {
+	t.Helper()
+
+	format, err := bump.ConvertToBUMP(proof)
+	require.NoError(t, err)
+	require.NoError(t, bump.Validate(format))
+
+	// The served BUMP must never contain the coinbase placeholder.
+	placeholder := subtreepkg.CoinbasePlaceholderHashValue.String()
+	for _, level := range format.Path {
+		for _, node := range level {
+			require.NotEqual(t, placeholder, node.Hash, "BUMP must not contain the coinbase placeholder")
+		}
+	}
+
+	binary, err := format.EncodeBinary()
+	require.NoError(t, err)
+
+	parsed, err := bc.NewBUMPFromBytes(binary)
+	require.NoError(t, err)
+
+	root, err := parsed.CalculateRootGivenTxid(proof.TxID.String())
+	require.NoError(t, err)
+	require.Equal(t, proof.MerkleRoot.String(), root,
+		"go-bc CalculateRootGivenTxid must reproduce the block header merkle root")
+}
+
+// TestBUMPCoinbasePlaceholderEndToEnd is the end-to-end regression test for discussion #989: it runs
+// the full Assets-API proof path (ConstructMerkleProof -> ConvertToBUMP -> binary) and verifies the
+// result with the go-bc reference implementation.
+func TestBUMPCoinbasePlaceholderEndToEnd(t *testing.T) {
+	coinbaseTx, err := bt.NewTxFromString(testCoinbaseHex)
+	require.NoError(t, err)
+
+	tx := make([]*chainhash.Hash, 8)
+	for i := range tx {
+		h := chainhash.DoubleHashH([]byte{byte(i + 1), 0xab})
+		tx[i] = &h
+	}
+
+	t.Run("single subtree, tx#1 adjacent to coinbase", func(t *testing.T) {
+		st0 := placeholderSubtree(t, tx[0], tx[1], tx[2])
+		mock := newMock(t, []*subtreepkg.Subtree{st0}, coinbaseTx, 0)
+
+		proof, err := merkleproof.ConstructMerkleProof(tx[0], mock)
+		require.NoError(t, err)
+
+		verifyViaGoBC(t, proof)
+	})
+
+	t.Run("single subtree, deeper tx", func(t *testing.T) {
+		st0 := placeholderSubtree(t, tx[0], tx[1], tx[2])
+		mock := newMock(t, []*subtreepkg.Subtree{st0}, coinbaseTx, 0)
+
+		proof, err := merkleproof.ConstructMerkleProof(tx[2], mock)
+		require.NoError(t, err)
+
+		verifyViaGoBC(t, proof)
+	})
+
+	t.Run("multi-subtree complete, tx in subtree 1", func(t *testing.T) {
+		st0 := placeholderSubtree(t, tx[0])
+		st1 := regularSubtree(t, tx[1], tx[2])
+		mock := newMock(t, []*subtreepkg.Subtree{st0, st1}, coinbaseTx, 1)
+
+		proof, err := merkleproof.ConstructMerkleProof(tx[1], mock)
+		require.NoError(t, err)
+
+		verifyViaGoBC(t, proof)
+	})
+
+	t.Run("incomplete final subtree, tx in final subtree", func(t *testing.T) {
+		st0 := placeholderSubtree(t, tx[0], tx[1], tx[2]) // length 4
+		st1 := regularSubtree(t, tx[3], tx[4], tx[5], tx[6])
+		st2 := regularSubtree(t, tx[7]) // length 1, incomplete -> padded
+		mock := newMock(t, []*subtreepkg.Subtree{st0, st1, st2}, coinbaseTx, 2)
+
+		proof, err := merkleproof.ConstructMerkleProof(tx[7], mock)
+		require.NoError(t, err)
+
+		verifyViaGoBC(t, proof)
+	})
+}

--- a/util/bump/format.go
+++ b/util/bump/format.go
@@ -80,48 +80,32 @@ func ConvertToBUMP(proof *merkleproof.MerkleProof) (*Format, error) {
 		Path:        make([]Level, 0),
 	}
 
-	// Convert subtree proof levels
-	txIndex := proof.TxIndexInSubtree
+	// A BUMP is a single flat merkle tree over the block's transactions; offsets at every level live
+	// in one continuous space. Teranode splits the proof into a subtree-level path and a block-level
+	// path, but together they form that one tree: the subtree contributes the low `subtreeLevels` bits
+	// of the transaction's global leaf offset, and the subtree index contributes the high bits. (The
+	// previous code numbered the two segments independently, which produced wrong offsets — and thus
+	// unverifiable BUMPs — for any block with more than one subtree.)
+	subtreeLevels := len(proof.SubtreeProof)
+	globalOffset := (uint32(proof.SubtreeIndex) << uint(subtreeLevels)) | uint32(proof.TxIndexInSubtree) //nolint:gosec
 
-	for levelIdx, siblingHash := range proof.SubtreeProof {
-		level := make(Level, 0, 2)
+	appendLevel := func(levelIdx int, siblingHash chainhash.Hash) {
+		// Sibling offset at this level: the working hash sits at globalOffset>>levelIdx; its sibling is
+		// the adjacent node (low bit flipped).
+		siblingOffset := (globalOffset >> uint(levelIdx)) ^ 1
 
-		// Calculate the offset at this level
-		// At each level up the tree, the index is divided by 2
-		offset := uint32(txIndex >> levelIdx)
-
-		// Determine sibling offset (adjacent node)
-		siblingOffset := offset ^ 1 // Flip the last bit to get sibling
-
-		// Add the sibling node with its hash in display order (BRC-74 convention)
-		level = append(level, Node{
+		bump.Path = append(bump.Path, Level{Node{
 			Offset: siblingOffset,
 			Hash:   hashToDisplayHex(siblingHash),
-		})
-
-		bump.Path = append(bump.Path, level)
+		}})
 	}
 
-	// Convert block proof levels if present
-	// Block proofs represent the path from subtree root to block merkle root
-	subtreeIndex := proof.SubtreeIndex
+	for levelIdx, siblingHash := range proof.SubtreeProof {
+		appendLevel(levelIdx, siblingHash)
+	}
 
-	for levelIdx, siblingHash := range proof.BlockProof {
-		level := make(Level, 0, 2)
-
-		// Calculate the offset at this block level
-		blockLevelOffset := uint32(subtreeIndex >> levelIdx)
-
-		// Determine sibling offset
-		siblingOffset := blockLevelOffset ^ 1
-
-		// Add the sibling node with its hash in display order (BRC-74 convention)
-		level = append(level, Node{
-			Offset: siblingOffset,
-			Hash:   hashToDisplayHex(siblingHash),
-		})
-
-		bump.Path = append(bump.Path, level)
+	for i, siblingHash := range proof.BlockProof {
+		appendLevel(subtreeLevels+i, siblingHash)
 	}
 
 	// BRC-74 requires level 0 to include the target txid (flag 0x02) alongside its sibling.
@@ -129,17 +113,17 @@ func ConvertToBUMP(proof *merkleproof.MerkleProof) (*Format, error) {
 	var zeroHash chainhash.Hash
 	if proof.TxID != zeroHash && len(bump.Path) > 0 {
 		txidNode := Node{
-			Offset: uint32(proof.TxIndexInSubtree),
+			Offset: globalOffset,
 			Hash:   hashToDisplayHex(proof.TxID),
 			TxID:   true,
 		}
 
 		level0 := bump.Path[0]
-		if uint32(proof.TxIndexInSubtree)%2 == 0 {
-			// Even index: txid is on the left, prepend
+		if globalOffset%2 == 0 {
+			// Even offset: txid is on the left, prepend
 			bump.Path[0] = append(Level{txidNode}, level0...)
 		} else {
-			// Odd index: txid is on the right, append
+			// Odd offset: txid is on the right, append
 			bump.Path[0] = append(level0, txidNode)
 		}
 	}

--- a/util/bump/format_test.go
+++ b/util/bump/format_test.go
@@ -58,26 +58,31 @@ func TestConvertToBUMP(t *testing.T) {
 		assert.Equal(t, uint32(12345), bump.BlockHeight)
 		assert.Equal(t, 3, len(bump.Path)) // 2 subtree levels + 1 block level
 
+		// A BUMP is one flat tree, so offsets are GLOBAL. With 2 subtree levels the transaction's
+		// global leaf offset is (subtreeIndex<<2)|txIndexInSubtree = (2<<2)|5 = 13. Sibling offsets are
+		// (13>>level)^1. (The earlier expectations used subtree-local offsets, which produced BUMPs the
+		// go-bc reference implementation rejects — see coinbase_placeholder_crosscheck_test.go.)
+
 		// Verify first subtree level (level 0)
 		level0 := bump.Path[0]
 		assert.Equal(t, 2, len(level0))
-		assert.Equal(t, uint32(4), level0[0].Offset)       // 5 XOR 1 = 4 (sibling of index 5)
+		assert.Equal(t, uint32(12), level0[0].Offset)      // 13 XOR 1 = 12 (sibling of global offset 13)
 		assert.Equal(t, sibling1.String(), level0[0].Hash) // display order (BRC-74)
 		assert.False(t, level0[0].TxID)
-		assert.Equal(t, uint32(5), level0[1].Offset)     // txid at index 5 (odd, appended)
+		assert.Equal(t, uint32(13), level0[1].Offset)    // txid at global offset 13 (odd, appended)
 		assert.Equal(t, txHash.String(), level0[1].Hash) // display order (BRC-74)
 		assert.True(t, level0[1].TxID)
 
 		// Verify second subtree level (level 1)
 		level1 := bump.Path[1]
 		assert.Equal(t, 1, len(level1))
-		assert.Equal(t, uint32(3), level1[0].Offset)       // (5>>1) XOR 1 = 2 XOR 1 = 3
+		assert.Equal(t, uint32(7), level1[0].Offset)       // (13>>1) XOR 1 = 6 XOR 1 = 7
 		assert.Equal(t, sibling2.String(), level1[0].Hash) // display order (BRC-74)
 
 		// Verify block level
 		blockLevel := bump.Path[2]
 		assert.Equal(t, 1, len(blockLevel))
-		assert.Equal(t, uint32(3), blockLevel[0].Offset)           // 2 XOR 1 = 3
+		assert.Equal(t, uint32(2), blockLevel[0].Offset)           // (13>>2) XOR 1 = 3 XOR 1 = 2
 		assert.Equal(t, blockSibling.String(), blockLevel[0].Hash) // display order (BRC-74)
 	})
 

--- a/util/merkleproof/merkle_proof.go
+++ b/util/merkleproof/merkle_proof.go
@@ -3,6 +3,7 @@ package merkleproof
 import (
 	"errors" //nolint:depguard
 	"fmt"
+	"math/bits"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-subtree"
@@ -136,6 +137,19 @@ func ConstructMerkleProof(txID *chainhash.Hash, repo MerkleProofConstructor) (*M
 		return nil, terr.NewProcessingError("failed to get subtree data", err)
 	}
 
+	// The first subtree of a block stores a coinbase placeholder at index 0, because the coinbase
+	// txid is not known until the block is assembled. The block header's merkle root is computed
+	// with that placeholder replaced by the real coinbase txid (see model.Block.CheckMerkleRoot),
+	// so the proof must mirror that replacement or it will never reconstruct the header root.
+	var coinbaseHash *chainhash.Hash
+	if block.CoinbaseTx != nil {
+		coinbaseHash = block.CoinbaseTx.TxIDChainHash()
+	}
+
+	firstHasPlaceholder := func(st *subtree.Subtree) bool {
+		return st != nil && len(st.Nodes) > 0 && st.Nodes[0].Hash.Equal(subtree.CoinbasePlaceholderHashValue)
+	}
+
 	// Find the transaction index within the subtree
 	txIndexInSubtree := -1
 	for i, node := range subtreeData.Nodes {
@@ -145,18 +159,104 @@ func ConstructMerkleProof(txID *chainhash.Hash, repo MerkleProofConstructor) (*M
 		}
 	}
 
+	// The coinbase transaction itself is stored as the placeholder in the first subtree, so a direct
+	// hash lookup fails. Treat a request for the coinbase txid as index 0 of the first subtree.
+	if txIndexInSubtree == -1 && subtreeIdx == 0 && coinbaseHash != nil &&
+		txID.IsEqual(coinbaseHash) && firstHasPlaceholder(subtreeData) {
+		txIndexInSubtree = 0
+	}
+
 	if txIndexInSubtree == -1 {
 		return nil, terr.NewProcessingError("transaction not found in subtree")
 	}
 
-	// Generate merkle proof within the subtree
-	subtreeProof, err := subtreeData.GetMerkleProof(txIndexInSubtree)
+	// Load the first subtree (it is needed both for the coinbase-replaced root and, when the final
+	// subtree is incomplete, for the target height used to lift it).
+	var firstSubtree *subtree.Subtree
+	if subtreeIdx == 0 {
+		firstSubtree = subtreeData
+	} else if len(block.Subtrees) > 0 {
+		firstSubtree, err = repo.GetSubtree(block.Subtrees[0])
+		if err != nil {
+			return nil, terr.NewProcessingError("failed to get first subtree data", err)
+		}
+	}
+
+	// Compute the coinbase-replaced root of the first subtree, when it carries a placeholder.
+	var firstRoot *chainhash.Hash
+	if coinbaseHash != nil && firstHasPlaceholder(firstSubtree) {
+		firstRoot, err = firstSubtree.RootHashWithReplaceRootNode(coinbaseHash, 0, uint64(block.CoinbaseTx.Size())) //nolint:gosec
+		if err != nil {
+			return nil, terr.NewProcessingError("failed to replace coinbase placeholder in first subtree", err)
+		}
+	}
+
+	// Compute the lifted (padded) root of the final subtree when it is incomplete, mirroring
+	// model.Block.CheckMerkleRoot, so it occupies the slot of a full-capacity subtree in the top tree.
+	lastIdx := len(block.Subtrees) - 1
+
+	var (
+		lastRoot     *chainhash.Hash
+		targetHeight int
+	)
+
+	if lastIdx > 0 && firstSubtree != nil {
+		targetLength := firstSubtree.Length()
+		targetHeight = firstSubtree.Height
+
+		var lastSubtree *subtree.Subtree
+		if subtreeIdx == lastIdx {
+			lastSubtree = subtreeData
+		} else {
+			lastSubtree, err = repo.GetSubtree(block.Subtrees[lastIdx])
+			if err != nil {
+				return nil, terr.NewProcessingError("failed to get final subtree data", err)
+			}
+		}
+
+		if lastSubtree.Length() < targetLength {
+			lastRoot, err = lastSubtree.RootHashPadded(targetHeight)
+			if err != nil {
+				return nil, terr.NewProcessingError("failed to pad final subtree", err)
+			}
+		}
+	}
+
+	// Build the effective subtree-root leaves for the block-level (top) merkle tree: the placeholder
+	// root of the first subtree is replaced with the coinbase-replaced root, and an incomplete final
+	// subtree's root is replaced with its lifted root.
+	effectiveRoots := block.Subtrees
+
+	if firstRoot != nil || lastRoot != nil {
+		effectiveRoots = make([]*chainhash.Hash, len(block.Subtrees))
+		copy(effectiveRoots, block.Subtrees)
+
+		if firstRoot != nil {
+			effectiveRoots[0] = firstRoot
+		}
+
+		if lastRoot != nil {
+			effectiveRoots[lastIdx] = lastRoot
+		}
+	}
+
+	// Generate the subtree-internal proof. For the first subtree, build it from a coinbase-replaced
+	// clone so the proof carries the real coinbase txid rather than the placeholder. Duplicate() copies
+	// the node slice, so the cached/stored subtree is never mutated.
+	proofSubtree := subtreeData
+	if subtreeIdx == 0 && firstRoot != nil {
+		clone := subtreeData.Duplicate()
+		clone.ReplaceRootNode(coinbaseHash, 0, uint64(block.CoinbaseTx.Size())) //nolint:gosec
+		proofSubtree = clone
+	}
+
+	subtreeProof, err := proofSubtree.GetMerkleProof(txIndexInSubtree)
 	if err != nil {
 		return nil, terr.NewProcessingError("failed to generate subtree merkle proof", err)
 	}
 
-	// Generate proof from subtree root to block merkle root
-	blockProof, flags, err := GenerateBlockMerkleProof(block.Subtrees, subtreeIdx)
+	// Generate proof from subtree root to block merkle root using the effective roots.
+	blockProof, blockFlags, err := GenerateBlockMerkleProof(effectiveRoots, subtreeIdx)
 	if err != nil {
 		return nil, terr.NewProcessingError("failed to generate block merkle proof", err)
 	}
@@ -168,16 +268,57 @@ func ConstructMerkleProof(txID *chainhash.Hash, repo MerkleProofConstructor) (*M
 		return nil, terr.NewProcessingError("failed to get block header", err)
 	}
 
-	// Convert proof hashes from pointers to values
-	subtreeProofHashes := make([]chainhash.Hash, len(subtreeProof))
-	for i, hash := range subtreeProof {
-		subtreeProofHashes[i] = *hash
+	// Convert subtree proof hashes from pointers to values and compute their left/right flags from the
+	// transaction index parity at each level (the previous code only carried block-level flags, which
+	// left odd-index transactions with the wrong sibling ordering during verification).
+	subtreeProofHashes := make([]chainhash.Hash, 0, len(subtreeProof))
+	subtreeFlags := make([]int, 0, len(subtreeProof))
+	levelIndex := txIndexInSubtree
+
+	for _, hash := range subtreeProof {
+		subtreeProofHashes = append(subtreeProofHashes, *hash)
+
+		if levelIndex%2 == 0 {
+			subtreeFlags = append(subtreeFlags, 1) // sibling is on the right
+		} else {
+			subtreeFlags = append(subtreeFlags, 0) // sibling is on the left
+		}
+
+		levelIndex >>= 1
+	}
+
+	// The root this subtree contributes to the top-level tree.
+	subtreeRootForProof := subtreeHash
+	if subtreeIdx == 0 && firstRoot != nil {
+		subtreeRootForProof = firstRoot
+	}
+
+	// When the transaction lives in an incomplete final subtree, the subtree-internal proof only
+	// reaches the subtree's natural root, but the top tree uses the lifted root. Append the lift levels
+	// (each a self-hash, H(h,h)) so verification reaches the lifted root that the top tree expects.
+	if subtreeIdx == lastIdx && lastRoot != nil {
+		actualHeight := bits.Len(uint(proofSubtree.Length() - 1))
+		current := *proofSubtree.RootHash()
+
+		for h := actualHeight; h < targetHeight; h++ {
+			subtreeProofHashes = append(subtreeProofHashes, current)
+			subtreeFlags = append(subtreeFlags, 1) // duplicate: combined = current || current
+
+			combined := append(current.CloneBytes(), current.CloneBytes()...)
+			current = chainhash.DoubleHashH(combined)
+		}
+
+		subtreeRootForProof = lastRoot
 	}
 
 	blockProofHashes := make([]chainhash.Hash, len(blockProof))
 	for i, hash := range blockProof {
 		blockProofHashes[i] = *hash
 	}
+
+	// Flags cover the subtree-level path first, then the block-level path (the order in which
+	// VerifyMerkleProof consumes them).
+	flags := append(subtreeFlags, blockFlags...)
 
 	// Build the complete proof structure
 	proof := &MerkleProof{
@@ -187,7 +328,7 @@ func ConstructMerkleProof(txID *chainhash.Hash, repo MerkleProofConstructor) (*M
 		MerkleRoot:       *blockHeader.HashMerkleRoot,
 		SubtreeIndex:     subtreeIdx,
 		TxIndexInSubtree: txIndexInSubtree,
-		SubtreeRoot:      *subtreeHash,
+		SubtreeRoot:      *subtreeRootForProof,
 		SubtreeProof:     subtreeProofHashes,
 		BlockProof:       blockProofHashes,
 		Flags:            flags,

--- a/util/merkleproof/merkle_proof_coinbase_test.go
+++ b/util/merkleproof/merkle_proof_coinbase_test.go
@@ -1,0 +1,280 @@
+package merkleproof
+
+import (
+	"math/bits"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/stretchr/testify/require"
+)
+
+// A real coinbase transaction (reused from blockassembly tests). Its txid is what the block
+// header's merkle root is actually computed with, in place of the coinbase placeholder.
+const testCoinbaseHex = "02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff03510101ffffffff0100f2052a01000000232103656065e6886ca1e947de3471c9e723673ab6ba34724476417fa9fcef8bafa604ac00000000"
+
+// canonicalMerkleRoot computes the block merkle root the same way model.Block.CheckMerkleRoot does:
+//   - subtree 0: replace the coinbase placeholder at Nodes[0] with the real coinbase txid
+//   - middle subtrees: their natural root
+//   - final subtree: lifted (padded) to the first subtree's height if it is incomplete
+//
+// then build the top-level merkle tree over those roots.
+func canonicalMerkleRoot(t *testing.T, subtrees []*subtreepkg.Subtree, coinbaseTx *bt.Tx) *chainhash.Hash {
+	t.Helper()
+
+	targetLength := subtrees[0].Length()
+	targetHeight := subtrees[0].Height
+
+	roots := make([]subtreepkg.Node, len(subtrees))
+
+	for i, st := range subtrees {
+		switch {
+		case i == 0:
+			r, err := st.RootHashWithReplaceRootNode(coinbaseTx.TxIDChainHash(), 0, uint64(coinbaseTx.Size()))
+			require.NoError(t, err)
+			roots[i] = subtreepkg.Node{Hash: *r}
+		case i == len(subtrees)-1 && st.Length() < targetLength:
+			r, err := st.RootHashPadded(targetHeight)
+			require.NoError(t, err)
+			roots[i] = subtreepkg.Node{Hash: *r}
+		default:
+			roots[i] = subtreepkg.Node{Hash: *st.RootHash()}
+		}
+	}
+
+	if len(roots) == 1 {
+		return &roots[0].Hash
+	}
+
+	store, err := subtreepkg.BuildMerkleTreeStoreFromBytes(roots)
+	require.NoError(t, err)
+
+	root := (*store)[len(*store)-1]
+
+	return &root
+}
+
+// newPlaceholderSubtree builds a subtree whose first node is the coinbase placeholder (matching how
+// the first subtree of a block is stored), followed by the supplied transaction hashes.
+func newPlaceholderSubtree(t *testing.T, txHashes ...*chainhash.Hash) *subtreepkg.Subtree {
+	t.Helper()
+
+	st, err := subtreepkg.NewTreeByLeafCount(len(txHashes) + 1)
+	require.NoError(t, err)
+	require.NoError(t, st.AddCoinbaseNode()) // adds CoinbasePlaceholder at index 0
+
+	for _, h := range txHashes {
+		require.NoError(t, st.AddNode(*h, 1, 1))
+	}
+
+	return st
+}
+
+func newRegularSubtree(t *testing.T, txHashes ...*chainhash.Hash) *subtreepkg.Subtree {
+	t.Helper()
+
+	st, err := subtreepkg.NewTreeByLeafCount(len(txHashes))
+	require.NoError(t, err)
+
+	for _, h := range txHashes {
+		require.NoError(t, st.AddNode(*h, 1, 1))
+	}
+
+	return st
+}
+
+// buildMock wires up a MockMerkleProofConstructor from a set of subtrees, the coinbase tx and the
+// subtree index of the transaction being proven. The header merkle root is the canonical one.
+func buildMock(t *testing.T, subtrees []*subtreepkg.Subtree, coinbaseTx *bt.Tx, subtreeIdx int) *MockMerkleProofConstructor {
+	t.Helper()
+
+	merkleRoot := canonicalMerkleRoot(t, subtrees, coinbaseTx)
+
+	subtreeHashes := make([]*chainhash.Hash, len(subtrees))
+	subtreeMap := make(map[string]*subtreepkg.Subtree, len(subtrees))
+
+	for i, st := range subtrees {
+		h := st.RootHash() // stored subtree identity = root WITH the placeholder
+		subtreeHashes[i] = h
+		subtreeMap[h.String()] = st
+	}
+
+	prevBlock, _ := chainhash.NewHashFromStr("0000000000000000000000000000000000000000000000000000000000000000")
+	blockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  prevBlock,
+		HashMerkleRoot: merkleRoot,
+		Timestamp:      1,
+		Nonce:          1,
+	}
+
+	block := &model.Block{
+		Header:     blockHeader,
+		CoinbaseTx: coinbaseTx,
+		Subtrees:   subtreeHashes,
+	}
+
+	return &MockMerkleProofConstructor{
+		txMeta: &TxMetaData{
+			BlockIDs:     []uint32{1},
+			BlockHeights: []uint32{100},
+			SubtreeIdxs:  []int{subtreeIdx},
+		},
+		block:       block,
+		blockHeader: blockHeader,
+		subtrees:    subtreeMap,
+	}
+}
+
+// containsHash reports whether the proof contains the given hash at any level.
+func proofContainsHash(proof *MerkleProof, h chainhash.Hash) bool {
+	for _, p := range proof.SubtreeProof {
+		if p.IsEqual(&h) {
+			return true
+		}
+	}
+
+	for _, p := range proof.BlockProof {
+		if p.IsEqual(&h) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestConstructMerkleProofCoinbasePlaceholder is the regression test for discussion #989:
+// the first subtree of a block stores a coinbase placeholder at index 0, and proofs must replace
+// it with the real coinbase txid so the reconstructed root matches the block header merkle root.
+func TestConstructMerkleProofCoinbasePlaceholder(t *testing.T) {
+	coinbaseTx, err := bt.NewTxFromString(testCoinbaseHex)
+	require.NoError(t, err)
+
+	coinbaseHash := *coinbaseTx.TxIDChainHash()
+	placeholder := subtreepkg.CoinbasePlaceholderHashValue
+
+	tx1, _ := chainhash.NewHashFromStr("1111111111111111111111111111111111111111111111111111111111111111")
+	tx2, _ := chainhash.NewHashFromStr("2222222222222222222222222222222222222222222222222222222222222222")
+	tx3, _ := chainhash.NewHashFromStr("3333333333333333333333333333333333333333333333333333333333333333")
+
+	t.Run("single subtree - tx#1 sibling is coinbase, not placeholder", func(t *testing.T) {
+		// subtree 0: [placeholder, tx1, tx2, tx3]
+		st0 := newPlaceholderSubtree(t, tx1, tx2, tx3)
+		mock := buildMock(t, []*subtreepkg.Subtree{st0}, coinbaseTx, 0)
+
+		proof, err := ConstructMerkleProof(tx1, mock)
+		require.NoError(t, err)
+		require.Equal(t, 1, proof.TxIndexInSubtree)
+
+		// The level-0 sibling of tx#1 is the coinbase node. It MUST be the real coinbase txid.
+		require.Len(t, proof.SubtreeProof, 2)
+		require.Equal(t, coinbaseHash, proof.SubtreeProof[0],
+			"tx#1's coinbase sibling must be the real coinbase txid")
+		require.False(t, proofContainsHash(proof, placeholder),
+			"proof must not contain the coinbase placeholder")
+
+		valid, _, err := VerifyMerkleProof(proof)
+		require.NoError(t, err)
+		require.True(t, valid, "reconstructed merkle root must match the block header merkle root")
+	})
+
+	t.Run("single subtree - tx#2 (deeper) verifies, no placeholder", func(t *testing.T) {
+		st0 := newPlaceholderSubtree(t, tx1, tx2, tx3)
+		mock := buildMock(t, []*subtreepkg.Subtree{st0}, coinbaseTx, 0)
+
+		proof, err := ConstructMerkleProof(tx2, mock)
+		require.NoError(t, err)
+		require.False(t, proofContainsHash(proof, placeholder))
+
+		valid, _, err := VerifyMerkleProof(proof)
+		require.NoError(t, err)
+		require.True(t, valid)
+	})
+
+	t.Run("coinbase tx proof", func(t *testing.T) {
+		st0 := newPlaceholderSubtree(t, tx1, tx2, tx3)
+		mock := buildMock(t, []*subtreepkg.Subtree{st0}, coinbaseTx, 0)
+
+		proof, err := ConstructMerkleProof(&coinbaseHash, mock)
+		require.NoError(t, err)
+		require.Equal(t, 0, proof.TxIndexInSubtree)
+
+		valid, _, err := VerifyMerkleProofForCoinbase(proof)
+		require.NoError(t, err)
+		require.True(t, valid)
+	})
+
+	t.Run("multi-subtree complete - tx in subtree 1 verifies", func(t *testing.T) {
+		// subtree 0: [placeholder, tx1] ; subtree 1: [tx2, tx3] (both complete, length 2)
+		st0 := newPlaceholderSubtree(t, tx1)
+		st1 := newRegularSubtree(t, tx2, tx3)
+		mock := buildMock(t, []*subtreepkg.Subtree{st0, st1}, coinbaseTx, 1)
+
+		proof, err := ConstructMerkleProof(tx2, mock)
+		require.NoError(t, err)
+		require.Equal(t, 1, proof.SubtreeIndex)
+		require.False(t, proofContainsHash(proof, placeholder),
+			"block-level sibling for subtree 0 must use the coinbase-replaced root")
+
+		valid, _, err := VerifyMerkleProof(proof)
+		require.NoError(t, err)
+		require.True(t, valid)
+	})
+}
+
+// TestConstructMerkleProofFinalSubtreePadding covers the block-level overhaul: a multi-subtree block
+// whose final subtree is incomplete must lift (pad) that subtree's root to the first subtree's height
+// exactly as model.Block.CheckMerkleRoot does.
+func TestConstructMerkleProofFinalSubtreePadding(t *testing.T) {
+	coinbaseTx, err := bt.NewTxFromString(testCoinbaseHex)
+	require.NoError(t, err)
+
+	tx := make([]*chainhash.Hash, 8)
+	for i := range tx {
+		h := chainhash.DoubleHashH([]byte{byte(i + 1)})
+		tx[i] = &h
+	}
+
+	// subtree 0: [placeholder, tx0, tx1, tx2] (length 4, complete, target)
+	// subtree 1: [tx3, tx4, tx5, tx6]          (length 4, complete)
+	// subtree 2: [tx7]                          (length 1, INCOMPLETE -> padded to height 2)
+	st0 := newPlaceholderSubtree(t, tx[0], tx[1], tx[2])
+	st1 := newRegularSubtree(t, tx[3], tx[4], tx[5], tx[6])
+	st2 := newRegularSubtree(t, tx[7])
+
+	require.Equal(t, 4, st0.Length())
+	require.True(t, st2.Length() < st0.Length(), "final subtree must be incomplete for this test")
+
+	subtrees := []*subtreepkg.Subtree{st0, st1, st2}
+
+	t.Run("tx NOT in incomplete final subtree", func(t *testing.T) {
+		mock := buildMock(t, subtrees, coinbaseTx, 1)
+
+		proof, err := ConstructMerkleProof(tx[4], mock)
+		require.NoError(t, err)
+
+		valid, _, err := VerifyMerkleProof(proof)
+		require.NoError(t, err)
+		require.True(t, valid, "padded final-subtree leaf must be used as a block-level sibling")
+	})
+
+	t.Run("tx IN incomplete final subtree", func(t *testing.T) {
+		mock := buildMock(t, subtrees, coinbaseTx, 2)
+
+		proof, err := ConstructMerkleProof(tx[7], mock)
+		require.NoError(t, err)
+
+		valid, _, err := VerifyMerkleProof(proof)
+		require.NoError(t, err)
+		require.True(t, valid, "proof for a tx in the incomplete final subtree must include padding levels")
+	})
+
+	t.Run("padding height matches CheckMerkleRoot expectation", func(t *testing.T) {
+		// Sanity check on the height math used by the implementation/test helper.
+		actualHeight := bits.Len(uint(st2.Length() - 1))
+		require.Equal(t, 0, actualHeight)
+		require.Equal(t, 2, st0.Height)
+	})
+}


### PR DESCRIPTION
Fixes #992 

This pull request significantly improves the correctness and robustness of Merkle proof generation and BUMP encoding, especially around coinbase transaction handling and subtree padding. It ensures that proofs are compatible with the go-bc reference implementation and conform to BRC-74 by treating the block's Merkle tree as a single flat structure, correctly handling global offsets, and mirroring all block header calculations (including coinbase placeholder replacement and subtree padding). The changes also introduce comprehensive end-to-end regression tests to prevent future regressions.

Key changes include:

### Correctness of Merkle Proof Construction and BUMP Encoding

* Refactored `ConvertToBUMP` in `format.go` to compute and use global transaction offsets (not subtree-local), ensuring BUMP proofs are valid for blocks with multiple subtrees and compatible with go-bc. Sibling offsets at each level are now calculated using the transaction's global leaf offset.
* Updated test expectations in `format_test.go` to match the new global offset logic, ensuring tests verify the correct BUMP structure and offsets.

### Coinbase Placeholder and Subtree Padding Handling

* In `merkle_proof.go`, added logic to detect and replace the coinbase placeholder in the first subtree with the actual coinbase txid, mirroring block header calculation. Also, implemented logic to pad the final subtree if incomplete, ensuring the Merkle root matches the block header. [[1]](diffhunk://#diff-73b1611dd63512c1f65d5e66ea9d34f7ce88d400f5e0e88d241b9965210103e6R140-R152) [[2]](diffhunk://#diff-73b1611dd63512c1f65d5e66ea9d34f7ce88d400f5e0e88d241b9965210103e6R162-R259)
* Adjusted subtree proof generation to use a coinbase-replaced clone of the subtree when necessary, and to append "lift" levels for incomplete final subtrees so the proof reaches the correct lifted root. [[1]](diffhunk://#diff-73b1611dd63512c1f65d5e66ea9d34f7ce88d400f5e0e88d241b9965210103e6R162-R259) [[2]](diffhunk://#diff-73b1611dd63512c1f65d5e66ea9d34f7ce88d400f5e0e88d241b9965210103e6L171-R322)

### Proof Flags and Offset Calculation

* Fixed calculation of left/right sibling flags for subtree-level proofs, ensuring correct sibling ordering for all transaction indices. Combined subtree and block-level flags into a single sequence for verification.

### Testing and Regression Coverage

* Added a comprehensive end-to-end regression test in `coinbase_placeholder_crosscheck_test.go` that covers coinbase placeholder replacement, subtree padding, and BUMP verification with go-bc, preventing regressions for these critical cases.

### Minor Improvements

* Imported `math/bits` in `merkle_proof.go` for efficient bit operations when calculating subtree heights and offsets.