### PR TITLE
fix(blob): close source reader on every path in ConcurrentBlob.Get

### DIFF
--- a/stores/blob/concurrent_blob.go
+++ b/stores/blob/concurrent_blob.go
@@ -132,13 +132,23 @@ func (c *ConcurrentBlob[K]) Get(ctx context.Context, key K, fileType fileformat.
 		return nil, err
 	}
 
+	// Always close the source reader on the way out. The Store.SetFromReader
+	// contract on whether the input reader is closed is inconsistent across
+	// implementations - memory does (defer at the top of its SetFromReader)
+	// but file does not - so the caller cannot rely on either. Closing here
+	// covers both. Close is idempotent for the readers used in practice
+	// (semaphoreReadCloser via sync.Once, http.Response.Body per net/http
+	// docs), so a redundant close from a store that does close internally
+	// is benign.
+	defer func() {
+		_ = resultReader.Close()
+	}()
+
 	// Cache the result
 	err = c.blobStore.SetFromReader(ctx, key[:], fileType, resultReader, c.options...)
 	if err != nil {
 		return nil, err
 	}
-
-	_ = resultReader.Close()
 
 	// Return a reader to the cached blob
 	return c.blobStore.GetIoReader(ctx, key[:], fileType, c.options...)

--- a/stores/blob/concurrent_blob_test.go
+++ b/stores/blob/concurrent_blob_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -133,4 +134,113 @@ func (e *errorReader) Read(p []byte) (n int, err error) {
 
 func (e *errorReader) Close() error {
 	return nil
+}
+
+// closingReader counts how many times Close was called and returns a
+// configurable error from Read. Used to assert the close contract.
+type closingReader struct {
+	readErr    error
+	closeCount int
+}
+
+func (r *closingReader) Read([]byte) (int, error) {
+	if r.readErr != nil {
+		return 0, r.readErr
+	}
+	return 0, io.EOF
+}
+
+func (r *closingReader) Close() error { r.closeCount++; return nil }
+
+// nonClosingSetStore wraps an underlying blob.Store but its SetFromReader
+// does NOT close the input reader - matching the file-store contract
+// (memory closes via defer, file does not). This exposes whether the
+// CALLER (ConcurrentBlob.Get in our case) closes the reader itself, which
+// is what determines whether ConcurrentBlob leaks under a file store.
+type nonClosingSetStore struct {
+	inner   Store
+	failSet bool
+}
+
+func (s *nonClosingSetStore) SetFromReader(ctx context.Context, key []byte, fileType fileformat.FileType, reader io.ReadCloser, opts ...options.FileOption) error {
+	if s.failSet {
+		return errors.NewStorageError("simulated SetFromReader failure")
+	}
+	// Mimic file-store behaviour: drain the reader but do NOT close it.
+	_, _ = io.Copy(io.Discard, reader)
+	return s.inner.SetFromReader(ctx, key, fileType, io.NopCloser(strings.NewReader("dummy")), opts...)
+}
+
+func (s *nonClosingSetStore) Health(ctx context.Context, b bool) (int, string, error) {
+	return s.inner.Health(ctx, b)
+}
+
+func (s *nonClosingSetStore) Exists(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (bool, error) {
+	return s.inner.Exists(ctx, key, fileType, opts...)
+}
+
+func (s *nonClosingSetStore) Get(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) ([]byte, error) {
+	return s.inner.Get(ctx, key, fileType, opts...)
+}
+
+func (s *nonClosingSetStore) GetIoReader(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (io.ReadCloser, error) {
+	return s.inner.GetIoReader(ctx, key, fileType, opts...)
+}
+
+func (s *nonClosingSetStore) Set(ctx context.Context, key []byte, fileType fileformat.FileType, value []byte, opts ...options.FileOption) error {
+	return s.inner.Set(ctx, key, fileType, value, opts...)
+}
+
+func (s *nonClosingSetStore) SetDAH(ctx context.Context, key []byte, fileType fileformat.FileType, newDAH uint32, opts ...options.FileOption) error {
+	return s.inner.SetDAH(ctx, key, fileType, newDAH, opts...)
+}
+
+func (s *nonClosingSetStore) Del(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) error {
+	return s.inner.Del(ctx, key, fileType, opts...)
+}
+
+func (s *nonClosingSetStore) Close(ctx context.Context) error { return s.inner.Close(ctx) }
+func (s *nonClosingSetStore) SetCurrentBlockHeight(h uint32)  { s.inner.SetCurrentBlockHeight(h) }
+
+// TestConcurrentBlob_GetBlobClosesReaderOnSetError pins that the source
+// io.ReadCloser returned by the user's getBlobReader callback is Closed
+// even when SetFromReader fails - and that ConcurrentBlob does the close
+// itself rather than relying on the store. The Store.SetFromReader
+// contract on whether the input reader is closed differs between
+// implementations (memory closes via defer, file does not), so a test
+// that uses memory cannot catch the leak. nonClosingSetStore models the
+// file-store contract.
+func TestConcurrentBlob_GetBlobClosesReaderOnSetError(t *testing.T) {
+	ctx := context.Background()
+	key := [32]byte{1, 2, 3}
+	store := &nonClosingSetStore{inner: memory.New(), failSet: true}
+
+	reader := &closingReader{} // any reader; we just track Close calls
+	cb := NewConcurrentBlob(store)
+	_, err := cb.Get(ctx, key, fileformat.FileTypeTesting, func() (io.ReadCloser, error) {
+		return reader, nil
+	})
+
+	assert.Error(t, err)
+	assert.GreaterOrEqual(t, reader.closeCount, 1,
+		"ConcurrentBlob.Get must Close the source reader itself when the underlying store's SetFromReader fails - otherwise the reader (HTTP body, file-store permit, etc.) leaks against any store that doesn't close its input")
+}
+
+// TestConcurrentBlob_GetBlobClosesReaderOnSuccess pins the same close
+// contract on the success path: ConcurrentBlob.Get must Close the source
+// reader itself, not rely on the store's SetFromReader to do it.
+func TestConcurrentBlob_GetBlobClosesReaderOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	key := [32]byte{4, 5, 6}
+	store := &nonClosingSetStore{inner: memory.New()}
+
+	reader := &closingReader{}
+	cb := NewConcurrentBlob(store)
+	r, err := cb.Get(ctx, key, fileformat.FileTypeTesting, func() (io.ReadCloser, error) {
+		return reader, nil
+	})
+	require.NoError(t, err)
+	_ = r.Close()
+
+	assert.GreaterOrEqual(t, reader.closeCount, 1, "source reader must be Closed on the success path too")
 }


### PR DESCRIPTION
## Summary

`ConcurrentBlob.Get` at `stores/blob/concurrent_blob.go:130` acquires an `io.ReadCloser` via the caller-supplied `getBlobReader` callback, then hands it to `Store.SetFromReader`. On the `SetFromReader` error path it returned without closing the source reader.

### Why this is a real bug

The `Store.SetFromReader` contract on whether to close the input reader is **inconsistent** across implementations:

- **memory store**: `defer reader.Close()` at the top of `SetFromReader`, so the input is closed even on error.
- **file store**: never closes the input reader on any path.

So composed over a file store, every `SetFromReader` failure leaked the source reader for the lifetime of the process. The previous explicit-close on the **success-only** branch wasn't enough:

```go
resultReader, err := getBlobReader()
if err != nil { return nil, err }

err = c.blobStore.SetFromReader(ctx, key[:], fileType, resultReader, c.options...)
if err != nil {
    return nil, err   // <-- LEAK when underlying store doesn't close
}

_ = resultReader.Close()  // success-only
```

`resultReader` could be:
- an `http.Response.Body` (network connection),
- a file-store `semaphoreReadCloser` (file-store read permit),
- or any other heavy resource

so per-failure leakage matters.

### Fix

Replace the success-only Close with a `defer` right after the `getBlobReader` error check. Both paths now close exactly once. Close is idempotent for the readers used in practice (`semaphoreReadCloser` via `sync.Once`, `http.Response.Body` per net/http docs), so a redundant close from a store that does close internally is benign.

### Regression tests

The existing `TestConcurrentBlob_GetBlobFetchError` and `*_GetBlobSetError` tests exercised the error path but asserted only on the returned `err` — they couldn't catch the leak because memory's `SetFromReader` closes via `defer` regardless. The new tests use a `nonClosingSetStore` wrapper that mimics the file-store contract (drain but don't close), making the call to `Close()` on the source reader directly observable.

- `TestConcurrentBlob_GetBlobClosesReaderOnSetError` — verifies close-on-failure
- `TestConcurrentBlob_GetBlobClosesReaderOnSuccess` — pins close-on-success too (the previous explicit close is now a defer; this asserts the defer still fires)

**A/B verified**: `*_OnSetError` fails with `closeCount=0` when the production fix is reverted, exactly the leak shape.

## Test plan

- [x] `go build ./stores/blob/` clean
- [x] New tests pass (~10ms)
- [x] A/B: `*_OnSetError` FAILS with `closeCount=0` without the production fix

## Related

Same audit thread:
- #1087 (merged) — utxopersister consolidator leak + reader-construction error paths
- #1088 — asset `GetLegacyBlock.go` per-iteration reader leak + pipe deadlock
- #1089 — `HTTPBlobServer.handleRangeRequest` reader leak on all 5 paths
- **This PR** — `ConcurrentBlob.Get` SetFromReader-error-path leak