### PR TITLE
fix(fileformat): make header readers consistent + accept chunked reads + fuzz

### DIFF
--- a/pkg/fileformat/header.go
+++ b/pkg/fileformat/header.go
@@ -166,26 +166,31 @@ func (h Header) Write(w io.Writer) error {
 	return nil
 }
 
-func (h *Header) Read(r io.Reader) error {
-	n, err := r.Read(h.magic[:])
-	if err != nil {
-		// nolint: forbidigo
-		return fmt.Errorf("error reading magic: %w", err)
-	}
-
-	if n != 8 {
-		// nolint: forbidigo
-		return fmt.Errorf("expected to read 8 bytes, got %d", n)
-	}
-
-	// For backward compatibility, replace any trailing 0x00 with 0x20 (space)
+// normalizeMagic rewrites trailing 0x00 bytes to 0x20 (space) for backward
+// compatibility with older files that padded the 8-byte magic with NULs rather
+// than spaces. Both header readers must apply it so they agree on which files
+// are valid.
+func normalizeMagic(magic *[8]byte) {
 	for i := 7; i >= 0; i-- {
-		if h.magic[i] == 0 {
-			h.magic[i] = ' '
+		if magic[i] == 0 {
+			magic[i] = ' '
 		} else {
 			break
 		}
 	}
+}
+
+func (h *Header) Read(r io.Reader) error {
+	// Use io.ReadFull, not a single r.Read: io.Reader.Read may return fewer
+	// than 8 bytes with a nil error (sockets, TLS, io.Pipe, bufio over a slow
+	// source), and a single Read would then reject a valid header that simply
+	// arrived in chunks.
+	if _, err := io.ReadFull(r, h.magic[:]); err != nil {
+		// nolint: forbidigo
+		return fmt.Errorf("error reading magic: expected to read 8 bytes: %w", err)
+	}
+
+	normalizeMagic(&h.magic)
 
 	if _, ok := magicToFileType[h.magic]; !ok {
 		// nolint: forbidigo
@@ -216,6 +221,8 @@ func ReadHeaderFromBytes(b []byte) (Header, error) {
 	header.magic = [8]byte{
 		b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
 	}
+
+	normalizeMagic(&header.magic)
 
 	if _, ok := magicToFileType[header.magic]; !ok {
 		// nolint: forbidigo

--- a/pkg/fileformat/header_fuzz_test.go
+++ b/pkg/fileformat/header_fuzz_test.go
@@ -1,0 +1,97 @@
+package fileformat
+
+import (
+	"bytes"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validMagics returns the 8-byte magic for every registered file type, used as
+// valid fuzz seeds and as the basis for the consistency checks below.
+func validMagics() [][]byte {
+	out := make([][]byte, 0, len(fileTypeToMagic))
+	for ft := range fileTypeToMagic {
+		m := NewHeader(ft).Bytes()
+		out = append(out, m)
+	}
+
+	return out
+}
+
+// TestHeaderRead_AcceptsChunkedReader pins that Header.Read accepts a valid
+// 8-byte magic even when the reader delivers it in pieces. io.Reader.Read is
+// permitted to return fewer than len(p) bytes with a nil error (network
+// sockets, TLS conns, io.Pipe, bufio over a slow source all do this). The old
+// implementation used a single r.Read and rejected anything that did not return
+// all 8 bytes in one call — so a valid header arriving in chunks failed with
+// "expected to read 8 bytes". Reading must use io.ReadFull.
+func TestHeaderRead_AcceptsChunkedReader(t *testing.T) {
+	for _, m := range validMagics() {
+		var h Header
+		// iotest.OneByteReader forces one byte per Read — the worst-case chunking.
+		err := h.Read(iotest.OneByteReader(bytes.NewReader(m)))
+		require.NoError(t, err, "valid magic %q must parse even when delivered one byte at a time", m)
+
+		fromBytes, err := ReadHeaderFromBytes(m)
+		require.NoError(t, err)
+		require.Equal(t, fromBytes.FileType(), h.FileType())
+	}
+}
+
+// TestReadHeaderFromBytes_BackwardCompatibility pins that ReadHeaderFromBytes
+// applies the same trailing-0x00 -> 0x20 normalization that Header.Read does
+// (see TestHeader_Read_BackwardCompatibility). Older files padded the magic
+// with NULs rather than spaces; without this, the streaming reader accepts such
+// a file while the byte-slice reader rejects it as "unknown magic" — the same
+// kind of reader/writer disagreement that has crashed the core sidecar before.
+func TestReadHeaderFromBytes_BackwardCompatibility(t *testing.T) {
+	magicWithNulls := []byte{'B', '-', '1', '.', '0', 0, 0, 0}
+
+	h, err := ReadHeaderFromBytes(magicWithNulls)
+	require.NoError(t, err)
+	require.Equal(t, FileTypeBlock, h.FileType())
+}
+
+// FuzzHeaderParsersAgree is a differential fuzz: the byte-slice parser
+// (ReadHeaderFromBytes) and the streaming parser (Header.Read) must agree on
+// whether arbitrary input is a valid header and, when it is, on the file type —
+// even when the stream is delivered one byte at a time. This catches both
+// reader/writer normalization drift and short-read mishandling.
+func FuzzHeaderParsersAgree(f *testing.F) {
+	for _, m := range validMagics() {
+		f.Add(m)
+	}
+	f.Add([]byte{'B', '-', '1', '.', '0', 0, 0, 0}) // NUL-padded (backward-compat)
+	f.Add([]byte("UNKNOWN!"))                       // 8 bytes, unknown magic
+	f.Add([]byte("SHORT"))                          // too short
+	f.Add([]byte{})                                 // empty
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fromBytes, errBytes := ReadHeaderFromBytes(data)
+		fromReader, errReader := ReadHeader(iotest.OneByteReader(bytes.NewReader(data)))
+
+		require.Equal(t, errBytes == nil, errReader == nil,
+			"parsers disagree on validity of %q: bytes err=%v, reader err=%v", data, errBytes, errReader)
+
+		if errBytes == nil && errReader == nil {
+			require.Equal(t, fromBytes.FileType(), fromReader.FileType(),
+				"parsers agree on validity but disagree on file type for %q", data)
+		}
+	})
+}
+
+// FuzzReadHeaderFromBytes asserts the byte-slice header parser never panics on
+// arbitrary input.
+func FuzzReadHeaderFromBytes(f *testing.F) {
+	for _, m := range validMagics() {
+		f.Add(m)
+	}
+	f.Add([]byte{})
+	f.Add(make([]byte, 8))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ReadHeaderFromBytes(data)
+	})
+}


### PR DESCRIPTION
Third in the deserializer-fuzzing series (after #1004 and #1005). I expected the fileformat header to be low-yield "insurance" (it already has a length guard) — but a differential fuzz of its two parsers surfaced **two real robustness bugs**.

## Bugs

**1. `Header.Read` used a single `r.Read` for the 8-byte magic.** `io.Reader.Read` is allowed to return fewer than 8 bytes with a `nil` error — sockets, TLS conns, `io.Pipe`, and `bufio` over a slow source all do this. The code then hit `n != 8` and rejected a perfectly valid header that simply arrived in chunks (`"expected to read 8 bytes, got 1"`). A file or `bytes.Reader` fills 8 in one call so it was invisible there, but streaming readers fail. → use `io.ReadFull`.

**2. `ReadHeaderFromBytes` lacked the trailing-`0x00`→`0x20` normalization that `Header.Read` has.** Older files padded the magic with NULs instead of spaces. `Header.Read` normalizes them (see the existing `TestHeader_Read_BackwardCompatibility`); `ReadHeaderFromBytes` did not — so the same file was accepted via the streaming path and rejected as `"unknown magic"` via the byte-slice path. That reader/writer disagreement is the same class that has crashed the `core` sidecar before.

## Fix

Extract the normalization into a shared `normalizeMagic` helper and apply it in both readers; switch `Header.Read` to `io.ReadFull`. Existing error-message assertions are preserved.

## Tests

- **`TestHeaderRead_AcceptsChunkedReader`** (bug 1): every valid magic parses when delivered one byte at a time via `iotest.OneByteReader`.
- **`TestReadHeaderFromBytes_BackwardCompatibility`** (bug 2): a NUL-padded magic is accepted with the correct file type.
- **`FuzzHeaderParsersAgree`**: differential fuzz asserting `ReadHeaderFromBytes` and `Header.Read` (over a one-byte-at-a-time reader) agree on validity and file type — catches both normalization drift and short-read mishandling.
- **`FuzzReadHeaderFromBytes`**: no-panic.

## Verification

- Both new unit tests fail before the fix (`got 1`, `unknown magic: [66 45 49 46 48 0 0 0]`), pass after.
- `FuzzHeaderParsersAgree` ~1.8M execs, `FuzzReadHeaderFromBytes` ~1.3M execs — no crashers.
- Full `pkg/fileformat` `-race`, `go vet`, `gofmt`, `gci` — clean. Existing tests unchanged.

Completes the planned three-target series. Net: 3 PRs, 4 distinct bugs (two unbounded-allocation/OOM, two header-parser inconsistencies), each pinned by a fuzz target + regression test.
