### PR TITLE
fix(asset): backpressure subtree-data streaming to stop mid-stream truncation

### DIFF
--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -302,19 +302,31 @@ func (repo *Repository) writeTransactionsViaSubtreeStoreStreaming(ctx context.Co
 	defer cancel()
 
 	resultsChan := make(chan chunkResult, concurrency)
+
+	// Window semaphore: bounds how far the chunk scheduler may run ahead of the chunk
+	// currently being written. A token is acquired before a chunk fetch is scheduled and
+	// released only once that chunk has been written to the output, in order. This couples
+	// fetch-ahead to write progress, so a slow in-order chunk applies backpressure to the
+	// scheduler rather than letting later out-of-order chunks pile up unbounded in `pending`
+	// (which previously overflowed the cap and truncated the response mid-stream). Sized at
+	// 2*concurrency: up to `concurrency` fetches in flight plus `concurrency` completed
+	// chunks buffered ahead of the writer, keeping fetchers busy while bounding peak memory.
+	window := 2 * concurrency
+	writeWindow := make(chan struct{}, window)
+
 	g, gCtx := errgroup.WithContext(streamCtx)
 	g.Go(func() error {
 		defer close(resultsChan)
-		return repo.scheduleSubtreeChunkFetches(gCtx, bufferedReader, subtreeHash, totalTxs, chunkSize, concurrency, resultsChan)
+		return repo.scheduleSubtreeChunkFetches(gCtx, bufferedReader, subtreeHash, totalTxs, chunkSize, concurrency, writeWindow, resultsChan)
 	})
 
 	pending := make(map[int]chunkResult)
 	nextChunk := 0
 
-	// Defensive cap on out-of-order chunks held in memory. With the current scheduler
-	// this should never exceed `concurrency`, but a future change to the scheduler could
-	// silently grow it. Aborting beats OOM. 2x leaves headroom for transient races.
-	pendingCap := 2 * concurrency
+	// Invariant guard: with the write-window semaphore the scheduler can never run more
+	// than `window` chunks ahead of the writer, so `pending` cannot exceed it. This only
+	// fires if that invariant is broken by a future change; aborting beats OOM.
+	pendingCap := window
 
 	for result := range resultsChan {
 		if result.err != nil {
@@ -329,7 +341,7 @@ func (repo *Repository) writeTransactionsViaSubtreeStoreStreaming(ctx context.Co
 			cancel()
 			drainChunkResults(resultsChan)
 			_ = g.Wait()
-			return errors.NewProcessingError("[writeTransactionsViaSubtreeStoreStreaming][%s] pending chunk buffer exceeded cap %d (likely scheduler regression)",
+			return errors.NewProcessingError("[writeTransactionsViaSubtreeStoreStreaming][%s] pending chunk buffer exceeded cap %d (write-window invariant violated)",
 				subtreeHash.String(), pendingCap)
 		}
 
@@ -348,6 +360,11 @@ func (repo *Repository) writeTransactionsViaSubtreeStoreStreaming(ctx context.Co
 
 			delete(pending, nextChunk)
 			nextChunk++
+
+			// Release the write-window slot this chunk occupied, letting the scheduler
+			// fetch one more chunk ahead. There is always at least this chunk's own token
+			// buffered, so the receive never blocks.
+			<-writeWindow
 		}
 	}
 
@@ -359,7 +376,7 @@ func (repo *Repository) writeTransactionsViaSubtreeStoreStreaming(ctx context.Co
 }
 
 func (repo *Repository) scheduleSubtreeChunkFetches(ctx context.Context, subtreeReader *bufio.Reader, subtreeHash *chainhash.Hash,
-	totalTxs, chunkSize, concurrency int, resultsChan chan<- chunkResult) error {
+	totalTxs, chunkSize, concurrency int, writeWindow chan struct{}, resultsChan chan<- chunkResult) error {
 	fetchCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -370,6 +387,22 @@ func (repo *Repository) scheduleSubtreeChunkFetches(ctx context.Context, subtree
 	for chunkIdx, offset := 0, 0; offset < totalTxs; chunkIdx, offset = chunkIdx+1, offset+chunkSize {
 		if readErr = gCtx.Err(); readErr != nil {
 			cancel()
+			break
+		}
+
+		// Acquire a write-window slot before scheduling this chunk; the consumer releases
+		// it once the chunk has been written in order. This blocks (applying backpressure)
+		// when the writer has fallen `window` chunks behind, bounding `pending`. Honour
+		// cancellation so teardown after a worker error can't deadlock here.
+		acquired := false
+		select {
+		case writeWindow <- struct{}{}:
+			acquired = true
+		case <-gCtx.Done():
+			readErr = gCtx.Err()
+			cancel()
+		}
+		if !acquired {
 			break
 		}
 

--- a/services/asset/repository/subtree_stream_backpressure_test.go
+++ b/services/asset/repository/subtree_stream_backpressure_test.go
@@ -1,0 +1,178 @@
+package repository
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/util/tracing"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// headStallingStore wraps a utxo.Store and stalls the BatchDecorate call belonging
+// to the first subtree chunk (the one containing headHash) until released, while
+// letting every other chunk's fetch complete immediately. This reproduces the
+// head-of-line blocking condition: the in-order chunk is the slowest, so all the
+// later out-of-order chunks pile up waiting to be written.
+type headStallingStore struct {
+	utxo.Store
+
+	headHash        *chainhash.Hash
+	release         chan struct{}
+	othersCompleted atomic.Int64
+}
+
+func (s *headStallingStore) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaData, f ...fields.FieldName) error {
+	isHead := false
+
+	for _, it := range items {
+		if bytes.Equal(it.Hash[:], s.headHash[:]) {
+			isHead = true
+			break
+		}
+	}
+
+	if isHead {
+		// Stall the head chunk. It is released either when the test's timer fires
+		// (the only completion signal the in-order chunk gets under a correct,
+		// backpressured scheduler) or when the stream is torn down via context
+		// cancellation (which is how the buggy scheduler's abort frees us).
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	err := s.Store.BatchDecorate(ctx, items, f...)
+
+	if !isHead {
+		s.othersCompleted.Add(1)
+	}
+
+	return err
+}
+
+// TestSubtreeStreamingHeadOfLineBackpressure proves the asset subtree-data streaming
+// path does not truncate a large response when the first (in-order) chunk is the
+// slowest to fetch. Before the windowed-backpressure fix the scheduler ran arbitrarily
+// far ahead of the chunk being written, overflowed the `2*concurrency` pending buffer,
+// and aborted the whole response mid-stream ("pending chunk buffer exceeded cap N").
+// With backpressure the scheduler never runs more than the window ahead of nextChunk,
+// so the stream always completes in order.
+func TestSubtreeStreamingHeadOfLineBackpressure(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	ctx := setup(t)
+
+	const concurrency = 4
+	const chunkSize = 4
+
+	ctx.settings.Asset.SubtreeDataStreamingConcurrency = concurrency
+	ctx.settings.Asset.SubtreeDataStreamingChunkSize = chunkSize
+
+	// 64 leaves (coinbase + 63 txs) / chunkSize 4 => 16 chunks. With the head chunk
+	// stalled, 15 later chunks can complete — far past the cap of 2*concurrency = 8.
+	numTxs := 63
+	txs := make([]*bt.Tx, numTxs+1)
+	txs[0] = coinbase
+
+	for i := 1; i <= numTxs; i++ {
+		txs[i] = &bt.Tx{
+			Version:  uint32(i), //nolint:gosec
+			LockTime: uint32(i), //nolint:gosec
+			Inputs:   []*bt.Input{},
+			Outputs:  []*bt.Output{},
+		}
+	}
+
+	testParams := blockInfo{
+		version:           1,
+		bits:              "2000ffff",
+		previousBlockHash: "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+		height:            1,
+		nonce:             2083236893,
+		timestamp:         uint32(time.Now().Unix()), //nolint:gosec
+		txs:               txs,
+	}
+
+	block, subtree := newBlockWithCorrectMerkleRoot(ctx, t, testParams)
+
+	blockchainClientMock := ctx.repo.BlockchainClient.(*blockchain.Mock)
+	blockchainClientMock.On("GetBlock", mock.Anything, mock.Anything).Return(block, nil).Once()
+
+	// Populate the real utxo store, then wrap it so the head chunk stalls.
+	for i := 1; i < len(txs); i++ {
+		_, err := ctx.repo.UtxoStore.Create(context.Background(), txs[i], testParams.height)
+		require.NoError(t, err)
+	}
+
+	// Store the subtree so GetSubtreeTxIDsReader can stream its tx IDs.
+	subtreeBytes, err := subtree.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, ctx.repo.SubtreeStore.Set(context.Background(), subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes))
+
+	stalling := &headStallingStore{
+		Store:    ctx.repo.UtxoStore,
+		headHash: txs[1].TxIDChainHash(), // txs[1] lives in chunk 0 (leaves 0..3)
+		release:  make(chan struct{}),
+	}
+	ctx.repo.UtxoStore = stalling
+
+	// The in-order head chunk has no upstream completion event of its own under a
+	// correct scheduler — release it after a bounded delay that is comfortably longer
+	// than the time the buggy scheduler needs to overflow its pending buffer (which it
+	// does autonomously in milliseconds on in-memory stores). The buggy path therefore
+	// aborts long before this fires; this timer only drives the fixed (passing) path.
+	releaseTimer := time.AfterFunc(800*time.Millisecond, func() { close(stalling.release) })
+	defer releaseTimer.Stop()
+
+	r, err := ctx.repo.GetLegacyBlockReader(context.Background(), &chainhash.Hash{})
+	require.NoError(t, err)
+
+	// Skip the legacy block header: magic(4)+size(4), block header(80), tx count varint.
+	buf := make([]byte, 4096)
+	_, err = io.ReadFull(r, buf[:8])
+	require.NoError(t, err)
+	_, err = io.ReadFull(r, buf[:80])
+	require.NoError(t, err)
+	_, err = r.Read(buf[:10])
+	require.NoError(t, err)
+
+	txCount, _ := bt.NewVarIntFromBytes(buf[:10])
+	require.Equal(t, uint64(len(txs)), uint64(txCount))
+
+	// The stream must deliver every transaction — no mid-stream abort/truncation.
+	allTxData, err := io.ReadAll(r)
+	require.ErrorIs(t, err, io.ErrClosedPipe, "stream did not complete cleanly (truncated/aborted)")
+
+	offset := 0
+	for i := 0; i < len(txs); i++ {
+		parsedTx, size, parseErr := bt.NewTxFromStream(allTxData[offset:])
+		require.NoError(t, parseErr, "failed to parse transaction %d — response was truncated", i)
+		require.NotNil(t, parsedTx)
+
+		if i == 0 {
+			require.Equal(t, coinbase.TxID(), parsedTx.TxID(), "coinbase mismatch at position 0")
+		} else {
+			require.Equal(t, uint32(i), parsedTx.Version, "transaction at position %d out of order", i)
+			require.Equal(t, txs[i].TxID(), parsedTx.TxID(), "transaction %d TxID mismatch", i)
+		}
+
+		offset += size
+	}
+
+	require.Equal(t, len(allTxData), offset, "not all transaction data was consumed")
+	require.GreaterOrEqual(t, stalling.othersCompleted.Load(), int64(concurrency),
+		"expected the scheduler to fetch later chunks while the head chunk stalled")
+}


### PR DESCRIPTION
## Problem

The chunked subtree-data streamer (`writeTransactionsViaSubtreeStoreStreaming`, introduced in #827 / cap added in #896) fetches chunks concurrently but must write them **in order**, holding out-of-order completions in a `pending` map. Nothing couples *chunks fetched ahead* to *chunks written*, so a single slow in-order chunk (e.g. one slow `getTxs`/Aerospike batch) holds one errgroup slot while the other slots churn through later chunks — all piling into `pending`. When `len(pending) > 2*concurrency` the server **aborts the whole response mid-stream**.

The `(likely scheduler regression)` text in that abort is a misdiagnosis: it trips on normal per-chunk latency variance under load, not a regression.

### Impact (observed on a multi-node scaling cluster)

The truncated body surfaces on the consumer as:

```
[catchup:fetchAndStoreSubtreeData] ... error reading transaction: previousTxID(32): got 21 bytes: unexpected EOF
```

and on the serving nginx as `upstream prematurely closed connection`. This breaks **block-validation catchup**: a node that has fallen behind must bulk-fetch each block's subtree data from a peer, every large fetch truncates, catchup hits its deadline → `ReportPeerFailure` → re-enter `CATCHINGBLOCKS` → retry → fail again. A node that falls behind can **never recover** — it stays wedged indefinitely while the chain advances. A node that stays `RUNNING` gets subtree data incrementally via the normal pipeline and never touches this path, so the failure is a self-reinforcing trap that only bites once you're already behind.

## Fix

Add a **write-window semaphore** (sized `2*concurrency`): the scheduler acquires a slot before scheduling each chunk fetch, and the consumer releases it only once that chunk has been **written in order**. A slow in-order chunk now applies backpressure to the scheduler instead of letting later chunks pile up unbounded, so `pending` is bounded by the window and the stream always completes.

- Memory envelope is unchanged (window = old cap = `2*concurrency`: up to `concurrency` fetches in flight + `concurrency` buffered ahead of the writer).
- Backpressure correctly propagates to a slow HTTP client (the stream blocks until the client reads, bounded, with the existing client-gone ctx checks).
- The existing cap check is kept purely as a defensive invariant guard that can no longer fire.

## Test

`TestSubtreeStreamingHeadOfLineBackpressure` wraps the utxo store to stall the head (in-order) chunk while later chunks complete, then asserts the full response is delivered in order. It fails on the current code (`transaction 1 truncated`, aborts in ~0.01s) and passes with the fix.

## Verification

- `go test -race ./services/asset/repository/` — ok (full package)
- new test: RED before fix → GREEN after; `-count=5` no flakes
- `go vet` / `golangci-lint` / `staticcheck` (changed files) — clean
- `go build ./...` — ok; `services/asset/httpimpl` subtree-data tests — ok