### PR TITLE
fix(subtreevalidation): treat already-exists subtreeToCheck store as benign

### DIFF
--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -355,8 +355,8 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to serialize subtree", subtreeHash.String(), err)
 					}
 
-					// Store the subtreeToCheck for later processing
-					// we not set a DAH as this is part of a block and will be permanently stored anyway
+					// Store the subtreeToCheck marker for later processing, with a DAH of
+					// current block height + subtree-validation retention (set above).
 					if err = u.subtreeStore.Set(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes, options.WithDeleteAt(dah)); err != nil {
 						// ErrBlobAlreadyExists is benign: the subtree filename is its content
 						// hash (verified above), so an existing file holds identical bytes. This
@@ -365,9 +365,9 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 						// addressed write must not fail the block. Mirrors the same handling for
 						// FileTypeSubtree/FileTypeSubtreeMeta in ValidateSubtreeInternal.
 						if errors.Is(err, errors.ErrBlobAlreadyExists) {
-							u.logger.Warnf("[CheckBlockSubtrees][%s] subtree already exists in store", subtreeHash.String())
+							u.logger.Warnf("[CheckBlockSubtrees][%s] subtreeToCheck already exists in store", subtreeHash.String())
 						} else {
-							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to store subtree", subtreeHash.String(), err)
+							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to store subtreeToCheck", subtreeHash.String(), err)
 						}
 					}
 				}

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -358,7 +358,17 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 					// Store the subtreeToCheck for later processing
 					// we not set a DAH as this is part of a block and will be permanently stored anyway
 					if err = u.subtreeStore.Set(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes, options.WithDeleteAt(dah)); err != nil {
-						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to store subtree", subtreeHash.String(), err)
+						// ErrBlobAlreadyExists is benign: the subtree filename is its content
+						// hash (verified above), so an existing file holds identical bytes. This
+						// happens when the same block is validated concurrently (announced by two
+						// peers) or retried after a partial attempt — racing on this content-
+						// addressed write must not fail the block. Mirrors the same handling for
+						// FileTypeSubtree/FileTypeSubtreeMeta in ValidateSubtreeInternal.
+						if errors.Is(err, errors.ErrBlobAlreadyExists) {
+							u.logger.Warnf("[CheckBlockSubtrees][%s] subtree already exists in store", subtreeHash.String())
+						} else {
+							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to store subtree", subtreeHash.String(), err)
+						}
 					}
 				}
 

