### PR TITLE
fix(utxo): expire mined transactions with no spendable outputs

### DIFF
--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -878,6 +878,29 @@ func (s *Store) GetBinsToStore(tx *bt.Tx, blockHeight uint32, blockIDs, blockHei
 	// Set UnminedSince for unmined transactions (when no blockIDs/blockHeights)
 	if len(blockIDs) == 0 && len(blockHeights) == 0 && len(subtreeIdxs) == 0 {
 		batches[0] = append(batches[0], aerospike.NewBin(fields.UnminedSince.String(), aerospike.NewIntegerValue(int(blockHeight))))
+	} else if !isConflicting {
+		// A transaction with no spendable outputs (e.g. one that only carries
+		// OP_RETURN / data outputs) can never be spent, so it never transitions
+		// to "all spent" via the spend path. When it is created already-mined
+		// during block validation it also bypasses setMined - the other place
+		// that assigns a deleteAtHeight. Without one, the record would never be
+		// eligible for pruning and would be retained in the UTXO store forever.
+		// Give such a mined transaction the same retention window as a
+		// fully-spent transaction so the pruner can expire it; we only want
+		// truly spendable outputs retained indefinitely. (Conflicting txs get
+		// their deleteAtHeight set separately by the caller.)
+		spendableUtxos := 0
+		for _, u := range utxos {
+			if u != nil {
+				spendableUtxos++
+			}
+		}
+
+		if spendableUtxos == 0 {
+			if retention := s.settings.GetUtxoStoreBlockHeightRetention(); retention > 0 {
+				batches[0] = append(batches[0], aerospike.NewBin(fields.DeleteAtHeight.String(), aerospike.NewIntegerValue(int(blockHeight+retention))))
+			}
+		}
 	}
 
 	// add the created at bin in milliseconds to the first record

--- a/stores/utxo/aerospike/create_test.go
+++ b/stores/utxo/aerospike/create_test.go
@@ -181,6 +181,154 @@ func TestStore_GetBinsToStore(t *testing.T) {
 	})
 }
 
