### PR TITLE
fix(utxo/aerospike): stop caller-side goroutine/connection leak in batchers

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -148,6 +148,11 @@ type Store struct {
 
 	// batchOperateFn is a test-only override for s.client.BatchOperate; nil means use the real client.
 	batchOperateFn func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error
+
+	// batcherWait bounds how long a submitter waits for a batcher to deliver a
+	// result before giving up, so a wedged dispatch fn can never park a caller
+	// for the life of the process. Computed once from the batch policy.
+	batcherWait time.Duration
 }
 
 // New creates a new Aerospike-based UTXO store.
@@ -225,6 +230,7 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 		utxoBatchSize:    utxoBatchSize,
 		externalTxCache:  externalTxCache,
 		externalStoreSem: externalStoreSem,
+		batcherWait:      batcherWaitTimeout(tSettings),
 	}
 
 	// Initialize spendLuaPackages array with configurable count

--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -155,6 +155,18 @@ type Store struct {
 	batcherWait time.Duration
 }
 
+// batchOperate runs a batch through the underlying Aerospike client, honouring
+// the test-only batchOperateFn override when set. Centralising the call lets
+// unit tests drive the dispatch functions' panic/error/result paths without a
+// live Aerospike instance.
+func (s *Store) batchOperate(policy *aerospike.BatchPolicy, records []aerospike.BatchRecordIfc) aerospike.Error {
+	if s.batchOperateFn != nil {
+		return s.batchOperateFn(policy, records)
+	}
+
+	return s.client.BatchOperate(policy, records)
+}
+
 // New creates a new Aerospike-based UTXO store.
 // The URL format is: aerospike://host:port/namespace?set=setname&
 // URL parameters:

--- a/stores/utxo/aerospike/batch_completion.go
+++ b/stores/utxo/aerospike/batch_completion.go
@@ -1,0 +1,96 @@
+package aerospike
+
+import (
+	"runtime/debug"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+)
+
+// signalBatchPanic is the panic safety net for the batcher dispatch functions
+// (sendGetBatch, sendStoreBatch, sendSpendBatchLua, sendOutpointBatch,
+// sendIncrementBatch, sendSetDAHBatch, setLockedBatch).
+//
+// go-batcher recovers panics raised inside the batch fn (see
+// dispatchAndRecord in go-batcher/v2: it wraps b.fn(batch) in a deferred
+// recover). Without our own guard, a panic part-way through a dispatch fn
+// leaves every not-yet-signalled per-item completion channel orphaned: the
+// worker survives, but the submitter goroutines waiting on those channels park
+// forever (the contexts threaded down from legacy sync / validation have no
+// deadline). That is the mechanism behind the production goroutine leak
+// (thousands parked in (*Store).get's select).
+//
+// Install it as the FIRST statement of each dispatch fn:
+//
+//	defer func() {
+//	    signalBatchPanic(recover(), batch, "sendGetBatch", s.logger, func(it *batchGetItem, err error) {
+//	        util.SafeSend(it.done, batchGetItemData{Err: err}, batchSignalTimeout)
+//	    })
+//	}()
+//
+// signal MUST be non-blocking / panic-safe (wrap util.SafeSend) so that a
+// submitter that already left (e.g. timed out) cannot block the worker, and a
+// double-send on a buffered-1 channel cannot deadlock it. Returns true if a
+// panic was actually handled (recovered != nil).
+func signalBatchPanic[T any](recovered any, batch []T, fnName string, logger ulogger.Logger, signal func(item T, err error)) bool {
+	if recovered == nil {
+		return false
+	}
+
+	if prometheusUtxoMapErrors != nil {
+		prometheusUtxoMapErrors.WithLabelValues("Batch", "PanicRecovered").Inc()
+	}
+
+	logger.Errorf("[%s] recovered panic, failing %d batch item(s): %v\n%s", fnName, len(batch), recovered, debug.Stack())
+
+	err := errors.NewProcessingError("panic in %s: %v", fnName, recovered)
+	for _, item := range batch {
+		signal(item, err)
+	}
+
+	return true
+}
+
+// trySignal delivers v on a completion channel without blocking and without
+// re-delivering when a result is already queued. It is the correct primitive for
+// the buffered-1 completion channels used across the batchers (get/outpoint/
+// spend/increment/setDAH/locked): a still-waiting submitter receives the value
+// immediately, an already-signalled channel (buffer full) is left untouched, and
+// a departed submitter cannot wedge the worker. Do NOT use it for unbuffered
+// channels — there it would race the receiver and silently drop the signal.
+func trySignal[T any](ch chan T, v T) {
+	select {
+	case ch <- v:
+	default:
+	}
+}
+
+// batchSignalTimeout bounds a single non-blocking completion send. It exists
+// only so an unbuffered completion channel whose submitter has already departed
+// cannot wedge the worker. Buffered-1 channels (the common case) never reach the
+// timeout. Kept small because it is paid per item only on the rare error/panic
+// fan-out paths.
+const batchSignalTimeout = 5 * time.Second
+
+// batcherWaitTimeout bounds how long a submitter waits for a batcher to deliver
+// a result before giving up with a ServiceUnavailable error. This is the
+// keystone guarantee against permanent leaks: even if a dispatch fn never
+// signals (panic, missed code path) or stays wedged inside a stuck v8 batch op,
+// the caller goroutine is released after this bound instead of parking for the
+// life of the process.
+//
+// It is derived from the batch policy's own TotalTimeout (the maximum a healthy
+// batch can legitimately take, retries included) plus grace, so it never fires
+// during normal slow operation — only on a genuine wedge. Falls back to a sane
+// default when the policy carries no total timeout.
+func batcherWaitTimeout(tSettings *settings.Settings) time.Duration {
+	d := util.GetAerospikeBatchPolicy(tSettings).TotalTimeout
+	if d <= 0 {
+		d = 2 * time.Minute
+	}
+
+	return d + 30*time.Second
+}

--- a/stores/utxo/aerospike/batch_completion_test.go
+++ b/stores/utxo/aerospike/batch_completion_test.go
@@ -1,0 +1,75 @@
+package aerospike
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignalBatchPanic verifies the panic safety net used by every batcher
+// dispatch fn: on a recovered panic it must surface an error on EVERY item's
+// completion channel, so go-batcher swallowing the panic can no longer orphan
+// the waiting submitter goroutines.
+func TestSignalBatchPanic(t *testing.T) {
+	InitPrometheusMetrics()
+
+	logger := ulogger.TestLogger{}
+
+	type item struct {
+		done chan error
+	}
+
+	signal := func(it *item, err error) {
+		util.SafeSend(it.done, err, batchSignalTimeout)
+	}
+
+	t.Run("nil recovered is a no-op", func(t *testing.T) {
+		batch := []*item{{done: make(chan error, 1)}}
+		handled := signalBatchPanic(recover(), batch, "test", logger, signal)
+		require.False(t, handled)
+		require.Len(t, batch[0].done, 0, "no signal should be sent when nothing was recovered")
+	})
+
+	t.Run("panic signals every waiter exactly once", func(t *testing.T) {
+		const n = 16
+		batch := make([]*item, n)
+		for i := range batch {
+			batch[i] = &item{done: make(chan error, 1)}
+		}
+
+		handled := signalBatchPanic("boom", batch, "sendGetBatch", logger, signal)
+		require.True(t, handled)
+
+		for i, it := range batch {
+			select {
+			case err := <-it.done:
+				require.Error(t, err, "item %d must receive an error", i)
+				require.Contains(t, err.Error(), "panic in sendGetBatch")
+			case <-time.After(time.Second):
+				t.Fatalf("item %d was orphaned: no completion signal after panic", i)
+			}
+		}
+	})
+
+	t.Run("already-signalled buffered-1 waiter does not block the worker", func(t *testing.T) {
+		// Mimics a dispatch fn that signalled some items before panicking: the
+		// channel buffer is already full, and the panic fan-out must not block.
+		it := &item{done: make(chan error, 1)}
+		it.done <- nil // pre-existing result
+
+		done := make(chan struct{})
+		go func() {
+			signalBatchPanic("boom", []*item{it}, "test", logger, signal)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * batchSignalTimeout):
+			t.Fatal("signalBatchPanic blocked on a full buffered channel")
+		}
+	})
+}

