### PR TITLE
ci(CI-143): isolate intermittent exit-143 in test job [DO NOT MERGE]

### DIFF
--- a/.github/workflows/benchmark-compare.yaml
+++ b/.github/workflows/benchmark-compare.yaml
@@ -2,6 +2,9 @@ name: Benchmark Comparison
 
 on:
   pull_request:
+    # TEMP (CI-143 experiment): disabled. Also stops benchmark-report (workflow_run
+    # off this). Revert before merge.
+    branches-ignore: ['**']
     types: [opened, synchronize, reopened]
 
 env:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,6 +17,9 @@ on:
     workflows: ["Teranode PR init"]
     types:
       - completed
+    # TEMP (CI-143 experiment): disabled (belt-and-suspenders; init is already
+    # neutered). '**' never matches the triggering run's head branch. Revert before merge.
+    branches-ignore: ['**']
 
 permissions:
   contents: read

--- a/.github/workflows/dashboard_pr_smoke.yaml
+++ b/.github/workflows/dashboard_pr_smoke.yaml
@@ -2,6 +2,8 @@ name: Dashboard PR smoke
 
 on:
   pull_request:
+    # TEMP (CI-143 experiment): disabled. Revert before merge.
+    branches-ignore: ['**']
     paths:
       - 'ui/dashboard/**'
       - '.github/workflows/dashboard_pr_smoke.yaml'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,8 @@ name: Dependency Review
 
 on:
   pull_request:
+    # TEMP (CI-143 experiment): disabled. Revert before merge.
+    branches-ignore: ['**']
 
 # Read-only default token; the job below elevates only what it needs.
 permissions:

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -16,6 +16,10 @@ on:
     workflows: ["Teranode PR tests"]
     types:
       - completed
+    # TEMP (CI-143 experiment): disabled. This chains off "Teranode PR tests",
+    # which we keep running, so it must be neutered directly. '**' never matches
+    # the triggering run's head branch. Revert before merge.
+    branches-ignore: ['**']
 
 concurrency:
   group: sonar-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}

--- a/.github/workflows/teranode_pr_init.yaml
+++ b/.github/workflows/teranode_pr_init.yaml
@@ -7,6 +7,10 @@ name: Teranode PR init
 
 on:
   pull_request:
+    # TEMP (CI-143 experiment): disabled — '**' never matches a base branch, so
+    # this never runs on a PR. Also stops claude-code-review (workflow_run off this).
+    # Revert before merge.
+    branches-ignore: ['**']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/teranode_pr_smoketests.yaml
+++ b/.github/workflows/teranode_pr_smoketests.yaml
@@ -2,6 +2,8 @@ name: Teranode PR smoke tests
 
 on:
   pull_request:
+    # TEMP (CI-143 experiment): disabled. Revert before merge.
+    branches-ignore: ['**']
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -32,12 +32,15 @@ jobs:
   # process, which is why it is the only one affected. Revert this branch before merge.
   test:
     name: test
-    # ARM runner: the x86 16-core runner OOM-killed the `go test -race
-    # -coverpkg=./...` compile (~13GB peak) — arm64 runners have ample RAM
-    # (~64GB on 16-core; telemetry showed ~70GB peak at 32 cores, and 32-core
-    # gave no speedup, so 16-core is the cost/perf sweet spot). Runs `make test`
-    # natively: postgres testcontainers (arm64) + testtxmetacache (no aerospike).
-    runs-on: teranode-runner-16-core-arm
+    # TEMP (CI-143): bumped 16-core (64GB) -> 32-core (128GB) arm to capture full
+    # telemetry. At 64GB the job OOM-died mid-run (sql.test ~26G + blockassembly
+    # ~16G + others overlapping tipped past the 62.7G host) before catchpoint's
+    # post-job summary could run. 128GB gives headroom so the job COMPLETES —
+    # catchpoint then posts, and combined with the live stdout sampler below we
+    # capture the whole peak. NOTE: 32 cores => -p=32, so more fat binaries
+    # overlap and the peak here will be HIGHER than the 16-core peak. Runs
+    # `make test` natively: postgres testcontainers (arm64) + testtxmetacache.
+    runs-on: teranode-runner-32-core-arm
     steps:
       # TEMP (CI-143): re-add catchpoint workflow telemetry (removed in PR #948)
       # to capture peak memory/CPU/IO for the whole job. Charts land in the job

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -70,7 +70,30 @@ jobs:
         uses: ./.github/actions/go-cache
 
       - name: Run Go tests
