### PR TITLE
fix(blob): close reader on every path in HTTPBlobServer.handleRangeRequest

### DIFF
--- a/stores/blob/server.go
+++ b/stores/blob/server.go
@@ -307,6 +307,12 @@ func (s *HTTPBlobServer) handleRangeRequest(w http.ResponseWriter, r *http.Reque
 
 		return
 	}
+	// Close on every return path - the underlying file-store reader holds
+	// a read permit. Previously this handler leaked the permit on success
+	// AND on all four mid-function error returns (seek failure, store does
+	// not support seeking, Read failure, and the fall-through after Write).
+	// handleGet just above has the same defer rc.Close() pattern.
+	defer dataReader.Close()
 
 	// seek the reader to the start position
 	if start > 0 {

--- a/stores/blob/server_test.go
+++ b/stores/blob/server_test.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/stores/blob/http"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
@@ -153,5 +155,153 @@ func TestServerOperations(t *testing.T) {
 
 		err = client.Del(context.Background(), key, fileformat.FileTypeTesting)
 		require.NoError(t, err)
+	})
+}
+
+// countingReadSeekCloser records Close calls and exposes a configurable
+// Read/Seek so handleRangeRequest's different error paths can be exercised
+// in isolation. It backs onto a bytes.Reader for the happy path.
+type countingReadSeekCloser struct {
+	src        *bytes.Reader
+	readErr    error
+	seekErr    error
+	closeCount int
+}
+
+func newCountingReadSeekCloser(data []byte) *countingReadSeekCloser {
+	return &countingReadSeekCloser{src: bytes.NewReader(data)}
+}
+
+func (c *countingReadSeekCloser) Read(p []byte) (int, error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return c.src.Read(p)
+}
+
+func (c *countingReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
+	if c.seekErr != nil {
+		return 0, c.seekErr
+	}
+	return c.src.Seek(offset, whence)
+}
+
+func (c *countingReadSeekCloser) Close() error { c.closeCount++; return nil }
+
+// nonSeekingCloser is an io.ReadCloser that deliberately does NOT implement
+// io.Seeker, so it triggers handleRangeRequest's "Store does not support
+// seeking" branch (handlers should still close it on the way out).
+type nonSeekingCloser struct{ closeCount int }
+
+func (n *nonSeekingCloser) Read([]byte) (int, error) { return 0, io.EOF }
+func (n *nonSeekingCloser) Close() error             { n.closeCount++; return nil }
+
+// fakeRangeStore is a minimal blob.Store whose only meaningful method is
+// GetIoReader, which returns a caller-supplied io.ReadCloser. Every other
+// method panics so a test that accidentally exercises an unrelated code
+// path fails loudly. handleRangeRequest only calls GetIoReader.
+type fakeRangeStore struct {
+	reader io.ReadCloser
+	err    error
+}
+
+func (s *fakeRangeStore) Health(context.Context, bool) (int, string, error) {
+	panic("fakeRangeStore.Health should not be called")
+}
+func (s *fakeRangeStore) Exists(context.Context, []byte, fileformat.FileType, ...options.FileOption) (bool, error) {
+	panic("fakeRangeStore.Exists should not be called")
+}
+func (s *fakeRangeStore) Get(context.Context, []byte, fileformat.FileType, ...options.FileOption) ([]byte, error) {
+	panic("fakeRangeStore.Get should not be called")
+}
+func (s *fakeRangeStore) GetIoReader(context.Context, []byte, fileformat.FileType, ...options.FileOption) (io.ReadCloser, error) {
+	return s.reader, s.err
+}
+func (s *fakeRangeStore) Set(context.Context, []byte, fileformat.FileType, []byte, ...options.FileOption) error {
+	panic("fakeRangeStore.Set should not be called")
+}
+func (s *fakeRangeStore) SetFromReader(context.Context, []byte, fileformat.FileType, io.ReadCloser, ...options.FileOption) error {
+	panic("fakeRangeStore.SetFromReader should not be called")
+}
+func (s *fakeRangeStore) SetDAH(context.Context, []byte, fileformat.FileType, uint32, ...options.FileOption) error {
+	panic("fakeRangeStore.SetDAH should not be called")
+}
+func (s *fakeRangeStore) GetDAH(context.Context, []byte, fileformat.FileType, ...options.FileOption) (uint32, error) {
+	panic("fakeRangeStore.GetDAH should not be called")
+}
+func (s *fakeRangeStore) Del(context.Context, []byte, fileformat.FileType, ...options.FileOption) error {
+	panic("fakeRangeStore.Del should not be called")
+}
+func (s *fakeRangeStore) Close(context.Context) error {
+	panic("fakeRangeStore.Close should not be called")
+}
+func (s *fakeRangeStore) SetCurrentBlockHeight(uint32) {
+	panic("fakeRangeStore.SetCurrentBlockHeight should not be called")
+}
+
+// TestHandleRangeRequest_ClosesReaderOnAllPaths pins the close contract on
+// HTTPBlobServer.handleRangeRequest. Before the fix, the function never
+// closed the io.ReadCloser returned by GetIoReader - not on the four
+// mid-function error returns (seek failure, store-not-seekable, Read
+// failure, the fall-through after Write), and not on the success path.
+// Each unclosed semaphoreReadCloser holds a file-store read permit; under
+// any non-trivial range-request volume the read semaphore (default 768)
+// exhausts and subsequent reads fail with SERVICE_UNAVAILABLE.
+func TestHandleRangeRequest_ClosesReaderOnAllPaths(t *testing.T) {
+	logger := ulogger.New("test")
+
+	t.Run("success", func(t *testing.T) {
+		reader := newCountingReadSeekCloser([]byte("hello, range request world!"))
+		srv := &HTTPBlobServer{store: &fakeRangeStore{reader: reader}, logger: logger}
+
+		req := httptest.NewRequest("GET", "/blob/Zm9vLnRlc3Rpbmc=", nil)
+		req.Header.Set("Range", "bytes=0-4")
+		rr := httptest.NewRecorder()
+
+		srv.handleRangeRequest(rr, req, []byte("foo"), fileformat.FileTypeTesting)
+
+		require.Equal(t, 1, reader.closeCount, "reader must be Closed exactly once on the success path")
+	})
+
+	t.Run("seek error", func(t *testing.T) {
+		reader := newCountingReadSeekCloser([]byte("data"))
+		reader.seekErr = errors.New(errors.ERR_PROCESSING, "deliberate seek failure")
+		srv := &HTTPBlobServer{store: &fakeRangeStore{reader: reader}, logger: logger}
+
+		req := httptest.NewRequest("GET", "/blob/Zm9vLnRlc3Rpbmc=", nil)
+		req.Header.Set("Range", "bytes=10-20")
+		rr := httptest.NewRecorder()
+
+		srv.handleRangeRequest(rr, req, []byte("foo"), fileformat.FileTypeTesting)
+
+		require.Equal(t, 1, reader.closeCount, "reader must be Closed when Seek fails")
+	})
+
+	t.Run("store not seekable", func(t *testing.T) {
+		reader := &nonSeekingCloser{}
+		srv := &HTTPBlobServer{store: &fakeRangeStore{reader: reader}, logger: logger}
+
+		req := httptest.NewRequest("GET", "/blob/Zm9vLnRlc3Rpbmc=", nil)
+		req.Header.Set("Range", "bytes=10-20")
+		rr := httptest.NewRecorder()
+
+		srv.handleRangeRequest(rr, req, []byte("foo"), fileformat.FileTypeTesting)
+
+		require.Equal(t, 1, reader.closeCount, "reader must be Closed when the store does not support seeking")
+		require.Contains(t, rr.Body.String(), "does not support seeking")
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		reader := newCountingReadSeekCloser([]byte("xx"))
+		reader.readErr = errors.New(errors.ERR_PROCESSING, "deliberate read failure")
+		srv := &HTTPBlobServer{store: &fakeRangeStore{reader: reader}, logger: logger}
+
+		req := httptest.NewRequest("GET", "/blob/Zm9vLnRlc3Rpbmc=", nil)
+		req.Header.Set("Range", "bytes=0-10")
+		rr := httptest.NewRecorder()
+
+		srv.handleRangeRequest(rr, req, []byte("foo"), fileformat.FileTypeTesting)
+
+		require.Equal(t, 1, reader.closeCount, "reader must be Closed when ReadFull fails")
 	})
 }


