### PR TITLE
fix(utxo/aerospike): clear locked flag on pagination records when mining (#1037)

### DIFF
--- a/stores/utxo/aerospike/set_mined.go
+++ b/stores/utxo/aerospike/set_mined.go
@@ -233,13 +233,13 @@ func (s *Store) SetMinedMulti(ctx context.Context, hashes []*chainhash.Hash, min
 	}
 
 	// Process batch results
-	blockIDs, lockClearItems, err := s.processBatchResultsForSetMined(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+	blockIDs, work, err := s.processBatchResultsForSetMined(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
 
 	// #1037: clear the lock on the pagination records of successfully-mined
 	// external txs. Done here (not inside the result processor) so the processor
 	// stays free of follow-up I/O. Runs even when err != nil so a tx mined
 	// successfully is fully unlocked despite a sibling failure in the same batch.
-	if clearErr := s.clearLockedOnRecordsMulti(lockClearItems); clearErr != nil {
+	if clearErr := s.applyLockClearWork(ctx, work); clearErr != nil {
 		err = errors.Join(err, clearErr)
 	}
 
@@ -314,7 +314,7 @@ func (s *Store) executeBatchOperation(batchRecords []aerospike.BatchRecordIfc) e
 // (SetMinedMulti) so this function stays free of follow-up writes for the
 // lock-clear path — keeping it unit-testable without a live client.
 func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords []aerospike.BatchRecordIfc,
-	hashes []*chainhash.Hash, thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo) (map[chainhash.Hash][]uint32, []lockClearItem, error) {
+	hashes []*chainhash.Hash, thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo) (map[chainhash.Hash][]uint32, lockClearWork, error) {
 	var errs error
 	okUpdates := 0
 	nrErrors := 0
@@ -335,7 +335,7 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 	// #1037: pagination/extra records of successfully-mined external txs whose
 	// `locked` flag must be cleared (the master-keyed setMined only clears the
 	// master). Populated from the setMined response's childCount (= totalExtraRecs).
-	var lockClearItems []lockClearItem
+	var work lockClearWork
 	// DAH timing assumption:
 	// - thisBatch operates under a fixed block-processing context.
 	// - thisBlockHeight and retention are immutable for the duration of SetMinedMulti() execution.
@@ -376,7 +376,7 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 			// UDF itself). childCount == totalExtraRecs is surfaced by setMined on a
 			// mine; UnsetMined never reaches here as a clear (childCount only on mine).
 			if res != nil && !minedBlockInfo.UnsetMined && res.ChildCount > 0 {
-				lockClearItems = append(lockClearItems, lockClearItem{txID: hashes[idx], childCount: res.ChildCount})
+				work.items = append(work.items, lockClearItem{txID: hashes[idx], childCount: res.ChildCount})
 			}
 		}
 
@@ -426,12 +426,12 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 
 	prometheusTxMetaAerospikeMapSetMinedBatchN.Add(float64(okUpdates))
 
-	// lockClearItems (pagination records of successfully-mined external txs) are
-	// returned to the caller for clearing, so a tx that was mined successfully is
-	// fully unlocked even if a sibling record in the same batch errored below.
+	// work (pagination records of successfully-mined external txs) is returned to
+	// the caller for clearing, so a tx that was mined successfully is fully
+	// unlocked even if a sibling record in the same batch errored below.
 	if errs != nil || nrErrors > 0 {
 		prometheusTxMetaAerospikeMapSetMinedBatchErrN.Add(float64(nrErrors))
-		return blockIDs, lockClearItems, errors.NewError("aerospike batchRecord errors", errs)
+		return blockIDs, work, errors.NewError("aerospike batchRecord errors", errs)
 	}
 
 	// Execute aggregated follow-ups in batches
@@ -459,10 +459,10 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 	// setDAHExternalTransactionMulti removed as it would no-op
 
 	if postErr != nil {
-		return blockIDs, lockClearItems, errors.NewError("aerospike setMined follow-up batch errors", postErr)
+		return blockIDs, work, errors.NewError("aerospike setMined follow-up batch errors", postErr)
 	}
 
-	return blockIDs, lockClearItems, nil
+	return blockIDs, work, nil
 }
 
 // processSingleBatchRecord processes a single batch record result, allocating a
@@ -562,13 +562,44 @@ func (s *Store) handleSetMinedSignal(ctx context.Context, signal LuaSignal, hash
 	return errs
 }
 
-// lockClearItem identifies a transaction whose pagination/extra records (and,
-// when includeMaster is set, its master record) must have the `locked` flag
-// cleared as part of marking the transaction mined.
+// lockClearItem identifies a transaction whose pagination/extra records must
+// have the `locked` flag cleared as part of marking the transaction mined. The
+// master record's lock is cleared by the setMined UDF / expression write itself.
 type lockClearItem struct {
-	txID          *chainhash.Hash
-	childCount    int  // number of pagination/extra records, cleared at indices 1..childCount
-	includeMaster bool // also clear the master record (index 0)
+	txID       *chainhash.Hash
+	childCount int // number of pagination/extra records, cleared at indices 1..childCount
+}
+
+// lockClearWork is the lock-clearing follow-up that a setMined result processor
+// hands back to its public caller (#1037). The processors stay free of follow-up
+// I/O so they remain unit-testable without a live client.
+type lockClearWork struct {
+	// items: pagination records to unlock directly (childCount known from the
+	// setMined response / totalExtraRecs bin; the master is already unlocked).
+	items []lockClearItem
+	// fullUnlock: transactions whose record state is unknown from the batch (the
+	// expression write was FILTERED_OUT, so the child count and even the master's
+	// lock state were not returned). SetLocked(false) reads the child count from
+	// the master and clears every record (master + all pagination records).
+	fullUnlock []chainhash.Hash
+}
+
+// applyLockClearWork performs the lock-clearing follow-up I/O collected by a
+// setMined result processor. Safe to call with empty work (no-op).
+func (s *Store) applyLockClearWork(ctx context.Context, work lockClearWork) error {
+	var err error
+
+	if clearErr := s.clearLockedOnRecordsMulti(work.items); clearErr != nil {
+		err = errors.Join(err, clearErr)
+	}
+
+	if len(work.fullUnlock) > 0 {
+		if unlockErr := s.SetLocked(ctx, work.fullUnlock, false); unlockErr != nil {
+			err = errors.Join(err, unlockErr)
+		}
+	}
+
+	return err
 }
 
 // clearLockedOnRecordsMulti clears the `locked` flag on the requested records in
@@ -592,9 +623,6 @@ type lockClearItem struct {
 func (s *Store) clearLockedOnRecordsMulti(items []lockClearItem) error {
 	total := 0
 	for _, it := range items {
-		if it.includeMaster {
-			total++
-		}
 		if it.childCount > 0 {
 			total += it.childCount
 		}
@@ -624,12 +652,6 @@ func (s *Store) clearLockedOnRecordsMulti(items []lockClearItem) error {
 	}
 
 	for _, it := range items {
-		if it.includeMaster {
-			if err := appendRecord(it.txID, 0); err != nil {
-				return err
-			}
-		}
-
 		for i := uint32(1); i <= uint32(it.childCount); i++ { // nolint:gosec
 			if err := appendRecord(it.txID, i); err != nil {
 				return err

--- a/stores/utxo/aerospike/set_mined.go
+++ b/stores/utxo/aerospike/set_mined.go
@@ -67,8 +67,10 @@ import (
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
+	"github.com/bsv-blockchain/teranode/util/uaerospike"
 )
 
 // batchRecordsPool pools slices of aerospike.BatchRecordIfc to reduce allocations
@@ -231,7 +233,17 @@ func (s *Store) SetMinedMulti(ctx context.Context, hashes []*chainhash.Hash, min
 	}
 
 	// Process batch results
-	return s.processBatchResultsForSetMined(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+	blockIDs, lockClearItems, err := s.processBatchResultsForSetMined(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+
+	// #1037: clear the lock on the pagination records of successfully-mined
+	// external txs. Done here (not inside the result processor) so the processor
+	// stays free of follow-up I/O. Runs even when err != nil so a tx mined
+	// successfully is fully unlocked despite a sibling failure in the same batch.
+	if clearErr := s.clearLockedOnRecordsMulti(lockClearItems); clearErr != nil {
+		err = errors.Join(err, clearErr)
+	}
+
+	return blockIDs, err
 }
 
 // prepareBatchRecordsForSetMined populates batch records for the setMined operation.
@@ -296,9 +308,13 @@ func (s *Store) executeBatchOperation(batchRecords []aerospike.BatchRecordIfc) e
 	return nil
 }
 
-// processBatchResultsForSetMined processes the results of the batch operation
+// processBatchResultsForSetMined processes the results of the batch operation.
+// It returns the per-tx blockID map and the set of records whose `locked` flag
+// must be cleared (#1037). The lock-clearing I/O is performed by the caller
+// (SetMinedMulti) so this function stays free of follow-up writes for the
+// lock-clear path — keeping it unit-testable without a live client.
 func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords []aerospike.BatchRecordIfc,
-	hashes []*chainhash.Hash, thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo) (map[chainhash.Hash][]uint32, error) {
+	hashes []*chainhash.Hash, thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo) (map[chainhash.Hash][]uint32, []lockClearItem, error) {
 	var errs error
 	okUpdates := 0
 	nrErrors := 0
@@ -316,6 +332,10 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 		ChildCount     int
 		DeleteAtHeight uint32
 	}, 0)
+	// #1037: pagination/extra records of successfully-mined external txs whose
+	// `locked` flag must be cleared (the master-keyed setMined only clears the
+	// master). Populated from the setMined response's childCount (= totalExtraRecs).
+	var lockClearItems []lockClearItem
 	// DAH timing assumption:
 	// - thisBatch operates under a fixed block-processing context.
 	// - thisBlockHeight and retention are immutable for the duration of SetMinedMulti() execution.
@@ -350,6 +370,14 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 			nrErrors++
 		} else if result {
 			okUpdates++
+
+			// #1037: a freshly-mined external tx may still have `locked` set on its
+			// pagination records. Clear them (the master's lock is cleared by the
+			// UDF itself). childCount == totalExtraRecs is surfaced by setMined on a
+			// mine; UnsetMined never reaches here as a clear (childCount only on mine).
+			if res != nil && !minedBlockInfo.UnsetMined && res.ChildCount > 0 {
+				lockClearItems = append(lockClearItems, lockClearItem{txID: hashes[idx], childCount: res.ChildCount})
+			}
 		}
 
 		if res != nil && res.BlockIDs != nil {
@@ -398,9 +426,12 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 
 	prometheusTxMetaAerospikeMapSetMinedBatchN.Add(float64(okUpdates))
 
+	// lockClearItems (pagination records of successfully-mined external txs) are
+	// returned to the caller for clearing, so a tx that was mined successfully is
+	// fully unlocked even if a sibling record in the same batch errored below.
 	if errs != nil || nrErrors > 0 {
 		prometheusTxMetaAerospikeMapSetMinedBatchErrN.Add(float64(nrErrors))
-		return blockIDs, errors.NewError("aerospike batchRecord errors", errs)
+		return blockIDs, lockClearItems, errors.NewError("aerospike batchRecord errors", errs)
 	}
 
 	// Execute aggregated follow-ups in batches
@@ -428,10 +459,10 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 	// setDAHExternalTransactionMulti removed as it would no-op
 
 	if postErr != nil {
-		return blockIDs, errors.NewError("aerospike setMined follow-up batch errors", postErr)
+		return blockIDs, lockClearItems, errors.NewError("aerospike setMined follow-up batch errors", postErr)
 	}
 
-	return blockIDs, nil
+	return blockIDs, lockClearItems, nil
 }
 
 // processSingleBatchRecord processes a single batch record result, allocating a
@@ -529,4 +560,103 @@ func (s *Store) handleSetMinedSignal(ctx context.Context, signal LuaSignal, hash
 	}
 
 	return errs
+}
+
+// lockClearItem identifies a transaction whose pagination/extra records (and,
+// when includeMaster is set, its master record) must have the `locked` flag
+// cleared as part of marking the transaction mined.
+type lockClearItem struct {
+	txID          *chainhash.Hash
+	childCount    int  // number of pagination/extra records, cleared at indices 1..childCount
+	includeMaster bool // also clear the master record (index 0)
+}
+
+// clearLockedOnRecordsMulti clears the `locked` flag on the requested records in
+// a single unfiltered BatchOperate.
+//
+// Why this exists (issue #1037): a transaction created WithLocked(true) — by the
+// block-validation quick-validate pipeline (services/blockvalidation/quick_validate.go)
+// or the validator's 2-phase commit — has the `locked` flag set on EVERY record:
+// the master record AND every pagination/extra record of an external (paginated)
+// transaction. The mined-status update (the setMined UDF and the expression batch)
+// is keyed on the master record only, so it clears the master's lock but never the
+// pagination records'. If the 2PC / quick-validate unlock then fails to run (its
+// documented "locked UTXOs remain ... rolled back on error" path), the pagination
+// records stay locked forever. Because mining a transaction makes ALL of its
+// outputs spendable, SetMinedMulti must clear the lock on every record — otherwise
+// a child spending an output that lives on a pagination record (vout >=
+// utxoBatchSize) fails permanently with TX_LOCKED, wedging legacy sync.
+//
+// A KEY_NOT_FOUND on any record is treated as benign: a record that does not exist
+// cannot be holding a lock.
+func (s *Store) clearLockedOnRecordsMulti(items []lockClearItem) error {
+	total := 0
+	for _, it := range items {
+		if it.includeMaster {
+			total++
+		}
+		if it.childCount > 0 {
+			total += it.childCount
+		}
+	}
+
+	if total == 0 {
+		return nil
+	}
+
+	batchWritePolicy := util.GetAerospikeBatchWritePolicy(s.settings)
+	batchWritePolicy.RecordExistsAction = aerospike.UPDATE_ONLY
+	clearOp := aerospike.PutOp(aerospike.NewBin(fields.Locked.String(), false))
+
+	batchRecords := make([]aerospike.BatchRecordIfc, 0, total)
+
+	appendRecord := func(txID *chainhash.Hash, idx uint32) error {
+		keySource := uaerospike.CalculateKeySourceInternal(txID, idx)
+
+		key, err := aerospike.NewKey(s.namespace, s.setName, keySource)
+		if err != nil {
+			return errors.NewProcessingError("[clearLockedOnRecordsMulti][%s] failed to create key for record %d", txID.String(), idx, err)
+		}
+
+		batchRecords = append(batchRecords, aerospike.NewBatchWrite(batchWritePolicy, key, clearOp))
+
+		return nil
+	}
+
+	for _, it := range items {
+		if it.includeMaster {
+			if err := appendRecord(it.txID, 0); err != nil {
+				return err
+			}
+		}
+
+		for i := uint32(1); i <= uint32(it.childCount); i++ { // nolint:gosec
+			if err := appendRecord(it.txID, i); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := s.batchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
+		return errors.NewStorageError("[clearLockedOnRecordsMulti] failed to clear locked flag", err)
+	}
+
+	var aggErr error
+
+	for _, br := range batchRecords {
+		recErr := br.BatchRec().Err
+		if recErr == nil {
+			continue
+		}
+
+		// A missing record cannot be holding a lock — tolerate it.
+		var aErr *aerospike.AerospikeError
+		if errors.As(recErr, &aErr) && aErr != nil && aErr.ResultCode == types.KEY_NOT_FOUND_ERROR {
+			continue
+		}
+
+		aggErr = errors.Join(aggErr, recErr)
+	}
+
+	return aggErr
 }

--- a/stores/utxo/aerospike/set_mined.go
+++ b/stores/utxo/aerospike/set_mined.go
@@ -587,15 +587,21 @@ type lockClearWork struct {
 // applyLockClearWork performs the lock-clearing follow-up I/O collected by a
 // setMined result processor. Safe to call with empty work (no-op).
 func (s *Store) applyLockClearWork(ctx context.Context, work lockClearWork) error {
+	// Assign the first non-nil error directly rather than errors.Join(nil, err),
+	// which would wrap it in a stdlib joinError and drop the rich *errors.Error type.
 	var err error
 
 	if clearErr := s.clearLockedOnRecordsMulti(work.items); clearErr != nil {
-		err = errors.Join(err, clearErr)
+		err = clearErr
 	}
 
 	if len(work.fullUnlock) > 0 {
 		if unlockErr := s.SetLocked(ctx, work.fullUnlock, false); unlockErr != nil {
-			err = errors.Join(err, unlockErr)
+			if err == nil {
+				err = unlockErr
+			} else {
+				err = errors.Join(err, unlockErr)
+			}
 		}
 	}
 
@@ -652,6 +658,13 @@ func (s *Store) clearLockedOnRecordsMulti(items []lockClearItem) error {
 	}
 
 	for _, it := range items {
+		// Guard against a non-positive childCount: uint32(negative) would wrap to
+		// ~4e9 and blow up the batch. Both producers only ever append childCount > 0,
+		// so this is belt-and-suspenders for self-consistency with the sizing loop.
+		if it.childCount <= 0 {
+			continue
+		}
+
 		for i := uint32(1); i <= uint32(it.childCount); i++ { // nolint:gosec
 			if err := appendRecord(it.txID, i); err != nil {
 				return err
@@ -659,6 +672,10 @@ func (s *Store) clearLockedOnRecordsMulti(items []lockClearItem) error {
 		}
 	}
 
+	// A non-nil top-level error here is a transport/batch-level failure, surfaced
+	// hard. The benign per-record KEY_NOT_FOUND tolerance below relies on Aerospike
+	// reporting missing records per-record (BatchRecord.Err), not as a top-level
+	// error — consistent with the rest of this package's batch handling.
 	if err := s.batchOperate(util.GetAerospikeBatchPolicy(s.settings), batchRecords); err != nil {
 		return errors.NewStorageError("[clearLockedOnRecordsMulti] failed to clear locked flag", err)
 	}

--- a/stores/utxo/aerospike/set_mined_expressions.go
+++ b/stores/utxo/aerospike/set_mined_expressions.go
@@ -322,17 +322,29 @@ func (s *Store) SetMinedMultiWithExpressions(ctx context.Context, hashes []*chai
 	prometheusTxMetaAerospikeMapSetMinedBatch.Inc()
 
 	// Process results
-	return s.processBatchResultsForSetMinedExpressions(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+	blockIDs, lockClearItems, err := s.processBatchResultsForSetMinedExpressions(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+
+	// #1037: clear the lock on pagination records, and on the master of any record
+	// whose write was FILTERED_OUT (blockID already present) — the filter would
+	// otherwise skip the Locked=false op. Done here, outside the result processor,
+	// so the processor performs no follow-up I/O and stays unit-testable.
+	if clearErr := s.clearLockedOnRecordsMulti(lockClearItems); clearErr != nil {
+		err = errors.Join(err, clearErr)
+	}
+
+	return blockIDs, err
 }
 
-// processBatchResultsForSetMinedExpressions processes the batch results and handles follow-up actions.
+// processBatchResultsForSetMinedExpressions processes the batch results and
+// returns the per-tx blockID map plus the records whose `locked` flag must be
+// cleared (#1037); the lock-clearing I/O is performed by the caller.
 func (s *Store) processBatchResultsForSetMinedExpressions(
 	ctx context.Context,
 	batchRecords []aerospike.BatchRecordIfc,
 	hashes []*chainhash.Hash,
 	thisBlockHeight uint32,
 	minedBlockInfo utxo.MinedBlockInfo,
-) (map[chainhash.Hash][]uint32, error) {
+) (map[chainhash.Hash][]uint32, []lockClearItem, error) {
 	blockIDs := make(map[chainhash.Hash][]uint32, len(hashes))
 	var errs error
 	okUpdates := 0
@@ -348,6 +360,10 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 		TxID *chainhash.Hash
 		DAH  uint32
 	}, 0)
+	// #1037: records whose `locked` flag must be cleared on the pagination/extra
+	// records (and on the master for FILTERED_OUT records, see below). The master
+	// of a non-filtered record is unlocked by the main batch write's Locked=false op.
+	var lockClearItems []lockClearItem
 
 	// Process each batch record result
 	for i, batchRecord := range batchRecords {
@@ -371,6 +387,13 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 					// check at the end of this function sees this hash as covered.
 					blockIDs[*hash] = []uint32{minedBlockInfo.BlockID}
 					okUpdates++
+
+					// #1037 (filter-gating): when the write is FILTERED_OUT the whole
+					// batch write — including the Locked=false op — is skipped, so a
+					// still-locked master would never be cleared by this path. The tx
+					// is mined (its blockID is present), therefore it must be spendable:
+					// clear the master's lock unconditionally via the unfiltered pass.
+					lockClearItems = append(lockClearItems, lockClearItem{txID: hash, includeMaster: true})
 					continue
 				}
 			}
@@ -435,6 +458,16 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 			}
 		}
 
+		// #1037: this batch write cleared `locked` on the master only. Clear it on
+		// the pagination/extra records too, so a child spending a high-index output
+		// (vout >= utxoBatchSize) of a freshly-mined paginated tx is not rejected
+		// with TX_LOCKED. Keyed on the presence of extra records (not the external
+		// flag) so it holds for any paginated tx. UnsetMined never uses this path
+		// (SetMinedMulti routes it to the UDF), so collecting here is always safe.
+		if state.TotalExtraRecs != nil && *state.TotalExtraRecs > 0 {
+			lockClearItems = append(lockClearItems, lockClearItem{txID: hash, childCount: *state.TotalExtraRecs})
+		}
+
 		okUpdates++
 	}
 
@@ -474,7 +507,9 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 	if nrErrors > 0 {
 		prometheusTxMetaAerospikeMapSetMinedBatchErrN.Add(float64(nrErrors))
 		if errs != nil {
-			return blockIDs, errors.NewError("aerospike batch record errors", errs)
+			// lockClearItems still returned so the caller unlocks successfully-mined
+			// (and FILTERED_OUT) records despite a sibling failure in this batch.
+			return blockIDs, lockClearItems, errors.NewError("aerospike batch record errors", errs)
 		}
 	}
 
@@ -488,8 +523,8 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 	}
 
 	if postErr != nil {
-		return blockIDs, errors.NewError("aerospike setMined follow-up batch errors", postErr)
+		return blockIDs, lockClearItems, errors.NewError("aerospike setMined follow-up batch errors", postErr)
 	}
 
-	return blockIDs, nil
+	return blockIDs, lockClearItems, nil
 }

--- a/stores/utxo/aerospike/set_mined_expressions.go
+++ b/stores/utxo/aerospike/set_mined_expressions.go
@@ -322,13 +322,13 @@ func (s *Store) SetMinedMultiWithExpressions(ctx context.Context, hashes []*chai
 	prometheusTxMetaAerospikeMapSetMinedBatch.Inc()
 
 	// Process results
-	blockIDs, lockClearItems, err := s.processBatchResultsForSetMinedExpressions(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+	blockIDs, work, err := s.processBatchResultsForSetMinedExpressions(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
 
-	// #1037: clear the lock on pagination records, and on the master of any record
-	// whose write was FILTERED_OUT (blockID already present) — the filter would
-	// otherwise skip the Locked=false op. Done here, outside the result processor,
+	// #1037: clear the lock on pagination records, and fully unlock (master + all
+	// pagination records) any tx whose write was FILTERED_OUT — the blockID filter
+	// otherwise skips the Locked=false op. Done here, outside the result processor,
 	// so the processor performs no follow-up I/O and stays unit-testable.
-	if clearErr := s.clearLockedOnRecordsMulti(lockClearItems); clearErr != nil {
+	if clearErr := s.applyLockClearWork(ctx, work); clearErr != nil {
 		err = errors.Join(err, clearErr)
 	}
 
@@ -336,15 +336,15 @@ func (s *Store) SetMinedMultiWithExpressions(ctx context.Context, hashes []*chai
 }
 
 // processBatchResultsForSetMinedExpressions processes the batch results and
-// returns the per-tx blockID map plus the records whose `locked` flag must be
-// cleared (#1037); the lock-clearing I/O is performed by the caller.
+// returns the per-tx blockID map plus the lock-clearing follow-up work (#1037);
+// the lock-clearing I/O is performed by the caller.
 func (s *Store) processBatchResultsForSetMinedExpressions(
 	ctx context.Context,
 	batchRecords []aerospike.BatchRecordIfc,
 	hashes []*chainhash.Hash,
 	thisBlockHeight uint32,
 	minedBlockInfo utxo.MinedBlockInfo,
-) (map[chainhash.Hash][]uint32, []lockClearItem, error) {
+) (map[chainhash.Hash][]uint32, lockClearWork, error) {
 	blockIDs := make(map[chainhash.Hash][]uint32, len(hashes))
 	var errs error
 	okUpdates := 0
@@ -360,10 +360,11 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 		TxID *chainhash.Hash
 		DAH  uint32
 	}, 0)
-	// #1037: records whose `locked` flag must be cleared on the pagination/extra
-	// records (and on the master for FILTERED_OUT records, see below). The master
-	// of a non-filtered record is unlocked by the main batch write's Locked=false op.
-	var lockClearItems []lockClearItem
+	// #1037: lock-clearing follow-up. Non-filtered records: pagination records via
+	// work.items (the master is unlocked by the main batch write's Locked=false op).
+	// FILTERED_OUT records: work.fullUnlock, since the filtered write returns no
+	// child count and may have skipped the master's Locked=false too.
+	var work lockClearWork
 
 	// Process each batch record result
 	for i, batchRecord := range batchRecords {
@@ -389,11 +390,13 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 					okUpdates++
 
 					// #1037 (filter-gating): when the write is FILTERED_OUT the whole
-					// batch write — including the Locked=false op — is skipped, so a
-					// still-locked master would never be cleared by this path. The tx
-					// is mined (its blockID is present), therefore it must be spendable:
-					// clear the master's lock unconditionally via the unfiltered pass.
-					lockClearItems = append(lockClearItems, lockClearItem{txID: hash, includeMaster: true})
+					// batch write — including the Locked=false op — is skipped, and the
+					// reads (totalExtraRecs etc.) return nothing, so we know neither the
+					// master's lock state nor the child count. The tx is mined (its
+					// blockID is present) and therefore must be spendable: fully unlock
+					// it (master + all pagination records) via SetLocked, which reads the
+					// child count from the master itself.
+					work.fullUnlock = append(work.fullUnlock, *hash)
 					continue
 				}
 			}
@@ -465,7 +468,7 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 		// flag) so it holds for any paginated tx. UnsetMined never uses this path
 		// (SetMinedMulti routes it to the UDF), so collecting here is always safe.
 		if state.TotalExtraRecs != nil && *state.TotalExtraRecs > 0 {
-			lockClearItems = append(lockClearItems, lockClearItem{txID: hash, childCount: *state.TotalExtraRecs})
+			work.items = append(work.items, lockClearItem{txID: hash, childCount: *state.TotalExtraRecs})
 		}
 
 		okUpdates++
@@ -507,9 +510,9 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 	if nrErrors > 0 {
 		prometheusTxMetaAerospikeMapSetMinedBatchErrN.Add(float64(nrErrors))
 		if errs != nil {
-			// lockClearItems still returned so the caller unlocks successfully-mined
-			// (and FILTERED_OUT) records despite a sibling failure in this batch.
-			return blockIDs, lockClearItems, errors.NewError("aerospike batch record errors", errs)
+			// work still returned so the caller unlocks successfully-mined (and
+			// FILTERED_OUT) records despite a sibling failure in this batch.
+			return blockIDs, work, errors.NewError("aerospike batch record errors", errs)
 		}
 	}
 
@@ -523,8 +526,8 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 	}
 
 	if postErr != nil {
-		return blockIDs, lockClearItems, errors.NewError("aerospike setMined follow-up batch errors", postErr)
+		return blockIDs, work, errors.NewError("aerospike setMined follow-up batch errors", postErr)
 	}
 
-	return blockIDs, lockClearItems, nil
+	return blockIDs, work, nil
 }

--- a/stores/utxo/aerospike/set_mined_expressions.go
+++ b/stores/utxo/aerospike/set_mined_expressions.go
@@ -507,13 +507,15 @@ func (s *Store) processBatchResultsForSetMinedExpressions(
 
 	prometheusTxMetaAerospikeMapSetMinedBatchN.Add(float64(okUpdates))
 
-	if nrErrors > 0 {
+	// Mirror the Lua path's single guard (set_mined.go) instead of the nested
+	// `if nrErrors > 0 { if errs != nil }`: every nrErrors++ is paired with an
+	// errs join, so the two conditions move together — keeping them as one
+	// expression removes the implicit coupling. work is still returned so the
+	// caller unlocks successfully-mined (and FILTERED_OUT) records despite a
+	// sibling failure in this batch.
+	if errs != nil || nrErrors > 0 {
 		prometheusTxMetaAerospikeMapSetMinedBatchErrN.Add(float64(nrErrors))
-		if errs != nil {
-			// work still returned so the caller unlocks successfully-mined (and
-			// FILTERED_OUT) records despite a sibling failure in this batch.
-			return blockIDs, work, errors.NewError("aerospike batch record errors", errs)
-		}
+		return blockIDs, work, errors.NewError("aerospike batch record errors", errs)
 	}
 
 	// Execute follow-up actions for external transactions (child record and blob storage DAH)

--- a/stores/utxo/aerospike/set_mined_expressions_test.go
+++ b/stores/utxo/aerospike/set_mined_expressions_test.go
@@ -139,7 +139,7 @@ func TestProcessBatchResultsForSetMinedExpressions_FilteredOutSynthesizesMapEntr
 	rec.BatchRec().Err = &aerospike.AerospikeError{ResultCode: types.FILTERED_OUT}
 
 	const blockID uint32 = 1234
-	got, _, err := s.processBatchResultsForSetMinedExpressions(
+	got, work, err := s.processBatchResultsForSetMinedExpressions(
 		context.Background(),
 		[]aerospike.BatchRecordIfc{rec},
 		[]*chainhash.Hash{hash},
@@ -150,6 +150,14 @@ func TestProcessBatchResultsForSetMinedExpressions_FilteredOutSynthesizesMapEntr
 	require.NoError(t, err, "FILTERED_OUT must be treated as a successful idempotent retry, not an error")
 	require.Contains(t, got, *hash, "hash must be present in the returned map so the model-layer coverage check passes")
 	assert.Equal(t, []uint32{blockID}, got[*hash], "synthesized slice must contain exactly the current blockID")
+
+	// #1037: the FILTERED_OUT write (incl. Locked=false) is skipped by the blockID
+	// filter, so the record must be enqueued for a full SetLocked(false) unlock —
+	// this guards the load-bearing line set_mined_expressions.go that appends to
+	// work.fullUnlock. Without it a still-locked pagination record never heals.
+	require.Len(t, work.fullUnlock, 1, "FILTERED_OUT record must be queued for full unlock")
+	assert.Equal(t, *hash, work.fullUnlock[0], "the FILTERED_OUT hash must be the one queued for unlock")
+	assert.Empty(t, work.items, "FILTERED_OUT records use fullUnlock, not the direct child-clear items")
 }
 
 // TestProcessBatchResultsForSetMinedExpressions_KeyNotFoundIsHardError pairs

--- a/stores/utxo/aerospike/set_mined_expressions_test.go
+++ b/stores/utxo/aerospike/set_mined_expressions_test.go
@@ -139,7 +139,7 @@ func TestProcessBatchResultsForSetMinedExpressions_FilteredOutSynthesizesMapEntr
 	rec.BatchRec().Err = &aerospike.AerospikeError{ResultCode: types.FILTERED_OUT}
 
 	const blockID uint32 = 1234
-	got, err := s.processBatchResultsForSetMinedExpressions(
+	got, _, err := s.processBatchResultsForSetMinedExpressions(
 		context.Background(),
 		[]aerospike.BatchRecordIfc{rec},
 		[]*chainhash.Hash{hash},
@@ -163,7 +163,7 @@ func TestProcessBatchResultsForSetMinedExpressions_KeyNotFoundIsHardError(t *tes
 	rec := newFakeBatchWrite(t, hash)
 	rec.BatchRec().Err = &aerospike.AerospikeError{ResultCode: types.KEY_NOT_FOUND_ERROR}
 
-	got, err := s.processBatchResultsForSetMinedExpressions(
+	got, _, err := s.processBatchResultsForSetMinedExpressions(
 		context.Background(),
 		[]aerospike.BatchRecordIfc{rec},
 		[]*chainhash.Hash{hash},
@@ -187,7 +187,7 @@ func TestProcessBatchResultsForSetMinedExpressions_CoverageGap_NilRecord(t *test
 	rec := newFakeBatchWrite(t, hash)
 	// Default state: rec.BatchRec().Err == nil && rec.BatchRec().Record == nil.
 
-	got, err := s.processBatchResultsForSetMinedExpressions(
+	got, _, err := s.processBatchResultsForSetMinedExpressions(
 		context.Background(),
 		[]aerospike.BatchRecordIfc{rec},
 		[]*chainhash.Hash{hash},
@@ -213,7 +213,7 @@ func TestProcessBatchResultsForSetMinedExpressions_CoverageGap_EmptyBlockIDs(t *
 		"blockIDs": []interface{}{},
 	}}
 
-	got, err := s.processBatchResultsForSetMinedExpressions(
+	got, _, err := s.processBatchResultsForSetMinedExpressions(
 		context.Background(),
 		[]aerospike.BatchRecordIfc{rec},
 		[]*chainhash.Hash{hash},
@@ -237,7 +237,7 @@ func TestProcessBatchResultsForSetMinedExpressions_UnsetMinedToleratesGap(t *tes
 	rec := newFakeBatchWrite(t, hash)
 	// Nil Record — same shape as the NilRecord test above.
 
-	got, err := s.processBatchResultsForSetMinedExpressions(
+	got, _, err := s.processBatchResultsForSetMinedExpressions(
 		context.Background(),
 		[]aerospike.BatchRecordIfc{rec},
 		[]*chainhash.Hash{hash},

--- a/stores/utxo/aerospike/set_mined_locked_test.go
+++ b/stores/utxo/aerospike/set_mined_locked_test.go
@@ -269,3 +269,63 @@ func TestSetMinedMultiHealsAlreadyMinedLockedPaginationRecord(t *testing.T) {
 		})
 	}
 }
+
+// TestSetMinedMultiUnlocksDespiteSiblingError pins the cross-sibling guarantee:
+// when a SetMinedMulti batch contains a paginated tx that mines successfully and a
+// sibling hash that errors (e.g. not found), the successfully-mined tx must still
+// have its pagination records unlocked — the lock-clear must not be skipped just
+// because another record in the batch failed. A regression that early-returns
+// before applyLockClearWork would re-introduce the #1037 wedge while still
+// compiling and passing the happy-path tests.
+func TestSetMinedMultiUnlocksDespiteSiblingError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Aerospike integration test in short mode")
+	}
+
+	for _, useExpressions := range []bool{false, true} {
+		name := "lua"
+		if useExpressions {
+			name = "expressions"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := ulogger.NewErrorTestLogger(t)
+			settings := test.CreateBaseTestSettings(t)
+			settings.UtxoStore.UtxoBatchSize = 4
+			settings.Aerospike.EnableSetMinedFilterExpressions = useExpressions
+
+			client, store, _, cleanup := initAerospike(t, settings, logger)
+			defer cleanup()
+
+			cleanDB(t, client)
+
+			const blockHeight = 604314
+
+			tx := createTransactionWithOutputs(10)
+			txHash := tx.TxIDChainHash()
+
+			_, err := store.Create(ctx, tx, blockHeight, utxo.WithLocked(true))
+			require.NoError(t, err)
+
+			extras := totalExtraRecs(t, client, store, txHash)
+			require.GreaterOrEqual(t, extras, 1)
+
+			// A hash that was never created — its record does not exist, so it errors
+			// (TX_NOT_FOUND) inside the same SetMinedMulti batch.
+			missing := &chainhash.Hash{0xDE, 0xAD, 0xBE, 0xEF}
+
+			_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash, missing}, utxo.MinedBlockInfo{
+				BlockID: 1, BlockHeight: blockHeight, OnLongestChain: true,
+			})
+			require.Error(t, err, "the missing sibling must surface an error")
+
+			// ...but the tx that did mine must be fully unlocked regardless.
+			require.False(t, recordLocked(t, client, store, txHash, 0), "master of the mined tx must be unlocked")
+			for i := uint32(1); i <= uint32(extras); i++ {
+				require.Falsef(t, recordLocked(t, client, store, txHash, i),
+					"pagination record %d of the successfully-mined tx must be unlocked despite the sibling error (issue #1037)", i)
+			}
+		})
+	}
+}

--- a/stores/utxo/aerospike/set_mined_locked_test.go
+++ b/stores/utxo/aerospike/set_mined_locked_test.go
@@ -197,3 +197,75 @@ func TestSetMinedMultiWithExpressionsClearsLockWhenBlockIDFilteredOut(t *testing
 	require.False(t, recordLocked(t, client, store, txHash, 0),
 		"master must be unlocked even when the blockID filter excludes the write (issue #1037)")
 }
+
+// TestSetMinedMultiHealsAlreadyMinedLockedPaginationRecord reproduces the wedged
+// state observed on the live node: the master is already mined (its blockID is
+// present) but a pagination record is still locked. The legacy IBD loop re-mines
+// the parent's block on every cycle, so a re-mine (SetMinedMulti with a blockID
+// already in the record's list) MUST clear the pagination lock — otherwise the
+// orphan never heals. Covers both store paths.
+func TestSetMinedMultiHealsAlreadyMinedLockedPaginationRecord(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Aerospike integration test in short mode")
+	}
+
+	for _, useExpressions := range []bool{false, true} {
+		name := "lua"
+		if useExpressions {
+			name = "expressions"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := ulogger.NewErrorTestLogger(t)
+			settings := test.CreateBaseTestSettings(t)
+			settings.UtxoStore.UtxoBatchSize = 4
+			settings.Aerospike.EnableSetMinedFilterExpressions = useExpressions
+
+			client, store, _, cleanup := initAerospike(t, settings, logger)
+			defer cleanup()
+
+			cleanDB(t, client)
+
+			const blockHeight = 604314
+			const blockID = 635313
+
+			tx := createTransactionWithOutputs(10) // master + extra records
+			txHash := tx.TxIDChainHash()
+
+			_, err := store.Create(ctx, tx, blockHeight, utxo.WithLocked(true))
+			require.NoError(t, err)
+
+			extras := totalExtraRecs(t, client, store, txHash)
+			require.GreaterOrEqual(t, extras, 1)
+
+			// First mine: blockID becomes present, locks cleared on all records.
+			_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxo.MinedBlockInfo{
+				BlockID: blockID, BlockHeight: blockHeight, OnLongestChain: true,
+			})
+			require.NoError(t, err)
+
+			// Simulate the orphan that survived: a pagination record is locked again
+			// (in production it was never unlocked because the quick-validate unlock
+			// failed to run; here we force the same end-state directly).
+			for i := uint32(1); i <= uint32(extras); i++ {
+				key, kerr := aerospike.NewKey(store.GetNamespace(), store.GetName(), uaerospike.CalculateKeySourceInternal(txHash, i))
+				require.NoError(t, kerr)
+				require.NoError(t, client.PutBins(nil, key, aerospike.NewBin(fields.Locked.String(), true)))
+				require.True(t, recordLocked(t, client, store, txHash, i))
+			}
+
+			// Re-mine with the SAME blockID (already present). This is what the legacy
+			// IBD loop does every cycle; it must heal the pagination lock.
+			_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxo.MinedBlockInfo{
+				BlockID: blockID, BlockHeight: blockHeight, OnLongestChain: true,
+			})
+			require.NoError(t, err)
+
+			for i := uint32(1); i <= uint32(extras); i++ {
+				require.Falsef(t, recordLocked(t, client, store, txHash, i),
+					"pagination record %d must be unlocked after a re-mine with an already-present blockID (issue #1037)", i)
+			}
+		})
+	}
+}

--- a/stores/utxo/aerospike/set_mined_locked_test.go
+++ b/stores/utxo/aerospike/set_mined_locked_test.go
@@ -1,0 +1,199 @@
+package aerospike_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	teranode_aerospike "github.com/bsv-blockchain/teranode/stores/utxo/aerospike"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/uaerospike"
+	"github.com/stretchr/testify/require"
+)
+
+// recordLocked reads the `locked` flag of a single Aerospike record (master =
+// index 0, pagination/extra records = 1..N) for the given transaction.
+func recordLocked(t *testing.T, client *uaerospike.Client, store *teranode_aerospike.Store, txHash *chainhash.Hash, recordIdx uint32) bool {
+	t.Helper()
+
+	keySource := uaerospike.CalculateKeySourceInternal(txHash, recordIdx)
+
+	key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), keySource)
+	require.NoError(t, err)
+
+	rec, err := client.Get(nil, key)
+	require.NoError(t, err)
+	require.NotNil(t, rec, "record %d for %s should exist", recordIdx, txHash.String())
+
+	v, ok := rec.Bins[fields.Locked.String()]
+	if !ok || v == nil {
+		return false // absent ⇒ not locked
+	}
+
+	switch val := v.(type) {
+	case bool:
+		return val
+	case int:
+		return val != 0
+	default:
+		t.Fatalf("unexpected type %T for locked bin", v)
+		return false
+	}
+}
+
+// totalExtraRecs reads the master record's pagination-record count.
+func totalExtraRecs(t *testing.T, client *uaerospike.Client, store *teranode_aerospike.Store, txHash *chainhash.Hash) int {
+	t.Helper()
+
+	key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), uaerospike.CalculateKeySourceInternal(txHash, 0))
+	require.NoError(t, err)
+
+	rec, err := client.Get(nil, key)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	v, ok := rec.Bins[fields.TotalExtraRecs.String()]
+	if !ok || v == nil {
+		return 0
+	}
+
+	n, ok := v.(int)
+	require.True(t, ok, "totalExtraRecs should be an int, got %T", v)
+
+	return n
+}
+
+// TestSetMinedMultiClearsLockOnPaginationRecords is the regression test for
+// issue #1037: a fresh legacy IBD wedged forever with TX_LOCKED because the
+// pagination/extra records of an external transaction kept the `locked` flag
+// that was set at create time (WithLocked(true)). SetMinedMulti only ever cleared
+// the lock on the MASTER record, so a child spending an output that lived on a
+// pagination record (vout >= utxoBatchSize) failed permanently with TX_LOCKED.
+//
+// Mining a transaction makes ALL of its outputs spendable, so after SetMinedMulti
+// every one of its records — master AND pagination — must be unlocked. The test
+// runs for both the Lua UDF path and the filter-expression path.
+func TestSetMinedMultiClearsLockOnPaginationRecords(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Aerospike integration test in short mode")
+	}
+
+	for _, useExpressions := range []bool{false, true} {
+		name := "lua"
+		if useExpressions {
+			name = "expressions"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := ulogger.NewErrorTestLogger(t)
+			settings := test.CreateBaseTestSettings(t)
+
+			// Small batch size so a modest tx spans multiple records (master + extras).
+			settings.UtxoStore.UtxoBatchSize = 4
+			settings.Aerospike.EnableSetMinedFilterExpressions = useExpressions
+
+			client, store, _, cleanup := initAerospike(t, settings, logger)
+			defer cleanup()
+
+			cleanDB(t, client)
+
+			const blockHeight = 604315
+
+			// 10 outputs / batch 4 => master (4) + 2 pagination records (4, 2).
+			tx := createTransactionWithOutputs(10)
+
+			// Create the tx LOCKED — exactly how the quick-validate pipeline and the
+			// validator 2PC create it (WithLocked(true) is applied to every record).
+			_, err := store.Create(ctx, tx, blockHeight, utxo.WithLocked(true))
+			require.NoError(t, err)
+
+			txHash := tx.TxIDChainHash()
+
+			extras := totalExtraRecs(t, client, store, txHash)
+			require.GreaterOrEqual(t, extras, 1, "test requires a paginated tx (at least one extra record)")
+
+			// Precondition: every record starts locked.
+			require.True(t, recordLocked(t, client, store, txHash, 0), "master must start locked")
+			for i := uint32(1); i <= uint32(extras); i++ {
+				require.Truef(t, recordLocked(t, client, store, txHash, i), "extra record %d must start locked", i)
+			}
+
+			// Mine it. This is the documented "mined ⇒ spendable" safety net.
+			_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxo.MinedBlockInfo{
+				BlockID:        1,
+				BlockHeight:    blockHeight,
+				SubtreeIdx:     0,
+				OnLongestChain: true,
+			})
+			require.NoError(t, err)
+
+			// The master was already unlocked by the master-keyed setMined before
+			// this fix; the pagination records are what regressed.
+			require.False(t, recordLocked(t, client, store, txHash, 0), "master must be unlocked after mining")
+			for i := uint32(1); i <= uint32(extras); i++ {
+				require.Falsef(t, recordLocked(t, client, store, txHash, i),
+					"pagination record %d must be unlocked after mining (issue #1037)", i)
+			}
+		})
+	}
+}
+
+// TestSetMinedMultiWithExpressionsClearsLockWhenBlockIDFilteredOut covers the
+// filter-gating bug in the expression path: SetMinedMultiWithExpressions gates the
+// whole batch write (including the Locked=false op) behind a "blockID not already
+// present" filter. When the blockID is already in the record's list the write is
+// FILTERED_OUT and the lock-clear is skipped. A mined transaction must be
+// spendable regardless, so the master lock must be cleared even on the filtered
+// path.
+func TestSetMinedMultiWithExpressionsClearsLockWhenBlockIDFilteredOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Aerospike integration test in short mode")
+	}
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	settings := test.CreateBaseTestSettings(t)
+	settings.Aerospike.EnableSetMinedFilterExpressions = true
+
+	client, store, _, cleanup := initAerospike(t, settings, logger)
+	defer cleanup()
+
+	cleanDB(t, client)
+
+	const blockHeight = 604315
+	const blockID = 7
+
+	tx := createTransactionWithOutputs(2) // single (master) record is enough here
+	txHash := tx.TxIDChainHash()
+
+	_, err := store.Create(ctx, tx, blockHeight, utxo.WithLocked(true))
+	require.NoError(t, err)
+
+	// First mine: blockID not yet present => filter passes => lock cleared, blockID added.
+	_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxo.MinedBlockInfo{
+		BlockID: blockID, BlockHeight: blockHeight, OnLongestChain: true,
+	})
+	require.NoError(t, err)
+	require.False(t, recordLocked(t, client, store, txHash, 0), "master unlocked after first mine")
+
+	// Re-lock just the master, simulating an orphaned lock that survived while the
+	// record already carries this blockID.
+	masterKey, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), uaerospike.CalculateKeySourceInternal(txHash, 0))
+	require.NoError(t, err)
+	require.NoError(t, client.PutBins(nil, masterKey, aerospike.NewBin(fields.Locked.String(), true)))
+	require.True(t, recordLocked(t, client, store, txHash, 0), "master re-locked")
+
+	// Second mine with the SAME blockID: the durable list already contains it, so
+	// the main write is FILTERED_OUT. The lock-clear must still happen.
+	_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxo.MinedBlockInfo{
+		BlockID: blockID, BlockHeight: blockHeight, OnLongestChain: true,
+	})
+	require.NoError(t, err)
+	require.False(t, recordLocked(t, client, store, txHash, 0),
+		"master must be unlocked even when the blockID filter excludes the write (issue #1037)")
+}

