### PR TITLE
fix(dashboard): peer catchup row-data lookup + FSM transitions single source (#982)

### DIFF
--- a/services/asset/httpimpl/fsm_handler.go
+++ b/services/asset/httpimpl/fsm_handler.go
@@ -71,31 +71,7 @@ func (h *FSMHandler) GetFSMEvents(c echo.Context) error {
 		return err
 	}
 
-	var events []string
-	// these transitions are stable and documented in stateMachine.md.
-	switch *state {
-	case blockchain_api.FSMStateType_IDLE:
-		events = []string{
-			blockchain_api.FSMEventType_RUN.String(),
-			blockchain_api.FSMEventType_LEGACYSYNC.String(),
-		}
-	case blockchain_api.FSMStateType_RUNNING:
-		events = []string{
-			blockchain_api.FSMEventType_STOP.String(),
-			blockchain_api.FSMEventType_CATCHUPBLOCKS.String(),
-		}
-	case blockchain_api.FSMStateType_LEGACYSYNCING:
-		events = []string{
-			blockchain_api.FSMEventType_RUN.String(),
-			blockchain_api.FSMEventType_STOP.String(),
-		}
-	case blockchain_api.FSMStateType_CATCHINGBLOCKS:
-		events = []string{
-			blockchain_api.FSMEventType_RUN.String(),
-		}
-	default:
-		events = []string{}
-	}
+	events := blockchain.AvailableEventsForState(state.String())
 
 	h.logger.WithTraceContext(c.Request().Context()).Debugf("Available blockchain FSM events: %v", events)
 

--- a/services/blockchain/fsm.go
+++ b/services/blockchain/fsm.go
@@ -11,6 +11,58 @@ import (
 	"github.com/looplab/fsm"
 )
 
+// FSMTransitions is the single source of truth for blockchain FSM transitions.
+// Used by NewFiniteStateMachine and by AvailableEventsForState.
+var FSMTransitions = fsm.Events{
+	{
+		Name: blockchain_api.FSMEventType_RUN.String(),
+		Src: []string{
+			blockchain_api.FSMStateType_IDLE.String(),
+			blockchain_api.FSMStateType_LEGACYSYNCING.String(),
+			blockchain_api.FSMStateType_CATCHINGBLOCKS.String(),
+		},
+		Dst: blockchain_api.FSMStateType_RUNNING.String(),
+	},
+	{
+		Name: blockchain_api.FSMEventType_LEGACYSYNC.String(),
+		Src: []string{
+			blockchain_api.FSMStateType_IDLE.String(),
+		},
+		Dst: blockchain_api.FSMStateType_LEGACYSYNCING.String(),
+	},
+	{
+		Name: blockchain_api.FSMEventType_CATCHUPBLOCKS.String(),
+		Src: []string{
+			blockchain_api.FSMStateType_RUNNING.String(),
+		},
+		Dst: blockchain_api.FSMStateType_CATCHINGBLOCKS.String(),
+	},
+	{
+		Name: blockchain_api.FSMEventType_STOP.String(),
+		Src: []string{
+			blockchain_api.FSMStateType_RUNNING.String(),
+			blockchain_api.FSMStateType_LEGACYSYNCING.String(),
+		},
+		Dst: blockchain_api.FSMStateType_IDLE.String(),
+	},
+}
+
+// AvailableEventsForState returns the event names valid from the given state,
+// derived from FSMTransitions (single source of truth). Order follows the
+// table's declaration order. Unknown state returns an empty (non-nil) slice.
+func AvailableEventsForState(state string) []string {
+	events := make([]string, 0)
+	for _, e := range FSMTransitions {
+		for _, src := range e.Src {
+			if src == state {
+				events = append(events, e.Name)
+				break
+			}
+		}
+	}
+	return events
+}
+
 // NewFiniteStateMachine creates a new finite state machine for the blockchain service.
 //
 // States: IDLE, RUNNING, CATCHINGBLOCKS, LEGACYSYNCING
@@ -44,39 +96,7 @@ func (b *Blockchain) NewFiniteStateMachine(opts ...func(*fsm.FSM)) *fsm.FSM {
 	// Create the finite state machine, with states and transitions
 	finiteStateMachine := fsm.NewFSM(
 		blockchain_api.FSMStateType_IDLE.String(),
-		fsm.Events{
-			{
-				Name: blockchain_api.FSMEventType_RUN.String(),
-				Src: []string{
-					blockchain_api.FSMStateType_IDLE.String(),
-					blockchain_api.FSMStateType_LEGACYSYNCING.String(),
-					blockchain_api.FSMStateType_CATCHINGBLOCKS.String(),
-				},
-				Dst: blockchain_api.FSMStateType_RUNNING.String(),
-			},
-			{
-				Name: blockchain_api.FSMEventType_LEGACYSYNC.String(),
-				Src: []string{
-					blockchain_api.FSMStateType_IDLE.String(),
-				},
-				Dst: blockchain_api.FSMStateType_LEGACYSYNCING.String(),
-			},
-			{
-				Name: blockchain_api.FSMEventType_CATCHUPBLOCKS.String(),
-				Src: []string{
-					blockchain_api.FSMStateType_RUNNING.String(),
-				},
-				Dst: blockchain_api.FSMStateType_CATCHINGBLOCKS.String(),
-			},
-			{
-				Name: blockchain_api.FSMEventType_STOP.String(),
-				Src: []string{
-					blockchain_api.FSMStateType_RUNNING.String(),
-					blockchain_api.FSMStateType_LEGACYSYNCING.String(),
-				},
-				Dst: blockchain_api.FSMStateType_IDLE.String(),
-			},
-		},
+		FSMTransitions,
 		callbacks,
 		// fsm.Callbacks{},
 	)

--- a/services/blockchain/fsm_available_events_test.go
+++ b/services/blockchain/fsm_available_events_test.go
@@ -1,0 +1,61 @@
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAvailableEventsForState(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  string
+		expect []string
+	}{
+		{
+			name:  "IDLE",
+			state: blockchain_api.FSMStateType_IDLE.String(),
+			expect: []string{
+				blockchain_api.FSMEventType_RUN.String(),
+				blockchain_api.FSMEventType_LEGACYSYNC.String(),
+			},
+		},
+		{
+			name:  "RUNNING",
+			state: blockchain_api.FSMStateType_RUNNING.String(),
+			expect: []string{
+				blockchain_api.FSMEventType_CATCHUPBLOCKS.String(),
+				blockchain_api.FSMEventType_STOP.String(),
+			},
+		},
+		{
+			name:  "LEGACYSYNCING",
+			state: blockchain_api.FSMStateType_LEGACYSYNCING.String(),
+			expect: []string{
+				blockchain_api.FSMEventType_RUN.String(),
+				blockchain_api.FSMEventType_STOP.String(),
+			},
+		},
+		{
+			name:  "CATCHINGBLOCKS",
+			state: blockchain_api.FSMStateType_CATCHINGBLOCKS.String(),
+			expect: []string{
+				blockchain_api.FSMEventType_RUN.String(),
+			},
+		},
+		{
+			name:   "unknown state",
+			state:  "UNKNOWN",
+			expect: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AvailableEventsForState(tt.state)
+			require.NotNil(t, got)
+			require.Equal(t, tt.expect, got)
+		})
+	}
+}