-        run: make test
+        # Live memory sampler streamed to the job log every 2s. GitHub uploads
+        # step logs in real time, so this SURVIVES the SIGTERM/143 that kills the
+        # job mid-run — unlike catchpoint's post-job summary (never runs when the
+        # job is terminated) and `if: always()` artifact uploads (also normal
+        # steps that don't run after a mid-step kill). Tells us whether RSS was
+        # near the 64GB ceiling at the moment of death (→ memory) or comfortably
+        # low (→ runner reclaim / infra). Also prints the top-3 RSS processes so
+        # we can see if one test binary is the hog or it's broad parallelism.
+        run: |
+          sample_mem() {
+            while :; do
+              awk -v t="$(date +%T)" '
+                /^MemTotal:/     {tot=$2}
+                /^MemAvailable:/ {av=$2}
+                END {printf "MEMSAMPLE %s used=%.1fG avail=%.1fG of %.1fG\n", t,(tot-av)/1048576,av/1048576,tot/1048576}
+              ' /proc/meminfo
+              ps -eo rss=,comm= --sort=-rss 2>/dev/null | awk 'NR<=3 {printf "  TOP %.1fG %s\n",$1/1048576,$2}'
+              sleep 2
+            done
+          }
+          sample_mem &
+          SAMPLER_PID=$!
+          trap 'kill "$SAMPLER_PID" 2>/dev/null || true' EXIT
+          make test
         continue-on-error: false
 
       - name: Upload coverage report

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -73,29 +73,55 @@ jobs:
         uses: ./.github/actions/go-cache
 
       - name: Run Go tests
-        # Live memory sampler streamed to the job log every 2s. GitHub uploads
-        # step logs in real time, so this SURVIVES the SIGTERM/143 that kills the
-        # job mid-run — unlike catchpoint's post-job summary (never runs when the
-        # job is terminated) and `if: always()` artifact uploads (also normal
-        # steps that don't run after a mid-step kill). Tells us whether RSS was
-        # near the 64GB ceiling at the moment of death (→ memory) or comfortably
-        # low (→ runner reclaim / infra). Also prints the top-3 RSS processes so
-        # we can see if one test binary is the hog or it's broad parallelism.
+        # Memory telemetry that captures true PEAKS (not point-in-time samples)
+        # and survives a SIGTERM/143:
+        #   * per-binary peak = VmHWM from /proc/<pid>/status — the kernel's
+        #     monotonic peak-RSS high-water mark — so we never miss a spike
+        #     between samples (sql.test grew ~8G in one 2s tick). Keyed by the
+        #     untruncated binary name from /proc/<pid>/cmdline.
+        #   * per-job peak    = cgroup memory.peak (v2) / max_usage_in_bytes (v1),
+        #     falling back to /proc/meminfo used. Exact kernel high-water.
+        # Samples stream to the live log every 5s (GitHub uploads logs in real
+        # time, so they survive the kill — unlike catchpoint's post-job summary or
+        # `if: always()` artifact uploads, both normal steps that don't run after a
+        # mid-step kill). A sorted FINAL table prints on exit for clean runs. The
+        # sampler runs under `set +e` so a SIGPIPE/no-match never trips the step's
+        # `set -e`; `make test` keeps `set -e`.
         run: |
