### PR TITLE
fix(utxopersister): bound allocations on untrusted UTXO count/script length + fuzz

### DIFF
--- a/services/utxopersister/UTXO.go
+++ b/services/utxopersister/UTXO.go
@@ -55,9 +55,8 @@ type UTXOWrapper struct {
 
 	// Reusable buffer for reading fixed-size fields
 	// not concurrently accessed
-	b8             [8]byte
-	b16            [16]byte
-	reusableScript []byte
+	b8  [8]byte
+	b16 [16]byte
 }
 
 // UTXO represents an Unspent Transaction Output.
@@ -230,13 +229,19 @@ func (uw *UTXOWrapper) FromReader(ctx context.Context, r io.Reader, readUtxos ..
 		uw.Coinbase = (encodedHeight & 1) == 1
 
 		if useReadUtxos {
-			uw.UTXOs = make([]*UTXO, numUTXOs)
+			// numUTXOs is an untrusted field read from the file. Cap the
+			// speculative pre-allocation and append as records are read, so a
+			// bogus count errors on the first missing record instead of
+			// forcing a multi-GB allocation up front.
+			uw.UTXOs = make([]*UTXO, 0, min(numUTXOs, 1024))
 
 			for i := uint32(0); i < numUTXOs; i++ {
-				uw.UTXOs[i] = &UTXO{}
-				if err = uw.NewUTXOFromReader(r, uw.UTXOs[i]); err != nil {
+				u := &UTXO{}
+				if err = uw.NewUTXOFromReader(r, u); err != nil {
 					return err
 				}
+
+				uw.UTXOs = append(uw.UTXOs, u)
 			}
 		} else {
 			var (
@@ -344,12 +349,20 @@ func (uw *UTXOWrapper) NewUTXOFromReader(r io.Reader, utxo *UTXO) error {
 	// Read the script length
 	l := uint32(uw.b16[12]) | uint32(uw.b16[13])<<8 | uint32(uw.b16[14])<<16 | uint32(uw.b16[15])<<24
 
-	// Read the script
-	utxo.Script = make([]byte, l)
-
-	if _, err := io.ReadFull(r, utxo.Script); err != nil {
-		return err
+	// l is an untrusted length from the file, so do NOT do make([]byte, l).
+	// io.CopyN here resolves to bytes.Buffer.ReadFrom(io.LimitReader(r, l)),
+	// and ReadFrom grows the buffer in fixed-size (512-byte) increments sized
+	// to the bytes actually read, stopping at the underlying EOF — it never
+	// pre-sizes to l. So a truncated record claiming a 4 GB script allocates
+	// only what is really there (~KB) and then errors, rather than forcing a
+	// multi-GB allocation. A script that genuinely contains l bytes still
+	// allocates l, but that is bounded by the real file size, not the claim.
+	var script bytes.Buffer
+	if _, err := io.CopyN(&script, r, int64(l)); err != nil {
+		return errors.NewStorageError("failed to read utxo script (%d bytes)", l, err)
 	}
+
+	utxo.Script = script.Bytes()
 
 	return nil
 }
@@ -364,17 +377,13 @@ func (uw *UTXOWrapper) NewUTXOValueFromReader(r io.Reader) (uint64, error) {
 	// Read the script length
 	l := uint32(uw.b16[12]) | uint32(uw.b16[13])<<8 | uint32(uw.b16[14])<<16 | uint32(uw.b16[15])<<24
 
-	// Read the script into reusable buffer
-	var script []byte
-	if cap(uw.reusableScript) < int(l) {
-		script = make([]byte, l)
-		uw.reusableScript = script
-	} else {
-		script = uw.reusableScript[:l]
-	}
-
-	if _, err := io.ReadFull(r, script); err != nil {
-		return 0, err
+	// We only need the value here, not the script bytes, so advance past the
+	// script with a streaming discard. l is untrusted, so io.CopyN (which
+	// streams in fixed-size chunks and stops at EOF) avoids pre-allocating l
+	// bytes for a truncated record claiming a huge script. io.Discard's
+	// ReadFrom uses a pooled buffer, so this is allocation-free.
+	if _, err := io.CopyN(io.Discard, r, int64(l)); err != nil {
+		return 0, errors.NewStorageError("failed to read utxo script (%d bytes)", l, err)
 	}
 
 	return value, nil

--- a/services/utxopersister/utxo_fuzz_test.go
+++ b/services/utxopersister/utxo_fuzz_test.go
@@ -1,0 +1,137 @@
+package utxopersister
+
+import (
+	"bytes"
+	"encoding/binary"
+	"runtime"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzUTXOWrapperFromBytes exercises the UTXO-set wrapper deserializer against
+// arbitrary bytes. A persisted .utxo-set file is untrusted at read time — it
+// can be corrupted, truncated, or seeded/imported from elsewhere — and a single
+// bad record historically took down the whole core sidecar via the
+// ServiceManager errgroup. The deserializer must therefore:
+//
+//   - never panic, and
+//   - never make an allocation sized from an untrusted length/count field
+//     (a header claiming 0xFFFFFFFF UTXOs or a 0xFFFFFFFF-byte script must not
+//     trigger a multi-GB allocation), and
+//   - when it does parse a wrapper, re-serialize to exactly the bytes it
+//     consumed (no over- or under-read).
+//
+// The no-panic guarantee is enforced by the fuzzing engine itself; the
+// round-trip invariant is checked below. The allocation bound is pinned
+// deterministically by TestUTXOWrapperFromBytes_HostileSizesAreBounded.
+func FuzzUTXOWrapperFromBytes(f *testing.F) {
+	// Valid seeds — round-trip real wrappers through Bytes().
+	f.Add((&UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("seed-single")),
+		Height: 1,
+		UTXOs:  []*UTXO{{Index: 0, Value: 100, Script: []byte{0x76, 0xa9, 0x88, 0xac}}},
+	}).Bytes())
+	f.Add((&UTXOWrapper{
+		TxID:     chainhash.HashH([]byte("seed-coinbase-multi")),
+		Height:   42,
+		Coinbase: true,
+		UTXOs: []*UTXO{
+			{Index: 0, Value: 5000000000, Script: []byte{0x51}},
+			{Index: 7, Value: 0, Script: nil},
+		},
+	}).Bytes())
+
+	// Hostile seeds — headers that claim enormous sizes with no body behind them.
+	f.Add(wrapperHeader(0xFFFFFFFF))           // numUTXOs = 4 billion, no UTXOs
+	f.Add(wrapperWithScriptLen(1, 0xFFFFFFFF)) // 1 UTXO whose script claims 4 GB
+	f.Add([]byte{})                            // empty
+	f.Add(make([]byte, 32))                    // bare txid, truncated before header
+	f.Add(make([]byte, 40))                    // header present, zero UTXOs, clean
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		w, err := NewUTXOWrapperFromBytes(data)
+		if err != nil {
+			return // a clean error on garbage is the expected outcome
+		}
+
+		require.NotNil(t, w)
+
+		// A wrapper parsed from `data` must re-serialize to exactly the bytes
+		// it consumed, which are a prefix of the input. If Bytes() is not a
+		// prefix of data, the reader and writer disagree on the wire format.
+		encoded := w.Bytes()
+		require.True(t, bytes.HasPrefix(data, encoded),
+			"re-serialized wrapper (%d bytes) is not a prefix of the %d-byte input", len(encoded), len(data))
+	})
+}
+
+// TestUTXOWrapperFromBytes_HostileSizesAreBounded pins that deserializing a
+// header which claims an enormous UTXO count or script length does NOT allocate
+// proportionally to that untrusted field. Before the fix, FromReader did
+// `make([]*UTXO, numUTXOs)` and the per-UTXO readers did `make([]byte, l)`, so a
+// tiny corrupt/truncated file could force a multi-GB allocation and OOM the core
+// sidecar. After the fix the allocation tracks the actual bytes available, so a
+// 40-to-56 byte input must allocate well under a few MB before erroring out.
+func TestUTXOWrapperFromBytes_HostileSizesAreBounded(t *testing.T) {
+	const (
+		hugeCount = 1 << 25         // 33M; pre-sizing []*UTXO would cost ~256 MB
+		hugeLen   = 1 << 25         // 33M; pre-sizing the script would cost ~32 MB
+		maxAlloc  = uint64(4 << 20) // 4 MB — far above a bounded parse, far below the bug
+	)
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"huge utxo count, no body", wrapperHeader(hugeCount)},
+		{"huge script length, no body", wrapperWithScriptLen(1, hugeLen)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alloc := totalAllocDelta(func() {
+				_, err := NewUTXOWrapperFromBytes(tc.data)
+				// Must reject the truncated body rather than succeed.
+				require.Error(t, err, "hostile header must not parse as a valid wrapper")
+			})
+
+			require.Less(t, alloc, maxAlloc,
+				"parsing a %d-byte input allocated %d bytes — allocation is sized from an untrusted length/count field, not the available input",
+				len(tc.data), alloc)
+		})
+	}
+}
+
+// wrapperHeader builds a UTXOWrapper byte stream containing only the 40-byte
+// header (32-byte txid + 4-byte encoded height + 4-byte UTXO count) with the
+// given count and no UTXO records behind it.
+func wrapperHeader(numUTXOs uint32) []byte {
+	b := make([]byte, 40)
+	// bytes 0-31: txid (zero is fine)
+	// bytes 32-35: encoded height/coinbase (zero)
+	binary.LittleEndian.PutUint32(b[36:40], numUTXOs)
+	return b
+}
+
+// wrapperWithScriptLen builds a header declaring numUTXOs records followed by a
+// single partial UTXO (index + value + script length) whose script length is
+// scriptLen, with no script bytes behind it.
+func wrapperWithScriptLen(numUTXOs, scriptLen uint32) []byte {
+	b := wrapperHeader(numUTXOs)
+	utxo := make([]byte, 16) // index(4) + value(8) + scriptLen(4)
+	binary.LittleEndian.PutUint32(utxo[12:16], scriptLen)
+	return append(b, utxo...)
+}
+
+// totalAllocDelta runs fn and returns how many bytes were allocated during it.
+// runtime.TotalAlloc is monotonic, so the delta is a stable measure unaffected
+// by GC. The call is single-goroutine so the reading is not racy.
+func totalAllocDelta(fn func()) uint64 {
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}


### PR DESCRIPTION
First in a small series adding Go native fuzzing to teranode's untrusted/persisted deserializers. teranode currently has **zero** fuzz tests, despite ingesting untrusted bytes from peers and persisted files. This PR targets the UTXO-set wrapper reader and fixes the unbounded-allocation bug it immediately surfaces.

## Bug

`UTXOWrapper` deserialization pre-allocated from length/count fields read straight out of the file, with no bounds check:

| Site | Allocation |
|------|-----------|
| `FromReader` (UTXO.go) | `make([]*UTXO, numUTXOs)` |
| `NewUTXOFromReader` | `make([]byte, scriptLen)` |
| `NewUTXOValueFromReader` | `make([]byte, scriptLen)` (via `reusableScript`) |

A corrupt or truncated `.utxo-set` whose header claims `numUTXOs = 0xFFFFFFFF` or `scriptLen = 0xFFFFFFFF` forces a multi-GB allocation **before** the follow-up read fails — a cheap OOM that takes down the `core` sidecar via the ServiceManager errgroup. This is the same crash class as the recently-fixed utxopersister read-path bugs (#969/#971/#985), and `recover()` does not save an OOM.

These readers are reachable from the consolidation loop, the seeder, `cmd/utxovalidator`, and `cmd/filereader`.

## Fix

Bound the allocations to the bytes actually available, never to an untrusted field:

- **UTXO slice:** cap the speculative capacity (`min(numUTXOs, 1024)`) and `append` as records are read, so a bogus count errors on the first missing record instead of pre-allocating.
- **Script bytes:** read via `io.CopyN`, which streams in fixed-size chunks and stops at EOF — a huge claimed length on a truncated record errors out instead of allocating. The value-only path discards via `io.CopyN(io.Discard, …)` (allocation-free; `io.Discard.ReadFrom` uses a pooled buffer) and drops the now-unused `reusableScript` buffer.

Valid-file parsing is unchanged.

## Tests

- **`FuzzUTXOWrapperFromBytes`** — fuzzes `NewUTXOWrapperFromBytes`; asserts no panic (enforced by the engine) and a re-serialization round-trip invariant (a parsed wrapper's `Bytes()` must be a prefix of the input). Seeded with valid round-tripped wrappers + hostile headers. Runs as plain corpus replay in CI (no `-fuzz` flag needed).
- **`TestUTXOWrapperFromBytes_HostileSizesAreBounded`** — deterministic regression: a hostile header allocates **< 4 MB** (was ~256 MB for the count case, ~32 MB for the script case) before erroring. Fails on the old code, passes on the fix.

## Verification

- Regression test fails before the fix (`268 MB` / `33 MB` observed), passes after.
- `go test -fuzz=FuzzUTXOWrapperFromBytes -fuzztime=45s` — 136K execs, no crashers.
- `go test -race ./services/utxopersister/` — pass (existing roundtrip tests green).
- `go vet`, `gofmt`, `gci` — clean.

Follow-ups (separate PRs): fuzz `model.NewBlockFromBytes` and `pkg/fileformat` header parsing. Wire/tx parsing lives in the separate `go-wire`/`go-bt` modules.
