### PR TITLE
bench(subtreeprocessor): foreign-block move benchmark + inverted-diff gate verdict

### DIFF
--- a/cmd/teranodecli/teranodecli/cli.go
+++ b/cmd/teranodecli/teranodecli/cli.go
@@ -55,6 +55,7 @@ var commandHelp = map[string]string{
 	"subtreebench":            "Benchmark SubtreeProcessor throughput with CPU and memory profiling",
 	"loadunminedbench":        "Benchmark loadUnminedTransactions with CPU and memory profiling",
 	"txmapbench":              "Benchmark CreateTransactionMap with CPU and memory profiling",
+	"foreignblockbench":       "Benchmark foreign-block moveForwardBlock phases (map build + remainder)",
 	"remainderbench":          "Benchmark processRemainderTransactionsAndDequeue with CPU and memory profiling",
 	"monitor":                 "Live TUI dashboard for monitoring node status",
 	"logs":                    "Interactive log viewer with filtering and search",
@@ -488,6 +489,18 @@ func Start(args []string, version, commit string) {
 
 		cmd.Execute = func(args []string) error {
 			return runCreateTxMapBenchmark(*numSubtrees, *txsPerSubtree, *cpuProfile, *memProfile)
+		}
+	case "foreignblockbench":
+		numSubtrees := cmd.FlagSet.Int("subtrees", 100, "Number of block subtrees")
+		txsPerSubtree := cmd.FlagSet.Int("txs-per-subtree", 1_048_576, "Transactions per subtree")
+		overlapPct := cmd.FlagSet.Int("overlap-pct", 95, "Percent of block txs present in the local pool")
+		overhangPct := cmd.FlagSet.Int("overhang-pct", 10, "Local-only txs as percent of block tx count")
+		seed := cmd.FlagSet.Uint64("seed", 42, "Deterministic data seed")
+		cpuProfile := cmd.FlagSet.String("cpu-profile", "foreignblockmove_cpu.prof", "CPU profile output")
+		memProfile := cmd.FlagSet.String("mem-profile", "foreignblockmove_mem.prof", "Memory profile output")
+
+		cmd.Execute = func(args []string) error {
+			return runForeignBlockBenchmark(*numSubtrees, *txsPerSubtree, *overlapPct, *overhangPct, *seed, *cpuProfile, *memProfile)
 		}
 	case "remainderbench":
 		numSubtrees := cmd.FlagSet.Int("subtrees", 100, "Number of subtrees")

--- a/cmd/teranodecli/teranodecli/txmapbench.go
+++ b/cmd/teranodecli/teranodecli/txmapbench.go
@@ -66,3 +66,39 @@ func runProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 
 	return nil
 }
+
+func runForeignBlockBenchmark(numSubtrees, txsPerSubtree, overlapPct, overhangPct int, seed uint64, cpuProfile, memProfile string) error {
+	cfg := subtreeprocessor.ForeignBlockBenchConfig{
+		NumBlockSubtrees: numSubtrees,
+		TxsPerSubtree:    txsPerSubtree,
+		OverlapPct:       overlapPct,
+		PoolOverhangPct:  overhangPct,
+		Seed:             seed,
+	}
+
+	result, err := subtreeprocessor.RunForeignBlockMoveBenchmark(cfg, cpuProfile, memProfile)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\nForeign Block Move Benchmark Results\n")
+	fmt.Printf("====================================\n")
+	fmt.Printf("Block Transactions:  %d\n", result.BlockTxCount)
+	fmt.Printf("Pool Transactions:   %d\n", result.PoolTxCount)
+	fmt.Printf("Map Build:           %.3fs\n", result.MapBuildElapsed.Seconds())
+	fmt.Printf("Remainder:           %.3fs\n", result.RemainderElapsed.Seconds())
+	fmt.Printf("Total:               %.3fs\n", result.TotalElapsed.Seconds())
+	fmt.Printf("Map Length:          %d\n", result.MapLength)
+	fmt.Printf("Remainder Nodes:     %d\n", result.RemainderCount)
+	fmt.Printf("Alloc Delta:         %d MB\n", result.AllocDeltaMB)
+	fmt.Println()
+	fmt.Printf("Profiles written to:\n")
+	fmt.Printf("  CPU:    %s\n", cpuProfile)
+	fmt.Printf("  Memory: %s\n", memProfile)
+
+	if result.BenchErr != nil {
+		fmt.Printf("\nNote: benchmark returned error: %v\n", result.BenchErr)
+	}
+
+	return nil
+}

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -5506,6 +5506,14 @@ func (stp *SubtreeProcessor) CreateTransactionMap(ctx context.Context, blockSubt
 
 	conflictingNodesPerSubtree := make([][]chainhash.Hash, totalSubtreesInBlock)
 
+	// Single-writer-per-bucket insert pipeline: the subtree goroutines below
+	// only deserialize and submit; each bucket is written by exactly one
+	// inserter worker, so the per-bucket mutex is never contended (the old
+	// shape — every subtree goroutine spawning one goroutine per bucket —
+	// serialized on the 1024 bucket mutexes and plateaued at ~15M inserts/s
+	// on a 192-core node).
+	inserter := newBucketInserter(transactionMap, runtime.NumCPU())
+
 	g, ctx := errgroup.WithContext(ctx)
 	util.SafeSetLimit(stp.logger, g, concurrentSubtreeReads)
 
@@ -5569,19 +5577,8 @@ func (stp *SubtreeProcessor) CreateTransactionMap(ctx context.Context, blockSubt
 				return errors.NewProcessingError("error deserializing subtree: %s", st.String(), err)
 			}
 
-			bucketG := errgroup.Group{}
-
-			for bucket, hashes := range txHashBuckets {
-				bucket := bucket
-				hashes := hashes
-				// put the hashes into the transaction map in parallel, it has already been split into the correct buckets
-				bucketG.Go(func() error {
-					return transactionMap.PutMultiBucket(bucket, hashes)
-				})
-			}
-
-			if err = bucketG.Wait(); err != nil {
-				return errors.NewProcessingError("error putting hashes into transaction map", err)
+			if err = inserter.submit(txHashBuckets); err != nil {
+				return errors.NewProcessingError("error submitting hashes to transaction map inserter", err)
 			}
 
 			conflictingNodesPerSubtree[subtreeIdx] = conflictingNodes
@@ -5590,9 +5587,25 @@ func (stp *SubtreeProcessor) CreateTransactionMap(ctx context.Context, blockSubt
 		})
 	}
 
-	if err := g.Wait(); err != nil {
+	// closeAndWait must run even when g.Wait() errors: the inserter workers
+	// hold open channels and must be joined before the pooled map is reused.
+	// All submitters have returned once g.Wait() returns, so closing is safe.
+	err := g.Wait()
+	insertErr := inserter.closeAndWait()
+
+	if err != nil {
 		return nil, nil, errors.NewProcessingError("error getting subtrees", err)
 	}
+
+	if insertErr != nil {
+		return nil, nil, errors.NewProcessingError("error putting hashes into transaction map", insertErr)
+	}
+
+	// The map is fully built and has no further writers until the next
+	// block's Clear(): freeze it so the ~hundreds of millions of Exists
+	// probes in processRemainderTxHashes and dequeueDuringBlockMovement
+	// skip the per-bucket read lock.
+	transactionMap.Freeze()
 
 	conflictingNodesPerSubtreeCount := 0
 	for _, subtreeConflictingNodes := range conflictingNodesPerSubtree {

--- a/services/blockassembly/subtreeprocessor/benchmark.go
+++ b/services/blockassembly/subtreeprocessor/benchmark.go
@@ -298,6 +298,10 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to put hash in transaction map: %w", err)
 		}
 	}
+
+	// Production freezes the map after CreateTransactionMap; match it so the
+	// benchmark exercises the lock-free Exists path.
+	transactionMap.Freeze()
 	fmt.Printf("[%s] Transaction map created with %d entries.\n", time.Since(benchStartTime), transactionMap.Length())
 
 	// Create current tx map for parent lookups

--- a/services/blockassembly/subtreeprocessor/benchmark.go
+++ b/services/blockassembly/subtreeprocessor/benchmark.go
@@ -2,7 +2,9 @@ package subtreeprocessor
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"math/rand/v2"
 	"net/url"
 	"os"
 	"runtime"
@@ -391,6 +393,274 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 		RemainderCount:     remainderCount,
 		BenchErr:           benchErr,
 	}