-          sample_mem() {
+          TRACK="$(mktemp)"
+          job_peak() {
+            local f
+            for f in /sys/fs/cgroup/memory.peak /sys/fs/cgroup/memory/memory.max_usage_in_bytes; do
+              if [ -r "$f" ]; then awk -v b="$(<"$f")" 'BEGIN{printf "%.1fG", b/1073741824}'; return; fi
+            done
+            awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} END{printf "%.1fG",(t-a)/1048576}' /proc/meminfo
+          }
+          sample() {
+            set +e
+            local st pid hwm cmd name
             while :; do
-              awk -v t="$(date +%T)" '
-                /^MemTotal:/     {tot=$2}
-                /^MemAvailable:/ {av=$2}
-                END {printf "MEMSAMPLE %s used=%.1fG avail=%.1fG of %.1fG\n", t,(tot-av)/1048576,av/1048576,tot/1048576}
-              ' /proc/meminfo
-              ps -eo rss=,comm= --sort=-rss 2>/dev/null | awk 'NR<=3 {printf "  TOP %.1fG %s\n",$1/1048576,$2}'
-              sleep 2
+              for st in /proc/[0-9]*/status; do
+                pid="${st#/proc/}"; pid="${pid%/status}"
+                hwm="$(awk '/^VmHWM:/{print $2; exit}' "$st" 2>/dev/null)"
+                [ -n "$hwm" ] || continue
+                cmd="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)"
+                name="${cmd%% *}"; name="${name##*/}"
+                case "$name" in *.test) echo "$hwm $name" >> "$TRACK" ;; esac
+              done
+              echo "PEAK $(date +%T) job=$(job_peak)"
+              sort -rn "$TRACK" 2>/dev/null | awk '!seen[$2]++{printf "  BIN %.1fG %s\n",$1/1048576,$2} NR>200{exit}'
+              sleep 5
             done
           }
-          sample_mem &
-          SAMPLER_PID=$!
-          trap 'kill "$SAMPLER_PID" 2>/dev/null || true' EXIT
+          sample & SAMPLER_PID=$!
+          finalize() {
+            set +e
+            kill "$SAMPLER_PID" 2>/dev/null
+            echo "=== FINAL PEAKS  job=$(job_peak) ==="
+            awk '$1>m[$2]{m[$2]=$1} END{for (k in m) printf "%d %s\n", m[k], k}' "$TRACK" 2>/dev/null \
+              | sort -rn | awk '{printf "  BINPEAK %.1fG %s\n",$1/1048576,$2}'
+          }
+          trap finalize EXIT
           make test
         continue-on-error: false
 

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -23,39 +23,13 @@ env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
 
 jobs:
-  golangci-lint:
-    name: golangci-lint
-    # arm64-safe: pure Go analysis, no containers (golangci-lint ships arm64).
-    runs-on: teranode-runner-8-core-arm
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
-      # golangci typechecks (no -race) and the action caches its own build
-      # artifacts, so restore the module cache only.
-      - name: Restore Go caches
-        uses: ./.github/actions/go-cache
-        with:
-          build_cache: 'false'
-
-      - name: golangci-lint with checkstyle report
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
-        with:
-          version: v2.10.1
-          args: --timeout=5m --disable gosec --disable prealloc --output.checkstyle.path=golangci-lint-report.xml --output.text.path=stdout
-
-      - name: Upload golangci-lint report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: golangci-lint-report
-          path: golangci-lint-report.xml
-          retention-days: 1
-
+  # NOTE — CI-143 experiment branch, DO NOT MERGE.
+  # The golangci-lint and filename-check-report jobs that normally live here are
+  # temporarily removed, and every other PR workflow is disabled, to isolate the
+  # intermittent `Process completed with exit code 143` (SIGTERM mid-run) in this
+  # `test` job and to save runner minutes while reproducing it. `test` is the only
+  # job that runs `go test -race -coverpkg=./...` across the whole repo in one
+  # process, which is why it is the only one affected. Revert this branch before merge.
   test:
     name: test
     # ARM runner: the x86 16-core runner OOM-killed the `go test -race
@@ -65,6 +39,17 @@ jobs:
     # natively: postgres testcontainers (arm64) + testtxmetacache (no aerospike).
     runs-on: teranode-runner-16-core-arm
     steps:
