### PR TITLE
ci(claude-review): bump action to v1.0.142 and switch to opus 4.8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.pr.outputs.is_draft == 'false'
         id: claude-review
-        uses: anthropics/claude-code-action@e8bad572273ce919ba15fec95aef0ce974464753 # v1
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -167,6 +167,7 @@ jobs:
               * If still broken: Leave unresolved, optionally add brief update to the thread
 
             **Review Guidelines:**
+            - Work fully autonomously: this is a non-interactive CI run, never pause to ask questions or offer follow-ups
             - DO NOT submit formal GitHub reviews using `gh pr review`
             - This is advisory/informational only - human reviewers make final decisions
             - Keep the sticky comment brief (max 3-4 short paragraphs when complete)
@@ -211,7 +212,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
 
       # If the Claude step failed (timeout, API error, runner death), any "In Progress" sticky
       # comment it created is now a zombie. Mark it Aborted so the PR doesn't show a stuck review.


### PR DESCRIPTION
## What

- Bump pinned `anthropics/claude-code-action` from v1.0.13 (`e8bad572`, Oct 2025) to v1.0.142 (`11ba6048`).
- Pin the review model explicitly: `--model claude-opus-4-8`.
- Add an autonomy instruction to the review prompt.

## Why

The old pin installed Claude Code CLI 2.0.15, whose default model is `claude-sonnet-4-5-20250929` — confirmed in recent run logs. That model is legacy; reviews have been running on an 8-month-old model.

The new action bundles the current Claude Agent SDK instead of curling an installer, so the default model would float with whatever the SDK ships. The explicit `--model` keeps review behavior deterministic.

Opus 4.8 is more deliberate than prior models and tends to pause to ask questions or offer follow-ups. That stalls a non-interactive CI run, hence the new prompt line telling it to work fully autonomously.

## Notes

- All four action inputs we use (`prompt`, `anthropic_api_key`, `github_token`, `claude_args`) verified present in v1.0.142.
- `use_sticky_comment` was evaluated and deliberately NOT adopted: it only activates on literal `pull_request` events and claude[bot] auth. Our `workflow_run` + explicit-prompt (agent mode) + `GITHUB_TOKEN` setup makes it a no-op — the hand-rolled sticky comment in the prompt stays.
- Cost: opus 4.8 is $5/$25 per MTok vs sonnet 4.5 $3/$15, roughly 1.7x per review.
