### PR TITLE
fix(legacy): stop flaky legacy-sync — nil-guard Server.Stop + ephemeral 942 port (#1032)

### DIFF
--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -699,7 +699,13 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 // Parameters:
 //   - _: Context parameter (unused in the current implementation)
 //
-// Returns an error if the shutdown process encounters problems, or nil on successful shutdown
+// Returns an error if the shutdown process encounters problems, or nil on successful shutdown.
+// Returns nil immediately if the inner server was never initialized (e.g. when Init failed
+// before newServer succeeded), so the daemon error path cannot dereference a nil server.
 func (s *Server) Stop(_ context.Context) error {
+	if s.server == nil {
+		return nil
+	}
+
 	return s.server.Stop()
 }

--- a/services/legacy/server_start_test.go
+++ b/services/legacy/server_start_test.go
@@ -35,3 +35,21 @@ func TestStart_FSMContextCancellation(t *testing.T) {
 	require.True(t, errors.IsContextError(err), "expected context error, got %v", err)
 	mockBlockchainClient.AssertExpectations(t)
 }
+
+// TestStop_NilInnerServer covers the issue #1032 crash path: when newServer
+// fails (e.g. "no valid listen address"), Server.Init leaves the inner
+// s.server nil. The daemon error path then calls Server.Stop, which must not
+// dereference the nil inner server. Without the guard this panics with a
+// SIGSEGV in a daemon goroutine and takes the whole test binary down.
+func TestStop_NilInnerServer(t *testing.T) {
+	s := &Server{
+		logger:   ulogger.TestLogger{},
+		settings: &settings.Settings{},
+		// server intentionally left nil — mirrors the post-Init-failure state.
+	}
+
+	require.NotPanics(t, func() {
+		err := s.Stop(context.Background())
+		require.NoError(t, err)
+	})
+}

--- a/test/e2e/daemon/ready/legacy_tx_broadcast_942_test.go
+++ b/test/e2e/daemon/ready/legacy_tx_broadcast_942_test.go
@@ -54,12 +54,17 @@ func TestLegacyTxBroadcast942_TeranodeRPCToSVMempool(t *testing.T) {
 
 	ctx := t.Context()
 
-	// Use non-default ports so this test runs alongside the
+	// SV's RPC/P2P use non-default ports so this test runs alongside the
 	// node-validation harness stack (which holds 18332/18333/18444).
+	// Teranode's legacy listener binds an ephemeral port (":0", OS-assigned):
+	// 942 only dials OUT (ConnectPeers=[sv]) and SV never connects back, so a
+	// fixed inbound port is unnecessary. A fixed port (was 48444) intermittently
+	// failed to bind under CI load (TIME_WAIT/teardown of preceding containers),
+	// which used to crash the whole package — see issue #1032.
 	const (
 		svRPCPort            = 48332
 		svP2PPort            = 48333
-		teranodeLegacyListen = "0.0.0.0:48444"
+		teranodeLegacyListen = "0.0.0.0:0"
 	)
 
 	opts := svnode.DefaultOptions()


### PR DESCRIPTION
## Summary

Fixes the intermittent `legacy-sync` CI failures on `TestLegacyTxBroadcast942_TeranodeRPCToSVMempool`. Two independent root causes, two fixes:

- **Nil guard in `legacy.Server.Stop`** (`services/legacy/Server.go`). When `newServer` fails (e.g. `no valid listen address`), `Server.Init` leaves the inner `s.server` nil. The daemon error path (`ServiceManager.Wait` → `Server.Stop`) then derefs the nil `*server` at `peer_server.go:2914` → unrecovered SIGSEGV in a daemon goroutine → crashes the whole test binary, reporting `(unknown)` and discarding all other results in the package. The guard returns nil when there's no inner server, downgrading a process-killing panic to a clean per-test failure. This is the load-bearing fix: any future startup error on this service hit the same crash path.

- **Ephemeral listen port in the 942 test** (`test/e2e/daemon/ready/legacy_tx_broadcast_942_test.go`). The test pinned the legacy listener to fixed `0.0.0.0:48444`; under CI load that bind intermittently failed (TIME_WAIT/teardown of the preceding containers), producing the startup error above. Switched to `0.0.0.0:0` (OS-assigned). Safe because 942 only dials **out** (`ConnectPeers=[sv]`) and SV never connects back, so a fixed inbound port is unnecessary — verified the tx-broadcast assertion rides the established outbound connection.

Confirmed via `ServiceManager` that `Stop` is the only method invoked on a service whose `Init` errored, so the guard fully closes the crash path. Production `initListeners` retry/backoff was deliberately left out (YAGNI — would mask genuinely-occupied ports).

## Test plan

- [x] New white-box regression test `TestStop_NilInnerServer` — fails (recovered nil-deref panic) before the guard, passes after.
- [x] `go test -race ./services/legacy/` green.
- [x] `go vet ./services/legacy/ ./test/e2e/daemon/ready/` clean.
- [x] `legacy-sync` CI job green (the authoritative signal for the e2e port change; Docker-gated locally).

Fixes #1032
