### PR TITLE
Add IdleTimeout to default docker.m Aerospike utxostore

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -1224,7 +1224,7 @@ utxostore                                                  = null:///
 utxostore.dev                                              = sqlite:///utxostore
 utxostore.dev.legacy                                       = aerospike://localhost:3000/utxo-store?set=utxo&externalStore=file://${DATADIR}/external
 utxostore.teratestnet                                      = aerospike://localhost:3000/utxo-store?set=utxo&externalStore=file://${DATADIR}/external
-utxostore.docker.m                                         = aerospike://aerospike:3000/utxo-store?WarmUp=0&ConnectionQueueSize=128&LimitConnectionsToQueueSize=true&MinConnectionsPerNode=16&set=utxo&externalStore=file://${DATADIR}/external%3FhashPrefix=2
+utxostore.docker.m                                         = aerospike://aerospike:3000/utxo-store?WarmUp=0&ConnectionQueueSize=128&LimitConnectionsToQueueSize=true&MinConnectionsPerNode=16&IdleTimeout=60s&set=utxo&externalStore=file://${DATADIR}/external%3FhashPrefix=2
 utxostore.docker.ss.teranode1                              = postgres://miner1:miner1@postgres:${POSTGRES_PORT}/teranode1
 # utxostore.docker                                         = aerospike://${aerospike_host}:${aerospike_port}/utxo-store?set=utxo&WarmUp=32&ConnectionQueueSize=32&LimitConnectionsToQueueSize=true&MinConnectionsPerNode=8&externalStore=file://${DATADIR}/${clientName}/external
 utxostore.test                                             = sqlite:///utxostore


### PR DESCRIPTION
## What

Add `IdleTimeout=60s` to the `utxostore.docker.m` Aerospike connection URL default.

## Why

The Aerospike Go client's `ClientPolicy.IdleTimeout` defaults to `0` — a live client never reaps its own idle sockets. The `docker.m` UTXO store URL never set it, so idle connections are never cleaned up on the client side.

Combined with a server that isn't reaping either (`proto-fd-idle-ms` is off by default and deprecated in the 8.x line), connections only ever accumulate toward `proto-fd-max` and never come back down. On a downed cluster — all Teranode containers stopped, zero live clients — the Aerospike server was observed holding ~21k orphan client connections (`client_connections_opened − client_connections_closed`) against a `proto-fd-max` of 30k. Booting Teranode on top of that pool walks straight into the ceiling and connections start failing.

`IdleTimeout=60s` makes a live client reap its own excess idle connections after 60s.

## Behavior notes

- The `MinConnectionsPerNode=16` reserve is **exempt** from idle reaping — verified in the client pool (`connection_heap.go DropIdle` only drops connections above the min floor; reserve conns get their idle deadline refreshed each tend). The reserve stays warm; only connections above 16 are reaped.
- Client `IdleTimeout` must stay **below** the server's `proto-fd-idle-ms` so the client reaps its own socket before the server does — grabbing a socket the server already reaped throws. Pair this with a server-side `proto-fd-idle-ms` higher than 60s (our deployment runs `120000` / 2 min).
- The IBD hot path is unaffected: under load connections are continuously in use and never sit idle long enough to reap. This only governs quiet-period pool shrink and dead-socket cleanup.

## Scope

`docker.m` profile only. The other Aerospike UTXO URLs (`dev.legacy`, `teratestnet`) also omit `IdleTimeout` but run single-node localhost dev setups where orphan accumulation hasn't bitten; left unchanged.