--- a/services/subtreevalidation/check_block_subtrees_subtreetocheck_overwrite_test.go
+++ b/services/subtreevalidation/check_block_subtrees_subtreetocheck_overwrite_test.go
@@ -1,0 +1,157 @@
+package subtreevalidation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation/subtreevalidation_api"
+	"github.com/bsv-blockchain/teranode/services/validator"
+	"github.com/bsv-blockchain/teranode/stores/blob"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// subtreeToCheckExistsStore wraps a blob.Store and simulates the production race
+// where a concurrent block-validation worker (the same block announced by two
+// peers) has already written a subtree's content-addressed .subtreeToCheck file
+// between this worker's existence check and its Set. The underlying store still
+// gets the bytes (write-through, since the "other worker" wrote identical content),
+// but the Set reports ErrBlobAlreadyExists — exactly what the File store returns
+// when the destination already exists and AllowOverwrite is off.
+type subtreeToCheckExistsStore struct {
+	blob.Store
+
+	targetKey   []byte
+	setAttempts atomic.Int32
+}
+
+func (s *subtreeToCheckExistsStore) Set(ctx context.Context, key []byte, fileType fileformat.FileType, value []byte, opts ...options.FileOption) error {
+	if fileType == fileformat.FileTypeSubtreeToCheck && bytes.Equal(key, s.targetKey) {
+		s.setAttempts.Add(1)
+		// The concurrent worker's identical write is already present.
+		_ = s.Store.Set(ctx, key, fileType, value, opts...)
+		return errors.NewBlobAlreadyExistsError("[File][allowOverwrite] [%x] already exists in store", key)
+	}
+
+	return s.Store.Set(ctx, key, fileType, value, opts...)
+}
+
+// TestCheckBlockSubtrees_SubtreeToCheckAlreadyExists asserts that CheckBlockSubtrees
+// does NOT fail a block when storing a fetched subtree's .subtreeToCheck file returns
+// ErrBlobAlreadyExists. On the scaling cluster this happened when a block announced by
+// two peers spawned two concurrent block-validation workers that raced storing the same
+// content-addressed subtree file; the loser got BLOB_EXISTS and the whole (valid) block
+// was rejected, then re-rejected on every retry. The subtree filename IS its content
+// hash (verified at the root-hash check), so an already-present file holds identical
+// bytes and "already exists" must be treated as success.
+func TestCheckBlockSubtrees_SubtreeToCheckAlreadyExists(t *testing.T) {
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	server.blockchainClient.(*blockchain.Mock).On("GetBlockHeaderIDs",
+		mock.Anything, mock.Anything, mock.Anything).
+		Return([]uint32{1, 2, 3}, nil).Maybe()
+	server.blockchainClient.(*blockchain.Mock).On("GetBestBlockHeader",
+		mock.Anything).
+		Return(testHeadersOverwrite(t)[0], &model.BlockHeaderMeta{}, nil).Maybe()
+	server.blockchainClient.(*blockchain.Mock).On("IsFSMCurrentState",
+		mock.Anything, blockchain.FSMStateRUNNING).
+		Return(true, nil).Maybe()
+
+	// Let the mock validator bless txs against the server's utxo store.
+	server.validatorClient.(*validator.MockValidatorClient).UtxoStore = server.utxoStore
+
+	// Build a real subtree (coinbase placeholder + one tx) so its root matches its
+	// served node bytes and the root-hash check passes, taking us to the store call.
+	tx, err := createTestTransaction("tx1")
+	require.NoError(t, err)
+
+	subtree, err := subtreepkg.NewIncompleteTreeByLeafCount(2)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	require.NoError(t, subtree.AddNode(*tx.TxIDChainHash(), 0, 0))
+	subtreeHash := subtree.RootHash()
+
+	// Wrap the store so this subtree's .subtreeToCheck Set reports already-exists.
+	wrapped := &subtreeToCheckExistsStore{Store: server.subtreeStore, targetKey: subtreeHash[:]}
+	server.subtreeStore = wrapped
+
+	baseURL := testPeerURL
+
+	// /subtree/<root> returns the raw node hashes (coinbase placeholder + tx hash).
+	nodeBytes := make([]byte, 0, 2*chainhash.HashSize)
+	nodeBytes = append(nodeBytes, subtreepkg.CoinbasePlaceholderHashValue[:]...)
+	nodeBytes = append(nodeBytes, tx.TxIDChainHash()[:]...)
+	httpmock.RegisterResponder("GET",
+		fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String()),
+		httpmock.NewBytesResponder(http.StatusOK, nodeBytes))
+
+	// /subtree_data/<root> returns the tx bytes (coinbase placeholder omitted).
+	httpmock.RegisterResponder("GET",
+		fmt.Sprintf("%s/subtree_data/%s", baseURL, subtreeHash.String()),
+		httpmock.NewBytesResponder(http.StatusOK, tx.Bytes()))
+
+	header := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()), //nolint:gosec
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}
+	coinbaseTx := &bt.Tx{Version: 1}
+	block, err := model.NewBlock(header, coinbaseTx, []*chainhash.Hash{subtreeHash}, 2, 500, 0, 0)
+	require.NoError(t, err)
+	blockBytes, err := block.Bytes()
+	require.NoError(t, err)
+
+	request := &subtreevalidation_api.CheckBlockSubtreesRequest{
+		Block:   blockBytes,
+		BaseUrl: baseURL,
+	}
+
+	_, err = server.CheckBlockSubtrees(context.Background(), request)
+
+	// Core contract: a pre-existing content-addressed .subtreeToCheck must never be
+	// the reason the block fails. Pre-fix, CheckBlockSubtrees returns the
+	// "failed to store subtree" / BLOB_EXISTS error and the block is rejected.
+	if err != nil {
+		require.NotContains(t, err.Error(), "failed to store subtree",
+			"BLOB_EXISTS on a content-addressed subtreeToCheck must be treated as benign, not fatal")
+		require.NotContains(t, err.Error(), "already exists in store",
+			"BLOB_EXISTS on a content-addressed subtreeToCheck must be treated as benign, not fatal")
+	}
+
+	require.Positive(t, wrapped.setAttempts.Load(),
+		"test must actually exercise the subtreeToCheck store path (else it proves nothing)")
+}
+
+func testHeadersOverwrite(t *testing.T) []*model.BlockHeader {
+	t.Helper()
+	return []*model.BlockHeader{{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()), //nolint:gosec
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}}
+}