--- a/stores/utxo/aerospike/batch_dispatch_leak_test.go
+++ b/stores/utxo/aerospike/batch_dispatch_leak_test.go
@@ -1,0 +1,174 @@
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/aerospike-client-go/v8/types"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive each batcher dispatch fn through its panic / BatchOperate-error
+// / result paths using the batchOperateFn seam, so the failure-path branches added
+// for the leak fix are exercised without a live Aerospike instance.
+
+func panicOperate() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+	return func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error { panic("simulated batch panic") }
+}
+
+func errorOperate() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+	return func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+		return &aerospike.AerospikeError{ResultCode: types.TIMEOUT}
+	}
+}
+
+func okOperate() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+	return func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error { return nil }
+}
+
+func requireSignalled[T any](t *testing.T, ch chan T, i int) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("item %d was orphaned: no completion signal", i)
+	}
+}
+
+func TestSendIncrementBatch_NeverOrphans(t *testing.T) {
+	mk := func() []*batchIncrement {
+		b := make([]*batchIncrement, 4)
+		for i := range b {
+			h := chainhash.Hash{byte(i + 1)}
+			b[i] = &batchIncrement{txID: &h, increment: 1, res: make(chan incrementSpentRecordsRes, 1)}
+		}
+		return b
+	}
+
+	for name, fn := range map[string]func() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error{
+		"panic": panicOperate, "batchOperate error": errorOperate, "ok (nil records)": okOperate,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := newTestStoreForGet(t)
+			s.batchOperateFn = fn()
+
+			b := mk()
+			require.NotPanics(t, func() { s.sendIncrementBatch(b) })
+
+			for i, it := range b {
+				requireSignalled(t, it.res, i)
+			}
+		})
+	}
+}
+
+func TestSendSetDAHBatch_NeverOrphans(t *testing.T) {
+	mk := func() []*batchDAH {
+		b := make([]*batchDAH, 4)
+		for i := range b {
+			h := chainhash.Hash{byte(i + 1)}
+			b[i] = &batchDAH{txID: &h, childIdx: uint32(i + 1), deleteAtHeight: 100, errCh: make(chan error, 1)}
+		}
+		return b
+	}
+
+	for name, fn := range map[string]func() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error{
+		"panic": panicOperate, "batchOperate error": errorOperate, "ok (nil records)": okOperate,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := newTestStoreForGet(t)
+			s.batchOperateFn = fn()
+
+			b := mk()
+			require.NotPanics(t, func() { s.sendSetDAHBatch(b) })
+
+			for i, it := range b {
+				requireSignalled(t, it.errCh, i)
+			}
+		})
+	}
+}
+
+func TestSetLockedBatch_NeverOrphans(t *testing.T) {
+	mk := func() []*batchLocked {
+		b := make([]*batchLocked, 4)
+		for i := range b {
+			b[i] = &batchLocked{ctx: context.Background(), txHash: chainhash.Hash{byte(i + 1)}, setValue: true, errCh: make(chan error, 1)}
+		}
+		return b
+	}
+
+	// "ok" exercises the previously-silent missing-LuaSuccess-bin branch (the
+	// mocked records carry no Record), which must now signal an error rather
+	// than fall through and orphan the submitter.
+	for name, fn := range map[string]func() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error{
+		"panic": panicOperate, "batchOperate error": errorOperate, "ok (missing response)": okOperate,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := newTestStoreForGet(t)
+			s.batchOperateFn = fn()
+
+			b := mk()
+			require.NotPanics(t, func() { s.setLockedBatch(b) })
+
+			for i, it := range b {
+				requireSignalled(t, it.errCh, i)
+			}
+		})
+	}
+}
+
+func TestSendSpendBatchLua_PanicSignalsAllWaiters(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.utxoBatchSize = 2
+	s.batchOperateFn = panicOperate()
+
+	const n = 4
+
+	batch := make([]*batchSpend, n)
+	for i := range batch {
+		txID := chainhash.HashH([]byte{byte(i), 't', 'x'})
+		utxoHash := chainhash.HashH([]byte{byte(i), 'u'})
+		spender := chainhash.HashH([]byte{byte(i), 's'})
+		batch[i] = &batchSpend{
+			spend: &utxo.Spend{
+				TxID:         &txID,
+				Vout:         uint32(i),
+				UTXOHash:     &utxoHash,
+				SpendingData: spendpkg.NewSpendingData(&spender, 0),
+			},
+			blockHeight: 100,
+			errCh:       make(chan error, 1),
+		}
+	}
+
+	require.NotPanics(t, func() { s.sendSpendBatchLua(batch) })
+
+	for i, it := range batch {
+		requireSignalled(t, it.errCh, i)
+	}
+}
+
+func TestSendStoreBatch_PanicSignalsAllWaiters(t *testing.T) {
+	s := newTestStoreForSendStoreBatch(t)
+	s.batchOperateFn = panicOperate()
+
+	const n = 3
+
+	batch := make([]*BatchStoreItem, n)
+	for i := range batch {
+		tx := txWithSingleOutput(t)
+		batch[i] = NewBatchStoreItem(tx.TxIDChainHash(), false, tx, 100, nil, 0, make(chan error, 1))
+	}
+
+	require.NotPanics(t, func() { s.sendStoreBatch(batch) })
+
+	for i, item := range batch {
+		requireSignalled(t, item.done, i)
+	}
+}

