### PR TITLE
test(multinode): skip 05/06 + harden Reset + fix utxopersister daemon-exit bug

### DIFF
--- a/services/utxopersister/Server.go
+++ b/services/utxopersister/Server.go
@@ -289,21 +289,39 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 			return ctx.Err()
 
 		case <-ch:
-			if err := s.trigger(ctx, "blockchain"); err != nil {
-				return err
-			}
+			s.handleTriggerError(ctx, s.trigger(ctx, "blockchain"), "blockchain")
 
 		case source := <-s.triggerCh:
-			if err := s.trigger(ctx, source); err != nil {
-				return err
-			}
+			s.handleTriggerError(ctx, s.trigger(ctx, source), source)
 
 		case <-time.After(duration):
-			if err := s.trigger(ctx, "timer"); err != nil {
-				return err
-			}
+			s.handleTriggerError(ctx, s.trigger(ctx, "timer"), "timer")
 		}
 	}
+}
+
+// handleTriggerError swallows transient errors from a trigger so the
+// long-running Start loop is not torn down by a single bad iteration.
+// Returning a non-nil error here would propagate into ServiceManager's
+// errgroup and cause it to gracefully stop every other service in the
+// process - so a transient storage error (e.g. blob-store read semaphore
+// timed out under load) would shut down the entire core sidecar daemon
+// rather than be retried on the next iteration.
+//
+// The trigger already converts the expected "no work to do" signal
+// (errors.ErrNotFound) into a nil return, so anything reaching here is
+// either ctx.Err (already handled by the main select on ctx.Done) or an
+// operational error. Both are recoverable by simply waiting for the next
+// blockchain notification, timer tick, or triggerCh push. The next
+// iteration will retry whatever failed.
+func (s *Server) handleTriggerError(ctx context.Context, err error, source string) {
+	if err == nil {
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	s.logger.Errorf("[UTXOPersister] trigger from %s failed, will retry on next iteration: %v", source, err)
 }
 
 // Stop stops the server's processing operations.

--- a/test/multinode/harness/harness.go
+++ b/test/multinode/harness/harness.go
@@ -218,6 +218,52 @@ func (s *Stack) Reset(t *testing.T) {
 	// Converge on some tip, whatever it is. Caller can use this as its
 	// baseline.
 	_ = WaitForConverged(t, s.Nodes(), 60*time.Second)
+
+	// Steady-state check: hold a clean RPC + matched-tip state for a short
+	// window before handing control back to the test body. Without this
+	// Reset would pass on the very first successful poll, which leaves it
+	// vulnerable to a service that briefly answers, then crashes / drops
+	// peers a second later under accumulated state from prior scenarios.
+	// Empirically observed: after a scenario fails mid-flight without
+	// running its cleanup, the next scenario's Reset would say "all RPCs
+	// ready" then fail in the test body with a connection-refused to a
+	// node we never touched.
+	s.waitSteady(t, 5*time.Second, 500*time.Millisecond)
+}
+
+// waitSteady polls every node's RPC at interval over window and returns once
+// every poll across the whole window has succeeded back-to-back. Any failure
+// resets the window. Useful as the final step of Reset to filter out
+// "just-started, about-to-crash" services that briefly answer ready and
+// then disappear before the test body needs them.
+func (s *Stack) waitSteady(t *testing.T, window, interval time.Duration) {
+	t.Helper()
+	clients := s.Nodes()
+	deadline := time.Now().Add(window + window) // hard cap so a permanently flaky stack still surfaces a failure
+	steadyStart := time.Now()
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		allOk := true
+		for _, c := range clients {
+			if err := c.Ready(ctx); err != nil {
+				allOk = false
+				break
+			}
+		}
+		cancel()
+		if allOk {
+			if time.Since(steadyStart) >= window {
+				return
+			}
+		} else {
+			steadyStart = time.Now()
+		}
+		if time.Now().After(deadline) {
+			t.Logf("waitSteady: stack did not hold steady for %s within %s; proceeding anyway", window, window*2)
+			return
+		}
+		time.Sleep(interval)
+	}
 }
 
 // Node returns an RPC client for node n (1-indexed).

--- a/test/multinode_split/scenario_05_validator_isolation_test.go
+++ b/test/multinode_split/scenario_05_validator_isolation_test.go
@@ -3,90 +3,51 @@
 package multinodesplit
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	"github.com/bsv-blockchain/teranode/test/multinode/harness"
-	"github.com/stretchr/testify/require"
 )
 
