### PR TITLE
chore(asset): demote noisy per-request logs to DEBUG level access log by status

### DIFF
--- a/services/asset/centrifuge_impl/centrifuge.go
+++ b/services/asset/centrifuge_impl/centrifuge.go
@@ -143,7 +143,19 @@ func (c *Centrifuge) Init(_ context.Context) (err error) {
 	c.centrifugeNode, err = centrifuge.New(centrifuge.Config{
 		LogLevel: centrifuge.LogLevelDebug,
 		LogHandler: func(e centrifuge.LogEntry) {
-			c.logger.Infof("[Centrifuge] %s: %s", e.Message, e.Fields)
+			// Map the centrifuge entry's own level to ours. LogLevelDebug above
+			// means the library emits debug-level entries too; logging them all
+			// at INFO floods the asset logs, so respect the per-entry level.
+			switch e.Level {
+			case centrifuge.LogLevelError:
+				c.logger.Errorf("[Centrifuge] %s: %s", e.Message, e.Fields)
+			case centrifuge.LogLevelWarn:
+				c.logger.Warnf("[Centrifuge] %s: %s", e.Message, e.Fields)
+			case centrifuge.LogLevelInfo:
+				c.logger.Infof("[Centrifuge] %s: %s", e.Message, e.Fields)
+			default:
+				c.logger.Debugf("[Centrifuge] %s: %s", e.Message, e.Fields)
+			}
 		},
 	})
 	if err != nil {
@@ -164,14 +176,14 @@ func (c *Centrifuge) Init(_ context.Context) (err error) {
 
 	c.centrifugeNode.OnConnect(func(client *centrifuge.Client) {
 		client.OnUnsubscribe(func(e centrifuge.UnsubscribeEvent) {
-			c.logger.Infof("user %s unsubscribed from %s", client.UserID(), e.Channel)
+			c.logger.Debugf("user %s unsubscribed from %s", client.UserID(), e.Channel)
 		})
 		client.OnDisconnect(func(e centrifuge.DisconnectEvent) {
-			c.logger.Infof("user %s disconnected, disconnect: %s", client.UserID(), e.Disconnect)
+			c.logger.Debugf("user %s disconnected, disconnect: %s", client.UserID(), e.Disconnect)
 		})
 
 		transport := client.Transport()
-		c.logger.Infof("user %s connected via %s", client.UserID(), transport.Name())
+		c.logger.Debugf("user %s connected via %s", client.UserID(), transport.Name())
 
 		// Send cached current node status first (replicates p2p behavior)
 		c.statusMutex.RLock()

--- a/services/asset/centrifuge_impl/client/client.go
+++ b/services/asset/centrifuge_impl/client/client.go
@@ -74,11 +74,11 @@ func (c *Client) Start(_ context.Context, addr string) error {
 	})
 
 	c.client.OnMessage(func(e centrifuge.MessageEvent) {
-		c.logger.Infof("[CentrifugeClient] message: %s", string(e.Data))
+		c.logger.Debugf("[CentrifugeClient] message: %s", string(e.Data))
 	})
 
 	c.client.OnPublication(func(e centrifuge.ServerPublicationEvent) {
-		c.logger.Infof("[CentrifugeClient] publication: %s", string(e.Data))
+		c.logger.Debugf("[CentrifugeClient] publication: %s", string(e.Data))
 	})
 
 	c.client.OnError(func(e centrifuge.ErrorEvent) {
@@ -87,7 +87,7 @@ func (c *Client) Start(_ context.Context, addr string) error {
 
 	subscriptions := []string{"blocks", "subtrees"}
 	for _, channel := range subscriptions {
-		c.logger.Infof("[CentrifugeClient] subscribing to %s", channel)
+		c.logger.Debugf("[CentrifugeClient] subscribing to %s", channel)
 
 		sub, err := c.client.NewSubscription(channel, centrifuge.SubscriptionConfig{})
 		if err != nil {

--- a/services/asset/httpimpl/GetBlock.go
+++ b/services/asset/httpimpl/GetBlock.go
@@ -141,7 +141,7 @@ func (h *HTTP) GetBlockByHeight(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockByHeight_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http] GetBlockByHeight in %s for %s: %s", mode, c.RealIP(), c.Param("height")),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetBlockByHeight in %s for %s: %s", mode, c.RealIP(), c.Param("height")),
 		)
 
 		defer deferFn()

--- a/services/asset/httpimpl/GetBlockHeader.go
+++ b/services/asset/httpimpl/GetBlockHeader.go
@@ -93,7 +93,7 @@ func (h *HTTP) GetBlockHeader(mode ReadMode) func(c echo.Context) error {
 
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockHeader_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http] GetBlockHeader in %s for %s: %s", mode, c.RealIP(), hashParam),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetBlockHeader in %s for %s: %s", mode, c.RealIP(), hashParam),
 		)
 
 		defer deferFn()

--- a/services/asset/httpimpl/GetBlockHeaders.go
+++ b/services/asset/httpimpl/GetBlockHeaders.go
@@ -116,7 +116,7 @@ func (h *HTTP) GetBlockHeaders(mode ReadMode) func(c echo.Context) error {
 
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockHeaders_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[GetBlockHeaders_http] Get %s Block Headers in %s for %s", mode, c.RealIP(), hashStr),
+			tracing.WithDebugLogMessage(h.logger, "[GetBlockHeaders_http] Get %s Block Headers in %s for %s", mode, c.RealIP(), hashStr),
 		)
 
 		defer deferFn()

--- a/services/asset/httpimpl/GetBlockHeadersFromCommonAncestor.go
+++ b/services/asset/httpimpl/GetBlockHeadersFromCommonAncestor.go
@@ -111,7 +111,7 @@ func (h *HTTP) GetBlockHeadersFromCommonAncestor(mode ReadMode) func(c echo.Cont
 
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockHeadersFromCommonAncestor_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[GetBlockHeadersFromCommonAncestor_http] Get %s Block Headers in %s for %s", mode, c.RealIP(), hashStr),
+			tracing.WithDebugLogMessage(h.logger, "[GetBlockHeadersFromCommonAncestor_http] Get %s Block Headers in %s for %s", mode, c.RealIP(), hashStr),
 		)
 		defer deferFn()
 

--- a/services/asset/httpimpl/GetBlockHeadersToCommonAncestor.go
+++ b/services/asset/httpimpl/GetBlockHeadersToCommonAncestor.go
@@ -114,7 +114,7 @@ func (h *HTTP) GetBlockHeadersToCommonAncestor(mode ReadMode) func(c echo.Contex
 
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockHeadersToCommonAncestor_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[GetBlockHeadersToCommonAncestor_http] Get %s Block Headers in %s for %s", mode, c.RealIP(), hashStr),
+			tracing.WithDebugLogMessage(h.logger, "[GetBlockHeadersToCommonAncestor_http] Get %s Block Headers in %s for %s", mode, c.RealIP(), hashStr),
 		)
 		defer deferFn()
 

--- a/services/asset/httpimpl/GetBlocks.go
+++ b/services/asset/httpimpl/GetBlocks.go
@@ -159,7 +159,7 @@ func (h *HTTP) GetBlocks(c echo.Context) error {
 		},
 	}
 
-	h.logger.Infof("[GetBlocks][%d][%d] sending to client in json (%d nodes)", offset, limit, len(blocks))
+	h.logger.Debugf("[GetBlocks][%d][%d] sending to client in json (%d nodes)", offset, limit, len(blocks))
 
 	return c.JSONPretty(200, response, "  ")
 }

--- a/services/asset/httpimpl/GetMerkleProof.go
+++ b/services/asset/httpimpl/GetMerkleProof.go
@@ -147,7 +147,7 @@ func (h *HTTP) GetMerkleProof(mode ReadMode) func(c echo.Context) error {
 
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetMerkleProof_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http] GetMerkleProof in %s for %s: %s", mode, c.RealIP(), hashStr),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetMerkleProof in %s for %s: %s", mode, c.RealIP(), hashStr),
 		)
 
 		defer deferFn()

--- a/services/asset/httpimpl/GetSubtree.go
+++ b/services/asset/httpimpl/GetSubtree.go
@@ -110,7 +110,7 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetSubtree_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http] GetSubtree in %s for %s: %s", mode, c.RealIP(), c.Param("hash")),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetSubtree in %s for %s: %s", mode, c.RealIP(), c.Param("hash")),
 		)
 
 		defer deferFn()

