### PR TITLE
ci(claude-review): switch review model to sonnet-4-6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -212,7 +212,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--model claude-opus-4-8 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+          claude_args: '--model claude-sonnet-4-6 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
 
       # If the Claude step failed (timeout, API error, runner death), any "In Progress" sticky
       # comment it created is now a zombie. Mark it Aborted so the PR doesn't show a stuck review.


### PR DESCRIPTION
## What

Switch the Claude Code Review model from `claude-opus-4-8` to `claude-sonnet-4-6`.

## Why

Opus 4.8 review latency is high for a PR feedback loop. Sonnet 4.6 is the current speed/intelligence-balance model: markedly faster, $3/$15 per MTok vs $5/$25 (~1.7x cheaper), 1M context, adaptive thinking supported. Advisory diff review fits its profile.

## Status

Draft on purpose — gathering more datapoints on opus 4.8 review latency before deciding. If opus speed turns out acceptable, this closes unmerged.