+      # TEMP (CI-143): re-add catchpoint workflow telemetry (removed in PR #948)
+      # to capture peak memory/CPU/IO for the whole job. Charts land in the job
+      # Summary (and a PR comment if the token has write access — fork PRs get a
+      # read-only token, so check the Summary). This is how we confirm whether
+      # `make test` actually exhausts the 64GB runner right before the SIGTERM.
+      - name: Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@f974e0c5942f8f37973c4cc395704165fbe629ba # v2
+        with:
+          theme: "dark"
+          comment_on_pr: "false"
+
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       # Only login to Docker Hub for internal PRs to avoid rate limits.
@@ -95,25 +80,3 @@ jobs:
           name: coverage-report
           path: coverage.out
           retention-days: 1
-
-      # - name: Publish Test Summary Results
-      #   if: always()
-      #   run: npx github-actions-ctrf ctrf-report.json
-
-  filename-check-report:
-    name: filename check report
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-
-      - name: Generate filename check report
-        run: ./scripts/check_filenames.sh
-
-      - name: Upload filename check report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: sonar-filename-report
-          path: sonar_filename_report.json
-          retention-days: 1
-


### PR DESCRIPTION
## DO NOT MERGE — throwaway experiment branch

Reproduce and measure the intermittent `Error: Process completed with exit code 143` in the PR `test` check (e.g. [run 27134100923](https://github.com/bsv-blockchain/teranode/actions/runs/27134100923/job/80082090162?pr=1044)).

### What 143 actually is here

`143 = 128 + 15 = SIGTERM`. In the failing logs the tests are **already passing** when `make` is killed mid-run:

```
✓  util/test/mocklogger (1.717s)
make: *** [Makefile:188: test] Terminated
##[error]Process completed with exit code 143.
```

So this is **not** the compile-time OOM (that happens at the start). The process group is terminated partway through the run.

### Why only `test`

`test` is the only PR job that runs `go test -race -coverpkg=./...` across the **whole repo in one process**: every test binary instruments the entire repo for coverage, and `go test` runs ~GOMAXPROCS of them in parallel. That is by far the most memory-hungry job — the in-file comment already notes ~70GB peak at 32 cores. Current runner is 16-core arm (64GB). If a few heavy race+coverage binaries overlap, peak can brush the 64GB ceiling → host memory pressure / runner reclaim → SIGTERM. None of the other jobs do `-race -coverpkg=./...` whole-repo, which is exactly why none of them are affected.

### Changes (all temporary)

- **Re-add `catchpoint/workflow-telemetry-action`** to the `test` job (it was removed in #948) to capture peak memory/CPU/IO. **Runner unchanged** — 16-core arm, 64GB — this run is purely to *measure* before deciding whether to bump RAM or cap parallelism. `comment_on_pr: false`; the charts are in the **job Summary** (fork PRs get a read-only token so a PR comment wouldn't post anyway).
- **Drop** the `golangci-lint` and `filename-check-report` sibling jobs.
- **Disable every other PR-reachable workflow** via `branches-ignore: ['**']` so only `test` runs and we don't burn runner minutes: `teranode_pr_smoketests`, `benchmark-compare` (+ chained `benchmark-report`), `dashboard_pr_smoke`, `dependency-review`, `sonar-pr-analyze`, `teranode_pr_init` (+ chained `claude-code-review`), `claude-code-review`.

### How to use

1. Let `test` run. Open the **test job → Summary** for the telemetry charts; note peak memory just before any 143.
2. Re-run a few times — the failure is intermittent, so one green run proves nothing.
3. Decide next step from the data: if peak ≈ 64GB → bump to 32-core/128GB **or** cap `-p`/drop `-coverpkg=./...`; if peak is comfortably under and it still 143s → it's runner reclaim, not memory.

### Next levers (not in this PR)

- Cap test-binary parallelism: `-p=N` on the `go test` line in `Makefile:188` — directly bounds concurrent heavy binaries.
- Drop `-coverpkg=./...` to per-package coverage — largest single memory reduction.
- 32-core arm (128GB) — known ~70GB peak fits, but expensive.

Revert this branch before merge.