--- a/services/asset/httpimpl/GetSubtreeTxs.go
+++ b/services/asset/httpimpl/GetSubtreeTxs.go
@@ -172,7 +172,7 @@ func (h *HTTP) GetSubtreeTxs(mode ReadMode) func(c echo.Context) error {
 					if err != nil {
 						// NewTxNotFoundError
 						if errors.Is(err, errors.ErrTxNotFound) {
-							h.logger.Infof("[GetSubtreeTxs][%s] not found in utxo store", node.Hash.String())
+							h.logger.Debugf("[GetSubtreeTxs][%s] not found in utxo store", node.Hash.String())
 						} else {
 							h.logger.Warnf("[GetSubtreeTxs][%s] error getting transaction meta: %s", node.Hash.String(), err.Error())
 						}

--- a/services/asset/httpimpl/GetTransaction.go
+++ b/services/asset/httpimpl/GetTransaction.go
@@ -136,7 +136,7 @@ func (h *HTTP) GetTransaction(mode ReadMode) func(c echo.Context) error {
 
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetTransaction_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http] GetTransaction in %s for %s: %s", mode, c.RealIP(), hashStr),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetTransaction in %s for %s: %s", mode, c.RealIP(), hashStr),
 		)
 
 		defer deferFn()

--- a/services/asset/httpimpl/GetTransactions.go
+++ b/services/asset/httpimpl/GetTransactions.go
@@ -79,7 +79,7 @@ func (h *HTTP) GetTransactions() func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetTransactions_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http:GetTransactions] for %s", c.RealIP()),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http:GetTransactions] for %s", c.RealIP()),
 		)
 
 		defer deferFn()
