### PR TITLE
test(multinode): add scenario 05 (validator isolation) and scenario 06 (subtreevalidation pause)

### DIFF
--- a/compose/cmd/gennodes/templates/settings.conf.tmpl
+++ b/compose/cmd/gennodes/templates/settings.conf.tmpl
@@ -24,6 +24,15 @@ p2p_bootstrap_peers.docker.teranode{{ .Index }}.test           =
 # inter-service gRPC/HTTP addresses to dial the sibling container's DNS name
 # instead of the all-in-one default ({{ "${clientName}" }}:port) which would
 # resolve to the node-level container that doesn't exist in split mode.
+#
+# Also force useLocalValidator=false here: settings.conf ships with it set to
+# true (suitable for the all-in-one default), which makes the daemon build an
+# in-process validator and ignore validator_grpcAddress entirely. In split
+# mode the standalone teranode{N}-validator container would then be dead code
+# and per-service chaos against it (e.g. KillService on validator) would have
+# no observable effect. Flipping the override makes split mode actually go
+# through gRPC, which is the whole point of running a separate container.
+useLocalValidator.docker.teranode{{ .Index }}                  = false
 blockchain_grpcAddress.docker.teranode{{ .Index }}             = teranode{{ .Index }}-blockchain:${BLOCKCHAIN_GRPC_PORT}
 blockassembly_grpcAddress.docker.teranode{{ .Index }}          = teranode{{ .Index }}-blockassembly:${BLOCK_ASSEMBLY_GRPC_PORT}
 blockvalidation_grpcAddress.docker.teranode{{ .Index }}        = teranode{{ .Index }}-blockvalidation:${BLOCK_VALIDATION_GRPC_PORT}

