### PR TITLE
fix(s3): close response body on header-validation error paths in GetIoReader

### DIFF
--- a/stores/blob/s3/s3.go
+++ b/stores/blob/s3/s3.go
@@ -370,13 +370,21 @@ func (g *S3) GetIoReader(ctx context.Context, key []byte, fileType fileformat.Fi
 		return nil, errors.NewStorageError("[S3][GetIoReader] [%s/%s] failed to get s3 data", g.bucket, objectKey, err)
 	}
 
-	// Consume the fileformat.Header before returning the rest of the stream
+	// Consume the fileformat.Header before returning the rest of the stream.
+	// result.Body is the S3 SDK's HTTP response body and holds a network
+	// connection until Close - if header validation fails we must Close
+	// before returning, otherwise the connection is held for the lifetime of
+	// the process. Mirrors the file store's pattern at
+	// stores/blob/file/file.go:996-1002 (validateFileHeader closes the
+	// underlying *os.File on mismatch).
 	header := &fileformat.Header{}
 	if err := header.Read(result.Body); err != nil {
+		_ = result.Body.Close()
 		return nil, errors.NewStorageError("[S3][GetIoReader] [%s/%s] missing or invalid header: %v", g.bucket, objectKey, err)
 	}
 	// Optionally, verify the header matches the expected fileType
 	if header.FileType() != fileType {
+		_ = result.Body.Close()
 		return nil, errors.NewStorageError("[S3][GetIoReader] [%s/%s] header filetype mismatch: got %s, want %s", g.bucket, objectKey, header.FileType(), fileType)
 	}
 

--- a/stores/blob/s3/s3_test.go
+++ b/stores/blob/s3/s3_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
@@ -359,4 +360,104 @@ func TestS3_GetCacheMiss(t *testing.T) {
 	cached, ok := cache.Get(objectKey)
 	assert.True(t, ok, "Value should be cached after Get")
 	assert.Equal(t, value, cached)
+}
+
+// trackingReadCloser wraps a Reader and records Close invocations so tests
+// can assert that consumers release the underlying HTTP response body.
+type trackingReadCloser struct {
+	io.Reader
+	closeCount int
+}
+
+func (t *trackingReadCloser) Close() error { t.closeCount++; return nil }
+
+// trackingS3Client is a mock S3 client that returns a caller-supplied Body
+// from GetObject and panics on any other method (we only test the
+// GetIoReader path here). The Body is a trackingReadCloser so the test can
+// assert Close on the header-validation error paths.
+type trackingS3Client struct {
+	body *trackingReadCloser
+}
+
+func (t *trackingS3Client) PutObject(context.Context, *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	panic("trackingS3Client.PutObject not implemented")
+}
+
+func (t *trackingS3Client) GetObject(context.Context, *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return &s3.GetObjectOutput{Body: t.body, ContentLength: aws.Int64(int64(64))}, nil
+}
+
+func (t *trackingS3Client) HeadObject(context.Context, *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	panic("trackingS3Client.HeadObject not implemented")
+}
+
+func (t *trackingS3Client) DeleteObject(context.Context, *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	panic("trackingS3Client.DeleteObject not implemented")
+}
+
+func (t *trackingS3Client) CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error) {
+	panic("trackingS3Client.CreateMultipartUpload not implemented")
+}
+
+func (t *trackingS3Client) UploadPart(context.Context, *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+	panic("trackingS3Client.UploadPart not implemented")
+}
+
+func (t *trackingS3Client) CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+	panic("trackingS3Client.CompleteMultipartUpload not implemented")
+}
+
+func (t *trackingS3Client) AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error) {
+	panic("trackingS3Client.AbortMultipartUpload not implemented")
+}
+
+func (t *trackingS3Client) Download(context.Context, *s3.GetObjectInput) ([]byte, error) {
+	panic("trackingS3Client.Download not implemented")
+}
+
+func (t *trackingS3Client) Upload(context.Context, *s3.PutObjectInput) error {
+	panic("trackingS3Client.Upload not implemented")
+}
+
+// TestS3_GetIoReader_ClosesBodyOnHeaderReadError pins the close contract on
+// S3.GetIoReader. result.Body is the AWS SDK's HTTP response body and holds
+// a network connection until Close - if the fileformat header read fails
+// (corrupted blob, truncated download) the function must Close before
+// returning, otherwise the connection is held for the lifetime of the
+// process. Mirrors the file store's pattern at file.go:996-1002.
+func TestS3_GetIoReader_ClosesBodyOnHeaderReadError(t *testing.T) {
+	// 0-byte body: header.Read will EOF on the first attempt to consume
+	// the 8-byte magic, which is the corrupted-header failure mode.
+	body := &trackingReadCloser{Reader: bytes.NewReader(nil)}
+	s3Store := &S3{
+		client:  &trackingS3Client{body: body},
+		bucket:  "test-bucket",
+		logger:  ulogger.TestLogger{},
+		options: options.NewStoreOptions(),
+	}
+
+	_, err := s3Store.GetIoReader(context.Background(), []byte("k"), fileformat.FileTypeTesting)
+	require.Error(t, err, "header read on empty body must fail")
+	require.Equal(t, 1, body.closeCount, "result.Body must be Closed exactly once when header read fails - otherwise the S3 HTTP connection leaks")
+}
+
+// TestS3_GetIoReader_ClosesBodyOnFileTypeMismatch pins the same contract on
+// the header file-type mismatch branch (a corrupted-or-wrong-typed blob in
+// S3 that opens fine but identifies as a different fileformat).
+func TestS3_GetIoReader_ClosesBodyOnFileTypeMismatch(t *testing.T) {
+	// Build a body whose magic header is valid but for a DIFFERENT file
+	// type than the caller will ask for, so header.Read succeeds but
+	// header.FileType() != requested type.
+	wrongMagic := fileformat.FileTypeBlock.ToMagicBytes()
+	body := &trackingReadCloser{Reader: bytes.NewReader(wrongMagic[:])}
+	s3Store := &S3{
+		client:  &trackingS3Client{body: body},
+		bucket:  "test-bucket",
+		logger:  ulogger.TestLogger{},
+		options: options.NewStoreOptions(),
+	}
+
+	_, err := s3Store.GetIoReader(context.Background(), []byte("k"), fileformat.FileTypeTesting)
+	require.Error(t, err, "file-type mismatch must surface as an error")
+	require.Equal(t, 1, body.closeCount, "result.Body must be Closed exactly once when file-type mismatches - otherwise the S3 HTTP connection leaks")
 }


