### PR TITLE
fix(aerospike): stop enabling client metrics (#1001)

### DIFF
--- a/util/aerospike.go
+++ b/util/aerospike.go
@@ -459,11 +459,21 @@ func aerospikePolicySummary(p *aerospike.ClientPolicy) string {
 }
 
 func initStats(logger ulogger.Logger, client *uaerospike.Client, tSettings *settings.Settings) {
+	if client == nil {
+		return
+	}
+
 	var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
 	aerospikeStatsRefreshInterval := tSettings.Aerospike.StatsRefreshDuration
 
-	client.EnableMetrics(nil)
+	// Aerospike client metrics are intentionally NOT enabled: the fork's
+	// per-record stats path (nodeStats.updateOrInsert) is quadratic per batch
+	// — every batch command pays ~N^2 counter increments. Worst observed during
+	// mainnet IBD (44-60% of legacy CPU) where batches are largest, but it is a
+	// general per-batch cost. Re-enable once the fork fix lands.
+	// See https://github.com/bsv-blockchain/teranode/issues/1001
+	// client.EnableMetrics(nil)
 
 	aerospikeLatencyBuckets := func() []float64 {
 		buckets := make([]float64, 24)


### PR DESCRIPTION
Stop calling `client.EnableMetrics(nil)` in `initStats`. The fork's per-record stats path (`nodeStats.updateOrInsert`) is **quadratic per batch** — batch commands have `getNamespace()==nil`, so `updateOrInsert` iterates every record's namespace via `nsIter`, and it is already called once per record. An N-record batch does ~N² increments against a `sync.RWMutex` map. This is a general cost on every batch command; mainnet IBD just exposes it most (44–60% of legacy CPU) because batches are largest, concurrency highest, and aerospike is local so there is no network latency to mask it.

The hot path is gated behind `cluster.metricsEnabled`, which only teranode flips on. Removing the call leaves it `false` and the path is never entered. Connection-pool and node-count metrics are recorded unconditionally, so the poller still exports them — only the per-command latency histograms and result-code counts go dark.

Stop-gap. Real fix is in the `aerospike-client-go` fork, tracked in #1001.
