### PR TITLE
fix(blockvalidation, legacy): Stop tickers in periodic goroutines

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -531,6 +531,7 @@ func (u *BlockValidation) start(ctx context.Context) error {
 		}
 		u.logger.Infof("[BlockValidation:start] starting periodic block processing goroutine (interval: %v)", interval)
 		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 
 		for {
 			select {

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -2472,6 +2472,7 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 	// add the number of orphan transactions to the prometheus metric
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
 
 		for {
 			select {


### PR DESCRIPTION
## Summary

Two background goroutines created a \`time.NewTicker\` but never \`Stop()\`-d it on exit:

1. **services/blockvalidation/BlockValidation.go:533** — periodic \`set subtrees/mined\` sweeper, 1 min default interval
2. **services/legacy/netsync/manager.go:2474** — orphan-tx prometheus metric updater, 5 s interval

Both goroutines correctly select on \`ctx.Done()\` / \`sm.quit\` and return, but leave the ticker running.

## Why it matters in modern Go

Go 1.23+ improved timer GC so an unreached ticker eventually becomes garbage. The runtime's timer heap still keeps the entry until the next scheduled tick fires, so for long-interval tickers (BlockValidation's is 1 minute by default) there's a bounded-but-non-trivial window per restart where the timer is alive but unreachable. \`defer ticker.Stop()\` reclaims it immediately.

For a long-running daemon that restarts services rarely, this is a small win. For tests that spin up + tear down many service instances, it's a clean fix that removes a class of noise.

## Fix

\`defer ticker.Stop()\` immediately after each \`NewTicker\`. Two lines, one each.

## Test plan

- [x] \`go build ./services/blockvalidation/... ./services/legacy/...\` clean
- [x] \`go vet\` (same) clean

## Audit context

Found during a goroutine-leak / ticker audit. Grepped for \`time.NewTicker | time.NewTimer\` across the codebase (~30 sites). The other ~28 are clean — every one of them either has \`defer .Stop()\` or an explicit shutdown path that calls Stop on a field-stored ticker (e.g. \`peerMapCleanupTicker\` on the p2p Server is stopped in the service's shutdown method). These two were the only outliers.

\`util/servicemanager/service_manager.go:234\` (waitForPreviousServiceToStart) also creates a Timer without Stop, but it fires within 5 s by design and is short-lived; not included here.