--- a/stores/utxo/aerospike/batch_dispatch_leak_test.go
+++ b/stores/utxo/aerospike/batch_dispatch_leak_test.go
@@ -18,7 +18,9 @@ import (
 // for the leak fix are exercised without a live Aerospike instance.
 
 func panicOperate() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
-	return func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error { panic("simulated batch panic") }
+	return func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+		panic("simulated batch panic")
+	}
 }
 
 func errorOperate() func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -57,6 +57,7 @@ package aerospike
 import (
 	"context"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/bsv-blockchain/aerospike-client-go/v8"
@@ -220,10 +221,28 @@ func (s *Store) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts 
 
 	s.storeBatcher.PutCtx(ctx, item)
 
-	err = <-errCh
-	if err != nil {
-		// return raw err, should already be wrapped
-		return nil, err
+	// Bound the wait: the store dispatch fn signals via util.SafeSend (panic-safe
+	// against the deferred close above), so a wedged batcher cannot pin this
+	// caller forever. A nil timeout channel disables the arm (Store built without New).
+	var timeoutCh <-chan time.Time
+
+	if s.batcherWait > 0 {
+		timer := time.NewTimer(s.batcherWait)
+		defer timer.Stop()
+
+		timeoutCh = timer.C
+	}
+
+	select {
+	case err = <-errCh:
+		if err != nil {
+			// return raw err, should already be wrapped
+			return nil, err
+		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timeoutCh:
+		return nil, errors.NewServiceUnavailableError("aerospike store batch did not complete within %s", s.batcherWait)
 	}
 
 	prometheusUtxostoreCreate.Inc()
@@ -256,6 +275,36 @@ func (s *Store) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts 
 // Parameters:
 //   - batch: Array of BatchStoreItems to process
 func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
+	// resultHandledElsewhere[idx] == true means batch[idx].done has already been
+	// notified by this iteration of sendStoreBatch (either directly via SafeSend
+	// below or via a goroutine that takes ownership of the result), so subsequent
+	// error/success loops MUST NOT send a second notification on the same channel.
+	// Declared up front so the panic guard below can skip already-handled items.
+	resultHandledElsewhere := make([]bool, len(batch))
+
+	// go-batcher recovers panics raised in this fn; without re-signalling the
+	// not-yet-handled done channels, a panic (e.g. a nil tx) would orphan every
+	// remaining waiting caller and leak their goroutines permanently.
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		if prometheusUtxoMapErrors != nil {
+			prometheusUtxoMapErrors.WithLabelValues("Batch", "PanicRecovered").Inc()
+		}
+
+		s.logger.Errorf("[sendStoreBatch] recovered panic, failing batch items: %v\n%s", r, debug.Stack())
+
+		var err error = errors.NewProcessingError("panic in sendStoreBatch: %v", r)
+		for idx, bItem := range batch {
+			if !resultHandledElsewhere[idx] {
+				util.SafeSend(bItem.done, err, batchSignalTimeout)
+			}
+		}
+	}()
+
 	start := time.Now()
 
 	stat := gocore.NewStat("sendStoreBatch")
@@ -276,14 +325,6 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 	batchWritePolicy.RecordExistsAction = aerospike.CREATE_ONLY
 
 	batchRecords := make([]aerospike.BatchRecordIfc, len(batch))
-	// resultHandledElsewhere[idx] = true means bItem.done has already been notified by
-	// this iteration of sendStoreBatch (either directly via SafeSend below or via a
-	// goroutine that takes ownership of the result), so subsequent error/success
-	// loops MUST NOT send a second notification on the same channel. Without this,
-	// items that were notified pre-BatchOperate would receive a duplicate from the
-	// per-record loop, and items that hit specific aerospike result codes would
-	// silently fall through unnotified.
-	resultHandledElsewhere := make([]bool, len(batch))
 
 	if s.settings.UtxoStore.VerboseDebug {
 		s.logger.Debugf("[STORE_BATCH] sending batch of %d txMetas", len(batch))

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -503,12 +503,7 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 
 	batchID := s.batchID.Add(1)
 
-	batchOperate := s.batchOperateFn
-	if batchOperate == nil {
-		batchOperate = s.client.BatchOperate
-	}
-
-	err = batchOperate(batchPolicy, batchRecords)
+	err = s.batchOperate(batchPolicy, batchRecords)
 	if err != nil {
 		var aErr *aerospike.AerospikeError
 
@@ -1067,12 +1062,7 @@ func (s *Store) storeExternallyWithLock(
 
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
 
-	batchOperate := s.batchOperateFn
-	if batchOperate == nil {
-		batchOperate = s.client.BatchOperate
-	}
-
-	if err := batchOperate(batchPolicy, batchRecords); err != nil {
+	if err := s.batchOperate(batchPolicy, batchRecords); err != nil {
 		util.SafeSend[error](bItem.done, errors.NewProcessingError("[%s] BatchOperate failed for tx %s", funcName, bItem.txHash, err))
 		return
 	}
@@ -1307,7 +1297,7 @@ func (s *Store) clearCreatingFlag(txHash *chainhash.Hash, numRecords int) error 
 
 	// Phase 1: Clear child records first (indices 1, 2, ..., N-1)
 	if len(childWrites) > 0 {
-		err := s.client.BatchOperate(batchPolicy, childWrites)
+		err := s.batchOperate(batchPolicy, childWrites)
 		if err != nil {
 			return errors.NewProcessingError("failed to unlock child records", err)
 		}
@@ -1334,7 +1324,7 @@ func (s *Store) clearCreatingFlag(txHash *chainhash.Hash, numRecords int) error 
 	// Phase 2: Clear master record last (index 0)
 	// Only executed if children succeeded - master's creating flag becomes atomic completion indicator
 	if masterWrite != nil {
-		err := s.client.BatchOperate(batchPolicy, []aerospike.BatchRecordIfc{masterWrite})
+		err := s.batchOperate(batchPolicy, []aerospike.BatchRecordIfc{masterWrite})
 		if err != nil {
 			return errors.NewProcessingError("failed to unlock master record", err)
 		}

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -177,7 +177,12 @@ func (s *Store) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts 
 		}
 	}
 
-	errCh := make(chan error)
+	// Buffered-1, matching every other completion channel in the package: now
+	// that the wait below can time out / cancel, Create may depart before
+	// sendStoreBatch sends. A buffered channel lets that send land in the buffer
+	// instead of relying on the deferred close turning it into a recovered
+	// send-on-closed (the resultHandledElsewhere guard ensures at most one send).
+	errCh := make(chan error, 1)
 	defer close(errCh)
 
 	var txHash *chainhash.Hash

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -608,12 +608,7 @@ func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaD
 		return nil
 	}
 
-	batchOperate := s.batchOperateFn
-	if batchOperate == nil {
-		batchOperate = s.client.BatchOperate
-	}
-
-	err = batchOperate(batchPolicy, batchRecords)
+	err = s.batchOperate(batchPolicy, batchRecords)
 	if err != nil {
 		s.logger.Errorf("error in aerospike map store batch records:\n%v\n%v", batchRecords, err)
 		return errors.NewStorageError("error in aerospike map store batch records", err)
@@ -1332,7 +1327,7 @@ func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
 	}
 
 	// send the batch to aerospike
-	err = s.client.BatchOperate(batchPolicy, batchRecords)
+	err = s.batchOperate(batchPolicy, batchRecords)
 	if err != nil {
 		for _, item := range batch {
 			sendErrorAndClose(item.errCh, errors.NewStorageError("error in aerospike send outpoint batch records", err))

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -379,6 +379,21 @@ func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.Fie
 		}()
 	}
 
+	// Bound the wait so a wedged batcher (e.g. a stuck v8 batch op, or a dispatch
+	// fn that failed to signal) cannot pin this goroutine for the life of the
+	// process. The legacy/validation callers thread a deadline-less context down
+	// here, so ctx.Done() alone is not enough. A nil timeout channel (batcherWait
+	// == 0, e.g. a Store built without New) disables the arm and preserves the
+	// original behaviour.
+	var timeoutCh <-chan time.Time
+
+	if s.batcherWait > 0 {
+		timer := time.NewTimer(s.batcherWait)
+		defer timer.Stop()
+
+		timeoutCh = timer.C
+	}
+
 	select {
 	case data := <-done:
 		if data.Err != nil {
@@ -394,6 +409,9 @@ func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.Fie
 	case <-ctx.Done():
 		prometheusTxMetaAerospikeMapErrors.WithLabelValues("Get", "ContextCanceled").Inc()
 		return nil, ctx.Err()
+	case <-timeoutCh:
+		prometheusTxMetaAerospikeMapErrors.WithLabelValues("Get", "BatchTimeout").Inc()
+		return nil, errors.NewServiceUnavailableError("aerospike get batch did not complete within %s", s.batcherWait)
 	}
 }
 
@@ -590,7 +608,12 @@ func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaD
 		return nil
 	}
 
-	err = s.client.BatchOperate(batchPolicy, batchRecords)
+	batchOperate := s.batchOperateFn
+	if batchOperate == nil {
+		batchOperate = s.client.BatchOperate
+	}
+
+	err = batchOperate(batchPolicy, batchRecords)
 	if err != nil {
 		s.logger.Errorf("error in aerospike map store batch records:\n%v\n%v", batchRecords, err)
 		return errors.NewStorageError("error in aerospike map store batch records", err)
@@ -1200,10 +1223,25 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 		})
 	}
 
-	// Wait for all error channels to receive a result
+	// Wait for all error channels to receive a result, bounded so a wedged
+	// outpoint batcher cannot pin this goroutine for the life of the process.
+	var timeoutCh <-chan time.Time
+
+	if s.batcherWait > 0 {
+		timer := time.NewTimer(s.batcherWait)
+		defer timer.Stop()
+
+		timeoutCh = timer.C
+	}
+
 	for _, errChan := range errChans {
-		if err := <-errChan; err != nil {
-			return err
+		select {
+		case err := <-errChan:
+			if err != nil {
+				return err
+			}
+		case <-timeoutCh:
+			return errors.NewServiceUnavailableError("aerospike outpoint batch did not complete within %s", s.batcherWait)
 		}
 	}
 
@@ -1241,6 +1279,14 @@ func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) 
 }
 
 func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
+	// go-batcher recovers panics in this fn; re-signal every errCh on panic so a
+	// crash mid-decoration cannot orphan the waiting submitters.
+	defer func() {
+		signalBatchPanic(recover(), batch, "sendOutpointBatch", s.logger, func(it *batchOutpoint, err error) {
+			util.SafeSend(it.errCh, err, batchSignalTimeout)
+		})
+	}()
+
 	start := gocore.CurrentTime()
 	defer func() {
 		previousOutputsDecorateStat.AddTimeForRange(start, len(batch))
@@ -1349,8 +1395,17 @@ func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
 			continue
 		}
 
-		batchItem.outpoint.PreviousTxSatoshis = previousTx.Outputs[batchItem.outpoint.PreviousTxOutIndex].Satoshis
-		batchItem.outpoint.PreviousTxScript = previousTx.Outputs[batchItem.outpoint.PreviousTxOutIndex].LockingScript
+		// Guard the output index: a corrupt/short Outputs slice (or a nil-padded
+		// entry from OP_RETURN removal) would otherwise panic here and, because
+		// go-batcher recovers the panic, orphan every remaining errCh in the batch.
+		outIdx := batchItem.outpoint.PreviousTxOutIndex
+		if int(outIdx) >= len(previousTx.Outputs) || previousTx.Outputs[outIdx] == nil {
+			sendErrorAndClose(batchItem.errCh, errors.NewTxInvalidError("previous tx %s has no output at index %d", batchItem.outpoint.PreviousTxID, outIdx))
+			continue
+		}
+
+		batchItem.outpoint.PreviousTxSatoshis = previousTx.Outputs[outIdx].Satoshis
+		batchItem.outpoint.PreviousTxScript = previousTx.Outputs[outIdx].LockingScript
 		batchItem.errCh <- nil
 		close(batchItem.errCh)
 	}
