### PR TITLE
ci: cache Go build cache via reusable go-cache action

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -1,0 +1,77 @@
+name: 'Go cache'
+description: >
+  Restore (and on the authoritative saver, save) the Go module cache
+  (~/go/pkg/mod) and build cache (~/.cache/go-build).
+
+  GitHub Actions caches are branch-scoped: only caches written on the default
+  branch are readable by all PRs. So exactly ONE job — the main-branch unit
+  test job — runs with save: 'true'. Every other job restores only.
+
+  The build cache key rotates daily (GO_CACHE_DATE) so it never goes stale for
+  weeks at a time; restore-keys fall back to the most recent dated entry, then
+  to any build cache for this OS.
+
+inputs:
+  save:
+    description: >
+      'true' on the single authoritative saver (main-branch unit tests).
+      'false' (default) everywhere else — restore only, no upload.
+    default: 'false'
+  build_cache:
+    description: >
+      Whether to include the build cache (~/.cache/go-build). The saver builds
+      it with -race, and Go keys the build cache by build flags, so jobs that do
+      NOT run -race (plain go build/test, golangci typecheck, benchmarks) get
+      near-zero hits and just waste bandwidth on a multi-GB tarball. Set 'false'
+      for those — the module cache (~/go/pkg/mod) is always restored regardless.
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Compute Go cache date
+      shell: bash
+      run: echo "GO_CACHE_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
+    # --- restore-only path (PR jobs, every non-main job) ---
+    - name: Restore Go module cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          gomod-${{ runner.os }}-
+
+    - name: Restore Go build cache
+      if: inputs.save != 'true' && inputs.build_cache == 'true'
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-${{ hashFiles('**/go.mod') }}-${{ env.GO_CACHE_DATE }}
+        restore-keys: |
+          gobuild-${{ runner.os }}-${{ hashFiles('**/go.mod') }}-
+          gobuild-${{ runner.os }}-
+
+    # --- save path (authoritative saver only: main-branch unit tests) ---
+    # actions/cache registers a post-job step that uploads at job end, AFTER
+    # the trim step in the caller has run. Saves only on a key miss (new day or
+    # new go.sum/go.mod), so same-day reruns are no-ops.
+    - name: Save Go module cache
+      if: inputs.save == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          gomod-${{ runner.os }}-
+
+    - name: Save Go build cache
+      if: inputs.save == 'true' && inputs.build_cache == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-${{ hashFiles('**/go.mod') }}-${{ env.GO_CACHE_DATE }}
+        restore-keys: |
+          gobuild-${{ runner.os }}-${{ hashFiles('**/go.mod') }}-
+          gobuild-${{ runner.os }}-

--- a/.github/workflows/benchmark-compare.yaml
+++ b/.github/workflows/benchmark-compare.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  GO_VERSION: "1.26.0"
+
 jobs:
   bench:
     name: Bench ${{ matrix.group }}
@@ -83,8 +86,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.2"
+          go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      # Benchmarks run -bench without -race: module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
 
       - name: Run PR benchmarks
         run: |
@@ -134,8 +143,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.2"
+          go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      # Benchmarks run -bench without -race: module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
 
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest

--- a/.github/workflows/chainintegrity-3blasters.yaml
+++ b/.github/workflows/chainintegrity-3blasters.yaml
@@ -26,6 +26,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
+      # Plain go build (no -race): module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 

--- a/.github/workflows/chainintegrity.yaml
+++ b/.github/workflows/chainintegrity.yaml
@@ -27,6 +27,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
+      # Plain go build (no -race): module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 

--- a/.github/workflows/long_tests.yaml
+++ b/.github/workflows/long_tests.yaml
@@ -35,6 +35,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+
       - name: Run Services Tests
         run: |
           make testall

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -32,6 +32,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
+      # Plain build/test (no -race): module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
@@ -182,6 +188,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
+      # Plain go test (no -race): module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
+
       - name: Run Daemon Ready Tests
         run: |
           go clean -testcache
@@ -208,6 +220,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      # Plain build/test (no -race): module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
 
       - name: Start required services for chaos testing
         run: |
@@ -280,6 +298,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      # Plain build/test (no -race): module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+        with:
+          build_cache: 'false'
 
       - name: Start required services for chaos testing
         run: |

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -36,17 +36,25 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
-      - name: Restore Go module cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      # Authoritative cache saver: the only job that WRITES the Go caches, and
+      # it runs on the default branch — so every PR job can read them back.
+      - name: Restore and save Go caches
+        uses: ./.github/actions/go-cache
         with:
-          path: ~/go/pkg/mod
-          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            gomod-${{ runner.os }}-
+          # Save only on the default branch. GitHub scopes caches by branch, so
+          # only main's cache is readable by every PR. staging/release/tag builds
+          # restore but don't write, leaving the 10 GB repo budget to main.
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run Go tests
         run: make test
         continue-on-error: false
