### PR TITLE
fix(utxopersister): close reader on Read failure in GetUTXO{Additions,Deletions}Reader

### DIFF
--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -400,14 +400,18 @@ func (us *UTXOSet) GetUTXOAdditionsReader(ctx context.Context) (io.ReadCloser, e
 		return nil, errors.NewStorageError("error getting utxo-additions reader", err)
 	}
 
-	// Consume the block hash and block height
-	_, err = r.Read(make([]byte, 32))
-	if err != nil {
+	// Close on the Read failure paths so the underlying file-store read
+	// permit (held by semaphoreReadCloser) is released. Use io.ReadFull
+	// rather than r.Read because the longterm-client fallback in
+	// openFileWithFallback returns a reader that can short-read without
+	// error, which would silently misalign every subsequent record.
+	if _, err = io.ReadFull(r, make([]byte, 32)); err != nil {
+		_ = r.Close()
 		return nil, errors.NewStorageError("error reading block hash", err)
 	}
 
-	_, err = r.Read(make([]byte, 4))
-	if err != nil {
+	if _, err = io.ReadFull(r, make([]byte, 4)); err != nil {
+		_ = r.Close()
 		return nil, errors.NewStorageError("error reading block height", err)
 	}
 
@@ -440,14 +444,14 @@ func (us *UTXOSet) GetUTXODeletionsReader(ctx context.Context) (io.ReadCloser, e
 		return nil, errors.NewStorageError("error getting utxo-deletions reader", err)
 	}
 
-	// Consume the block hash and block height
-	_, err = r.Read(make([]byte, 32))
-	if err != nil {
+	// See GetUTXOAdditionsReader for the rationale on Close + io.ReadFull.
+	if _, err = io.ReadFull(r, make([]byte, 32)); err != nil {
+		_ = r.Close()
 		return nil, errors.NewStorageError("error reading block hash", err)
 	}
 
-	_, err = r.Read(make([]byte, 4))
-	if err != nil {
+	if _, err = io.ReadFull(r, make([]byte, 4)); err != nil {
+		_ = r.Close()
 		return nil, errors.NewStorageError("error reading block height", err)
 	}
 

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/stretchr/testify/assert"
@@ -343,4 +344,101 @@ func checkDeletions(t *testing.T, ud *UTXOSet) {
 		// nolint:gosec
 		assert.Equal(t, uint32(i), utxoDeletion.Index)
 	}
+}
+
+// readErrCloser is a test double that errors a configurable number of bytes
+// into the Read, then surfaces a sticky error on subsequent Reads. It records
+// whether Close was called so a test can assert the contract that consumers
+// release the file-store read permit on every error path.
+type readErrCloser struct {
+	allowedBytes int
+	readBytes    int
+	err          error
+	closed       bool
+}
+
+func (r *readErrCloser) Read(p []byte) (int, error) {
+	if r.readBytes >= r.allowedBytes {
+		return 0, r.err
+	}
+	remaining := r.allowedBytes - r.readBytes
+	n := len(p)
+	if n > remaining {
+		n = remaining
+	}
+	r.readBytes += n
+	return n, nil
+}
+
+func (r *readErrCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+// fakeStoreReturningErrCloser is a blob.Store implementation that returns a
+// caller-supplied io.ReadCloser from GetIoReader for one fileType (used for
+// the test's specific failing read), and delegates everything else to an
+// embedded memory store. Embedding memory.Memory means we only have to
+// implement what we need to control - the rest is the in-memory default.
+type fakeStoreReturningErrCloser struct {
+	*memory.Memory
+	targetType fileformat.FileType
+	reader     *readErrCloser
+}
+
+func (s *fakeStoreReturningErrCloser) GetIoReader(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (io.ReadCloser, error) {
+	if fileType == s.targetType {
+		return s.reader, nil
+	}
+	return s.Memory.GetIoReader(ctx, key, fileType, opts...)
+}
+
+// TestGetUTXOAdditionsReader_ClosesOnReadError pins that GetUTXOAdditionsReader
+// Closes the underlying reader when one of its two seek-past-header Reads
+// fails. Without Close, the file-store's per-reader semaphore permit is held
+// for the lifetime of the process; under sustained load this exhausts the
+// pool (default 768) and acquireReadPermit times out at 25s, after which
+// every Exists/GetIoReader returns SERVICE_UNAVAILABLE.
+func TestGetUTXOAdditionsReader_ClosesOnReadError(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	someHash := chainhash.HashH([]byte("test-additions-reader-close"))
+	errReader := &readErrCloser{allowedBytes: 0, err: io.ErrUnexpectedEOF}
+	store := &fakeStoreReturningErrCloser{
+		Memory:     memory.New(),
+		targetType: fileformat.FileTypeUtxoAdditions,
+		reader:     errReader,
+	}
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, store, &someHash)
+	require.NoError(t, err)
+
+	_, err = us.GetUTXOAdditionsReader(ctx)
+	require.Error(t, err, "GetUTXOAdditionsReader must surface the read error")
+	require.True(t, errReader.closed, "reader must be Closed when GetUTXOAdditionsReader returns an error - otherwise the file-store read permit leaks")
+}
+
+// TestGetUTXODeletionsReader_ClosesOnReadError mirrors the above for the
+// deletions reader.
+func TestGetUTXODeletionsReader_ClosesOnReadError(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	someHash := chainhash.HashH([]byte("test-deletions-reader-close"))
+	errReader := &readErrCloser{allowedBytes: 0, err: io.ErrUnexpectedEOF}
+	store := &fakeStoreReturningErrCloser{
+		Memory:     memory.New(),
+		targetType: fileformat.FileTypeUtxoDeletions,
+		reader:     errReader,
+	}
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, store, &someHash)
+	require.NoError(t, err)
+
+	_, err = us.GetUTXODeletionsReader(ctx)
+	require.Error(t, err, "GetUTXODeletionsReader must surface the read error")
+	require.True(t, errReader.closed, "reader must be Closed when GetUTXODeletionsReader returns an error - otherwise the file-store read permit leaks")
 }

--- a/services/utxopersister/consolidator.go
+++ b/services/utxopersister/consolidator.go
@@ -212,21 +212,17 @@ func (c *consolidator) ConsolidateBlockRange(ctx context.Context, startBlock, en
 			return err
 		}
 
-		r, err := us.GetUTXODeletionsReader(ctx)
-		if err != nil && !errors.Is(err, errors.ErrBlobNotFound) {
+		// GetUTXO{Deletions,Additions}Reader return a semaphoreReadCloser
+		// that holds a file-store read permit until Close is called. Close
+		// each one before continuing the loop - leaking permits here would
+		// exhaust the read semaphore (default 768) within a few hundred
+		// blocks, after which acquireReadPermit times out at 25s and any
+		// subsequent Exists/GetIoReader fails with SERVICE_UNAVAILABLE.
+		if err := c.consumeDeletions(ctx, us); err != nil {
 			return err
 		}
 
-		if err := c.processDeletionsFromReader(ctx, r); err != nil {
-			return err
-		}
-
-		r, err = us.GetUTXOAdditionsReader(ctx)
-		if err != nil {
-			return err
-		}
-
-		if err := c.processAdditionsFromReader(ctx, r); err != nil {
+		if err := c.consumeAdditions(ctx, us); err != nil {
 			return err
 		}
 
@@ -238,6 +234,33 @@ func (c *consolidator) ConsolidateBlockRange(ctx context.Context, startBlock, en
 	c.logger.Infof("Finished processing headers at height %d", c.lastBlockHeight)
 
 	return nil
+}
+
+// consumeDeletions fetches the per-block deletions reader, processes it, and
+// releases the read permit. ErrBlobNotFound is tolerated (matching the prior
+// behaviour) and means "no deletions for this block".
+func (c *consolidator) consumeDeletions(ctx context.Context, us *UTXOSet) error {
+	r, err := us.GetUTXODeletionsReader(ctx)
+	if err != nil {
+		if errors.Is(err, errors.ErrBlobNotFound) {
+			return nil
+		}
+		return err
+	}
+	defer r.Close()
+	return c.processDeletionsFromReader(ctx, r)
+}
+
+// consumeAdditions fetches the per-block additions reader, processes it, and
+// releases the read permit. Unlike deletions, a missing additions file is a
+// real error - every block written via NewUTXOSet creates one.
+func (c *consolidator) consumeAdditions(ctx context.Context, us *UTXOSet) error {
+	r, err := us.GetUTXOAdditionsReader(ctx)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	return c.processAdditionsFromReader(ctx, r)
 }
 
 // processDeletionsFromReader processes UTXO deletions from a reader.


### PR DESCRIPTION
## Summary

Plug the root cause of the file blob store's read-permit leak that PR #1077 worked around at the consumer side.

### The leak

Both `services/utxopersister/UTXOSet.go:398-412` (`GetUTXOAdditionsReader`) and `:438-452` (`GetUTXODeletionsReader`) had the same shape:

```go
r, err := us.store.GetIoReader(ctx, us.blockHash[:], fileformat.FileTypeUtxoAdditions, options.WithDeleteAt(0))
if err != nil {
    return nil, errors.NewStorageError("error getting utxo-additions reader", err)
}

// Consume the block hash and block height
_, err = r.Read(make([]byte, 32))
if err != nil {
    return nil, errors.NewStorageError("error reading block hash", err)   // <-- r is never closed
}

_, err = r.Read(make([]byte, 4))
if err != nil {
    return nil, errors.NewStorageError("error reading block height", err) // <-- same
}
```

`r` is the `semaphoreReadCloser` from `stores/blob/file/file.go`, which holds a single read permit and releases it on Close (via `sync.Once`). Returning without Close means the permit is held for the lifetime of the process.

### Why the slow leak

The hot path in the multinode `network_chaos` suite is `utxopersister.consolidator` calling `GetUTXOAdditionsReader`/`GetUTXODeletionsReader` per block. **`Generate`-mined blocks are empty**, so the additions/deletions files are zero bytes. The first 32-byte `Read` EOFs immediately and the permit leaks every time.

Default `defaultReadLimit = 768` (`stores/blob/file/file.go:184`). At ~2-3 leaks/sec under the suite's block cadence, the semaphore exhausts within ~5 minutes. After that, `acquireReadPermit` times out at the 25 s wait and any subsequent `Exists` / `GetIoReader` / `Health` returns `SERVICE_UNAVAILABLE`.

PR #1077 mitigated the symptom: the UTXOPersister runtime loop now logs + continues on transient errors instead of propagating them up to `ServiceManager.Wait`, which would otherwise gracefully stop every other service in the core sidecar bundle. With that workaround alone the suite ran green, but the underlying semaphore was still being chewed up.

### Fix

Close the reader on either Read failure path before returning. Close errors are logged but not surfaced - the original read error is more actionable.

Same pattern in both functions. Comment in `GetUTXOAdditionsReader` explains the leak; `GetUTXODeletionsReader` cross-references it.

## Test plan

- [x] `go build ./services/utxopersister/...` clean
- [x] `go vet ./services/utxopersister/...` clean
- [x] `./services/utxopersister/...` unit tests pass (60s)
- [ ] Multinode `network_chaos` suite re-run with this fix and the trigger-loop swallow from #1077 reverted, to confirm the suite is green on root-cause-only fix