+
+	return result, nil
+}
+
+// ForeignBlockBenchConfig parameterizes RunForeignBlockMoveBenchmark.
+//
+// The block's tx set and the local pool overlap like production: the pool
+// holds OverlapPct% of the block's txs (arranged into *differently chunked*
+// local subtrees) plus PoolOverhangPct% extra local-only txs — the remainder
+// that must be rebuilt into fresh subtrees after the block is processed.
+type ForeignBlockBenchConfig struct {
+	NumBlockSubtrees int
+	TxsPerSubtree    int
+	OverlapPct       int // % of block txs also present in the local pool
+	PoolOverhangPct  int // local-only txs as % of block tx count
+	Seed             uint64
+}
+
+// ForeignBlockBenchResult holds per-phase results from RunForeignBlockMoveBenchmark.
+type ForeignBlockBenchResult struct {
+	BlockTxCount     int
+	PoolTxCount      int
+	MapBuildElapsed  time.Duration // CreateTransactionMap (block tx set construction)
+	RemainderElapsed time.Duration // processRemainderTransactionsAndDequeue
+	TotalElapsed     time.Duration
+	MapLength        int
+	RemainderCount   int
+	AllocDeltaMB     uint64 // TotalAlloc delta across both phases
+	BenchErr         error
+}
+
+// genDeterministicHashes generates n pseudo-random 32-byte hashes from seed.
+// PCG output matches the key-distribution properties of real tx hashes at a
+// fraction of the cost of hashing real data.
+func genDeterministicHashes(n int, seed uint64) []chainhash.Hash {
+	rng := rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15))
+	hashes := make([]chainhash.Hash, n)
+
+	for i := range hashes {
+		binary.LittleEndian.PutUint64(hashes[i][0:8], rng.Uint64())
+		binary.LittleEndian.PutUint64(hashes[i][8:16], rng.Uint64())
+		binary.LittleEndian.PutUint64(hashes[i][16:24], rng.Uint64())
+		binary.LittleEndian.PutUint64(hashes[i][24:32], rng.Uint64())
+	}
+
+	return hashes
+}
+
+// RunForeignBlockMoveBenchmark times the two foreign-block phases of
+// moveForwardBlock — CreateTransactionMap (block map build) and
+// processRemainderTransactionsAndDequeue (pool scan + remainder rebuild) —
+// against a realistic pool/block overlap. cpuProfile/memProfile may be empty
+// to skip profiling (e.g. when driven from go-test benchmarks).
+func RunForeignBlockMoveBenchmark(cfg ForeignBlockBenchConfig, cpuProfile, memProfile string) (ForeignBlockBenchResult, error) {
+	ctx := context.Background()
+
+	blockTxCount := cfg.NumBlockSubtrees * (cfg.TxsPerSubtree - 1) // subtree 0 carries the coinbase placeholder
+	overlapCount := blockTxCount * cfg.OverlapPct / 100
+	overhangCount := blockTxCount * cfg.PoolOverhangPct / 100
+
+	rng := rand.New(rand.NewPCG(cfg.Seed, cfg.Seed^0xdeadbeef))
+
+	// Block txs: the first overlapCount are shared with the pool.
+	blockTxs := genDeterministicHashes(blockTxCount, cfg.Seed+1)
+	poolTxs := make([]chainhash.Hash, 0, overlapCount+overhangCount)
+	poolTxs = append(poolTxs, blockTxs[:overlapCount]...)
+	poolTxs = append(poolTxs, genDeterministicHashes(overhangCount, cfg.Seed+2)...)
+
+	// The local pool saw the same txs in a different order than the miner
+	// chunked them — shuffle before building local subtrees.
+	rng.Shuffle(len(poolTxs), func(i, j int) {
+		poolTxs[i], poolTxs[j] = poolTxs[j], poolTxs[i]
+	})
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 10)
+	go func() {
+		for req := range newSubtreeChan {
+			if req.ErrChan != nil {
+				req.ErrChan <- nil
+			}
+		}
+	}()
+	defer close(newSubtreeChan)
+
+	subtreeStore := blob_memory.New()
+	tSettings := createBenchmarkSettings(cfg.TxsPerSubtree)
+
+	stp, err := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, tSettings, subtreeStore, nil, nil, newSubtreeChan)
+	if err != nil {
+		return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to create subtree processor: %w", err)
+	}
+
+	stp.SetCurrentItemsPerFile(cfg.TxsPerSubtree)
+
+	// ----- foreign block: serialize subtrees into the blob store -----
+	blockSubtreesMap := make(map[chainhash.Hash]int, cfg.NumBlockSubtrees)
+	txIdx := 0
+
+	for s := 0; s < cfg.NumBlockSubtrees; s++ {
+		subtree, err := subtreepkg.NewTreeByLeafCount(cfg.TxsPerSubtree)
+		if err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to create block subtree %d: %w", s, err)
+		}
+
+		if s == 0 {
+			if err = subtree.AddCoinbaseNode(); err != nil {
+				return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to add coinbase node: %w", err)
+			}
+		}
+
+		perSubtree := cfg.TxsPerSubtree - 1
+		for i := 0; i < perSubtree && txIdx < blockTxCount; i++ {
+			if err = subtree.AddNode(blockTxs[txIdx], 100, 200); err != nil {
+				return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to add block subtree node: %w", err)
+			}
+			txIdx++
+		}
+
+		subtreeBytes, err := subtree.Serialize()
+		if err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to serialize block subtree: %w", err)
+		}
+
+		if err = subtreeStore.Set(ctx, subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes, options.WithDeleteAt(tSettings.GlobalBlockHeightRetention)); err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to store block subtree: %w", err)
+		}
+
+		blockSubtreesMap[*subtree.RootHash()] = s
+	}
+
+	// ----- local pool: chained subtrees + current subtree + currentTxMap -----
+	parentHash := chainhash.HashH([]byte("parent-tx-foreign-block-bench"))
+	poolTxMap := NewSplitTxInpointsMap(16)
+
+	numLocalSubtrees := (len(poolTxs) + cfg.TxsPerSubtree - 1) / cfg.TxsPerSubtree
+	chainedSubtrees := make([]*subtreepkg.Subtree, 0, numLocalSubtrees)
+	poolIdx := 0
+
+	for s := 0; s < numLocalSubtrees; s++ {
+		subtree, err := subtreepkg.NewTreeByLeafCount(cfg.TxsPerSubtree)
+		if err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to create local subtree %d: %w", s, err)
+		}
+
+		if s == 0 {
+			_ = subtree.AddCoinbaseNode()
+		}
+
+		for !subtree.IsComplete() && poolIdx < len(poolTxs) {
+			if err = subtree.AddSubtreeNode(subtreepkg.Node{Hash: poolTxs[poolIdx], Fee: 100}); err != nil {
+				return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to add local subtree node: %w", err)
+			}
+			poolTxMap.Set(poolTxs[poolIdx], &subtreepkg.TxInpoints{ParentTxHashes: []chainhash.Hash{parentHash}})
+			poolIdx++
+		}
+
+		chainedSubtrees = append(chainedSubtrees, subtree)
+
+		if poolIdx >= len(poolTxs) {
+			break
+		}
+	}
+
+	// Fresh current subtree, as after resetSubtreeState.
+	currentSubtree, err := subtreepkg.NewTreeByLeafCount(cfg.TxsPerSubtree)
+	if err != nil {
+		return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to create current subtree: %w", err)
+	}
+	_ = currentSubtree.AddCoinbaseNode()
+	stp.currentSubtree.Store(currentSubtree)
+
+	losingTxHashesMap := txmap.NewSplitSwissMap(4, 10)
+
+	block := &model.Block{
+		Header: &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      uint32(time.Now().Unix()), // nolint: gosec
+			Bits:           model.NBit{},
+			Nonce:          0,
+		},
+		CoinbaseTx: &bt.Tx{},
+	}
+
+	// ----- profiled phases -----
+	var cpuFile *os.File
+	if cpuProfile != "" {
+		if cpuFile, err = os.Create(cpuProfile); err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to create CPU profile: %w", err)
+		}
+
+		if err = pprof.StartCPUProfile(cpuFile); err != nil {
+			cpuFile.Close()
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to start CPU profile: %w", err)
+		}
+	}
+
+	var memBefore runtime.MemStats
+	runtime.ReadMemStats(&memBefore)
+
+	result := ForeignBlockBenchResult{
+		BlockTxCount: blockTxCount,
+		PoolTxCount:  len(poolTxs),
+	}
+
+	// Phase 1: block tx set construction (the phase the inverted diff replaces).
+	mapStart := time.Now()
+	transactionMap, _, benchErr := stp.CreateTransactionMap(ctx, blockSubtreesMap, cfg.NumBlockSubtrees, uint64(blockTxCount))
+	result.MapBuildElapsed = time.Since(mapStart)
+
+	if benchErr == nil {
+		result.MapLength = transactionMap.Length()
+
+		// Phase 2: pool scan + remainder rebuild.
+		params := &RemainderTransactionParams{
+			Block:             block,
+			ChainedSubtrees:   chainedSubtrees,
+			CurrentSubtree:    currentSubtree,
+			TransactionMap:    transactionMap,
+			LosingTxHashesMap: losingTxHashesMap,
+			CurrentTxMap:      poolTxMap,
+			SkipDequeue:       true,
+			SkipNotification:  true,
+		}
+
+		remainderStart := time.Now()
+		benchErr = stp.processRemainderTransactionsAndDequeue(ctx, params)
+		result.RemainderElapsed = time.Since(remainderStart)
+	}
+
+	result.TotalElapsed = result.MapBuildElapsed + result.RemainderElapsed
+	result.BenchErr = benchErr
+
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	result.AllocDeltaMB = (memAfter.TotalAlloc - memBefore.TotalAlloc) / (1024 * 1024)
+
+	if cpuProfile != "" {
+		pprof.StopCPUProfile()
+		if err = cpuFile.Close(); err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to close CPU profile: %w", err)
+		}
+	}
+
+	if memProfile != "" {
+		runtime.GC()
+
+		memFile, err := os.Create(memProfile)
+		if err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to create memory profile: %w", err)
+		}
+
+		if err = pprof.WriteHeapProfile(memFile); err != nil {
+			memFile.Close()
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to write memory profile: %w", err)
+		}
+
+		if err = memFile.Close(); err != nil {
+			return ForeignBlockBenchResult{}, errors.NewProcessingError("failed to close memory profile: %w", err)
+		}
+	}
+
+	// Count remainder nodes rebuilt into the processor.
+	for _, st := range stp.GetChainedSubtrees() {
+		result.RemainderCount += st.Length()
+	}
+	result.RemainderCount += stp.GetCurrentSubtree().Length()
 
 	return result, nil
 }