### PR DESCRIPTION
## Summary

`HTTPBlobServer.handleRangeRequest` at `stores/blob/server.go:291` acquired an `io.ReadCloser` via `s.store.GetIoReader(...)` and never closed it - not on the four mid-function error returns (Seek failure, store-not-seekable, Read failure, the fall-through after Write) and not on the success path.

The underlying file-store reader is a `semaphoreReadCloser` that holds a single read permit until `Close`, so this handler leaked a permit per HTTP range request, regardless of outcome.

`handleGet` immediately above (line 251) has exactly the right pattern: `defer rc.Close()` right after the `GetIoReader` error check.

### Diff shape

```go
dataReader, err := s.store.GetIoReader(r.Context(), key, fileType, opts...)
if err != nil { ... return }
+	// Close on every return path - the underlying file-store reader holds
+	// a read permit. Previously this handler leaked the permit on success
+	// AND on all four mid-function error returns (...).
+	defer dataReader.Close()
```

## Regression test

`TestHandleRangeRequest_ClosesReaderOnAllPaths` covers all four paths in subtests:

- **success** - happy path, body fully Read + Written
- **seek error** - reader returns an error from Seek
- **store not seekable** - reader does not implement `io.Seeker`
- **read error** - reader returns an error from Read

Test scaffolding:

- `countingReadSeekCloser` / `nonSeekingCloser` - test doubles that record `Close` calls
- `fakeRangeStore` - minimal `blob.Store` implementing only `GetIoReader`; every other method panics so accidental coverage drift fails loudly

All four pass with the fix. **A/B verified**: with the fix reverted, all four subtests fail with `closeCount=0`.

## Test plan

- [x] `go build ./stores/blob/` clean
- [x] New test passes (~15ms)
- [x] A/B: same test FAILS on all four sub-paths without the production fix

## Related

Same audit thread as #1087 (utxopersister leak) and #1088 (asset legacy-block reader + pipe-deadlock). Different code, same class of bug: per-request `GetIoReader` consumers that forget to `Close`.