### PR TITLE
perf(utxo): eliminate encode-side allocations in the store Create path (#1002)

### DIFF
--- a/stores/utxo/aerospike/arena_pool.go
+++ b/stores/utxo/aerospike/arena_pool.go
@@ -1,0 +1,36 @@
+package aerospike
+
+import (
+	"sync"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+const (
+	createArenaInitialCap = 1 << 20  // 1 MiB
+	createArenaShrinkCap  = 32 << 20 // 32 MiB
+)
+
+// createArenaPool holds bt.Arena instances reused across sendStoreBatch calls.
+// Contract: get an arena at the top of sendStoreBatch, put it back after
+// BatchOperate has returned (all arena-backed bin bytes have been packed into
+// the wire buffer). Bins handed to goroutines that outlive sendStoreBatch must
+// NOT reference arena memory — see the escape rebuild in sendStoreBatch.
+var createArenaPool = sync.Pool{
+	New: func() any { return bt.NewArena(createArenaInitialCap) },
+}
+
+// getCreateArena returns an arena ready for use. The arena's cursor is at
+// zero on entry.
+func getCreateArena() *bt.Arena {
+	return createArenaPool.Get().(*bt.Arena)
+}
+
+// putCreateArena returns the arena to the pool after Reset+Shrink. The
+// caller must release all bin slices backed by arena memory before invoking
+// putCreateArena — those bytes will be reused or freed by subsequent pool
+// consumers.
+func putCreateArena(a *bt.Arena) {
+	a.ResetAndShrink(createArenaShrinkCap)
+	createArenaPool.Put(a)
+}

--- a/stores/utxo/aerospike/arena_pool_test.go
+++ b/stores/utxo/aerospike/arena_pool_test.go
@@ -1,0 +1,23 @@
+package aerospike
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateArenaPool_GetResetPut(t *testing.T) {
+	a := getCreateArena()
+	require.NotNil(t, a)
+	require.Equal(t, 0, a.Used())
+
+	buf := a.Alloc(128)
+	require.Len(t, buf, 128)
+	require.Equal(t, 128, a.Used())
+
+	putCreateArena(a)
+
+	b := getCreateArena()
+	require.Equal(t, 0, b.Used()) // reset on return
+	putCreateArena(b)
+}

--- a/stores/utxo/aerospike/container_helper_test.go
+++ b/stores/utxo/aerospike/container_helper_test.go
@@ -303,7 +303,7 @@ func prepareBatchStoreItem(t *testing.T, s *teranode_aerospike.Store, tx *bt.Tx,
 	txHash := tx.TxIDChainHash()
 	isCoinbase := tx.IsCoinbase()
 
-	binsToStore, err := s.GetBinsToStore(tx, blockHeight, blockIDs, blockHeights, subtreeIdxs, true, txHash, isCoinbase, false, false)
+	binsToStore, err := s.GetBinsToStore(tx, blockHeight, blockIDs, blockHeights, subtreeIdxs, true, txHash, isCoinbase, false, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, binsToStore)
 

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -295,6 +295,9 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 		err         error
 	)
 
+	arena := getCreateArena()
+	defer putCreateArena(arena)
+
 	for idx, bItem := range batch {
 		key, err = aerospike.NewKey(s.namespace, s.setName, bItem.txHash[:])
 		if err != nil {
@@ -331,7 +334,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 			external = true
 		}
 
-		binsToStore, err = s.GetBinsToStore(bItem.tx, bItem.blockHeight, bItem.blockIDs, bItem.blockHeights, bItem.subtreeIdxs, external, bItem.txHash, bItem.isCoinbase, bItem.conflicting, bItem.locked, nil) // false is to say this is a normal record, not external.
+		binsToStore, err = s.GetBinsToStore(bItem.tx, bItem.blockHeight, bItem.blockIDs, bItem.blockHeights, bItem.subtreeIdxs, external, bItem.txHash, bItem.isCoinbase, bItem.conflicting, bItem.locked, arena) // false is to say this is a normal record, not external.
 		if err != nil {
 			util.SafeSend[error](bItem.done, errors.NewProcessingError("could not get bins to store", err))
 			resultHandledElsewhere[idx] = true
@@ -345,6 +348,19 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 		start = stat.NewStat("GetBinsToStore").AddTime(start)
 
 		if len(binsToStore) > 1 {
+			// This tx splits into multiple records and is persisted by a goroutine
+			// that outlives sendStoreBatch (and the per-batch arena). Rebuild its
+			// bins with heap-owned backing (nil arena) so the deferred arena reset
+			// cannot corrupt the bytes the goroutine still references.
+			binsToStore, err = s.GetBinsToStore(bItem.tx, bItem.blockHeight, bItem.blockIDs, bItem.blockHeights, bItem.subtreeIdxs, external, bItem.txHash, bItem.isCoinbase, bItem.conflicting, bItem.locked, nil)
+			if err != nil {
+				util.SafeSend[error](bItem.done, errors.NewProcessingError("could not rebuild bins for external store", err))
+				resultHandledElsewhere[idx] = true
+				batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
+
+				continue
+			}
+
 			// Make this batch item a NOOP and persist all of these to be written via a queue
 			batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
 			// Goroutine takes ownership of bItem.done; the per-record loop must not touch it.

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -600,6 +600,32 @@ func (s *Store) splitIntoBatches(utxos []interface{}, commonBins []*aerospike.Bi
 	return batches
 }
 
+// extendedTxSize returns len(tx.ExtendedBytes()) without serializing the tx.
+// Mirrors go-bt's extended layout: standard size, plus the 6-byte EF marker,
+// plus per-input PreviousTxSatoshis(8) and the previous-script varint+bytes
+// (a nil PreviousTxScript serializes as a single 0x00 == VarInt(0)).
+//
+// Precondition: every input has its previousTxIDHash set (non-nil). This holds
+// for all txs reaching GetBinsToStore — bytes-decoded txs and legacy
+// WireTxToGoBtTx (which calls PreviousTxIDAdd per input) both populate it, and a
+// coinbase's input carries 32 zero bytes (still non-nil). bt.Input.Size()
+// unconditionally counts those 32 bytes while ExtendedBytes() omits a nil hash,
+// so a nil-hash input would make this overcount by 32 — not reachable in the
+// store path.
+func extendedTxSize(tx *bt.Tx) int {
+	size := tx.Size() + 6
+	for _, in := range tx.Inputs {
+		size += 8
+		if in.PreviousTxScript == nil {
+			size += 1
+		} else {
+			l := len(*in.PreviousTxScript)
+			size += bt.VarInt(uint64(l)).Length() + l
+		}
+	}
+	return size
+}
+
 // GetBinsToStore prepares Aerospike bins for storage, handling transaction data
 // and UTXO organization.
 //
@@ -641,7 +667,7 @@ func (s *Store) GetBinsToStore(tx *bt.Tx, blockHeight uint32, blockIDs, blockHei
 		utxoHashes, err = utxo.GetUtxoHashes(tx, txHash)
 	} else {
 		size = tx.Size()
-		extendedSize = len(tx.ExtendedBytes())
+		extendedSize = extendedTxSize(tx)
 		fee, utxoHashes, err = utxo.GetFeesAndUtxoHashes(context.Background(), tx, blockHeight)
 	}
 

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -600,6 +600,76 @@ func (s *Store) splitIntoBatches(utxos []interface{}, commonBins []*aerospike.Bi
 	return batches
 }
 
+// appendOutputInto serializes output in standard format (satoshis(8 LE) +
+// VarInt(scriptLen) + script) into an arena-backed slice. Replicates go-bt's
+// unexported Output.appendTo. When arena is nil it allocates via make. Zero
+// heap allocations on the arena path (output.Size() gives the exact length).
+func appendOutputInto(arena *bt.Arena, o *bt.Output) []byte {
+	size := o.Size()
+	var buf []byte
+	if arena != nil {
+		buf = arena.Alloc(size)[:0]
+	} else {
+		buf = make([]byte, 0, size)
+	}
+	buf = append(buf,
+		byte(o.Satoshis), byte(o.Satoshis>>8), byte(o.Satoshis>>16), byte(o.Satoshis>>24),
+		byte(o.Satoshis>>32), byte(o.Satoshis>>40), byte(o.Satoshis>>48), byte(o.Satoshis>>56))
+	buf = bt.VarInt(uint64(len(*o.LockingScript))).AppendTo(buf)
+	return append(buf, *o.LockingScript...)
+}
+
+// appendInputExtendedInto serializes input in the store's extended format
+// (standard input bytes + PreviousTxSatoshis(8 LE) + VarInt(prevScriptLen) +
+// prevScript; nil prevScript => single 0x00) into an arena-backed slice.
+// Matches the previous manual layout in GetBinsToStore. When arena is nil it
+// allocates via make.
+func appendInputExtendedInto(arena *bt.Arena, in *bt.Input) []byte {
+	size := in.Size() + 8
+	if in.PreviousTxScript == nil {
+		size += 1
+	} else {
+		l := len(*in.PreviousTxScript)
+		size += bt.VarInt(uint64(l)).Length() + l
+	}
+
+	var buf []byte
+	if arena != nil {
+		buf = arena.Alloc(size)[:0]
+	} else {
+		buf = make([]byte, 0, size)
+	}
+
+	// standard input layout (previousTxIDHash + outindex + unlocking script + sequence)
+	if in.PreviousTxIDChainHash() != nil {
+		buf = append(buf, in.PreviousTxIDChainHash()[:]...)
+	}
+	buf = append(buf,
+		byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
+		byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24))
+	if in.UnlockingScript == nil {
+		buf = append(buf, 0x00)
+	} else {
+		buf = bt.VarInt(uint64(len(*in.UnlockingScript))).AppendTo(buf)
+		buf = append(buf, *in.UnlockingScript...)
+	}
+	buf = append(buf,
+		byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
+		byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24))
+
+	// extended suffix
+	buf = append(buf,
+		byte(in.PreviousTxSatoshis), byte(in.PreviousTxSatoshis>>8), byte(in.PreviousTxSatoshis>>16), byte(in.PreviousTxSatoshis>>24),
+		byte(in.PreviousTxSatoshis>>32), byte(in.PreviousTxSatoshis>>40), byte(in.PreviousTxSatoshis>>48), byte(in.PreviousTxSatoshis>>56))
+	if in.PreviousTxScript == nil {
+		buf = append(buf, 0x00)
+	} else {
+		buf = bt.VarInt(uint64(len(*in.PreviousTxScript))).AppendTo(buf)
+		buf = append(buf, *in.PreviousTxScript...)
+	}
+	return buf
+}
+
 // extendedTxSize returns len(tx.ExtendedBytes()) without serializing the tx.
 // Mirrors go-bt's extended layout: standard size, plus the 6-byte EF marker,
 // plus per-input PreviousTxSatoshis(8) and the previous-script varint+bytes

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -331,7 +331,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 			external = true
 		}
 
-		binsToStore, err = s.GetBinsToStore(bItem.tx, bItem.blockHeight, bItem.blockIDs, bItem.blockHeights, bItem.subtreeIdxs, external, bItem.txHash, bItem.isCoinbase, bItem.conflicting, bItem.locked) // false is to say this is a normal record, not external.
+		binsToStore, err = s.GetBinsToStore(bItem.tx, bItem.blockHeight, bItem.blockIDs, bItem.blockHeights, bItem.subtreeIdxs, external, bItem.txHash, bItem.isCoinbase, bItem.conflicting, bItem.locked, nil) // false is to say this is a normal record, not external.
 		if err != nil {
 			util.SafeSend[error](bItem.done, errors.NewProcessingError("could not get bins to store", err))
 			resultHandledElsewhere[idx] = true
@@ -509,7 +509,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 				}
 
 				if aErr.ResultCode == types.RECORD_TOO_BIG {
-					binsToStore, err = s.GetBinsToStore(batch[idx].tx, batch[idx].blockHeight, batch[idx].blockIDs, batch[idx].blockHeights, batch[idx].subtreeIdxs, true, batch[idx].txHash, batch[idx].isCoinbase, batch[idx].conflicting, batch[idx].locked) // true is to say this is a big record
+					binsToStore, err = s.GetBinsToStore(batch[idx].tx, batch[idx].blockHeight, batch[idx].blockIDs, batch[idx].blockHeights, batch[idx].subtreeIdxs, true, batch[idx].txHash, batch[idx].isCoinbase, batch[idx].conflicting, batch[idx].locked, nil) // true is to say this is a big record
 					if err != nil {
 						util.SafeSend[error](batch[idx].done, errors.NewProcessingError("could not get bins to store", err))
 						continue
@@ -719,7 +719,7 @@ func extendedTxSize(tx *bt.Tx) int {
 //   - Whether the transaction has UTXOs
 //   - Any error that occurred
 func (s *Store) GetBinsToStore(tx *bt.Tx, blockHeight uint32, blockIDs, blockHeights []uint32, subtreeIdxs []int, external bool,
-	txHash *chainhash.Hash, isCoinbase bool, isConflicting bool, isLocked bool) ([][]*aerospike.Bin, error) {
+	txHash *chainhash.Hash, isCoinbase bool, isConflicting bool, isLocked bool, arena *bt.Arena) ([][]*aerospike.Bin, error) {
 	var (
 		fee          uint64
 		utxoHashes   []*chainhash.Hash
@@ -759,29 +759,7 @@ func (s *Store) GetBinsToStore(tx *bt.Tx, blockHeight uint32, blockIDs, blockHei
 		inputs = make([]interface{}, len(tx.Inputs))
 
 		for i, input := range tx.Inputs {
-			h := input.Bytes(false)
-
-			// this is needed for extended txs, go-bt does not do this itself
-			h = append(h, []byte{
-				byte(input.PreviousTxSatoshis),
-				byte(input.PreviousTxSatoshis >> 8),
-				byte(input.PreviousTxSatoshis >> 16),
-				byte(input.PreviousTxSatoshis >> 24),
-				byte(input.PreviousTxSatoshis >> 32),
-				byte(input.PreviousTxSatoshis >> 40),
-				byte(input.PreviousTxSatoshis >> 48),
-				byte(input.PreviousTxSatoshis >> 56),
-			}...)
-
-			if input.PreviousTxScript == nil {
-				h = append(h, bt.VarInt(0).Bytes()...)
-			} else {
-				l := uint64(len(*input.PreviousTxScript))
-				h = append(h, bt.VarInt(l).Bytes()...)
-				h = append(h, *input.PreviousTxScript...)
-			}
-
-			inputs[i] = h
+			inputs[i] = appendInputExtendedInto(arena, input)
 		}
 	}
 
@@ -790,7 +768,7 @@ func (s *Store) GetBinsToStore(tx *bt.Tx, blockHeight uint32, blockIDs, blockHei
 
 	for i, output := range tx.Outputs {
 		if output != nil {
-			outputs[i] = output.Bytes()
+			outputs[i] = appendOutputInto(arena, output)
 
 			// store all coinbases, non-zero utxos and exceptions from pre-genesis
 			if utxo.ShouldStoreOutputAsUTXO(isCoinbase, output, blockHeight) {

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -326,8 +326,9 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 				}
 			}
 		} else {
-			// we cannot use tx.Size() here, because it doesn't include the extended data for the inputs
-			extendedSize = len(batch[idx].tx.ExtendedBytes())
+			// tx.Size() omits the extended per-input data; extendedTxSize adds it
+			// (matches len(tx.ExtendedBytes()) without serializing).
+			extendedSize = extendedTxSize(batch[idx].tx)
 		}
 
 		if extendedSize > MaxTxSizeInStoreInBytes {

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -319,7 +319,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 			// This is a partial transaction, and we calculate the size of the outputs only
 			for _, output := range batch[idx].tx.Outputs {
 				if output != nil {
-					extendedSize += len(output.Bytes())
+					extendedSize += output.Size()
 				}
 			}
 		} else {

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -692,16 +692,16 @@ func appendInputExtendedInto(arena *bt.Arena, in *bt.Input) []byte {
 // plus per-input PreviousTxSatoshis(8) and the previous-script varint+bytes
 // (a nil PreviousTxScript serializes as a single 0x00 == VarInt(0)).
 //
-// Precondition: every input has its previousTxIDHash set (non-nil). This holds
-// for all txs reaching GetBinsToStore — bytes-decoded txs and legacy
-// WireTxToGoBtTx (which calls PreviousTxIDAdd per input) both populate it, and a
-// coinbase's input carries 32 zero bytes (still non-nil). bt.Input.Size()
-// unconditionally counts those 32 bytes while ExtendedBytes() omits a nil hash,
-// so a nil-hash input would make this overcount by 32 — not reachable in the
-// store path.
+// bt.Input.Size() counts 32 bytes for the previous txid unconditionally, but
+// ExtendedBytes() omits them when previousTxIDHash is nil; the correction below
+// keeps this exact for inputs with an unset hash too (production txs always set
+// it — via decode or WireTxToGoBtTx — but we don't rely on that).
 func extendedTxSize(tx *bt.Tx) int {
 	size := tx.Size() + 6
 	for _, in := range tx.Inputs {
+		if in.PreviousTxIDChainHash() == nil {
+			size -= 32
+		}
 		size += 8
 		if in.PreviousTxScript == nil {
 			size += 1

--- a/stores/utxo/aerospike/create_arena_test.go
+++ b/stores/utxo/aerospike/create_arena_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/util/test"
 )
 
@@ -40,58 +41,133 @@ func TestCreateArena_ConcurrentReuseNoCorruption(t *testing.T) {
 	wg.Wait()
 }
 
+// assertArenaEqualNoArena is a helper that calls GetBinsToStore twice on the
+// same tx — once with nil arena, once with the supplied arena — and asserts
+// byte-identical results.  A fresh arena must be passed for each call so that
+// prior test cases' allocations do not interfere.
+func assertArenaEqualNoArena(t *testing.T, s *Store, tx *bt.Tx, isCoinbase bool, name string) {
+	t.Helper()
+
+	txHash := tx.TxIDChainHash()
+
+	want, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, txHash, isCoinbase, false, false, nil)
+	require.NoError(t, err, "%s: GetBinsToStore(nil arena) failed", name)
+
+	arena := bt.NewArena(0)
+
+	got, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, txHash, isCoinbase, false, false, arena)
+	require.NoError(t, err, "%s: GetBinsToStore(arena) failed", name)
+
+	require.Equal(t, len(want), len(got), "%s: number of bin groups differs", name)
+
+	for ri := range want {
+		require.Equal(t, len(want[ri]), len(got[ri]), "%s: number of bins in group %d differs", name, ri)
+
+		for bi, wb := range want[ri] {
+			gb := got[ri][bi]
+			require.Equal(t, wb.Name, gb.Name, "%s: bin name mismatch at [%d][%d]", name, ri, bi)
+
+			// createdAt is time.Now().UnixMilli() — by definition different between
+			// two separate GetBinsToStore calls. Skip it; it is not affected by arena
+			// vs nil and is covered by functional tests elsewhere.
+			if wb.Name == fields.CreatedAt.String() {
+				continue
+			}
+
+			wBytes, wOk := wb.Value.GetObject().([]byte)
+			gBytes, gOk := gb.Value.GetObject().([]byte)
+
+			if wOk && gOk {
+				require.Equal(t, wBytes, gBytes, "%s: byte content mismatch for bin %q at [%d][%d]", name, wb.Name, ri, bi)
+			} else {
+				// Integers, booleans, and list values (inputs/outputs) — deep equality
+				// recurses into nested []byte slices inside list entries.
+				require.Equal(t, wb.Value, gb.Value, "%s: value mismatch for bin %q at [%d][%d]", name, wb.Name, ri, bi)
+			}
+		}
+	}
+}
+
 // TestGetBinsToStore_ArenaMatchesNoArena asserts that GetBinsToStore produces
-// byte-identical bin values whether or not an arena is supplied.
-// The Store is constructed the same way TestStore_GetBinsToStore does it —
-// no Docker required.
+// byte-identical bin values whether or not an arena is supplied, across a
+// corpus of tx shapes.
 func TestGetBinsToStore_ArenaMatchesNoArena(t *testing.T) {
 	InitPrometheusMetrics()
-
-	txHex, err := os.ReadFile("testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
-	require.NoError(t, err)
-
-	tx, err := bt.NewTxFromString(string(txHex))
-	require.NoError(t, err)
 
 	s := Store{}
 	s.SetUtxoBatchSize(100)
 	s.SetSettings(test.CreateBaseTestSettings(t))
 
-	want, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false, nil)
+	p2pkhScript, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
 	require.NoError(t, err)
 
-	arena := bt.NewArena(0)
-
-	got, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false, arena)
+	opReturnScript, err := bscript.NewFromHexString("6a0b68656c6c6f20776f726c64")
 	require.NoError(t, err)
 
-	// Structural equality: same number of record groups and same number of bins per group.
-	require.Equal(t, len(want), len(got), "number of bin groups differs")
+	// shape: real/extended tx from testdata (the original single-case corpus)
+	t.Run("real_extended_tx", func(t *testing.T) {
+		txHex, err := os.ReadFile("testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
+		require.NoError(t, err)
 
-	for ri := range want {
-		require.Equal(t, len(want[ri]), len(got[ri]), "number of bins in group %d differs", ri)
+		tx, err := bt.NewTxFromString(string(txHex))
+		require.NoError(t, err)
 
-		for bi, wb := range want[ri] {
-			gb := got[ri][bi]
-			require.Equal(t, wb.Name, gb.Name, "bin name mismatch at [%d][%d]", ri, bi)
+		assertArenaEqualNoArena(t, &s, tx, false, "real_extended_tx")
+	})
 
-			// The only scalar []byte bin is txID (txHash[:]); compare it by
-			// content so pointer identity differences don't matter.
-			// The arena-backed bytes live in inputs/outputs, which are stored
-			// as aerospike ListValue ([]interface{} of []byte chunks). Those
-			// bins fall through to the else branch where require.Equal recurses
-			// via reflect.DeepEqual into the nested byte slices — a single
-			// flipped byte in any chunk causes a failure there.
-			wBytes, wOk := wb.Value.GetObject().([]byte)
-			gBytes, gOk := gb.Value.GetObject().([]byte)
+	// shape: coinbase-shaped tx (single input with 32 zero-byte prev txid, one output)
+	t.Run("coinbase_shaped", func(t *testing.T) {
+		tx := bt.NewTx()
+		cbIn := &bt.Input{PreviousTxOutIndex: 0xffffffff, SequenceNumber: 0xffffffff}
+		cbIn.UnlockingScript = &bscript.Script{0x03, 0x4e, 0x01, 0x00}
+		require.NoError(t, cbIn.PreviousTxIDAddStr("0000000000000000000000000000000000000000000000000000000000000000"))
+		tx.Inputs = append(tx.Inputs, cbIn)
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 5000000000, LockingScript: p2pkhScript})
 
-			if wOk && gOk {
-				require.Equal(t, wBytes, gBytes, "byte content mismatch for bin %q at [%d][%d]", wb.Name, ri, bi)
-			} else {
-				// Integers, booleans, and list values (inputs/outputs) — deep equality
-				// covers the nested []byte slices inside the list entries.
-				require.Equal(t, wb.Value, gb.Value, "value mismatch for bin %q at [%d][%d]", wb.Name, ri, bi)
-			}
+		assertArenaEqualNoArena(t, &s, tx, true, "coinbase_shaped")
+	})
+
+	// shape: multi-output tx (5 outputs, mixed satoshi values)
+	// Input satoshis (20000) exceeds total output satoshis (1000+2000+3000+4000+5000=15000)
+	// so fee computation does not underflow.
+	t.Run("multi_output", func(t *testing.T) {
+		tx := bt.NewTx()
+		in := &bt.Input{PreviousTxOutIndex: 0, PreviousTxSatoshis: 20000, SequenceNumber: 0xffffffff}
+		in.UnlockingScript = p2pkhScript
+		in.PreviousTxScript = p2pkhScript
+		require.NoError(t, in.PreviousTxIDAddStr("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+		tx.Inputs = append(tx.Inputs, in)
+		for i := range 5 {
+			tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: uint64(1000 * (i + 1)), LockingScript: p2pkhScript})
 		}
-	}
+
+		assertArenaEqualNoArena(t, &s, tx, false, "multi_output")
+	})
+
+	// shape: OP_RETURN / zero-satoshi output tx
+	t.Run("op_return_zero_satoshi", func(t *testing.T) {
+		tx := bt.NewTx()
+		in := &bt.Input{PreviousTxOutIndex: 1, PreviousTxSatoshis: 2000, SequenceNumber: 0xffffffff}
+		in.UnlockingScript = p2pkhScript
+		in.PreviousTxScript = p2pkhScript
+		require.NoError(t, in.PreviousTxIDAddStr("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+		tx.Inputs = append(tx.Inputs, in)
+		// regular output
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 1999, LockingScript: p2pkhScript})
+		// OP_RETURN with zero satoshis
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 0, LockingScript: opReturnScript})
+
+		assertArenaEqualNoArena(t, &s, tx, false, "op_return_zero_satoshi")
+	})
+
+	// shape: no-input (partial) tx — len(Inputs)==0, external=false.
+	// GetBinsToStore handles this via the GetUtxoHashes path (no fee calculation).
+	t.Run("no_input_partial_tx", func(t *testing.T) {
+		tx := bt.NewTx()
+		// no inputs
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 5000, LockingScript: p2pkhScript})
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 3000, LockingScript: p2pkhScript})
+
+		assertArenaEqualNoArena(t, &s, tx, false, "no_input_partial_tx")
+	})
 }

--- a/stores/utxo/aerospike/create_arena_test.go
+++ b/stores/utxo/aerospike/create_arena_test.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
-	"github.com/stretchr/testify/require"
-
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCreateArena_ConcurrentReuseNoCorruption verifies that the pool's

--- a/stores/utxo/aerospike/create_arena_test.go
+++ b/stores/utxo/aerospike/create_arena_test.go
@@ -1,0 +1,97 @@
+package aerospike
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/teranode/util/test"
+)
+
+// TestCreateArena_ConcurrentReuseNoCorruption verifies that the pool's
+// get/put cycle is race-free and that arena-backed slices produced within
+// a single lease hold the correct bytes before the arena is returned.
+func TestCreateArena_ConcurrentReuseNoCorruption(t *testing.T) {
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+
+		go func(g int) {
+			defer wg.Done()
+
+			for i := 0; i < 50; i++ {
+				a := getCreateArena()
+				out := &bt.Output{Satoshis: uint64(g*100 + i), LockingScript: script}
+				got := appendOutputInto(a, out)
+				require.Equal(t, out.Bytes(), got) // bytes correct despite reuse
+				putCreateArena(a)
+			}
+		}(g)
+	}
+
+	wg.Wait()
+}
+
+// TestGetBinsToStore_ArenaMatchesNoArena asserts that GetBinsToStore produces
+// byte-identical bin values whether or not an arena is supplied.
+// The Store is constructed the same way TestStore_GetBinsToStore does it —
+// no Docker required.
+func TestGetBinsToStore_ArenaMatchesNoArena(t *testing.T) {
+	InitPrometheusMetrics()
+
+	txHex, err := os.ReadFile("testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
+	require.NoError(t, err)
+
+	tx, err := bt.NewTxFromString(string(txHex))
+	require.NoError(t, err)
+
+	s := Store{}
+	s.SetUtxoBatchSize(100)
+	s.SetSettings(test.CreateBaseTestSettings(t))
+
+	want, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false, nil)
+	require.NoError(t, err)
+
+	arena := bt.NewArena(0)
+
+	got, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false, arena)
+	require.NoError(t, err)
+
+	// Structural equality: same number of record groups and same number of bins per group.
+	require.Equal(t, len(want), len(got), "number of bin groups differs")
+
+	for ri := range want {
+		require.Equal(t, len(want[ri]), len(got[ri]), "number of bins in group %d differs", ri)
+
+		for bi, wb := range want[ri] {
+			gb := got[ri][bi]
+			require.Equal(t, wb.Name, gb.Name, "bin name mismatch at [%d][%d]", ri, bi)
+
+			// The only scalar []byte bin is txID (txHash[:]); compare it by
+			// content so pointer identity differences don't matter.
+			// The arena-backed bytes live in inputs/outputs, which are stored
+			// as aerospike ListValue ([]interface{} of []byte chunks). Those
+			// bins fall through to the else branch where require.Equal recurses
+			// via reflect.DeepEqual into the nested byte slices — a single
+			// flipped byte in any chunk causes a failure there.
+			wBytes, wOk := wb.Value.GetObject().([]byte)
+			gBytes, gOk := gb.Value.GetObject().([]byte)
+
+			if wOk && gOk {
+				require.Equal(t, wBytes, gBytes, "byte content mismatch for bin %q at [%d][%d]", wb.Name, ri, bi)
+			} else {
+				// Integers, booleans, and list values (inputs/outputs) — deep equality
+				// covers the nested []byte slices inside the list entries.
+				require.Equal(t, wb.Value, gb.Value, "value mismatch for bin %q at [%d][%d]", wb.Name, ri, bi)
+			}
+		}
+	}
+}

