### PR TITLE
fix(blockassembly): make DiskTxMap.bytesWritten access atomic

### DIFF
--- a/services/blockassembly/subtreeprocessor/disk_tx_map.go
+++ b/services/blockassembly/subtreeprocessor/disk_tx_map.go
@@ -44,7 +44,7 @@ type diskShard struct {
 	done         chan struct{}
 	path         string
 	prefix       string
-	bytesWritten int64 // only touched by the single writer goroutine — no atomic needed
+	bytesWritten int64 // written by this disk's writerLoop, read concurrently by Stats(); access via sync/atomic
 }
 
 // DiskTxMap implements TxInpointsMap using sharded cuckoo filters for fast
@@ -166,7 +166,7 @@ func (m *DiskTxMap) writerLoop(diskIdx int) {
 
 		value := serializeTxMapValue(entry.inpoints)
 		_ = d.batch.Set(entry.key[:], value)
-		d.bytesWritten += int64(chainhash.HashSize + len(value))
+		atomic.AddInt64(&d.bytesWritten, int64(chainhash.HashSize+len(value)))
 		pending++
 
 		if pending >= writerFlushThreshold {
@@ -493,11 +493,13 @@ type DiskMapStats struct {
 	DiskBytesWritten int64
 }
 
-// Stats returns current metrics. Safe to call after Flush() when writer goroutines are idle.
+// Stats returns current metrics. It may be called concurrently with active
+// writer goroutines (e.g. reportDiskMapStats during moveForwardBlock before
+// Clear()), so bytesWritten is read atomically.
 func (m *DiskTxMap) Stats() DiskMapStats {
 	var diskBytes int64
 	for i := range m.disks {
-		diskBytes += m.disks[i].bytesWritten
+		diskBytes += atomic.LoadInt64(&m.disks[i].bytesWritten)
 	}
 	return DiskMapStats{
 		Entries:          m.count.Load(),

--- a/services/blockassembly/subtreeprocessor/disk_tx_map_race_test.go
+++ b/services/blockassembly/subtreeprocessor/disk_tx_map_race_test.go
@@ -1,0 +1,45 @@
+package subtreeprocessor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+)
+
+// TestDiskTxMap_StatsRaceWithWriters is a -race regression. Stats() sums each
+// disk shard's bytesWritten, and in production it is called (via
+// reportDiskMapStats during moveForwardBlock) while the per-disk writerLoop
+// goroutines are still incrementing bytesWritten — Clear() only quiesces them
+// afterwards. bytesWritten was a plain int64 written by one goroutine and read
+// by another with no synchronization, which `go test -race` flags. After the
+// fix both sides use sync/atomic.
+//
+// Run under -race; reverting bytesWritten to plain += / read makes this fail
+// with a data-race report.
+func TestDiskTxMap_StatsRaceWithWriters(t *testing.T) {
+	m := newTestDiskTxMap(t)
+
+	const iterations = 5000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: drive the per-disk writerLoop increments via Set.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			m.Set(chainhash.HashH([]byte{byte(i), byte(i >> 8)}), makeInpoints(int16(i%30000)))
+		}
+	}()
+
+	// Reader: read the same counters concurrently via Stats.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = m.Stats()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Data race

`diskShard.bytesWritten` was a plain `int64`:

- **written** by each disk's `writerLoop` goroutine (`d.bytesWritten += …`), and
- **read** by `Stats()` (`diskBytes += m.disks[i].bytesWritten`).

`Stats()` is called in production via `reportDiskMapStats` during `moveForwardBlock` — *before* `Clear()` quiesces the writers — so the read races the active increments from a different goroutine. That's a data race (`go test -race` flags it) and a torn read on 32-bit. The field's own comment claimed "only touched by the single writer goroutine — no atomic needed", which `Stats()` violates.

## Fix

Access `bytesWritten` via `sync/atomic` (`AddInt64` in the writer, `LoadInt64` in `Stats()`). The field stays a plain `int64` rather than `atomic.Int64` on purpose: `diskShard` is assigned as a struct literal at construction (`m.disks[i] = diskShard{…}`), so keeping it copy-safe avoids tainting the struct with a `noCopy` and a `vet` copylocks failure.

## Test

`TestDiskTxMap_StatsRaceWithWriters` drives `Set` (writer-loop increments) concurrently with `Stats()` reads. Reverting to plain access makes it fail under `-race` with a `DATA RACE` report on `bytesWritten`; with the fix it's clean.

## Verification

- `go test -race`: passes with fix; **fails (DATA RACE)** when reverted to plain access.
- `go build`, `go vet`, `gofmt`, `gci`: clean.

Third fix from the concurrency/lifecycle audit (after #1027 kafka final-drain and #1028 blockassembly ErrChan deadlock).
