### PR TITLE
ci: migrate native-Go + aerospike CI jobs to arm64; bump aerospike 8.0→8.1

### DIFF
--- a/.github/workflows/chainintegrity-3blasters.yaml
+++ b/.github/workflows/chainintegrity-3blasters.yaml
@@ -14,7 +14,9 @@ env:
 jobs:
   chainintegrity:
     name: Chain Integrity Test
-    runs-on: teranode-runner-16-core
+    # arm64: no SV-node; all images arm64-capable (teranode multi-arch,
+    # aerospike-server:8.1 arm64, postgres + redpanda arm64).
+    runs-on: teranode-runner-16-core-arm
     timeout-minutes: 30
     steps:
       - name: Checkout code

--- a/.github/workflows/chainintegrity.yaml
+++ b/.github/workflows/chainintegrity.yaml
@@ -15,7 +15,9 @@ env:
 jobs:
   chainintegrity:
     name: Chain Integrity Test
-    runs-on: teranode-runner-16-core
+    # arm64: no SV-node here; all images arm64-capable — teranode:latest
+    # (multi-arch), aerospike-server:8.1 (arm64), postgres + redpanda (arm64).
+    runs-on: teranode-runner-16-core-arm
     timeout-minutes: 30
     steps:
       - name: Checkout code

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -32,7 +32,9 @@ env:
 jobs:
   sonarqube:
     name: SonarQube Analysis
-    runs-on: teranode-runner-4-core
+    # arm64-safe: only downloads coverage artifacts + runs the sonar scanner CLI
+    # (arm64-available); no Go build, no containers.
+    runs-on: teranode-runner-4-core-arm
     # Only run if:
     # 1. The triggering workflow succeeded (ensures all artifacts were generated)
     # 2. It was triggered by a pull_request event (not push to main)

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Go test
     # ARM runner (see teranode_pr_tests.yaml): more headroom for the heavy
     # `make test` -race+coverage compile; runs natively on arm64.
-    runs-on: teranode-runner-32-core-arm
+    runs-on: teranode-runner-16-core-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -102,7 +102,8 @@ jobs:
 
   prunertest:
     name: prunertest
-    runs-on: teranode-runner-8-core
+    # arm64: aerospike (8.1, arm64), no SV-node (see teranode_pr_smoketests.yaml).
+    runs-on: teranode-runner-8-core-arm
     continue-on-error: true
     steps:
       - name: Login to Docker Hub

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -19,7 +19,9 @@ permissions:
 jobs:
   go-test:
     name: Go test
-    runs-on: teranode-runner-16-core
+    # ARM runner (see teranode_pr_tests.yaml): more headroom for the heavy
+    # `make test` -race+coverage compile; runs natively on arm64.
+    runs-on: teranode-runner-16-core-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Go test
     # ARM runner (see teranode_pr_tests.yaml): more headroom for the heavy
     # `make test` -race+coverage compile; runs natively on arm64.
-    runs-on: teranode-runner-16-core-arm
+    runs-on: teranode-runner-32-core-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/teranode_pr_smoketests.yaml
+++ b/.github/workflows/teranode_pr_smoketests.yaml
@@ -61,7 +61,9 @@ jobs:
 
   prunertest:
     name: prunertest
-    runs-on: teranode-runner-8-core
+    # arm64: TestPruner/TestBlobDeletion use aerospike (8.1, arm64) but no
+    # SV-node, so this moves to arm unlike smoketest/legacy-sync/sequential.
+    runs-on: teranode-runner-8-core-arm
     steps:
       - name: Login to Docker Hub
         if: github.event.pull_request.head.repo.full_name == github.repository
@@ -129,7 +131,9 @@ jobs:
 
   chainintegrity:
     name: chainintegrity
-    runs-on: teranode-runner-8-core
+    # arm64: no SV-node; images all arm64-capable (teranode multi-arch,
+    # aerospike-server:8.1 arm64, postgres + redpanda arm64).
+    runs-on: teranode-runner-8-core-arm
     steps:
       - name: Login to Docker Hub
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -25,7 +25,8 @@ env:
 jobs:
   golangci-lint:
     name: golangci-lint
