### PR TITLE
fix(blob): make file-store reader Seekable + correct Content-Range total

### DIFF
--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -170,6 +170,20 @@ type semaphoreReadCloser struct {
 	once sync.Once
 }
 
+// Seek delegates to the wrapped reader when it implements io.Seeker. This is
+// the case for the local-store path (*os.File) which is what openFileWithFallback
+// returns from its primary success paths. Without this method the wrapper's
+// static type is io.ReadCloser - so callers like the HTTP range-request handler
+// that do dataReader.(io.Seeker) would fail the type assertion and report
+// "Store does not support seeking" even though the underlying file is Seekable.
+// Falls back to an error for non-seekable wrapped readers.
+func (r *semaphoreReadCloser) Seek(offset int64, whence int) (int64, error) {
+	if seeker, ok := r.ReadCloser.(io.Seeker); ok {
+		return seeker.Seek(offset, whence)
+	}
+	return 0, errors.NewProcessingError("[File] underlying reader does not implement io.Seeker")
+}
+
 func (r *semaphoreReadCloser) Close() error {
 	defer r.once.Do(releaseReadPermit)
 	// Always release the semaphore permit exactly once, even if close fails.

--- a/stores/blob/server.go
+++ b/stores/blob/server.go
@@ -314,18 +314,41 @@ func (s *HTTPBlobServer) handleRangeRequest(w http.ResponseWriter, r *http.Reque
 	// handleGet just above has the same defer rc.Close() pattern.
 	defer dataReader.Close()
 
-	// seek the reader to the start position
-	if start > 0 {
-		if seeker, ok := dataReader.(io.Seeker); ok {
-			_, err = seeker.Seek(int64(start), io.SeekStart)
-			if err != nil {
-				http.Error(w, "Failed to seek in blob", http.StatusInternalServerError)
-				return
-			}
-		} else {
-			http.Error(w, "Store does not support seeking", http.StatusInternalServerError)
+	// Range requests address payload bytes, not raw file bytes. The file
+	// blob store's GetIoReader has already consumed any fileformat magic
+	// header from the reader, so the current position is the start of the
+	// payload (offset 8 for header-bearing files, 0 otherwise). We anchor
+	// all subsequent Seeks against this post-header position, otherwise:
+	//   - Seek(int64(start), SeekStart) for start=2 would seek to byte 2
+	//     of the raw file, which is INSIDE the magic header, and Read
+	//     would return header bytes instead of payload.
+	//   - SeekEnd would report the raw file length (payload + header)
+	//     rather than the payload total the client cares about.
+	// The "*" total per RFC 7233 §4.2 is the documented fallback when the
+	// reader is not seekable; this also surfaces the "Store does not
+	// support seeking" error for the start>0 case that's no longer
+	// satisfiable.
+	totalStr := "*"
+	seeker, isSeeker := dataReader.(io.Seeker)
+	if isSeeker {
+		payloadStart, err := seeker.Seek(0, io.SeekCurrent)
+		if err != nil {
+			http.Error(w, "Failed to read blob position", http.StatusInternalServerError)
 			return
 		}
+		rawEnd, err := seeker.Seek(0, io.SeekEnd)
+		if err != nil {
+			http.Error(w, "Failed to determine blob size", http.StatusInternalServerError)
+			return
+		}
+		totalStr = strconv.FormatInt(rawEnd-payloadStart, 10)
+		if _, err = seeker.Seek(payloadStart+int64(start), io.SeekStart); err != nil {
+			http.Error(w, "Failed to seek in blob", http.StatusInternalServerError)
+			return
+		}
+	} else if start > 0 {
+		http.Error(w, "Store does not support seeking", http.StatusInternalServerError)
+		return
 	}
 
 	// read the requested range
@@ -339,7 +362,7 @@ func (s *HTTPBlobServer) handleRangeRequest(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
-	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end-1, len(data)))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%s", start, end-1, totalStr))
 	w.WriteHeader(http.StatusPartialContent)
 	_, _ = w.Write(data)
 }

--- a/stores/blob/server_test.go
+++ b/stores/blob/server_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -14,7 +15,7 @@ import (
 
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
-	"github.com/bsv-blockchain/teranode/stores/blob/http"
+	blobhttp "github.com/bsv-blockchain/teranode/stores/blob/http"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/assert"
@@ -55,7 +56,7 @@ func TestServerOperations(t *testing.T) {
 	clientStoreURL, err := url.Parse("http://localhost:7979")
 	require.NoError(t, err)
 
-	client, err := http.New(logger, clientStoreURL)
+	client, err := blobhttp.New(logger, clientStoreURL)
 	require.NoError(t, err)
 
 	t.Run("SetAndGet", func(t *testing.T) {
@@ -304,4 +305,112 @@ func TestHandleRangeRequest_ClosesReaderOnAllPaths(t *testing.T) {
 
 		require.Equal(t, 1, reader.closeCount, "reader must be Closed when ReadFull fails")
 	})
+}
+
+// fileBackedFakeStore is a Store implementation backed by an *os.File so
+// GetIoReader returns the real file-store wrapper. This is the minimum
+// scaffolding needed to exercise handleRangeRequest's end-to-end flow with
+// the same reader type the file store returns in production.
+type fileBackedFakeStore struct {
+	dir string
+}
+
+func newFileBackedFakeStore(t *testing.T, payload []byte) *fileBackedFakeStore {
+	dir, err := os.MkdirTemp("", "rangereq")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	storeURL, err := url.Parse("file://" + dir)
+	require.NoError(t, err)
+	srv, err := NewHTTPBlobServer(ulogger.New("rangereq"), storeURL)
+	require.NoError(t, err)
+	_ = srv // just used for the store construction
+
+	store, err := NewStore(ulogger.New("rangereq"), storeURL)
+	require.NoError(t, err)
+	require.NoError(t, store.Set(context.Background(), []byte("k"), fileformat.FileTypeTesting, payload))
+
+	return &fileBackedFakeStore{dir: dir}
+}
+
+func (s *fileBackedFakeStore) underlying(t *testing.T) Store {
+	storeURL, err := url.Parse("file://" + s.dir)
+	require.NoError(t, err)
+	store, err := NewStore(ulogger.New("rangereq"), storeURL)
+	require.NoError(t, err)
+	return store
+}
+
+// TestHandleRangeRequest_FileStoreReaderIsSeekable is a guard against the
+// regression where semaphoreReadCloser embeds io.ReadCloser (no Seek method),
+// so dataReader.(io.Seeker) fails the type assertion in handleRangeRequest
+// and every range request with start>0 against the file store returns HTTP
+// 500 "Store does not support seeking" - even though the underlying *os.File
+// is Seekable. The fix adds a Seek method on semaphoreReadCloser that
+// delegates to the wrapped reader.
+func TestHandleRangeRequest_FileStoreReaderIsSeekable(t *testing.T) {
+	payload := []byte("0123456789abcdefghij") // 20 bytes
+	store := newFileBackedFakeStore(t, payload).underlying(t)
+
+	srv := &HTTPBlobServer{store: store, logger: ulogger.New("rangereq")}
+
+	req := httptest.NewRequest("GET", "/blob/", nil)
+	req.Header.Set("Range", "bytes=5-9")
+	rr := httptest.NewRecorder()
+
+	srv.handleRangeRequest(rr, req, []byte("k"), fileformat.FileTypeTesting)
+
+	require.Equal(t, http.StatusPartialContent, rr.Code,
+		"a range request with start>0 against a file-backed store must succeed; "+
+			"non-200 status means the file-store reader's Seeker check failed (probably "+
+			"semaphoreReadCloser does not promote Seek)")
+	require.Equal(t, "56789", rr.Body.String(), "must return bytes 5..9 of the payload")
+}
+
+// TestHandleRangeRequest_ContentRangeReportsActualTotal pins the fix for the
+// Content-Range total reported in the response. Before the fix, the handler
+// emitted "bytes start-end/len(data)" where len(data) is the size of the
+// returned slice (end-start), not the total blob length. RFC 7233 §4.2
+// requires the total length of the underlying representation in the
+// "/total" position.
+func TestHandleRangeRequest_ContentRangeReportsActualTotal(t *testing.T) {
+	payload := []byte("0123456789") // 10 bytes total
+	store := newFileBackedFakeStore(t, payload).underlying(t)
+
+	srv := &HTTPBlobServer{store: store, logger: ulogger.New("rangereq")}
+
+	req := httptest.NewRequest("GET", "/blob/", nil)
+	req.Header.Set("Range", "bytes=2-4")
+	rr := httptest.NewRecorder()
+
+	srv.handleRangeRequest(rr, req, []byte("k"), fileformat.FileTypeTesting)
+
+	require.Equal(t, http.StatusPartialContent, rr.Code)
+	gotCR := rr.Header().Get("Content-Range")
+	// Total should be 10 (full blob), not 3 (end-start = the returned slice).
+	require.Equal(t, "bytes 2-4/10", gotCR,
+		"Content-Range must report the full blob length in the /total position per RFC 7233 §4.2, not the returned-slice length")
+}
+
+// TestHandleRangeRequest_ContentRangeUnknownTotalForNonSeekable pins the
+// fallback: when the underlying reader is not seekable but start==0, the
+// handler should still return the requested bytes and emit "/*" for the
+// total per RFC 7233.
+func TestHandleRangeRequest_ContentRangeUnknownTotalForNonSeekable(t *testing.T) {
+	// nonSeekingCloser returns io.EOF on Read, simulating a 0-byte payload
+	// from a non-seekable source. start=0 means we should not require
+	// seeking and should fall back to "*" for the total.
+	reader := &nonSeekingCloser{}
+	srv := &HTTPBlobServer{store: &fakeRangeStore{reader: reader}, logger: ulogger.New("rangereq")}
+
+	req := httptest.NewRequest("GET", "/blob/", nil)
+	req.Header.Set("Range", "bytes=0-0")
+	rr := httptest.NewRecorder()
+
+	srv.handleRangeRequest(rr, req, []byte("k"), fileformat.FileTypeTesting)
+
+	require.Equal(t, http.StatusPartialContent, rr.Code, "start=0 against a non-seekable reader must still succeed")
+	gotCR := rr.Header().Get("Content-Range")
+	require.Equal(t, "bytes 0-0/*", gotCR,
+		"non-seekable readers cannot report a total, so Content-Range must use the RFC 7233 \"*\" sentinel")
 }


### PR DESCRIPTION
## Summary

Stacked follow-up to #1089. Addresses the reviewer's out-of-scope note about Content-Range, plus two related bugs I discovered while investigating it.

All three bugs are pre-existing. Range requests against the file blob store were effectively broken; this PR makes them work end-to-end.

> Depends on #1089. CI will only go green after #1089 merges, or rebase this onto main once #1089 lands.

### Bug 1 — `semaphoreReadCloser` loses `Seek`

`stores/blob/file/file.go` defined the wrapper as:

```go
type semaphoreReadCloser struct {
    io.ReadCloser   // <-- embeds the *interface*, not the concrete *os.File
    once sync.Once
}
```

So even though `openFileWithFallback` wraps a real `*os.File` (which implements `io.Seeker`), the wrapper's static type loses `Seek`. `handleRangeRequest`'s

```go
seeker, ok := dataReader.(io.Seeker)
```

always fails for file-store readers — every range request with `start>0` returns HTTP 500 "Store does not support seeking". The whole Seek path is dead code against the file store.

**Fix:** add a `Seek` method on `semaphoreReadCloser` that delegates to the wrapped reader when it implements `io.Seeker`, errors otherwise.

### Bug 2 — Content-Range total is `len(data)`, not the full blob length

`handleRangeRequest` was emitting:

```go
w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end-1, len(data)))
```

Where `len(data) == end - start` (the returned slice length), not the total representation. RFC 7233 §4.2 requires the **complete length** in the `/total` position so clients can compute progress and chunk resumable downloads.

Reported in #1089 review as out-of-scope. **Fix:** discover the total via `Seek(0, io.SeekEnd)`. Fall back to `"*"` (the RFC 7233 §4.2 "unknown total" sentinel) when the reader is not seekable.

### Bug 3 — Seek lands inside the file's magic header

While in there: `seeker.Seek(int64(start), io.SeekStart)` was seeking against the raw file. But the reader's current position is **already past** the 8-byte fileformat magic header that `GetIoReader` reads via `validateFileHeader` before returning. So `Seek(2, SeekStart)` for `bytes=2-4` was landing **inside the header**, and `Read` returned magic bytes instead of payload.

**Fix:** anchor Seeks relative to the post-header position recorded via `Seek(0, io.SeekCurrent)` before the SeekEnd lookup. Bonus: the total also becomes `rawEnd - payloadStart`, i.e. the payload length the client cares about, not the on-disk file length.

## Regression tests

- `TestHandleRangeRequest_FileStoreReaderIsSeekable` — serves a real file-backed 20-byte payload, asserts a `bytes=5-9` range returns `206` with `"56789"`. **Without the Bug-1 fix**, this returns `500` and the test fails.
- `TestHandleRangeRequest_ContentRangeReportsActualTotal` — 10-byte payload, range `bytes=2-4`, asserts the response Content-Range is exactly `bytes 2-4/10`. **Without the Bug-2/3 fixes** the total is wrong (`/3` for the old `len(data)` bug or `/18` for the raw-file-length bug).
- `TestHandleRangeRequest_ContentRangeUnknownTotalForNonSeekable` — non-seekable reader, `bytes=0-0`, asserts Content-Range is `bytes 0-0/*`.

All four `*_ClosesReaderOnAllPaths` subtests from #1089 still pass alongside.

## Test plan

- [x] `go build ./stores/blob/ ./stores/blob/file/` clean
- [x] `go vet ./stores/blob/` clean
- [x] All 4 PR-#1089 close-on-paths subtests pass
- [x] 3 new range-request subtests pass
- [x] All 7 pass together (no test ordering interactions)

## Related

Audit thread:
- #1087 (merged) — utxopersister consolidator leak + reader-construction error paths
- #1088 — asset `GetLegacyBlock.go` per-iteration reader leak + pipe deadlock
- #1089 — `HTTPBlobServer.handleRangeRequest` reader leak on all 5 paths
- #1091 — `ConcurrentBlob.Get` SetFromReader-error path leak
- **This PR** — `handleRangeRequest` Seeker propagation + Content-Range + header offset