### PR TITLE
fix(subtreevalidation): repair test compile break on main from #799/#1065 cross-merge

### DIFF
--- a/services/subtreevalidation/legacy_real_validator_integration_test.go
+++ b/services/subtreevalidation/legacy_real_validator_integration_test.go
@@ -101,7 +101,7 @@ func TestLegacyUnconfirmedParent_RealValidatorIntegration(t *testing.T) {
 
 	// Real validator: TxValidator + GoBDK inside, no mocks.
 	realValidator, err := validator.New(ctx, logger, tSettings, utxoStore,
-		kafka.NewKafkaAsyncProducerMock(), kafka.NewKafkaAsyncProducerMock(), nil, blockchainClient)
+		kafka.NewKafkaAsyncProducerMock(), kafka.NewKafkaAsyncProducerMock(), nil, nil, blockchainClient)
 	require.NoError(t, err)
 
 	// Parent in the store, unmined — BlockHeights empty: the wedge
@@ -126,7 +126,7 @@ func TestLegacyUnconfirmedParent_RealValidatorIntegration(t *testing.T) {
 
 	nilConsumer := &kafka.KafkaConsumerGroup{}
 
-	server, err := New(ctx, logger, tSettings, subtreeStore, txStore, utxoStore, realValidator, blockchainClient, nilConsumer, nilConsumer, nil)
+	server, err := New(ctx, logger, tSettings, subtreeStore, txStore, utxoStore, realValidator, blockchainClient, nilConsumer, nilConsumer, nil, nil)
 	require.NoError(t, err)
 
 	response, err := server.CheckSubtreeFromBlock(ctx, &subtreevalidation_api.CheckSubtreeFromBlockRequest{

--- a/services/subtreevalidation/legacy_unconfirmed_parents_test.go
+++ b/services/subtreevalidation/legacy_unconfirmed_parents_test.go
@@ -88,7 +88,7 @@ func TestCheckSubtreeFromBlockLegacyUnconfirmedParents(t *testing.T) {
 
 		fsmClient := &fsmStateOverrideClient{ClientI: blockchainClient, state: fsmState}
 
-		server, err := New(context.Background(), ulogger.TestLogger{}, tSettings, subtreeStore, txStore, utxoStore, recordingClient, fsmClient, nilConsumer, nilConsumer, nil)
+		server, err := New(context.Background(), ulogger.TestLogger{}, tSettings, subtreeStore, txStore, utxoStore, recordingClient, fsmClient, nilConsumer, nilConsumer, nil, nil)
 		require.NoError(t, err)
 
 		return server, recordingClient


### PR DESCRIPTION
## What

Main does not compile in `services/subtreevalidation` test code. Cross-PR semantic conflict:

- #799 added a `policyRejectedTx` Kafka producer/consumer parameter to `validator.New` and `subtreevalidation.New`
- #1065 added `legacy_real_validator_integration_test.go` and `legacy_unconfirmed_parents_test.go` on a branch based before #799 merged, calling the old signatures

No textual conflict, both merged green individually. Result: `go vet` / golangci-lint fails on main, and every PR that syncs with main inherits the failure (first noticed on #1074, a docs PR).

## Fix

Pass `nil` for the new parameter at the three call sites, matching the pattern in the already-updated tests in the same package (`SubtreeValidation_test.go` uses `nilConsumer, nilConsumer, nil, nil`).

## Verification

- `go vet ./services/subtreevalidation/`: clean (fails on current main)
- `go test -race -tags testtxmetacache -run "TestLegacyUnconfirmedParent_RealValidatorIntegration|TestCheckSubtreeFromBlockLegacyUnconfirmedParents" ./services/subtreevalidation/`: pass