-    runs-on: teranode-runner-8-core
+    # arm64-safe: pure Go analysis, no containers (golangci-lint ships arm64).
+    runs-on: teranode-runner-8-core-arm
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
@@ -59,11 +60,11 @@ jobs:
   test:
     name: test
     # ARM runner: the x86 16-core runner OOM-killed the `go test -race
-    # -coverpkg=./...` compile of the whole repo (~13GB peak). arm64 has more
-    # headroom and runs `make test` natively (proven locally on arm64). Only
-    # this `make test` job moves — postgres testcontainers (arm64-available) +
-    # the testtxmetacache tag (no aerospike images). Trying 32-core for speed.
-    runs-on: teranode-runner-32-core-arm
+    # -coverpkg=./...` compile (~13GB peak) — arm64 runners have ample RAM
+    # (~64GB on 16-core; telemetry showed ~70GB peak at 32 cores, and 32-core
+    # gave no speedup, so 16-core is the cost/perf sweet spot). Runs `make test`
+    # natively: postgres testcontainers (arm64) + testtxmetacache (no aerospike).
+    runs-on: teranode-runner-16-core-arm
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
@@ -90,30 +91,7 @@ jobs:
             gomod-${{ runner.os }}-
 
       - name: Run Go tests
-        # TEMP telemetry: log runner specs + sample peak mem/disk during the run
-        # to size the runner. Remove before merge once core count is decided.
-        run: |
-          echo "::group::runner resources"
-          echo "cores=$(nproc)  GOMAXPROCS=$(go env GOMAXPROCS)"
-          free -h || true
-          df -h / || true
-          echo "::endgroup::"
-          ( peak=0; pdisk=0
-            while :; do
-              u=$(awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} END{print t-a}' /proc/meminfo)
-              [ "${u:-0}" -gt "$peak" ] && peak=$u
-              d=$(df --output=used -k / 2>/dev/null | tail -1 | tr -dc '0-9')
-              [ "${d:-0}" -gt "$pdisk" ] && pdisk=$d
-              printf '%s %s\n' "$peak" "${pdisk:-0}" > /tmp/peak.txt
-              sleep 5
-            done ) & SAMPLER=$!
-          set +e; make test; rc=$?; set -e
-          kill "$SAMPLER" 2>/dev/null || true
-          if [ -f /tmp/peak.txt ]; then
-            read pm pd < /tmp/peak.txt
-            echo "::notice title=test resource usage::peak mem $((pm/1024)) MiB, peak disk $((pd/1024)) MiB on $(nproc) cores"
-          fi
-          exit $rc
+        run: make test
         continue-on-error: false
 
       - name: Upload coverage report

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -58,7 +58,12 @@ jobs:
 
   test:
     name: test
-    runs-on: teranode-runner-16-core
+    # ARM runner: the x86 16-core runner OOM-killed the `go test -race
+    # -coverpkg=./...` compile of the whole repo (~13GB peak). Trying arm64,
+    # which has more headroom and runs `make test` natively (proven locally on
+    # arm64). Only this `make test` job moves — it uses postgres testcontainers
+    # (arm64-available) and the testtxmetacache tag (no aerospike images).
+    runs-on: teranode-runner-16-core-arm
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -59,11 +59,11 @@ jobs:
   test:
     name: test
     # ARM runner: the x86 16-core runner OOM-killed the `go test -race
-    # -coverpkg=./...` compile of the whole repo (~13GB peak). Trying arm64,
-    # which has more headroom and runs `make test` natively (proven locally on
-    # arm64). Only this `make test` job moves — it uses postgres testcontainers
-    # (arm64-available) and the testtxmetacache tag (no aerospike images).
-    runs-on: teranode-runner-16-core-arm
+    # -coverpkg=./...` compile of the whole repo (~13GB peak). arm64 has more
+    # headroom and runs `make test` natively (proven locally on arm64). Only
+    # this `make test` job moves — postgres testcontainers (arm64-available) +
+    # the testtxmetacache tag (no aerospike images). Trying 32-core for speed.
+    runs-on: teranode-runner-32-core-arm
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
@@ -90,7 +90,30 @@ jobs:
             gomod-${{ runner.os }}-
 
       - name: Run Go tests