@@ -184,7 +184,7 @@ func (h *HTTP) GetTransactions() func(c echo.Context) error {
 
 		prometheusAssetHTTPGetTransactions.WithLabelValues("OK", "200").Add(float64(nrTxAdded))
 
-		h.logger.Infof("[Asset_http:GetTransactions] sending %d txs to client (%d bytes)", nrTxAdded, len(responseBytes))
+		h.logger.Debugf("[Asset_http:GetTransactions] sending %d txs to client (%d bytes)", nrTxAdded, len(responseBytes))
 
 		return c.Blob(200, echo.MIMEOctetStream, responseBytes)
 	}

--- a/services/asset/httpimpl/GetUTXOs.go
+++ b/services/asset/httpimpl/GetUTXOs.go
@@ -94,7 +94,7 @@ func (h *HTTP) GetUTXOs(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetUTXOs_http",
 			tracing.WithParentStat(AssetStat),
-			tracing.WithLogMessage(h.logger, "[Asset_http:GetUTXOs] in %s for %s", mode, c.Request().RemoteAddr),
+			tracing.WithDebugLogMessage(h.logger, "[Asset_http:GetUTXOs] in %s for %s", mode, c.Request().RemoteAddr),
 		)
 
 		defer deferFn()
@@ -155,7 +155,7 @@ func (h *HTTP) GetUTXOs(mode ReadMode) func(c echo.Context) error {
 
 		prometheusAssetHTTPGetUTXOs.WithLabelValues("OK", "200").Add(float64(numRecords))
 
-		h.logger.Infof("[Asset_http:GetUTXOs] served %d records in %s", numRecords, mode)
+		h.logger.Debugf("[Asset_http:GetUTXOs] served %d records in %s", numRecords, mode)
 
 		return writeUTXOsResponse(c, mode, results)
 	}

--- a/services/asset/httpimpl/block_handler.go
+++ b/services/asset/httpimpl/block_handler.go
@@ -105,7 +105,7 @@ func (h *BlockHandler) handleBlockOperation(c echo.Context, operationName string
 
 	ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "BlockHandler."+operationName,
 		tracing.WithParentStat(AssetStat),
-		tracing.WithLogMessage(h.logger, "[Asset_http] %s block: %s", operationName, blockHash),
+		tracing.WithDebugLogMessage(h.logger, "[Asset_http] %s block: %s", operationName, blockHash),
 	)
 
 	defer deferFn()

--- a/services/asset/httpimpl/http.go
+++ b/services/asset/httpimpl/http.go
@@ -734,8 +734,19 @@ func accessLogMiddleware(logger ulogger.Logger) echo.MiddlewareFunc {
 			// RequestURI is intentionally omitted to keep query-string values out
 			// of the access log; any future endpoint adding sensitive query
 			// parameters won't accidentally leak them here.
-			logger.Infof("[Asset_http] %s %s client_ip=%s status=%d duration=%v size=%d tier=%s",
-				method, path, ip, status, duration, size, tier)
+			//
+			// Level is chosen by status so healthy traffic (2xx/3xx, including the
+			// high-frequency /health probes) stays at DEBUG and does not flood the
+			// logs; only client (4xx) and server (5xx) errors surface by default.
+			const logFmt = "[Asset_http] %s %s client_ip=%s status=%d duration=%v size=%d tier=%s"
+			switch {
+			case status >= 500:
+				logger.Errorf(logFmt, method, path, ip, status, duration, size, tier)
+			case status >= 400:
+				logger.Warnf(logFmt, method, path, ip, status, duration, size, tier)
+			default:
+				logger.Debugf(logFmt, method, path, ip, status, duration, size, tier)
+			}
 
 			return nil
 		}