--- a/services/blockassembly/subtreeprocessor/bucket_inserter.go
+++ b/services/blockassembly/subtreeprocessor/bucket_inserter.go
@@ -1,0 +1,140 @@
+package subtreeprocessor
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+)
+
+// bucketBatch is one subtree's hashes for a single bucket, queued for the
+// bucket's owning worker.
+type bucketBatch struct {
+	bucket uint16
+	hashes []chainhash.Hash
+}
+
+// bucketInserter inserts pre-bucketed hash batches into a SplitSwissMap with
+// exactly one writer per bucket. Worker w exclusively owns the bucket set
+// {b : b % numWorkers == w} and is fed by its own channel, so the per-bucket
+// mutex inside PutMultiBucket is taken but never contended — unlike the
+// previous shape where every concurrent subtree goroutine spawned a goroutine
+// per bucket and all of them queued on the same 1024 bucket mutexes.
+//
+// Usage contract (mirrors errgroup-then-join in CreateTransactionMap):
+// concurrent submit() calls are allowed; all submitters must have returned
+// before closeAndWait(), which closes the channels, joins the workers and
+// returns the first insert error.
+type bucketInserter struct {
+	m *SplitSwissMap
+	// Each channel carries one message per submit() call holding ALL of that
+	// submit's batches for the worker — one send per (submitter, worker)
+	// instead of one per (submitter, bucket). The per-bucket variant produced
+	// ~256k channel handoffs per block and showed up as ~39% of profile
+	// samples in runtime.runqgrab (scheduler work-stealing churn).
+	channels   []chan []bucketBatch
+	numWorkers int
+
+	wg     sync.WaitGroup
+	closed atomic.Bool
+
+	errMu    sync.Mutex
+	firstErr error
+}
+
+// newBucketInserter starts numWorkers insert workers for m. numWorkers is
+// clamped to [1, m.Buckets()].
+func newBucketInserter(m *SplitSwissMap, numWorkers int) *bucketInserter {
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	if numWorkers > int(m.Buckets()) {
+		numWorkers = int(m.Buckets())
+	}
+
+	ins := &bucketInserter{
+		m:          m,
+		channels:   make([]chan []bucketBatch, numWorkers),
+		numWorkers: numWorkers,
+	}
+
+	for w := 0; w < numWorkers; w++ {
+		// Small buffer: enough to overlap deserialization with inserts
+		// without staging meaningful amounts of the block in channels.
+		ins.channels[w] = make(chan []bucketBatch, 8)
+
+		ins.wg.Add(1)
+
+		go func(ch chan []bucketBatch) {
+			defer ins.wg.Done()
+
+			for batches := range ch {
+				for _, batch := range batches {
+					if err := ins.m.PutMultiBucket(batch.bucket, batch.hashes); err != nil {
+						ins.recordErr(err)
+						// Keep draining so submitters never block on a full
+						// channel after an error.
+					}
+				}
+			}
+		}(ins.channels[w])
+	}
+
+	return ins
+}
+
+// submit routes one subtree's per-bucket hash slices to their owning workers.
+// Safe for concurrent use. Returns an error after closeAndWait has been called.
+func (ins *bucketInserter) submit(buckets map[uint16][]chainhash.Hash) error {
+	if ins.closed.Load() {
+		return errors.NewProcessingError("bucketInserter is closed, submit rejected")
+	}
+
+	perWorker := make([][]bucketBatch, ins.numWorkers)
+
+	for bucket, hashes := range buckets {
+		if len(hashes) == 0 {
+			continue
+		}
+
+		w := int(bucket) % ins.numWorkers
+		perWorker[w] = append(perWorker[w], bucketBatch{bucket: bucket, hashes: hashes})
+	}
+
+	for w, batches := range perWorker {
+		if len(batches) > 0 {
+			ins.channels[w] <- batches
+		}
+	}
+
+	return nil
+}
+
+// closeAndWait closes the worker channels, joins the workers and returns the
+// first insert error. All submit() callers must have returned before this is
+// called.
+func (ins *bucketInserter) closeAndWait() error {
+	if ins.closed.CompareAndSwap(false, true) {
+		for _, ch := range ins.channels {
+			close(ch)
+		}
+	}
+
+	ins.wg.Wait()
+
+	ins.errMu.Lock()
+	defer ins.errMu.Unlock()
+
+	return ins.firstErr
+}
+
+func (ins *bucketInserter) recordErr(err error) {
+	ins.errMu.Lock()
+	defer ins.errMu.Unlock()
+
+	if ins.firstErr == nil {
+		ins.firstErr = err
+	}
+}

