### PR TITLE
fix(kafka): drain the final buffered batch on async producer Stop

### DIFF
--- a/util/kafka/kafka_producer_async.go
+++ b/util/kafka/kafka_producer_async.go
@@ -115,6 +115,12 @@ type KafkaAsyncProducer struct {
 	// For in-memory support
 	inMemoryProducer *inmemorykafka.InMemoryAsyncProducer
 	isInMemory       bool
+
+	// produceHook, when non-nil, replaces the real client.Produce call in the
+	// flush path. Test-only seam: lets a test capture what the batching loop
+	// emits — including the final drain on Stop — without a live broker. It is
+	// nil in production.
+	produceHook func(*Message)
 }
 
 // ProducerOption mutates the KafkaProducerConfig built from a URL before the
@@ -348,11 +354,26 @@ func (c *KafkaAsyncProducer) currentBackpressureThreshold() int {
 	return threshold
 }
 
+// flushBuffered produces the buffered messages. It gates only on `closed` (the
+// client is gone), deliberately NOT on `shuttingDown`: Stop sets shuttingDown
+// before closing the publish channel but closes the client only after the
+// worker goroutine has returned (publishWg.Wait precedes client.Close), so
+// producing while shutting-down is always safe — and is exactly what the final
+// drain on Stop relies on to avoid silently dropping the last buffered batch.
+// An earlier shuttingDown gate here defeated that drain and also lost any batch
+// cleared after a size/linger flush during shutdown.
 func (c *KafkaAsyncProducer) flushBuffered(internalCtx context.Context, buffered []*Message) {
 	for _, msgBytes := range buffered {
-		if c.closed.Load() || c.shuttingDown.Load() {
+		if c.closed.Load() {
 			return
 		}
+
+		// Test seam: capture instead of producing to a real broker.
+		if c.produceHook != nil {
+			c.produceHook(msgBytes)
+			continue
+		}
+
 		record := &kgo.Record{
 			Topic: c.Config.Topic,
 			Key:   msgBytes.Key,
@@ -368,6 +389,144 @@ func (c *KafkaAsyncProducer) flushBuffered(internalCtx context.Context, buffered
 				c.Config.Logger.Debugf("Successfully sent message to topic %s, partition: %d, offset: %d", r.Topic, r.Partition, r.Offset)
 			}
 		})
+	}
+}
+
+// runProducerWorker is the async producer's batching loop: it accumulates
+// messages from ch into a local buffer and flushes them on batch-size or linger
+// timeout. On shutdown it relies on Stop closing ch: the close drains any
+// channel-resident messages into the buffer and the final drain produces them,
+// so a graceful Stop does not silently drop buffered messages. (It deliberately
+// does NOT break out of the loop merely because shuttingDown is set, which would
+// strand messages still queued in ch.)
+func (c *KafkaAsyncProducer) runProducerWorker(internalCtx context.Context, ch chan *Message) {
+	buffered := make([]*Message, 0, 256)
+	backpressureLogged := false
+	bufferedGauge := prometheusBufferedMessages.WithLabelValues(c.Config.Topic)
+	backpressureCounter := prometheusBackpressureSignals.WithLabelValues(c.Config.Topic)
+	bufferedGauge.Set(0)
+
+	slowMode := c.adaptiveSlow.Load()
+	linger := c.currentBatchLinger()
+	maxBatch := c.currentBatchSize()
+	backpressureThreshold := c.currentBackpressureThreshold()
+
+	const metricsUpdateInterval = 64
+	metricTick := 0
+
+	var lingerTimer *time.Timer
+	var lingerCh <-chan time.Time
+	defer func() {
+		if lingerTimer == nil {
+			return
+		}
+		if !lingerTimer.Stop() {
+			select {
+			case <-lingerTimer.C:
+			default:
+			}
+		}
+	}()
+
+	resetLingerTimer := func(d time.Duration) {
+		if lingerTimer == nil {
+			lingerTimer = time.NewTimer(d)
+		} else {
+			if !lingerTimer.Stop() {
+				select {
+				case <-lingerTimer.C:
+				default:
+				}
+			}
+			lingerTimer.Reset(d)
+		}
+		lingerCh = lingerTimer.C
+	}
+
+	flushBufferedFinal := func() {
+		if len(buffered) == 0 {
+			return
+		}
+		// Use a fresh context so final drain still runs after parent cancellation.
+		flushCtx, flushCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer flushCancel()
+		c.flushBuffered(flushCtx, buffered)
+		buffered = buffered[:0]
+		bufferedGauge.Set(0)
+	}
+
+	for {
+		// A fully-closed producer cannot produce, so just exit. Shutdown-in-
+		// progress is intentionally NOT an exit condition here: the worker
+		// keeps draining until Stop closes ch (handled by the receive paths
+		// below), so messages still queued in ch are not stranded.
+		if c.closed.Load() {
+			break
+		}
+
+		newSlowMode := c.adaptiveSlow.Load()
+		if newSlowMode != slowMode {
+			slowMode = newSlowMode
+			linger = c.currentBatchLinger()
+			maxBatch = c.currentBatchSize()
+			backpressureThreshold = c.currentBackpressureThreshold()
+		}
+
+		metricTick++
+		if metricTick >= metricsUpdateInterval {
+			bufferedGauge.Set(float64(len(buffered)))
+			metricTick = 0
+		}
+
+		if len(buffered) > backpressureThreshold {
+			if !backpressureLogged {
+				backpressureLogged = true
+				backpressureCounter.Inc()
+				c.Config.Logger.Warnf("[kafka] producer backpressure on topic %s: buffered=%d threshold=%d",
+					c.Config.Topic, len(buffered), backpressureThreshold)
+			}
+		} else {
+			backpressureLogged = false
+		}
+
+		if len(buffered) == 0 {
+			msgBytes, ok := <-ch
+			if !ok {
+				break
+			}
+			if msgBytes != nil {
+				buffered = append(buffered, msgBytes)
+			}
+			continue
+		}
+
+		if len(buffered) >= maxBatch {
+			c.flushBuffered(internalCtx, buffered)
+			buffered = buffered[:0]
+			bufferedGauge.Set(0)
+			continue
+		}
+
+		resetLingerTimer(linger)
+
+		select {
+		case msgBytes, ok := <-ch:
+			if !ok {
+				flushBufferedFinal()
+				return
+			}
+			if msgBytes != nil {
+				buffered = append(buffered, msgBytes)
+			}
+		case <-lingerCh:
+			lingerCh = nil
+			c.flushBuffered(internalCtx, buffered)
+			buffered = buffered[:0]
+			bufferedGauge.Set(0)
+		case <-internalCtx.Done():
+			flushBufferedFinal()
+			return
+		}
 	}
 }
 
