### PR TITLE
fix(blockassembly): guard subtree worker ErrChan send against shutdown deadlock

### DIFF
--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -426,10 +426,27 @@ func (ba *BlockAssembly) subtreeStorageWorker(ctx context.Context, workChan <-ch
 			<-allDone
 		}
 
-		// Send error back to caller if channel exists
-		if work.request.ErrChan != nil {
-			work.request.ErrChan <- result.err
-		}
+		// Send error back to caller if channel exists.
+		sendCallerErr(ctx, work.request.ErrChan, result.err)
+	}
+}
+
+// sendCallerErr delivers err on the caller's ErrChan, if any, abandoning the
+// send when ctx is cancelled. ErrChan is unbuffered and its receiver (the
+// SubtreeProcessor) abandons the matching receive on its own context
+// cancellation, so a bare send here would block this worker forever during
+// shutdown — which would hang runNewSubtreeListener's wg.Wait() and deadlock
+// block-assembly shutdown. Dropping the result once ctx is cancelled is safe:
+// the caller is no longer waiting for it. Mirrors the ctx-guarded resultChan
+// send above.
+func sendCallerErr(ctx context.Context, errChan chan error, err error) {
+	if errChan == nil {
+		return
+	}
+
+	select {
+	case errChan <- err:
+	case <-ctx.Done():
 	}
 }
 

--- a/services/blockassembly/send_caller_err_test.go
+++ b/services/blockassembly/send_caller_err_test.go
@@ -1,0 +1,68 @@
+package blockassembly
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendCallerErr_AbandonsOnCancel pins the fix for the block-assembly
+// shutdown deadlock: the subtree storage worker delivers its result on the
+// caller's unbuffered ErrChan, but the caller (SubtreeProcessor) abandons the
+// matching receive on its own context cancellation. A bare send then blocked
+// the worker forever, which hung runNewSubtreeListener's wg.Wait() and
+// deadlocked shutdown. sendCallerErr must instead release on ctx cancel.
+func TestSendCallerErr_AbandonsOnCancel(t *testing.T) {
+	errChan := make(chan error) // unbuffered, deliberately no reader
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		sendCallerErr(ctx, errChan, errors.NewProcessingError("boom"))
+		close(done)
+	}()
+
+	// With no reader it must be blocked on the send.
+	select {
+	case <-done:
+		t.Fatal("sendCallerErr returned before cancel; expected it to block on the send")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Cancelling the context must release it — this is the fix.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendCallerErr blocked after ctx cancel — would hang block-assembly shutdown")
+	}
+}
+
+// TestSendCallerErr_DeliversToReader pins the happy path: with a reader present,
+// the result is delivered.
+func TestSendCallerErr_DeliversToReader(t *testing.T) {
+	errChan := make(chan error)
+	want := errors.NewProcessingError("delivered")
+
+	go sendCallerErr(context.Background(), errChan, want)
+
+	select {
+	case got := <-errChan:
+		require.Equal(t, want, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("error was not delivered to the waiting reader")
+	}
+}
+
+// TestSendCallerErr_NilChannelNoop pins that a nil ErrChan is a no-op — the
+// caller may not supply one.
+func TestSendCallerErr_NilChannelNoop(t *testing.T) {
+	require.NotPanics(t, func() {
+		sendCallerErr(context.Background(), nil, nil)
+	})
+}


### PR DESCRIPTION
## Bug (shutdown deadlock)

The subtree storage worker (`subtreeStorageWorker`) sends its result back to the caller on `work.request.ErrChan` with a **bare, unbuffered send**:

```go
if work.request.ErrChan != nil {
    work.request.ErrChan <- result.err   // no ctx escape
}
```

But the caller — the `SubtreeProcessor` — abandons the matching receive on its own context cancellation:

```go
select {
case <-send.ErrChan:
    ...
case <-processorCtx.Done():
    return   // receiver gone
}
```

So on shutdown the worker's send has no receiver and blocks forever. That keeps the worker's `for work := range workChan` loop from returning, so `runNewSubtreeListener`'s `wg.Wait()` (in the `ctx.Done()` shutdown path) never completes — **block-assembly shutdown deadlocks**. The `resultChan` send immediately above is already `select`-guarded on `ctx.Done()`; this `ErrChan` send was the one that wasn't.

## Fix

Extract the send into `sendCallerErr`, which `select`s on `ctx.Done()` and so releases on shutdown. Dropping the result once ctx is cancelled is safe — the caller has already abandoned the receive and isn't waiting for it. This mirrors the existing ctx-guarded `resultChan` send.

## Tests

`send_caller_err_test.go`:
- **AbandonsOnCancel** — with an unbuffered ErrChan and no reader, `sendCallerErr` blocks until ctx is cancelled, then returns. Reverting the helper to a bare send makes this fail (reproduces the deadlock: "blocked after ctx cancel").
- **DeliversToReader** — happy path still delivers.
- **NilChannelNoop** — nil ErrChan is a no-op.

## Verification

- Negative check: bare-send variant fails `AbandonsOnCancel` (hangs → fatal); guarded version passes.
- `go test -race` on the new tests: pass. `go build`, `go vet`, `gofmt`, `gci`: clean.

Second fix from the concurrency/lifecycle audit (after #1027, the kafka final-drain). The audit's remaining items: the netsync `Queue*` shutdown hang and the `DiskTxMap.bytesWritten` race.