### PR DESCRIPTION
## Summary

\`stores/blob/s3/s3.go GetIoReader\` acquires an \`*s3.GetObjectOutput\` from the AWS S3 SDK, then consumes the 8-byte fileformat magic header and verifies its file type before handing the rest of the stream to the caller. On either validation failure the function returned an error **without closing \`result.Body\`**.

\`\`\`go
result, err := g.client.GetObject(ctx, &s3.GetObjectInput{...})
if err != nil { ... return nil, ... }

header := &fileformat.Header{}
if err := header.Read(result.Body); err != nil {
    return nil, errors.NewStorageError(...)   // <-- LEAKS result.Body
}
if header.FileType() != fileType {
    return nil, errors.NewStorageError(...)   // <-- LEAKS result.Body
}
\`\`\`

\`result.Body\` is the AWS SDK's HTTP response body and holds a network connection until Close. Every failed GetIoReader leaks one connection from the SDK's pool. Under load against a misconfigured store or a corrupted blob, the pool exhausts.

The file blob store handles this correctly at \`stores/blob/file/file.go:996-1002\` (Closes the underlying \`*os.File\` on validateFileHeader failure). S3 was the odd one out.

## Fix

Close \`result.Body\` on both header-validation error paths before returning. Comment cross-references the file-store pattern.

## Regression tests

- \`TestS3_GetIoReader_ClosesBodyOnHeaderReadError\` — empty body causes \`header.Read\` to EOF; asserts \`closeCount == 1\`
- \`TestS3_GetIoReader_ClosesBodyOnFileTypeMismatch\` — body has a valid magic but for a different file type than requested; asserts \`closeCount == 1\`

Both use a \`trackingS3Client\` fake whose \`GetObject\` returns a tracking ReadCloser. Every other S3 client method on the fake panics so a future change that accidentally exercises something else fails loudly.

**A/B verified**: both subtests fail with \`closeCount=0\` when the production fix is reverted, exactly the leak shape.

## Test plan

- [x] \`go build ./stores/blob/s3/\` clean
- [x] \`go vet ./stores/blob/s3/\` clean
- [x] 2 new tests pass (~11ms)
- [x] A/B: both subtests fail without the production fix

## Related

Same audit thread; wrapper-store extension of:
- #1087 (merged) - utxopersister consolidator + reader-construction
- #1088 (merged) - asset GetLegacyBlock reader + pipe deadlock
- #1089 (merged) - HTTPBlobServer handleRangeRequest reader leak
- #1091 (merged) - ConcurrentBlob.Get SetFromReader-error path
- #1092 (open) - HTTPBlobServer Seeker propagation + Content-Range
- #1098 (open) - subtreevalidation continue not return on cached-tx skip
- **This PR** - S3 store header-validation error paths

Other wrappers audited and clean: \`logger\` (pure passthrough), \`http\` (already Closes on non-200), \`batcher\` (returns "not supported"), and \`concurrent_blob\` (fixed in #1091).