### PR TITLE
test(multinode): add split-topology scenarios 07 (p2p), 08 (propagation freeze), 09 (asset control)

### DIFF
--- a/compose/multinode.sh
+++ b/compose/multinode.sh
@@ -650,11 +650,16 @@ chaos_pause() {
 chaos_unpause() {
   local node="${1:?usage: chaos unpause <node> [service]}"
   local svc="${2:-}"
+  # Suppress 'docker unpause' errors on every branch (matching the existing
+  # bulk-split branch below): tests routinely run a defensive defer-unpause
+  # alongside an explicit one on the happy path, and a bare 'docker unpause'
+  # exits non-zero on an already-running container, which MustRun turns into
+  # t.Fatalf. Idempotent semantics are what "chaos cleanup" actually wants.
   if [[ -n "$svc" ]]; then
     assert_known_service "$svc" "chaos unpause"
     local ctr="teranode${node}-${svc}-multinode"
     echo "unpausing $ctr..."
-    docker unpause "$ctr"
+    docker unpause "$ctr" 2>/dev/null || true
     echo "$ctr is unfrozen"
     return
   fi
@@ -671,7 +676,7 @@ chaos_unpause() {
   local ctr
   ctr=$(container_name "$node")
   echo "unpausing $ctr..."
-  docker unpause "$ctr"
+  docker unpause "$ctr" 2>/dev/null || true
   echo "teranode$node is unfrozen"
 }
 

--- a/test/multinode_split/scenario_07_p2p_isolation_test.go
+++ b/test/multinode_split/scenario_07_p2p_isolation_test.go
@@ -1,0 +1,83 @@
+//go:build network_chaos
+
+package multinodesplit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/test/multinode/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestP2PIsolation kills the p2p service on node 3 and asserts the node can
+// no longer receive blocks from peers until p2p is restored.
+//
+// p2p is the inter-node block- and tx-announcement control plane. With it
+// down, node 3 loses both directions: it cannot receive block/tx INVs from
+// nodes 1 and 2, and it cannot pull headers/blocks from them. The blockchain,
+// blockvalidation, subtreevalidation, validator, propagation, asset, and core
+// containers all stay up on node 3, so node 3's RPC keeps answering: it is
+// alive but blind to the rest of the mesh.
+//
+// Note: the multinode docker stack relays blocks between teranode nodes only
+// via the native p2p service, not the legacy SV wire protocol. Legacy lives
+// in the core sidecar but its peering is configured for bridging to actual
+// Bitcoin SV nodes, not for inter-teranode block relay. So killing
+// teranodeN-p2p genuinely severs node N from the test mesh.
+//
+// Shape mirrors TestBlockAssemblyIsolation: kill on node 3, mine on node 1,
+// assert node 3 stalls, restart, assert catch-up and convergence.
+func TestP2PIsolation(t *testing.T) {
+	s := stack()
+	s.Reset(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	node1 := s.Node(1)
+	node3 := s.Node(3)
+	all := s.Nodes()
+
+	info, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	baselineHeight := info.Blocks
+	baselineTip := info.BestBlockHash
+	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(baselineTip))
+
+	t.Log("killing teranode3-p2p...")
+	s.KillService(t, 3, "p2p")
+
+	t.Log("mining 5 blocks on teranode1...")
+	_, err = node1.Generate(ctx, 5)
+	require.NoError(t, err, "node 1 generate")
+
+	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
+	survivorInfo, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	survivorTip := survivorInfo.BestBlockHash
+
+	// Settle window: if block relay had any path not routed through p2p,
+	// catch-up would happen here.
+	t.Log("waiting 15s to confirm teranode3 stays stalled (no inbound block announcements without p2p)...")
+	time.Sleep(15 * time.Second)
+
+	stalledInfo, err := node3.GetBlockchainInfo(ctx)
+	require.NoError(t, err, "node 3 RPC must still answer (only p2p is down, not core)")
+	require.Equal(t, baselineHeight, stalledInfo.Blocks,
+		"teranode3 should be stuck at baseline height while p2p is down (no path for peer blocks to arrive)")
+	require.Equal(t, baselineTip, stalledInfo.BestBlockHash, "teranode3 tip should still be the baseline")
+	t.Logf("teranode3 correctly stalled at height=%d while node 1 is at %d", stalledInfo.Blocks, baselineHeight+5)
+
+	t.Log("restarting teranode3-p2p...")
+	s.StartService(t, 3, "p2p")
+
+	t.Log("waiting for teranode3 to catch up to node 1...")
+	harness.WaitForHeight(t, node3, baselineHeight+5, 2*time.Minute)
+	t.Logf("teranode3 caught up to height %d", baselineHeight+5)
+
+	converged := harness.WaitForConverged(t, all, 1*time.Minute)
+	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip after node 3 catches up")
+	t.Logf("all 3 nodes converged at %s", short(converged))
+}

--- a/test/multinode_split/scenario_08_propagation_freeze_test.go
+++ b/test/multinode_split/scenario_08_propagation_freeze_test.go
@@ -1,0 +1,89 @@
+//go:build network_chaos
+
+package multinodesplit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/test/multinode/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPropagationFreeze is the suite's first *asymmetric* scenario: pausing
+// the propagation service on node 2 must NOT stall block sync, because
+// propagation is the tx-ingress path (RPC sendrawtransaction -> propagation
+// -> validator -> blockassembly), not the block-relay path. Inbound peer
+// blocks reach node 2 via p2p -> blockvalidation -> subtreevalidation; they
+// never touch propagation.
+//
+// We use PauseService (docker pause / SIGSTOP) rather than KillService so any
+// accidental gRPC call into propagation from a block-path code site would
+// hang the caller (frozen-dependency failure mode), making the coupling
+// visible. If block sync were silently depending on propagation, a paused
+// container would manifest as a stall here, not as a connection-refused
+// error.
+//
+// Shape:
+//
+//  1. Reset to a converged 3-node baseline.
+//  2. Pause teranode2-propagation. blockchain, blockvalidation,
+//     subtreevalidation, validator, p2p, asset, and core all stay healthy
+//     on node 2.
+//  3. Mine 5 blocks on node 1.
+//  4. After a settle window, assert node 2 *has* caught up — proving the
+//     block-acceptance path is independent of propagation.
+//  5. Unpause propagation. Assert all 3 nodes converge.
+//
+// A `defer s.UnpauseService` guarantees the container is thawed even if a
+// require assertion fails, so the shared stack stays healthy for the next
+// scenario's Reset.
+func TestPropagationFreeze(t *testing.T) {
+	s := stack()
+	s.Reset(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	node1 := s.Node(1)
+	node2 := s.Node(2)
+	all := s.Nodes()
+
+	info, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	baselineHeight := info.Blocks
+	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(info.BestBlockHash))
+
+	t.Log("pausing teranode2-propagation (docker pause - any gRPC call from a block-path site would hang)...")
+	s.PauseService(t, 2, "propagation")
+	defer s.UnpauseService(t, 2, "propagation")
+
+	t.Log("mining 5 blocks on teranode1...")
+	_, err = node1.Generate(ctx, 5)
+	require.NoError(t, err, "node 1 generate")
+
+	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
+	survivorInfo, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	survivorTip := survivorInfo.BestBlockHash
+
+	// Asymmetric expectation: node 2 must catch up despite propagation
+	// being frozen. WaitForHeight enforces this with a real timeout — if
+	// block sync silently depends on propagation, the wait fails and we
+	// learn the coupling exists.
+	t.Log("waiting for teranode2 to catch up via p2p+blockvalidation (propagation still frozen)...")
+	harness.WaitForHeight(t, node2, baselineHeight+5, 2*time.Minute)
+	caughtUp, err := node2.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	require.Equal(t, baselineHeight+5, caughtUp.Blocks,
+		"teranode2 should catch up to node 1 even with propagation frozen (block sync goes via p2p, not propagation)")
+	t.Logf("teranode2 reached height=%d with propagation still paused", caughtUp.Blocks)
+
+	t.Log("unpausing teranode2-propagation...")
+	s.UnpauseService(t, 2, "propagation")
+
+	converged := harness.WaitForConverged(t, all, 1*time.Minute)
+	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip")
+	t.Logf("all 3 nodes converged at %s", short(converged))
+}

--- a/test/multinode_split/scenario_09_asset_isolation_test.go
+++ b/test/multinode_split/scenario_09_asset_isolation_test.go
@@ -1,0 +1,94 @@
+//go:build network_chaos
+
+package multinodesplit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/test/multinode/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssetIsolation is a control / null-hypothesis scenario: killing the
+// asset service on node 3 must NOT stall block sync. Asset is the HTTP
+// server that exposes this node's subtrees and block data to external
+// queries and to peers fetching for their own subtreevalidation. The
+// node-3 receive path for peer blocks is:
+//
+//	node1 p2p inv -> node3 p2p -> node3 blockvalidation
+//	  -> node3 subtreevalidation (pulls subtree blobs from node1's asset)
+//	  -> node3 validator (tx validation)
+//	  -> node3 blockchain (commit)
+//
+// node3-asset only serves outbound queries from peers and external clients.
+// It is not on node3's own block-acceptance path. Killing it should make
+// node3 invisible to *peers* fetching from it, but not affect node3 itself.
+//
+// Without a control like this, the suite cannot distinguish "block-assembly /
+// validator / subtreevalidation / p2p kills stalled node 3 because they're
+// on the consensus path" from "any KillService stalls node 3 because the
+// harness or compose graph is broken." This scenario rules out the latter.
+//
+// If this test surprisingly fails — i.e. node 3 *does* stall after asset is
+// killed — then asset is silently on node 3's own block-acceptance path
+// (most likely subtreevalidation reaches into localhost asset rather than
+// the originating peer's asset), and that coupling is a finding worth
+// documenting and fixing.
+//
+// Shape:
+//
+//  1. Reset to a converged 3-node baseline.
+//  2. Kill teranode3-asset. All other node-3 services stay up.
+//  3. Mine 5 blocks on node 1.
+//  4. Assert node 3 catches up — proving asset is off node 3's
+//     receive-side consensus path.
+//  5. Restart asset. Assert 3-node convergence.
+func TestAssetIsolation(t *testing.T) {
+	s := stack()
+	s.Reset(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	node1 := s.Node(1)
+	node3 := s.Node(3)
+	all := s.Nodes()
+
+	info, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	baselineHeight := info.Blocks
+	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(info.BestBlockHash))
+
+	t.Log("killing teranode3-asset...")
+	s.KillService(t, 3, "asset")
+
+	t.Log("mining 5 blocks on teranode1...")
+	_, err = node1.Generate(ctx, 5)
+	require.NoError(t, err, "node 1 generate")
+
+	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
+	survivorInfo, err := node1.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	survivorTip := survivorInfo.BestBlockHash
+
+	// Asymmetric expectation: node 3 must catch up despite its own asset
+	// being dead. If subtreevalidation actually reaches into localhost
+	// asset rather than the originating peer's asset, this wait fails
+	// and we have a finding.
+	t.Log("waiting for teranode3 to catch up (its own asset is dead, subtreevalidation should pull from node1's)...")
+	harness.WaitForHeight(t, node3, baselineHeight+5, 2*time.Minute)
+	caughtUp, err := node3.GetBlockchainInfo(ctx)
+	require.NoError(t, err)
+	require.Equal(t, baselineHeight+5, caughtUp.Blocks,
+		"teranode3 should catch up to node 1 even with its own asset dead (asset is outbound-only on the receive path)")
+	t.Logf("teranode3 reached height=%d with its asset still down", caughtUp.Blocks)
+
+	t.Log("restarting teranode3-asset...")
+	s.StartService(t, 3, "asset")
+
+	converged := harness.WaitForConverged(t, all, 1*time.Minute)
+	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip")
+	t.Logf("all 3 nodes converged at %s", short(converged))
+}


### PR DESCRIPTION
## Summary

Three new split-topology chaos scenarios that broaden coverage beyond the validation pipeline tests (04/05/06) to the relay control plane and the off-path services. All gated on `//go:build network_chaos`.

### Scenario 07 — P2P isolation (`KillService`, expected stall)
- Kills `teranode3-p2p`. The multinode docker stack relays blocks between teranodes only via the native p2p service, so killing `teranodeN-p2p` genuinely severs node N from the mesh. (Legacy lives in `core` but is configured for SV bridging, not inter-teranode relay.)
- Mine 5 on node 1, assert node 3 stalls at baseline, restart, assert catch-up and 3-node convergence.

### Scenario 08 — Propagation freeze (`PauseService`, asymmetric expected NO stall)
- The suite's **first asymmetric scenario**. Pauses `teranode2-propagation` and asserts node 2 still catches up via `p2p` + `blockvalidation`, because propagation is the tx-ingress path (`RPC sendrawtransaction -> propagation -> validator -> blockassembly`), not the block-relay path.
- Uses `PauseService` (SIGSTOP) rather than `KillService` so any accidental gRPC call from a block-path site would **hang** the caller (frozen-dependency failure mode), making a hidden coupling visible rather than letting it surface as connection-refused.
- `defer s.UnpauseService` so a failed assertion still leaves the shared stack healthy for the next scenario.

### Scenario 09 — Asset isolation (`KillService`, control / null hypothesis)
- Kills `teranode3-asset` and asserts node 3 still catches up. Asset is the outbound HTTP server that serves a node's subtree/block data to peers and external clients; it is not on the **receive-side** consensus path.
- Without a control like this, the suite cannot distinguish *"validator/p2p/etc kills stalled node 3 because they're on the consensus path"* from *"any `KillService` stalls node 3 because the harness or compose graph is broken."* This scenario rules out the latter.
- If it surprisingly fails (node 3 *does* stall after asset is killed), that documents a real coupling worth chasing, namely subtreevalidation reaching localhost asset rather than the originating peer's asset.

## Test plan

- [x] `go build -tags network_chaos ./test/multinode_split/...` clean
- [ ] CI / a local 3-node split stack to run `go test -tags network_chaos -run 'TestP2PIsolation|TestPropagationFreeze|TestAssetIsolation'` end-to-end