+// TestStore_GetBinsToStore_UnspendableTransactionExpires verifies that a mined
+// transaction with no spendable outputs (e.g. an OP_RETURN-only data-carrier
+// transaction) is assigned a deleteAtHeight at creation time so the pruner can
+// expire it after the retention window.
+//
+// Such transactions never transition to "all spent" via the spend path (there
+// is nothing spendable to spend), and when they are created already-mined during
+// block validation they also bypass setMined - the other place that assigns a
+// deleteAtHeight. Without this, the record is never eligible for pruning and is
+// retained in the UTXO store forever. We only want truly spendable outputs to be
+// retained indefinitely.
+func TestStore_GetBinsToStore_UnspendableTransactionExpires(t *testing.T) {
+	teranodeaerospike.InitPrometheusMetrics()
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	retention := tSettings.GetUtxoStoreBlockHeightRetention()
+	require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+	s := teranodeaerospike.Store{}
+	s.SetUtxoBatchSize(100)
+	s.SetSettings(tSettings)
+
+	const minedHeight = uint32(1000)
+
+	findBin := func(t *testing.T, bins [][]*aerospike.Bin, name string) (aerospike.Value, bool) {
+		t.Helper()
+		require.NotEmpty(t, bins)
+		for _, b := range bins[0] {
+			if b.Name == name {
+				return b.Value, true
+			}
+		}
+
+		return nil, false
+	}
+
+	// opReturnOnlyTx builds a transaction whose only output is an OP_RETURN data
+	// output, i.e. a transaction with zero spendable outputs (recordUtxos == 0).
+	opReturnOnlyTx := func(t *testing.T) *bt.Tx {
+		t.Helper()
+		txHex, err := os.ReadFile("testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
+		require.NoError(t, err)
+		tx, err := bt.NewTxFromString(string(txHex))
+		require.NoError(t, err)
+
+		tx.Outputs = []*bt.Output{}
+		require.NoError(t, tx.AddOpReturnOutput([]byte("teranode op_return data carrier")))
+		require.False(t, utxo.ShouldStoreOutputAsUTXO(false, tx.Outputs[0], minedHeight),
+			"sanity: the op_return output must be unspendable")
+
+		return tx
+	}
+
+	t.Run("mined unspendable tx is given a deleteAtHeight", func(t *testing.T) {
+		tx := opReturnOnlyTx(t)
+
+		bins, err := s.GetBinsToStore(tx, minedHeight,
+			[]uint32{1}, []uint32{minedHeight}, []int{0},
+			false, tx.TxIDChainHash(), false, false, false, nil)
+		require.NoError(t, err)
+
+		dah, ok := findBin(t, bins, fields.DeleteAtHeight.String())
+		require.True(t, ok, "a mined tx with no spendable outputs must have a deleteAtHeight so the pruner can expire it")
+		assert.Equal(t, aerospike.NewIntegerValue(int(minedHeight+retention)), dah)
+
+		_, hasUnmined := findBin(t, bins, fields.UnminedSince.String())
+		assert.False(t, hasUnmined, "a mined tx must not carry an unminedSince marker")
+	})
+
+	t.Run("unmined unspendable tx is not expired", func(t *testing.T) {
+		tx := opReturnOnlyTx(t)
+
+		bins, err := s.GetBinsToStore(tx, minedHeight,
+			nil, nil, nil,
+			false, tx.TxIDChainHash(), false, false, false, nil)
+		require.NoError(t, err)
+
+		_, ok := findBin(t, bins, fields.DeleteAtHeight.String())
+		assert.False(t, ok, "an unmined tx must not be given a deleteAtHeight - it is not in a block yet")
+
+		_, hasUnmined := findBin(t, bins, fields.UnminedSince.String())
+		assert.True(t, hasUnmined, "an unmined tx must carry an unminedSince marker")
+	})
+
+	t.Run("mined spendable tx is not expired at creation", func(t *testing.T) {
+		txHex, err := os.ReadFile("testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
+		require.NoError(t, err)
+		tx, err := bt.NewTxFromString(string(txHex))
+		require.NoError(t, err)
+
+		bins, err := s.GetBinsToStore(tx, minedHeight,
+			[]uint32{1}, []uint32{minedHeight}, []int{0},
+			false, tx.TxIDChainHash(), false, false, false, nil)
+		require.NoError(t, err)
+
+		_, ok := findBin(t, bins, fields.DeleteAtHeight.String())
+		assert.False(t, ok, "a tx with spendable outputs must only get a deleteAtHeight once those outputs are spent, not at creation")
+	})
+}
+
+// TestCreateMinedUnspendableGetsDAH is the end-to-end counterpart to
+// TestStore_GetBinsToStore_UnspendableTransactionExpires: it drives the real
+// Create path with a transaction that is created already-mined (as happens
+// during block validation / catchup) and whose only output is an OP_RETURN, and
+// asserts the persisted record carries a deleteAtHeight so the pruner can expire
+// it. Before the fix this record had no deleteAtHeight and was retained forever.
+func TestCreateMinedUnspendableGetsDAH(t *testing.T) {
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	retention := tSettings.GetUtxoStoreBlockHeightRetention()
+	require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+	client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+	t.Cleanup(deferFn)
+
+	teranodeaerospike.InitPrometheusMetrics()
+
+	// Build an OP_RETURN-only transaction: real inputs, a single unspendable
+	// (zero spendable outputs) OP_RETURN output.
+	txHex, err := os.ReadFile("testdata/fbebcc148e40cb6c05e57c6ad63abd49d5e18b013c82f704601bc4ba567dfb90.hex")
+	require.NoError(t, err)
+	tx, err := bt.NewTxFromString(string(txHex))
+	require.NoError(t, err)
+	tx.Outputs = []*bt.Output{}
+	require.NoError(t, tx.AddOpReturnOutput([]byte("teranode op_return data carrier")))
+
+	const minedHeight = uint32(1000)
+
+	// Create the transaction already-mined, mirroring the block-validation path.
+	_, err = store.Create(ctx, tx, minedHeight, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+		BlockID: 1, BlockHeight: minedHeight, SubtreeIdx: 0, OnLongestChain: true,
+	}))
+	require.NoError(t, err)
+
+	key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), tx.TxIDChainHash().CloneBytes())
+	require.NoError(t, err)
+
+	response, err := client.Get(nil, key)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	assert.Equal(t, 0, response.Bins[fields.RecordUtxos.String()], "tx must have no spendable outputs")
+	assert.Equal(t, int(minedHeight+retention), response.Bins[fields.DeleteAtHeight.String()],
+		"a mined unspendable tx must be assigned deleteAtHeight = minedHeight + retention so the pruner can expire it")
+}
+
 func TestStore_StoreTransactionExternally(t *testing.T) {
 	logger := ulogger.NewErrorTestLogger(t)
 	tSettings := test.CreateBaseTestSettings(t)

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -474,6 +474,13 @@ func (s *Store) createWithRetry(ctx context.Context, tx *bt.Tx, blockHeight uint
 		return s.createCTE(ctx, tx, blockHeight, options, txHash, txMeta, isCoinbase, unminedSince)
 	}
 
+	// A transaction created already-mined with no spendable outputs (e.g. an
+	// OP_RETURN-only data carrier) can never be spent and never passes through
+	// setMined, so it would otherwise never be assigned a delete_at_height and
+	// would be retained forever. Expire it after the retention window. NULL for
+	// any other transaction.
+	deleteAtHeight := s.unspendableMinedTxDAH(tx, blockHeight, options, isCoinbase)
+
 	// Insert the transaction row...
 	q := `
 		INSERT INTO transactions (
@@ -487,6 +494,7 @@ func (s *Store) createWithRetry(ctx context.Context, tx *bt.Tx, blockHeight uint
 		,conflicting
 		,locked
 		,unmined_since
+		,delete_at_height
 	  ) VALUES (
 		 $1
 		,$2
@@ -498,6 +506,7 @@ func (s *Store) createWithRetry(ctx context.Context, tx *bt.Tx, blockHeight uint
 		,$8
 		,$9
 		,$10
+		,$11
 		)
 		RETURNING id
 	`
@@ -527,6 +536,7 @@ func (s *Store) createWithRetry(ctx context.Context, tx *bt.Tx, blockHeight uint
 		options.Conflicting,
 		options.Locked,
 		unminedSince,
+		deleteAtHeight,
 	).Scan(&transactionID)
 	if err != nil {
 		if pgErr := asPgUniqueViolation(err); pgErr != nil {
@@ -576,6 +586,38 @@ func (s *Store) createWithRetry(ctx context.Context, tx *bt.Tx, blockHeight uint
 	}
 
 	return txMeta, nil
+}
+
+// unspendableMinedTxDAH returns the delete_at_height to assign at creation time
+// for a transaction that is created already-mined and has no spendable outputs
+// (e.g. an OP_RETURN-only data-carrier transaction), or nil otherwise.
+//
+// Such a transaction can never be spent, so it never transitions to "all spent"
+// via the spend path, and because it is created already-mined (the block
+// validation / catchup path) it also bypasses setMined - the other place that
+// assigns a delete_at_height. Without this it would never be eligible for
+// pruning and would be retained forever; we only want truly spendable outputs
+// retained indefinitely. Returns nil (SQL NULL) for transactions that must not
+// be expired at creation: unmined, conflicting (handled separately), retention
+// disabled, or having at least one spendable output (those are expired via the
+// spend path once their spendable outputs are gone).
+func (s *Store) unspendableMinedTxDAH(tx *bt.Tx, blockHeight uint32, options *utxo.CreateOptions, isCoinbase bool) interface{} {
+	if options.Conflicting || len(options.MinedBlockInfos) == 0 {
+		return nil
+	}
+
+	retention := s.settings.GetUtxoStoreBlockHeightRetention()
+	if retention == 0 {
+		return nil
+	}
+
+	for _, output := range tx.Outputs {
+		if output != nil && utxo.ShouldStoreOutputAsUTXO(isCoinbase, output, blockHeight) {
+			return nil
+		}
+	}
+
+	return int64(blockHeight) + int64(retention)
 }
 
 // createInputsBatched inserts all transaction inputs in chunked multi-value INSERTs.
@@ -714,8 +756,8 @@ func (s *Store) createBlockIDsBatched(ctx context.Context, txn *sql.Tx, transact
 // Parameters: $1-$10 = transaction scalars, $11-$17 = input arrays, $18-$22 = output arrays, $23-$25 = block_id arrays.
 const createCTESQL = `
 WITH new_tx AS (
-	INSERT INTO transactions (hash,version,lock_time,fee,size_in_bytes,coinbase,frozen,conflicting,locked,unmined_since)
-	VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+	INSERT INTO transactions (hash,version,lock_time,fee,size_in_bytes,coinbase,frozen,conflicting,locked,unmined_since,delete_at_height)
+	VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$26)
 	ON CONFLICT (hash) DO NOTHING
 	RETURNING id
 ), ins_inputs AS (
@@ -772,6 +814,8 @@ func (s *Store) createCTE(ctx context.Context, btTx *bt.Tx, blockHeight uint32, 
 			outArrs.coinbaseSpendingHeight, outArrs.utxoHash,
 			// $23-$25: block_id arrays
 			blkArrs.blockID, blkArrs.blockHeight, blkArrs.subtreeIdx,
+			// $26: delete_at_height for a mined tx with no spendable outputs
+			s.unspendableMinedTxDAH(btTx, blockHeight, options, isCoinbase),
 		)
 		if execErr != nil {
 			return execErr
@@ -1072,6 +1116,8 @@ func (s *Store) sendCreateBatch(batch []*batchCreateItem) {
 				// $23-$25: block_id arrays
 				p.blkArrs.blockID, p.blkArrs.blockHeight,
 				p.blkArrs.subtreeIdx,
+				// $26: delete_at_height for a mined tx with no spendable outputs
+				s.unspendableMinedTxDAH(item.tx, item.blockHeight, item.options, p.isCoinbase),
 			)
 		}
 

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -115,6 +115,73 @@ func TestCreate(t *testing.T) {
 	assert.Equal(t, uint64(259), meta.SizeInBytes)
 }
 
+// TestCreateMinedUnspendableSetsDAH verifies that a transaction created
+// already-mined with no spendable outputs (e.g. an OP_RETURN-only data-carrier
+// transaction) is assigned a delete_at_height at creation time so the pruner can
+// expire it after the retention window. Such transactions never transition to
+// "all spent" via the spend path and bypass setMined, so without this they were
+// retained in the store forever. We only want truly spendable outputs retained.
+func TestCreateMinedUnspendableSetsDAH(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const minedHeight = uint32(1000)
+
+	makeOpReturnOnly := func(base *bt.Tx) *bt.Tx {
+		base.Outputs = base.Outputs[:0]
+		require.NoError(t, base.AddOpReturnOutput([]byte("teranode op_return data carrier")))
+		return base
+	}
+
+	readDAH := func(t *testing.T, store *Store, h *chainhash.Hash) *int64 {
+		t.Helper()
+		var dah *int64
+		err := store.db.QueryRowContext(ctx, "SELECT delete_at_height FROM transactions WHERE hash = $1", h[:]).Scan(&dah)
+		require.NoError(t, err)
+		return dah
+	}
+
+	t.Run("mined unspendable tx is given a delete_at_height", func(t *testing.T) {
+		store, tx := setup(ctx, t)
+		retention := store.settings.GetUtxoStoreBlockHeightRetention()
+		require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+		tx = makeOpReturnOnly(tx)
+
+		_, err := store.Create(ctx, tx, minedHeight, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+			BlockID: 1, BlockHeight: minedHeight, SubtreeIdx: 0, OnLongestChain: true,
+		}))
+		require.NoError(t, err)
+
+		dah := readDAH(t, store, tx.TxIDChainHash())
+		require.NotNil(t, dah, "a mined tx with no spendable outputs must have a delete_at_height so the pruner can expire it")
+		assert.Equal(t, int64(minedHeight)+int64(retention), *dah)
+	})
+
+	t.Run("unmined unspendable tx is not expired", func(t *testing.T) {
+		store, tx := setup(ctx, t)
+		tx = makeOpReturnOnly(tx)
+
+		_, err := store.Create(ctx, tx, minedHeight)
+		require.NoError(t, err)
+
+		dah := readDAH(t, store, tx.TxIDChainHash())
+		assert.Nil(t, dah, "an unmined tx must not be given a delete_at_height - it is not in a block yet")
+	})
+
+	t.Run("mined spendable tx is not expired at creation", func(t *testing.T) {
+		store, tx := setup(ctx, t)
+
+		_, err := store.Create(ctx, tx, minedHeight, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+			BlockID: 1, BlockHeight: minedHeight, SubtreeIdx: 0, OnLongestChain: true,
+		}))
+		require.NoError(t, err)
+
+		dah := readDAH(t, store, tx.TxIDChainHash())
+		assert.Nil(t, dah, "a tx with spendable outputs must only get a delete_at_height once those outputs are spent")
+	})
+}
+
 func TestCreateDuplicate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -65,6 +65,49 @@ func setupPostgresStore(t *testing.T) (*Store, context.Context) {
 	return store, ctx
 }
 
+// TestCreateMinedUnspendableSetsDAH_Postgres is the Postgres counterpart of the
+// SQLite TestCreateMinedUnspendableSetsDAH: it exercises the real Postgres create
+// path (CTE / batcher) and asserts that a transaction created already-mined with
+// no spendable outputs (an OP_RETURN-only data carrier) is assigned a
+// delete_at_height so the pruner can expire it. Before the fix this record had no
+// delete_at_height and was retained forever.
+func TestCreateMinedUnspendableSetsDAH_Postgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Postgres integration test in short mode")
+	}
+
+	store, ctx := setupPostgresStore(t)
+
+	retention := store.settings.GetUtxoStoreBlockHeightRetention()
+	require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+	const minedHeight = uint32(1000)
+
+	// Build an OP_RETURN-only (zero spendable outputs) transaction.
+	tx, err := bt.NewTxFromString("010000000000000000ef01032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a18700000000" +
+		"8c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5" +
+		"ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c933158" +
+		"6c82e0fd1f633f25f87c161bc6f8a630121df2b3d3ffffffff00f2052a010000001976a91471d7dd96d9edda09180fe9d57a477b5acc9cad1188ac02" +
+		"00e32321000000001976a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac000fe208010000001976a914948c765a6914d43f2a7ac177da2c" +
+		"2f6b52de3d7c88ac00000000")
+	require.NoError(t, err)
+
+	tx.Outputs = tx.Outputs[:0]
+	require.NoError(t, tx.AddOpReturnOutput([]byte("teranode op_return data carrier")))
+	defer func() { _ = store.Delete(ctx, tx.TxIDChainHash()) }()
+
+	_, err = store.Create(ctx, tx, minedHeight, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+		BlockID: 1, BlockHeight: minedHeight, SubtreeIdx: 0, OnLongestChain: true,
+	}))
+	require.NoError(t, err)
+
+	var dah *int64
+	err = store.db.QueryRowContext(ctx, "SELECT delete_at_height FROM transactions WHERE hash = $1", tx.TxIDChainHash()[:]).Scan(&dah)
+	require.NoError(t, err)
+	require.NotNil(t, dah, "a mined unspendable tx must be assigned delete_at_height via the Postgres create path")
+	assert.Equal(t, int64(minedHeight)+int64(retention), *dah)
+}
+
 // TestUnlockBatcher_Postgres_SingleHash verifies that a single-hash
 // SetLocked(false) call goes through the unlock batcher on Postgres and
 // correctly clears the locked flag.


### PR DESCRIPTION
## Problem

A transaction with no spendable outputs — e.g. an OP_RETURN-only data-carrier transaction — has zero spendable UTXOs. It therefore never transitions to "all spent" through the spend path, and when it is created already-mined during block validation it also bypasses `setMined`. Those are the only two places that assign a delete marker (`deleteAtHeight` / `delete_at_height`).

The result: such a transaction never gets a delete marker and is retained in the UTXO store indefinitely instead of being pruned after the normal retention window. Only truly spendable outputs should be retained indefinitely; this is a design oversight in the create path.

## Fix

When a transaction is created **mined**, **non-conflicting**, and has **zero spendable outputs** (`ShouldStoreOutputAsUTXO == false` for every output), assign the delete marker at creation: `blockHeight + retention` — the same window a fully-spent transaction receives. Transactions with at least one spendable output are unaffected and still get a delete marker only once their spendable outputs are spent.

- **aerospike**: `GetBinsToStore` sets the `deleteAtHeight` bin on the master record.
- **sql**: new `unspendableMinedTxDAH` helper; `delete_at_height` set in the transactions insert for both the inline path (sqlite / pg-no-batch) and the shared `createCTESQL` path (used by `createCTE` and `sendCreateBatch`).

## Tests

- **aerospike**: `TestStore_GetBinsToStore_UnspendableTransactionExpires` (unit, no container) + `TestCreateMinedUnspendableGetsDAH` (integration, real Aerospike). Regression: `TestCreateZeroSat`.
- **sql**: `TestCreateMinedUnspendableSetsDAH` (SQLite) + `TestCreateMinedUnspendableSetsDAH_Postgres` (Postgres). Each asserts: mined + unspendable → marker set; unmined → none; mined + spendable → none at create.
- `go vet` clean and `go build ./...` ok; changed-package tests pass locally (Aerospike + Postgres via testcontainers).

## Known limitation / follow-up (sql only)

The SQL store never applies `ShouldStoreOutputAsUTXO` to its `outputs` table, and `setDAH` counts unspent as `outputs WHERE spending_data IS NULL` — which includes OP_RETURN rows. So a *mixed* transaction (a spendable output **and** an OP_RETURN) whose spendable output is later spent still never reaches "all spent" and is never pruned. The aerospike store does not have this gap (it excludes unspendable outputs from the UTXO slots at create). This PR fixes the pure-unspendable case in both stores; the SQL mixed case needs the unspent count to exclude unspendable outputs and is left as a separate change.