--- a/stores/utxo/aerospike/create_test.go
+++ b/stores/utxo/aerospike/create_test.go
@@ -34,7 +34,7 @@ func TestStore_GetBinsToStore(t *testing.T) {
 
 	t.Run("TestStore_GetBinsToStore empty", func(t *testing.T) {
 		tx := &bt.Tx{}
-		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false)
+		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false, nil)
 		require.Error(t, err)
 		require.Nil(t, bins)
 	})
@@ -49,7 +49,7 @@ func TestStore_GetBinsToStore(t *testing.T) {
 		tx, err := bt.NewTxFromString(string(txHex))
 		require.NoError(t, err)
 
-		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false)
+		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, false, tx.TxIDChainHash(), false, false, false, nil)
 		require.NoError(t, err)
 		require.NotNil(t, bins)
 
@@ -130,7 +130,7 @@ func TestStore_GetBinsToStore(t *testing.T) {
 		// external should be set by the aerospike create function for huge txs
 		external := len(tx.ExtendedBytes()) > teranodeaerospike.MaxTxSizeInStoreInBytes
 
-		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, external, tx.TxIDChainHash(), false, false, false)
+		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, external, tx.TxIDChainHash(), false, false, false, nil)
 		require.NoError(t, err)
 		require.NotNil(t, bins)
 	})
