### PR TITLE
fix(subtreevalidation): continue not return on cached-tx skip

### DIFF
--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -1204,10 +1204,16 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 				return errors.NewProcessingError("[processTransactionsInLevels] transaction is nil at level %d", level)
 			}
 
-			// Skip transactions that were already validated (found in cache or UTXO store)
+			// Skip transactions that were already validated (found in cache or UTXO store).
+			// Today both prepareTxsPerLevel variants filter out cached txs (mTx.tx == nil)
+			// before returning, so this branch is defensive and never fires under the
+			// current contract. If the filter ever passes cached entries through, this
+			// must continue to the next tx in the level rather than abort the entire
+			// level (the previous `return nil` would silently leave the rest of
+			// levelTxs un-validated and report success).
 			if txMetaSlice[mTx.idx].isSet {
 				u.logger.Debugf("[processTransactionsInLevels] Transaction %s already validated (pre-check), skipping", tx.TxIDChainHash().String())
-				return nil
+				continue
 			}
 
 			// Pre-filter the block-scoped accumulator to just this tx's input


### PR DESCRIPTION
## Summary

`services/subtreevalidation/check_block_subtrees.go:1208-1211` had a defensive cached-tx check that returned `nil` from the enclosing function instead of advancing to the next iteration:

\`\`\`go
for _, mTx := range levelTxs {
    if tx == nil { return errors.NewProcessingError(...) }
    if txMetaSlice[mTx.idx].isSet {
        u.logger.Debugf("...already validated...skipping")
        return nil                 // <-- bails out of the entire level
    }
    ...
    g.Go(func() error { ... })
}
\`\`\`

If the check ever fires it silently abandons **every subsequent tx in the level** (and every later level), reports `nil` to the caller, and the block is marked as having had its subtrees validated without those txs ever being run through the validator.

## Why it's latent today (and why it still matters)

The upstream filter is correct: both `prepareTxsPerLevel` and `prepareTxsPerLevelOrdered` skip cached entries (`mTx.tx == nil`) at `SubtreeValidation.go:1606` and `:1787`, so by the time `levelTxs` reaches `processTransactionsInLevels` every `mTx.idx` points to a tx that needs validation. The check never fires under the current contract.

But the failure mode if it ever does is **silent and severe** — same shape as the empty-block bypass finding from PR #1069's review (scenarios 05/06 were silent no-ops because the receive path short-circuited before the per-tx call). `continue` is the right shape for a defensive guard: skip this tx, keep going on the rest of the level.

## Fix

One-character semantic: `return nil` → `continue`. Plus a docstring on the check that names the upstream filter contract, so the next reader doesn't have to retrace it.

## Test plan

- [x] \`go build ./services/subtreevalidation/...\` clean
- [x] \`go vet ./services/subtreevalidation/...\` clean

Discovered while auditing the subtreevalidation receive path for a skip-on-cache short-circuit (the receive equivalent of mempool-hit skipping, in support of throughput work). The short-circuit exists correctly upstream at \`processTxMetaUsingCache\`/\`processTxMetaUsingStore\` + early-return when \`missed == 0\` — this is just a defensive guard with the wrong return that I noticed in passing.