-// TestValidatorIsolation kills the validator service on node 3 and asserts the
-// node can no longer commit inbound blocks until validator is restored.
-//
-// The coupling: validating a peer's block walks
+// TestValidatorIsolation is intended to assert that killing teranode3-validator
+// stalls node 3's block sync, because the receive path
 //
 //	blockvalidation.ProcessBlock
 //	  -> subtreeValidationClient.CheckBlockSubtrees   (BlockValidation.go)
 //	    -> validatorClient.ValidateWithOptions         (SubtreeValidation.go)
 //
-// i.e. the per-transaction validation of a block's subtrees goes through the
-// validator service. With validator down, node 3 cannot validate the txs in
-// the blocks node 1 mines and should stay pinned at the baseline height.
+// would fail when validator is gone.
 //
-// Important config dependency: this only holds when subtreevalidation calls
-// out to the standalone validator container over gRPC, NOT when it embeds an
-// in-process validator. settings.conf ships useLocalValidator=true (the right
-// default for all-in-one), so a vanilla docker.teranode{N}.test context
-// would build an in-process validator and ignore the validator container
-// entirely — making this scenario a no-op. The split-mode overlay generated
-// by compose/cmd/gennodes/templates/settings.conf.tmpl now flips
-// useLocalValidator to false per node, which is what makes the kill
-// observable here. If a future edit drops that override, this test fails
-// loudly and points at it.
+// Currently SKIPPED: the receive path has a fast-path at
+// services/blockvalidation/BlockValidation.go:2023-2027 that returns nil
+// before subtreevalidation (and thus validator) is ever called when the
+// inbound block has no subtrees:
 //
-// Shape mirrors TestBlockAssemblyIsolation: kill on node 3, mine on node 1,
-// assert node 3 stalls, restart, assert catch-up and convergence.
+//	if len(block.Subtrees) == 0 {
+//	    return nil
+//	}
+//
+// `Generate`-mined blocks are empty (coinbase-only, txCount=1, 0 subtrees),
+// confirmed empirically by inspecting node 3 logs after a 2-block Generate:
+//
+//	[ValidateBlock][...] not caching block - subtrees not loaded (0 slices, 0 hashes)
+//	[Block ... (height: 2, id: 2, txCount: 1, size: 261)] fetching and validating subtrees DONE in 67.344µs
+//	[UpdateTxMinedStatus] [...] blockID 2 for 0 subtrees
+//
+// So with the current harness mining only empty blocks, killing the
+// standalone validator container is a no-op on the receive path and node 3
+// catches up regardless.
+//
+// To meaningfully exercise this coupling the test needs txs inside the
+// mined blocks, which requires either:
+//   - injecting via the harness's StartBlaster (the coinbase blaster handles
+//     UTXO sourcing but needs CoinbaseMaturity blocks of warmup), or
+//   - sendrawtransaction RPC against a fresh stack with CoinbaseMaturity
+//     overridden low (regtest already, but the test would need to construct
+//     and sign a valid spending tx from a mature coinbase).
+//
+// Both add real test-infrastructure work beyond the scope of the original
+// scenario file. Leaving SKIPPED rather than deleted so the intent and the
+// path forward stay visible.
+//
+// Tracking: follow-up to add tx-injection plumbing before unskipping.
 func TestValidatorIsolation(t *testing.T) {
-	s := stack()
-	s.Reset(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	node1 := s.Node(1)
-	node3 := s.Node(3)
-	all := s.Nodes()
-
-	info, err := node1.GetBlockchainInfo(ctx)
-	require.NoError(t, err)
-	baselineHeight := info.Blocks
-	baselineTip := info.BestBlockHash
-	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(baselineTip))
-
-	t.Log("killing teranode3-validator...")
-	s.KillService(t, 3, "validator")
-
-	t.Log("mining 5 blocks on teranode1...")
-	_, err = node1.Generate(ctx, 5)
-	require.NoError(t, err, "node 1 generate")
-
-	// Sanity: node 1 actually advanced (its validator is healthy).
-	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
-	survivorInfo, err := node1.GetBlockchainInfo(ctx)
-	require.NoError(t, err)
-	survivorTip := survivorInfo.BestBlockHash
-
-	// Settle window: catch-up would happen here if block validation did not
-	// depend on the validator service.
-	t.Log("waiting 15s to confirm teranode3 stays stalled (block validation needs the validator)...")
-	time.Sleep(15 * time.Second)
-
-	stalledInfo, err := node3.GetBlockchainInfo(ctx)
-	require.NoError(t, err, "node 3 RPC must still answer (only validator is down, not core)")
-	require.Equal(t, baselineHeight, stalledInfo.Blocks,
-		"teranode3 should be stuck at baseline height while validator is down (cannot validate block txs)")
-	require.Equal(t, baselineTip, stalledInfo.BestBlockHash, "teranode3 tip should still be the baseline")
-	t.Logf("teranode3 correctly stalled at height=%d while node 1 is at %d", stalledInfo.Blocks, baselineHeight+5)
-
-	t.Log("restarting teranode3-validator...")
-	s.StartService(t, 3, "validator")
-
-	t.Log("waiting for teranode3 to catch up to node 1...")
-	harness.WaitForHeight(t, node3, baselineHeight+5, 2*time.Minute)
-	t.Logf("teranode3 caught up to height %d", baselineHeight+5)
-
-	converged := harness.WaitForConverged(t, all, 1*time.Minute)
-	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip after node 3 catches up")
-	t.Logf("all 3 nodes converged at %s", short(converged))
+	t.Skip("validator coupling on the receive path requires non-empty blocks; see file-level docstring for the path forward")
 }