@@ -405,131 +564,7 @@ func (c *KafkaAsyncProducer) Start(ctx context.Context, ch chan *Message) {
 			ch := c.publishChannel
 			c.channelMu.RUnlock()
 
-			buffered := make([]*Message, 0, 256)
-			backpressureLogged := false
-			bufferedGauge := prometheusBufferedMessages.WithLabelValues(c.Config.Topic)
-			backpressureCounter := prometheusBackpressureSignals.WithLabelValues(c.Config.Topic)
-			bufferedGauge.Set(0)
-
-			slowMode := c.adaptiveSlow.Load()
-			linger := c.currentBatchLinger()
-			maxBatch := c.currentBatchSize()
-			backpressureThreshold := c.currentBackpressureThreshold()
-
-			const metricsUpdateInterval = 64
-			metricTick := 0
-
-			var lingerTimer *time.Timer
-			var lingerCh <-chan time.Time
-			defer func() {
-				if lingerTimer == nil {
-					return
-				}
-				if !lingerTimer.Stop() {
-					select {
-					case <-lingerTimer.C:
-					default:
-					}
-				}
-			}()
-
-			resetLingerTimer := func(d time.Duration) {
-				if lingerTimer == nil {
-					lingerTimer = time.NewTimer(d)
-				} else {
-					if !lingerTimer.Stop() {
-						select {
-						case <-lingerTimer.C:
-						default:
-						}
-					}
-					lingerTimer.Reset(d)
-				}
-				lingerCh = lingerTimer.C
-			}
-
-			flushBufferedFinal := func() {
-				if len(buffered) == 0 {
-					return
-				}
-				// Use a fresh context so final drain still runs after parent cancellation.
-				flushCtx, flushCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer flushCancel()
-				c.flushBuffered(flushCtx, buffered)
-				buffered = buffered[:0]
-				bufferedGauge.Set(0)
-			}
-
-			for {
-				if c.closed.Load() || c.shuttingDown.Load() {
-					break
-				}
-
-				newSlowMode := c.adaptiveSlow.Load()
-				if newSlowMode != slowMode {
-					slowMode = newSlowMode
-					linger = c.currentBatchLinger()
-					maxBatch = c.currentBatchSize()
-					backpressureThreshold = c.currentBackpressureThreshold()
-				}
-
-				metricTick++
-				if metricTick >= metricsUpdateInterval {
-					bufferedGauge.Set(float64(len(buffered)))
-					metricTick = 0
-				}
-
-				if len(buffered) > backpressureThreshold {
-					if !backpressureLogged {
-						backpressureLogged = true
-						backpressureCounter.Inc()
-						c.Config.Logger.Warnf("[kafka] producer backpressure on topic %s: buffered=%d threshold=%d",
-							c.Config.Topic, len(buffered), backpressureThreshold)
-					}
-				} else {
-					backpressureLogged = false
-				}
-
-				if len(buffered) == 0 {
-					msgBytes, ok := <-ch
-					if !ok {
-						break
-					}
-					if msgBytes != nil {
-						buffered = append(buffered, msgBytes)
-					}
-					continue
-				}
-
-				if len(buffered) >= maxBatch {
-					c.flushBuffered(internalCtx, buffered)
-					buffered = buffered[:0]
-					bufferedGauge.Set(0)
-					continue
-				}
-
-				resetLingerTimer(linger)
-
-				select {
-				case msgBytes, ok := <-ch:
-					if !ok {
-						flushBufferedFinal()
-						return
-					}
-					if msgBytes != nil {
-						buffered = append(buffered, msgBytes)
-					}
-				case <-lingerCh:
-					lingerCh = nil
-					c.flushBuffered(internalCtx, buffered)
-					buffered = buffered[:0]
-					bufferedGauge.Set(0)
-				case <-internalCtx.Done():
-					flushBufferedFinal()
-					return
-				}
-			}
-
+			c.runProducerWorker(internalCtx, ch)
 		}()
 
 		signals := make(chan os.Signal, 1)