--- a/ui/dashboard/src/routes/admin/+page.svelte
+++ b/ui/dashboard/src/routes/admin/+page.svelte
@@ -63,25 +63,6 @@
     return error instanceof Error ? error.message : String(error)
   }
 
-  // duplicates the FSM transition logic from the backend (fsm_handler.go 
-  // If the backend state machine changes, the UI will become out of sync. 
-  function isEventAllowedForState(state: string | undefined, eventName: string): boolean {
-    if (!state || !eventName) return false
-
-    switch (state) {
-      case 'IDLE':
-        return eventName === 'RUN' || eventName === 'LEGACYSYNC'
-      case 'RUNNING':
-        return eventName === 'STOP' || eventName === 'CATCHUPBLOCKS'
-      case 'LEGACYSYNCING':
-        return eventName === 'RUN' || eventName === 'STOP'
-      case 'CATCHINGBLOCKS':
-        return eventName === 'RUN'
-      default:
-        return false
-    }
-  }
-
   async function delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
@@ -108,14 +89,6 @@
     if (invalidBlocksLoading || !invalidBlocksHasMore) return
     const nextOffset = invalidBlocksOffset + INVALID_BLOCKS_PAGE_SIZE
     fetchInvalidBlocks(nextOffset)
-  }
-
-  function getEventDisabledReason(state: string | undefined, eventName: string): string {
-    if (!state) return 'FSM state not available'
-    if (state === 'CATCHINGBLOCKS' && eventName !== 'RUN') {
-      return 'Catchup must complete first'
-    }
-    return `Not allowed from ${state}`
   }
 
   function formatTimeAgo(timestamp: number): string {
@@ -680,14 +653,12 @@
                   <div class="action-buttons">
                     {#each fsmEvents.sort((a, b) => a.value - b.value) as event}
                       {#if event && event.name}
-                        {@const allowed = isEventAllowedForState(fsmState?.state, event.name)}
                         <button
                           onclick={() => sendFSMEvent(event.name)}
-                          disabled={fsmLoading || !allowed}
+                          disabled={fsmLoading}
                           class="action-button"
                           data-event={event.name.toLowerCase()}
                           data-event-id={event.value}
-                          title={!allowed ? getEventDisabledReason(fsmState?.state, event.name) : ''}
                         >
                           {#if fsmLoading}
                             <div class="spinner"></div>

--- a/ui/dashboard/src/routes/peers/+page.svelte
+++ b/ui/dashboard/src/routes/peers/+page.svelte
@@ -16,6 +16,7 @@
   import RenderSpan from '$lib/components/table/renderers/render-span/index.svelte'
   import RenderSpanWithTooltip from '$lib/components/table/renderers/render-span-with-tooltip/index.svelte'
   import RenderLink from '$lib/components/table/renderers/render-link/index.svelte'
+  import RenderClickableSpan from '$lib/components/table/renderers/render-clickable-span/index.svelte'
 
   const t = $derived($i18n.t)
 
@@ -598,10 +599,15 @@
     },
     catchup: (idField, item, colId) => {
       return {
-        component: RenderSpan,
+        component: RenderClickableSpan,
         props: {
-          value: 'View',
+          text: 'View',
           className: 'catchup-view-link',
+          // Capture the row's peer directly — order-independent, no DOM-index lookup.
+          onClick: () => {
+            selectedPeer = item
+            showCatchupModal = true
+          },
         },
         value: '',
       }
@@ -624,30 +630,7 @@
     refreshInterval = window.setInterval(fetchPeers, 10000)
     // Check catchup status more frequently to provide real-time updates
     catchupRefreshInterval = window.setInterval(fetchCatchupStatus, 3000)
-
-    // Add event listener for catchup view buttons
-    document.addEventListener('click', handleCatchupButtonClick)
   })
-
-  // Handle clicks on catchup view buttons
-  function handleCatchupButtonClick(event: MouseEvent) {
-    const target = event.target as HTMLElement
-    if (target.classList.contains('catchup-view-link')) {
-      // Find the row element
-      let row = target.closest('tr')
-      if (row) {
-        // Get the row index
-        const tbody = row.parentElement
-        const rowIndex = Array.from(tbody?.children || []).indexOf(row)
-        // Get the peer from the displayed data
-        const peer = data[rowIndex]
-        if (peer) {
-          selectedPeer = peer
-          showCatchupModal = true
-        }
-      }
-    }
-  }
 
   onDestroy(() => {
     if (refreshInterval) {
@@ -656,8 +639,6 @@
     if (catchupRefreshInterval) {
       clearInterval(catchupRefreshInterval)
     }
-    // Remove event listener
-    document.removeEventListener('click', handleCatchupButtonClick)
   })
 </script>
 


### PR DESCRIPTION
Resolves the two remaining items of #982 (item 1, the duplicate `best_height` renderCells key, was already fixed in #987).

## Item 2 — peers catchup button: row data instead of DOM-index traversal
The catchup "View" button used a **global `document` click listener** that walked `target.closest('tr')` → `row.parentElement` → `indexOf(row)` → `data[rowIndex]` to recover the peer. That couples the handler to the table's exact DOM shape and silently breaks under sort / paginate / virtualize (rendered row order ≠ `data` order). The table renderCell already receives the row `item`, so the catchup cell now uses `RenderClickableSpan` with an `onClick` that captures the peer directly — order-independent, no global listener.

## Item 3 — FSM transitions: single source of truth
The blockchain FSM transition table was duplicated **three** ways: the real FSM (`services/blockchain/fsm.go`), the asset `/fsm/events` handler's hardcoded `switch`, and the dashboard's `isEventAllowedForState`. Any backend transition change would silently desync the other two.

- `services/blockchain/fsm.go`: extracted the inline `fsm.Events{}` to an exported `FSMTransitions` var (used by `NewFiniteStateMachine`) + a pure `AvailableEventsForState(state)` helper.
- `services/asset/httpimpl/fsm_handler.go`: `GetFSMEvents` derives the list from `blockchain.AvailableEventsForState(...)` instead of its own switch. Response shape unchanged (`{events: [...]}`); no proto/gRPC change.
- `ui/dashboard/.../admin/+page.svelte`: dropped `isEventAllowedForState` / `getEventDisabledReason` — the endpoint is already state-scoped, so the rendered events are authoritative.

`services/blockchain/fsm.go` is now the single source; the other two derive from it.

## Verification
- `go build` / `go vet` clean on `services/blockchain` + `services/asset`.
- `go test ./services/blockchain -run 'FSM|AvailableEvents'` and `./services/asset/httpimpl -run FSM` pass (added a table-driven test for `AvailableEventsForState` covering all states + unknown).
- Dashboard: `npm run check` 0 errors; `npm run test:integration` 16/16 smoke green.

Closes #982.