+
+      # Drop build-cache objects unused for 90+ min before the post-job save,
+      # keeping the uploaded tarball under the 10 GB repo cache cap.
+      - name: Trim Go build cache
+        if: always()
+        run: find ~/.cache/go-build -type f -mmin +90 -delete 2>/dev/null || true
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -76,13 +84,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
-      - name: Restore Go module cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/go/pkg/mod
-          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            gomod-${{ runner.os }}-
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
 
       - name: Run Smoke tests
         run: make smoketest
@@ -118,13 +121,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
-      - name: Restore Go module cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/go/pkg/mod
-          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            gomod-${{ runner.os }}-
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
 
       - name: Run Pruner tests
         run: make prunertest
@@ -166,13 +164,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
-      - name: Restore Go module cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      # golangci typechecks (no -race) and Sonar reads prebuilt reports, so
+      # restore the module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
         with:
-          path: ~/go/pkg/mod
-          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            gomod-${{ runner.os }}-
+          build_cache: 'false'
 
       # Re-run golangci-lint separately without exiting on errors and generating a report for use in Sonar
       - name: golangci-lint

--- a/.github/workflows/teranode_pr_smoketests.yaml
+++ b/.github/workflows/teranode_pr_smoketests.yaml
@@ -46,6 +46,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+
       - name: Run Smoke tests
         run: make smoketest SHARD=${{ matrix.shard }} TOTAL=3
         env:
@@ -78,6 +81,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
+
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
 
       - name: Run Pruner tests
         run: make prunertest
@@ -113,6 +119,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
 
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
+
       - name: Run Legacy Sync tests
         run: make legacy-sync
         continue-on-error: false
@@ -146,6 +155,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
+
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
 
       - name: Run Chain Integrity tests
         run: make chainintegrity
@@ -184,6 +196,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: "false"
+
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
 
       - name: Run sequential shard
         run: make sequentialtest-shard SHARD=${{ matrix.shard }} TOTAL=7

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -34,13 +34,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Restore Go module cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      # golangci typechecks (no -race) and the action caches its own build
+      # artifacts, so restore the module cache only.
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
         with:
-          path: ~/go/pkg/mod
-          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            gomod-${{ runner.os }}-
+          build_cache: 'false'
 
       - name: golangci-lint with checkstyle report
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
@@ -76,13 +75,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Restore Go module cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/go/pkg/mod
-          key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            gomod-${{ runner.os }}-
+      - name: Restore Go caches
+        uses: ./.github/actions/go-cache
 
       - name: Run Go tests
         run: make test


### PR DESCRIPTION
## What

CI never cached the Go **build cache** (`~/.cache/go-build`). `setup-go`'s cache was disabled and we manually cached only the module cache (`~/go/pkg/mod`). For our workload — `go test -race` across the whole tree — the `-race` compile is the dominant cost, and it was rebuilt from scratch on every job.

This adds a reusable composite action `.github/actions/go-cache` and wires it into every Go-compiling workflow.

## How

- **One authoritative saver, on `main`.** GitHub scopes caches by branch — only the default branch's cache is readable by all PRs. So the main-branch unit-test job (`teranode_main_tests` → `go-test`) is the only writer (`save` gated to `refs/heads/main`); every other job is restore-only. staging/release/tag builds restore but don't write, leaving the 10 GB repo budget to main.
- **Daily-rotating build-cache key** (`gobuild-${os}-${hash(go.mod)}-${date}`) with prefix restore-key fallback, so the build cache never pins stale for weeks. Module cache keeps the existing `gomod-${os}-${hash(go.sum)}` scheme.
- **Trim before save** (`find ~/.cache/go-build -mmin +90 -delete`) keeps the uploaded tarball under the 10 GB cap.
- **`-race` vs not.** Go keys the build cache by build flags, so a non-race job restoring the `-race` saver's multi-GB tarball gets ~zero hits — pure wasted bandwidth. The composite exposes `build_cache` (default `true`); non-race jobs set it `false` and restore the module cache only.

| jobs | Go work | cache |
|---|---|---|
| pr/main tests, smoketests, long tests | `-race` | module + build |
| golangci, sonar, nightly, chainintegrity builds, benchmarks | plain build/test | module only |

## Also

- `benchmark-compare` was on Go **1.25.2** while everything else is **1.26.0** — aligned it (added a workflow `env: GO_VERSION` so it can't drift again). Benches now compile/run under 1.26.0.

## Notes

- First PR after this merges is cold — the cache only warms once `main`'s `go-test` runs post-merge. Merge first, then watch a follow-up PR for the build-cache hit.
- Validated with `actionlint` on all touched workflows (clean; remaining notes are pre-existing shellcheck warnings in unrelated docker-log loops and the known custom-runner-label notes). Cache hit/timing can only be confirmed by a live run.
