### PR TITLE
test(e2e): replace hardcoded time.Sleep with condition-polling in gated tests (#998)

### DIFF
--- a/test/e2e/daemon/ready/banlist_e2e_test.go
+++ b/test/e2e/daemon/ready/banlist_e2e_test.go
@@ -44,9 +44,6 @@ func TestBanListGRPCE2E(t *testing.T) {
 		})
 		defer daemonNode.Stop(t)
 
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
-
 		// Create client using the daemon's settings (which already has the correct ports and API key)
 		clientI, err := p2p.NewClient(context.Background(), ulogger.NewVerboseTestLogger(t), daemonNode.Settings)
 		require.NoError(t, err)
@@ -80,7 +77,6 @@ func TestBanListGRPCE2E(t *testing.T) {
 			},
 		})
 		defer daemonNode.Stop(t)
-		time.Sleep(5 * time.Second)
 
 		clientI, err = p2p.NewClient(context.Background(), ulogger.NewVerboseTestLogger(t), daemonNode.Settings)
 		require.NoError(t, err)
@@ -175,9 +171,6 @@ func TestPeerIDBanE2E(t *testing.T) {
 			},
 		})
 		defer daemonNode.Stop(t)
-
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
 
 		// Create client using the daemon's settings
 		clientI, err := p2p.NewClient(context.Background(), ulogger.NewVerboseTestLogger(t), daemonNode.Settings)
@@ -282,9 +275,6 @@ func TestPeerIDBanExpirationE2E(t *testing.T) {
 		})
 		defer daemonNode.Stop(t)
 
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
-
 		// Create client using the daemon's settings
 		clientI, err := p2p.NewClient(context.Background(), ulogger.NewVerboseTestLogger(t), daemonNode.Settings)
 		require.NoError(t, err)
@@ -317,7 +307,7 @@ func TestPeerIDBanExpirationE2E(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, isBanned, "Peer should be banned after reaching threshold")
 
-		// Wait for the ban to expire (ban duration + 1 second buffer)
+		// intentional: ban TTL must physically elapse (banDuration + 1s buffer); polling cannot shorten a real timeout
 		t.Logf("Waiting %v for ban to expire...", banDuration+time.Second)
 		time.Sleep(banDuration + time.Second)
 
@@ -352,9 +342,6 @@ func TestBanListRPCE2E(t *testing.T) {
 			},
 		})
 		defer daemonNode.Stop(t)
-
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
 
 		ctx := context.Background()
 		ip := "192.168.200.1"
@@ -449,9 +436,6 @@ func TestBanListRPCAbsoluteTimeE2E(t *testing.T) {
 		})
 		defer daemonNode.Stop(t)
 
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
-
 		ctx := context.Background()
 		ip := "192.168.201.1"
 
@@ -505,9 +489,6 @@ func TestBanListRPCIPv6Subnet(t *testing.T) {
 		})
 		defer daemonNode.Stop(t)
 
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
-
 		ctx := context.Background()
 		banTimeSeconds := int64(3600)
 
@@ -552,9 +533,6 @@ func TestIsBannedRPCWithPeerID(t *testing.T) {
 			},
 		})
 		defer daemonNode.Stop(t)
-
-		// Wait for node to be ready
-		time.Sleep(5 * time.Second)
 
 		// Create gRPC P2P client for AddBanScore
 		clientI, err := p2p.NewClient(context.Background(), ulogger.NewVerboseTestLogger(t), daemonNode.Settings)