--- a/stores/utxo/aerospike/teranode.go
+++ b/stores/utxo/aerospike/teranode.go
@@ -72,7 +72,7 @@ import (
 var teranodeLUA []byte
 
 var (
-	LuaPackage      = "teranode_v59" // N.B. Do not have any "." in this string
+	LuaPackage      = "teranode_v60" // N.B. Do not have any "." in this string
 	LuaPackageMined = LuaPackage + "_mined"
 )
 

--- a/stores/utxo/aerospike/teranode.lua
+++ b/stores/utxo/aerospike/teranode.lua
@@ -676,6 +676,16 @@ function setMined(rec, blockID, blockHeight, subtreeIdx, currentBlockHeight, blo
     -- a child spending an output that lives on a pagination record (vout >=
     -- utxoBatchSize) would fail permanently with TX_LOCKED. The client clears the
     -- pagination records using this count.
+    --
+    -- INVARIANT: this is the SAME value the DAH-signal branch above may already
+    -- have written to FIELD_CHILD_COUNT. setDeleteAtHeight returns its childCount
+    -- as exactly rec[BIN_TOTAL_EXTRA_RECS] (and only for external records, which
+    -- are the ones that have pagination records), so the two are always equal and
+    -- this unconditional overwrite is consistent. We overwrite unconditionally
+    -- because the DAH signal only fires on a DAH transition, whereas the lock-clear
+    -- must happen on every mine. If setDeleteAtHeight's childCount ever stops
+    -- meaning totalExtraRecs, THIS overwrite is the source of truth for the
+    -- lock-clear and must keep using totalExtraRecs.
     if not unsetMined then
         local totalExtraRecs = rec[BIN_TOTAL_EXTRA_RECS]
         if totalExtraRecs and totalExtraRecs > 0 then

--- a/stores/utxo/aerospike/teranode.lua
+++ b/stores/utxo/aerospike/teranode.lua
@@ -667,6 +667,22 @@ function setMined(rec, blockID, blockHeight, subtreeIdx, currentBlockHeight, blo
         end
     end
 
+    -- #1037: On a mine, always surface the pagination/extra-record count so the
+    -- client can clear the `locked` flag on the pagination records too. This UDF
+    -- runs on (and can only mutate) the master record, so the lock-clear above
+    -- only affects the master. For an external/paginated tx, any pagination
+    -- record left locked (e.g. created WithLocked(true) by quick-validate or the
+    -- validator 2PC, whose unlock then never ran) would stay locked forever, and
+    -- a child spending an output that lives on a pagination record (vout >=
+    -- utxoBatchSize) would fail permanently with TX_LOCKED. The client clears the
+    -- pagination records using this count.
+    if not unsetMined then
+        local totalExtraRecs = rec[BIN_TOTAL_EXTRA_RECS]
+        if totalExtraRecs and totalExtraRecs > 0 then
+            response[FIELD_CHILD_COUNT] = totalExtraRecs
+        end
+    end
+
     return response
 end
 


### PR DESCRIPTION
## Summary

Fixes #1037 — fresh legacy IBD wedges forever at testnet block 604,315 with `TX_LOCKED` on two parent UTXOs that read as unlocked.

**Root cause:** `SetMinedMulti` (the "mined ⇒ spendable" safety net) only cleared the `locked` flag on the **master** UTXO record. For external/paginated transactions (>`utxoBatchSize` outputs) the **pagination/extra records kept `locked=true` forever**, so a child spending an output that lives on a pagination record (vout ≥ `utxoBatchSize`) failed permanently with `TX_LOCKED`.

### Causal chain (verified on the wedged node)

1. A tx is created `WithLocked(true)` on **every** record (master + pagination) by the block-validation quick-validate pipeline (`quick_validate.go:1147`) and the validator 2PC.
2. The child-aware unlock (`SetLocked(false)`, which recurses into pagination records) only runs on success. `quick_validate.go:440-443` documents that on error the unlock is **never called**; recovery is expected from `SetMinedMulti` on retry (block 604,314 = internal id 635313 fails at `SetMinedMulti`, then permanently at block-add `BLOCK_EXISTS`, so the unlock never runs).
3. `SetMinedMulti` (lua `setMined` UDF `teranode.lua:647` and the Go expression batch `set_mined_expressions.go:276`) is keyed on `hash[:]` = **master only**, so the documented recovery never touches the pagination records.

Live `aerospikereader` on both stuck parents:

| record | `locked` | generation |
|---|---|---|
| master (vouts 0–511) | `false` | 15 |
| extra rec 1 (vouts 512+) | `true` | 2 |

Children spend `cdb5409c…` **vout 827** and `1519b4cd…` **vout 575** — both `>512`, both on the locked pagination record. The master reads unlocked while `SPEND_BATCH_LUA` reports the parent locked. Node runs the lua path (`EnableSetMinedFilterExpressions=false`).

## Fix

`SetMinedMulti` now clears `locked` on **all** of a mined tx's records, restoring the documented invariant.

- `teranode.lua` `setMined` surfaces `totalExtraRecs` as `childCount` on every mine so the client knows how many pagination records to unlock. **Lua version bumped `v59`→`v60`** so the UDF re-registers on startup.
- New `clearLockedOnRecordsMulti` helper (unfiltered `UPDATE_ONLY` `Locked=false`, tolerant of `KEY_NOT_FOUND`) clears pagination records. The lock-clearing follow-up is returned from the result processors as a `lockClearWork` value and executed by the public `SetMinedMulti` / `SetMinedMultiWithExpressions` methods (`applyLockClearWork`), so the processors do no follow-up I/O and stay unit-testable.
- Expression path, **FILTERED_OUT** records (blockID already present, where the filter skips the whole write incl. `Locked=false` and the reads): fully unlocked via `SetLocked(false)`, which reads the child count from the master and clears every record. Closes the filter-gating bug.

## Testing

- `go build ./...`, `go vet ./stores/utxo/aerospike/`, `gofmt -l`: clean.
- Regression tests (`set_mined_locked_test.go`, lua + expression paths):
  - `TestSetMinedMultiClearsLockOnPaginationRecords` — mine clears all records.
  - `TestSetMinedMultiWithExpressionsClearsLockWhenBlockIDFilteredOut` — master unlocked on a FILTERED_OUT write.
  - `TestSetMinedMultiHealsAlreadyMinedLockedPaginationRecord` — re-mine of an already-mined tx whose pagination record is still locked heals it (this **failed on the expression path** before the FILTERED_OUT fix).
- Full `stores/utxo/aerospike` package suite: `ok`.

## Deploy / remediation — important

This fix is triggered by `SetMinedMulti`. It **prevents** the permanent lock and **heals an orphan whenever `SetMinedMulti` re-runs on the affected tx** (i.e. while its block is (re)processed during IBD).

It does **not** passively heal an instance that is already wedged with the affected block as the **accepted tip**: on such a node only the failing block (604,315) loops, its parents' block (604,314) is never reprocessed, so `SetMinedMulti` is never called on the parents and nothing clears the stale pagination lock. To clear an already-wedged instance, do one of:

- **Reset + resync** (simplest). On a fresh sync the parents' block is processed under the new code, so the create→fail→retry→`SetMinedMulti` path heals the orphan as the block is applied — no permanent wedge.
- **Force-reprocess the parents' block** without a full resync: `invalidateblock <604314 hash>` then `reconsiderblock <604314 hash>`, which re-runs `SetMinedMulti` on the parents and clears the pagination locks.

Requires the **v60 bump** (included) so the UDF re-registers on startup.

Server investigation was read-only (`docker ps/inspect/logs`, `asinfo`, `aerospikereader`, `getfsmstate`, settings dump) — no writes, no FSM changes, no restarts.