### PR TITLE
perf(tracing): cut per-span allocation on the hot path (gocore.Stat, tags, StartTime)

### DIFF
--- a/services/blockvalidation/catchup_get_block_headers.go
+++ b/services/blockvalidation/catchup_get_block_headers.go
@@ -33,6 +33,7 @@ import (
 func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Block, peerID, baseURL string) (*catchup.Result, *model.BlockHeader, error) {
 	ctx, _, deferFn := tracing.Tracer("subtreevalidation").Start(ctx, "catchupGetBlockHeaders",
 		tracing.WithParentStat(u.stats),
+		tracing.WithStartTime(), // startTime is read back from ctx below
 		tracing.WithLogMessage(u.logger, "[catchup][%s] fetching headers up to %s from peer %s", blockUpTo.Hash().String(), baseURL, peerID),
 		tracing.WithContextTimeout(time.Duration(u.settings.BlockValidation.CatchupOperationTimeout)*time.Second),
 	)

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -69,6 +69,7 @@ type TraceOptions struct {
 	LogMessages      []logMessage            // log messages to be added to the span
 	Timeout          time.Duration           // timeout for the span, if set
 	SampleRate       *float64                // per-span sample rate override (nil = use default)
+	InjectStartTime  bool                    // inject the span start time into the context under StartTime
 }
 
 // addLogMessage adds a log message to the trace options
@@ -210,6 +211,19 @@ func WithContextTimeout(timeout time.Duration) Options {
 func WithParentStat(stat *gocore.Stat) Options {
 	return func(s *TraceOptions) {
 		s.ParentStat = stat
+	}
+}
+
+// WithStartTime injects the span's start time into the returned context under the
+// StartTime key, so callers can read it back via ctx.Value(tracing.StartTime).
+//
+// This is opt-in because injecting it costs a context.WithValue (and boxing the
+// time.Time) on every span, and only a few call sites read it. The hot validation
+// path opens many spans per transaction and does not need it, so it must not pay
+// the cost by default.
+func WithStartTime() Options {
+	return func(s *TraceOptions) {
+		s.InjectStartTime = true
 	}
 }
 
@@ -417,8 +431,12 @@ func (u *UTracer) Start(ctx context.Context, spanName string, opts ...Options) (
 		start = gocore.CurrentTime()
 	}
 
-	// add the start time to the context (read downstream, e.g. blockvalidation catchup status)
-	ctx = context.WithValue(ctx, StartTime, start)
+	// add the start time to the context only when a caller opts in (read downstream,
+	// e.g. blockvalidation catchup). Skipped by default to avoid the context.WithValue
+	// boxing on the hot path, where many spans are opened per transaction.
+	if options.InjectStartTime {
+		ctx = context.WithValue(ctx, StartTime, start)
+	}
 
 	// inject sample rate override into context for the custom sampler
 	if options.SampleRate != nil {

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -216,6 +216,13 @@ func WithParentStat(stat *gocore.Stat) Options {
 // WithTag adds a key-value tag to the trace
 func WithTag(key, value string) Options {
 	return func(s *TraceOptions) {
+		// Tags are only consumed when building OpenTelemetry span attributes, which
+		// is skipped entirely when tracing is disabled. Avoid the slice allocation
+		// (and append growth) on the disabled hot path.
+		if !tracingEnabled.Load() {
+			return
+		}
+
 		if s.Tags == nil {
 			s.Tags = make([]tracingTag, 0)
 		}
@@ -386,19 +393,31 @@ func (u *UTracer) Start(ctx context.Context, spanName string, opts ...Options) (
 		ctx, cancelFunc = context.WithTimeout(ctx, options.Timeout)
 	}
 
-	// Create gocore.Stat (only if enabled)
+	// Create gocore.Stat (only when tracing is enabled).
+	//
+	// The gocore.Stat tree is consumed by the /stats perf endpoint via
+	// WithParentStat. Creating it allocates a Stat (each with its own RWMutex and
+	// child sync.Map) and takes the parent's child-map lock on every span. On the
+	// hot sync path the validator opens several spans per transaction across
+	// millions of transactions per block, so this allocation + lock is a dominant,
+	// contended cost. When tracing is disabled (the documented "zero overhead"
+	// state) skip it; start is still needed for metrics/log durations and StartTime.
 	var (
 		start time.Time
 		stat  *gocore.Stat
 	)
 
-	if options.ParentStat != nil {
-		start, stat, ctx = NewStatFromContext(ctx, spanName, options.ParentStat)
+	if tracingEnabled {
+		if options.ParentStat != nil {
+			start, stat, ctx = NewStatFromContext(ctx, spanName, options.ParentStat)
+		} else {
+			start, stat, ctx = NewStatFromContext(ctx, spanName, defaultStat)
+		}
 	} else {
-		start, stat, ctx = NewStatFromContext(ctx, spanName, defaultStat)
+		start = gocore.CurrentTime()
 	}
 
-	// add the start time to the context
+	// add the start time to the context (read downstream, e.g. blockvalidation catchup status)
 	ctx = context.WithValue(ctx, StartTime, start)
 
 	// inject sample rate override into context for the custom sampler

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -415,7 +415,8 @@ func (u *UTracer) Start(ctx context.Context, spanName string, opts ...Options) (
 	// hot sync path the validator opens several spans per transaction across
 	// millions of transactions per block, so this allocation + lock is a dominant,
 	// contended cost. When tracing is disabled (the documented "zero overhead"
-	// state) skip it; start is still needed for metrics/log durations and StartTime.
+	// state) skip it; start is still computed for metrics/log durations and for the
+	// StartTime context value when a caller opts in via WithStartTime.
 	var (
 		start time.Time
 		stat  *gocore.Stat

--- a/util/tracing/tracing_test.go
+++ b/util/tracing/tracing_test.go
@@ -773,3 +773,56 @@ func TestWithSampleRate_ChildSpanInheritsOverride(t *testing.T) {
 	defer endChild()
 	assert.True(t, childSpan.IsRecording(), "child should be recording due to inherited context override")
 }
+
+// TestStart_DisabledSkipsStatCreation verifies that when tracing is disabled the
+// per-span gocore.Stat is not created/injected (it is the dominant unconditional
+// cost on the hot sync path), while StartTime is still injected because downstream
+// services (e.g. blockvalidation catchup status) read it from the context.
+func TestStart_DisabledSkipsStatCreation(t *testing.T) {
+	originalState := IsTracingEnabled()
+	defer SetTracingEnabled(originalState)
+
+	SetTracingEnabled(false)
+
+	tracer := Tracer("test-service")
+	ctx := context.Background()
+
+	newCtx, _, endFn := tracer.Start(ctx, "op",
+		WithTag("key", "value"),
+		WithParentStat(gocore.NewStat("parent")),
+	)
+	defer endFn()
+
+	// No gocore.Stat should be injected when tracing is disabled.
+	require.Nil(t, newCtx.Value(statsKey{}), "no gocore.Stat should be injected when tracing disabled")
+
+	// StartTime must still be present (read by blockvalidation catchup status).
+	st := newCtx.Value(StartTime)
+	require.NotNil(t, st, "StartTime must be injected even when tracing disabled")
+
+	_, ok := st.(time.Time)
+	require.True(t, ok, "StartTime should be a time.Time")
+}
+
+// BenchmarkStart_Disabled measures per-span allocation on the disabled hot path
+// (the legacy sync path creates millions of these per block).
+func BenchmarkStart_Disabled(b *testing.B) {
+	originalState := IsTracingEnabled()
+	defer SetTracingEnabled(originalState)
+
+	SetTracingEnabled(false)
+
+	tracer := Tracer("bench")
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _, endFn := tracer.Start(ctx, "op",
+			WithTag("txid", "abc123"),
+			WithTag("height", "875800"),
+		)
+		endFn()
+	}
+}

--- a/util/tracing/tracing_test.go
+++ b/util/tracing/tracing_test.go
@@ -796,12 +796,36 @@ func TestStart_DisabledSkipsStatCreation(t *testing.T) {
 	// No gocore.Stat should be injected when tracing is disabled.
 	require.Nil(t, newCtx.Value(statsKey{}), "no gocore.Stat should be injected when tracing disabled")
 
-	// StartTime must still be present (read by blockvalidation catchup status).
-	st := newCtx.Value(StartTime)
-	require.NotNil(t, st, "StartTime must be injected even when tracing disabled")
+	// StartTime is opt-in (WithStartTime) and must not be injected by default.
+	require.Nil(t, newCtx.Value(StartTime), "StartTime should not be injected without WithStartTime")
+}
+
+// TestStart_StartTimeOptIn verifies StartTime is injected into the context only
+// when WithStartTime is supplied (blockvalidation catchup reads it), and is absent
+// otherwise — avoiding the per-span context.WithValue boxing on the hot path.
+func TestStart_StartTimeOptIn(t *testing.T) {
+	originalState := IsTracingEnabled()
+	defer SetTracingEnabled(originalState)
+
+	SetTracingEnabled(false)
+
+	tracer := Tracer("test-service")
+
+	// Without WithStartTime: absent.
+	ctxNo, _, endNo := tracer.Start(context.Background(), "no-opt")
+	require.Nil(t, ctxNo.Value(StartTime), "StartTime should be absent without WithStartTime")
+
+	endNo()
+
+	// With WithStartTime: present and a time.Time.
+	ctxYes, _, endYes := tracer.Start(context.Background(), "opt", WithStartTime())
+	st := ctxYes.Value(StartTime)
+	require.NotNil(t, st, "StartTime should be injected with WithStartTime")
 
 	_, ok := st.(time.Time)
 	require.True(t, ok, "StartTime should be a time.Time")
+
+	endYes()
 }
 
 // BenchmarkStart_Disabled measures per-span allocation on the disabled hot path

--- a/util/tracing/tracing_test.go
+++ b/util/tracing/tracing_test.go
@@ -776,8 +776,8 @@ func TestWithSampleRate_ChildSpanInheritsOverride(t *testing.T) {
 
 // TestStart_DisabledSkipsStatCreation verifies that when tracing is disabled the
 // per-span gocore.Stat is not created/injected (it is the dominant unconditional
-// cost on the hot sync path), while StartTime is still injected because downstream
-// services (e.g. blockvalidation catchup status) read it from the context.
+// cost on the hot sync path), and that StartTime is not injected by default
+// (it is opt-in via WithStartTime; see TestStart_StartTimeOptIn).
 func TestStart_DisabledSkipsStatCreation(t *testing.T) {
 	originalState := IsTracingEnabled()
 	defer SetTracingEnabled(originalState)


### PR DESCRIPTION
## What

`UTracer.Start` did real work on every span **even when tracing is disabled** — the default in production and the documented "zero overhead" state. Two commits cut the per-span cost on the hot path:

**1. Skip gocore.Stat creation and tag allocation when tracing disabled**
- `NewStatFromContext` created a `gocore.Stat` (each with its own `RWMutex` and child `sync.Map`, taking the parent's child-map lock) on every span — unconditionally.
- the tag options allocated a `[]tracingTag` slice that is only read when building OTel span attributes (already skipped when disabled).

Both are now gated on `tracingEnabled`; `WithTag` is a no-op when disabled.

**2. Make StartTime context injection opt-in**
- `context.WithValue(ctx, StartTime, start)` boxed a `time.Time` and allocated a valueCtx on every span. Only one call site reads it back (`blockvalidation.catchupGetBlockHeaders`).
- new `WithStartTime()` option; injection happens only when set. The one consumer opts in (it already had a `time.Now()` fallback, so behavior is unchanged). Every other span skips the boxing.

## Where this came from

CPU profiling a mainnet legacy sync (operator single-node, Aerospike). `UTracer.Start` was ~10% cumulative CPU with tracing already off. The cost was the unconditional `gocore.Stat` machinery, tag allocation, and StartTime boxing — not the OTel SDK (which was correctly gated). After deploying commit 1 as a beta and re-profiling, the `gocore.Stat`/tag overhead was confirmed gone and the residual `UTracer.Start` cost was dominated by the StartTime `context.WithValue`, which commit 2 removes from the hot path.

## Behavior changes

- The `gocore.Stat` `/stats` perf tree is **no longer populated when tracing is disabled**. This affects `WithParentStat` consumers (blockvalidation / utxopersister / validator). Enable tracing (`tracing_enabled=true`) to restore it. Aligns with the `tracing_enabled` setting's documented contract ("all tracing operations become no-ops … for zero performance overhead").
- `tracing.StartTime` is now only present in the context when the span was started with `WithStartTime()`. The sole reader (`catchupGetBlockHeaders`) opts in and is unaffected.

## Benchmark

`BenchmarkStart_Disabled` (disabled path, 2 tags/span):

|                 | ns/op | B/op | allocs/op |
|-----------------|-------|------|-----------|
| baseline        | 437.4 | 760  | 10        |
| after commit 1  | 167.7 | 328  | 4         |
| after commit 2  | 119.3 | 272  | 2         |

~73% faster, ~80% fewer allocations per span.

## Tests

- `go test -race ./util/tracing` — green (existing suite + `TestStart_DisabledSkipsStatCreation`, `TestStart_StartTimeOptIn`)
- `go build ./...` — green
- `go test ./services/blockvalidation` (the `StartTime` consumer, with the opt-in) — green
- `go test -tags testtxmetacache ./services/validator` (hottest `WithParentStat` consumer) — green

## Follow-up

Profiling after these changes shows the next bottleneck is the Aerospike UTXO store batcher's per-operation channel/select machinery on the consensus-critical UTXO path — tracked separately in #1100 (higher risk, scoped on its own).