@@ -148,7 +148,7 @@ func TestStore_GetBinsToStore(t *testing.T) {
 		// external should be set by the aerospike create function for huge txs
 		external := len(tx.ExtendedBytes()) > teranodeaerospike.MaxTxSizeInStoreInBytes
 
-		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, external, tx.TxIDChainHash(), true, true, true)
+		bins, err := s.GetBinsToStore(tx, 0, nil, nil, nil, external, tx.TxIDChainHash(), true, true, true, nil)
 		require.NoError(t, err)
 		require.NotNil(t, bins)
 

--- a/stores/utxo/aerospike/encode_helpers_test.go
+++ b/stores/utxo/aerospike/encode_helpers_test.go
@@ -96,3 +96,85 @@ func TestExtendedTxSize_DecodedTxShape(t *testing.T) {
 	cb.Outputs = append(cb.Outputs, &bt.Output{Satoshis: 5000000000, LockingScript: script})
 	require.Equal(t, len(cb.ExtendedBytes()), extendedTxSize(cb))
 }
+
+func TestAppendOutputInto_MatchesOutputBytes(t *testing.T) {
+	arena := bt.NewArena(0)
+	for _, hexScript := range []string{"", "76a914000000000000000000000000000000000000000088ac"} {
+		s, err := bscript.NewFromHexString(hexScript)
+		require.NoError(t, err)
+		out := &bt.Output{Satoshis: 999, LockingScript: s}
+
+		withArena := appendOutputInto(arena, out)
+		require.Equal(t, out.Bytes(), withArena)
+
+		withoutArena := appendOutputInto(nil, out)
+		require.Equal(t, out.Bytes(), withoutArena)
+	}
+}
+
+func TestAppendInputExtendedInto_MatchesManualLayout(t *testing.T) {
+	arena := bt.NewArena(0)
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+
+	in := &bt.Input{PreviousTxOutIndex: 2, PreviousTxSatoshis: 4242, SequenceNumber: 0xffffffff}
+	in.UnlockingScript = script
+	in.PreviousTxScript = script
+	require.NoError(t, in.PreviousTxIDAddStr("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))
+
+	// Reference = the current manual layout: input.Bytes(false) + satoshis(8 LE)
+	// + VarInt(prevScriptLen) + prevScript.
+	want := in.Bytes(false)
+	want = append(want,
+		byte(in.PreviousTxSatoshis), byte(in.PreviousTxSatoshis>>8), byte(in.PreviousTxSatoshis>>16), byte(in.PreviousTxSatoshis>>24),
+		byte(in.PreviousTxSatoshis>>32), byte(in.PreviousTxSatoshis>>40), byte(in.PreviousTxSatoshis>>48), byte(in.PreviousTxSatoshis>>56))
+	want = append(want, bt.VarInt(uint64(len(*in.PreviousTxScript))).Bytes()...)
+	want = append(want, *in.PreviousTxScript...)
+
+	require.Equal(t, want, appendInputExtendedInto(arena, in))
+	require.Equal(t, want, appendInputExtendedInto(nil, in))
+}
+
+func TestAppendInputExtendedInto_NilPrevScript(t *testing.T) {
+	arena := bt.NewArena(0)
+	script, err := bscript.NewFromHexString("ac")
+	require.NoError(t, err)
+	in := &bt.Input{PreviousTxOutIndex: 0, PreviousTxSatoshis: 1, SequenceNumber: 1}
+	in.UnlockingScript = script
+	in.PreviousTxScript = nil
+	require.NoError(t, in.PreviousTxIDAddStr("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))
+
+	want := in.Bytes(false)
+	// satoshis = 1 little-endian (8 bytes)
+	want = append(want, 1, 0, 0, 0, 0, 0, 0, 0)
+	want = append(want, bt.VarInt(0).Bytes()...) // single 0x00 for nil prev script
+
+	require.Equal(t, want, appendInputExtendedInto(arena, in))
+}
+
+func TestAppendHelpers_LargeScripts(t *testing.T) {
+	big := make([]byte, 300) // > 252 => 3-byte VarInt length prefix
+	for i := range big {
+		big[i] = 0x51
+	}
+	bigScript := bscript.Script(big)
+
+	// Output with a >252-byte locking script
+	out := &bt.Output{Satoshis: 7, LockingScript: &bigScript}
+	require.Equal(t, out.Bytes(), appendOutputInto(bt.NewArena(0), out))
+	require.Equal(t, out.Bytes(), appendOutputInto(nil, out))
+
+	// Input with >252-byte unlocking AND prev script
+	in := &bt.Input{PreviousTxOutIndex: 1, PreviousTxSatoshis: 9, SequenceNumber: 0xffffffff}
+	in.UnlockingScript = &bigScript
+	in.PreviousTxScript = &bigScript
+	require.NoError(t, in.PreviousTxIDAddStr("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"))
+
+	want := in.Bytes(false)
+	want = append(want, 9, 0, 0, 0, 0, 0, 0, 0) // satoshis = 9 LE
+	want = append(want, bt.VarInt(uint64(len(bigScript))).Bytes()...)
+	want = append(want, bigScript...)
+
+	require.Equal(t, want, appendInputExtendedInto(bt.NewArena(0), in))
+	require.Equal(t, want, appendInputExtendedInto(nil, in))
+}

--- a/stores/utxo/aerospike/encode_helpers_test.go
+++ b/stores/utxo/aerospike/encode_helpers_test.go
@@ -152,6 +152,24 @@ func TestAppendInputExtendedInto_NilPrevScript(t *testing.T) {
 	require.Equal(t, want, appendInputExtendedInto(arena, in))
 }
 
+func TestExtendedTxSize_NilPrevTxIDHash(t *testing.T) {
+	// An input with no previousTxIDHash set: go-bt's ExtendedBytes() omits the
+	// 32 txid bytes, but Input.Size() counts them. extendedTxSize must still
+	// match len(ExtendedBytes()) — i.e. not rely on the hash being set.
+	tx := bt.NewTx()
+	in := &bt.Input{PreviousTxOutIndex: 0, PreviousTxSatoshis: 1000, SequenceNumber: 0xffffffff}
+	in.UnlockingScript = &bscript.Script{}
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+	in.PreviousTxScript = script
+	// deliberately do NOT set the previousTxIDHash
+	require.Nil(t, in.PreviousTxIDChainHash(), "precondition for this test: hash is nil")
+	tx.Inputs = append(tx.Inputs, in)
+	tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 1, LockingScript: script})
+
+	require.Equal(t, len(tx.ExtendedBytes()), extendedTxSize(tx))
+}
+
 func BenchmarkAppendOutputInto_Arena(b *testing.B) {
 	s, _ := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
 	out := &bt.Output{Satoshis: 1, LockingScript: s}

--- a/stores/utxo/aerospike/encode_helpers_test.go
+++ b/stores/utxo/aerospike/encode_helpers_test.go
@@ -21,3 +21,78 @@ func TestOutputSizeEqualsBytesLen(t *testing.T) {
 		require.Equal(t, len(out.Bytes()), out.Size())
 	}
 }
+
+func makeTxForSize(t *testing.T, nIn, nOut int, withPrevScript bool) *bt.Tx {
+	t.Helper()
+	tx := bt.NewTx()
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+	for i := 0; i < nIn; i++ {
+		in := &bt.Input{PreviousTxOutIndex: uint32(i), PreviousTxSatoshis: 1000, SequenceNumber: 0xffffffff}
+		in.UnlockingScript = script
+		if withPrevScript {
+			in.PreviousTxScript = script
+		}
+		// PreviousTxIDAddStr sets the 32-byte previousTxIDHash, which is required for
+		// Input.Size() to match the actual serialized length (Bytes() skips it when nil).
+		require.NoError(t, in.PreviousTxIDAddStr("0000000000000000000000000000000000000000000000000000000000000000"))
+		tx.Inputs = append(tx.Inputs, in)
+	}
+	for i := 0; i < nOut; i++ {
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 1, LockingScript: script})
+	}
+	return tx
+}
+
+func TestExtendedTxSizeMatchesExtendedBytes(t *testing.T) {
+	cases := []struct {
+		nIn, nOut  int
+		prevScript bool
+	}{
+		{1, 1, true}, {1, 1, false}, {3, 5, true}, {2, 0, true}, {0, 2, true}, {5, 1, false},
+	}
+	for _, c := range cases {
+		tx := makeTxForSize(t, c.nIn, c.nOut, c.prevScript)
+		require.Equal(t, len(tx.ExtendedBytes()), extendedTxSize(tx),
+			"nIn=%d nOut=%d prevScript=%v", c.nIn, c.nOut, c.prevScript)
+	}
+}
+
+func TestExtendedTxSize_LargePrevScript(t *testing.T) {
+	tx := bt.NewTx()
+	big := make([]byte, 300) // > 252 => 3-byte VarInt length prefix
+	for i := range big {
+		big[i] = 0x51
+	}
+	bigScript := bscript.Script(big)
+	in := &bt.Input{PreviousTxOutIndex: 0, PreviousTxSatoshis: 1000, SequenceNumber: 0xffffffff}
+	in.UnlockingScript = &bscript.Script{}
+	in.PreviousTxScript = &bigScript
+	require.NoError(t, in.PreviousTxIDAddStr("0000000000000000000000000000000000000000000000000000000000000000"))
+	tx.Inputs = append(tx.Inputs, in)
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+	tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 1, LockingScript: script})
+
+	require.Equal(t, len(tx.ExtendedBytes()), extendedTxSize(tx))
+}
+
+func TestExtendedTxSize_DecodedTxShape(t *testing.T) {
+	// Round-trip a constructed extended tx through bytes so inputs carry a real
+	// (non-nil) previousTxIDHash, matching the production decode path.
+	src := makeTxForSize(t, 3, 4, true)
+	decoded, err := bt.NewTxFromBytes(src.ExtendedBytes())
+	require.NoError(t, err)
+	require.Equal(t, len(decoded.ExtendedBytes()), extendedTxSize(decoded))
+
+	// Coinbase-shaped tx: single input with 32 zero-byte prev txid (non-nil).
+	cb := bt.NewTx()
+	cbIn := &bt.Input{PreviousTxOutIndex: 0xffffffff, SequenceNumber: 0xffffffff}
+	cbIn.UnlockingScript = &bscript.Script{0x03, 0x01, 0x02, 0x03}
+	require.NoError(t, cbIn.PreviousTxIDAddStr("0000000000000000000000000000000000000000000000000000000000000000"))
+	cb.Inputs = append(cb.Inputs, cbIn)
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+	cb.Outputs = append(cb.Outputs, &bt.Output{Satoshis: 5000000000, LockingScript: script})
+	require.Equal(t, len(cb.ExtendedBytes()), extendedTxSize(cb))
+}