-        run: make test
+        # TEMP telemetry: log runner specs + sample peak mem/disk during the run
+        # to size the runner. Remove before merge once core count is decided.
+        run: |
+          echo "::group::runner resources"
+          echo "cores=$(nproc)  GOMAXPROCS=$(go env GOMAXPROCS)"
+          free -h || true
+          df -h / || true
+          echo "::endgroup::"
+          ( peak=0; pdisk=0
+            while :; do
+              u=$(awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} END{print t-a}' /proc/meminfo)
+              [ "${u:-0}" -gt "$peak" ] && peak=$u
+              d=$(df --output=used -k / 2>/dev/null | tail -1 | tr -dc '0-9')
+              [ "${d:-0}" -gt "$pdisk" ] && pdisk=$d
+              printf '%s %s\n' "$peak" "${pdisk:-0}" > /tmp/peak.txt
+              sleep 5
+            done ) & SAMPLER=$!
+          set +e; make test; rc=$?; set -e
+          kill "$SAMPLER" 2>/dev/null || true
+          if [ -f /tmp/peak.txt ]; then
+            read pm pd < /tmp/peak.txt
+            echo "::notice title=test resource usage::peak mem $((pm/1024)) MiB, peak disk $((pd/1024)) MiB on $(nproc) cores"
+          fi
+          exit $rc
         continue-on-error: false
 
       - name: Upload coverage report

--- a/compose/cmd/gennodes/templates/docker-compose-split.yml.tmpl
+++ b/compose/cmd/gennodes/templates/docker-compose-split.yml.tmpl
@@ -81,7 +81,7 @@ services:
 
   aerospike-{{ .Index }}:
     container_name: aerospike-{{ .Index }}-multinode
-    image: aerospike/aerospike-server:8.0
+    image: aerospike/aerospike-server:8.1
     networks:
       - teranode-network
     command: --config-file /etc/aerospike.conf

--- a/compose/cmd/gennodes/templates/docker-compose.yml.tmpl
+++ b/compose/cmd/gennodes/templates/docker-compose.yml.tmpl
@@ -73,7 +73,7 @@ services:
 
   aerospike-{{ .Index }}:
     container_name: aerospike-{{ .Index }}-multinode
-    image: aerospike/aerospike-server:8.0
+    image: aerospike/aerospike-server:8.1
     networks:
       - teranode-network
     command: --config-file /etc/aerospike.conf

--- a/compose/docker-compose-3blasters.yml
+++ b/compose/docker-compose-3blasters.yml
@@ -18,7 +18,7 @@ x-teranode-coinbase-base: &teranode-coinbase-base
     - kafka-shared
 
 x-aerospike-base: &aerospike-base
-  image: aerospike/aerospike-server:8.0
+  image: aerospike/aerospike-server:8.1
   networks:
     - teranode-network
   command: --config-file /etc/aerospike.conf

--- a/compose/docker-compose-chainintegrity.yml
+++ b/compose/docker-compose-chainintegrity.yml
@@ -17,7 +17,7 @@ x-teranode-coinbase-base: &teranode-coinbase-base
     - kafka-shared
 
 x-aerospike-base: &aerospike-base
-  image: aerospike/aerospike-server:8.0
+  image: aerospike/aerospike-server:8.1
   networks:
     - teranode-network
   command: --config-file /etc/aerospike.conf

--- a/test/docker-compose-host.yml
+++ b/test/docker-compose-host.yml
@@ -17,7 +17,7 @@ x-teranode-coinbase-base: &teranode-coinbase-base
     - kafka-shared
 
 x-aerospike-base: &aerospike-base
-  image: aerospike/aerospike-server:8.0
+  image: aerospike/aerospike-server:8.1
   network_mode: "host"
   command: --config-file /etc/aerospike.conf
 

