### PR TITLE
chore(utxopersister): clarify footer-read match per #985 review

### DIFF
--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -629,23 +630,37 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				// Read the next 36 bytes...
+				// Read the next UTXOWrapper record (txid + encoded
+				// height/coinbase + its UTXOs).
 				utxoWrapper, err := NewUTXOWrapperFromReader(ctx, previousUTXOSetReader)
 				if err != nil {
 					// CreateUTXOSet appends a 16-byte footer (txCount +
-					// utxoCount) after the final UTXOWrapper. The wrapper
-					// stream carries no record count, so the reader only
-					// discovers the end when the next txid read either lands
-					// exactly on EOF (io.EOF) or comes up short against that
-					// footer (io.ErrUnexpectedEOF). Treat both as the normal
-					// end of the wrapper stream, mirroring the reader in
-					// cmd/utxovalidator. Without this, every non-genesis
-					// consolidation crashes the service on the footer with
-					// "failed to read txid, expected 32 bytes got 16". A
-					// genuinely truncated final record is indistinguishable
-					// from the footer here — an accepted limitation of the
-					// on-disk format.
-					if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
+					// utxoCount) after the final UTXOWrapper. This loop does
+					// not consult that count, so it only learns the records
+					// are exhausted when the next read either lands exactly on
+					// EOF (a bare io.EOF) or short-reads the footer, which
+					// io.ReadFull reports as io.ErrUnexpectedEOF ("unexpected
+					// EOF"). cmd/utxovalidator handles the same footer.
+					//
+					// The short read is matched by substring, not
+					// structurally: errors.New flattens a non-*Error cause to
+					// its message (errors/errors.go:334-336), discarding the
+					// io.ErrUnexpectedEOF sentinel - so errors.Is(err,
+					// io.ErrUnexpectedEOF) would itself reduce to this same
+					// strings.Contains. (And do not fold the io.EOF clause into
+					// errors.Is: "EOF" is a substring of "unexpected EOF", so
+					// it would swallow this footer error too.) A structural fix
+					// - FromReader returning a typed sentinel, and validating
+					// records-read == txCount against the footer - is tracked
+					// as a follow-up.
+					//
+					// Consequence: a genuinely truncated tail is
+					// indistinguishable from the footer and is silently
+					// accepted (pre-existing; same as utxovalidator). Matching
+					// only "unexpected EOF" - not the broader "failed to read
+					// txid" utxovalidator also matches - keeps a real non-EOF
+					// read error loud rather than swallowed.
+					if err == io.EOF || strings.Contains(err.Error(), "unexpected EOF") {
 						break OUTER
 					}
 


### PR DESCRIPTION
Follow-up to #985, addressing review comments that merged before they could be applied. **No behavior change** — purely clarity plus one stale-comment fix.

The reviewer correctly pointed out that the match in #985 is not the clean structural check it appeared to be:

- **"carries no record count" was wrong.** The 16-byte footer *is* `txCount` + `utxoCount`. The loop just doesn't consult it. Reworded.
- **`errors.Is` was masquerading as structural.** `teranode`'s `errors.New` flattens a non-`*Error` cause to its message string (`errors/errors.go:334-336`), discarding the `io.ErrUnexpectedEOF` sentinel — so `errors.Is(err, io.ErrUnexpectedEOF)` reduces to `strings.Contains(err.Error(), "unexpected EOF")`. Switched to the explicit `strings.Contains` so the substring nature is visible in the code, with a comment explaining it. Also documented the footgun the reviewer flagged: `errors.Is(err, io.EOF)` would *also* match this footer error (`"EOF"` ⊂ `"unexpected EOF"`), so the `io.EOF` clause stays a pointer comparison.
- **Documented the limitation and the structural follow-up.** A genuinely truncated tail is indistinguishable from the footer and silently accepted (pre-existing; same as `cmd/utxovalidator`). The real structural fix — `FromReader` returning a typed sentinel, plus validating `records-read == txCount` across the consolidation loop, the seeder, and `utxovalidator` — is noted as a follow-up.
- **Fixed the stale `// Read the next 36 bytes...` comment** (a txid is 32 bytes; pre-existing, sat right above the change).

## Verification

- `go test ./services/utxopersister/` — pass
- `go vet`, `gofmt`, `gci` — clean