--- a/stores/utxo/aerospike/encode_helpers_test.go
+++ b/stores/utxo/aerospike/encode_helpers_test.go
@@ -1,0 +1,23 @@
+package aerospike
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputSizeEqualsBytesLen(t *testing.T) {
+	scripts := []string{
+		"",
+		"76a914000000000000000000000000000000000000000088ac",
+		"6a4c64" + "00",
+	}
+	for _, hexScript := range scripts {
+		s, err := bscript.NewFromHexString(hexScript)
+		require.NoError(t, err)
+		out := &bt.Output{Satoshis: 12345, LockingScript: s}
+		require.Equal(t, len(out.Bytes()), out.Size())
+	}
+}

--- a/stores/utxo/aerospike/encode_helpers_test.go
+++ b/stores/utxo/aerospike/encode_helpers_test.go
@@ -152,6 +152,20 @@ func TestAppendInputExtendedInto_NilPrevScript(t *testing.T) {
 	require.Equal(t, want, appendInputExtendedInto(arena, in))
 }
 
+func BenchmarkAppendOutputInto_Arena(b *testing.B) {
+	s, _ := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	out := &bt.Output{Satoshis: 1, LockingScript: s}
+	arena := bt.NewArena(1 << 16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if arena.Used() > 1<<15 {
+			arena.Reset()
+		}
+		_ = appendOutputInto(arena, out)
+	}
+}
+
 func TestAppendHelpers_LargeScripts(t *testing.T) {
 	big := make([]byte, 300) // > 252 => 3-byte VarInt length prefix
 	for i := range big {

--- a/stores/utxo/utils.go
+++ b/stores/utxo/utils.go
@@ -13,6 +13,12 @@ import (
 	"github.com/bsv-blockchain/teranode/util"
 )
 
+// utxoPreimageScratchCap is the initial capacity for the UTXO-hash preimage
+// scratch buffer: comfortably fits a txid (32B) + index varint + locking
+// script + satoshis varint for typical outputs. UTXOHashInto grows it safely
+// if an unusually large script exceeds this.
+const utxoPreimageScratchCap = 256
+
 // CalculateUtxoStatus determines the status of a UTXO based on its spending state
 // and coinbase maturity requirements.
 //
@@ -66,6 +72,7 @@ func GetFeesAndUtxoHashes(ctx context.Context, tx *bt.Tx, blockHeight uint32) (u
 
 	var fees uint64
 
+	hashes := make([]chainhash.Hash, len(tx.Outputs))
 	utxoHashes := make([]*chainhash.Hash, len(tx.Outputs))
 
 	if !tx.IsCoinbase() {
@@ -76,6 +83,7 @@ func GetFeesAndUtxoHashes(ctx context.Context, tx *bt.Tx, blockHeight uint32) (u
 
 	txid := tx.TxIDChainHash()
 
+	scratch := make([]byte, 0, utxoPreimageScratchCap)
 	for i, output := range tx.Outputs {
 		select {
 		case <-ctx.Done():
@@ -90,12 +98,13 @@ func GetFeesAndUtxoHashes(ctx context.Context, tx *bt.Tx, blockHeight uint32) (u
 				return 0, nil, errors.NewProcessingError("failed to convert i", err)
 			}
 
-			utxoHash, utxoErr := util.UTXOHashFromOutput(txid, output, iUint32)
+			h, s, utxoErr := util.UTXOHashInto(scratch, txid, iUint32, output.LockingScript, output.Satoshis)
 			if utxoErr != nil {
 				return 0, nil, errors.NewProcessingError("error getting output utxo hash: %s", utxoErr)
 			}
-
-			utxoHashes[i] = utxoHash
+			scratch = s
+			hashes[i] = h
+			utxoHashes[i] = &hashes[i]
 		}
 	}
 
@@ -120,8 +129,10 @@ func GetUtxoHashes(tx *bt.Tx, txHash ...*chainhash.Hash) ([]*chainhash.Hash, err
 		txChainHash = tx.TxIDChainHash()
 	}
 
+	hashes := make([]chainhash.Hash, len(tx.Outputs))
 	utxoHashes := make([]*chainhash.Hash, len(tx.Outputs))
 
+	scratch := make([]byte, 0, utxoPreimageScratchCap)
 	for i, output := range tx.Outputs {
 		if output != nil {
 			iUint32, err := safeconversion.IntToUint32(i)
@@ -129,12 +140,13 @@ func GetUtxoHashes(tx *bt.Tx, txHash ...*chainhash.Hash) ([]*chainhash.Hash, err
 				return nil, errors.NewProcessingError("failed to convert i", err)
 			}
 
-			utxoHash, utxoErr := util.UTXOHashFromOutput(txChainHash, output, iUint32)
+			h, s, utxoErr := util.UTXOHashInto(scratch, txChainHash, iUint32, output.LockingScript, output.Satoshis)
 			if utxoErr != nil {
 				return nil, errors.NewProcessingError("error getting output utxo hash: %s", utxoErr)
 			}
-
-			utxoHashes[i] = utxoHash
+			scratch = s
+			hashes[i] = h
+			utxoHashes[i] = &hashes[i]
 		}
 	}
 

--- a/stores/utxo/utils_test.go
+++ b/stores/utxo/utils_test.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-chaincfg"
 	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/bsv-blockchain/teranode/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,6 +112,55 @@ func TestShouldStoreNonZeroUTXO(t *testing.T) {
 		assert.True(t, ShouldStoreOutputAsUTXO(tx.IsCoinbase(), tx.Outputs[0], chaincfg.GenesisActivationHeight-1))
 		assert.True(t, ShouldStoreOutputAsUTXO(tx.IsCoinbase(), tx.Outputs[0], chaincfg.GenesisActivationHeight+1))
 	})
+}
+
+func buildExtendedTx(t *testing.T, nOutputs int) *bt.Tx {
+	t.Helper()
+	tx := bt.NewTx()
+	err := tx.From(
+		"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+		0,
+		"76a914000000000000000000000000000000000000000088ac",
+		uint64(nOutputs)*1000,
+	)
+	require.NoError(t, err)
+	script, err := bscript.NewFromHexString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+	for i := 0; i < nOutputs; i++ {
+		tx.AddOutput(&bt.Output{Satoshis: 1, LockingScript: script})
+	}
+	return tx
+}
+
+func TestGetUtxoHashes_AllocsAreConstant(t *testing.T) {
+	small := buildExtendedTx(t, 1)
+	large := buildExtendedTx(t, 64)
+
+	allocsSmall := testing.AllocsPerRun(50, func() {
+		_, err := GetUtxoHashes(small)
+		require.NoError(t, err)
+	})
+	allocsLarge := testing.AllocsPerRun(50, func() {
+		_, err := GetUtxoHashes(large)
+		require.NoError(t, err)
+	})
+
+	// O(1) in output count: large (64 outputs) allocates no more than small.
+	require.LessOrEqual(t, allocsLarge, allocsSmall)
+	// 4 fixed allocs: scratch buf, hashes backing array, utxoHashes slice, TxIDChainHash heap escape.
+	require.LessOrEqual(t, allocsSmall, float64(4))
+}
+
+func TestGetUtxoHashes_ValuesUnchanged(t *testing.T) {
+	tx := buildExtendedTx(t, 4)
+	got, err := GetUtxoHashes(tx)
+	require.NoError(t, err)
+	txid := tx.TxIDChainHash()
+	for i, output := range tx.Outputs {
+		want, err := util.UTXOHashFromOutput(txid, output, uint32(i))
+		require.NoError(t, err)
+		require.Equal(t, *want, *got[i])
+	}
 }
 
 func BenchmarkGetUtxoHashes(b *testing.B) {

--- a/util/utxo_hash.go
+++ b/util/utxo_hash.go
@@ -7,41 +7,48 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 )
 
-// UTXOHash returns the hash of the UTXO for the given input parameters.
-// The hash is calculated by concatenating the previous txid, the output index, the locking script and the satoshis.
-// The hash is then hashed using SHA256.
-func UTXOHash(previousTxid *chainhash.Hash, index uint32, lockingScript *bscript.Script, satoshis uint64) (*chainhash.Hash, error) {
+// UTXOHashInto appends the UTXO preimage (previous txid || VarInt(index) ||
+// locking script || VarInt(satoshis)) into scratch[:0], hashes it with a single
+// SHA-256, and returns the hash by value plus the (possibly grown) scratch for
+// reuse. The returned scratch may share backing with the input; callers should
+// rebind it (h, scratch, err = UTXOHashInto(scratch, ...)).
+//
+// Zero heap allocations when scratch has sufficient capacity.
+func UTXOHashInto(scratch []byte, previousTxid *chainhash.Hash, index uint32,
+	lockingScript *bscript.Script, satoshis uint64) (chainhash.Hash, []byte, error) {
 	if lockingScript == nil {
-		return nil, errors.NewProcessingError("locking script is nil")
+		return chainhash.Hash{}, scratch, errors.NewProcessingError("locking script is nil")
 	}
 
-	utxoHash := make([]byte, 0, 256)
-	utxoHash = append(utxoHash, previousTxid.CloneBytes()...)
-	utxoHash = append(utxoHash, bt.VarInt(index).Bytes()...)
-	utxoHash = append(utxoHash, *lockingScript...)
-	utxoHash = append(utxoHash, bt.VarInt(satoshis).Bytes()...)
+	scratch = scratch[:0]
+	scratch = append(scratch, previousTxid[:]...)
+	scratch = bt.VarInt(index).AppendTo(scratch)
+	scratch = append(scratch, *lockingScript...)
+	scratch = bt.VarInt(satoshis).AppendTo(scratch)
 
-	chHash := chainhash.HashH(utxoHash)
+	return chainhash.HashH(scratch), scratch, nil
+}
 
-	return &chHash, nil
+// UTXOHash returns the hash of the UTXO for the given input parameters.
+// The hash is calculated by concatenating the previous txid, the output index,
+// the locking script and the satoshis, then hashing with SHA-256.
+func UTXOHash(previousTxid *chainhash.Hash, index uint32, lockingScript *bscript.Script, satoshis uint64) (*chainhash.Hash, error) {
+	h, _, err := UTXOHashInto(nil, previousTxid, index, lockingScript, satoshis)
+	if err != nil {
+		return nil, err
+	}
+	return &h, nil
 }
 
 // UTXOHashFromInput returns the hash of the UTXO for the given input.
-// The hash is calculated by concatenating the previous txid, the output index, the locking script and the satoshis.
-// The hash is then hashed using SHA256.
 func UTXOHashFromInput(input *bt.Input) (*chainhash.Hash, error) {
-	hash := input.PreviousTxIDChainHash()
-
 	if input.PreviousTxScript == nil {
 		return nil, errors.NewProcessingError("locking script is nil")
 	}
-
-	return UTXOHash(hash, input.PreviousTxOutIndex, input.PreviousTxScript, input.PreviousTxSatoshis)
+	return UTXOHash(input.PreviousTxIDChainHash(), input.PreviousTxOutIndex, input.PreviousTxScript, input.PreviousTxSatoshis)
 }
 
 // UTXOHashFromOutput returns the hash of the UTXO for the given output.
-// The hash is calculated by concatenating the previous txid, the output index, the locking script and the satoshis.
-// The hash is then hashed using SHA256.
 func UTXOHashFromOutput(hash *chainhash.Hash, output *bt.Output, vOut uint32) (*chainhash.Hash, error) {
 	return UTXOHash(hash, vOut, output.LockingScript, output.Satoshis)
 }

--- a/util/utxo_hash_test.go
+++ b/util/utxo_hash_test.go
@@ -104,6 +104,48 @@ func TestGetOutputUtxoHash(t *testing.T) {
 	}
 }
 
+func mustScript(t *testing.T, hexScript string) *bscript.Script {
+	t.Helper()
+	s, err := bscript.NewFromHexString(hexScript)
+	require.NoError(t, err)
+	return s
+}
+
+func TestUTXOHashInto_MatchesUTXOHash(t *testing.T) {
+	prev, err := chainhash.NewHashFromStr("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+	require.NoError(t, err)
+	script := mustScript(t, "76a914000000000000000000000000000000000000000088ac")
+
+	want, err := UTXOHash(prev, 7, script, 5000)
+	require.NoError(t, err)
+
+	got, _, err := UTXOHashInto(nil, prev, 7, script, 5000)
+	require.NoError(t, err)
+	require.Equal(t, *want, got)
+}
+
+func TestUTXOHashInto_ZeroAllocWithScratch(t *testing.T) {
+	prev, err := chainhash.NewHashFromStr("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+	require.NoError(t, err)
+	script := mustScript(t, "76a914000000000000000000000000000000000000000088ac")
+	scratch := make([]byte, 0, 256)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_, s, _ := UTXOHashInto(scratch, prev, 9, script, 1)
+		scratch = s
+	})
+	require.Zero(t, allocs)
+}
+
+func TestUTXOHashInto_NilScript(t *testing.T) {
+	prev := &chainhash.Hash{}
+	scratch := []byte{1, 2, 3}
+	h, out, err := UTXOHashInto(scratch, prev, 0, nil, 0)
+	require.ErrorContains(t, err, "locking script is nil")
+	require.Equal(t, chainhash.Hash{}, h)
+	require.Equal(t, scratch, out) // scratch returned unchanged on the error path
+}
+
 func TestCollision(t *testing.T) {
 	// tx id 955c4de19e3428a2620891dad1f4f2f7e5948c6a61b1602372fee47370bb23c2
 	script, err := bscript.NewFromHexString("76a9146d6baa116674e3ccc2afef914145f0d020a0366088ac")


### PR DESCRIPTION
## What

Cuts avoidable heap allocations in the Aerospike utxo-store `Create` path — the live source of the encode-side churn from #1002. The repeated `TxIDChainHash` re-serialization the issue describes is already neutralised on the legacy path (`createTxMap` → `SetTxHash`); the remaining churn is per-tx/per-output/per-input serialization inside `GetBinsToStore`.

teranode-only, no go-bt change (v2.6.4 already ships the zero-alloc primitives). No stored byte format, `ExtendedSize` bin value, or hashing semantics change — output is byte-identical.

## Changes

- `util.UTXOHashInto(scratch, ...)` — scratch-reusing, zero-alloc UTXO hash. `UTXOHash`/`UTXOHashFromInput`/`UTXOHashFromOutput` become thin wrappers (signatures unchanged).
- `GetUtxoHashes` / `GetFeesAndUtxoHashes` — allocations now O(1) in output count (contiguous `[]chainhash.Hash` backing + reused scratch) instead of O(N). Signatures unchanged.
- Sizing: `output.Size()` instead of `len(output.Bytes())`; arithmetic `extendedTxSize(tx)` instead of `len(tx.ExtendedBytes())` at both measure-only sites — removes two full-tx serializations done purely to read a length.
- `appendOutputInto` / `appendInputExtendedInto` — zero-alloc serialization into a pooled per-batch `bt.Arena` (mirrors the #929 `subtreevalidation/arena_pool.go` convention), reset after `BatchOperate`. The multi-record / external escape paths rebuild bins heap-owned so the arena reset can't corrupt the fire-and-forget goroutines that outlive `sendStoreBatch`.

## Verification

- Byte-equivalence (property/golden): `appendOutputInto == Output.Bytes()`, `appendInputExtendedInto ==` prior manual layout, `extendedTxSize == len(ExtendedBytes())` (incl. >252B scripts, coinbase, decoded-tx shape), `UTXOHashInto == UTXOHash`, and arena-vs-nil bins byte-identical across coinbase / multi-output / OP_RETURN / no-input shapes.
- Alloc gates: `UTXOHashInto` 0 allocs/op with scratch; `GetUtxoHashes` flat in output count (195→4 allocs for 64 outputs); `BenchmarkAppendOutputInto_Arena` 0 allocs/op.
- Lifetime: `-race` test on concurrent arena reuse + the escape-rebuild path. Arena bytes are only referenced until `BatchOperate` (NewBytesValue does not copy); reset is deferred to after it returns.
- `go build ./...` clean; touched-package tests + `go vet` + `staticcheck` green.

## Test plan

- [ ] CI: full aerospike testcontainer suite — the integration tests need a live Aerospike + grpc endpoints and don't run in a bare local env.
- [ ] Post-merge profile on a busy legacy node during IBD: `appendTo` + `toBytesHelper` + `Output.Bytes` should drop from ~50% to <20% of cumulative `alloc_space` (the #1002 acceptance criterion — mainnet IBD isn't reproducible locally, so the alloc-gate benchmarks stand in for it pre-merge).

Addresses #1002.