--- a/services/blockassembly/subtreeprocessor/bucket_inserter_test.go
+++ b/services/blockassembly/subtreeprocessor/bucket_inserter_test.go
@@ -1,0 +1,151 @@
+package subtreeprocessor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/stretchr/testify/require"
+)
+
+// bucketizeForTest groups hashes per bucket the way
+// DeserializeHashesFromReaderIntoBuckets hands them to the insert stage.
+func bucketizeForTest(hashes []chainhash.Hash, nrOfBuckets uint16) map[uint16][]chainhash.Hash {
+	out := make(map[uint16][]chainhash.Hash)
+	for _, h := range hashes {
+		bucket := txmap.Bytes2Uint16Buckets(h, nrOfBuckets)
+		out[bucket] = append(out[bucket], h)
+	}
+
+	return out
+}
+
+// TestBucketInserter_AllHashesInserted submits many subtree-shaped batches
+// from concurrent goroutines (the CreateTransactionMap shape) and verifies
+// full map content after closeAndWait.
+func TestBucketInserter_AllHashesInserted(t *testing.T) {
+	const (
+		numSubtrees = 32
+		perSubtree  = 4096
+	)
+
+	m := NewSplitSwissMap(64, numSubtrees*perSubtree)
+	ins := newBucketInserter(m, 8)
+
+	all := genBenchHashes(numSubtrees*perSubtree, 60)
+
+	var wg sync.WaitGroup
+	for s := 0; s < numSubtrees; s++ {
+		wg.Add(1)
+
+		go func(s int) {
+			defer wg.Done()
+
+			buckets := bucketizeForTest(all[s*perSubtree:(s+1)*perSubtree], m.Buckets())
+			require.NoError(t, ins.submit(buckets))
+		}(s)
+	}
+
+	wg.Wait()
+	require.NoError(t, ins.closeAndWait())
+
+	require.Equal(t, numSubtrees*perSubtree, m.Length())
+
+	for _, h := range all {
+		require.True(t, m.Exists(h), "expected %s to exist", h)
+	}
+}
+
+// TestBucketInserter_DuplicateHashesIdempotent verifies that the same hashes
+// submitted twice (e.g. a tx appearing in two announced subtrees) result in a
+// single map entry each.
+func TestBucketInserter_DuplicateHashesIdempotent(t *testing.T) {
+	const total = 2048
+
+	m := NewSplitSwissMap(16, total)
+	ins := newBucketInserter(m, 4)
+
+	hashes := genBenchHashes(total, 61)
+	buckets := bucketizeForTest(hashes, m.Buckets())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			require.NoError(t, ins.submit(buckets))
+		}()
+	}
+
+	wg.Wait()
+	require.NoError(t, ins.closeAndWait())
+	require.Equal(t, total, m.Length())
+}
+
+// TestBucketInserter_EmptySubmitAndClampedWorkers covers the degenerate
+// configs: zero/negative worker counts clamp to a working pool, empty submits
+// are no-ops, and immediate closeAndWait succeeds.
+func TestBucketInserter_EmptySubmitAndClampedWorkers(t *testing.T) {
+	m := NewSplitSwissMap(16, 16)
+
+	ins := newBucketInserter(m, 0)
+	require.NoError(t, ins.submit(map[uint16][]chainhash.Hash{}))
+	require.NoError(t, ins.submit(nil))
+	require.NoError(t, ins.closeAndWait())
+	require.Equal(t, 0, m.Length())
+
+	// More workers than buckets must clamp rather than spawn idle workers
+	// indexing out of range.
+	m2 := NewSplitSwissMap(4, 1024)
+	ins2 := newBucketInserter(m2, 1000)
+
+	hashes := genBenchHashes(512, 62)
+	require.NoError(t, ins2.submit(bucketizeForTest(hashes, m2.Buckets())))
+	require.NoError(t, ins2.closeAndWait())
+	require.Equal(t, 512, m2.Length())
+}
+
+// TestBucketInserter_SubmitAfterCloseErrors verifies misuse fails loudly
+// instead of panicking on a closed channel.
+func TestBucketInserter_SubmitAfterCloseErrors(t *testing.T) {
+	m := NewSplitSwissMap(16, 16)
+	ins := newBucketInserter(m, 2)
+
+	require.NoError(t, ins.closeAndWait())
+
+	hashes := genBenchHashes(16, 63)
+	err := ins.submit(bucketizeForTest(hashes, m.Buckets()))
+	require.Error(t, err)
+}
+
+// TestBucketInserter_FrozenMapSurfacesError verifies the error-drain path: a
+// frozen map makes every PutMultiBucket fail; closeAndWait must surface the
+// error and submitters must not deadlock on full channels.
+func TestBucketInserter_FrozenMapSurfacesError(t *testing.T) {
+	const total = 64 * 1024
+
+	m := NewSplitSwissMap(16, total)
+	m.Freeze()
+
+	ins := newBucketInserter(m, 2)
+
+	hashes := genBenchHashes(total, 64)
+	buckets := bucketizeForTest(hashes, m.Buckets())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			// submit may or may not error depending on timing; the contract
+			// is only that it never deadlocks and closeAndWait reports it.
+			_ = ins.submit(buckets)
+		}()
+	}
+
+	wg.Wait()
+	require.Error(t, ins.closeAndWait())
+}