--- a/services/asset/repository/GetSubtreeData.go
+++ b/services/asset/repository/GetSubtreeData.go
@@ -283,7 +283,7 @@ func (repo *Repository) dualStreamWithFileCreation(ctx context.Context, subtreeH
 		if release != nil {
 			metricLabel = "on_demand_created_locked"
 		}
-		repo.logger.Infof("[GetSubtreeDataReader] Successfully created subtreeData file on-demand for %s", subtreeHash.String())
+		repo.logger.Debugf("[GetSubtreeDataReader] Successfully created subtreeData file on-demand for %s", subtreeHash.String())
 		_ = httpWriter.Close()
 		prometheusAssetSubtreeDataCreated.WithLabelValues("success", metricLabel).Inc()
 		return nil

--- a/services/asset/repository/repository.go
+++ b/services/asset/repository/repository.go
@@ -696,7 +696,7 @@ func (repo *Repository) GetSubtreeDataReaderFromBlockPersister(ctx context.Conte
 //   - error: Any error encountered during retrieval
 func (repo *Repository) GetSubtree(ctx context.Context, hash *chainhash.Hash) (*subtree.Subtree, error) {
 	ctx, _, _ = tracing.Tracer("repository").Start(ctx, "GetSubtree",
-		tracing.WithLogMessage(repo.logger, "[Repository] GetSubtree: %s", hash.String()),
+		tracing.WithDebugLogMessage(repo.logger, "[Repository] GetSubtree: %s", hash.String()),
 	)
 
 	subtreeReader, err := repo.SubtreeStore.GetIoReader(ctx, hash.CloneBytes(), fileformat.FileTypeSubtree)
@@ -741,7 +741,7 @@ func (repo *Repository) GetSubtreeData(ctx context.Context, hash *chainhash.Hash
 // This is used internally to avoid nested semaphore acquisition.
 func (repo *Repository) getSubtreeDataInternal(ctx context.Context, hash *chainhash.Hash) (*subtree.Data, error) {
 	ctx, _, _ = tracing.Tracer("repository").Start(ctx, "GetSubtreeData",
-		tracing.WithLogMessage(repo.logger, "[Repository] GetSubtreeData: %s", hash.String()),
+		tracing.WithDebugLogMessage(repo.logger, "[Repository] GetSubtreeData: %s", hash.String()),
 	)
 
 	st, err := repo.GetSubtree(ctx, hash)
@@ -776,7 +776,7 @@ func (repo *Repository) GetSubtreeTransactions(ctx context.Context, hash *chainh
 	defer releaseSemaphorePermit(repo.semGetSubtreeTransactions)
 
 	ctx, _, _ = tracing.Tracer("repository").Start(ctx, "GetSubtreeTransactions",
-		tracing.WithLogMessage(repo.logger, "[Repository] GetSubtreeTransactions: %s", hash.String()),
+		tracing.WithDebugLogMessage(repo.logger, "[Repository] GetSubtreeTransactions: %s", hash.String()),
 	)
 
 	// Call internal method to avoid nested semaphore acquisition


### PR DESCRIPTION
The asset server logged every HTTP request (including high-frequency /health probes) at INFO, plus start+DONE tracing lines per request and per-record handler details — flooding the logs.

- access-log middleware: level by status (5xx Error, 4xx Warn, 2xx/3xx Debug)
- per-request tracing start/DONE: WithLogMessage -> WithDebugLogMessage across the httpimpl handlers and repository (GetSubtree/Block/UTXO/Tx/MerkleProof)
- per-request/per-node handler details (served/sending/not-found/on-demand created): Infof -> Debugf
- centrifuge: per-client connect/disconnect/unsubscribe and per-message lines -> Debugf; library LogHandler now respects each entry's level instead of emitting all (including Debug) at INFO

Lifecycle, one-time init, and admin actions (invalidate/FSM/reset-reputation) stay at INFO.