@@ -1524,6 +1579,16 @@ func (s *Store) GetTxInpointsFromExternalStore(ctx context.Context, txHash chain
 
 // sendGetBatch processes a batch of get requests efficiently
 func (s *Store) sendGetBatch(batch []*batchGetItem) {
+	// go-batcher recovers panics raised in this fn, so without re-signalling the
+	// per-item done channels a panic (e.g. a malformed bin tripping an unchecked
+	// type assertion in getTxFromBins) would orphan every waiter in this batch
+	// and leak their goroutines permanently.
+	defer func() {
+		signalBatchPanic(recover(), batch, "sendGetBatch", s.logger, func(it *batchGetItem, err error) {
+			trySignal(it.done, batchGetItemData{Err: err})
+		})
+	}()
+
 	items := make([]*utxo.UnresolvedMetaData, 0, len(batch))
 
 	for idx, item := range batch {
@@ -1534,30 +1599,19 @@ func (s *Store) sendGetBatch(batch []*batchGetItem) {
 		})
 	}
 
-	retries := 0
+	// BatchDecorate already retries internally up to the batch policy MaxRetries
+	// within its TotalTimeout. The previous extra 3x retry-with-sleep loop here
+	// stacked on top of that (worst case ~3 x TotalTimeout, observed ~15m),
+	// turning a transient stall into a multi-minute pin of every waiting
+	// submitter. Make a single attempt and surface the error.
+	if err := s.BatchDecorate(s.ctx, items); err != nil {
+		s.logger.Errorf("failed to get batch of txmeta: %v", err)
 
-	for {
-		if err := s.BatchDecorate(s.ctx, items); err != nil {
-			if retries < 3 {
-				retries++
-
-				s.logger.Errorf("failed to get batch of txmeta: %v", err)
-				time.Sleep(time.Duration(retries) * time.Second)
-
-				continue
-			}
-
-			// mark all items as errored
-			for _, bItem := range batch {
-				bItem.done <- batchGetItemData{
-					Err: err,
-				}
-			}
-
-			return
+		for _, bItem := range batch {
+			bItem.done <- batchGetItemData{Err: err}
 		}
 
-		break
+		return
 	}
 
 	for _, item := range items {

--- a/stores/utxo/aerospike/get_batch_leak_test.go
+++ b/stores/utxo/aerospike/get_batch_leak_test.go
@@ -1,0 +1,97 @@
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/aerospike-client-go/v8/types"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStoreForGet builds the minimum Store fields the get path touches. It
+// leaves s.client nil — tests install batchOperateFn so BatchOperate is never
+// called through the real client.
+func newTestStoreForGet(t *testing.T) *Store {
+	t.Helper()
+
+	InitPrometheusMetrics()
+
+	tSettings := &settings.Settings{}
+	tSettings.Aerospike.UseDefaultPolicies = true
+
+	return &Store{
+		ctx:       context.Background(),
+		namespace: "test-ns",
+		setName:   "test-set",
+		logger:    ulogger.TestLogger{},
+		settings:  tSettings,
+	}
+}
+
+// TestSendGetBatch_PanicSignalsAllWaiters reproduces the production leak: a
+// panic inside the dispatch fn (here simulated at BatchOperate; in production it
+// was an unchecked type assertion in getTxFromBins) must not orphan the waiting
+// submitters. go-batcher recovers the panic, so without our own recover-defer
+// every done channel in the batch would be orphaned and its goroutine leaked.
+func TestSendGetBatch_PanicSignalsAllWaiters(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.batchOperateFn = func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+		panic("simulated batch panic")
+	}
+
+	const n = 8
+
+	batch := make([]*batchGetItem, n)
+	for i := range batch {
+		batch[i] = &batchGetItem{
+			hash:   chainhash.Hash{byte(i)},
+			fields: []fields.FieldName{fields.Fee},
+			done:   make(chan batchGetItemData, 1),
+		}
+	}
+
+	// Our recover-defer must swallow the panic (after signalling), so calling it
+	// directly does not propagate.
+	require.NotPanics(t, func() { s.sendGetBatch(batch) })
+
+	for i, it := range batch {
+		select {
+		case data := <-it.done:
+			require.Error(t, data.Err, "item %d was orphaned", i)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("item %d orphaned: no done signal after panic", i)
+		}
+	}
+}
+
+// TestGet_BoundedWaitWhenBatcherWedged verifies the keystone guarantee: when the
+// batch op wedges and the caller context has no deadline (as in legacy sync /
+// validation), get() still returns after batcherWait instead of parking forever.
+func TestGet_BoundedWaitWhenBatcherWedged(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.batcherWait = 150 * time.Millisecond
+
+	release := make(chan struct{})
+	defer close(release)
+
+	s.batchOperateFn = func(*aerospike.BatchPolicy, []aerospike.BatchRecordIfc) aerospike.Error {
+		<-release // wedge the batch op until the test ends
+		return &aerospike.AerospikeError{ResultCode: types.TIMEOUT}
+	}
+
+	// getBatcher is nil, so get() dispatches sendGetBatch on a goroutine that
+	// wedges inside batchOperate; done never fires and ctx has no deadline.
+	start := time.Now()
+
+	_, err := s.get(context.Background(), &chainhash.Hash{0x01}, []fields.FieldName{fields.Fee})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "did not complete within")
+	require.Less(t, time.Since(start), time.Second, "get() should return at ~batcherWait, not block")
+}

--- a/stores/utxo/aerospike/locked.go
+++ b/stores/utxo/aerospike/locked.go
@@ -118,7 +118,7 @@ func (s *Store) setLockedBatch(batch []*batchLocked) {
 		)
 	}
 
-	if err := s.client.BatchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
+	if err := s.batchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
 		for idx, batchItem := range batch {
 			if handled[idx] {
 				continue

--- a/stores/utxo/aerospike/locked.go
+++ b/stores/utxo/aerospike/locked.go
@@ -2,8 +2,7 @@ package aerospike
 
 import (
 	"context"
-	"fmt"
-	"os"
+	"time"
 
 	"github.com/bsv-blockchain/aerospike-client-go/v8"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -20,6 +19,32 @@ type batchLocked struct {
 	childIndex uint32 // This will default to 0 which is the master record
 	setValue   bool
 	errCh      chan error // Channel for completion notification
+}
+
+// waitForLockedResult waits for a single locked-batch item to complete, bounded
+// so a wedged lockedBatcher (including the same-pool child-record recursion in
+// setLockedBatch) can never pin the caller — or a dispatch worker — forever.
+func (s *Store) waitForLockedResult(ctx context.Context, errCh chan error) error {
+	if s.batcherWait <= 0 {
+		select {
+		case err := <-errCh:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	timer := time.NewTimer(s.batcherWait)
+	defer timer.Stop()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return errors.NewServiceUnavailableError("set locked did not complete within %s", s.batcherWait)
+	}
 }
 
 func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setValue bool) error {
@@ -40,7 +65,7 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 
 			// Now we need to get totalRecords and do all the child records if necessary...
 
-			return <-errCh
+			return s.waitForLockedResult(ctx, errCh)
 		})
 	}
 
@@ -49,36 +74,58 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 
 // setLockedBatch sets the locked flag on the given transactions in a batch
 func (s *Store) setLockedBatch(batch []*batchLocked) {
+	// go-batcher recovers panics in this fn; re-signal every errCh on panic so a
+	// crash (e.g. in ParseLuaMapResponse) cannot orphan the waiting submitters.
+	defer func() {
+		signalBatchPanic(recover(), batch, "setLockedBatch", s.logger, func(it *batchLocked, err error) {
+			trySignal(it.errCh, err)
+		})
+	}()
+
 	var (
 		batchUDFPolicy = aerospike.NewBatchUDFPolicy()
-		batchRecords   = make([]aerospike.BatchRecordIfc, 0, len(batch))
+		batchRecords   = make([]aerospike.BatchRecordIfc, len(batch))
+		handled        = make([]bool, len(batch))
 	)
 
 	// Go through each batch item and set the tx to be locked
-	for _, batchItem := range batch {
+	for idx, batchItem := range batch {
 		// We will do the master record first...
 		keySource := uaerospike.CalculateKeySourceInternal(&batchItem.txHash, batchItem.childIndex)
 
 		key, err := aerospike.NewKey(s.namespace, s.setName, keySource)
 		if err != nil {
-			fmt.Printf("Failed to create key: %s\n", err)
-			os.Exit(1)
+			// Previously this called os.Exit(1), turning a recoverable key error
+			// into a process crash. Surface it to the caller and keep the batch
+			// index aligned with a NOOP placeholder instead.
+			var keyErr error = errors.NewProcessingError("[setLockedBatch] failed to create key", err)
+			trySignal(batchItem.errCh, keyErr)
+
+			handled[idx] = true
+			batchRecords[idx] = aerospike.NewBatchRead(nil, placeholderKey, nil)
+
+			continue
 		}
 
 		// Now we need to get totalRecords and do all the child records if necessary...
 
-		batchRecords = append(batchRecords, aerospike.NewBatchUDF(
+		batchRecords[idx] = aerospike.NewBatchUDF(
 			batchUDFPolicy,
 			key,
 			LuaPackage,
 			"setLocked",
 			aerospike.NewValue(batchItem.setValue),
-		))
+		)
 	}
 
 	if err := s.client.BatchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
-		for _, batchItem := range batch {
-			batchItem.errCh <- errors.NewProcessingError("could not batch write locked flag", err)
+		for idx, batchItem := range batch {
+			if handled[idx] {
+				continue
+			}
+
+			var sendErr error = errors.NewProcessingError("could not batch write locked flag", err)
+			trySignal(batchItem.errCh, sendErr)
 		}
 
 		return
@@ -86,55 +133,74 @@ func (s *Store) setLockedBatch(batch []*batchLocked) {
 
 	// Now we need to get totalRecords and do all the child records if necessary...
 	for idx, batchRecord := range batchRecords {
-		if batchRecord.BatchRec().Err != nil {
-			batch[idx].errCh <- errors.NewProcessingError("could not batch write locked flag", batchRecord.BatchRec().Err)
+		if handled[idx] {
+			continue
+		}
+
+		if recErr := batchRecord.BatchRec().Err; recErr != nil {
+			var sendErr error = errors.NewProcessingError("could not batch write locked flag", recErr)
+			trySignal(batch[idx].errCh, sendErr)
+
 			continue
 		}
 
 		response := batchRecord.BatchRec().Record
-		if response != nil && response.Bins != nil && response.Bins[LuaSuccess.String()] != nil {
-			res, err := s.ParseLuaMapResponse(response.Bins[LuaSuccess.String()])
-			if err != nil {
-				batch[idx].errCh <- errors.NewProcessingError("could not parse response", err)
-				continue
-			}
+		if response == nil || response.Bins == nil || response.Bins[LuaSuccess.String()] == nil {
+			// Previously this fell through without signalling — orphaning the
+			// submitter on any nil/missing-bin response. Signal an error instead.
+			var sendErr error = errors.NewProcessingError("setLocked: missing response for %s", batch[idx].txHash.String())
+			trySignal(batch[idx].errCh, sendErr)
 
-			if res.Status != LuaStatusOK {
-				if res.ErrorCode == LuaErrorCodeTxNotFound {
-					batch[idx].errCh <- errors.NewTxNotFoundError("transaction not found: %s", batch[idx].txHash.String())
-				} else {
-					batch[idx].errCh <- errors.NewProcessingError("error from setLocked: %s", res.Message)
-				}
-				continue
-			}
-
-			extraRecords := res.ChildCount
-			if extraRecords == 0 {
-				batch[idx].errCh <- nil
-				continue
-			}
-
-			// We need to do the child records...
-			g, _ := errgroup.WithContext(batch[idx].ctx)
-
-			for i := 1; i <= extraRecords; i++ {
-				i := i
-
-				g.Go(func() error {
-					errCh := make(chan error, 1)
-
-					s.lockedBatcher.PutCtx(batch[idx].ctx, &batchLocked{
-						txHash:     batch[idx].txHash,
-						childIndex: uint32(i), // nolint:gosec
-						setValue:   batch[idx].setValue,
-						errCh:      errCh,
-					})
-
-					return <-errCh
-				})
-			}
-
-			batch[idx].errCh <- g.Wait()
+			continue
 		}
+
+		res, err := s.ParseLuaMapResponse(response.Bins[LuaSuccess.String()])
+		if err != nil {
+			var sendErr error = errors.NewProcessingError("could not parse response", err)
+			trySignal(batch[idx].errCh, sendErr)
+
+			continue
+		}
+
+		if res.Status != LuaStatusOK {
+			if res.ErrorCode == LuaErrorCodeTxNotFound {
+				var sendErr error = errors.NewTxNotFoundError("transaction not found: %s", batch[idx].txHash.String())
+				trySignal(batch[idx].errCh, sendErr)
+			} else {
+				var sendErr error = errors.NewProcessingError("error from setLocked: %s", res.Message)
+				trySignal(batch[idx].errCh, sendErr)
+			}
+
+			continue
+		}
+
+		extraRecords := res.ChildCount
+		if extraRecords == 0 {
+			trySignal(batch[idx].errCh, error(nil))
+
+			continue
+		}
+
+		// We need to do the child records...
+		g, _ := errgroup.WithContext(batch[idx].ctx)
+
+		for i := 1; i <= extraRecords; i++ {
+			i := i
+
+			g.Go(func() error {
+				errCh := make(chan error, 1)
+
+				s.lockedBatcher.PutCtx(batch[idx].ctx, &batchLocked{
+					txHash:     batch[idx].txHash,
+					childIndex: uint32(i), // nolint:gosec
+					setValue:   batch[idx].setValue,
+					errCh:      errCh,
+				})
+
+				return s.waitForLockedResult(batch[idx].ctx, errCh)
+			})
+		}
+
+		trySignal(batch[idx].errCh, g.Wait())
 	}
 }

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -496,6 +496,18 @@ func (s *Store) useExpressionSpend() bool {
 //  5. Manages DAH settings
 //  6. Updates external storage
 func (s *Store) sendSpendBatchLua(batch []*batchSpend) {
+	// go-batcher recovers panics in this fn; re-signal every item's errCh on
+	// panic (e.g. the unchecked .(int) in processSpendBatchResults) so a crash
+	// cannot orphan waiting spenders. trySignal is a no-op for items already
+	// signalled (buffered-1 full), so this never double-delivers or blocks.
+	defer func() {
+		signalBatchPanic(recover(), batch, "sendSpendBatchLua", s.logger, func(it *batchSpend, err error) {
+			if it != nil {
+				trySignal(it.errCh, err)
+			}
+		})
+	}()
+
 	batch = utxo.FilterConflictingDuplicateSpendClaims(batch,
 		func(item *batchSpend) *utxo.Spend {
 			if item == nil {
@@ -671,8 +683,12 @@ func (s *Store) executeSpendBatch(batchRecords []aerospike.BatchRecordIfc, batch
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
 	err := s.client.BatchOperate(batchPolicy, batchRecords)
 	if err != nil {
+		// trySignal (not a blocking send): items skipped in prepareSpendBatches
+		// already have a queued result on their buffered-1 errCh, and a blocking
+		// re-send here would wedge the dispatch worker permanently.
 		for idx, bItem := range batch {
-			bItem.errCh <- errors.NewStorageError("[SPEND_BATCH_LUA][%s] failed to batch spend aerospike map utxo in batchId %d: %d - %w", bItem.spend.TxID.String(), batchID, idx, err)
+			var sendErr error = errors.NewStorageError("[SPEND_BATCH_LUA][%s] failed to batch spend aerospike map utxo in batchId %d: %d - %w", bItem.spend.TxID.String(), batchID, idx, err)
+			trySignal(bItem.errCh, sendErr)
 		}
 		return err
 	}
@@ -899,7 +915,9 @@ func (s *Store) SetDAHForChildRecords(txID *chainhash.Hash, childCount int, dah 
 	errs := make([]error, childCount)
 
 	for i := uint32(0); i < uint32(childCount); i++ { // nolint: gosec
-		errCh := make(chan error)
+		// Buffered-1 so the dispatch fn's trySignal always delivers and never
+		// wedges the batcher worker if this caller has already given up below.
+		errCh := make(chan error, 1)
 
 		go func() {
 			s.setDAHBatcher.Put(&batchDAH{
@@ -910,7 +928,19 @@ func (s *Store) SetDAHForChildRecords(txID *chainhash.Hash, childCount int, dah 
 			})
 		}()
 
-		errs[i] = <-errCh
+		// Bound the wait so a wedged setDAH batcher cannot pin this caller forever.
+		if s.batcherWait > 0 {
+			timer := time.NewTimer(s.batcherWait)
+			select {
+			case errs[i] = <-errCh:
+			case <-timer.C:
+				errs[i] = errors.NewServiceUnavailableError("[setDAHForChildRecords][%s] set DAH for child record %d did not complete within %s", txID.String(), i, s.batcherWait)
+			}
+			timer.Stop()
+		} else {
+			errs[i] = <-errCh
+		}
+
 		if errs[i] != nil {
 			s.logger.Errorf("[setDAHForChildRecords][%s] failed to set DAH for child record %d: %v", txID.String(), i, errs[i])
 		}
@@ -1113,43 +1143,51 @@ func (s *Store) IncrementSpentRecords(txid *chainhash.Hash, increment int) (inte
 }
 
 func (s *Store) sendIncrementBatch(batch []*batchIncrement) {
-	var err error
+	// go-batcher recovers panics in this fn; re-signal every res channel on panic.
+	defer func() {
+		signalBatchPanic(recover(), batch, "sendIncrementBatch", s.logger, func(it *batchIncrement, err error) {
+			trySignal(it.res, incrementSpentRecordsRes{err: err})
+		})
+	}()
 
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
 	batchUDFPolicy := aerospike.NewBatchUDFPolicy()
 
-	// Create a batch of records to read, with a max size of the batch
-	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(batch))
+	// Keep batchRecords index-aligned 1:1 with batch. A key-creation failure used
+	// to skip the append, after which the result loop indexed batch[idx] with the
+	// wrong position — signalling the wrong item and orphaning the tail. Use a
+	// NOOP placeholder + handled[] guard instead so alignment is preserved.
+	batchRecords := make([]aerospike.BatchRecordIfc, len(batch))
+	handled := make([]bool, len(batch))
 
 	currentBlockHeight := s.blockHeight.Load()
 
-	// Create a batch of records to read from the txHashes
-	for _, item := range batch {
+	for i, item := range batch {
 		aeroKey, err := aerospike.NewKey(s.namespace, s.setName, item.txID[:])
 		if err != nil {
-			item.res <- incrementSpentRecordsRes{
-				res: nil,
-				err: errors.NewProcessingError("failed to init new aerospike key for txMeta", err),
-			}
+			trySignal(item.res, incrementSpentRecordsRes{err: errors.NewProcessingError("failed to init new aerospike key for txMeta", err)})
+
+			handled[i] = true
+			batchRecords[i] = aerospike.NewBatchRead(nil, placeholderKey, nil)
 
 			continue
 		}
 
-		batchRecords = append(batchRecords, aerospike.NewBatchUDF(batchUDFPolicy, aeroKey, LuaPackage, "incrementSpentExtraRecs",
+		batchRecords[i] = aerospike.NewBatchUDF(batchUDFPolicy, aeroKey, LuaPackage, "incrementSpentExtraRecs",
 			aerospike.NewIntegerValue(item.increment),
 			aerospike.NewIntegerValue(int(currentBlockHeight)),
 			aerospike.NewValue(s.settings.GetUtxoStoreBlockHeightRetention()),
-		))
+		)
 	}
 
 	// send the batch to aerospike
-	err = s.client.BatchOperate(batchPolicy, batchRecords)
-	if err != nil {
-		for _, item := range batch {
-			item.res <- incrementSpentRecordsRes{
-				res: nil,
-				err: errors.NewStorageError("error in aerospike send outpoint batch records", err),
+	if err := s.client.BatchOperate(batchPolicy, batchRecords); err != nil {
+		for i, item := range batch {
+			if handled[i] {
+				continue
 			}
+
+			trySignal(item.res, incrementSpentRecordsRes{err: errors.NewStorageError("error in aerospike increment batch records", err)})
 		}
 
 		return
@@ -1157,39 +1195,44 @@ func (s *Store) sendIncrementBatch(batch []*batchIncrement) {
 
 	// Process the batch records
 	for idx, batchRecordIfc := range batchRecords {
+		if handled[idx] {
+			continue
+		}
+
 		batchRecord := batchRecordIfc.BatchRec()
 		if batchRecord.Err != nil {
-			batch[idx].res <- incrementSpentRecordsRes{
-				res: nil,
-				err: errors.NewStorageError("error in aerospike send outpoint batch records", err),
-			}
+			trySignal(batch[idx].res, incrementSpentRecordsRes{err: errors.NewStorageError("error in aerospike increment batch record", batchRecord.Err)})
+			continue
+		}
 
+		if batchRecord.Record == nil {
+			trySignal(batch[idx].res, incrementSpentRecordsRes{err: errors.NewProcessingError("no record returned from Lua")})
 			continue
 		}
 
 		// Get the raw response from Lua
 		rawResponse := batchRecord.Record.Bins[LuaSuccess.String()]
 		if rawResponse == nil {
-			batch[idx].res <- incrementSpentRecordsRes{
-				res: nil,
-				err: errors.NewProcessingError("no response from Lua"),
-			}
+			trySignal(batch[idx].res, incrementSpentRecordsRes{err: errors.NewProcessingError("no response from Lua")})
 			continue
 		}
 
 		// Pass through the raw response - let the caller handle parsing
-		batch[idx].res <- incrementSpentRecordsRes{
-			res: rawResponse,
-			err: nil,
-		}
+		trySignal(batch[idx].res, incrementSpentRecordsRes{res: rawResponse})
 	}
 }
 
 func (s *Store) sendSetDAHBatch(batch []*batchDAH) {
-	var err error
+	// go-batcher recovers panics in this fn; re-signal every errCh on panic.
+	defer func() {
+		signalBatchPanic(recover(), batch, "sendSetDAHBatch", s.logger, func(it *batchDAH, err error) {
+			trySignal(it.errCh, err)
+		})
+	}()
 
 	// Create batch records with individual TTLs
 	batchRecords := make([]aerospike.BatchRecordIfc, len(batch))
+	handled := make([]bool, len(batch))
 	batchWritePolicy := util.GetAerospikeBatchWritePolicy(s.settings)
 	dahBinName := fields.DeleteAtHeight.String()
 	unsetOp := aerospike.PutOp(aerospike.NewBin(dahBinName, nil))
@@ -1199,7 +1242,18 @@ func (s *Store) sendSetDAHBatch(batch []*batchDAH) {
 
 		key, err := aerospike.NewKey(s.namespace, s.setName, keySource)
 		if err != nil {
+			// Previously this only logged and continued, leaving batchRecords[i]
+			// nil (→ nil-deref panic in the result loop) AND never signalling the
+			// item's errCh (→ the submitter blocked forever). Signal it and keep
+			// the slot index-aligned with a NOOP placeholder.
 			s.logger.Errorf("[SetDAHBatch][%s] failed to create key for pagination record %d: %v", b.txID.String(), b.childIdx, err)
+
+			var keyErr error = errors.NewProcessingError("[SetDAHBatch] failed to create key", err)
+			trySignal(b.errCh, keyErr)
+
+			handled[i] = true
+			batchRecords[i] = aerospike.NewBatchRead(nil, placeholderKey, nil)
+
 			continue
 		}
 
@@ -1211,10 +1265,14 @@ func (s *Store) sendSetDAHBatch(batch []*batchDAH) {
 	}
 
 	// Execute batch operation
-	err = s.client.BatchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords)
-	if err != nil {
-		for _, bItem := range batch {
-			bItem.errCh <- errors.NewStorageError("[SetDAHBatch][%s] failed to set DAH", err)
+	if err := s.client.BatchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
+		for i, bItem := range batch {
+			if handled[i] {
+				continue
+			}
+
+			var sendErr error = errors.NewStorageError("[SetDAHBatch][%s] failed to set DAH", bItem.txID.String(), err)
+			trySignal(bItem.errCh, sendErr)
 		}
 
 		return
@@ -1222,13 +1280,16 @@ func (s *Store) sendSetDAHBatch(batch []*batchDAH) {
 
 	// batchOperate may have no errors, but some of the records may have failed
 	for batchIdx, batchRecord := range batchRecords {
-		err = batchRecord.BatchRec().Err
-
-		if err != nil {
-			batch[batchIdx].errCh <- err
+		if handled[batchIdx] {
 			continue
 		}
 
-		batch[batchIdx].errCh <- nil
+		if recErr := batchRecord.BatchRec().Err; recErr != nil {
+			var sendErr error = recErr
+			trySignal(batch[batchIdx].errCh, sendErr)
+			continue
+		}
+
+		trySignal(batch[batchIdx].errCh, error(nil))
 	}
 }

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -129,7 +129,7 @@ func (s *Store) IncrementSpentRecordsMulti(txids []*chainhash.Hash, increment in
 		))
 	}
 
-	if err := s.client.BatchOperate(batchPolicy, batchRecords); err != nil {
+	if err := s.batchOperate(batchPolicy, batchRecords); err != nil {
 		*batchRecordsPtr = batchRecords
 		putBatchRecordsSlice(batchRecordsPtr)
 		return errors.NewStorageError("[IncrementSpentRecordsMulti] error in aerospike batch", err)
@@ -202,7 +202,7 @@ func (s *Store) SetDAHForChildRecordsMulti(items []struct {
 		}
 	}
 
-	if err := s.client.BatchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
+	if err := s.batchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
 		return errors.NewStorageError("[SetDAHForChildRecordsMulti] failed to set DAH", err)
 	}
 
@@ -681,7 +681,7 @@ func (s *Store) createBatchRecords(batchesByKey map[keyIgnoreLocked][]aerospike.
 // executeSpendBatch executes the batch operation
 func (s *Store) executeSpendBatch(batchRecords []aerospike.BatchRecordIfc, batch []*batchSpend, batchID uint64) error {
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
-	err := s.client.BatchOperate(batchPolicy, batchRecords)
+	err := s.batchOperate(batchPolicy, batchRecords)
 	if err != nil {
 		// trySignal (not a blocking send): items skipped in prepareSpendBatches
 		// already have a queued result on their buffered-1 errCh, and a blocking
@@ -1075,7 +1075,7 @@ func (s *Store) verifyAllChildrenSpent(ctx context.Context, txID *chainhash.Hash
 		))
 	}
 
-	if err := s.client.BatchOperate(batchPolicy, batchRecords); err != nil {
+	if err := s.batchOperate(batchPolicy, batchRecords); err != nil {
 		return false, errors.NewStorageError("[verifyAllChildrenSpent][%s] batch read failed", txID.String(), err)
 	}
 
@@ -1181,7 +1181,7 @@ func (s *Store) sendIncrementBatch(batch []*batchIncrement) {
 	}
 
 	// send the batch to aerospike
-	if err := s.client.BatchOperate(batchPolicy, batchRecords); err != nil {
+	if err := s.batchOperate(batchPolicy, batchRecords); err != nil {
 		for i, item := range batch {
 			if handled[i] {
 				continue
@@ -1265,7 +1265,7 @@ func (s *Store) sendSetDAHBatch(batch []*batchDAH) {
 	}
 
 	// Execute batch operation
-	if err := s.client.BatchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
+	if err := s.batchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
 		for i, bItem := range batch {
 			if handled[i] {
 				continue


### PR DESCRIPTION
## Problem

A production node (`bsva-ovh-teranode-eu-2`) accumulated **13,693 goroutines** — 8,664 parked in `(*Store).get`'s `select` and 4,096 in validator errgroups — that **persisted after the underlying Aerospike wedge cleared** and `client_connections` had returned to 0. A leak that survives the wedge is not the wedge; it's a caller-side bug holding the resources.

## Root cause (teranode-side, not the v8 client)

1. **Orphaned completion channels on panic.** go-batcher recovers panics raised inside the batch dispatch fn (`dispatchAndRecord` wraps `b.fn(batch)` in `defer recover()`). A panic part-way through a `sendXxxBatch` — e.g. an unchecked type assertion in `getTxFromBins` on a malformed/missing bin — left every not-yet-signalled per-item completion channel orphaned. The worker survived; the submitters parked **forever**, because the contexts threaded down from legacy sync / validation carry **no deadline**, so the `get` select's `ctx.Done()` arm never fires.
2. **Retry amplification.** `sendGetBatch` wrapped the already-retrying v8 batch call (MaxRetries within `TotalTimeout=5m`) in *another* 3× retry loop, stacking the worst-case stall to ~3× TotalTimeout (~15m) and growing the submitter backlog faster than it drained under sustained server slowness.

The v8 client itself bounds the batch read at `TotalTimeout` (5m) and releases the connection — verified against `v8.7.1-bsv3`. No v8 change is required to stop this leak. (One latent v8 robustness bug — `connection.go` resets the socket deadline on every partial read, so `SocketTimeout` is per-syscall and a slow-drip server evades it; only bites callers with `TotalTimeout=0`, which teranode is not — flagged separately, out of scope here.)

## Changes

- **Panic safety net** — `signalBatchPanic` + `trySignal` (new `batch_completion.go`); a recover-defer on all 7 dispatch fns (`sendGetBatch`, `sendOutpointBatch`, `sendStoreBatch`, `sendSpendBatchLua`, `sendIncrementBatch`, `sendSetDAHBatch`, `setLockedBatch`) re-signals every per-item channel on panic. Non-blocking, so it never double-delivers or wedges the worker.
- **Bounded submitter waits (keystone)** — new cached `Store.batcherWait` (= batch policy `TotalTimeout` + 30s grace) on `(*Store).get`, `PreviousOutputsDecorate`, `Create`, `SetDAHForChildRecords`, `SetLocked`. A wedged batcher now releases the caller after the bound instead of for the life of the process.
- **Drop nested retry** in `sendGetBatch` — rely on the v8 policy's own retries.
- **Per-fn correctness bugs:**
  - `setLockedBatch`: `os.Exit(1)` on a key error → per-item error; signal the previously-silent missing-`LuaSuccess`-bin path; bound the same-pool child-record recursion with a timeout — this converts a potential pool-exhaustion **hang** into a bounded `ServiceUnavailable`; fully eliminating the recursion is tracked in #1033.
  - `sendSetDAHBatch`: signal + NOOP placeholder on key-skip (was a nil `batchRecords` slot → nil-deref panic + orphaned `errCh`); fix a `%s`-without-arg format bug.
  - `sendIncrementBatch`: fix index desync after a key-creation skip (placeholder + `handled[]`).
  - `sendSpendBatchLua` / `executeSpendBatch`: replace double-signal on already-completed buffered-1 items with non-blocking `trySignal`.
  - `sendOutpointBatch`: bounds-check the previous-output index.
- Route `BatchDecorate`'s `BatchOperate` through the existing `batchOperateFn` test seam.

## Verification

`go build ./...`, `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gofmt` all clean. New unit tests pass under `-race`. Live-container Aerospike integration green: increment, setDAH/drift, decorate, split-tx (SetLocked child recursion), `TestAerospike`, spend (dup-spender / multi-record / unspend / nil-panic). Full package unit suite passes.

## Review follow-ups (@ordishs)

- Applied: `Create`'s `errCh` is now buffered-1, matching every other completion channel (it was the lone unbuffered one; the new bounded wait meant `Create` could depart before `sendStoreBatch` sends).
- Per-dispatch-fn panic-guard unit tests added (`batch_dispatch_leak_test.go`).
- Tracked as follow-up: full elimination of `setLockedBatch`'s same-pool child recursion — #1033.