--- a/test/docker-compose.e2etest.legacy.yml
+++ b/test/docker-compose.e2etest.legacy.yml
@@ -9,7 +9,7 @@ x-teranode-base: &teranode-base
     - ./data/test/${TEST_ID:-default}:/app/data
 
 x-aerospike-base: &aerospike-base
-  image: aerospike/aerospike-server:8.0
+  image: aerospike/aerospike-server:8.1
   networks:
     - teranode-network
   command: --config-file /etc/aerospike.conf

--- a/test/docker-compose.e2etest.yml
+++ b/test/docker-compose.e2etest.yml
@@ -7,7 +7,7 @@ x-teranode-base: &teranode-base
     - e2etest
 
 x-aerospike-base: &aerospike-base
-  image: aerospike/aerospike-server:8.0
+  image: aerospike/aerospike-server:8.1
   networks:
     - e2etest
   command: --config-file /etc/aerospike.conf

--- a/test/longtest/stores/utxo/aerospike/aerospike8_test.go
+++ b/test/longtest/stores/utxo/aerospike/aerospike8_test.go
@@ -16,7 +16,7 @@ func TestAerospike8TransactionSupport(t *testing.T) {
 
 	ctx := context.Background()
 
-	container, err := aeroTest.RunContainer(ctx, aeroTest.WithImage("aerospike/aerospike-server:8.0"), aeroTest.WithTTLSupport("test"))
+	container, err := aeroTest.RunContainer(ctx, aeroTest.WithImage("aerospike/aerospike-server:8.1"), aeroTest.WithTTLSupport("test"))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

Migrate the CI jobs that can safely run on **arm64** to arm runners, and bump **aerospike 8.0 → 8.1** (which has an arm64 image). This fixes the x86 `make test` OOM (arm runners have ample RAM) without `-p` caps or build-cache churn, and is cheaper.

## Why

On x86 `teranode-runner-16-core`, `make test` (`go test -race -coverpkg=./...` over the whole repo) SIGTERM'd ~3min in during the **compile** — that cold race+coverage build peaks **~13GB** and OOM'd the runner. Telemetry on a 32-core arm run showed **~70GB peak / 125GB**, and **32-core gave no speedup** (the suite is I/O/container-bound, not CPU-bound) — so **16-core arm** is the cost/perf sweet spot. arm runners are cheaper/min and have the headroom the x86 runner lacked.

## Runner matrix

**Moved to arm64** (verified arm-safe — compiles incl. CGO/BDK, containers are arm64-available):

| job | runner |
|---|---|
| `test`, `go-test` (`make test`) | 16-core-arm — postgres testcontainers (arm64), `testtxmetacache` tag (no aerospike) |
| `golangci-lint` | 8-core-arm — pure Go analysis, no containers |
| `sonar` | 4-core-arm — scanner CLI + artifacts, no build |
| `prunertest` (pr + main) | 8-core-arm — aerospike 8.1 (arm64), no SV-node |
| `chainintegrity` (pr) | 8-core-arm — teranode multi-arch + aerospike 8.1 + postgres/redpanda |
| `chainintegrity`, `chainintegrity-3blasters` | 16-core-arm — same |

**Kept on x86** — `smoketest`, `legacy-sync`, `sequential`: they stand up a real **`bitcoinsv/bitcoin-sv` SV-Node container, which is x86-only** (no arm64 image). teranode being multi-arch doesn't unblock these — the SV-node image does.

## aerospike 8.0 → 8.1

Bumped all official `aerospike/aerospike-server:8.0` refs (test compose, chainintegrity + 3blasters compose, longtest aerospike8 test, **and the gennodes templates** used by `make gen-multinode`). Left the custom `ghcr.io/bsv-blockchain/aerospike-server:8.0.0-3` and the already-8.1 deploy manifests as-is.

## Test plan

- [x] `test` job green on arm64 (no compile-phase SIGTERM)
- [x] `prunertest` + `chainintegrity` green on arm64 — confirms aerospike 8.1 arm64 + the compose stack come up
- [ ] follow-up: move `smoketest`/`legacy-sync`/`sequential` once an arm64 SV-node image exists