### PR TITLE
fix(blockvalidation): make catchup reputation gRPC calls outside activeCatchupCtxMu with a bounded context

### DIFF
--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -28,6 +28,11 @@ const (
 	// maxCatchupIterations was the old iteration limit, kept for reference but no longer used
 	// since we now make a single request for headers
 	maxCatchupIterations = 1000
+
+	// catchupReputationReportTimeout bounds the best-effort peer-reputation gRPC calls
+	// made when releasing the catchup lock, so a slow or hung P2P service cannot stall
+	// catchup teardown or detach the calls from shutdown.
+	catchupReputationReportTimeout = 5 * time.Second
 )
 
 // CatchupContext holds all the state needed during a catchup operation
@@ -333,20 +338,32 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 		prometheusCatchupActive.Set(0)
 	}
 
+	// Reputation reporting decisions captured under the lock, executed after release.
+	// We must NOT make gRPC calls while holding activeCatchupCtxMu: a slow or hung P2P
+	// service would block the lock indefinitely, which in turn blocks GetCatchupStatus
+	// (it RLocks the same mutex) and prevents the active catchup context from clearing.
+	var (
+		reportMalicious bool
+		reportPeerErr   bool
+		peerID          string
+		errorMsg        string
+	)
+
 	// Capture failure details for dashboard before clearing context
 	u.activeCatchupCtxMu.Lock()
 	if *err != nil && ctx != nil {
 		// Determine error type based on error characteristics
 		errorType := "unknown_error"
-		errorMsg := (*err).Error()
+		errorMsg = (*err).Error()
+		peerID = ctx.peerID
 		isPeerError := true // Track if this is a peer-related error
 
 		// TODO: all of these should be using error types, and not checking the strings (!)
 		switch {
 		case errors.Is(*err, errors.ErrBlockInvalid) || errors.Is(*err, errors.ErrTxInvalid):
 			errorType = "validation_failure"
-			// Mark peer as malicious for validation failure
-			u.reportCatchupMalicious(context.Background(), ctx.peerID, "validation_failure")
+			// Mark peer as malicious for validation failure (reported after unlock)
+			reportMalicious = true
 		case errors.IsNetworkError(*err):
 			errorType = "network_error"
 		case strings.Contains(errorMsg, "secret mining") || strings.Contains(errorMsg, "secretly mined"):
@@ -386,7 +403,7 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 		// Only store the error in the peer registry if it's a peer-related error
 		// Local system errors (like block assembly being behind) should not affect peer reputation
 		if isPeerError {
-			u.reportCatchupError(context.Background(), ctx.peerID, errorMsg)
+			reportPeerErr = true
 		} else {
 			u.logger.Infof("[catchup][%s] Skipping peer error report for local system error: %s", ctx.blockUpTo.Hash().String(), errorType)
 		}
@@ -395,6 +412,22 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 	// Clear the active catchup context
 	u.activeCatchupCtx = nil
 	u.activeCatchupCtxMu.Unlock()
+
+	// Make the fire-and-forget reputation gRPC calls outside the lock with a bounded
+	// context, so a stalled P2P service can neither hold activeCatchupCtxMu nor outlive
+	// shutdown. These are best-effort; failures are logged inside the helpers.
+	if reportMalicious || reportPeerErr {
+		rpcCtx, cancel := context.WithTimeout(context.Background(), catchupReputationReportTimeout)
+		defer cancel()
+
+		if reportMalicious {
+			u.reportCatchupMalicious(rpcCtx, peerID, "validation_failure")
+		}
+
+		if reportPeerErr {
+			u.reportCatchupError(rpcCtx, peerID, errorMsg)
+		}
+	}
 
 	// Update catchup tracking for health checks
 	u.catchupStatsMu.Lock()

--- a/services/blockvalidation/catchup_release_lock_test.go
+++ b/services/blockvalidation/catchup_release_lock_test.go
@@ -1,0 +1,174 @@
+package blockvalidation
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingP2PClient is a minimal P2PClientI used to simulate a slow or hung P2P
+// service. It blocks inside RecordCatchupMalicious until released, letting tests
+// assert that releaseCatchupLock makes reputation gRPC calls *outside* the
+// activeCatchupCtxMu lock. Only the methods exercised by releaseCatchupLock are
+// overridden; the embedded interface is nil and will panic if any other method is
+// called (which would itself be a useful signal that the test assumptions changed).
+type blockingP2PClient struct {
+	P2PClientI
+
+	maliciousStarted chan struct{} // closed when RecordCatchupMalicious is entered
+	release          chan struct{} // unblocks RecordCatchupMalicious when closed
+
+	mu              sync.Mutex
+	maliciousCalled bool
+	maliciousPeer   string
+	maliciousCtx    context.Context
+	errorCalled     bool
+	errorPeer       string
+	errorMsg        string
+}
+
+func (b *blockingP2PClient) RecordCatchupMalicious(ctx context.Context, peerID string) error {
+	b.mu.Lock()
+	b.maliciousCalled = true
+	b.maliciousPeer = peerID
+	b.maliciousCtx = ctx
+	b.mu.Unlock()
+
+	close(b.maliciousStarted)
+	<-b.release // simulate a hung P2P service
+
+	return nil
+}
+
+func (b *blockingP2PClient) UpdateCatchupError(_ context.Context, peerID string, errorMsg string) error {
+	b.mu.Lock()
+	b.errorCalled = true
+	b.errorPeer = peerID
+	b.errorMsg = errorMsg
+	b.mu.Unlock()
+
+	return nil
+}
+
+// TestReleaseCatchupLock_DoesNotHoldMutexDuringReputationRPC verifies that a slow
+// or hung P2P reputation gRPC call cannot hold activeCatchupCtxMu, which would
+// otherwise block GetCatchupStatus and prevent the active catchup context from
+// being cleared.
+func TestReleaseCatchupLock_DoesNotHoldMutexDuringReputationRPC(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	blocker := &blockingP2PClient{
+		maliciousStarted: make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+	server.p2pClient = blocker
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo: &model.Block{Header: header, Height: 1000},
+		baseURL:   "http://peer1",
+		peerID:    "peer-123",
+		startTime: time.Now(),
+	}
+
+	require.NoError(t, server.acquireCatchupLock(ctx))
+
+	// A validation failure triggers the (blocking) reportCatchupMalicious RPC.
+	relErr := error(errors.NewBlockInvalidError("bad block"))
+
+	releaseDone := make(chan struct{})
+	go func() {
+		server.releaseCatchupLock(ctx, &relErr)
+		close(releaseDone)
+	}()
+
+	// Wait for the hung RPC to begin. Reaching this point proves releaseCatchupLock
+	// already passed the unlock (the RPC is made after activeCatchupCtxMu is released).
+	select {
+	case <-blocker.maliciousStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reportCatchupMalicious was never invoked")
+	}
+
+	// While the RPC is hung, GetCatchupStatus must NOT block on activeCatchupCtxMu.
+	statusDone := make(chan *CatchupStatus, 1)
+	go func() {
+		statusDone <- server.getCatchupStatusInternal()
+	}()
+
+	select {
+	case status := <-statusDone:
+		require.NotNil(t, status)
+		// The active context was cleared under the lock before the RPC ran.
+		require.False(t, status.IsCatchingUp)
+		require.NotNil(t, status.PreviousAttempt)
+		require.Equal(t, "validation_failure", status.PreviousAttempt.ErrorType)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetCatchupStatus blocked while P2P reputation RPC was hung — mutex held during gRPC")
+	}
+
+	// releaseCatchupLock should still be in flight, blocked on the RPC.
+	select {
+	case <-releaseDone:
+		t.Fatal("releaseCatchupLock returned before the RPC was unblocked")
+	default:
+	}
+
+	// Unblock the RPC and confirm release completes promptly.
+	close(blocker.release)
+	select {
+	case <-releaseDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("releaseCatchupLock did not complete after the RPC unblocked")
+	}
+
+	// The reputation RPC must run with a bounded context, detached from neither
+	// shutdown nor a timeout.
+	blocker.mu.Lock()
+	require.True(t, blocker.maliciousCalled, "malicious report should have been made")
+	require.Equal(t, "peer-123", blocker.maliciousPeer)
+	require.True(t, blocker.errorCalled, "peer error report should have been made")
+	require.Equal(t, "peer-123", blocker.errorPeer)
+	_, hasDeadline := blocker.maliciousCtx.Deadline()
+	blocker.mu.Unlock()
+	require.True(t, hasDeadline, "reputation RPC should use a bounded (timeout) context")
+}
+
+// TestReleaseCatchupLock_LocalErrorSkipsReputationRPC ensures that local system
+// errors (not attributable to the peer) do not trigger reputation gRPC calls.
+func TestReleaseCatchupLock_LocalErrorSkipsReputationRPC(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	blocker := &blockingP2PClient{
+		maliciousStarted: make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+	server.p2pClient = blocker
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo: &model.Block{Header: header, Height: 1000},
+		baseURL:   "http://peer1",
+		peerID:    "peer-123",
+		startTime: time.Now(),
+	}
+
+	require.NoError(t, server.acquireCatchupLock(ctx))
+
+	// ErrServiceUnavailable is a local system error — must not affect peer reputation.
+	relErr := error(errors.NewServiceUnavailableError("block assembly unavailable"))
+	server.releaseCatchupLock(ctx, &relErr)
+
+	blocker.mu.Lock()
+	defer blocker.mu.Unlock()
+	require.False(t, blocker.maliciousCalled, "local error must not report malicious")
+	require.False(t, blocker.errorCalled, "local error must not report peer error")
+}


### PR DESCRIPTION
## Problem

`releaseCatchupLock` made P2P reputation gRPC calls (`reportCatchupMalicious`, `reportCatchupError`) **while holding `activeCatchupCtxMu`**, using `context.Background()` with no timeout:

## Fix

Capture the reporting decisions under the lock, release the lock, then make the fire-and-forget reputation RPCs outside the lock with a bounded context:

- Under `activeCatchupCtxMu`: classify the error, build `previousCatchupAttempt`, capture `reportMalicious` / `reportPeerErr` flags plus `peerID` / `errorMsg`, and clear `activeCatchupCtx`.
- After `Unlock()`: issue the gRPC calls with `context.WithTimeout(context.Background(), 5*time.Second)` (new `catchupReputationReportTimeout` constant) and `defer cancel()`.

This shortens the lock-hold time to in-memory work only, guarantees prompt release/clearing of the catchup context regardless of P2P health, and bounds the reputation RPCs (max 5s instead of forever). Behavior is otherwise unchanged: the same peers are reported for the same error classes, and local system errors still skip peer-reputation reporting.

## Changes

- `services/blockvalidation/catchup.go`:
  - Added `catchupReputationReportTimeout = 5 * time.Second` constant.
  - Refactored `releaseCatchupLock` so the `reportCatchupMalicious` / `reportCatchupError` gRPC calls run after the mutex is released, with a bounded context instead of `context.Background()`.
- `services/blockvalidation/catchup_release_lock_test.go` (new):
  - `TestReleaseCatchupLock_DoesNotHoldMutexDuringReputationRPC` — uses a P2P mock that blocks inside `RecordCatchupMalicious`; asserts `GetCatchupStatus` returns promptly while the RPC is hung (lock no longer held during gRPC), that the active context is cleared, and that the RPC runs with a context that has a deadline.
  - `TestReleaseCatchupLock_LocalErrorSkipsReputationRPC` — asserts local system errors (e.g. `ErrServiceUnavailable`) trigger no reputation RPCs.

## Verification

- `go vet ./services/blockvalidation/`: pass (compiles clean, including the new test).
- `gofmt -l`: clean on both files.
- `go test -race`: not runnable locally due to the known vendored-GoBDK cgo link failure (`libGoBDK` missing `_TxValidator_*` symbols) — an environment issue unrelated to this change. The new tests are deterministic (channel-synchronized, no sleeps) and run in CI.