### PR TITLE
perf(blockchain/sql): fast-path GetBlockInChainByHeightHash on on_main_chain (#1018)

### DIFF
--- a/stores/blockchain/sql/GetBlockInChainByHeight.go
+++ b/stores/blockchain/sql/GetBlockInChainByHeight.go
@@ -69,7 +69,38 @@ func (s *SQL) GetBlockInChainByHeightHash(ctx context.Context, height uint32, st
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	q := `
+	// The fast path filters blocks by on_main_chain = true and height <=
+	// startHash's height. That matches the CTE's walk-from-startHash semantics
+	// only when startHash is itself on the main chain. When it is a fork tip
+	// (a known hash with on_main_chain = false), the two paths disagree — the
+	// CTE follows the fork's ancestors, the fast path would substitute whichever
+	// main-chain block sits at the same height. Fall back to the CTE in that
+	// case. Treat DB errors or unknown hashes as "not on main chain" so the CTE
+	// (which also surfaces that error) stays authoritative.
+	//
+	// TOCTOU: the guard check and startOnMain preflight are non-atomic with the
+	// main query that follows. A concurrent writer can bump the guard after this
+	// check but before the main query runs. In the worst case the caller sees
+	// one call's worth of slightly-stale data; on the next call the guard is
+	// observed > 0 and the CTE path is taken. Acceptable under the store's
+	// single-writer model, where these transient inconsistencies are bounded
+	// and self-healing.
+	rebuilding := s.mainChainRebuilding.Load() > 0
+	startOnMain := false
+	if !rebuilding {
+		if scanErr := s.db.QueryRowContext(ctx,
+			`SELECT COALESCE((SELECT on_main_chain FROM blocks WHERE hash = $1 LIMIT 1), false)`,
+			startHash.CloneBytes(),
+		).Scan(&startOnMain); scanErr != nil {
+			// Error falls through to the CTE path, which will re-run the same
+			// kind of DB access and surface the error to the caller.
+			startOnMain = false
+		}
+	}
+
+	var q string
+	if rebuilding || !startOnMain {
+		q = `
 		WITH RECURSIVE ChainBlocks AS (
 			SELECT id, parent_id, height
 			FROM blocks
@@ -102,6 +133,37 @@ func (s *SQL) GetBlockInChainByHeightHash(ctx context.Context, height uint32, st
 		WHERE cb.height = $1
 		LIMIT 1
 	`
+	} else {
+		// Fast path: use on_main_chain flag instead of the recursive CTE walk.
+		// We still enforce the startHash height upper bound so that only blocks
+		// that are ancestors-of or equal-to startHash are considered — matching
+		// the CTE's walk-from-startHash semantics exactly. The height <= bound
+		// ensures we return no row when height > startHash.height, identical to
+		// the CTE. If startHash is not in the DB the subquery returns NULL and
+		// the height comparison yields no rows, producing the same ErrNoRows as
+		// the CTE path.
+		q = `
+		SELECT
+		 b.ID
+		,b.version
+		,b.block_time
+		,b.n_bits
+		,b.nonce
+		,b.previous_hash
+		,b.merkle_root
+		,b.tx_count
+		,b.size_in_bytes
+		,b.coinbase_tx
+		,b.subtree_count
+		,b.subtrees
+		,b.invalid
+		FROM blocks b
+		WHERE b.on_main_chain = true
+		  AND b.height = $1
+		  AND b.height <= (SELECT height FROM blocks WHERE hash = $2 LIMIT 1)
+		LIMIT 1
+	`
+	}
 
 	block = &model.Block{
 		Header: &model.BlockHeader{},

--- a/stores/blockchain/sql/GetBlockInChainByHeight_test.go
+++ b/stores/blockchain/sql/GetBlockInChainByHeight_test.go
@@ -107,6 +107,83 @@ func TestSQL_GetBlockInChainByHeightHash(t *testing.T) {
 	}
 }
 
+// TestSQL_GetBlockInChainByHeightHash_FastPathEquivalence verifies the #1018
+// on_main_chain fast path returns results identical to the recursive CTE for a
+// start hash that is on the main chain, and that the mainChainRebuilding guard
+// forces the CTE path. It is independent of which fork wins the chain-work tie:
+// the main-chain tip is discovered dynamically.
+func TestSQL_GetBlockInChainByHeightHash_FastPathEquivalence(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	block0, err := store.GetBlockByHeight(ctx, 0)
+	require.NoError(t, err)
+
+	// Linear main chain plus a competing fork off block1, so on_main_chain is
+	// meaningfully set for some rows and false for others.
+	block1 := createTestBlock(t, 1, block0.Hash())
+	block2 := createTestBlock(t, 2, block1.Hash())
+	block3 := createTestBlock(t, 3, block2.Hash())
+	forkB := createTestBlock(t, 99, block1.Hash()) // sibling of block2, off main
+
+	for _, b := range []*model.Block{block1, block2, block3, forkB} {
+		_, _, err := store.StoreBlock(ctx, b, "")
+		require.NoError(t, err)
+	}
+
+	// Discover the actual main-chain tip (chain-work tie-break is the store's
+	// business, not this test's assumption).
+	_, tipMeta, err := store.GetBestBlockHeader(ctx)
+	require.NoError(t, err)
+	tipHeight := tipMeta.Height
+
+	tip, err := store.GetBlockByHeight(ctx, tipHeight)
+	require.NoError(t, err)
+	tipHash := tip.Hash()
+
+	// Sanity: the preflight must see the tip as on the main chain.
+	var tipOnMain bool
+	require.NoError(t, store.db.QueryRowContext(ctx,
+		`SELECT COALESCE((SELECT on_main_chain FROM blocks WHERE hash = $1 LIMIT 1), false)`,
+		tipHash.CloneBytes(),
+	).Scan(&tipOnMain))
+	require.True(t, tipOnMain, "main-chain tip must have on_main_chain=true")
+
+	for h := uint32(0); h <= tipHeight; h++ {
+		// Fast path (guard == 0).
+		require.Equal(t, int32(0), store.mainChainRebuilding.Load())
+		fast, _, err := store.GetBlockInChainByHeightHash(ctx, h, tipHash)
+		require.NoError(t, err, "fast path height %d", h)
+		store.responseCache.DeleteAll() // avoid the cache masking the CTE branch
+
+		// CTE path (guard > 0 forces fallback even with an on-main start).
+		store.mainChainRebuilding.Add(1)
+		cte, _, err := store.GetBlockInChainByHeightHash(ctx, h, tipHash)
+		store.mainChainRebuilding.Add(-1)
+		require.NoError(t, err, "cte path height %d", h)
+		store.responseCache.DeleteAll()
+
+		require.Equal(t, fast.Hash().String(), cte.Hash().String(),
+			"fast path and CTE disagree at height %d", h)
+
+		// Both must equal the canonical main-chain block at that height.
+		mainByHeight, err := store.GetBlockByHeight(ctx, h)
+		require.NoError(t, err)
+		require.Equal(t, mainByHeight.Hash().String(), fast.Hash().String(),
+			"fast path is not the main-chain block at height %d", h)
+	}
+
+	// Edge: height == startHash.height returns the start block itself.
+	startAtTip, _, err := store.GetBlockInChainByHeightHash(ctx, tipHeight, tipHash)
+	require.NoError(t, err)
+	require.Equal(t, tipHash.String(), startAtTip.Hash().String())
+
+	// Edge: height > startHash.height must yield BlockNotFound on the fast path,
+	// identical to the CTE (which never walks above the seed height).
+	_, _, err = store.GetBlockInChainByHeightHash(ctx, tipHeight+1, tipHash)
+	require.Error(t, err)
+}
+
 // Helper function to create a test block
 func createTestBlock(t *testing.T, nonce uint32, previousHash *chainhash.Hash) *model.Block {
 	t.Helper()

--- a/stores/blockchain/sql/GetForkedBlockHeaders.go
+++ b/stores/blockchain/sql/GetForkedBlockHeaders.go
@@ -76,6 +76,16 @@ func (s *SQL) GetForkedBlockHeaders(ctx context.Context, blockHashFrom *chainhas
 	blockHeaders := make([]*model.BlockHeader, 0, numberOfHeaders)
 	blockHeaderMetas := make([]*model.BlockHeaderMeta, 0, numberOfHeaders)
 
+	// No on_main_chain fast path is possible here. This query's semantic is
+	// "all blocks NOT in the ancestor set of blockHashFrom", which has no
+	// equivalent on_main_chain predicate:
+	//   - NOT on_main_chain is wrong when blockHashFrom is a main-chain tip:
+	//     it would exclude the main-chain ancestors of blockHashFrom.
+	//   - on_main_chain = false is wrong when blockHashFrom is a fork tip:
+	//     the fork's own ancestors also have on_main_chain = false.
+	// The recursive CTE is the only correct way to compute the complement of the
+	// ancestor set, so it is retained deliberately (unlike the locator/height
+	// lookups in this package, which the #1018 fast path covers).
 	q := `
 		SELECT
 			 b.version


### PR DESCRIPTION
Closes #1018 (for the remaining sites).

## What

8 of the 10 sites in #1018 already had the `on_main_chain` fast path merged. This finishes the list:

- **`GetBlockInChainByHeightHash`** — added the fast path. Because the function is parameterized by a `startHash` that may be a fork tip, it uses the *preflight* variant (same as `GetLatestBlockHeaderFromBlockLocator`), not the plain `mainChainRebuilding`-only gate: it checks whether `startHash` is itself `on_main_chain` and only then replaces the recursive `ChainBlocks` walk with a single `WHERE on_main_chain = true AND height = $1` lookup on `idx_on_main_chain_height`. Fork-tip starts and reorg windows (`mainChainRebuilding > 0`) fall back to the CTE.
  - The fast path keeps `AND height <= startHash.height` so it is exactly equivalent to the CTE (no row when `height > startHash.height`).
- **`GetForkedBlockHeaders`** — intentionally **kept** on the CTE. Its semantic is "all blocks NOT in the ancestor set of `startHash`", which has no equivalent `on_main_chain` predicate (`NOT on_main_chain` drops the main-chain ancestors when the start is a main tip; `on_main_chain = false` is wrong when the start is a fork tip). Documented inline. It also has no production callers outside the store.

The other 6 `WITH RECURSIVE` sites in the package (`GetSuitableBlock`, `GetBlockHeadersFromTill`, `CheckBlockIsAncestorOfBlock`, `GetBlockHeadersFromOldest`, `GetHashOfAncestorBlock`, `GetBlocks`) are not in the #1018 list and are genuinely fork-aware — left unchanged.

## Correctness

The fast path is only taken when `startHash` is on the main chain, so the ancestor at any lower height is also on the main chain by definition. The `mainChainRebuilding` reference counter brackets every window where `on_main_chain` is transiently inconsistent (`StoreBlock`, `InvalidateBlock`, `RevalidateBlock`, `rebuildOnMainChainFlag`); when it is non-zero the CTE path is forced. The preflight/main-query TOCTOU is bounded and self-healing under the store's single-writer model (same reasoning as the existing locator fast path).

## Tests

Added `TestSQL_GetBlockInChainByHeightHash_FastPathEquivalence`: asserts the fast path, the CTE (forced via the rebuilding flag), and `GetBlockByHeight` all agree across every height for an on-main start, plus the `height == startHash.height` and `height > startHash.height` edges. The pre-existing fork-tip test already covers the CTE fallback.

- `go build ./stores/blockchain/... ./services/blockchain/...` — ok
- `go vet` / `staticcheck` / `golangci-lint` — clean
- `go test ./stores/blockchain/sql/` — ok
- `go test -race ./stores/blockchain/sql/` — ok

## Note on #1019

#1019 (drop 4 indexes) was investigated alongside this. Conclusion: **do not drop them** — all four have real readers; the "0 scans" was a measurement-window artefact. Details posted on that issue.
