### PR TITLE
fix(blockassembly/subtreeprocessor): surface dispatcher-handler panics as errors instead of hanging the caller

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -629,11 +629,8 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 				}
 			}()
 
-			var (
-				err error
-				// Phase 1: Dequeue multiple batches
-				dequeueBatches = make([]*TxBatch, 0, maxBatchesPerIteration)
-			)
+			// Phase 1: Dequeue multiple batches
+			dequeueBatches := make([]*TxBatch, 0, maxBatchesPerIteration)
 
 			for {
 				select {
@@ -833,23 +830,25 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 					stp.setCurrentRunningState(StateRunning)
 
 				case resetBlocksMsg := <-stp.resetCh:
-					stp.setCurrentRunningState(StateResetBlocks)
-
-					err = stp.reset(resetBlocksMsg.blockHeader, resetBlocksMsg.moveBackBlocks, resetBlocksMsg.moveForwardBlocks,
-						resetBlocksMsg.useFastForwardReset, resetBlocksMsg.postProcess)
+					resetErr := stp.runHandlerWithRecover("reset", func() error {
+						stp.setCurrentRunningState(StateResetBlocks)
+						return stp.reset(resetBlocksMsg.blockHeader, resetBlocksMsg.moveBackBlocks, resetBlocksMsg.moveForwardBlocks,
+							resetBlocksMsg.useFastForwardReset, resetBlocksMsg.postProcess)
+					})
 
 					if resetBlocksMsg.responseCh != nil {
-						resetBlocksMsg.responseCh <- ResetResponse{Err: err}
+						resetBlocksMsg.responseCh <- ResetResponse{Err: resetErr}
 					}
 
 					stp.setCurrentRunningState(StateRunning)
 
 				case removeTxHash := <-stp.removeTxCh:
 					// remove the given transaction from the subtrees
-					stp.setCurrentRunningState(StateRemoveTx)
-
-					if err = stp.removeTxFromSubtrees(processorCtx, removeTxHash); err != nil {
-						stp.logger.Errorf("[SubtreeProcessor] error removing tx from subtrees: %s", err.Error())
+					if rmErr := stp.runHandlerWithRecover("removeTxFromSubtrees", func() error {
+						stp.setCurrentRunningState(StateRemoveTx)
+						return stp.removeTxFromSubtrees(processorCtx, removeTxHash)
+					}); rmErr != nil {
+						stp.logger.Errorf("[SubtreeProcessor] error removing tx from subtrees: %s", rmErr.Error())
 					}
 
 					stp.setCurrentRunningState(StateRunning)
@@ -859,9 +858,10 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 					lengthCh <- stp.currentSubtree.Load().Length()
 
 				case errCh := <-stp.checkSubtreeProcessorCh:
-					stp.setCurrentRunningState(StateCheckSubtreeProcessor)
-
-					stp.checkSubtreeProcessor(errCh)
+					errCh <- stp.runHandlerWithRecover("checkSubtreeProcessor", func() error {
+						stp.setCurrentRunningState(StateCheckSubtreeProcessor)
+						return stp.checkSubtreeProcessor()
+					})
 
 					stp.setCurrentRunningState(StateRunning)
 
@@ -2805,8 +2805,13 @@ func (stp *SubtreeProcessor) CheckSubtreeProcessor() error {
 }
 
 // checkSubtreeProcessor performs a check on the subtree processor's state.
-func (stp *SubtreeProcessor) checkSubtreeProcessor(errCh chan error) {
+// Returns the first inconsistency encountered, or nil if everything matches.
+// The dispatcher relays the returned value to the caller's errCh, so this
+// function must NOT touch errCh itself - returning multiple errors would
+// wedge the dispatcher on the unbuffered response channel.
+func (stp *SubtreeProcessor) checkSubtreeProcessor() error {
 	stp.logger.Infof("[SubtreeProcessor] checking subtree processor")
+	defer stp.logger.Infof("[SubtreeProcessor] check subtree processor DONE")
 
 	// check all the transactions in the currentTxMap are in the subtrees
 	for subtreeIdx, subtree := range stp.chainedSubtrees {
@@ -2814,18 +2819,14 @@ func (stp *SubtreeProcessor) checkSubtreeProcessor(errCh chan error) {
 			if node.Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
 				// check that the coinbase placeholder is in the first subtree
 				if subtreeIdx != 0 || nodeIdx != 0 {
-					errCh <- errors.NewSubtreeError("[SubtreeProcessor] coinbase placeholder not in first subtree %d", subtreeIdx)
-
-					break
+					return errors.NewSubtreeError("[SubtreeProcessor] coinbase placeholder not in first subtree %d", subtreeIdx)
 				}
 
 				continue
 			}
 
 			if _, ok := stp.currentTxMap.Get(node.Hash); !ok {
-				errCh <- errors.NewSubtreeError("[SubtreeProcessor] tx %s from subtree %d not in currentTxMap", node.Hash.String(), subtreeIdx)
-
-				break
+				return errors.NewSubtreeError("[SubtreeProcessor] tx %s from subtree %d not in currentTxMap", node.Hash.String(), subtreeIdx)
 			}
 		}
 	}
@@ -2836,17 +2837,13 @@ func (stp *SubtreeProcessor) checkSubtreeProcessor(errCh chan error) {
 			if node.Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
 				// check that the coinbase placeholder is in the first subtree
 				if nodeIdx != 0 {
-					errCh <- errors.NewSubtreeError("[SubtreeProcessor] coinbase placeholder not in first node of subtree %d", nodeIdx)
-
-					break
+					return errors.NewSubtreeError("[SubtreeProcessor] coinbase placeholder not in first node of subtree %d", nodeIdx)
 				}
 
 				continue
 			}
 
-			errCh <- errors.NewSubtreeError("[SubtreeProcessor] tx %s from currentSubtree not in currentTxMap", node.Hash.String())
-
-			break
+			return errors.NewSubtreeError("[SubtreeProcessor] tx %s from currentSubtree not in currentTxMap", node.Hash.String())
 		}
 	}
 
@@ -2858,12 +2855,10 @@ func (stp *SubtreeProcessor) checkSubtreeProcessor(errCh chan error) {
 	txCount := stp.TxCount()
 
 	if currentTxMapSize != int(txCount)-1 { // nolint:gosec
-		errCh <- errors.NewSubtreeError("[SubtreeProcessor] currentTxMap size %d does not match txCount %d", currentTxMapSize, txCount-1)
+		return errors.NewSubtreeError("[SubtreeProcessor] currentTxMap size %d does not match txCount %d", currentTxMapSize, txCount-1)
 	}
 
-	errCh <- nil
-
-	stp.logger.Infof("[SubtreeProcessor] check subtree processor DONE")
+	return nil
 }
 
 // GetCompletedSubtreesForMiningCandidate retrieves all completed subtrees for block mining.

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -796,34 +796,59 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 					moveForwardReq.errChan <- stp.runHandlerWithRecover("moveForwardBlock", func() error {
 						stp.setCurrentRunningState(StateMoveForwardBlock)
 
-						logger.Infof("[SubtreeProcessor][%s] moveForwardBlock subtree processor", moveForwardReq.block.String())
-
-						// create empty map for processed conflicting hashes
-						processedConflictingHashesMap := make(map[chainhash.Hash]struct{})
-
-						// store current state before attempting to move forward the block
+						// Snapshot + defer registration BEFORE any user-input deref (e.g.
+						// the block.String() in the log line below) so that a panic on
+						// nil/malformed input still unwinds via the rollback defer rather
+						// than skipping past it. Cheap pointer loads, ordering matters.
 						originalChainedSubtrees := stp.chainedSubtrees
 						originalCurrentSubtree := stp.currentSubtree.Load()
 						originalCurrentTxMap := stp.currentTxMap
 						currentBlockHeader := stp.currentBlockHeader.Load()
 
-						_, _, mfErr := stp.moveForwardBlock(processorCtx, moveForwardReq.block, false, processedConflictingHashesMap, false, true)
-						if mfErr != nil {
-							// rollback to previous state
+						rollback := func() {
 							stp.chainedSubtrees = originalChainedSubtrees
 							stp.currentSubtree.Store(originalCurrentSubtree)
 							stp.currentTxMap = originalCurrentTxMap
 							stp.currentBlockHeader.Store(currentBlockHeader)
-
-							// recalculate tx count from subtrees
 							stp.setTxCountFromSubtrees()
-						} else {
-							// Finalize block processing
-							// this will also set the current block header
-							stp.finalizeBlockProcessing(processorCtx, moveForwardReq.block)
 						}
 
-						return mfErr
+						// Defer panic-aware rollback so a panic in moveForwardBlock unwinds
+						// the partial state too, not just an error return. Without this,
+						// runHandlerWithRecover surfaces "panicked" to the caller while the
+						// in-memory state stays half-mutated until BA's reset fallback fires.
+						// Finalize-time panics are intentionally NOT rolled back: by then the
+						// block has been applied (chainedSubtrees reflect it), and rewinding
+						// the 4 fields would put them out of sync with the SetBlockProcessedAt
+						// side effect that may have already committed.
+						committed := false
+						defer func() {
+							if r := recover(); r != nil {
+								if !committed {
+									rollback()
+								}
+								panic(r)
+							}
+						}()
+
+						logger.Infof("[SubtreeProcessor][%s] moveForwardBlock subtree processor", moveForwardReq.block.String())
+
+						// create empty map for processed conflicting hashes
+						processedConflictingHashesMap := make(map[chainhash.Hash]struct{})
+
+						_, _, mfErr := stp.moveForwardBlock(processorCtx, moveForwardReq.block, false, processedConflictingHashesMap, false, true)
+						if mfErr != nil {
+							rollback()
+							return mfErr
+						}
+
+						// moveForwardBlock succeeded - past the point where rollback is correct.
+						committed = true
+
+						// Finalize block processing - sets current block header, fires SetBlockProcessedAt, etc.
+						stp.finalizeBlockProcessing(processorCtx, moveForwardReq.block)
+
+						return nil
 					})
 
 					logger.Infof("[SubtreeProcessor][%s] moveForwardBlock subtree processor DONE", moveForwardReq.block.String())
@@ -843,13 +868,22 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 					stp.setCurrentRunningState(StateRunning)
 
 				case removeTxHash := <-stp.removeTxCh:
-					// remove the given transaction from the subtrees
-					if rmErr := stp.runHandlerWithRecover("removeTxFromSubtrees", func() error {
+					// remove the given transaction from the subtrees.
+					// Inline panic recovery (rather than runHandlerWithRecover) because
+					// there is no errChan response - the case body logs failures itself,
+					// and using the shared helper would double-log on panic (helper logs
+					// panic + stack, case body then logs the wrapped error).
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								stp.logger.Errorf("[SubtreeProcessor][removeTxFromSubtrees] panic recovered: %v\n%s", r, debug.Stack())
+							}
+						}()
 						stp.setCurrentRunningState(StateRemoveTx)
-						return stp.removeTxFromSubtrees(processorCtx, removeTxHash)
-					}); rmErr != nil {
-						stp.logger.Errorf("[SubtreeProcessor] error removing tx from subtrees: %s", rmErr.Error())
-					}
+						if err := stp.removeTxFromSubtrees(processorCtx, removeTxHash); err != nil {
+							stp.logger.Errorf("[SubtreeProcessor] error removing tx from subtrees: %s", err.Error())
+						}
+					}()
 
 					stp.setCurrentRunningState(StateRunning)
 