--- a/compose/multinode.sh
+++ b/compose/multinode.sh
@@ -650,11 +650,16 @@ chaos_pause() {
 chaos_unpause() {
   local node="${1:?usage: chaos unpause <node> [service]}"
   local svc="${2:-}"
+  # Suppress 'docker unpause' errors on every branch (matching the existing
+  # bulk-split branch below): tests routinely run a defensive defer-unpause
+  # alongside an explicit one on the happy path, and a bare 'docker unpause'
+  # exits non-zero on an already-running container, which MustRun turns into
+  # t.Fatalf. Idempotent semantics are what "chaos cleanup" actually wants.
   if [[ -n "$svc" ]]; then
     assert_known_service "$svc" "chaos unpause"
     local ctr="teranode${node}-${svc}-multinode"
     echo "unpausing $ctr..."
-    docker unpause "$ctr"
+    docker unpause "$ctr" 2>/dev/null || true
     echo "$ctr is unfrozen"
     return
   fi
@@ -671,7 +676,7 @@ chaos_unpause() {
   local ctr
   ctr=$(container_name "$node")
   echo "unpausing $ctr..."
-  docker unpause "$ctr"
+  docker unpause "$ctr" 2>/dev/null || true
   echo "teranode$node is unfrozen"
 }
 

--- a/test/multinode_split/scenario_05_validator_isolation_test.go
+++ b/test/multinode_split/scenario_05_validator_isolation_test.go
@@ -1,0 +1,92 @@
+//go:build network_chaos
+
+package multinodesplit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/test/multinode/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidatorIsolation kills the validator service on node 3 and asserts the
+// node can no longer commit inbound blocks until validator is restored.
+//
+// The coupling: validating a peer's block walks
+//
+//	blockvalidation.ProcessBlock
+//	  -> subtreeValidationClient.CheckBlockSubtrees   (BlockValidation.go)
+//	    -> validatorClient.ValidateWithOptions         (SubtreeValidation.go)
+//
+// i.e. the per-transaction validation of a block's subtrees goes through the
+// validator service. With validator down, node 3 cannot validate the txs in
+// the blocks node 1 mines and should stay pinned at the baseline height.
+//
+// Important config dependency: this only holds when subtreevalidation calls
+// out to the standalone validator container over gRPC, NOT when it embeds an
+// in-process validator. settings.conf ships useLocalValidator=true (the right
+// default for all-in-one), so a vanilla docker.teranode{N}.test context
+// would build an in-process validator and ignore the validator container
+// entirely — making this scenario a no-op. The split-mode overlay generated
+// by compose/cmd/gennodes/templates/settings.conf.tmpl now flips
+// useLocalValidator to false per node, which is what makes the kill
+// observable here. If a future edit drops that override, this test fails
+// loudly and points at it.
+//
+// Shape mirrors TestBlockAssemblyIsolation: kill on node 3, mine on node 1,
+// assert node 3 stalls, restart, assert catch-up and convergence.
+func TestValidatorIsolation(t *testing.T) {
+	s := stack()
+	s.Reset(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	node1 := s.Node(1)
+	node3 := s.Node(3)
+	all := s.Nodes()
+
+	info, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	baselineHeight := info.Blocks
+	baselineTip := info.BestBlockHash
+	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(baselineTip))
+
+	t.Log("killing teranode3-validator...")
+	s.KillService(t, 3, "validator")
+
+	t.Log("mining 5 blocks on teranode1...")
+	_, err = node1.Generate(ctx, 5)
+	require.NoError(t, err, "node 1 generate")
+
+	// Sanity: node 1 actually advanced (its validator is healthy).
+	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
+	survivorInfo, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	survivorTip := survivorInfo.BestBlockHash
+
+	// Settle window: catch-up would happen here if block validation did not
+	// depend on the validator service.
+	t.Log("waiting 15s to confirm teranode3 stays stalled (block validation needs the validator)...")
+	time.Sleep(15 * time.Second)
+
+	stalledInfo, err := node3.GetBlockchainInfo(ctx)
+	require.NoError(t, err, "node 3 RPC must still answer (only validator is down, not core)")
+	require.Equal(t, baselineHeight, stalledInfo.Blocks,
+		"teranode3 should be stuck at baseline height while validator is down (cannot validate block txs)")
+	require.Equal(t, baselineTip, stalledInfo.BestBlockHash, "teranode3 tip should still be the baseline")
+	t.Logf("teranode3 correctly stalled at height=%d while node 1 is at %d", stalledInfo.Blocks, baselineHeight+5)
+
+	t.Log("restarting teranode3-validator...")
+	s.StartService(t, 3, "validator")
+
+	t.Log("waiting for teranode3 to catch up to node 1...")
+	harness.WaitForHeight(t, node3, baselineHeight+5, 2*time.Minute)
+	t.Logf("teranode3 caught up to height %d", baselineHeight+5)
+
+	converged := harness.WaitForConverged(t, all, 1*time.Minute)
+	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip after node 3 catches up")
+	t.Logf("all 3 nodes converged at %s", short(converged))
+}

--- a/test/multinode_split/scenario_06_subtree_validation_isolation_test.go
+++ b/test/multinode_split/scenario_06_subtree_validation_isolation_test.go
@@ -1,0 +1,83 @@
+//go:build network_chaos
+
+package multinodesplit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/test/multinode/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubtreeValidationIsolation PAUSES (does not kill) the subtreevalidation
+// service on node 3 and asserts the node cannot commit inbound blocks until it
+// is resumed.
+//
+// blockvalidation calls subtreeValidationClient.CheckBlockSubtrees
+// (BlockValidation.go) on every inbound block, so subtreevalidation is squarely
+// on the block-acceptance path. This is the most direct dependency in the
+// split graph, which makes it the cleanest stall to assert.
+//
+// We use PauseService rather than KillService deliberately: docker pause
+// SIGSTOPs the container, so the gRPC call from blockvalidation HANGS (no
+// connection-refused, no responder) — the "frozen / unresponsive dependency"
+// failure mode, distinct from a process that has exited. Either way node 3
+// cannot make progress; UnpauseService thaws it and validation resumes. This is
+// the first scenario to exercise the pause/unpause verbs.
+//
+// Shape mirrors TestBlockAssemblyIsolation otherwise.
+func TestSubtreeValidationIsolation(t *testing.T) {
+	s := stack()
+	s.Reset(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	node1 := s.Node(1)
+	node3 := s.Node(3)
+	all := s.Nodes()
+
+	info, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	baselineHeight := info.Blocks
+	baselineTip := info.BestBlockHash
+	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(baselineTip))
+
+	t.Log("pausing teranode3-subtreevalidation (docker pause - gRPC calls will hang)...")
+	s.PauseService(t, 3, "subtreevalidation")
+	// Ensure the service is thawed even if an assertion below fails, so the
+	// shared stack is left healthy for the next scenario's Reset.
+	defer s.UnpauseService(t, 3, "subtreevalidation")
+
+	t.Log("mining 5 blocks on teranode1...")
+	_, err = node1.Generate(ctx, 5)
+	require.NoError(t, err, "node 1 generate")
+
+	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
+	survivorInfo, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	survivorTip := survivorInfo.BestBlockHash
+
+	t.Log("waiting 15s to confirm teranode3 stays stalled (CheckBlockSubtrees hangs on the frozen service)...")
+	time.Sleep(15 * time.Second)
+
+	stalledInfo, err := node3.GetBlockchainInfo(ctx)
+	require.NoError(t, err, "node 3 RPC must still answer (only subtreevalidation is frozen, not core)")
+	require.Equal(t, baselineHeight, stalledInfo.Blocks,
+		"teranode3 should be stuck at baseline height while subtreevalidation is paused (cannot validate block subtrees)")
+	require.Equal(t, baselineTip, stalledInfo.BestBlockHash, "teranode3 tip should still be the baseline")
+	t.Logf("teranode3 correctly stalled at height=%d while node 1 is at %d", stalledInfo.Blocks, baselineHeight+5)
+
+	t.Log("unpausing teranode3-subtreevalidation...")
+	s.UnpauseService(t, 3, "subtreevalidation")
+
+	t.Log("waiting for teranode3 to catch up to node 1...")
+	harness.WaitForHeight(t, node3, baselineHeight+5, 2*time.Minute)
+	t.Logf("teranode3 caught up to height %d", baselineHeight+5)
+
+	converged := harness.WaitForConverged(t, all, 1*time.Minute)
+	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip after node 3 catches up")
+	t.Logf("all 3 nodes converged at %s", short(converged))
+}


### PR DESCRIPTION
## Summary

Two new split-topology chaos scenarios in `test/multinode_split/`, building on the harness landed in #958 and the un-skip work in #995. Both are gated on `//go:build network_chaos`.

### Scenario 05 — Validator isolation (`KillService`)
- Kills `teranode3-validator`, mines 5 blocks on node 1, asserts node 3 stays at baseline because the block-tx validation path is `blockvalidation.ProcessBlock` → `subtreevalidation.CheckBlockSubtrees` → `validator.ValidateWithOptions`, so with validator down node 3 cannot validate the txs inside the new blocks.
- Restarts validator, asserts catch-up to height `baseline+5` and 3-node convergence on node 1's tip.
- Doc-comment also records a hypothesis worth falsifying: if subtreevalidation ever switches to an in-process validator on the block path, this test fails loudly and the real coupling is documented here rather than assumed.

### Scenario 06 — Subtreevalidation pause (`PauseService` / `UnpauseService`)
- **PAUSES** rather than kills `teranode3-subtreevalidation` via `docker pause` (SIGSTOP), so the gRPC call from blockvalidation **hangs** (no connection-refused, no responder), exercising the frozen / unresponsive dependency failure mode, distinct from a process that has exited.
- First scenario to use the pause/unpause verbs.
- Uses `defer s.UnpauseService` so a failed assertion still leaves the shared stack healthy for the next scenario's `Reset`.

## Test plan

- [x] `go build -tags network_chaos ./test/multinode_split/...` clean
- [ ] CI / a local docker stack to run `go test -tags network_chaos -run TestValidatorIsolation` and `... -run TestSubtreeValidationIsolation` end-to-end against a 3-node split stack