### PR TITLE
fix(security): resolve open CodeQL code-scanning alerts

### DIFF
--- a/daemon/daemon_memlimit.go
+++ b/daemon/daemon_memlimit.go
@@ -77,7 +77,7 @@ func configureGOMEMLIMIT(ratio float64) {
 	memlimit := int64(memlimitFloat)
 	prev := debug.SetMemoryLimit(memlimit)
 	fmt.Printf("GC tuning: GOMEMLIMIT set to %s (%.0f%% of %s cgroup limit, was %s)\n",
-		formatBytes(memlimit), ratio*100, formatBytes(int64(limit)), formatBytes(prev))
+		formatBytes(uint64(memlimit)), ratio*100, formatBytes(limit), formatBytes(uint64(prev)))
 }
 
 // detectCgroupMemoryLimit reads the memory limit from cgroup v2 or v1.
@@ -140,7 +140,7 @@ func parseCgroupMemoryValue(s string) (uint64, error) {
 }
 
 // formatBytes formats a byte count as a human-readable string.
-func formatBytes(b int64) string {
+func formatBytes(b uint64) string {
 	const (
 		mib = 1024 * 1024
 		gib = 1024 * mib

--- a/daemon/daemon_memlimit_test.go
+++ b/daemon/daemon_memlimit_test.go
@@ -36,7 +36,7 @@ func TestParseCgroupMemoryValue(t *testing.T) {
 
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
-		input int64
+		input uint64
 		want  string
 	}{
 		{input: 1073741824, want: "1.0GiB"},

--- a/services/asset/centrifuge_impl/client/index.html
+++ b/services/asset/centrifuge_impl/client/index.html
@@ -104,7 +104,7 @@
 
         function drawText(text) {
           let e = document.createElement('li');
-          e.innerHTML = [
+          e.textContent = [
             (new Date()).toLocaleString('en-UK'),
             ' ' + text
           ].join('\n');

--- a/services/asset/httpimpl/GetBlocks.go
+++ b/services/asset/httpimpl/GetBlocks.go
@@ -3,6 +3,7 @@
 package httpimpl
 
 import (
+	"math"
 	"net/http"
 	"strings"
 
@@ -125,7 +126,11 @@ func (h *HTTP) GetBlocks(c echo.Context) error {
 
 	latestBlockHeight := blockMeta.Height
 
-	// Validate offset doesn't exceed block height to prevent underflow
+	// Validate offset is within uint32 range before casting to prevent truncation,
+	// then validate it doesn't exceed block height to prevent underflow.
+	if offset > math.MaxUint32 {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("offset exceeds maximum allowed value").Error())
+	}
 	if uint32(offset) > latestBlockHeight {
 		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("offset exceeds block height").Error())
 	}

--- a/services/asset/httpimpl/GetNearestForkHeights.go
+++ b/services/asset/httpimpl/GetNearestForkHeights.go
@@ -1,6 +1,7 @@
 package httpimpl
 
 import (
+	"math"
 	"net/http"
 	"strconv"
 
@@ -51,6 +52,10 @@ func (h *HTTP) GetNearestForkHeights(c echo.Context) error {
 	if rangeStr != "" {
 		r, err := strconv.Atoi(rangeStr)
 		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid range parameter").Error())
+		}
+
+		if r < 0 || r > math.MaxUint32 {
 			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid range parameter").Error())
 		}
 

--- a/ui/dashboard/src/internal/stores/p2pStore.ts
+++ b/ui/dashboard/src/internal/stores/p2pStore.ts
@@ -27,6 +27,13 @@ function createCurrentNodePeerIDStore() {
 
 export const currentNodePeerID = createCurrentNodePeerIDStore() // Track our own node's peer ID
 
+// Keys that must never be used on a plain object — doing so pollutes Object.prototype.
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function isSafeKey(key: unknown): key is string {
+  return typeof key === 'string' && key.length > 0 && !DANGEROUS_KEYS.has(key)
+}
+
 const maxMessages = 500
 const MAX_RECONNECT_ATTEMPTS = 5
 const BASE_RECONNECT_DELAY = 2000 // Start with 2 seconds
@@ -47,6 +54,9 @@ function cleanupExpiredPeers() {
 
   // Check each peer and remove if last update was more than 30 seconds ago
   for (const nodeKey in miningNodeSet) {
+    if (!Object.prototype.hasOwnProperty.call(miningNodeSet, nodeKey)) {
+      continue
+    }
     const node = miningNodeSet[nodeKey]
     if (node.receivedAt) {
       const lastUpdate = new Date(node.receivedAt).getTime()
@@ -173,6 +183,9 @@ export async function connectToP2PServer() {
             if (jsonData.type === 'node_status') {
               // Handle node_status messages - these provide comprehensive node information
               const nodeKey = jsonData.peer_id
+              if (!isSafeKey(nodeKey)) {
+                return
+              }
 
               // The very first node_status message we receive should be from our own node
               // (sent immediately upon WebSocket connection by the backend)
@@ -241,6 +254,9 @@ export async function connectToP2PServer() {
               // Don't return here - let it fall through to add to messages array
             } else if (jsonData.type === 'block') {
               const nodeKey = jsonData.peer_id
+              if (!isSafeKey(nodeKey)) {
+                return
+              }
               const currentPeerID = get(currentNodePeerID)
               const existingNode = miningNodeSet[nodeKey]
 
@@ -296,6 +312,9 @@ export async function connectToP2PServer() {
               }
             } else if (jsonData.peer_id) {
               const nodeKey = jsonData.peer_id
+              if (!isSafeKey(nodeKey)) {
+                return
+              }
               const currentPeerID = get(currentNodePeerID)
               if (!miningNodeSet[nodeKey]) {
                 miningNodeSet[nodeKey] = {

--- a/ui/dashboard/src/internal/utils/urlUtils.ts
+++ b/ui/dashboard/src/internal/utils/urlUtils.ts
@@ -45,18 +45,3 @@ export function validateUrl(url: string): string | null {
   console.warn('Invalid redirect URL detected:', url)
   return null
 }
-
-/**
- * Sanitizes a URL by removing potentially dangerous characters
- *
- * @param url The URL to sanitize
- * @returns The sanitized URL
- */
-export function sanitizeUrl(url: string): string {
-  if (!url) {
-    return ''
-  }
-
-  // Remove any script tags, HTML entities, or other potentially dangerous content
-  return url.replace(/<script.*?>.*?<\/script>/gi, '').replace(/[<>"']/g, '')
-}

--- a/util/grpc_helper.go
+++ b/util/grpc_helper.go
@@ -69,7 +69,7 @@ func (PasswordCredentials) RequireTransportSecurity() bool {
 // including security settings, authentication, retries, and message size limits.
 type ConnectionOptions struct {
 	MaxMessageSize   int                 // Max message size in bytes
-	SecurityLevel    int                 // 0 = insecure, 1 = secure, 2 = secure with client cert
+	SecurityLevel    int                 // 0 = insecure, 1 = TLS without server cert verification (client side: MITM-vulnerable), 2 = secure with client cert
 	CertFile         string              // CA cert file if SecurityLevel > 0
 	CaCertFile       string              // CA cert file if SecurityLevel > 0
 	KeyFile          string              // Client key file if SecurityLevel > 1
@@ -382,7 +382,9 @@ func retryInterceptor(maxAttempts int, retryBackoff time.Duration, callerName st
 // loadTLSCredentials configures TLS transport credentials based on the specified security level.
 // Supports four security levels:
 //   - Level 0: No security (insecure connection)
-//   - Level 1: TLS with no client certificate required
+//   - Level 1: TLS with no client certificate required. NOTE: on the client side this enables
+//     InsecureSkipVerify, so the server certificate is NOT verified (vulnerable to MITM). Use only
+//     in trusted/controlled networks where an operator has explicitly opted in via security_level_grpc.
 //   - Level 2: TLS with any client certificate accepted
 //   - Level 3: TLS with client certificate required and verified
 //
@@ -416,8 +418,11 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 				MinVersion:   tls.VersionTLS12,
 			}), nil
 		} else {
+			// SecurityLevel 1 (client): encrypt the channel without verifying the server
+			// certificate. This is a deliberate, operator-opted-in mode (security_level_grpc=1,
+			// not the default) for trusted/controlled networks; it is MITM-exploitable by design.
 			return credentials.NewTLS(&tls.Config{
-				//nolint:gosec // G402: TLS InsecureSkipVerify set true. (gosec)
+				//nolint:gosec // G402: InsecureSkipVerify is an intentional, config-gated security level. (gosec)
 				InsecureSkipVerify: true,
 			}), nil
 		}


### PR DESCRIPTION
## What

Resolves the 11 open CodeQL code-scanning alerts.

| Alert(s) | File | Fix |
|---|---|---|
| #90 #91 #117 | `services/asset/httpimpl/{GetBlocks,GetNearestForkHeights}.go` | Bound-check the `int`→`uint32` conversion before casting (reject out-of-range `offset`/`range` with HTTP 400). Prevents silent truncation/wrap-around. |
| #113 | `daemon/daemon_memlimit.go` | `formatBytes` now takes `uint64`, removing the unchecked `int64(limit)` narrowing of the cgroup memory limit. Log output unchanged. |
| #79 #81 #83 | `ui/dashboard/src/internal/stores/p2pStore.ts` | Reject `__proto__`/`constructor`/`prototype` as `peer_id` keys before any plain-object write; guard the `for…in` with `hasOwnProperty`. Prevents prototype pollution from WebSocket data. |
| #2 #4 | `ui/dashboard/src/internal/utils/urlUtils.ts` | Removed the dead `sanitizeUrl` function entirely (no callers, no tests). Its broken script-tag regex was the source of both alerts; `validateUrl` (the function actually in use) is untouched. |
| #1 | `services/asset/centrifuge_impl/client/index.html` | `innerHTML` → `textContent` in `drawText` — real DOM XSS from server-controlled push data. `white-space: pre` preserves rendering. |
| #42 | `util/grpc_helper.go` | No behaviour change. `InsecureSkipVerify` is reached only via the explicit, operator-opted-in `SecurityLevel==1` (default is `0`). Added godoc/comment warning that level 1 leaves the server certificate unverified (MITM). Alert dismissed on GitHub as intentional/config-gated. |

## Verification

- `go build` + `go vet` on affected packages (`daemon`, `services/asset/httpimpl`, `util`) — clean
- `go test` (targeted: `TestFormatBytes`, `TestParseCgroupMemoryValue`, `GetBlocks`, `LimitOffset`, `NearestForkHeights`) — pass
- `svelte-check` — 0 errors (798 files; 14 pre-existing warnings, none in changed files)
- `gofmt -l` — clean

## Notes

- Behaviour changes are limited to rejecting previously-unsound inputs: negative/oversized `range`/`offset` now return HTTP 400 instead of silently wrapping; WS messages with a `__proto__`-style `peer_id` are dropped. No legitimate request is affected.
- #42 is documentation-only plus a GitHub dismissal; the weak-TLS mode itself is intentional and gated behind explicit operator config.
- 32-bit nit (non-blocking): the `x > math.MaxUint32` guards won't compile on 32-bit (untyped-const overflow). Moot — Teranode builds only amd64/arm64 and the asset pkg requires 64-bit cgo.