@@ -3091,31 +3125,48 @@ func (stp *SubtreeProcessor) reorgBlocks(ctx context.Context, moveBackBlocks []*
 		originalCurrentTxMap := stp.currentTxMap
 		currentBlockHeader := stp.currentBlockHeader.Load()
 
+		rollback := func() {
+			stp.chainedSubtrees = originalChainedSubtrees
+			stp.currentSubtree.Store(originalCurrentSubtree)
+			stp.currentTxMap = originalCurrentTxMap
+			stp.currentBlockHeader.Store(currentBlockHeader)
+			stp.setTxCountFromSubtrees()
+		}
+
+		// Defer panic-aware rollback so a panic mid-loop unwinds the partial
+		// state too. The inline rollback below only fires on error return;
+		// without this defer a panic would leave chainedSubtrees / currentSubtree
+		// / currentTxMap / currentBlockHeader half-mutated until BA's reset
+		// fallback fires. Re-panic so the dispatcher's runHandlerWithRecover
+		// still surfaces "panicked" to the caller.
+		catchupCommitted := false
+		defer func() {
+			if r := recover(); r != nil {
+				if !catchupCommitted {
+					rollback()
+				}
+				panic(r)
+			}
+		}()
+
 		// Just move forward the blocks and do not go into a full reorg
 		for idx, block := range moveForwardBlocks {
 			// skip dequeue if not the last block
 			skipNotificationsAndDequeue := idx != len(moveForwardBlocks)-1
 
 			if _, _, err = stp.moveForwardBlock(ctx, block, skipNotificationsAndDequeue, processedConflictingHashesMap, skipNotificationsAndDequeue, true); err != nil {
-				// rollback to previous state
-				stp.chainedSubtrees = originalChainedSubtrees
-				stp.currentSubtree.Store(originalCurrentSubtree)
-				stp.currentTxMap = originalCurrentTxMap
-				stp.currentBlockHeader.Store(currentBlockHeader)
-
-				// recalculate tx count from subtrees
-				stp.setTxCountFromSubtrees()
-
+				rollback()
 				return err
-			} else {
-				// Finalize block processing
-				// this will also set the current block header
-				stp.finalizeBlockProcessing(ctx, block)
 			}
+			// Finalize block processing - sets current block header etc. Any
+			// panic from here is past the rollback point: the block has been
+			// applied and SetBlockProcessedAt may have committed.
+			stp.finalizeBlockProcessing(ctx, block)
 
 			stp.currentBlockHeader.Store(block.Header)
 		}
 
+		catchupCommitted = true
 		return nil
 
 	} else {

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"runtime"
+	"runtime/debug"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -782,44 +783,51 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 					stp.setCurrentRunningState(StateRunning)
 
 				case reorgReq := <-stp.reorgBlockChan:
-					stp.setCurrentRunningState(StateReorg)
-					logger.Infof("[SubtreeProcessor] reorgReq subtree processor: %d, %d", len(reorgReq.moveBackBlocks), len(reorgReq.moveForwardBlocks))
+					reorgReq.errChan <- stp.runHandlerWithRecover("reorgBlocks", func() error {
+						stp.setCurrentRunningState(StateReorg)
+						logger.Infof("[SubtreeProcessor] reorgReq subtree processor: %d, %d", len(reorgReq.moveBackBlocks), len(reorgReq.moveForwardBlocks))
 
-					reorgReq.errChan <- stp.reorgBlocks(processorCtx, reorgReq.moveBackBlocks, reorgReq.moveForwardBlocks)
+						reorgErr := stp.reorgBlocks(processorCtx, reorgReq.moveBackBlocks, reorgReq.moveForwardBlocks)
 
-					logger.Infof("[SubtreeProcessor] reorgReq subtree processor DONE: %d, %d", len(reorgReq.moveBackBlocks), len(reorgReq.moveForwardBlocks))
+						logger.Infof("[SubtreeProcessor] reorgReq subtree processor DONE: %d, %d", len(reorgReq.moveBackBlocks), len(reorgReq.moveForwardBlocks))
+						return reorgErr
+					})
+
 					stp.setCurrentRunningState(StateRunning)
 
 				case moveForwardReq := <-stp.moveForwardBlockChan:
-					stp.setCurrentRunningState(StateMoveForwardBlock)
+					moveForwardReq.errChan <- stp.runHandlerWithRecover("moveForwardBlock", func() error {
+						stp.setCurrentRunningState(StateMoveForwardBlock)
 
-					logger.Infof("[SubtreeProcessor][%s] moveForwardBlock subtree processor", moveForwardReq.block.String())
+						logger.Infof("[SubtreeProcessor][%s] moveForwardBlock subtree processor", moveForwardReq.block.String())
 
-					// create empty map for processed conflicting hashes
-					processedConflictingHashesMap := make(map[chainhash.Hash]struct{})
+						// create empty map for processed conflicting hashes
+						processedConflictingHashesMap := make(map[chainhash.Hash]struct{})
 
-					// store current state before attempting to move forward the block
-					originalChainedSubtrees := stp.chainedSubtrees
-					originalCurrentSubtree := stp.currentSubtree.Load()
-					originalCurrentTxMap := stp.currentTxMap
-					currentBlockHeader := stp.currentBlockHeader.Load()
+						// store current state before attempting to move forward the block
+						originalChainedSubtrees := stp.chainedSubtrees
+						originalCurrentSubtree := stp.currentSubtree.Load()
+						originalCurrentTxMap := stp.currentTxMap
+						currentBlockHeader := stp.currentBlockHeader.Load()
 
-					if _, _, err = stp.moveForwardBlock(processorCtx, moveForwardReq.block, false, processedConflictingHashesMap, false, true); err != nil {
-						// rollback to previous state
-						stp.chainedSubtrees = originalChainedSubtrees
-						stp.currentSubtree.Store(originalCurrentSubtree)
-						stp.currentTxMap = originalCurrentTxMap
-						stp.currentBlockHeader.Store(currentBlockHeader)
+						_, _, mfErr := stp.moveForwardBlock(processorCtx, moveForwardReq.block, false, processedConflictingHashesMap, false, true)
+						if mfErr != nil {
+							// rollback to previous state
+							stp.chainedSubtrees = originalChainedSubtrees
+							stp.currentSubtree.Store(originalCurrentSubtree)
+							stp.currentTxMap = originalCurrentTxMap
+							stp.currentBlockHeader.Store(currentBlockHeader)
 
-						// recalculate tx count from subtrees
-						stp.setTxCountFromSubtrees()
-					} else {
-						// Finalize block processing
-						// this will also set the current block header
-						stp.finalizeBlockProcessing(processorCtx, moveForwardReq.block)
-					}
+							// recalculate tx count from subtrees
+							stp.setTxCountFromSubtrees()
+						} else {
+							// Finalize block processing
+							// this will also set the current block header
+							stp.finalizeBlockProcessing(processorCtx, moveForwardReq.block)
+						}
 
-					moveForwardReq.errChan <- err
+						return mfErr
+					})
 
 					logger.Infof("[SubtreeProcessor][%s] moveForwardBlock subtree processor DONE", moveForwardReq.block.String())
 					stp.setCurrentRunningState(StateRunning)
@@ -2936,6 +2944,41 @@ func (stp *SubtreeProcessor) updatePrecomputedMiningData() {
 		Subtrees:       subtreesCopy,
 		UpdatedAt:      time.Now(),
 	})
