### PR TITLE
fix(util): clamp SafeSetLimit to a safe default instead of panicking on 0

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -668,7 +668,7 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 	}
 
 	g := new(errgroup.Group)
-	util.SafeSetLimit(g, concurrency)
+	util.SafeSetLimit(logger, g, concurrency)
 
 	transactionCountUint32, err := safeconversion.Uint64ToUint32(b.TransactionCount)
 	if err != nil {
@@ -813,7 +813,7 @@ func (b *Block) validOrderAndBlessed(ctx context.Context, logger ulogger.Logger,
 
 	concurrency := b.getValidationConcurrency(validOrderAndBlessedConcurrency)
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, concurrency)
+	util.SafeSetLimit(logger, g, concurrency)
 
 	for sIdx := 0; sIdx < len(b.SubtreeSlices); sIdx++ {
 		subtree := b.SubtreeSlices[sIdx]
@@ -897,7 +897,7 @@ func (b *Block) checkParentsExistOnChain(ctx context.Context, logger ulogger.Log
 
 	// check all the parent transactions in parallel, this allows us to batch read from the txMetaStore
 	parentG := new(errgroup.Group)
-	util.SafeSetLimit(parentG, 1024*32)
+	util.SafeSetLimit(logger, parentG, 1024*32)
 
 	for _, parentTxStruct := range checkParentTxHashes {
 		parentTxStruct := parentTxStruct
@@ -1205,7 +1205,7 @@ func (b *Block) GetAndValidateSubtrees(ctx context.Context, logger ulogger.Logge
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, concurrency)
+	util.SafeSetLimit(logger, g, concurrency)
 	// we have the hashes. Get the actual subtrees from the subtree store
 	for i, subtreeHash := range b.Subtrees {
 		i := i

--- a/model/update-tx-mined.go
+++ b/model/update-tx-mined.go
@@ -212,7 +212,7 @@ func updateTxMinedStatus(ctx context.Context, logger ulogger.Logger, tSettings *
 	maxMinedBatchSize := tSettings.UtxoStore.MaxMinedBatchSize
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, tSettings.UtxoStore.MaxMinedRoutines)
+	util.SafeSetLimit(logger, g, tSettings.UtxoStore.MaxMinedRoutines)
 
 	var (
 		blockInvalidError   error

--- a/services/asset/httpimpl/GetTransactions.go
+++ b/services/asset/httpimpl/GetTransactions.go
@@ -131,7 +131,7 @@ func (h *HTTP) GetTransactions() func(c echo.Context) error {
 
 		// Read the body into a 32 byte hashes one by one and stream the tx data back to the client
 		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, 1024)
+		util.SafeSetLimit(h.logger, g, 1024)
 
 		responseBytes := make([]byte, 0, 32*1024*1024) // 32MB initial capacity
 		responseBytesMu := sync.Mutex{}

--- a/services/asset/httpimpl/GetUTXOs.go
+++ b/services/asset/httpimpl/GetUTXOs.go
@@ -114,7 +114,7 @@ func (h *HTTP) GetUTXOs(mode ReadMode) func(c echo.Context) error {
 		results := make([]*utxo.SpendResponse, numRecords)
 
 		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, utxosFanoutLimit)
+		util.SafeSetLimit(h.logger, g, utxosFanoutLimit)
 
 		for i := 0; i < numRecords; i++ {
 			recOffset := i * utxosRequestRecordSize

--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -353,7 +353,7 @@ func (repo *Repository) scheduleSubtreeChunkFetches(ctx context.Context, subtree
 	defer cancel()
 
 	g, gCtx := errgroup.WithContext(fetchCtx)
-	util.SafeSetLimit(g, concurrency)
+	util.SafeSetLimit(repo.logger, g, concurrency)
 
 	var readErr error
 	for chunkIdx, offset := 0, 0; offset < totalTxs; chunkIdx, offset = chunkIdx+1, offset+chunkSize {
@@ -503,7 +503,7 @@ func (repo *Repository) getTxs(ctx context.Context, txHashes []chainhash.Hash, t
 	processSubtreeConcurrency := repo.settings.BlockValidation.ProcessTxMetaUsingStoreConcurrency
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, processSubtreeConcurrency)
+	util.SafeSetLimit(repo.logger, g, processSubtreeConcurrency)
 
 	var missed atomic.Int32
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1478,7 +1478,7 @@ func (stp *SubtreeProcessor) getConflictingNodes(ctx context.Context, block *mod
 	conflictingNodesMu := sync.Mutex{}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, stp.settings.BlockAssembly.MoveBackBlockConcurrency)
+	util.SafeSetLimit(stp.logger, g, stp.settings.BlockAssembly.MoveBackBlockConcurrency)
 
 	// get the conflicting transactions from the block subtrees
 	for _, subtreeHash := range block.Subtrees {
@@ -3525,7 +3525,7 @@ func (stp *SubtreeProcessor) checkMarkNotOnLongestChain(ctx context.Context, inv
 	// both MaxMinedRoutines and GetBatcherSize at 0) rather than letting g.Go
 	// deadlock on a zero-capacity semaphore. With defaults (MaxMinedRoutines=128)
 	// this is always >= 1.
-	util.SafeSetLimit(g, max(stp.settings.UtxoStore.MaxMinedRoutines, stp.settings.UtxoStore.GetBatcherSize*2))
+	util.SafeSetLimit(stp.logger, g, max(stp.settings.UtxoStore.MaxMinedRoutines, stp.settings.UtxoStore.GetBatcherSize*2))
 
 	// we need to check each transaction in the block we moved back and see if it is still on the longest chain or not
 	for idx, hash := range markNotOnLongestChain {
@@ -3850,7 +3850,7 @@ func (stp *SubtreeProcessor) moveBackBlockGetSubtrees(ctx context.Context, block
 	defer deferFn()
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, stp.settings.BlockAssembly.MoveBackBlockConcurrency)
+	util.SafeSetLimit(stp.logger, g, stp.settings.BlockAssembly.MoveBackBlockConcurrency)
 
 	// get all the subtrees in parallel
 	subtreesNodes := make([][]subtreepkg.Node, len(block.Subtrees))
@@ -4772,7 +4772,7 @@ func (stp *SubtreeProcessor) processRemainderTxHashes(ctx context.Context, chain
 	// clean out the transactions from the old current subtree that were in the block
 	// and add the remainderSubtreeNodes to the new current subtree
 	g, _ := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, stp.settings.BlockAssembly.ProcessRemainderTxHashesConcurrency)
+	util.SafeSetLimit(stp.logger, g, stp.settings.BlockAssembly.ProcessRemainderTxHashesConcurrency)
 
 	// we need to process this in order, so we first process all subtrees in parallel, but keeping the order
 	remainderSubtrees := make([][]subtreepkg.Node, len(chainedSubtrees))
@@ -5052,7 +5052,7 @@ func (stp *SubtreeProcessor) parallelBuildRemainderSubtrees(ctx context.Context,
 	// chunk's ~100 ms of post-cancel work, which is below the typical block-
 	// movement wall-time floor.
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, stp.settings.BlockAssembly.ProcessRemainderTxHashesConcurrency)
+	util.SafeSetLimit(stp.logger, g, stp.settings.BlockAssembly.ProcessRemainderTxHashesConcurrency)
 
 	for i := range chunks {
 		i := i
@@ -5268,7 +5268,7 @@ func (stp *SubtreeProcessor) bucketShardedGetAndSetIfNotExists(
 	// gather parents from the old map, bulk-insert into the new map. No two
 	// goroutines ever touch the same destination bucket.
 	g, _ := errgroup.WithContext(context.Background())
-	util.SafeSetLimit(g, concurrencyLimit)
+	util.SafeSetLimit(stp.logger, g, concurrencyLimit)
 
 	for b := uint16(0); b < nrOfBuckets; b++ {
 		indices := perBucket[b]
@@ -5442,7 +5442,7 @@ func (stp *SubtreeProcessor) CreateTransactionMap(ctx context.Context, blockSubt
 	conflictingNodesPerSubtree := make([][]chainhash.Hash, totalSubtreesInBlock)
 
 	g, ctx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, concurrentSubtreeReads)
+	util.SafeSetLimit(stp.logger, g, concurrentSubtreeReads)
 
 	// get all the subtrees from the block that we have not yet cleaned out
 	for subtreeHash, subtreeIdx := range blockSubtreesMap {
@@ -5570,7 +5570,7 @@ func (stp *SubtreeProcessor) markConflictingTxsInSubtrees(ctx context.Context, l
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, stp.settings.BlockAssembly.MoveBackBlockConcurrency)
+	util.SafeSetLimit(stp.logger, g, stp.settings.BlockAssembly.MoveBackBlockConcurrency)
 
 	// mark all the losing txs in the subtrees in the blocks they were mined into as conflicting
 	for blockID, txHashes := range blockIdsMap {

--- a/services/blockpersister/persist_block.go
+++ b/services/blockpersister/persist_block.go
@@ -102,7 +102,7 @@ func (u *Server) persistBlock(ctx context.Context, hash *chainhash.Hash, blockBy
 		u.logger.Infof("[persistBlock][%s] Phase 1: Creating %d subtreeData files", block.String(), len(block.Subtrees))
 
 		g1, gCtx1 := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g1, concurrency)
+		util.SafeSetLimit(u.logger, g1, concurrency)
 
 		for i, subtreeHash := range block.Subtrees {
 			subtreeHash := subtreeHash

--- a/services/blockpersister/processTxMetaUsingStore.go
+++ b/services/blockpersister/processTxMetaUsingStore.go
@@ -55,7 +55,7 @@ func (u *Server) processTxMetaUsingStore(ctx context.Context, subtree *subtreepk
 	validateSubtreeInternalConcurrency := subtreepkg.Max(4, runtime.NumCPU()*2)
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, validateSubtreeInternalConcurrency)
+	util.SafeSetLimit(u.logger, g, validateSubtreeInternalConcurrency)
 
 	var (
 		subtreeLen = subtree.Length()

--- a/services/blockpersister/streaming_process_subtree.go
+++ b/services/blockpersister/streaming_process_subtree.go
@@ -123,7 +123,7 @@ func (u *Server) CreateSubtreeDataFileStreaming(ctx context.Context, subtreeHash
 	concurrency := subtreepkg.Max(4, runtime.NumCPU()/2)
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, concurrency)
+	util.SafeSetLimit(u.logger, g, concurrency)
 
 	subtreeLen := subtree.Length()
 

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -268,7 +268,7 @@ func New(
 
 	// TEMP limit to 1, to prevent multiple subtrees processing at the same time
 	subtreeGroup := errgroup.Group{}
-	util.SafeSetLimit(&subtreeGroup, tSettings.BlockValidation.SubtreeGroupConcurrency)
+	util.SafeSetLimit(logger, &subtreeGroup, tSettings.BlockValidation.SubtreeGroupConcurrency)
 
 	// Initialize circuit breakers for peer management
 	cbConfig := &catchup.CircuitBreakerConfig{

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -930,7 +930,7 @@ func (u *BlockValidation) unlockSubtreeTransactions(ctx context.Context, subtree
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, 128)
+	util.SafeSetLimit(u.logger, g, 128)
 
 	for subtreeIdx, subtree := range subtrees {
 		if subtree == nil || len(subtree.Nodes) == 0 {
@@ -1046,7 +1046,7 @@ func (u *BlockValidation) processSubtreeBatch(
 
 	readerCtx, cancelReaders := context.WithCancel(ctx)
 	g, gCtx := errgroup.WithContext(readerCtx)
-	util.SafeSetLimit(g, 128)
+	util.SafeSetLimit(u.logger, g, 128)
 
 	for i := 0; i < batchSize; i++ {
 		globalIdx := batchStart + i
@@ -1151,7 +1151,7 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 	// Set concurrency to 8x StoreBatcherSize to allow sufficient parallelism while the
 	// UTXO store batches operations internally. This multiplier balances throughput with
 	// resource usage, allowing multiple batches to be in flight simultaneously.
-	util.SafeSetLimit(createG, u.settings.UtxoStore.StoreBatcherSize*8)
+	util.SafeSetLimit(u.logger, createG, u.settings.UtxoStore.StoreBatcherSize*8)
 
 	// Track transactions that already exist so we can update their mined info
 	var existingTxsMu sync.Mutex
@@ -1205,7 +1205,7 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 
 	// Phase 2: Spend all transactions in parallel
 	spendG, spendCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(spendG, u.settings.UtxoStore.SpendBatcherSize*u.settings.UtxoStore.SpendBatcherConcurrency*2)
+	util.SafeSetLimit(u.logger, spendG, u.settings.UtxoStore.SpendBatcherSize*u.settings.UtxoStore.SpendBatcherConcurrency*2)
 
 	for _, tx := range batch.batchTxs {
 		tx := tx
@@ -1233,7 +1233,7 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 //   - error: If file writing fails
 func (u *BlockValidation) writeSubtreeFilesForBatch(ctx context.Context, block *model.Block, batch *SubtreeProcessingBatch) error {
 	writeG, writeCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(writeG, u.settings.BlockValidation.SubtreeBatchWriteConcurrency)
+	util.SafeSetLimit(u.logger, writeG, u.settings.BlockValidation.SubtreeBatchWriteConcurrency)
 
 	batchSize := batch.batchEnd - batch.batchStart
 	for i := 0; i < batchSize; i++ {
@@ -1270,7 +1270,7 @@ func (u *BlockValidation) writeSubtreeFilesForBatch(ctx context.Context, block *
 func (u *BlockValidation) buildSubtreeJobsForBatch(ctx context.Context, block *model.Block, batch *SubtreeProcessingBatch, writeJobsChan chan<- *SubtreeWriteJob) error {
 	// Build subtrees in parallel (CPU-bound work)
 	buildG, buildCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(buildG, u.settings.BlockValidation.SubtreeBatchWriteConcurrency)
+	util.SafeSetLimit(u.logger, buildG, u.settings.BlockValidation.SubtreeBatchWriteConcurrency)
 
 	batchSize := batch.batchEnd - batch.batchStart
 	jobs := make([]*SubtreeWriteJob, batchSize)
@@ -1357,7 +1357,7 @@ func (u *BlockValidation) prefetchSubtreeBatch(
 
 	readerCtx, cancelReaders := context.WithCancel(ctx)
 	g, gCtx := errgroup.WithContext(readerCtx)
-	util.SafeSetLimit(g, 128)
+	util.SafeSetLimit(u.logger, g, 128)
 
 	for i := 0; i < batchSize; i++ {
 		globalIdx := batchStart + i

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -496,7 +496,7 @@ func (sm *SyncManager) writeSubtree(ctx context.Context, block *bsvutil.Block, s
 
 	g, gCtx := errgroup.WithContext(ctx)
 	// Limit to 3 concurrent writes (subtree, subtreeData, subtreeMeta)
-	util.SafeSetLimit(g, 3)
+	util.SafeSetLimit(sm.logger, g, 3)
 
 	g.Go(func() error {
 		subtreeBytes, err := subtree.Serialize()
@@ -914,7 +914,7 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 	storeBatcherConcurrency := sm.settings.Legacy.StoreBatcherConcurrency
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, storeBatcherSize*storeBatcherConcurrency) // we limit the number of concurrent requests, to not overload Aerospike
+	util.SafeSetLimit(sm.logger, g, storeBatcherSize*storeBatcherConcurrency) // we limit the number of concurrent requests, to not overload Aerospike
 
 	blockHeightUint32, err := safeconversion.Int32ToUint32(block.Height())
 	if err != nil {
@@ -1118,7 +1118,7 @@ func (sm *SyncManager) PreValidateTransactions(ctx context.Context, txMap *txmap
 		}
 
 		g, _ := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, concurrencyLimit)
+		util.SafeSetLimit(sm.logger, g, concurrencyLimit)
 
 		var (
 			mu           sync.Mutex
@@ -1306,7 +1306,7 @@ func (sm *SyncManager) validateTransactions(ctx context.Context, maxLevel uint32
 		} else {
 			// process all the transactions on a certain level in parallel
 			g, gCtx := errgroup.WithContext(ctx)
-			util.SafeSetLimit(g, spendBatcherSize*spendBatcherConcurrency) // we limit the number of concurrent requests, to not overload Aerospike
+			util.SafeSetLimit(sm.logger, g, spendBatcherSize*spendBatcherConcurrency) // we limit the number of concurrent requests, to not overload Aerospike
 
 			for txIdx := range blockTxsPerLevel[i] {
 				txIdx := txIdx
@@ -1363,7 +1363,7 @@ func (sm *SyncManager) extendTransactions(ctx context.Context, block *bsvutil.Bl
 	// are populated independently; this phase reads same-block parent outputs
 	// immediately and does not wait for the parent transaction to be extended first.
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, outpointBatcherSize)
+	util.SafeSetLimit(sm.logger, g, outpointBatcherSize)
 
 	// Blocks always include a coinbase, but guard against 0-tx edge cases
 	// (malformed/test blocks) where len-1 would produce a negative capacity.
@@ -1743,7 +1743,7 @@ func (sm *SyncManager) ExtendTransaction(ctx context.Context, tx *bt.Tx, txMap *
 	g := errgroup.Group{}
 	// Limit goroutines to number of CPU cores to prevent scheduler thrashing
 	// This prevents spawning thousands of goroutines for transactions with many inputs
-	util.SafeSetLimit(&g, runtime.NumCPU()*2)
+	util.SafeSetLimit(sm.logger, &g, runtime.NumCPU()*2)
 
 	for i, input := range tx.Inputs {
 		i := i         // capture the loop variable

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -1217,7 +1217,7 @@ func (u *Server) processMissingTransactions(ctx context.Context, subtreeHash cha
 
 	for level := uint32(0); level <= maxLevel; level++ {
 		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, u.settings.SubtreeValidation.SpendBatcherSize*2)
+		util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.SpendBatcherSize*2)
 
 		u.logger.Debugf("[processMissingTransactions][%s] processing level %d/%d with %d transactions", subtreeHash.String(), level+1, maxLevel+1, len(txsPerLevel[level]))
 
@@ -1947,7 +1947,7 @@ func (u *Server) getMissingTransactionsFromPeer(ctx context.Context, subtreeHash
 	getMissingTransactionsConcurrency := u.settings.SubtreeValidation.GetMissingTransactions
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, getMissingTransactionsConcurrency) // keep 32 cores free for other tasks
+	util.SafeSetLimit(u.logger, g, getMissingTransactionsConcurrency) // keep 32 cores free for other tasks
 
 	// get the transactions in batches of 500
 	batchSize := u.settings.SubtreeValidation.MissingTransactionsBatchSize

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -98,7 +98,7 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 	// concurrency at CheckBlockSubtreesConcurrency keeps the burst predictable.
 	subtreeMissing := make([]bool, len(block.Subtrees))
 	existsGroup, existsCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(existsGroup, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
+	util.SafeSetLimit(u.logger, existsGroup, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
 
 	for idx, subtreeHash := range block.Subtrees {
 		idx := idx
@@ -253,7 +253,7 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 		subtreeTxs := make([][]*bt.Tx, len(batchSubtrees))
 		batchArenas := make([]*bt.Arena, len(batchSubtrees))
 		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
+		util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
 
 		for subtreeIdx, subtreeHash := range batchSubtrees {
 			subtreeHash := subtreeHash
@@ -652,7 +652,7 @@ func (u *Server) validateMissingSubtreesWithOrderedRetry(
 	failedParallel := make([]bool, len(missingSubtrees))
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
+	util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
 
 	for i, subtreeHash := range missingSubtrees {
 		i, subtreeHash := i, subtreeHash
@@ -734,7 +734,7 @@ func (u *Server) validateMissingSubtreesWithOrderedRetryAccumulated(
 	subtreeDeltas := make([]map[chainhash.Hash]*validator.ParentTxMetadata, len(missingSubtrees))
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
+	util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
 
 	// Single shared read-only snapshot of the live accumulator. All Phase 2
 	// goroutines reference this same map for reads; writes go to per-subtree
@@ -1194,7 +1194,7 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 
 		// Process all transactions at this level in parallel
 		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, u.settings.SubtreeValidation.SpendBatcherSize*2)
+		util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.SpendBatcherSize*2)
 
 		for _, mTx := range levelTxs {
 			tx := mTx.tx

--- a/services/subtreevalidation/processTxMetaUsingCache.go
+++ b/services/subtreevalidation/processTxMetaUsingCache.go
@@ -45,7 +45,7 @@ func (u *Server) processTxMetaUsingCache(ctx context.Context, txHashes []chainha
 	missingTxThreshold := u.settings.SubtreeValidation.ProcessTxMetaUsingCacheMissingTxThreshold
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, validateSubtreeInternalConcurrency)
+	util.SafeSetLimit(u.logger, g, validateSubtreeInternalConcurrency)
 
 	cache, ok := u.utxoStore.(*txmetacache.TxMetaCache)
 	if !ok {

--- a/services/subtreevalidation/processTxMetaUsingStore.go
+++ b/services/subtreevalidation/processTxMetaUsingStore.go
@@ -83,7 +83,7 @@ func (u *Server) processTxMetaUsingStore(ctx context.Context, txHashes []chainha
 	missingTxThreshold := u.settings.BlockValidation.ProcessTxMetaUsingStoreMissingTxThreshold
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, validateSubtreeInternalConcurrency)
+	util.SafeSetLimit(u.logger, g, validateSubtreeInternalConcurrency)
 
 	var missed atomic.Int32
 

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -874,7 +874,7 @@ func (v *Validator) twoPhaseCommitTransaction(ctx context.Context, tx *bt.Tx, tx
 func (v *Validator) getUtxoBlockHeightsAndExtendTx(ctx context.Context, tx *bt.Tx, txID string, validationOptions *Options) ([]uint32, error) {
 	// get the block heights of the input transactions of the transaction
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, v.settings.UtxoStore.GetBatcherSize)
+	util.SafeSetLimit(v.logger, g, v.settings.UtxoStore.GetBatcherSize)
 
 	parentTxHashes := make(map[chainhash.Hash][]int)
 	utxoHeights := make([]uint32, len(tx.Inputs))

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -737,7 +737,7 @@ func (t *TxMetaCache) RemoveBlockIDs(ctx context.Context, removals []utxo.BlockI
 //     the actual store update happens before this method is invoked.
 func (t *TxMetaCache) setMinedInCacheParallel(ctx context.Context, hashes []*chainhash.Hash, _ uint32) error {
 	g := new(errgroup.Group)
-	util.SafeSetLimit(g, 100)
+	util.SafeSetLimit(t.logger, g, 100)
 
 	for _, hash := range hashes {
 		hash := hash

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -1261,7 +1261,7 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 // not the goroutine count, since producers are mostly parked on errChan receives.
 func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) error {
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, s.settings.UtxoStore.OutpointBatcherSize)
+	util.SafeSetLimit(s.logger, g, s.settings.UtxoStore.OutpointBatcherSize)
 
 	for _, tx := range txs {
 		tx := tx

--- a/stores/utxo/aerospike/get_test.go
+++ b/stores/utxo/aerospike/get_test.go
@@ -330,7 +330,7 @@ func ProcessTx(ctx context.Context, txStore blob.Store, b *bitcoin.Bitcoind, s *
 	blockHeight uint32, parentTxs *map[string]struct{}) (err error) {
 
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, 32)
+	util.SafeSetLimit(ulogger.TestLogger{}, g, 32)
 
 	parentTxsMu := sync.Mutex{}
 

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -601,7 +601,7 @@ func (s *Service) partitionWorker(
 	var mu sync.Mutex
 
 	chunkGroup := &errgroup.Group{}
-	util.SafeSetLimit(chunkGroup, s.chunkGroupLimit)
+	util.SafeSetLimit(s.logger, chunkGroup, s.chunkGroupLimit)
 
 	submitChunk := func(chunkToProcess []*aerospike.Result) {
 		chunkGroup.Go(func() error {

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -4025,7 +4025,7 @@ func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) 
 
 	var missingInputs atomic.Int64
 	g, gCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(g, concurrency)
+	util.SafeSetLimit(s.logger, g, concurrency)
 
 	for chunkStart := 0; chunkStart < len(pairs); chunkStart += chunkSize {
 		chunkEnd := chunkStart + chunkSize

--- a/util/safe_set_limit.go
+++ b/util/safe_set_limit.go
@@ -1,20 +1,29 @@
 package util
 
-import "golang.org/x/sync/errgroup"
+import (
+	"runtime"
 
-// SafeSetLimit safely sets the limit on an errgroup.Group, ensuring the limit
-// is not zero to prevent a panic. It panics if the limit is 0, which would
-// indicate a programming error as errgroup.SetLimit(0) panics.
+	"golang.org/x/sync/errgroup"
+)
+
+// SafeSetLimit sets the active-goroutine limit on an errgroup.Group, guarding
+// against an invalid limit.
+//
+// errgroup.SetLimit(0) creates a zero-capacity semaphore, which leaves the
+// group unable to ever start a goroutine — every subsequent Go call blocks
+// forever. A zero (or negative) limit reaching this helper is therefore almost
+// always a configuration mistake (e.g. a *Concurrency setting left at 0). These
+// call sites all want a bounded-but-positive number of workers, so rather than
+// panic or deadlock, SafeSetLimit falls back to a safe default of
+// runtime.NumCPU() whenever the requested limit is less than 1.
 //
 // Parameters:
 //   - g: The errgroup.Group to set the limit on
-//   - limit: The maximum number of goroutines that can be active at once (must be > 0)
-//
-// Panics:
-//   - If limit is 0, as this would cause errgroup.SetLimit to panic
+//   - limit: The maximum number of goroutines active at once; values < 1 fall
+//     back to runtime.NumCPU().
 func SafeSetLimit(g *errgroup.Group, limit int) {
-	if limit == 0 {
-		panic("limit cannot be 0")
+	if limit < 1 {
+		limit = runtime.NumCPU()
 	}
 
 	g.SetLimit(limit)

--- a/util/safe_set_limit.go
+++ b/util/safe_set_limit.go
@@ -3,6 +3,7 @@ package util
 import (
 	"runtime"
 
+	"github.com/bsv-blockchain/teranode/ulogger"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -17,13 +18,20 @@ import (
 // panic or deadlock, SafeSetLimit falls back to a safe default of
 // runtime.NumCPU() whenever the requested limit is less than 1.
 //
+// The fallback is logged at WARN so the underlying misconfiguration is never
+// silent — the system stays up, but the bad setting is still visible.
+//
 // Parameters:
+//   - logger: used to warn when the limit is clamped to the default
 //   - g: The errgroup.Group to set the limit on
 //   - limit: The maximum number of goroutines active at once; values < 1 fall
 //     back to runtime.NumCPU().
-func SafeSetLimit(g *errgroup.Group, limit int) {
+func SafeSetLimit(logger ulogger.Logger, g *errgroup.Group, limit int) {
 	if limit < 1 {
-		limit = runtime.NumCPU()
+		def := runtime.NumCPU()
+		logger.Warnf("SafeSetLimit: limit %d < 1, clamping to runtime.NumCPU()=%d", limit, def)
+
+		limit = def
 	}
 
 	g.SetLimit(limit)

--- a/util/safe_set_limit_test.go
+++ b/util/safe_set_limit_test.go
@@ -1,40 +1,53 @@
 package util
 
 import (
+	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
 func TestSafeSetLimit(t *testing.T) {
+	// runAll launches n trivial goroutines on g and asserts they all run to
+	// completion. If SafeSetLimit had left a zero-capacity limit, Go would block
+	// forever and the test would hang (caught by the go test timeout).
+	runAll := func(t *testing.T, g *errgroup.Group, n int) {
+		t.Helper()
+
+		var counter atomic.Int32
+
+		for i := 0; i < n; i++ {
+			g.Go(func() error {
+				counter.Add(1)
+				return nil
+			})
+		}
+
+		require.NoError(t, g.Wait())
+		require.Equal(t, int32(n), counter.Load())
+	}
+
 	t.Run("valid positive limit", func(t *testing.T) {
 		g := &errgroup.Group{}
 
-		// Should not panic
-		SafeSetLimit(g, 1)
-		SafeSetLimit(g, 10)
-		SafeSetLimit(g, 100)
+		SafeSetLimit(g, 2)
+		runAll(t, g, 5)
 	})
 
-	t.Run("zero limit panics", func(t *testing.T) {
+	t.Run("zero limit falls back to a usable default", func(t *testing.T) {
 		g := &errgroup.Group{}
 
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("SafeSetLimit(g, 0) did not panic")
-			} else if r != "limit cannot be 0" {
-				t.Errorf("SafeSetLimit(g, 0) panicked with wrong message: %v", r)
-			}
-		}()
-
+		// Must not panic and must not deadlock — a raw SetLimit(0) would make
+		// every Go call block forever.
 		SafeSetLimit(g, 0)
+		runAll(t, g, 5)
 	})
 
-	t.Run("negative limit", func(t *testing.T) {
+	t.Run("negative limit falls back to a usable default", func(t *testing.T) {
 		g := &errgroup.Group{}
 
-		// Should not panic from SafeSetLimit, but errgroup.SetLimit might
-		// We'll let errgroup handle negative values as per its own behavior
 		SafeSetLimit(g, -1)
+		runAll(t, g, 5)
 	})
 }

--- a/util/safe_set_limit_test.go
+++ b/util/safe_set_limit_test.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -28,10 +29,12 @@ func TestSafeSetLimit(t *testing.T) {
 		require.Equal(t, int32(n), counter.Load())
 	}
 
+	logger := ulogger.TestLogger{}
+
 	t.Run("valid positive limit", func(t *testing.T) {
 		g := &errgroup.Group{}
 
-		SafeSetLimit(g, 2)
+		SafeSetLimit(logger, g, 2)
 		runAll(t, g, 5)
 	})
 
@@ -40,14 +43,14 @@ func TestSafeSetLimit(t *testing.T) {
 
 		// Must not panic and must not deadlock — a raw SetLimit(0) would make
 		// every Go call block forever.
-		SafeSetLimit(g, 0)
+		SafeSetLimit(logger, g, 0)
 		runAll(t, g, 5)
 	})
 
 	t.Run("negative limit falls back to a usable default", func(t *testing.T) {
 		g := &errgroup.Group{}
 
-		SafeSetLimit(g, -1)
+		SafeSetLimit(logger, g, -1)
 		runAll(t, g, 5)
 	})
 }


### PR DESCRIPTION
## What this does

`util.SafeSetLimit` is a thin wrapper around `errgroup.Group.SetLimit` used at ~45 call sites to bound goroutine concurrency. Originally it **panicked** if the limit was `0`.

`errgroup.SetLimit(0)` creates a zero-capacity semaphore, so every subsequent `Go` call blocks forever — a `0` (or negative) limit reaching this helper is always a configuration mistake (e.g. a `*Concurrency` setting left at `0`). Panicking turned that misconfiguration into a hard crash.

This PR makes the helper **resilient *and* loud**:

- It clamps any limit `< 1` to a safe default of `runtime.NumCPU()` — a bounded, positive worker count that preserves the intent of every call site. It does **not** fall through to unbounded concurrency (which would remove the very protection the limit exists for), and it cannot deadlock.
- It **logs a `WARN`** on every clamp (`SafeSetLimit: limit %d < 1, clamping to runtime.NumCPU()=%d`), so the underlying misconfiguration is never silent. The system stays up, but the bad setting is still visible in the logs and can be fixed.

This is the key change from the first cut of this PR, which clamped *silently* — that traded a loud-but-crashing failure for a quiet-but-wrong one, which is arguably worse. Logging gives us resilience without hiding the bug.

## Why a separate PR

This was flagged during review of #378 (the `CheckBlockSubtrees` parallelisation) as a pre-existing foot-gun that now sits on one more code path. It's unrelated to that change, so it's split out here to keep both PRs focused.

## What changed

- `util/safe_set_limit.go`: signature is now `SafeSetLimit(logger ulogger.Logger, g *errgroup.Group, limit int)`. `limit < 1` logs a `WARN` and falls back to `runtime.NumCPU()` instead of panicking (or clamping silently).
- **All ~45 call sites** updated to pass their in-scope logger as the first argument (`logger` param / `s.logger` / `u.logger` / `v.logger` / `sm.logger` / `stp.logger` / etc.). One test helper passes `ulogger.TestLogger{}`.
- `util/safe_set_limit_test.go`: the \"zero panics\" test became \"zero falls back to a usable default\", asserting the group actually runs its goroutines to completion (proving it neither panics nor deadlocks). Negative-limit case updated likewise.

### Note on the signature change

This intentionally changes `SafeSetLimit`'s signature (adds a leading `logger` param) — there is no logger available inside `util` otherwise, and logging the misconfiguration is the whole point. There is no fallback/name parameter: `runtime.NumCPU()` remains the hard-coded default, keeping the change minimal.

## Testing

- `go build ./...`: success
- `go vet ./...`: clean (pre-existing lock-by-value warnings in `test/utils/` are unrelated)
- `go vet -tags aerospike ./stores/utxo/aerospike/`: clean
- `go test -race -run TestSafeSetLimit ./util/`: 4 passed
- `gofmt -l` on all changed files: clean