### PR TITLE
fix(asset): close subtree reader + pipe on streaming errors in GetLegacyBlockReader

### DIFF
--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -129,6 +129,14 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 							break
 						}
 
+						// Close the underlying reader before returning so the file-store
+						// read permit held by the semaphoreReadCloser is released, and
+						// close the pipe so the consumer's Read returns instead of
+						// hanging forever waiting for bytes that will never arrive.
+						_ = subtreeDataReader.Close()
+						_ = w.CloseWithError(io.ErrClosedPipe)
+						_ = r.CloseWithError(err)
+
 						return errors.NewProcessingError("error reading transaction: %s", err)
 					}
 
@@ -142,6 +150,9 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 
 					// Write the normal transaction bytes to the writer
 					if _, err = tx.WriteTo(w); err != nil {
+						// Close the underlying reader so the file-store read permit
+						// is released. The pipe close below already wakes the consumer.
+						_ = subtreeDataReader.Close()
 						_ = w.CloseWithError(io.ErrClosedPipe)
 						_ = r.CloseWithError(err)
 

--- a/services/asset/repository/GetLegacyBlock_test.go
+++ b/services/asset/repository/GetLegacyBlock_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/settings"
 	memory_blob "github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -1710,6 +1711,91 @@ func TestSendChunkResult_DeliversWhenChannelHasCapacity(t *testing.T) {
 	default:
 		t.Fatal("result was not delivered to channel")
 	}