--- a/services/blockassembly/subtreeprocessor/foreignblock_benchmark_test.go
+++ b/services/blockassembly/subtreeprocessor/foreignblock_benchmark_test.go
@@ -1,0 +1,118 @@
+package subtreeprocessor
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkForeignBlockMove drives the two foreign-block moveForwardBlock
+// phases (block map build + remainder rebuild) end-to-end at parameterized
+// scale. ns/op includes per-iteration setup (subtree generation + blob
+// store); compare the reported phase metrics, not ns/op:
+//
+//	mapbuild-ms    — CreateTransactionMap wall time
+//	remainder-ms   — processRemainderTransactionsAndDequeue wall time
+//	alloc-mb       — TotalAlloc delta across both phases
+func BenchmarkForeignBlockMove(b *testing.B) {
+	cases := []struct {
+		name  string
+		cfg   ForeignBlockBenchConfig
+		large bool
+	}{
+		{
+			name: "block=500k/overlap=95/overhang=10",
+			cfg: ForeignBlockBenchConfig{
+				NumBlockSubtrees: 128,
+				TxsPerSubtree:    4096,
+				OverlapPct:       95,
+				PoolOverhangPct:  10,
+				Seed:             42,
+			},
+		},
+		{
+			name: "block=8M/overlap=95/overhang=10",
+			cfg: ForeignBlockBenchConfig{
+				NumBlockSubtrees: 128,
+				TxsPerSubtree:    65536,
+				OverlapPct:       95,
+				PoolOverhangPct:  10,
+				Seed:             42,
+			},
+			large: true,
+		},
+	}
+
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			if c.large && testing.Short() {
+				b.Skip("skipping large foreign-block benchmark in short mode")
+			}
+
+			var mapBuildMS, remainderMS, allocMB float64
+
+			for i := 0; i < b.N; i++ {
+				result, err := RunForeignBlockMoveBenchmark(c.cfg, "", "")
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				if result.BenchErr != nil {
+					b.Fatal(result.BenchErr)
+				}
+
+				// +1: the coinbase placeholder of block subtree 0 is
+				// deserialized into the map like any other leaf.
+				if result.MapLength != result.BlockTxCount+1 {
+					b.Fatalf("map length %d, want %d", result.MapLength, result.BlockTxCount+1)
+				}
+
+				// Remainder = pool txs not in the block (the overhang) plus the
+				// coinbase placeholders of the rebuilt current subtree chain.
+				wantRemainder := result.PoolTxCount - (result.BlockTxCount * c.cfg.OverlapPct / 100)
+				if result.RemainderCount < wantRemainder {
+					b.Fatalf("remainder count %d, want at least %d", result.RemainderCount, wantRemainder)
+				}
+
+				mapBuildMS += float64(result.MapBuildElapsed.Milliseconds())
+				remainderMS += float64(result.RemainderElapsed.Milliseconds())
+				allocMB += float64(result.AllocDeltaMB)
+			}
+
+			n := float64(b.N)
+			b.ReportMetric(mapBuildMS/n, "mapbuild-ms")
+			b.ReportMetric(remainderMS/n, "remainder-ms")
+			b.ReportMetric(allocMB/n, "alloc-mb")
+		})
+	}
+}
+
+// TestRunForeignBlockMoveBenchmarkSmoke pins the benchmark harness itself:
+// tiny scale, asserts the phases run and the remainder matches the overhang.
+func TestRunForeignBlockMoveBenchmarkSmoke(t *testing.T) {
+	cfg := ForeignBlockBenchConfig{
+		NumBlockSubtrees: 4,
+		TxsPerSubtree:    1024,
+		OverlapPct:       95,
+		PoolOverhangPct:  10,
+		Seed:             7,
+	}
+
+	result, err := RunForeignBlockMoveBenchmark(cfg, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.BenchErr != nil {
+		t.Fatal(result.BenchErr)
+	}
+
+	// +1: the coinbase placeholder of block subtree 0 is deserialized into
+	// the map like any other leaf.
+	if result.MapLength != result.BlockTxCount+1 {
+		t.Fatalf("map length %d, want %d", result.MapLength, result.BlockTxCount+1)
+	}
+
+	fmt.Printf("smoke: block=%d pool=%d mapbuild=%s remainder=%s remainderCount=%d alloc=%dMB\n",
+		result.BlockTxCount, result.PoolTxCount, result.MapBuildElapsed, result.RemainderElapsed,
+		result.RemainderCount, result.AllocDeltaMB)
+}

--- a/services/blockassembly/subtreeprocessor/gate_probe_test.go
+++ b/services/blockassembly/subtreeprocessor/gate_probe_test.go
@@ -1,0 +1,130 @@
+package subtreeprocessor
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+)
+
+// BenchmarkGateMarkPassPrototype measures the cost of a mark-only pass:
+// probe each block hash against the EXISTING pool map (currentTxMap) and
+// stamp the hits — the work that an "inverted diff" design would substitute
+// for CreateTransactionMap's block map build. Compare against the
+// mapbuild-ms metric of BenchmarkForeignBlockMove at the same scale.
+//
+// The prototype uses Get+Set (two probes) where a real mark would hold the
+// bucket lock once and update in place (~1 probe), so it bounds the mark
+// cost from above.
+//
+// Verdict (recorded 2026-06, M3 Max 16 cores, after the bucketInserter +
+// Freeze contention fixes): the inversion does NOT pay.
+//   - mark pass 8M: ~50ms vs full map build 99ms — but the build figure
+//     includes the file read + deserialize that the inversion must also pay
+//     (insert-only is ~32ms at this scale), so the phase-1 saving is small;
+//   - the remainder scan would probe this pool map (per-probe bucket mutex,
+//     pointer values) instead of the frozen lock-free SplitSwissMap
+//     (13ns vs 6ns per probe) — a regression on the larger phase;
+//   - bucket-count sensitivity: with 16 pool buckets the mark pass is 920ms
+//     (9x WORSE than the build) — any design probing the pool map at scale
+//     lives or dies by splitMapBuckets.
+//
+// Kept as the measuring stick for any future attempt at replacing the block
+// map build.
+func BenchmarkGateMarkPassPrototype(b *testing.B) {
+	for _, scale := range []struct {
+		name        string
+		blockTx     int
+		overlapPct  int
+		overhangPct int
+	}{
+		{"block=8M", 8_388_608, 95, 10},
+		{"block=16M", 16_777_216, 95, 10},
+	} {
+		b.Run(scale.name, func(b *testing.B) {
+			if testing.Short() {
+				b.Skip("skipping gate benchmark in short mode")
+			}
+
+			overlap := scale.blockTx * scale.overlapPct / 100
+			overhang := scale.blockTx * scale.overhangPct / 100
+
+			blockTxs := genDeterministicHashes(scale.blockTx, 1)
+
+			parent := chainhash.HashH([]byte("gate-parent"))
+			pool := NewSplitTxInpointsMap(16 * 1024) // production splitMapBuckets default
+
+			for _, h := range blockTxs[:overlap] {
+				pool.Set(h, &subtreepkg.TxInpoints{ParentTxHashes: []chainhash.Hash{parent}})
+			}
+
+			for _, h := range genDeterministicHashes(overhang, 2) {
+				pool.Set(h, &subtreepkg.TxInpoints{ParentTxHashes: []chainhash.Hash{parent}})
+			}
+
+			// Pre-bucket the block hashes by the pool map's bucket count
+			// (the deserializer produces this shape for free).
+			nBuckets := pool.Buckets()
+			buckets := make([][]chainhash.Hash, nBuckets)
+			for _, h := range blockTxs {
+				bkt := txmap.Bytes2Uint16Buckets(h, nBuckets)
+				buckets[bkt] = append(buckets[bkt], h)
+			}
+
+			numWorkers := runtime.GOMAXPROCS(0)
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				var found, notFound int64
+
+				var wg sync.WaitGroup
+				results := make([]struct{ found, notFound int64 }, numWorkers)
+
+				for w := 0; w < numWorkers; w++ {
+					wg.Add(1)
+
+					go func(w int) {
+						defer wg.Done()
+
+						var f, nf int64
+
+						for bkt := w; bkt < int(nBuckets); bkt += numWorkers {
+							for _, h := range buckets[bkt] {
+								if tip, ok := pool.Get(h); ok {
+									pool.Set(h, tip) // stand-in for the gen stamp
+									f++
+								} else {
+									nf++
+								}
+							}
+						}
+
+						results[w].found = f
+						results[w].notFound = nf
+					}(w)
+				}
+
+				wg.Wait()
+
+				for _, r := range results {
+					found += r.found
+					notFound += r.notFound
+				}
+
+				if int(found) != overlap || int(notFound) != scale.blockTx-overlap {
+					b.Fatalf("found=%d notFound=%d, want %d/%d", found, notFound, overlap, scale.blockTx-overlap)
+				}
+			}
+
+			b.StopTimer()
+			b.ReportMetric(float64(b.Elapsed().Milliseconds())/float64(b.N), "markpass-ms")
+			fmt.Printf("  [gate] %s: mark pass %.1f ms/op over %d block txs\n",
+				scale.name, float64(b.Elapsed().Milliseconds())/float64(b.N), scale.blockTx)
+		})
+	}
+}

--- a/services/blockassembly/subtreeprocessor/map.go
+++ b/services/blockassembly/subtreeprocessor/map.go
@@ -3,17 +3,29 @@ package subtreeprocessor
 import (
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/dolthub/swiss"
 )
 
 type SplitSwissMap struct {
-	m           map[uint16]*swiss.Map[chainhash.Hash, struct{}]
-	mu          map[uint16]*sync.RWMutex
+	// m and mu are dense, indexed by bucket (0..nrOfBuckets-1). Slices, not
+	// map[uint16]: with hundreds of millions of operations per block, the
+	// per-op Go-map lookup (hash + probe of the bucket key) showed up at ~5%
+	// of insert CPU in profiles; a slice index is free.
+	m           []*swiss.Map[chainhash.Hash, struct{}]
+	mu          []*sync.RWMutex
 	nrOfBuckets uint16
+
+	// frozen marks the map read-only: Exists skips the per-bucket RLock and
+	// the write methods fail. The caller must join all writers before calling
+	// Freeze — that join is the happens-before edge that makes bucket contents
+	// safe for lock-free readers. Clear un-freezes for pool reuse.
+	frozen atomic.Bool
 }
 
 // swissBucketHeadroomNumerator / swissBucketHeadroomDenominator give the