--- a/util/kafka/kafka_producer_async_drain_test.go
+++ b/util/kafka/kafka_producer_async_drain_test.go
@@ -1,0 +1,75 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAsyncProducer_DrainsBufferedBatchOnStop pins that a graceful Stop() flushes
+// whatever is still in the worker's batch buffer instead of silently dropping it.
+//
+// Before the fix, Stop() set shuttingDown before closing the publish channel, and
+// flushBuffered (including the final drain) bailed early on shuttingDown — so a
+// buffered batch, up to a full linger window or batch size, was lost on every
+// graceful shutdown. This exercises the real batching loop via the produceHook
+// seam (no live broker): with linger and batch size set huge, the messages only
+// ever leave through the final drain on Stop.
+func TestAsyncProducer_DrainsBufferedBatchOnStop(t *testing.T) {
+	// The worker reads package-level prometheus collectors that the production
+	// startup path initializes lazily; do the same here.
+	initProducerMetrics()
+
+	var (
+		mu       sync.Mutex
+		produced int
+	)
+
+	c := &KafkaAsyncProducer{
+		Config: KafkaProducerConfig{
+			Topic:          "drain-test",
+			Logger:         ulogger.TestLogger{},
+			FlushFrequency: time.Hour, // never linger-flush during the test
+			FlushMessages:  1_000_000, // never size-flush during the test
+		},
+		produceHook: func(*Message) {
+			mu.Lock()
+			produced++
+			mu.Unlock()
+		},
+	}
+
+	const n = 25
+	ch := make(chan *Message, n)
+
+	c.channelMu.Lock()
+	c.publishChannel = ch
+	c.channelMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.publishWg.Add(1)
+	go func() {
+		defer c.publishWg.Done()
+		c.runProducerWorker(ctx, ch)
+	}()
+
+	for i := 0; i < n; i++ {
+		c.Publish(&Message{Value: []byte{byte(i)}})
+	}
+
+	// Stop closes the channel; the worker must drain the channel-resident
+	// messages into its buffer and produce all of them in the final drain.
+	// Stop blocks on publishWg.Wait until the worker has returned, so `produced`
+	// is final once Stop returns.
+	require.NoError(t, c.Stop())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, n, produced, "graceful Stop must drain the buffered batch, not drop it")
+}


### PR DESCRIPTION
## Bug

The Kafka async producer's worker accumulates messages into a local batch buffer and flushes on size/linger. On a graceful `Stop()`, that buffer was **silently dropped**:

- `Stop()` sets `shuttingDown=true` **before** closing the publish channel.
- `flushBuffered` — including the *final drain* triggered on channel-close — bailed early on `shuttingDown`.

So up to a full linger window / batch of messages (txmeta, blocks-final, rejected-tx, …) was lost on **every** graceful shutdown, across every service using the producer. It's a logic drop, not a panic, so `recover()` doesn't help. (Found during a concurrency/lifecycle audit; the send-on-closed race that #1009 patched is a *different*, already-handled issue — this is the buffered batch behind it.)

Two compounding causes, both removed:
1. `flushBuffered` returned early on `shuttingDown`, defeating the final drain — and also discarding any batch the size/linger paths cleared right after that no-op flush.
2. The worker loop `break`ed the instant `shuttingDown` was observed, which could also strand messages still queued in the channel.

## Fix

`flushBuffered` now gates only on `closed` (client gone), not `shuttingDown`. This is provably safe: `Stop` closes the client only **after** `publishWg.Wait()` — i.e. after the worker has returned — so producing while shutting-down is always valid, and the subsequent `client.Flush()` delivers it. The worker now keeps draining until `Stop` closes the channel; the close drains channel-resident messages into the buffer and the final drain produces them.

Steady-state behaviour is unchanged (`shuttingDown` is false then, so the removed gate never fired).

## Testability

The buffered loop is extracted into `runProducerWorker` (behaviour-preserving move) and a `produceHook` test seam captures what the loop emits without a live broker (the in-memory producer path is separate and doesn't reproduce the bug, and project policy is no kafka mocking).

`TestAsyncProducer_DrainsBufferedBatchOnStop`: linger/batch set huge so messages only ever leave via the final drain; asserts all are produced on `Stop`.

## Verification

- New test **fails on the old code** (`0 of 25` produced), passes on the fix.
- Full `util/kafka` suite passes under `-race` (81s).
- `go vet`, `gofmt`, `gci` clean.

Note: the large line count in `kafka_producer_async.go` is mostly the `runProducerWorker` extraction (the loop moved out of `Start`), not new logic.