--- a/test/e2e/daemon/ready/block_persister_test.go
+++ b/test/e2e/daemon/ready/block_persister_test.go
@@ -133,19 +133,13 @@ func TestBlockPersister(t *testing.T) {
 	// Phase 4: Verify all blocks are marked as persisted in the database
 	t.Log("Phase 4: Verifying no unpersisted blocks remain...")
 
-	// Give the persister a moment to finish any remaining work
-	time.Sleep(2 * time.Second)
-
-	// Check that there are no unpersisted blocks
-	unpersistedBlocks, err := node.BlockchainClient.GetBlocksNotPersisted(node.Ctx, 100)
-	require.NoError(t, err, "Failed to get unpersisted blocks")
-
-	if len(unpersistedBlocks) > 0 {
-		for _, b := range unpersistedBlocks {
-			t.Logf("  Unpersisted block: height=%d, hash=%s", b.Height, b.Hash().String())
-		}
-	}
-	require.Empty(t, unpersistedBlocks, "All blocks should be persisted, but found %d unpersisted", len(unpersistedBlocks))
+	// Poll until the persister has marked all blocks persisted.
+	var unpersistedBlocks []*model.Block
+	require.Eventually(t, func() bool {
+		var err error
+		unpersistedBlocks, err = node.BlockchainClient.GetBlocksNotPersisted(node.Ctx, 100)
+		return err == nil && len(unpersistedBlocks) == 0
+	}, 15*time.Second, 500*time.Millisecond, "all blocks should be persisted")
 	t.Log("  All blocks are marked as persisted in the database")
 
 	// Phase 5: Verify block data can be retrieved from store and parsed correctly
@@ -443,11 +437,13 @@ func TestBlockPersisterMultipleBlocksSequential(t *testing.T) {
 		currentTx = newTx
 	}
 
-	// Final check: no unpersisted blocks should remain
-	time.Sleep(2 * time.Second) // Give persister time to finish
-	unpersistedBlocks, err := node.BlockchainClient.GetBlocksNotPersisted(node.Ctx, 100)
-	require.NoError(t, err)
-	require.Empty(t, unpersistedBlocks, "All blocks should be persisted")
+	// Final check: poll until no unpersisted blocks remain.
+	var unpersistedBlocks []*model.Block
+	require.Eventually(t, func() bool {
+		var err error
+		unpersistedBlocks, err = node.BlockchainClient.GetBlocksNotPersisted(node.Ctx, 100)
+		return err == nil && len(unpersistedBlocks) == 0
+	}, 15*time.Second, 500*time.Millisecond, "all blocks should be persisted")
 
 	t.Logf("=== Test Passed: All %d blocks persisted correctly ===", numBlocks)
 }