+}
+
+// runHandlerWithRecover invokes the supplied handler and converts any
+// panic into an error. The dispatcher loop uses this around handlers
+// whose callers wait on a response channel - reorgBlocks and
+// moveForwardBlock are the production-critical ones - so a panic in
+// consensus-critical code surfaces to the in-flight Reorg/MoveForward
+// caller as an actionable error rather than leaving them blocked on
+// errChan forever.
+//
+// Before this helper, a panic in reorgBlocks was caught by the
+// goroutine-level recover at the dispatcher's top (which only logs and
+// exits), so:
+//
+//   - The processor goroutine died, signalling stopped=true.
+//   - The errChan send never happened, so the caller of Reorg() blocked
+//     forever on <-errChan.
+//   - The next BlockAssembler.handleReorg call would also try to send on
+//     reorgBlockChan, which now has no reader, blocking forever too.
+//
+// A peer-controllable panic during reorg processing (deep reorgs touch
+// a lot of code) would therefore wedge BlockAssembly's reorg pipeline.
+// This helper catches the panic at the handler boundary so the response
+// channel always gets a value, and the dispatcher keeps running.
+//
+// The recovered panic is logged with a stack trace; operators who see
+// repeated panics for the same input have a clear escalation signal.
+func (stp *SubtreeProcessor) runHandlerWithRecover(name string, fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			stp.logger.Errorf("[SubtreeProcessor][%s] panic recovered: %v\n%s", name, r, debug.Stack())
+			err = errors.NewProcessingError("[SubtreeProcessor][%s] panicked: %v", name, r)
+		}
+	}()
+	return fn()
 }
 
 // MoveForwardBlock updates the subtrees when a new block is found.

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -452,9 +452,7 @@ func TestReChainSubtrees(t *testing.T) {
 	assert.Equal(t, uint64(21), stp.chainedSubtrees[5].Nodes[2].Fee)
 
 	// Check state using internal method (since Start() is not running)
-	errCh := make(chan error, 1)
-	stp.checkSubtreeProcessor(errCh)
-	require.NoError(t, <-errCh)
+	require.NoError(t, stp.checkSubtreeProcessor())
 
 	node := stp.chainedSubtrees[5].Nodes[2]
 
@@ -488,9 +486,7 @@ func TestReChainSubtrees(t *testing.T) {
 	}
 
 	// Check state using internal method (since Start() is not running)
-	errCh2 := make(chan error, 1)
-	stp.checkSubtreeProcessor(errCh2)
-	require.NoError(t, <-errCh2)
+	require.NoError(t, stp.checkSubtreeProcessor())
 }
 
 func TestGetMerkleProofForCoinbase(t *testing.T) {

--- a/services/blockassembly/subtreeprocessor/handler_panic_test.go
+++ b/services/blockassembly/subtreeprocessor/handler_panic_test.go
@@ -19,10 +19,13 @@ import (
 // reorgBlockChan (no reader). A peer-controllable panic in reorg
 // processing would therefore wedge BlockAssembly's reorg pipeline.
 //
-// We trigger a deterministic panic by passing a nil *model.Block in
-// moveForwardBlocks with empty moveBackBlocks: this hits the catch-up
-// fast path which calls moveForwardBlocks[len-1].Hash() at
-// SubtreeProcessor.go:3038, where Hash() on nil dereferences.
+// We trigger a panic by passing a nil *model.Block in moveForwardBlocks
+// with empty moveBackBlocks: this reaches the catch-up fast path which
+// dereferences moveForwardBlocks[len-1].Hash() (SubtreeProcessor.go).
+// The contract this test pins is "caller gets an error, does not hang" -
+// it does NOT assert the error string contains "panicked", because a
+// future defensive nil-check on this code path would return a regular
+// error and would still satisfy the contract.
 func TestReorg_PanicSurfacesAsError(t *testing.T) {
 	stp := setupTestSubtreeProcessor(t)
 
@@ -37,11 +40,8 @@ func TestReorg_PanicSurfacesAsError(t *testing.T) {
 	select {
 	case err := <-done:
 		require.Error(t, err,
-			"Reorg must return an error when reorgBlocks panics, not nil; "+
-				"otherwise the caller has no way to know the work failed")
-		require.Contains(t, err.Error(), "panicked",
-			"the surfaced error should explicitly identify a panic so operators "+
-				"can recognise the dispatcher's panic-recovery path fired")
+			"Reorg must return an error rather than nil when handed an input "+
+				"that triggers a panic or hits a defensive early-return")
 	case <-time.After(5 * time.Second):
 		t.Fatal("Reorg hung waiting on errChan - panic in handler did not unblock the caller. " +
 			"This is the pre-fix behaviour: dispatcher's goroutine-level recover exits without " +
@@ -52,22 +52,25 @@ func TestReorg_PanicSurfacesAsError(t *testing.T) {
 // TestMoveForwardBlock_PanicSurfacesAsError pins the same contract on
 // the MoveForwardBlock dispatcher case, which shares the
 // runHandlerWithRecover protection with the reorgBlocks case.
+//
+// As with TestReorg_PanicSurfacesAsError, the contract is "caller gets
+// an error, does not hang"; the test does not assert "panicked" in the
+// message so a future defensive nil-check stays compatible.
 func TestMoveForwardBlock_PanicSurfacesAsError(t *testing.T) {
 	stp := setupTestSubtreeProcessor(t)
 
 	done := make(chan error, 1)
 	go func() {
 		// Passing a nil block triggers a nil-deref inside the
-		// moveForwardBlock handler when it dereferences block.Hash() or
-		// similar methods on the input.
+		// dispatcher's moveForward case (logger.Infof with block.String()).
 		done <- stp.MoveForwardBlock(nil)
 	}()
 
 	select {
 	case err := <-done:
 		require.Error(t, err,
-			"MoveForwardBlock must return an error when its handler panics")
-		require.Contains(t, err.Error(), "panicked")
+			"MoveForwardBlock must return an error rather than nil when handed "+
+				"an input that triggers a panic or hits a defensive early-return")
 	case <-time.After(5 * time.Second):
 		t.Fatal("MoveForwardBlock hung waiting on errChan after handler panic")
 	}

--- a/services/blockassembly/subtreeprocessor/handler_panic_test.go
+++ b/services/blockassembly/subtreeprocessor/handler_panic_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/stretchr/testify/require"
 )
@@ -68,5 +70,83 @@ func TestMoveForwardBlock_PanicSurfacesAsError(t *testing.T) {
 		require.Contains(t, err.Error(), "panicked")
 	case <-time.After(5 * time.Second):
 		t.Fatal("MoveForwardBlock hung waiting on errChan after handler panic")
+	}
+}
+
+// TestReset_PanicSurfacesAsError pins the same contract on the reset
+// dispatcher case. A panicking postProcess callback (a caller-supplied
+// hook invoked from inside reset()) must not wedge the responseCh —
+// the dispatcher must catch the panic and report it back via
+// ResetResponse.Err so BlockAssembler.reset() can log and continue.
+func TestReset_PanicSurfacesAsError(t *testing.T) {
+	stp := setupTestSubtreeProcessor(t)
+
+	done := make(chan ResetResponse, 1)
+	go func() {
+		done <- stp.Reset(model.GenesisBlockHeader, nil, nil, false, func() error {
+			panic("simulated panic in postProcess")
+		})
+	}()
+
+	select {
+	case resp := <-done:
+		require.Error(t, resp.Err,
+			"Reset must return an error when reset()/postProcess panics, not nil")
+		require.Contains(t, resp.Err.Error(), "panicked",
+			"the surfaced error should identify a panic so operators can spot the recovery path firing")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Reset hung waiting on responseCh after handler panic")
+	}
+}
+
+// TestCheckSubtreeProcessor_NoWedgeOnInconsistency pins that
+// checkSubtreeProcessor returns the first inconsistency as a normal
+// error without wedging the dispatcher. Pre-fix, the helper sent
+// each detected error on the unbuffered response channel and then
+// also sent nil at the end; the caller only reads one value, so any
+// inconsistency wedged the dispatcher goroutine on the second send
+// and every subsequent reorg/moveForward/reset call hung.
+//
+// We seed currentSubtree with a non-coinbase node that is NOT in
+// currentTxMap. checkSubtreeProcessor must surface that as the
+// returned error AND the dispatcher must still respond to a
+// follow-up call within the timeout.
+func TestCheckSubtreeProcessor_NoWedgeOnInconsistency(t *testing.T) {
+	stp := setupTestSubtreeProcessor(t)
+
+	bogus := chainhash.HashH([]byte("not-in-tx-map"))
+	cur := stp.currentSubtree.Load()
+	require.NoError(t, cur.AddNode(bogus, 1, 0))
+	stp.currentSubtree.Store(cur)
+	// Do NOT register `bogus` in currentTxMap — that is the inconsistency.
+
+	first := make(chan error, 1)
+	go func() { first <- stp.CheckSubtreeProcessor() }()
+
+	select {
+	case err := <-first:
+		require.Error(t, err,
+			"CheckSubtreeProcessor must report the inconsistency")
+		require.Contains(t, err.Error(), "currentSubtree not in currentTxMap")
+	case <-time.After(5 * time.Second):
+		t.Fatal("CheckSubtreeProcessor hung — dispatcher wedged on the response channel")
+	}
+
+	// Heal the state, then call again. The dispatcher must still be
+	// responsive: a second call returns within the timeout, which the
+	// pre-fix multi-send path could not satisfy because the dispatcher
+	// was stuck on the unread errCh from the first call.
+	stp.currentTxMap.Set(bogus, &subtreepkg.TxInpoints{})
+
+	second := make(chan error, 1)
+	go func() { second <- stp.CheckSubtreeProcessor() }()
+
+	select {
+	case err := <-second:
+		// May still report the txmap-vs-txcount tally error; what
+		// matters is that the call RETURNS rather than hanging.
+		_ = err
+	case <-time.After(5 * time.Second):
+		t.Fatal("Second CheckSubtreeProcessor hung — dispatcher did not recover")
 	}
 }

--- a/services/blockassembly/subtreeprocessor/handler_panic_test.go
+++ b/services/blockassembly/subtreeprocessor/handler_panic_test.go
@@ -1,0 +1,72 @@
+package subtreeprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReorg_PanicSurfacesAsError pins that a panic inside reorgBlocks
+// returns an error to the Reorg() caller rather than leaving them
+// blocked forever on errChan. Pre-fix, the goroutine-level recover at
+// the dispatcher (SubtreeProcessor.go ~626) only logged the panic and
+// exited the processor goroutine; the in-flight Reorg() call hung on
+// <-errChan, and the next Reorg() also blocked sending on
+// reorgBlockChan (no reader). A peer-controllable panic in reorg
+// processing would therefore wedge BlockAssembly's reorg pipeline.
+//
+// We trigger a deterministic panic by passing a nil *model.Block in
+// moveForwardBlocks with empty moveBackBlocks: this hits the catch-up
+// fast path which calls moveForwardBlocks[len-1].Hash() at
+// SubtreeProcessor.go:3038, where Hash() on nil dereferences.
+func TestReorg_PanicSurfacesAsError(t *testing.T) {
+	stp := setupTestSubtreeProcessor(t)
+
+	moveForwardBlocks := []*model.Block{nil}
+	moveBackBlocks := []*model.Block{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- stp.Reorg(moveBackBlocks, moveForwardBlocks)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err,
+			"Reorg must return an error when reorgBlocks panics, not nil; "+
+				"otherwise the caller has no way to know the work failed")
+		require.Contains(t, err.Error(), "panicked",
+			"the surfaced error should explicitly identify a panic so operators "+
+				"can recognise the dispatcher's panic-recovery path fired")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Reorg hung waiting on errChan - panic in handler did not unblock the caller. " +
+			"This is the pre-fix behaviour: dispatcher's goroutine-level recover exits without " +
+			"sending anything to the request's errChan.")
+	}
+}
+
+// TestMoveForwardBlock_PanicSurfacesAsError pins the same contract on
+// the MoveForwardBlock dispatcher case, which shares the
+// runHandlerWithRecover protection with the reorgBlocks case.
+func TestMoveForwardBlock_PanicSurfacesAsError(t *testing.T) {
+	stp := setupTestSubtreeProcessor(t)
+
+	done := make(chan error, 1)
+	go func() {
+		// Passing a nil block triggers a nil-deref inside the
+		// moveForwardBlock handler when it dereferences block.Hash() or
+		// similar methods on the input.
+		done <- stp.MoveForwardBlock(nil)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err,
+			"MoveForwardBlock must return an error when its handler panics")
+		require.Contains(t, err.Error(), "panicked")
+	case <-time.After(5 * time.Second):
+		t.Fatal("MoveForwardBlock hung waiting on errChan after handler panic")
+	}
+}


### PR DESCRIPTION
## Summary

The SubtreeProcessor dispatcher goroutine services `reorgBlockChan` and `moveForwardBlockChan` with request/response pairs: callers of `Reorg()` / `MoveForwardBlock()` send a request struct carrying an unbuffered `errChan`, then block on `<-errChan` waiting for the result.

The dispatcher's only panic recovery was the goroutine-level recover at the top (`SubtreeProcessor.go:624-629`), which **by design just logs the panic and exits** so `Stop()` does not hang. That's correct for shutdown-time panics (send on closed channel), but for a handler-side panic during normal operation it leaves the in-flight request stuck:

1. `reorgBlocks` / `moveForwardBlock` panics partway through
2. The dispatcher goroutine's deferred recover fires, logs, sets `stopped=true`, exits
3. The `errChan` send never happens, so `Reorg()`/`MoveForwardBlock()` block forever on `<-errChan`
4. Subsequent `Reorg()` calls block on the **send** to `reorgBlockChan` (no reader)

A peer-controllable panic in reorg processing - depth-related, conflict handling, subtree-pointer-chain edge cases - would therefore wedge BlockAssembly's entire reorg pipeline.

## Fix

Introduce `runHandlerWithRecover` that wraps the per-case handler body, catches panics with a stack-trace log, and returns the panic as a `ProcessingError`. The dispatcher uses this around the `reorgBlocks`, `moveForwardBlock`, `reset`, `removeTxFromSubtrees`, and `checkSubtreeProcessor` handler bodies, so the response channel (or the operator log, for removeTx which has no response channel) always gets a value. The dispatcher **keeps running** on a recovered panic, so subsequent requests still get answered; the operator's recurring-panic signal is now structured error logs with stack traces rather than a silent wedge.

The second commit also fixes a separate multi-send wedge in `checkSubtreeProcessor`: pre-fix the helper wrote zero, one, or many errors to an unbuffered `errCh` and then a final `nil`. The caller (the gRPC `CheckBlockAssembly` handler) reads exactly one value, so any state with two or more inconsistencies wedged the dispatcher on the second send. Refactored to return a single error - first inconsistency wins, or nil if everything matches - and the dispatcher relays it.

## Regression tests

`handler_panic_test.go`:

- **TestReorg_PanicSurfacesAsError** - triggers a nil-deref by passing `[]*Block{nil}` as `moveForwardBlocks` (hits the catch-up fast path where `moveForwardBlocks[len-1].Hash()` dereferences). Pre-fix the test hangs 5 s on `errChan`; post-fix it returns a `"panicked"` error.
- **TestMoveForwardBlock_PanicSurfacesAsError** - same shape, hits the dispatcher's moveForward case where the leading `logger.Infof(...block.String())` dereferences nil.
- **TestReset_PanicSurfacesAsError** - passes a `postProcess` callback that panics; the dispatcher must surface the panic via `ResetResponse.Err`.
- **TestCheckSubtreeProcessor_NoWedgeOnInconsistency** - seeds an inconsistent state (a tx in `currentSubtree` that is not in `currentTxMap`), asserts the call returns the error AND a follow-up call still completes (would hang pre-fix on the second errCh send).

**All A/B-verified**: tests fail with timeouts on the unpatched code, pass after the fix.

## Out of scope

State restoration on a finalize-time panic is best-effort. The existing rollback only fires when `moveForwardBlock` returns a regular error; a panic in `finalizeBlockProcessing` would leave in-memory state potentially half-mutated. **The pre-fix behaviour was the same** (goroutine died, state left as-is); this PR strictly improves on it by also notifying the caller. Full transactional finalize is a separate concern.

A separate shutdown wedge still exists: callers of `Reorg`/`MoveForwardBlock`/`Reset` that arrive after the dispatcher has exited (clean shutdown, ctx cancellation) block forever on the unbuffered request-channel send because the function signatures take no `context.Context`. Worth a follow-up but a bigger surgical change (signature + every call site).

## Test plan

- [x] `go build ./services/blockassembly/subtreeprocessor/` clean
- [x] `go vet ./services/blockassembly/...` clean
- [x] `staticcheck ./services/blockassembly/subtreeprocessor/` clean
- [x] Full subtreeprocessor package passes with `-race` (165 s)
- [x] Parent `services/blockassembly` test pass (88 s)
- [x] A/B: all four new tests time out without the production fix