### PR TITLE
fix(blockassembly/subtreeprocessor): make entry points abort instead of hanging when dispatcher is stopped

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -620,9 +620,18 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 		stp.setCurrentRunningState(StateRunning)
 
 		go func() {
-			// Recover from panics (e.g., send on closed channel during shutdown)
+			// Recover from panics (e.g., send on closed channel during shutdown).
+			// Cancel the lifecycle context on EVERY exit path - clean ctx-done,
+			// panic recovery, fall-through - so callers blocked on
+			// processorContext().Done() (the entry-point shutdown-wedge guards
+			// below) unblock fast. Without the cancel, a panicked exit left
+			// stopped=true but processorContext() still live, so subsequent
+			// Reorg/MoveForwardBlock/Reset/CheckSubtreeProcessor calls would
+			// block forever on the request send despite the dispatcher being
+			// dead. cancel() is idempotent with the one in Stop().
 			defer func() {
 				stp.stopped.Store(true) // Must be set on any exit so Stop() does not hang
+				cancel()
 				if r := recover(); r != nil {
 					logger.Warnf("[SubtreeProcessor] goroutine recovered from panic: %v", r)
 				}
@@ -2804,6 +2813,14 @@ func (stp *SubtreeProcessor) reChainSubtrees(fromIndex int) error {
 func (stp *SubtreeProcessor) CheckSubtreeProcessor() error {
 	ctx := stp.processorContext()
 
+	// NOTE: cap-1 here makes the response-receive side ctx-cancellable, but it
+	// does NOT eliminate the dispatcher-side wedge that exists pre-#1110: the
+	// dispatcher's checkSubtreeProcessor handler can send multiple values on
+	// errCh (one per detected inconsistency, plus a final nil), and only the
+	// first send completes - any second send blocks because the caller has
+	// read once and returned. PR #1110 refactors checkSubtreeProcessor to
+	// return a single error so the dispatcher relays exactly one value;
+	// once that lands, the cap-1 buffer is sufficient.
 	errCh := make(chan error, 1)
 
 	select {

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1191,8 +1191,10 @@ func (stp *SubtreeProcessor) GetCurrentLength() int {
 // Returns:
 //   - ResetResponse: Response containing any errors encountered
 func (stp *SubtreeProcessor) Reset(blockHeader *model.BlockHeader, moveBackBlocks []*model.Block, moveForwardBlocks []*model.Block, useFastForwardReset bool, postProcess func() error) ResetResponse {
-	responseCh := make(chan ResetResponse)
-	stp.resetCh <- &resetBlocks{
+	ctx := stp.processorContext()
+
+	responseCh := make(chan ResetResponse, 1)
+	req := &resetBlocks{
 		blockHeader:         blockHeader,
 		moveBackBlocks:      moveBackBlocks,
 		moveForwardBlocks:   moveForwardBlocks,
@@ -1201,7 +1203,18 @@ func (stp *SubtreeProcessor) Reset(blockHeader *model.BlockHeader, moveBackBlock
 		postProcess:         postProcess,
 	}
 
-	return <-responseCh
+	select {
+	case stp.resetCh <- req:
+	case <-ctx.Done():
+		return ResetResponse{Err: errors.NewProcessingError("[SubtreeProcessor] Reset aborted: processor stopped before request delivered", ctx.Err())}
+	}
+
+	select {
+	case resp := <-responseCh:
+		return resp
+	case <-ctx.Done():
+		return ResetResponse{Err: errors.NewProcessingError("[SubtreeProcessor] Reset aborted: processor stopped while waiting for response", ctx.Err())}
+	}
 }
 
 func (stp *SubtreeProcessor) reset(blockHeader *model.BlockHeader, moveBackBlocks []*model.Block, moveForwardBlocks []*model.Block,
@@ -2789,11 +2802,22 @@ func (stp *SubtreeProcessor) reChainSubtrees(fromIndex int) error {
 // Returns:
 //   - error: Any error encountered during the check
 func (stp *SubtreeProcessor) CheckSubtreeProcessor() error {
-	errCh := make(chan error)
+	ctx := stp.processorContext()
 
-	stp.checkSubtreeProcessorCh <- errCh
+	errCh := make(chan error, 1)
 
-	return <-errCh
+	select {
+	case stp.checkSubtreeProcessorCh <- errCh:
+	case <-ctx.Done():
+		return errors.NewProcessingError("[SubtreeProcessor] CheckSubtreeProcessor aborted: processor stopped before request delivered", ctx.Err())
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return errors.NewProcessingError("[SubtreeProcessor] CheckSubtreeProcessor aborted: processor stopped while waiting for response", ctx.Err())
+	}
 }
 
 // checkSubtreeProcessor performs a check on the subtree processor's state.
@@ -2946,14 +2970,26 @@ func (stp *SubtreeProcessor) updatePrecomputedMiningData() {
 // Returns:
 //   - error: Any error encountered during processing
 func (stp *SubtreeProcessor) MoveForwardBlock(block *model.Block) error {
-	errChan := make(chan error)
+	ctx := stp.processorContext()
 
-	stp.moveForwardBlockChan <- moveBlockRequest{
+	errChan := make(chan error, 1)
+	req := moveBlockRequest{
 		block:   block,
 		errChan: errChan,
 	}
 
-	return <-errChan
+	select {
+	case stp.moveForwardBlockChan <- req:
+	case <-ctx.Done():
+		return errors.NewProcessingError("[SubtreeProcessor] MoveForwardBlock aborted: processor stopped before request delivered", ctx.Err())
+	}
+
+	select {
+	case err := <-errChan:
+		return err
+	case <-ctx.Done():
+		return errors.NewProcessingError("[SubtreeProcessor] MoveForwardBlock aborted: processor stopped while waiting for response", ctx.Err())
+	}
 }
 
 // Reorg handles blockchain reorganization by processing moved blocks.
@@ -2965,14 +3001,27 @@ func (stp *SubtreeProcessor) MoveForwardBlock(block *model.Block) error {
 // Returns:
 //   - error: Any error encountered during reorganization
 func (stp *SubtreeProcessor) Reorg(moveBackBlocks []*model.Block, moveForwardBlocks []*model.Block) error {
-	errChan := make(chan error)
-	stp.reorgBlockChan <- reorgBlocksRequest{
+	ctx := stp.processorContext()
+
+	errChan := make(chan error, 1)
+	req := reorgBlocksRequest{
 		moveBackBlocks:    moveBackBlocks,
 		moveForwardBlocks: moveForwardBlocks,
 		errChan:           errChan,
 	}
 
-	return <-errChan
+	select {
+	case stp.reorgBlockChan <- req:
+	case <-ctx.Done():
+		return errors.NewProcessingError("[SubtreeProcessor] Reorg aborted: processor stopped before request delivered", ctx.Err())
+	}
+
+	select {
+	case err := <-errChan:
+		return err
+	case <-ctx.Done():
+		return errors.NewProcessingError("[SubtreeProcessor] Reorg aborted: processor stopped while waiting for response", ctx.Err())
+	}
 }
 
 // reorgBlocks performs an incremental blockchain reorganization by processing blocks efficiently.

--- a/services/blockassembly/subtreeprocessor/shutdown_wedge_test.go
+++ b/services/blockassembly/subtreeprocessor/shutdown_wedge_test.go
@@ -1,0 +1,95 @@
+package subtreeprocessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/stretchr/testify/require"
+)
+
+// The four public entry points - Reorg, MoveForwardBlock, Reset,
+// CheckSubtreeProcessor - hand work to the dispatcher goroutine via an
+// unbuffered request channel and then block on an unbuffered response
+// channel. Pre-fix, neither side was ctx-aware: callers who arrived
+// after the dispatcher exited (clean shutdown, ctx cancellation, panic
+// caught by the goroutine-level recover) blocked forever on the send.
+// Callers who arrived during the work but whose response was lost
+// (dispatcher dying mid-handler) blocked forever on the receive.
+//
+// The fix selects processorContext().Done() against both halves so a
+// stopped processor returns an actionable error in O(ms) instead of
+// hanging the caller indefinitely.
+//
+// These tests pin the contract by Stop()ping the processor first, then
+// calling each entry point and asserting it returns an error within a
+// short timeout. Pre-fix the goroutine-style timeout would fire and the
+// helper would t.Fatal. Post-fix the entry point returns "processor
+// stopped" and the test passes.
+
+func TestShutdown_Reorg_DoesNotHang(t *testing.T) {
+	stp := newStoppedSubtreeProcessor(t)
+
+	done := make(chan error, 1)
+	go func() { done <- stp.Reorg(nil, nil) }()
+
+	requireErrorBeforeTimeout(t, done, "Reorg")
+}
+
+func TestShutdown_MoveForwardBlock_DoesNotHang(t *testing.T) {
+	stp := newStoppedSubtreeProcessor(t)
+
+	done := make(chan error, 1)
+	go func() { done <- stp.MoveForwardBlock(&model.Block{Header: model.GenesisBlockHeader}) }()
+
+	requireErrorBeforeTimeout(t, done, "MoveForwardBlock")
+}
+
+func TestShutdown_Reset_DoesNotHang(t *testing.T) {
+	stp := newStoppedSubtreeProcessor(t)
+
+	done := make(chan ResetResponse, 1)
+	go func() { done <- stp.Reset(model.GenesisBlockHeader, nil, nil, false, nil) }()
+
+	select {
+	case resp := <-done:
+		require.Error(t, resp.Err,
+			"Reset must return an error when called against a stopped processor, not hang on the response channel")
+		require.Contains(t, resp.Err.Error(), "processor stopped")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reset hung after Stop(); the unbuffered request-channel send blocks forever pre-fix")
+	}
+}
+
+func TestShutdown_CheckSubtreeProcessor_DoesNotHang(t *testing.T) {
+	stp := newStoppedSubtreeProcessor(t)
+
+	done := make(chan error, 1)
+	go func() { done <- stp.CheckSubtreeProcessor() }()
+
+	requireErrorBeforeTimeout(t, done, "CheckSubtreeProcessor")
+}
+
+// newStoppedSubtreeProcessor returns a SubtreeProcessor with its dispatcher
+// goroutine torn down. setupTestSubtreeProcessor already registers a Cleanup
+// hook that calls Stop again, which is safe via stopOnce.
+func newStoppedSubtreeProcessor(t *testing.T) *SubtreeProcessor {
+	t.Helper()
+	stp := setupTestSubtreeProcessor(t)
+	stp.Stop(context.Background())
+	return stp
+}
+
+func requireErrorBeforeTimeout(t *testing.T, done <-chan error, label string) {
+	t.Helper()
+	select {
+	case err := <-done:
+		require.Error(t, err,
+			"%s must return an error when called against a stopped processor", label)
+		require.Contains(t, err.Error(), "processor stopped",
+			"the surfaced error should identify the shutdown path so operators can spot it in logs")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s hung after Stop(); the unbuffered channel patterns block forever pre-fix", label)
+	}
+}

--- a/services/blockassembly/subtreeprocessor/shutdown_wedge_test.go
+++ b/services/blockassembly/subtreeprocessor/shutdown_wedge_test.go
@@ -71,6 +71,44 @@ func TestShutdown_CheckSubtreeProcessor_DoesNotHang(t *testing.T) {
 	requireErrorBeforeTimeout(t, done, "CheckSubtreeProcessor")
 }
 
+// TestShutdown_PanicExit_DoesNotHang pins the contract for the harder
+// exit path: the dispatcher is killed by a recovered panic, NOT by
+// Stop(). Pre-fix this branch left processorContext() live (only Stop's
+// cancel() closed it), so entry-point callers selecting on
+// processorContext().Done() would still block forever on the request
+// send despite the dispatcher being dead. The Major-item fix cancels
+// the context in the dispatcher's deferred recover so any exit path -
+// clean ctx-done, fall-through, panic recovery - releases blocked
+// callers.
+//
+// The panic is induced by closing the response channel of a lengthCh
+// request before the dispatcher consumes it. The dispatcher's
+// `lengthCh <- stp.currentSubtree.Load().Length()` send on a closed
+// channel panics; the goroutine-level recover at the top of Start
+// catches it.
+func TestShutdown_PanicExit_DoesNotHang(t *testing.T) {
+	stp := setupTestSubtreeProcessor(t)
+
+	// Inject a panic into the dispatcher's lengthCh handler: close the
+	// response channel before the dispatcher writes to it. The dispatcher
+	// runs `lengthCh <- ...` which panics on send-to-closed-channel.
+	poisoned := make(chan int)
+	close(poisoned)
+	stp.lengthCh <- poisoned
+
+	// Wait for the goroutine-level recover to fire and set stopped=true.
+	// Bounded poll, not a sleep loop - tests under load may take longer
+	// than a single sleep would tolerate.
+	require.Eventually(t, stp.stopped.Load, 2*time.Second, 10*time.Millisecond,
+		"dispatcher did not exit within 2 s after the induced panic; the goroutine-level recover may not have fired")
+
+	// Confirm the entry-point caller now unblocks on processorContext().Done()
+	// even though Stop() was never called.
+	done := make(chan error, 1)
+	go func() { done <- stp.Reorg(nil, nil) }()
+	requireErrorBeforeTimeout(t, done, "Reorg-after-panic-exit")
+}
+
 // newStoppedSubtreeProcessor returns a SubtreeProcessor with its dispatcher
 // goroutine torn down. setupTestSubtreeProcessor already registers a Cleanup
 // hook that calls Stop again, which is safe via stopOnce.


### PR DESCRIPTION
## Summary

Follow-up to #1110. The four public SubtreeProcessor entry points - \`Reorg\`, \`MoveForwardBlock\`, \`Reset\`, \`CheckSubtreeProcessor\` - hand work to the dispatcher goroutine via an unbuffered request channel and then block on an unbuffered response channel. Neither side was ctx-aware: callers who arrived after the dispatcher exited (clean shutdown, ctx cancellation, panic caught by the goroutine-level recover) blocked forever on the send. Callers who arrived during the work but whose response was lost (dispatcher dying mid-handler) blocked forever on the receive.

## Symptoms

- BlockAssembler's announcement-handler goroutine (which calls \`Reorg\`/\`MoveForwardBlock\` from \`processNewBlockAnnouncement\`) gets stuck on the next chain notification after shutdown begins, preventing graceful exit. The service stays \"draining\" indefinitely until the process is killed.
- \`ResetWithInputValidation\`'s wrapper goroutine (which fires the resetCh path) accumulates as a goroutine leak across repeated reset attempts against a dead dispatcher.

## Fix

Select \`processorContext().Done()\` against both halves of every entry point so a stopped processor returns an actionable error in O(ms):

\`\`\`go
select {
case stp.reorgBlockChan <- req:
case <-ctx.Done():
    return errors.NewProcessingError(\"[SubtreeProcessor] Reorg aborted: processor stopped before request delivered\", ctx.Err())
}
\`\`\`

\`processorContext()\` falls back to \`context.Background()\` pre-Start, preserving the historical blocking-send behaviour for AddDirectly-style seeding before the dispatcher starts (the existing test surface depends on this).

Response channels are also bumped to cap 1 so the dispatcher's send always completes without blocking, even if the caller gave up on the ctx-abort path between the request send and the response receive. Without this the dispatcher could wedge on the response send to an abandoned channel and stall the next iteration.

## Regression tests

\`shutdown_wedge_test.go\`:

- \`TestShutdown_Reorg_DoesNotHang\`
- \`TestShutdown_MoveForwardBlock_DoesNotHang\`
- \`TestShutdown_Reset_DoesNotHang\`
- \`TestShutdown_CheckSubtreeProcessor_DoesNotHang\`

Each Stop()s the processor, then calls the entry point, then asserts an error returns within 2 s. **A/B-verified**: pre-fix the Reorg test fails with \"Reorg hung after Stop()\" at the 2 s timeout, post-fix it returns \"processor stopped\" within ~20 ms.

## Out of scope

- The dispatcher's per-handler panic protection lives in #1110.
- A panic mid-handler still leaves in-memory state partially mutated; the deferred rollbacks in \`reorgBlocks\` and \`moveForwardBlock\` only run on error return, not on panic. Documented gap; the BA-side reset fallback handles the divergence within one reconcile cycle.

## Test plan

- [x] \`go build ./services/blockassembly/subtreeprocessor/\` clean
- [x] \`go vet ./services/blockassembly/subtreeprocessor/\` clean
- [x] Full subtreeprocessor package with \`-race\`: 162 s, all PASS
- [x] Parent \`services/blockassembly\` package: 88 s, all PASS
- [x] A/B verification on TestShutdown_Reorg_DoesNotHang (pre-fix fails, post-fix passes)