--- a/test/e2e/daemon/ready/legacy_sync_test.go
+++ b/test/e2e/daemon/ready/legacy_sync_test.go
@@ -423,6 +423,7 @@ func TestBidirectionalSync(t *testing.T) {
 	const teranodeBlocks = 5
 	var teranodeMinedBlocks []*model.Block
 	for i := 0; i < teranodeBlocks; i++ {
+		// intentional pacing: svnode rejects blocks whose timestamps are too close together
 		time.Sleep(500 * time.Millisecond)
 		block := td.MineAndWait(t, 1)
 		teranodeMinedBlocks = append(teranodeMinedBlocks, block)
@@ -665,6 +666,7 @@ func TestMultistreamSVNodeSyncFromTeranode(t *testing.T) {
 
 	var minedBlocks []*model.Block
 	for i := 0; i < teranodeBlocks; i++ {
+		// intentional pacing: svnode rejects blocks whose timestamps are too close together
 		time.Sleep(500 * time.Millisecond)
 		block := td.MineAndWait(t, 1)
 		minedBlocks = append(minedBlocks, block)

--- a/test/e2e/daemon/ready/multi_node_send_2_tx_test.go
+++ b/test/e2e/daemon/ready/multi_node_send_2_tx_test.go
@@ -55,12 +55,12 @@ func TestMultiNodeSend2Tx(t *testing.T) {
 	err := node1.PropagationClient.ProcessTransaction(node1.Ctx, tx0)
 	require.NoError(t, err, "Failed to process tx through propagation client")
 
-	time.Sleep(10 * time.Second)
-
-	txHashes, err := node1.BlockAssemblyClient.GetTransactionHashes(node1.Ctx)
-	require.NoError(t, err)
-
-	require.Len(t, txHashes, 2, "Node1 should have coinbase placeholder + tx0")
+	var txHashes []string
+	require.Eventually(t, func() bool {
+		var err error
+		txHashes, err = node1.BlockAssemblyClient.GetTransactionHashes(node1.Ctx)
+		return err == nil && len(txHashes) == 2
+	}, 10*time.Second, 100*time.Millisecond, "node1 should have coinbase placeholder + tx0 in block assembly")
 
 	txHashes, err = node2.BlockAssemblyClient.GetTransactionHashes(node2.Ctx)
 	require.NoError(t, err)

--- a/test/e2e/daemon/ready/pruner_parent_before_child_test.go
+++ b/test/e2e/daemon/ready/pruner_parent_before_child_test.go
@@ -200,8 +200,8 @@ func TestPrunerParentNotDeletedBeforeChildren(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Current height: %d (child1 DAH ~%d)", meta.Height, grandchildMinedHeight+blockHeightRetention)
 
-	// Wait for pruner to process
-	time.Sleep(5 * time.Second)
+	// Wait for the pruner to complete a cycle before asserting what survived.
+	node.WaitForPruner(t, 15*time.Second)
 
 	// ========== Verify: Parent must NOT be deleted ==========
 	// The parent still has output 4 unspent, and child2 is not fully spent.
@@ -358,8 +358,8 @@ func TestPrunerParentFullySpentNotDeletedBeforeChildren(t *testing.T) {
 	err = node.BlockValidation.ValidateBlock(node.Ctx, forkBlockWithChild2, node.AssetURL, false)
 	require.NoError(t, err)
 
-	// node.WaitForBlockAssemblyToProcessTx(t, child2Hex)
-	time.Sleep(2 * time.Second)
+	// Wait for child2 to be (re)loaded into block assembly after the forked block.
+	require.NoError(t, node.WaitForTransactionInBlockAssembly(child2, 10*time.Second))
 
 	node.VerifyNotOnLongestChainInUtxoStore(t, child2)
 	node.VerifyInBlockAssembly(t, child2)

--- a/test/e2e/daemon/ready/utxo_test.go
+++ b/test/e2e/daemon/ready/utxo_test.go
@@ -283,8 +283,6 @@ func TestDeleteAtHeightHappyPath(t *testing.T) {
 	_, err = td.CallRPC(td.Ctx, "generate", []any{blocksToGenerate + 1})
 	require.NoError(t, err)
 
-	time.Sleep(10 * time.Second)
-
 	// Verify transaction still exists
 	meta, err := td.UtxoStore.Get(td.Ctx, parentTx.TxIDChainHash())
 

--- a/test/sequentialtest/block_assembly/block_assembly_restart_test.go
+++ b/test/sequentialtest/block_assembly/block_assembly_restart_test.go
@@ -328,9 +328,6 @@ func testBlockAssemblyRestartWithExternalTx(t *testing.T, utxoStoreType string) 
 	err = td.BlockAssemblyClient.ResetBlockAssemblyFully(td.Ctx)
 	require.NoError(t, err, "Block assembly reset should succeed with external transactions")
 
-	// Wait a bit for reset to complete
-	time.Sleep(2 * time.Second)
-
 	// Step 5: Verify transaction is still in block assembly after reset
 	t.Log("Verifying external transaction is reloaded after reset")
 	err = td.WaitForTransactionInBlockAssembly(externalTx, blockWait)
@@ -489,8 +486,6 @@ func testBlockAssemblyRestartWithMultipleExternalTx(t *testing.T, utxoStoreType 
 	err = td.BlockAssemblyClient.ResetBlockAssemblyFully(td.Ctx)
 	require.NoError(t, err)
 
-	time.Sleep(2 * time.Second)
-
 	// Verify all transactions are reloaded
 	t.Log("Verifying all external transactions are reloaded after reset")
 	require.NoError(t, td.WaitForTransactionInBlockAssembly(externalTx1, blockWait))
@@ -638,8 +633,6 @@ func testBlockAssemblyRestartWithMixedTx(t *testing.T, utxoStoreType string) {
 	t.Log("Triggering block assembly reset")
 	err = td.BlockAssemblyClient.ResetBlockAssemblyFully(td.Ctx)
 	require.NoError(t, err)
-
-	time.Sleep(2 * time.Second)
 
 	// Verify all transactions are reloaded (both regular and external)
 	t.Log("Verifying all mixed transactions are reloaded after reset")


### PR DESCRIPTION
## What

Replace hardcoded `time.Sleep` "sleep-then-assert" waits with poll-until-condition (or delete redundant sleeps) across the **running** gated e2e tests. Cuts serial wall-clock (the gated suites run `-parallel 1`) and removes a flakiness source. Test-only — no production code, CI, or Makefile changes.

Closes #998.

## Changes

- **banlist** — deleted 8 redundant "wait for node ready" sleeps. `daemon.NewTestDaemon` already blocks on readiness before returning (`readyCh` 30s + `WaitForHealthLiveness` 10s + FSM `RUNNING`); the first client/RPC call self-errors if not ready. Kept the `banDuration + 1s` ban-TTL wait — genuine wall-clock, polling can't shorten it.
- **multi_node_send_2_tx** — 10s sleep → `require.Eventually` polling `GetTransactionHashes` for `len == 2`.
- **utxo (`TestDeleteAtHeightHappyPath`)** — deleted a 10s sleep that guarded commented-out assertions (`//require.Error`, `// require.Nil`).
- **block_assembly_restart** — deleted 3× 2s sleeps that each immediately preceded `WaitForTransactionInBlockAssembly` (already polls).
- **block_persister** — 2× 2s sleeps → `require.Eventually` polling `GetBlocksNotPersisted` empty (15s/500ms).
- **pruner_parent_before_child** — `:204` → `WaitForPruner` (real completion barrier: `EnablePruner: true` registers the observer); `:362` → `WaitForTransactionInBlockAssembly`.
- **legacy_sync** — comments only: documented the intentional inter-block timestamp pacing (svnode rejects blocks with too-close timestamps).

## Verified

- `go build` + `go vet` clean across `test/e2e/daemon/ready/...` and `test/sequentialtest/block_assembly/...`; `gofmt` clean on all 7 files.
- Ran locally (without `-race`, see note): banlist (3×), multi_node_send_2_tx, utxo, block_assembly_restart, block_persister (both), pruner_parent (both) — all PASS. Per-file wall-clock dropped: banlist ~27s/run, multi_node ~9s, utxo ~10s, block_assembly_restart ~6s.
- **legacy_sync**: build + vet only — needs an SV node; relies on the CI `legacy-sync` gate.

## Out of scope (left intentionally — no benefit)

- **reorg_test.go** and **smoke_test.go** target sleeps: all inside `t.Skip`'d tests (`TestDynamicSubtreeSize`, `TestTracing`, `TestSendTxDeleteParentResendTx`, `TestTransactionPurgeAndSyncConflicting`). They never run, so converting saves zero wall-clock and can't be run-verified. The issue's ~99s estimate counted ~17s here that doesn't execute.
- **legacy_sync 500ms sleeps**: genuine inter-block timestamp pacing + ticks inside existing poll loops — not the anti-pattern.
- **wip/\*** sleeps: not run by the smoke gate.

## Notes

- `-race` currently fails on a **pre-existing** libp2p NAT data race (`go-libp2p` `natpmp.randomPort`), unrelated to this change — fails identically before and after on these commits.
- `pruner_parent_before_child` has a latent `WaitForBlockPersisted` timeout under container contention (~line 390), pre-existing (akin to #997).
- `WaitForPruner` at `:204` waits for *a* completed prune cycle, not provably the child1-DAH-height cycle — same property as the sleep it replaced. The `:204` assertions only check transactions that must *survive*, so an early return can't mask a false negative; the same helper backs the stable `:392` "parent was pruned" assertion.
