### PR TITLE
chore(settings): docker.m Aerospike overload-safe batcher defaults

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -155,6 +155,12 @@ aerospike_debug = false
 # SleepMultiplier is not being used in the current implementation
 # ExitFastOnExhaustedConnectionPool is not being used in the current implementation
 aerospike_batchPolicy = aerospike:///?MaxRetries=5&SleepBetweenRetries=500ms&SleepMultiplier=1&TotalTimeout=5m&SocketTimeout=60s&ConcurrentNodes=0
+# docker.m: bound a single BatchOperate so the client's own retry loop cannot hang for
+# minutes on an overloaded single node. The 5m global TotalTimeout means one stuck batch
+# blocks a worker far longer than the server-side overload retry budget in
+# bsv-blockchain/teranode#1085 (30s default) — the inner call must finish well inside that
+# budget for the wrapper retry to control the cadence. 10s total / 5s socket / 2 retries.
+aerospike_batchPolicy.docker.m = aerospike:///?MaxRetries=2&SleepBetweenRetries=200ms&SleepMultiplier=1&TotalTimeout=10s&SocketTimeout=5s&ConcurrentNodes=0
 aerospike_readPolicy  = aerospike:///?MaxRetries=5&SleepBetweenRetries=500ms&SleepMultiplier=1&TotalTimeout=1s&SocketTimeout=1s
 aerospike_writePolicy = aerospike:///?MaxRetries=5&SleepBetweenRetries=500ms&SleepMultiplier=1&TotalTimeout=1s&SocketTimeout=1s
 aerospike_queryPolicy = aerospike:///?MaxRetries=3&SleepBetweenRetries=500ms&SleepMultiplier=1&TotalTimeout=30m&SocketTimeout=25m
@@ -700,6 +706,11 @@ legacy_spendBatcherConcurrency = 4
 legacy_spendBatcherSize = 1024
 
 legacy_storeBatcherConcurrency = 32
+# docker.m: createUtxos feeds the store batcher from an errgroup limited to
+# legacy_storeBatcherSize x legacy_storeBatcherConcurrency. The global 1024 x 32 = 32768
+# concurrent Create calls force-feed a single-node Aerospike far faster than it drains.
+# 1024 x 4 = 4096 keeps the feed in line with utxostore_batcherMaxConcurrent.docker.m.
+legacy_storeBatcherConcurrency.docker.m = 4
 
 legacy_storeBatcherSize = 1024
 
@@ -1264,6 +1275,33 @@ utxostore_spendBatcherSize = 1024
 utxostore_storeBatcherDurationMillis = 10
 
 utxostore_storeBatcherSize = 2048
+
+# --- docker.m single-node Aerospike overload defaults ---------------------------
+# docker.m runs ONE Aerospike node with a 128-connection pool (see utxostore.docker.m:
+# ConnectionQueueSize=128, LimitConnectionsToQueueSize=true, MinConnectionsPerNode=16),
+# so ~112 connections are usable for bursts.
+#
+# batcherMaxConcurrent caps in-flight BatchOperate sends PER batcher type. During the
+# legacy quick-validation spend phase three types fire together (spend + increment +
+# setDAH). At the global default of 64 that is up to 3x64 = 192 concurrent batch calls
+# against a ~112-usable pool -> connection exhaustion (MAX_ERROR_RATE) and device
+# write-queue overflow (DEVICE_OVERLOAD). 24 keeps the worst case at 3x24 = 72 < 112,
+# leaving headroom for the get/store batchers and the 16 reserved warm connections.
+#
+# This is the preventive half of a pair: keep the single node UNDER the overload
+# threshold so overloads are rare, and let the server-side overload retry in
+# bsv-blockchain/teranode#1085 absorb the residual transient spikes within its budget.
+# The error-chain blow-up that previously made a single overload catastrophic (a
+# multi-hour errors.Is grind) is fixed separately in bsv-blockchain/teranode#1083.
+utxostore_batcherMaxConcurrent.docker.m = 24
+
+# Keep batch payloads large but concurrency low — the single-node-friendly shape: fewer
+# concurrent connections, more work per call. The increment/setDAH batchers act on the
+# pagination ("child") records of >20k-output transactions, the first ops to fail under
+# overload; larger batches mean fewer round-trips for the same work. The struct defaults
+# (256) are tuned for clustered deployments.
+utxostore_incrementBatcherSize.docker.m = 1024
+utxostore_setDAHBatcherSize.docker.m    = 1024
 
 # this value determines if a caching mechanism will be used for external transactions
 # if you have the memory available, it will speed up your IBD


### PR DESCRIPTION
## Problem

The `docker.m` single-node context runs against **one** Aerospike node with a 128-connection pool (`utxostore.docker.m`: `ConnectionQueueSize=128`, `LimitConnectionsToQueueSize=true`, `MinConnectionsPerNode=16` → ~112 usable), but the batcher-concurrency defaults are sized for clustered deployments.

During legacy quick-validation IBD, the spend phase fires **three** batcher types concurrently (spend + increment + setDAH), each capped at the global `utxostore_batcherMaxConcurrent=64`. Worst case **3×64 = 192 concurrent `BatchOperate` calls against a ~112-usable pool** → connection exhaustion (`MAX_ERROR_RATE`, -15) and device write-queue overflow (`DEVICE_OVERLOAD`, 18).

Observed on a mainnet quickstart host: repeated stalls through the ~820k blocks (many >20k-output transactions). The overload itself was transient, but each one previously triggered a multi-hour `errors.Is` grind on the giant aggregated spend-error chain.

## Change

`docker.m`-scoped overrides only — clustered defaults untouched:

| Setting | docker.m | was (global) | why |
|---|---|---|---|
| `utxostore_batcherMaxConcurrent` | 24 | 64 | 3×24=72 < 112 pool, with headroom for get/store + 16 warm conns |
| `utxostore_incrementBatcherSize` | 1024 | 256 | bigger batches = fewer round-trips on >20k-output pagination records (first ops to fail) |
| `utxostore_setDAHBatcherSize` | 1024 | 256 | same |
| `legacy_storeBatcherConcurrency` | 4 | 32 | createUtxos feed 1024×32=32768 → 4096, matched to the batcher cap |
| `aerospike_batchPolicy` TotalTimeout | 10s | 5m | a single `BatchOperate` must finish well inside the server-side overload-retry budget for that retry to control cadence |

## How it fits with the in-flight overload work

This is the **preventive** half of a pair:

- **This PR** keeps offered concurrency under the connection pool / device capacity, so overload is *rare* rather than per-block.
- **#1085** (server-side overload retry, 30s budget) absorbs the *residual* transient spikes that still slip through — and its retry only works as designed if the inner client policy is shorter than its budget, which the `aerospike_batchPolicy.docker.m` timeout here provides.
- **#1083** (linear `errors.Is` / capped spend error chains) removes the catastrophic amplification that made a single overload cost hours instead of a retry.

Each stands alone; together they should eliminate overload-induced stalls on single-node `docker.m` IBD.

## Testing

- Loader test: `NewSettings("docker.m")` resolves all five overrides; `NewSettings()` (default) keeps 64 / 32 — confirms the context scoping.
- `go build ./...`, `go test ./settings/` green.

Config-only; no runtime code paths changed. Recommend a confirming run on a single-node mainnet host through a known-heavy era (watch `write_q` + `DEVICE_OVERLOAD` count) before relying on it.