@@ -46,8 +58,8 @@ const swissBucketHeadroomDenominator = 10
 // Returns:
 //   - A pointer to the newly created SplitSwissMap.
 func NewSplitSwissMap(nrOfBuckets uint16, length int) *SplitSwissMap {
-	m := make(map[uint16]*swiss.Map[chainhash.Hash, struct{}], nrOfBuckets)
-	mu := make(map[uint16]*sync.RWMutex, nrOfBuckets)
+	m := make([]*swiss.Map[chainhash.Hash, struct{}], nrOfBuckets)
+	mu := make([]*sync.RWMutex, nrOfBuckets)
 
 	perBucketSizeHint := length / int(nrOfBuckets)
 	if perBucketSizeHint > 0 {
@@ -79,10 +91,26 @@ func NewSplitSwissMap(nrOfBuckets uint16, length int) *SplitSwissMap {
 // not serialise on each other; readers and writers within one bucket do.
 func (s *SplitSwissMap) Exists(hash chainhash.Hash) bool {
 	bucket := txmap.Bytes2Uint16Buckets(hash, s.nrOfBuckets)
+
+	// Frozen maps have no writers (Put/PutMultiBucket are rejected), so the
+	// RLock — whose readerCount atomics dominate profiles at ~190 concurrent
+	// readers — can be skipped entirely.
+	if s.frozen.Load() {
+		_, ok := s.m[bucket].Get(hash)
+		return ok
+	}
+
 	s.mu[bucket].RLock()
 	_, ok := s.m[bucket].Get(hash)
 	s.mu[bucket].RUnlock()
 	return ok
+}
+
+// Freeze marks the map read-only. All writers must have finished (joined)
+// before this call; afterwards Exists reads lock-free and Put/PutMultiBucket
+// return an error. Clear lifts the freeze for pooled reuse.
+func (s *SplitSwissMap) Freeze() {
+	s.frozen.Store(true)
 }
 
 func (s *SplitSwissMap) Length() int {
@@ -102,6 +130,10 @@ func (s *SplitSwissMap) Buckets() uint16 {
 }
 
 func (s *SplitSwissMap) Put(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return errors.NewProcessingError("SplitSwissMap is frozen, Put rejected for %s", hash.String())
+	}
+
 	bucket := txmap.Bytes2Uint16Buckets(hash, s.nrOfBuckets)
 
 	s.mu[bucket].Lock()
@@ -113,6 +145,10 @@ func (s *SplitSwissMap) Put(hash chainhash.Hash) error {
 }
 
 func (s *SplitSwissMap) PutMultiBucket(bucket uint16, hashes []chainhash.Hash) error {
+	if s.frozen.Load() {
+		return errors.NewProcessingError("SplitSwissMap is frozen, PutMultiBucket rejected for bucket %d", bucket)
+	}
+
 	s.mu[bucket].Lock()
 	defer s.mu[bucket].Unlock()
 
@@ -139,6 +175,11 @@ func (s *SplitSwissMap) Iter(f func(hash chainhash.Hash, v struct{}) bool) {
 // is memory-bandwidth-bound on its key/value/ctrl arrays, and with 1024
 // buckets the work is naturally embarrassingly parallel.
 func (s *SplitSwissMap) Clear() {
+	// Lift any freeze before clearing: the pooled map is recycled across
+	// blocks (fill → Freeze → read → Clear → fill ...), and the next block's
+	// inserts must succeed.
+	s.frozen.Store(false)
+
 	ncpu := runtime.NumCPU()
 	if ncpu > int(s.nrOfBuckets) {
 		ncpu = int(s.nrOfBuckets)

--- a/services/blockassembly/subtreeprocessor/map_freeze_test.go
+++ b/services/blockassembly/subtreeprocessor/map_freeze_test.go
@@ -1,0 +1,163 @@
+package subtreeprocessor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSplitSwissMap_FreezeExistsReturnsCorrectResults verifies that freezing
+// the map does not change lookup results: present hashes stay present, absent
+// hashes stay absent, before and after Freeze.
+func TestSplitSwissMap_FreezeExistsReturnsCorrectResults(t *testing.T) {
+	m := NewSplitSwissMap(16, 1024)
+
+	present := genBenchHashes(512, 10)
+	absent := genBenchHashes(512, 20)
+
+	for _, h := range present {
+		require.NoError(t, m.Put(h))
+	}
+
+	for _, h := range present {
+		require.True(t, m.Exists(h), "pre-freeze: expected %s to exist", h)
+	}
+
+	for _, h := range absent {
+		require.False(t, m.Exists(h), "pre-freeze: expected %s to be absent", h)
+	}
+
+	m.Freeze()
+
+	for _, h := range present {
+		require.True(t, m.Exists(h), "post-freeze: expected %s to exist", h)
+	}
+
+	for _, h := range absent {
+		require.False(t, m.Exists(h), "post-freeze: expected %s to be absent", h)
+	}
+
+	require.Equal(t, len(present), m.Length())
+}
+
+// TestSplitSwissMap_PutAfterFreezeReturnsError verifies that all write paths
+// fail loudly on a frozen map instead of silently corrupting the unlocked
+// read path.
+func TestSplitSwissMap_PutAfterFreezeReturnsError(t *testing.T) {
+	m := NewSplitSwissMap(16, 1024)
+
+	h := genBenchHashes(1, 30)[0]
+	require.NoError(t, m.Put(h))
+
+	m.Freeze()
+
+	err := m.Put(genBenchHashes(1, 31)[0])
+	require.Error(t, err)
+
+	extra := genBenchHashes(8, 32)
+	bucket := txmap.Bytes2Uint16Buckets(extra[0], m.Buckets())
+
+	err = m.PutMultiBucket(bucket, extra)
+	require.Error(t, err)
+
+	// The frozen map must be unchanged by the rejected writes.
+	require.Equal(t, 1, m.Length())
+	require.True(t, m.Exists(h))
+}
+
+// TestSplitSwissMap_ClearUnfreezesForPoolReuse verifies the pooled-map cycle
+// used by CreateTransactionMap: fill → Freeze → Clear → fill again. Clear must
+// un-freeze, or the next block's inserts would all fail.
+func TestSplitSwissMap_ClearUnfreezesForPoolReuse(t *testing.T) {
+	m := NewSplitSwissMap(16, 1024)
+
+	first := genBenchHashes(256, 40)
+	for _, h := range first {
+		require.NoError(t, m.Put(h))
+	}
+
+	m.Freeze()
+	m.Clear()
+
+	require.Equal(t, 0, m.Length())
+
+	second := genBenchHashes(256, 41)
+	for _, h := range second {
+		require.NoError(t, m.Put(h), "Put after Clear must succeed (pool reuse)")
+	}
+
+	for _, h := range second {
+		require.True(t, m.Exists(h))
+	}
+
+	for _, h := range first {
+		require.False(t, m.Exists(h), "cleared hash must be gone")
+	}
+
+	// A second freeze cycle must work the same way.
+	m.Freeze()
+	require.Error(t, m.Put(genBenchHashes(1, 42)[0]))
+	require.True(t, m.Exists(second[0]))
+}
+
+// TestSplitSwissMap_FrozenConcurrentReads builds the map concurrently, freezes
+// it, then hammers Exists from many goroutines. Run with -race: the frozen
+// read path takes no locks, which is only safe because freezing happens after
+// all writers have finished.
+func TestSplitSwissMap_FrozenConcurrentReads(t *testing.T) {
+	const total = 64 * 1024
+
+	hashes := genBenchHashes(total, 50)
+	m := NewSplitSwissMap(64, total)
+
+	// Concurrent build via PutMultiBucket, one goroutine per bucket group
+	// (mirrors the single-writer-per-bucket production pattern).
+	grouped := make(map[uint16][]chainhash.Hash)
+	for _, h := range hashes {
+		bucket := txmap.Bytes2Uint16Buckets(h, m.Buckets())
+		grouped[bucket] = append(grouped[bucket], h)
+	}
+
+	var buildWg sync.WaitGroup
+	for bucket, bucketHashes := range grouped {
+		buildWg.Add(1)
+
+		go func(bucket uint16, bucketHashes []chainhash.Hash) {
+			defer buildWg.Done()
+			require.NoError(t, m.PutMultiBucket(bucket, bucketHashes))
+		}(bucket, bucketHashes)
+	}
+
+	buildWg.Wait()
+	m.Freeze()
+
+	absent := genBenchHashes(total, 51)
+
+	var readWg sync.WaitGroup
+	for w := 0; w < 16; w++ {
+		readWg.Add(1)
+
+		go func(offset int) {
+			defer readWg.Done()
+
+			for i := 0; i < total; i++ {
+				idx := (i + offset) % total
+				if !m.Exists(hashes[idx]) {
+					t.Errorf("expected %s to exist", hashes[idx])
+					return
+				}
+
+				if m.Exists(absent[idx]) {
+					t.Errorf("expected %s to be absent", absent[idx])
+					return
+				}
+			}
+		}(w * 1024)
+	}
+
+	readWg.Wait()
+	require.Equal(t, total, m.Length())
+}

--- a/services/blockassembly/subtreeprocessor/txmap_contention_benchmark_test.go
+++ b/services/blockassembly/subtreeprocessor/txmap_contention_benchmark_test.go
@@ -1,0 +1,379 @@
+package subtreeprocessor
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand/v2"
+	"net/url"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	blob_memory "github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"golang.org/x/sync/errgroup"
+)
+
+// These benchmarks reproduce, at reduced scale, the two phases of foreign-block
+// moveForwardBlock that profiling showed plateau at ~15M map-ops/s on a
+// 192-core node (~27 cores busy):
+//
+//   - Phase A (CreateTransactionMap): many concurrent per-subtree goroutines,
+//     each spawning one goroutine per non-empty bucket, all contending on the
+//     1024 bucket mutexes of a shared SplitSwissMap.
+//   - Phase B (processRemainderTxHashes): NumCPU readers probing the same map
+//     via Exists, each taking the bucket RWMutex read lock although the map is
+//     read-only for the whole phase.
+//
+// Baselines are recorded before the contention fix and compared after; see the
+// PR description for the numbers.
+
+// contentionBenchBuckets matches the bucket count used by the production
+// txMapPool (NewSplitSwissMap(1024, ...) in CreateTransactionMap).
+const contentionBenchBuckets = 1024
+
+// benchConcurrentSubtreeReads mirrors the blockassembly_subtreeProcessorConcurrentReads
+// default that bounds the per-subtree goroutines in CreateTransactionMap.
+const benchConcurrentSubtreeReads = 375
+
+// genBenchHashes deterministically generates n pseudo-random 32-byte hashes.
+// PCG is ~50x faster than hashing real data and the SplitSwissMap only cares
+// about key distribution, which PCG output matches.
+func genBenchHashes(n int, seed uint64) []chainhash.Hash {
+	rng := rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15))
+	hashes := make([]chainhash.Hash, n)
+
+	for i := range hashes {
+		binary.LittleEndian.PutUint64(hashes[i][0:8], rng.Uint64())
+		binary.LittleEndian.PutUint64(hashes[i][8:16], rng.Uint64())
+		binary.LittleEndian.PutUint64(hashes[i][16:24], rng.Uint64())
+		binary.LittleEndian.PutUint64(hashes[i][24:32], rng.Uint64())
+	}
+
+	return hashes
+}
+
+// bucketizeBySubtree splits hashes into numSubtrees groups, each pre-bucketed
+// per Bytes2Uint16Buckets — the shape DeserializeHashesFromReaderIntoBuckets
+// hands to the insert stage in CreateTransactionMap.
+func bucketizeBySubtree(hashes []chainhash.Hash, numSubtrees int) []map[uint16][]chainhash.Hash {
+	perSubtree := len(hashes) / numSubtrees
+	out := make([]map[uint16][]chainhash.Hash, numSubtrees)
+
+	for s := range out {
+		buckets := make(map[uint16][]chainhash.Hash, contentionBenchBuckets)
+		for _, h := range hashes[s*perSubtree : (s+1)*perSubtree] {
+			bucket := txmap.Bytes2Uint16Buckets(h, contentionBenchBuckets)
+			buckets[bucket] = append(buckets[bucket], h)
+		}
+
+		out[s] = buckets
+	}
+
+	return out
+}
+
+// fillMapUncontended prefills m with hashes using one goroutine per bucket
+// (setup helper, not the measured path).
+func fillMapUncontended(b *testing.B, m *SplitSwissMap, hashes []chainhash.Hash) {
+	b.Helper()
+
+	grouped := make(map[uint16][]chainhash.Hash, contentionBenchBuckets)
+	for _, h := range hashes {
+		bucket := txmap.Bytes2Uint16Buckets(h, contentionBenchBuckets)
+		grouped[bucket] = append(grouped[bucket], h)
+	}
+
+	g := errgroup.Group{}
+	for bucket, bucketHashes := range grouped {
+		g.Go(func() error {
+			return m.PutMultiBucket(bucket, bucketHashes)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+// benchmarkPhaseAInsert replicates the CreateTransactionMap insert stage as it
+// exists today: per-subtree goroutines (bounded like SubtreeProcessorConcurrentReads)
+// each spawning one PutMultiBucket goroutine per non-empty bucket of a shared map.
+func benchmarkPhaseAInsert(b *testing.B, totalTx, numSubtrees int) {
+	subtreeBuckets := bucketizeBySubtree(genBenchHashes(totalTx, 1), numSubtrees)
+	m := NewSplitSwissMap(contentionBenchBuckets, totalTx)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		m.Clear()
+
+		g := errgroup.Group{}
+		g.SetLimit(benchConcurrentSubtreeReads)
+
+		for _, buckets := range subtreeBuckets {
+			g.Go(func() error {
+				bucketG := errgroup.Group{}
+				for bucket, hashes := range buckets {
+					bucketG.Go(func() error {
+						return m.PutMultiBucket(bucket, hashes)
+					})
+				}
+
+				return bucketG.Wait()
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(totalTx)*float64(b.N)/b.Elapsed().Seconds(), "tx/s")
+
+	if got := m.Length(); got != totalTx {
+		b.Fatalf("map length %d, want %d", got, totalTx)
+	}
+}
+
+// phaseAInsertCases are shared by the current-shape and owners-shape insert
+// benchmarks so the two are directly comparable.
+var phaseAInsertCases = []struct {
+	totalTx     int
+	numSubtrees int
+	large       bool
+}{
+	{4_000_000, 64, false},
+	{16_000_000, 64, true},
+	{16_000_000, 256, true},
+	{40_000_000, 256, true},
+}
+
+func BenchmarkPhaseAInsertCurrent(b *testing.B) {
+	for _, c := range phaseAInsertCases {
+		b.Run(fmt.Sprintf("tx=%dM/subtrees=%d", c.totalTx/1_000_000, c.numSubtrees), func(b *testing.B) {
+			if c.large && testing.Short() {
+				b.Skip("skipping large insert benchmark in short mode")
+			}
+
+			benchmarkPhaseAInsert(b, c.totalTx, c.numSubtrees)
+		})
+	}
+}
+
+// benchmarkPhaseAInsertOwners drives the same input through the bucketInserter:
+// per-subtree submitter goroutines, one exclusive writer per bucket stripe.
+func benchmarkPhaseAInsertOwners(b *testing.B, totalTx, numSubtrees int) {
+	subtreeBuckets := bucketizeBySubtree(genBenchHashes(totalTx, 1), numSubtrees)
+	m := NewSplitSwissMap(contentionBenchBuckets, totalTx)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		m.Clear()
+
+		ins := newBucketInserter(m, runtime.GOMAXPROCS(0))
+
+		g := errgroup.Group{}
+		g.SetLimit(benchConcurrentSubtreeReads)
+
+		for _, buckets := range subtreeBuckets {
+			g.Go(func() error {
+				return ins.submit(buckets)
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			b.Fatal(err)
+		}
+
+		if err := ins.closeAndWait(); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(totalTx)*float64(b.N)/b.Elapsed().Seconds(), "tx/s")
+
+	if got := m.Length(); got != totalTx {
+		b.Fatalf("map length %d, want %d", got, totalTx)
+	}
+}
+
+func BenchmarkPhaseAInsertOwners(b *testing.B) {
+	for _, c := range phaseAInsertCases {
+		b.Run(fmt.Sprintf("tx=%dM/subtrees=%d", c.totalTx/1_000_000, c.numSubtrees), func(b *testing.B) {
+			if c.large && testing.Short() {
+				b.Skip("skipping large insert benchmark in short mode")
+			}
+
+			benchmarkPhaseAInsertOwners(b, c.totalTx, c.numSubtrees)
+		})
+	}
+}
+
+// benchmarkPhaseBExists replicates the processRemainderTxHashes membership scan:
+// all CPUs probing a fully-built (read-only) map, ~50% hit ratio. With frozen
+// set, the map is frozen first so Exists takes the lock-free path.
+func benchmarkPhaseBExists(b *testing.B, totalTx int, frozen bool) {
+	hashes := genBenchHashes(totalTx, 1)
+	m := NewSplitSwissMap(contentionBenchBuckets, totalTx)
+	fillMapUncontended(b, m, hashes)
+
+	if frozen {
+		m.Freeze()
+	}
+
+	// Probe set: half present, half absent, deterministically shuffled.
+	probes := make([]chainhash.Hash, 0, totalTx)
+	probes = append(probes, hashes[:totalTx/2]...)
+	probes = append(probes, genBenchHashes(totalTx/2, 2)...)
+
+	rng := rand.New(rand.NewPCG(3, 3))
+	rng.Shuffle(len(probes), func(i, j int) {
+		probes[i], probes[j] = probes[j], probes[i]
+	})
+
+	var start atomic.Uint64
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Spread goroutines across the probe slice so they don't all walk the
+		// same cache lines in lockstep.
+		local := start.Add(0x9e3779b9)
+		n := uint64(len(probes))
+
+		for pb.Next() {
+			_ = m.Exists(probes[local%n])
+			local++
+		}
+	})
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/s")
+}
+
+func BenchmarkPhaseBExists(b *testing.B) {
+	for _, totalTx := range []int{4_000_000, 16_000_000} {
+		b.Run(fmt.Sprintf("tx=%dM", totalTx/1_000_000), func(b *testing.B) {
+			if totalTx > 4_000_000 && testing.Short() {
+				b.Skip("skipping large Exists benchmark in short mode")
+			}
+
+			benchmarkPhaseBExists(b, totalTx, false)
+		})
+	}
+}
+
+func BenchmarkPhaseBExistsFrozen(b *testing.B) {
+	for _, totalTx := range []int{4_000_000, 16_000_000} {
+		b.Run(fmt.Sprintf("tx=%dM", totalTx/1_000_000), func(b *testing.B) {
+			if totalTx > 4_000_000 && testing.Short() {
+				b.Skip("skipping large Exists benchmark in short mode")
+			}
+
+			benchmarkPhaseBExists(b, totalTx, true)
+		})
+	}
+}
+
+// BenchmarkCreateTransactionMapE2E drives the real CreateTransactionMap
+// (subtree files in a memory blob store → deserialize → insert) at CI scale,
+// pooled-map reuse across iterations as in production.
+func BenchmarkCreateTransactionMapE2E(b *testing.B) {
+	const (
+		numSubtrees   = 16
+		txsPerSubtree = 16384
+	)
+
+	ctx := context.Background()
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 10)
+	go func() {
+		for req := range newSubtreeChan {
+			if req.ErrChan != nil {
+				req.ErrChan <- nil
+			}
+		}
+	}()
+	defer close(newSubtreeChan)
+
+	subtreeStore := blob_memory.New()
+	tSettings := createBenchmarkSettings(txsPerSubtree)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	utxoStore, err := sql.New(ctx, ulogger.TestLogger{}, tSettings, utxoStoreURL)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	stp, err := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, tSettings, subtreeStore, nil, utxoStore, newSubtreeChan)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	stp.SetCurrentItemsPerFile(txsPerSubtree)
+
+	blockSubtreesMap := make(map[chainhash.Hash]int, numSubtrees)
+
+	for s := 0; s < numSubtrees; s++ {
+		subtree, err := subtreepkg.NewTreeByLeafCount(txsPerSubtree)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if s == 0 {
+			if err = subtree.AddCoinbaseNode(); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		for i := 0; i < txsPerSubtree-1; i++ {
+			txHash := chainhash.HashH([]byte(fmt.Sprintf("tx-%d-%d", s, i)))
+			if err = subtree.AddNode(txHash, uint64(s*txsPerSubtree+i+1), 100); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		subtreeBytes, err := subtree.Serialize()
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if err = subtreeStore.Set(ctx, subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes,
+			options.WithDeleteAt(tSettings.GlobalBlockHeightRetention)); err != nil {
+			b.Fatal(err)
+		}
+
+		blockSubtreesMap[*subtree.RootHash()] = s
+	}
+
+	totalTx := numSubtrees * txsPerSubtree
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		transactionMap, _, err := stp.CreateTransactionMap(ctx, blockSubtreesMap, numSubtrees, uint64(totalTx))
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if transactionMap == nil {
+			b.Fatal("nil transaction map")
+		}
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(totalTx)*float64(b.N)/b.Elapsed().Seconds(), "tx/s")
+}

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -73,6 +73,10 @@ func setup(ctx context.Context, t *testing.T) (*Store, *bt.Tx) {
 	tSettings := test.CreateBaseTestSettings(t)
 	tSettings.UtxoStore.DBTimeout = 30 * time.Second
 	tSettings.BatcherDrainMode = true // batcher fires immediately in tests
+	// Pin pruning mode: TestMinedThenSpendAllPrunes asserts default-mode
+	// deletion and must not flip when a developer's settings_local.conf sets
+	// pruner_utxoDefensiveEnabled=true.
+	tSettings.Pruner.UTXODefensiveEnabled = false
 
 	tx, err := bt.NewTxFromString("010000000000000000ef01032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a18700000000" +
 		"8c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5" +

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -52,6 +52,10 @@ func setupPostgresStore(t *testing.T) (*Store, context.Context) {
 	tSettings.BatcherDrainMode = true // batcher fires immediately in tests
 	tSettings.UtxoStore.LockedBatcherSize = 64
 	tSettings.UtxoStore.LockedBatcherDurationMillis = 5
+	// Pin pruning mode: TestMinedThenSpendAllPrunes asserts default-mode
+	// deletion and must not flip when a developer's settings_local.conf sets
+	// pruner_utxoDefensiveEnabled=true.
+	tSettings.Pruner.UTXODefensiveEnabled = false
 
 	store, err := New(ctx, ulogger.TestLogger{}, tSettings, dbURL)
 	require.NoError(t, err)


### PR DESCRIPTION
## What this is

The planned follow-up to #1078 was an algorithmic change: replace `CreateTransactionMap`'s per-block ~420M-entry map build with an "inverted diff" that probes block txs against the existing `currentTxMap`. Per plan, the change was **gated on benchmarks written first** — this PR delivers those benchmarks, and the verdict they produced: **the inversion does not pay post-#1078, so it is not being built.** What lands here is the durable measurement harness.

## Contents

- **`RunForeignBlockMoveBenchmark`** + `teranodecli foreignblockbench`: end-to-end benchmark of the two foreign-block `moveForwardBlock` phases (block map build, remainder rebuild) against a realistic pool/block overlap (pool holds N% of the block's txs in a *different* subtree arrangement + local-only overhang). Parameterized scale/overlap/seed; per-phase wall, throughput, and alloc-delta reporting; optional CPU/heap profiles.
- **`BenchmarkForeignBlockMove`**: go-test wrapper (CI scale + `-short`-gated 8M scale) with a smoke test pinning harness correctness.
- **`BenchmarkGateMarkPassPrototype`**: the gate measurement, kept as the measuring stick for any future attempt, with the verdict recorded in its doc comment.

## The gate verdict (M3 Max 16 cores, on top of #1078)

| Scale | Map build (current) | Mark-pass (inversion) |
|---|---|---|
| 8M block txs | 99 ms | ~50 ms |
| 16M block txs | 249 ms | ~93–178 ms |

The mark pass looks faster in isolation, but the end-to-end accounting kills it:

1. The inversion still pays the file read + deserialize that dominates the map-build wall time (insert-only is ~32ms of the 99ms at 8M) — the real phase-1 saving is small.
2. The remainder scan — the **larger** phase (175–390ms) — would regress: per-probe bucket-mutex + pointer-value lookups against `currentTxMap` (≥13ns) instead of #1078's frozen lock-free swiss-set probes (6ns).
3. Extreme sensitivity to `splitMapBuckets`: with 16 pool buckets the mark pass is **920ms — 9× worse** than the build it replaces. (Production default is 16k.)

Net effect ≈ neutral-to-negative wall time, versus an always-on +8B/entry pool-map layout change and generation-mark machinery across the rollback paths. The ~20GB steady-state RSS saving does not justify that on nodes running at 211GB/500GB.

## Verification

- `go test -race` on the package (incl. the new smoke test) — pass
- `go vet`, `golangci-lint run` (0 issues), `staticcheck` — clean