--- a/services/subtreevalidation/check_block_subtrees_subtreetocheck_overwrite_test.go
+++ b/services/subtreevalidation/check_block_subtrees_subtreetocheck_overwrite_test.go
@@ -43,8 +43,14 @@ type subtreeToCheckExistsStore struct {
 func (s *subtreeToCheckExistsStore) Set(ctx context.Context, key []byte, fileType fileformat.FileType, value []byte, opts ...options.FileOption) error {
 	if fileType == fileformat.FileTypeSubtreeToCheck && bytes.Equal(key, s.targetKey) {
 		s.setAttempts.Add(1)
-		// The concurrent worker's identical write is already present.
-		_ = s.Store.Set(ctx, key, fileType, value, opts...)
+		// The concurrent worker's identical write is already present. Write it
+		// through so the store holds the content the production race would leave
+		// behind, but surface any genuine write failure rather than masking it as
+		// "already exists" — otherwise the test could pass for the wrong reason.
+		if err := s.Store.Set(ctx, key, fileType, value, opts...); err != nil {
+			return err
+		}
+
 		return errors.NewBlobAlreadyExistsError("[File][allowOverwrite] [%x] already exists in store", key)
 	}
 
@@ -132,13 +138,10 @@ func TestCheckBlockSubtrees_SubtreeToCheckAlreadyExists(t *testing.T) {
 
 	// Core contract: a pre-existing content-addressed .subtreeToCheck must never be
 	// the reason the block fails. Pre-fix, CheckBlockSubtrees returns the
-	// "failed to store subtree" / BLOB_EXISTS error and the block is rejected.
-	if err != nil {
-		require.NotContains(t, err.Error(), "failed to store subtree",
-			"BLOB_EXISTS on a content-addressed subtreeToCheck must be treated as benign, not fatal")
-		require.NotContains(t, err.Error(), "already exists in store",
-			"BLOB_EXISTS on a content-addressed subtreeToCheck must be treated as benign, not fatal")
-	}
+	// "failed to store subtreeToCheck" / BLOB_EXISTS error and the block is rejected;
+	// post-fix the block validates cleanly, so assert success directly.
+	require.NoError(t, err,
+		"BLOB_EXISTS on a content-addressed subtreeToCheck must be treated as benign, not fatal")
 
 	require.Positive(t, wrapped.setAttempts.Load(),
 		"test must actually exercise the subtreeToCheck store path (else it proves nothing)")


### PR DESCRIPTION
## Problem

`CheckBlockSubtrees` stores a fetched subtree's content-addressed `.subtreeToCheck` file **without** an allow-overwrite option:

```go
u.subtreeStore.Set(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes, options.WithDeleteAt(dah))
```

So a second write of the same subtree returns `BLOB_EXISTS` and fails the whole block:

```
[CheckBlockSubtreesRequest] Failed to get subtree tx hashes for batch 2
  -> [CheckBlockSubtrees][75affcb0…] failed to store subtree
  -> BLOB_EXISTS (90): [File][allowOverwrite] [/data/.../75affcb0….subtreeToCheck] already exists in store
```

On a multi-node cluster a block is announced by several peers, which spawns **concurrent block-validation workers** for the same block (observed: Worker 1 and Worker 2 failing on the same block at the same instant). They race storing the same subtree files; the loser gets `BLOB_EXISTS` and an otherwise-valid block is rejected — then re-rejected on every retry, because the prior attempt's `.subtreeToCheck` file persists under its `DeleteAt` DAH. The same hazard applies to any retry after a partial first attempt.

## Fix

The subtree filename **is** its content hash, and the content is verified against that hash immediately above the store call (`subtreeHash.Equal(*subtreeToCheck.RootHash())`). So an already-present file holds byte-identical content, and `ErrBlobAlreadyExists` must be treated as success.

This mirrors the existing handling for `FileTypeSubtree` and `FileTypeSubtreeMeta` in `ValidateSubtreeInternal` (`SubtreeValidation.go`), which already log-and-continue on `ErrBlobAlreadyExists`.

## Test

`TestCheckBlockSubtrees_SubtreeToCheckAlreadyExists` reaches the store path via the peer-fetch branch with a real subtree (so the root-hash check passes), and wraps the store so the `.subtreeToCheck` `Set` returns `ErrBlobAlreadyExists` (simulating the concurrent worker's identical write). It fails before the fix with the exact production error and passes after.

## Verification

- new test: RED before fix → GREEN after
- `go test -race ./services/subtreevalidation/` — passes (the only failures are pre-existing Docker/TestContainers integration tests, `policy_rejected_tx_integration_test.go`, which fail identically without this change)
- `go vet` / `golangci-lint` / `staticcheck` (changed files) — clean

## Scope

This is a robustness fix for the concurrent-validation race. It does not address the separate, dominant issue of follower nodes falling behind on very large blocks (block-validation + `setTxMined` duration vs. the required parent-wait).