--- a/test/multinode_split/scenario_06_subtree_validation_isolation_test.go
+++ b/test/multinode_split/scenario_06_subtree_validation_isolation_test.go
@@ -3,81 +3,25 @@
 package multinodesplit
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	"github.com/bsv-blockchain/teranode/test/multinode/harness"
-	"github.com/stretchr/testify/require"
 )
 
-// TestSubtreeValidationIsolation PAUSES (does not kill) the subtreevalidation
-// service on node 3 and asserts the node cannot commit inbound blocks until it
-// is resumed.
+// TestSubtreeValidationIsolation is intended to assert that PAUSING the
+// subtreevalidation service on node 3 stalls block sync, exercising the
+// frozen-dependency failure mode (gRPC call hangs, not refused) along the
+// blockvalidation.CheckBlockSubtrees -> subtreevalidation path.
 //
-// blockvalidation calls subtreeValidationClient.CheckBlockSubtrees
-// (BlockValidation.go) on every inbound block, so subtreevalidation is squarely
-// on the block-acceptance path. This is the most direct dependency in the
-// split graph, which makes it the cleanest stall to assert.
+// Currently SKIPPED for the same reason as TestValidatorIsolation: the
+// receive path short-circuits before the subtreevalidation gRPC call when
+// the inbound block has 0 subtrees (services/blockvalidation/BlockValidation.go:2023-2027),
+// and `Generate`-mined blocks are empty. See the file-level docstring on
+// scenario_05_validator_isolation_test.go for the empirical evidence and
+// the path forward.
 //