+}
+
+// readErrCloser is a test double whose Read returns a sticky error and that
+// records whether Close was called. Used to assert that consumers release
+// file-store read permits on every error path.
+type readErrCloser struct {
+	err    error
+	closed bool
+}
+
+func (r *readErrCloser) Read([]byte) (int, error) { return 0, r.err }
+func (r *readErrCloser) Close() error             { r.closed = true; return nil }
+
+// subtreeStoreFakeReader wraps an in-memory subtree store and replaces the
+// GetIoReader return for a specific (key, fileType) pair with a caller-supplied
+// io.ReadCloser. Everything else delegates to the embedded store so the rest
+// of the repository plumbing keeps working.
+type subtreeStoreFakeReader struct {
+	*memory_blob.Memory
+	targetKey  []byte
+	targetType fileformat.FileType
+	reader     io.ReadCloser
+}
+
+func (s *subtreeStoreFakeReader) GetIoReader(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (io.ReadCloser, error) {
+	if fileType == s.targetType && bytes.Equal(key, s.targetKey) {
+		return s.reader, nil
+	}
+	return s.Memory.GetIoReader(ctx, key, fileType, opts...)
+}
+
+// TestGetLegacyBlockReader_ClosesSubtreeReaderOnReadError pins the close
+// contract on the legacy-block streaming path. If a subtree's data file
+// exists but reading transactions out of it fails partway through, the
+// per-iteration io.ReadCloser must be Closed (releasing the file-store
+// read permit held by the underlying semaphoreReadCloser) and the output
+// pipe must be CloseWithError'd so the consumer's Read returns instead of
+// blocking forever on bytes that will never arrive. Prior to the fix, the
+// non-EOF read-failure path at GetLegacyBlock.go returned without doing
+// either, leaking a permit per affected request and deadlocking the
+// consumer.
+func TestGetLegacyBlockReader_ClosesSubtreeReaderOnReadError(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	ctx := setup(t)
+	block, subtree := newBlock(ctx, t, params)
+
+	blockchainClientMock := ctx.repo.BlockchainClient.(*blockchain.Mock)
+	blockchainClientMock.On("GetBlock", mock.Anything, mock.Anything).Return(block, nil).Once()
+
+	// Pre-write a non-empty SubtreeData so Exists() returns true and the
+	// inline streaming branch is taken. The body's exact contents don't
+	// matter because the fake reader will override what GetIoReader returns.
+	subtreeData := subtreepkg.NewSubtreeData(subtree)
+	for i, tx := range params.txs {
+		if i != 0 {
+			require.NoError(t, subtreeData.AddTx(tx, i))
+		}
+	}
+	subtreeDataBytes, err := subtreeData.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, ctx.repo.SubtreeStore.Set(t.Context(), subtree.RootHash()[:], fileformat.FileTypeSubtreeData, subtreeDataBytes))
+
+	// Wrap the existing in-memory store so that GetIoReader for
+	// (subtreeRoot, SubtreeData) returns a reader that errors on the
+	// first Read with a non-EOF error - the leak-prone path.
+	fakeReader := &readErrCloser{err: io.ErrUnexpectedEOF}
+	ctx.repo.SubtreeStore = &subtreeStoreFakeReader{
+		Memory:     ctx.repo.SubtreeStore.(*memory_blob.Memory),
+		targetKey:  subtree.RootHash()[:],
+		targetType: fileformat.FileTypeSubtreeData,
+		reader:     fakeReader,
+	}
+
+	r, err := ctx.repo.GetLegacyBlockReader(t.Context(), &chainhash.Hash{})
+	require.NoError(t, err)
+
+	// Drain the pipe. The streaming goroutine will hit the read error
+	// inside the subtree loop and CloseWithError the pipe; we should
+	// receive the same error from io.ReadAll, NOT hang.
+	_, readErr := io.ReadAll(r)
+	require.Error(t, readErr, "consumer's Read must return after the streaming goroutine errors; if this hangs, the pipe was not closed on the error path")
+
+	require.True(t, fakeReader.closed,
+		"subtreeDataReader must be Closed when the streaming loop returns an error - otherwise the file-store read permit leaks for the lifetime of the process")
 }
 
 func TestSendChunkResult_ReturnsCtxErrWhenBlocked(t *testing.T) {


### PR DESCRIPTION
## Summary

Two leak/deadlock bugs on the legacy-block streaming path discovered via the same `GetIoReader` audit that found PR #1087.

### The bugs

`services/asset/repository/GetLegacyBlock.go` streams the block by iterating `block.Subtrees`, opening a `SubtreeStore.GetIoReader` per subtree and copying transactions into a pipe writer. Two error returns inside the loop didn't clean up:

**1. `tx.ReadFromWithArena` non-EOF error** (corrupt subtree file, torn write, ctx cancellation mid-decode):

```go
for {
    tx := &bt.Tx{}
    if _, err = tx.ReadFromWithArena(bufferedReader, arena); err != nil {
        if err == io.EOF { break }
        return errors.NewProcessingError("error reading transaction: %s", err)
        //  ^^^^^^^^^^^^^ subtreeDataReader leaked + pipe never closed
    }
    ...
}
```

The reader is the file-store's `semaphoreReadCloser`, so the read permit leaks for the lifetime of the process. The pipe stays open so the **consumer's `Read` blocks forever** — the streaming goroutine has returned but the caller is still waiting for bytes that will never arrive. That's a real-world deadlock, not just a permit leak.

**2. `tx.WriteTo(w)` error** (consumer closed the pipe early, network drop on the HTTP side):

```go
if _, err = tx.WriteTo(w); err != nil {
    _ = w.CloseWithError(io.ErrClosedPipe)
    _ = r.CloseWithError(err)
    return errors.NewProcessingError(...)
    // pipe closed correctly; subtreeDataReader leaked
}
```

Pipe close is right but the reader is still leaked.

### Fix

Both paths now Close the underlying reader before returning, and the `ReadFromWithArena` path also `CloseWithError`'s the pipe so the consumer unblocks. Matches the existing cleanup pattern at the `GetIoReader`-error branch (lines 112-117) and the end-of-iteration close at the EOF-break path (line 158).

### Regression test

`TestGetLegacyBlockReader_ClosesSubtreeReaderOnReadError` uses a fake `SubtreeStore` (embeds `memory_blob.Memory` and overrides only `GetIoReader` for the target `(subtreeHash, SubtreeData)` pair) to return a Read-erroring `io.ReadCloser`. Asserts both contracts directly:

- `io.ReadAll(r)` returns an error rather than hanging (proves pipe was closed on the streaming error path)
- `fakeReader.closed == true` (proves the file-store read permit was released)

Confirmed it catches the bug: with the fix reverted, the test fails via the suite-level 60s timeout — `io.ReadAll` hangs forever. With the fix it passes in 0.01s.

## Test plan

- [x] `go build ./services/asset/...` clean
- [x] `go vet ./services/asset/...` clean
- [x] New test passes (0.01s); full `./services/asset/repository/...` test pass (1.8s)
- [x] A/B: same test FAILS without the production fix (60s timeout, consumer deadlock)