### PR TITLE
perf(ci): fix degenerate unit-test coverage (469MB→merged) via covdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ vite.config.ts.timestamp-*
 *.private_key
 
 coverage.out
+coverage.covdata/
 golangci-lint-report.xml
 sonar_filename_report.json
 

--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,17 @@ install-tools:
 	go install github.com/ctrf-io/go-ctrf-json-reporter/cmd/go-ctrf-json-reporter@latest
 	go install gotest.tools/gotestsum@latest
 
+# Coverage via binary-format coverage (GOCOVERDIR) merged once with `go tool covdata`,
+# instead of `-coverprofile` + `-coverpkg=./...` which emitted a 469MB profile with every
+# block duplicated ~115x (one full-codebase profile per test binary, concatenated not
+# merged) and spent minutes writing it. covdata produces the same coverage, merged + small.
 .PHONY: test
 test:
 	@command -v gotestsum >/dev/null 2>&1 || { echo "gotestsum not found. Installing..."; $(MAKE) install-tools; }
-	SETTINGS_CONTEXT=test gotestsum --format pkgname -- -race -tags "testtxmetacache" -count=1 -timeout=10m -coverprofile=coverage.out -coverpkg=./... $$(go list ./... | grep -v github.com/bsv-blockchain/teranode/test/ | sort)
+	@rm -rf $(CURDIR)/coverage.covdata && mkdir -p $(CURDIR)/coverage.covdata
+	SETTINGS_CONTEXT=test gotestsum --format pkgname -- -race -covermode=atomic -tags "testtxmetacache" -count=1 -timeout=10m -cover -coverpkg=./... $$(go list ./... | grep -v github.com/bsv-blockchain/teranode/test/ | sort) -args -test.gocoverdir=$(CURDIR)/coverage.covdata
+	go tool covdata textfmt -i=$(CURDIR)/coverage.covdata -o=coverage.out
+	@rm -rf $(CURDIR)/coverage.covdata
 
 # run tests in the test/longtest directory
 .PHONY: longtest


### PR DESCRIPTION
The `test` job's coverage output is a **469 MB / 5.5M-line** `coverage.out` that's **~115× duplicated**: `-coverpkg=./...` instruments every test binary for the whole codebase, and `go test` *concatenates* (not merges) all ~105 binaries' full-codebase profiles. Only 47,667 blocks are real; coverage is **58.71%**. Writing/handling that file is **~313s of the ~511s `Run Go tests` step** (the 10,173 tests themselves run in ~94s), and SonarQube then ingests the full 469 MB.

## Fix

Switch `make test` to Go binary coverage: `-cover -coverpkg=./... … -args -test.gocoverdir=<dir>`, then merge once with `go tool covdata textfmt`. Same instrumentation, same coverage — but the output is properly merged into a few-MB profile instead of a 469 MB concatenation.

Verified the mechanism locally: covdata output is deduped (1,334 blocks → 1,335 lines, no duplication), coverage % identical, format is standard Go coverage (`mode: atomic`), `gotestsum` forwards the flags, `-race` compatible.

## Expected

- `Run Go tests` step ~511s → ~230s (the ~313s coverage-write tail goes away); `test` job ~9.2m → ~4.5m.
- `coverage.out` ~469 MB → a few MB; faster artifact upload + SonarQube ingest.
- SonarQube coverage unchanged (~58.71%) — same filename/format, just merged.

This speeds the unit job and cuts runner-minutes + SonarQube load. It does **not** lower the overall PR gate (set by `pr-smoketests` ~10.6m; `pr-tests` sits just under it) — it's an efficiency + faster-unit-feedback fix.

## Verify on this PR

- `test` job duration drops.
- SonarQube coverage % stays ~58.71% (not lower).
- `coverage.out` artifact is small (few MB, not ~469 MB).
