### PR TITLE
fix(legacy): prevent sync stalls from backpressure-triggered peer rotation and dropped orphan continuation

### DIFF
--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -407,6 +407,14 @@ type SyncManager struct {
 	syncPeerState   *syncPeerState
 	peerStates      *txmap.SyncedMap[*peerpkg.Peer, *peerSyncState]
 
+	// blockBacklog counts blocks sitting in the local processing pipeline:
+	// queued in blockHandler's blockQueue plus the one inside handleBlockMsg.
+	// While it is non-zero the node is backpressuring its own network reads
+	// (OnBlock blocks until the previous block is processed), so the stall
+	// detector must not hold the resulting zero throughput against the sync
+	// peer. Written by the blockHandler goroutines, read by handleCheckSyncPeer.
+	blockBacklog atomic.Int64
+
 	// The following fields are used for headers-first mode.
 	headersFirstMode atomic.Bool // accessed from multiple goroutines, must be atomic
 	headerList       *list.List
@@ -839,6 +847,18 @@ func (sm *SyncManager) handleCheckSyncPeer() {
 
 	// Update network stats at the end of this tick.
 	defer sps.updateNetwork(sp)
+
+	// While blocks are queued or mid-validation locally, OnBlock deliberately
+	// stops reading from the peer (it blocks on blockProcessed), so zero
+	// throughput and a stale last-block-time measure our own validation speed,
+	// not the peer's health. Skip stall checks until the backlog drains — a
+	// genuinely stalled peer keeps failing them afterwards. The deferred
+	// updateNetwork still runs, keeping throughput samples fresh for the next
+	// tick.
+	if backlog := sm.blockBacklog.Load(); backlog > 0 {
+		sm.logger.Debugf("[CheckSyncPeer] sync peer %s check skipped: %d blocks pending local processing", sp.String(), backlog)
+		return
+	}
 
 	headersFirst := sm.headersFirstMode.Load()
 	lastBlockSince := time.Since(sps.getLastBlockTime())
@@ -2066,6 +2086,9 @@ func (sm *SyncManager) blockHandler() {
 				sm.logger.Debugf("[blockHandler][%s] processing block queue message into handleBlockMsg", msg.blockHash)
 
 				err := sm.handleBlockMsg(msg)
+
+				sm.blockBacklog.Add(-1)
+
 				if msg.reply != nil {
 					msg.reply <- err
 				}
@@ -2116,6 +2139,8 @@ out:
 
 			case *blockMsg:
 				sm.logger.Debugf("[blockHandler][%s] queueing block for validation", msg.block.Hash())
+
+				sm.blockBacklog.Add(1)
 
 				blockQueue <- &blockQueueMsg{
 					block:       msg.block.MsgBlock(),

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -1361,12 +1361,18 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	// promote block to the block validation via kafka (p2p -> blockvalidation message),
 	// without calling HandleBlockDirect. Such that it doesn't interfere with the operation of block validation.
 	if err = sm.HandleBlockDirect(sm.ctx, bmsg.peer, bmsg.blockHash, bmsg.block); err != nil {
-		if (legacySyncMode || catchingBlocks) && errors.Is(err, errors.ErrBlockNotFound) {
-			// previous block not found? Probably a new block message from our syncPeer while we are still syncing
-			sm.logger.Errorf("Failed to process new block in legacy mode %v: %v", bmsg.blockHash, err)
-			return nil
-		} else if errors.Is(err, errors.ErrBlockNotFound) {
-			// We don't have the parent of this block/header, so we'll request it.
+		if errors.Is(err, errors.ErrBlockNotFound) {
+			// We don't have the parent of this block. During legacy sync /
+			// catching blocks this is typically the peer announcing its tip
+			// while we are still behind — and in the legacy sync protocol that
+			// orphan tip doubles as the batch-continuation signal: the peer
+			// pushes its tip inv after delivering a getblocks batch and waits
+			// for the next getblocks before sending more. Swallowing the
+			// orphan here stalls the sync until the stall detector rotates
+			// the peer, so always answer with a getblocks from our best
+			// block. PushGetBlocksMsg filters duplicate requests and the peer
+			// only invs blocks past the locator fork point, so a redundant
+			// request costs one inv message at most.
 			sm.logger.Infof("Block %v has missing parent %v, requesting missing blocks",
 				bmsg.blockHash, bmsg.block.Header.PrevBlock)
 

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -923,6 +923,60 @@ func TestHandleCheckSyncPeer_HeadersFirstMode(t *testing.T) {
 	})
 }
 
+// TestHandleCheckSyncPeer_LocalBacklog verifies the stall detector does not
+// blame the sync peer for backpressure the node inflicts on itself: while
+// blocks are queued or mid-validation locally, OnBlock stops reading from the
+// peer, so zero throughput and a stale last-block-time say nothing about the
+// peer's health.
+func TestHandleCheckSyncPeer_LocalBacklog(t *testing.T) {
+	// Zero throughput (recvBytes == recvBytesLastTick) one violation short of
+	// the rotation threshold, plus a last-block-time far past maxLastBlockTime:
+	// without a backlog this tick rotates the sync peer.
+	newStalledState := func() *syncPeerState {
+		return &syncPeerState{
+			lastBlockTime: time.Now().Add(-10 * time.Minute),
+			ticks:         1,
+			violations:    maxNetworkViolations - 1,
+		}
+	}
+
+	newSyncManager := func(sp *peer.Peer, sps *syncPeerState) *SyncManager {
+		sm := &SyncManager{
+			logger:                  ulogger.TestLogger{},
+			peerStates:              txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+			minSyncPeerNetworkSpeed: 51200,
+		}
+		sm.storeSyncPeer(sp, sps)
+		sm.headersFirstMode.Store(false)
+		sm.peerStates.Set(sp, &peerSyncState{})
+
+		return sm
+	}
+
+	t.Run("keeps sync peer and accrues no violation while backlog pending", func(t *testing.T) {
+		sp := &peer.Peer{}
+		sps := newStalledState()
+		sm := newSyncManager(sp, sps)
+
+		sm.blockBacklog.Add(1) // a block is queued or mid-validation locally
+
+		// Rotation would panic in this minimal SyncManager (no blockchain
+		// client), so NotPanics proves the peer was kept.
+		require.NotPanics(t, func() { sm.handleCheckSyncPeer() })
+		assert.Equal(t, sp, sm.loadSyncPeer())
+		assert.Equal(t, maxNetworkViolations-1, sps.getViolations())
+	})
+
+	t.Run("still rotates on zero throughput once backlog drained", func(t *testing.T) {
+		sp := &peer.Peer{}
+		sm := newSyncManager(sp, newStalledState())
+
+		// No local backlog: the same zero-throughput state is a real peer
+		// stall, so the rotation path runs (and panics in this minimal setup).
+		assert.Panics(t, func() { sm.handleCheckSyncPeer() })
+	})
+}
+
 func TestHasHealthyDownloadThroughput(t *testing.T) {
 	const minSpeed = 51200 // 50 KiB/s, matches default minSyncPeerNetworkSpeed
 

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -16,6 +16,7 @@ import (
 	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/go-wire"
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	blockchain2 "github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation"
@@ -28,6 +29,7 @@ import (
 	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/expiringmap"
 	"github.com/bsv-blockchain/teranode/util/kafka"
 	kafkamessage "github.com/bsv-blockchain/teranode/util/kafka/kafka_message"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -921,6 +923,71 @@ func TestHandleCheckSyncPeer_HeadersFirstMode(t *testing.T) {
 		// (which panics in this minimal SyncManager).
 		assert.Panics(t, func() { sm.handleCheckSyncPeer() })
 	})
+}
+
+// TestHandleBlockMsg_OrphanDuringCatchup verifies a block with an unknown
+// parent arriving during legacy sync / catching blocks triggers a getblocks
+// continuation request instead of being silently dropped. In the legacy sync
+// protocol the peer announces its tip after delivering a getblocks batch; that
+// orphan tip is the only signal to request the next batch, so swallowing it
+// stalls the sync until the stall detector rotates the peer.
+func TestHandleBlockMsg_OrphanDuringCatchup(t *testing.T) {
+	prevHash := chainhash.Hash{0x01}
+
+	msgBlock := wire.NewMsgBlock(wire.NewBlockHeader(1, &prevHash, &chainhash.Hash{}, 0, 0))
+	blockHash := msgBlock.Header.BlockHash()
+
+	catchingBlocks := blockchain2.FSMStateCATCHINGBLOCKS
+
+	bestHeader := &model.BlockHeader{
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+	}
+
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&catchingBlocks, nil)
+	blockchainClient.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
+	// Parent header lookup fails — the block is an orphan to us.
+	blockchainClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return(nil, nil, errors.NewBlockNotFoundError("not found"))
+	blockchainClient.On("GetBestBlockHeader", mock.Anything).Return(bestHeader, &model.BlockHeaderMeta{Height: 100}, nil)
+	blockchainClient.On("GetBlockLocator", mock.Anything, mock.Anything, mock.Anything).Return([]*chainhash.Hash{bestHeader.Hash()}, nil)
+
+	// Real (unconnected) peer: PushGetBlocksMsg needs a logger, and
+	// QueueMessage is a no-op on a disconnected peer.
+	p := peer.NewInboundPeer(ulogger.TestLogger{}, test.CreateBaseTestSettings(t), &peer.Config{})
+
+	state := &peerSyncState{
+		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second),
+		requestedBlocks: expiringmap.New[chainhash.Hash, struct{}](time.Minute),
+	}
+	defer state.requestedTxns.Stop()
+	defer state.requestedBlocks.Stop()
+	state.requestedBlocks.Set(blockHash, struct{}{})
+
+	sm := &SyncManager{
+		ctx:              context.Background(),
+		logger:           ulogger.TestLogger{},
+		blockchainClient: blockchainClient,
+		peerStates:       txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+		requestedBlocks:  expiringmap.New[chainhash.Hash, struct{}](time.Minute),
+	}
+	defer sm.requestedBlocks.Stop()
+	sm.peerStates.Set(p, state)
+	sm.requestedBlocks.Set(blockHash, struct{}{})
+
+	err := sm.handleBlockMsg(&blockQueueMsg{
+		block:       msgBlock,
+		blockHash:   blockHash,
+		blockHeight: 101,
+		peer:        p,
+	})
+
+	// The orphan is dropped without error or peer disconnect...
+	require.NoError(t, err)
+
+	// ...but it must trigger the batch-continuation request: a block locator
+	// from our best block, pushed to the peer as getblocks.
+	blockchainClient.AssertCalled(t, "GetBlockLocator", mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestHandleCheckSyncPeer_LocalBacklog verifies the stall detector does not


### PR DESCRIPTION
Two fixes for legacy sync stalling mid-catchup (observed on testnet in CATCHINGBLOCKS past the checkpoints).

> Fix 3 (never announce block-originated transactions) was split out to #1073 per review, with the provenance flag reworked as an explicit validator option.

## Fix 1: stall detector blames the sync peer for local validation backpressure

1. Block processing is single-threaded with backpressure — `OnBlock` blocks on `<-sp.blockProcessed` (`peer_server.go:966`), so the node stops reading from the sync peer while a block validates.
2. A 2958-tx block took 48.5s in `checkSubtreeFromBlock` (full validation path past the highest checkpoint). Measured throughput dropped to zero, network-speed violations accrued each 30s tick, and at 3 violations `handleCheckSyncPeer` disconnected the healthy sync peer and removed it from `peerStates`.
3. The ~92 blocks the rotated peer had already streamed ahead on its DATA1 stream then drained from the block queue, each failing the `peerStates` lookup (primary peer gone): `SERVICE_ERROR (59): [handleBlockMsg] Received block message from unknown peer`.
4. The new sync peer restarted from the last accepted height and re-downloaded everything that was dropped. With every big block this repeats: validate slow → rotate → drop queued work → re-download.

The violation counter also ratchets: it only resets on a good-throughput tick, so violations accumulated across earlier backpressure ticks.

**Fix:** track the local block backlog on `SyncManager` (`blockBacklog`: blockQueue depth plus the block inside `handleBlockMsg`). While it is non-zero, `handleCheckSyncPeer` skips both stall checks — zero throughput during local validation measures our own validation speed, not the peer's health. The deferred `updateNetwork` still runs, so throughput samples stay fresh for the first tick after the backlog drains. A genuinely stalled peer delivers no blocks, so the backlog is empty and the detector behaves exactly as before.

Tradeoffs (raised in review, intentional): the suppression is not bounded by `MaxBlockDownloadTime` — rotation cannot fix slow local validation, and the suppression only persists while the sync peer keeps delivering blocks, which is the opposite of stalled. The counter is currently peer-agnostic; scoping it to the sync peer's association is a possible follow-up hardening.

## Fix 2: orphan blocks dropped during sync break the getblocks continuation

In the legacy sync protocol the peer pushes its tip inv after delivering a getblocks batch and sends nothing further until the next getblocks arrives — the orphan tip block IS the batch-continuation signal (upstream btcd answers any sync-peer orphan with `PushGetBlocksMsg`). The legacy-sync/catching-blocks branch of `handleBlockMsg` dropped orphans with a bare `return nil`:

```
[HandleBlockDirect][...] failed to get block header for previous block ...: BLOCK_NOT_FOUND
Failed to process new block in legacy mode ...
```

After that, the pipeline ran dry and sync stalled until the stall detector rotated the sync peer (~90s dead time plus re-download) — the rotation machinery was accidentally the only recovery path.

**Fix:** remove the special case — answer every `ErrBlockNotFound` with getblocks from our best block, as the non-legacy branch already did. Safe mid-batch: `PushGetBlocksMsg` filters duplicate requests, `requestedBlocks` dedups in-flight getdata, and the peer only invs blocks past the locator fork point, so a redundant request costs one inv message (≤500 hashes).

## Testing

- `TestHandleCheckSyncPeer_LocalBacklog`: backlog pending → peer kept, no violation accrued; backlog drained → same zero-throughput state still rotates.
- `TestHandleBlockMsg_OrphanDuringCatchup`: orphan in CATCHINGBLOCKS → no error, no disconnect, and the getblocks continuation path runs (block locator requested).
- Both watched fail before their fix. `go test -race ./services/legacy/netsync/` clean, `go vet` clean, `golangci-lint` 0 issues.