-// We use PauseService rather than KillService deliberately: docker pause
-// SIGSTOPs the container, so the gRPC call from blockvalidation HANGS (no
-// connection-refused, no responder) — the "frozen / unresponsive dependency"
-// failure mode, distinct from a process that has exited. Either way node 3
-// cannot make progress; UnpauseService thaws it and validation resumes. This is
-// the first scenario to exercise the pause/unpause verbs.
-//
-// Shape mirrors TestBlockAssemblyIsolation otherwise.
+// Tracking: follow-up to add tx-injection plumbing before unskipping. When
+// unskipped, this scenario specifically exercises the PauseService verb (vs
+// scenario 05's KillService) to surface any hidden coupling as a hang rather
+// than a connection-refused.
 func TestSubtreeValidationIsolation(t *testing.T) {
-	s := stack()
-	s.Reset(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	node1 := s.Node(1)
-	node3 := s.Node(3)
-	all := s.Nodes()
-
-	info, err := node1.GetBlockchainInfo(ctx)
-	require.NoError(t, err)
-	baselineHeight := info.Blocks
-	baselineTip := info.BestBlockHash
-	t.Logf("baseline: height=%d tip=%s", baselineHeight, short(baselineTip))
-
-	t.Log("pausing teranode3-subtreevalidation (docker pause - gRPC calls will hang)...")
-	s.PauseService(t, 3, "subtreevalidation")
-	// Ensure the service is thawed even if an assertion below fails, so the
-	// shared stack is left healthy for the next scenario's Reset.
-	defer s.UnpauseService(t, 3, "subtreevalidation")
-
-	t.Log("mining 5 blocks on teranode1...")
-	_, err = node1.Generate(ctx, 5)
-	require.NoError(t, err, "node 1 generate")
-
-	harness.WaitForHeight(t, node1, baselineHeight+5, 1*time.Minute)
-	survivorInfo, err := node1.GetBlockchainInfo(ctx)
-	require.NoError(t, err)
-	survivorTip := survivorInfo.BestBlockHash
-
-	t.Log("waiting 15s to confirm teranode3 stays stalled (CheckBlockSubtrees hangs on the frozen service)...")
-	time.Sleep(15 * time.Second)
-
-	stalledInfo, err := node3.GetBlockchainInfo(ctx)
-	require.NoError(t, err, "node 3 RPC must still answer (only subtreevalidation is frozen, not core)")
-	require.Equal(t, baselineHeight, stalledInfo.Blocks,
-		"teranode3 should be stuck at baseline height while subtreevalidation is paused (cannot validate block subtrees)")
-	require.Equal(t, baselineTip, stalledInfo.BestBlockHash, "teranode3 tip should still be the baseline")
-	t.Logf("teranode3 correctly stalled at height=%d while node 1 is at %d", stalledInfo.Blocks, baselineHeight+5)
-
-	t.Log("unpausing teranode3-subtreevalidation...")
-	s.UnpauseService(t, 3, "subtreevalidation")
-
-	t.Log("waiting for teranode3 to catch up to node 1...")
-	harness.WaitForHeight(t, node3, baselineHeight+5, 2*time.Minute)
-	t.Logf("teranode3 caught up to height %d", baselineHeight+5)
-
-	converged := harness.WaitForConverged(t, all, 1*time.Minute)
-	require.Equal(t, survivorTip, converged, "all 3 nodes should converge on the survivors' tip after node 3 catches up")
-	t.Logf("all 3 nodes converged at %s", short(converged))
+	t.Skip("subtreevalidation coupling on the receive path requires non-empty blocks; see scenario_05 file-level docstring for the path forward")
 }


### PR DESCRIPTION
## Summary

End-to-end run of the `network_chaos` suite surfaced **three distinct findings**:

1. **Scenarios 05 and 06 are silent no-ops** as written, because of a fast-path in `services/blockvalidation/BlockValidation.go:2023-2027`.
2. **`harness.Reset` returned on the first successful RPC**, which let "just-started, about-to-crash" services slip through and caused downstream scenarios to fail.
3. **A real Teranode robustness bug**: a transient storage-semaphore timeout in UTXOPersister was bringing down the entire core sidecar daemon. This was the underlying cause of what initially looked like a scenario 10 flake.

## Finding 1 - Scenarios 05 and 06 are no-ops

`services/blockvalidation/BlockValidation.go:2023-2027` has a fast-path:

```go
func (u *BlockValidation) validateBlockSubtrees(...) error {
    if len(block.Subtrees) == 0 {
        return nil
    }
    return u.subtreeValidationClient.CheckBlockSubtrees(...)
}
```

`Generate`-mined blocks are empty (coinbase-only, `txCount=1`, 0 subtrees). Verified by inspecting node 3 logs after a 2-block `Generate`:

```
[ValidateBlock][...] not caching block - subtrees not loaded (0 slices, 0 hashes)
[Block ... (height: 2, id: 2, txCount: 1, size: 261)] fetching and validating subtrees DONE in 67.344µs
[UpdateTxMinedStatus] [...] blockID 2 for 0 subtrees
```

So killing `teranode3-validator` (05) and pausing `teranode3-subtreevalidation` (06) are no-ops on the receive path. Node 3 catches up regardless, the stall assertions fail, and the test exits without running its post-test cleanup.

**Action:** `t.Skip` both with a file-level docstring explaining the empty-block bypass and the path forward (tx injection via the harness blaster, or `sendrawtransaction` with a maturity-bypassed UTXO). Intent preserved; once tx injection is wired into the harness they can be unskipped without restructuring.

## Finding 2 - `Reset` returns too early

`harness.Reset` previously returned on the first successful RPC. A service that briefly answered then crashed under accumulated state from prior scenarios would slip through, and the next scenario's test body would hit `connection-refused` on a node nothing in this scenario touched.

**Action:** Add `waitSteady` as the final step of `Reset`. Polls every node at 500 ms across a 5 s window and only returns once every poll across the window succeeds back-to-back. Any failure resets the window. Hard cap at `2 * window` so a permanently flaky stack still surfaces a clear log line rather than hanging the suite.

## Finding 3 - UTXOPersister error propagation kills the daemon (real Teranode bug)

What initially looked like "scenario 10 is flaky" turned out to be a real production-relevant bug. The "flake" migrated across scenarios on consecutive runs (10 once, 10 again, then 09) which is the tell.

### Root cause

After ~3-5 min of suite runtime, the file blob store's read semaphore (default 768 permits, `stores/blob/file/file.go:182-186`) exhausts and `acquireReadPermit` times out at the 25 s wait (`stores/blob/file/file.go:334-353`). The call chain that errored:

```
services/utxopersister/consolidator.go:210 GetUTXOSetWithExistCheck
  -> services/utxopersister/UTXOSet.go:260 store.Exists(..., FileTypeUtxoSet)
    -> stores/blob/file/file.go:1133 acquireReadPermit
      -> stores/blob/file/file.go:346 SERVICE_UNAVAILABLE
```

That `SERVICE_UNAVAILABLE` then bubbled through `s.trigger` → `Start`'s main `select` → `util/servicemanager/service_manager.go:255-289`:

```go
func (sm *ServiceManager) Wait() error {
    err := sm.g.Wait()                // any non-context-cancel error reaches here
    ...
    for i := len(sm.services) - 1; i >= 0; i-- {
        sm.logger.Infof("🟠 Stopping service %s...", service.name)
        ... // gracefully stops EVERY service
    }
    return err                        // process exits
}
```

ServiceManager treats any non-context-canceled error as fatal, gracefully stops every service in the bundle, and the whole core sidecar process exits cleanly (`exitCode=0`, no panic, no OOM, observed via `docker events`). Once the core sidecar is down, that node's RPC port disappears and whichever scenario is running fails with `connection refused`. Reset on the next scenario sees one container exited and restarts it.

### Fix in this PR

UTXOPersister's `Start()` main loop was propagating *every* trigger error out of the loop:

```go
case <-ch:
    if err := s.trigger(ctx, "blockchain"); err != nil {
        return err   // <-- propagates to errgroup -> ServiceManager -> daemon exit
    }
```

`trigger` already converts the expected `ErrNotFound` ("no work to do") to nil; anything else reaching the loop body is either `ctx.Err` (already handled by the `ctx.Done` case) or an operational error that's recoverable on the next iteration (blockchain notification, timer tick, or `triggerCh` push). Logging and continuing is the correct shape, matching the BlockPersister loop in `services/blockpersister/Server.go` which already does this.

Patched the three error returns in the runtime loop with a helper that logs + continues. Conservative: only the runtime loop body, not initialization.

### What's still upstream

The wider issue - `ServiceManager` treating any single service's transient error as fatal for the entire process - has broader risk and should be addressed separately. This PR removes the most acute trigger; other services in the core sidecar may have similar patterns. Out of scope here.

## Suite results

**Before this PR:**

```
TestBlockAssemblyIsolation     PASS
TestValidatorIsolation         FAIL  (empty-block bypass)
TestSubtreeValidationIsolation FAIL  (empty-block bypass)
TestP2PIsolation               FAIL  (state leak from 05/06)
TestPropagationFreeze          FAIL  (state leak from 05/06)
TestAssetIsolation             PASS
TestNetworkPartitionReorg      PASS
```

**After this PR (image rebuilt with `compose/multinode.sh up --build` so the daemon actually contains the fix):**

```
TestBlockAssemblyIsolation     PASS (48s)
TestValidatorIsolation         SKIP
TestSubtreeValidationIsolation SKIP
TestP2PIsolation               PASS (66s)
TestPropagationFreeze          PASS (40s)
TestAssetIsolation             PASS (42s)
TestNetworkPartitionReorg      PASS (73s)
```

Full suite green end-to-end. Sanity-checking the verification: the first re-run after the source fix still failed because the running `teranode:latest` Docker image was 8 days old and did not contain the patched binary. After `./multinode.sh up 3 -allinone=0 --build` (which rebuilds the image), every scenario passes. CI workflows that exercise the network_chaos suite need to make sure the image is rebuilt as part of the run, not pulled stale.

## Files

- `services/utxopersister/Server.go` - runtime loop now logs + continues on transient errors via `handleTriggerError`
- `test/multinode/harness/harness.go` - `Reset` adds `waitSteady` steady-state check
- `test/multinode_split/scenario_05_validator_isolation_test.go` - `t.Skip` + docstring
- `test/multinode_split/scenario_06_subtree_validation_isolation_test.go` - `t.Skip` + docstring

## Test plan

- [x] `go build -tags network_chaos ./test/...` clean
- [x] `./services/utxopersister/...` unit tests pass (60s)
- [x] Full multinode `network_chaos` suite end-to-end: 4 PASS, 2 SKIP, 0 FAIL
- [ ] Follow-up: file the `ServiceManager`-fatal-by-default and `acquireReadPermit` semaphore-exhaustion as separate issues
- [ ] Follow-up: add tx injection plumbing and unskip 05/06