### PR TITLE
perf(subtreevalidation): dedup catchup parent reads via per-level bulk prefetch

### DIFF
--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -1212,11 +1212,12 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 // buildParentMapFromLevel builds a hash map of all transactions in a level for quick parent lookups.
 // This map is built ONCE per level and reused for all child transactions in the next level,
 // avoiding O(n²) complexity from rebuilding the map for every child transaction.
-// prefetchParentFields are the metadata fields a bulk parent read must fetch to
-// stand in for the validator's per-parent Get: block IDs/heights (for the
-// unconfirmed-parent sentinel + height resolution) plus the parent tx outputs
-// (needed to extend a non-extended child's inputs).
-var prefetchParentFields = []fields.FieldName{fields.BlockIDs, fields.BlockHeights, fields.Tx}
+// prefetchParentBaseFields are the metadata fields a bulk parent read always
+// fetches to stand in for the validator's per-parent Get: block IDs/heights, for
+// the unconfirmed-parent sentinel + height resolution. The parent tx outputs
+// (fields.Tx) are appended only when the level has a non-extended tx — see
+// prefetchLevelParents.
+var prefetchParentBaseFields = []fields.FieldName{fields.BlockIDs, fields.BlockHeights}
 
 // prefetchLevelParents bulk-reads the distinct parent transactions referenced by
 // a level's transactions and returns them keyed by parent hash, for
@@ -1232,9 +1233,21 @@ var prefetchParentFields = []fields.FieldName{fields.BlockIDs, fields.BlockHeigh
 func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx) (map[chainhash.Hash]*meta.Data, error) {
 	distinct := make(map[chainhash.Hash]struct{})
 
+	// Mirror the validator's per-tx `extend := !tx.IsExtended()` decision at the
+	// level grain: only fetch the parent tx outputs (fields.Tx) if at least one tx
+	// in this level still needs extending. A fully-extended level (e.g. all inputs
+	// extended via extendTxWithInBlockParents) resolves heights from
+	// BlockIDs/BlockHeights alone, so fetching Tx would force a needless
+	// external-store round-trip per distinct parent.
+	needTx := false
+
 	for _, mTx := range levelTxs {
 		if mTx.tx == nil {
 			continue
+		}
+
+		if !mTx.tx.IsExtended() {
+			needTx = true
 		}
 
 		for _, in := range mTx.tx.Inputs {
@@ -1249,6 +1262,11 @@ func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx)
 
 	if len(distinct) == 0 {
 		return nil, nil
+	}
+
+	prefetchFields := prefetchParentBaseFields
+	if needTx {
+		prefetchFields = append(append([]fields.FieldName(nil), prefetchParentBaseFields...), fields.Tx)
 	}
 
 	items := make([]*utxostore.UnresolvedMetaData, 0, len(distinct))
@@ -1270,7 +1288,7 @@ func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx)
 
 		g.Go(func() error {
 			end := subtreepkg.Min(i+batchSize, len(items))
-			return u.utxoStore.BatchDecorate(gCtx, items[i:end], prefetchParentFields...)
+			return u.utxoStore.BatchDecorate(gCtx, items[i:end], prefetchFields...)
 		})
 	}
 

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -1225,11 +1225,12 @@ var prefetchParentBaseFields = []fields.FieldName{fields.BlockIDs, fields.BlockH
 //
 // It deduplicates shared parents — a fan-out level (one funding tx, many
 // children) reads that parent ONCE instead of once per child — and batches the
-// reads. Parents that the store does not resolve are omitted: the validator
-// falls back to a per-parent Get for them, which preserves the existing
-// missing-parent (ErrTxNotFound → deferred revalidation) handling. A genuine
-// store read error is returned so the caller aborts — the bulk read is an
-// optimization, never an authority, but a DB failure must halt, not be swallowed.
+// reads. Parents the store reports as not-found (ErrTxNotFound) are omitted: the
+// validator falls back to a per-parent Get for them, which preserves the existing
+// missing-parent → deferred-revalidation handling. Any other per-item read error
+// — or a function-level error from BatchDecorate — aborts: the bulk read is an
+// optimization, never an authority, but a DB failure must halt, not be silently
+// downgraded to a fallback Get that masks it.
 func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx) (map[chainhash.Hash]*meta.Data, error) {
 	distinct := make(map[chainhash.Hash]struct{})
 
@@ -1299,9 +1300,23 @@ func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx)
 	result := make(map[chainhash.Hash]*meta.Data, len(items))
 
 	for _, item := range items {
-		// Omit not-found / per-item errors: the validator falls back to a
-		// per-parent Get, preserving missing-parent handling.
-		if item.Data != nil && item.Err == nil {
+		if item.Err != nil {
+			// BatchDecorate reports per-record failures on item.Err while returning
+			// a nil function error (the Aerospike contract). A genuine not-found is
+			// expected — the parent lives in a later batch (cross-subtree) — so we
+			// omit it and let the validator fall back to a per-parent Get, preserving
+			// the missing-parent / deferred-revalidation path. Any OTHER per-item
+			// error (store timeout, external-store read failure, decode error) is a
+			// real DB failure: it must halt the level, never be silently downgraded
+			// to a fallback Get that would mask the failure and amplify reads.
+			if errors.Is(item.Err, errors.ErrTxNotFound) {
+				continue
+			}
+
+			return nil, errors.NewStorageError("[prefetchLevelParents] failed to read parent %s", item.Hash, item.Err)
+		}
+
+		if item.Data != nil {
 			result[item.Hash] = item.Data
 		}
 	}

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -20,6 +20,9 @@ import (
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation/subtreevalidation_api"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"golang.org/x/sync/errgroup"
@@ -1076,6 +1079,22 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 			}
 		}
 
+		// Bulk-read this level's distinct parent transactions once, so the
+		// validator resolves each input's height/outputs from the prefetch instead
+		// of issuing a per-parent Get for every child (the fan-out dedup win).
+		// Built per level AFTER the previous level's transactions were created, so
+		// an in-block parent from an earlier level is seen exactly as a per-parent
+		// Get would see it (empty BlockHeights → unconfirmed sentinel). Parents the
+		// store does not resolve are omitted, so the validator falls back to a Get
+		// and the existing missing-parent handling is preserved.
+		prefetchedParents, prefetchErr := u.prefetchLevelParents(ctx, levelTxs)
+		if prefetchErr != nil {
+			return prefetchErr
+		}
+
+		levelValidatorOptions := *processedValidatorOptions
+		levelValidatorOptions.PrefetchedParents = prefetchedParents
+
 		// Process all transactions at this level in parallel
 		g, gCtx := errgroup.WithContext(ctx)
 		util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.SpendBatcherSize*2)
@@ -1100,7 +1119,7 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 
 			g.Go(func() error {
 				// Use existing blessMissingTransaction logic for validation
-				txMeta, err := u.blessMissingTransaction(gCtx, blockHash, subtreeHash, tx, blockHeight, blockIds, processedValidatorOptions)
+				txMeta, err := u.blessMissingTransaction(gCtx, blockHash, subtreeHash, tx, blockHeight, blockIds, &levelValidatorOptions)
 				if err != nil {
 					u.logger.Debugf("[processTransactionsInLevels] Failed to validate transaction %s: %v", tx.TxIDChainHash().String(), err)
 
@@ -1183,6 +1202,85 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 // buildParentMapFromLevel builds a hash map of all transactions in a level for quick parent lookups.
 // This map is built ONCE per level and reused for all child transactions in the next level,
 // avoiding O(n²) complexity from rebuilding the map for every child transaction.
+// prefetchParentFields are the metadata fields a bulk parent read must fetch to
+// stand in for the validator's per-parent Get: block IDs/heights (for the
+// unconfirmed-parent sentinel + height resolution) plus the parent tx outputs
+// (needed to extend a non-extended child's inputs).
+var prefetchParentFields = []fields.FieldName{fields.BlockIDs, fields.BlockHeights, fields.Tx}
+
+// prefetchLevelParents bulk-reads the distinct parent transactions referenced by
+// a level's transactions and returns them keyed by parent hash, for
+// validator.Options.PrefetchedParents.
+//
+// It deduplicates shared parents — a fan-out level (one funding tx, many
+// children) reads that parent ONCE instead of once per child — and batches the
+// reads. Parents that the store does not resolve are omitted: the validator
+// falls back to a per-parent Get for them, which preserves the existing
+// missing-parent (ErrTxNotFound → deferred revalidation) handling. A genuine
+// store read error is returned so the caller aborts — the bulk read is an
+// optimization, never an authority, but a DB failure must halt, not be swallowed.
+func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx) (map[chainhash.Hash]*meta.Data, error) {
+	distinct := make(map[chainhash.Hash]struct{})
+
+	for _, mTx := range levelTxs {
+		if mTx.tx == nil {
+			continue
+		}
+
+		for _, in := range mTx.tx.Inputs {
+			parentHash := *in.PreviousTxIDChainHash()
+			if parentHash.Equal(*subtreepkg.CoinbasePlaceholderHash) {
+				continue
+			}
+
+			distinct[parentHash] = struct{}{}
+		}
+	}
+
+	if len(distinct) == 0 {
+		return nil, nil
+	}
+
+	items := make([]*utxostore.UnresolvedMetaData, 0, len(distinct))
+	for parentHash := range distinct {
+		parentHash := parentHash
+		items = append(items, &utxostore.UnresolvedMetaData{Hash: parentHash})
+	}
+
+	batchSize := u.settings.BlockValidation.ProcessTxMetaUsingStoreBatchSize
+	if batchSize <= 0 {
+		batchSize = 1024
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	util.SafeSetLimit(u.logger, g, u.settings.BlockValidation.ProcessTxMetaUsingStoreConcurrency)
+
+	for i := 0; i < len(items); i += batchSize {
+		i := i
+
+		g.Go(func() error {
+			end := subtreepkg.Min(i+batchSize, len(items))
+			return u.utxoStore.BatchDecorate(gCtx, items[i:end], prefetchParentFields...)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, errors.NewStorageError("[prefetchLevelParents] failed to bulk-read level parents", err)
+	}
+
+	result := make(map[chainhash.Hash]*meta.Data, len(items))
+
+	for _, item := range items {
+		// Omit not-found / per-item errors: the validator falls back to a
+		// per-parent Get, preserving missing-parent handling.
+		if item.Data != nil && item.Err == nil {
+			result[item.Hash] = item.Data
+		}
+	}
+
+	return result, nil
+}
+
 func buildParentMapFromLevel(parentLevelTxs []missingTx) map[chainhash.Hash]*bt.Tx {
 	if len(parentLevelTxs) == 0 {
 		return nil

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -1209,9 +1209,6 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 	return nil
 }
 
-// buildParentMapFromLevel builds a hash map of all transactions in a level for quick parent lookups.
-// This map is built ONCE per level and reused for all child transactions in the next level,
-// avoiding O(n²) complexity from rebuilding the map for every child transaction.
 // prefetchParentBaseFields are the metadata fields a bulk parent read always
 // fetches to stand in for the validator's per-parent Get: block IDs/heights, for
 // the unconfirmed-parent sentinel + height resolution. The parent tx outputs
@@ -1324,6 +1321,9 @@ func (u *Server) prefetchLevelParents(ctx context.Context, levelTxs []missingTx)
 	return result, nil
 }
 
+// buildParentMapFromLevel builds a hash map of all transactions in a level for quick parent lookups.
+// This map is built ONCE per level and reused for all child transactions in the next level,
+// avoiding O(n²) complexity from rebuilding the map for every child transaction.
 func buildParentMapFromLevel(parentLevelTxs []missingTx) map[chainhash.Hash]*bt.Tx {
 	if len(parentLevelTxs) == 0 {
 		return nil

--- a/services/subtreevalidation/prefetch_level_parents_bench_test.go
+++ b/services/subtreevalidation/prefetch_level_parents_bench_test.go
@@ -1,0 +1,177 @@
+package subtreevalidation
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/ulogger"
+)
+
+// countingLatencyStore embeds MockUtxostore and intercepts BatchDecorate to
+// (a) count the number of records read and (b) inject a per-record latency that
+// models an Aerospike batch read (server-side cost scales with record count).
+// It lets the benchmark compare the OLD per-tx read pattern against the NEW
+// per-level deduped read in both records-read and wall-clock terms.
+type countingLatencyStore struct {
+	*utxostore.MockUtxostore
+
+	recordsRead    atomic.Int64
+	perRecordDelay time.Duration
+	resolve        map[chainhash.Hash]*meta.Data
+}
+
+func (s *countingLatencyStore) BatchDecorate(_ context.Context, items []*utxostore.UnresolvedMetaData, _ ...fields.FieldName) error {
+	s.recordsRead.Add(int64(len(items)))
+
+	if s.perRecordDelay > 0 {
+		time.Sleep(s.perRecordDelay * time.Duration(len(items)))
+	}
+
+	for _, it := range items {
+		if d, ok := s.resolve[it.Hash]; ok {
+			it.Data = d
+		}
+	}
+
+	return nil
+}
+
+// buildLevel constructs a level of single-input transactions arranged as
+// `parents` distinct parents, each spent by `childrenPerParent` children, and
+// returns the level plus a resolve map seeding every parent in the store.
+//
+//	FanOut    : parents=1,    childrenPerParent=N  (the tx-blaster shape)
+//	Distinct  : parents=N,    childrenPerParent=1  (no sharing — dedup no-op)
+//	Mixed     : parents=M,    childrenPerParent=K
+func buildLevel(b *testing.B, parents, childrenPerParent int) ([]missingTx, map[chainhash.Hash]*meta.Data) {
+	b.Helper()
+
+	const lockingScript = "76a914000000000000000000000000000000000000000088ac"
+
+	levelTxs := make([]missingTx, 0, parents*childrenPerParent)
+	resolve := make(map[chainhash.Hash]*meta.Data, parents)
+
+	idx := 0
+
+	for p := 0; p < parents; p++ {
+		parentHex := fmt.Sprintf("%064x", p+1)
+
+		for c := 0; c < childrenPerParent; c++ {
+			tx := bt.NewTx()
+			if err := tx.From(parentHex, uint32(c), lockingScript, 1000); err != nil {
+				b.Fatalf("build tx: %v", err)
+			}
+
+			parentHash := *tx.Inputs[0].PreviousTxIDChainHash()
+			resolve[parentHash] = &meta.Data{BlockHeights: []uint32{uint32(p + 1)}}
+
+			levelTxs = append(levelTxs, missingTx{tx: tx, idx: idx})
+			idx++
+		}
+	}
+
+	return levelTxs, resolve
+}
+
+// readOldPattern reproduces the pre-change read pattern: the validator resolves
+// each transaction's parents independently (one read per distinct parent per
+// tx), with NO dedup across transactions in the level — sendGetBatch coalesces
+// round-trips but reads the same shared parent record once per child. The
+// validator-package parity tests confirm the new path eliminates these reads in
+// favour of the prefetch.
+func readOldPattern(ctx context.Context, store *countingLatencyStore, levelTxs []missingTx) {
+	for _, mTx := range levelTxs {
+		seen := make(map[chainhash.Hash]struct{}, len(mTx.tx.Inputs))
+		items := make([]*utxostore.UnresolvedMetaData, 0, len(mTx.tx.Inputs))
+
+		for _, in := range mTx.tx.Inputs {
+			ph := *in.PreviousTxIDChainHash()
+			if _, dup := seen[ph]; dup {
+				continue
+			}
+
+			seen[ph] = struct{}{}
+			items = append(items, &utxostore.UnresolvedMetaData{Hash: ph})
+		}
+
+		_ = store.BatchDecorate(ctx, items)
+	}
+}
+
+// BenchmarkCatchupParentReads compares the OLD per-tx read pattern with the NEW
+// per-level deduped bulk read (the real prefetchLevelParents), reporting both
+// records-read/op and ns/op. Records-read is the hard, deterministic metric (it
+// is what loads Aerospike during catchup); the ns/op numbers under non-zero
+// perRecordDelay are illustrative — they show the wall-clock win scaling with
+// store latency, but the absolute latency is a modelling choice.
+func BenchmarkCatchupParentReads(b *testing.B) {
+	ctx := context.Background()
+
+	shapes := []struct {
+		name              string
+		parents           int
+		childrenPerParent int
+	}{
+		{"FanOut_1x1000", 1, 1000},
+		{"FanOut_10x100", 10, 100},
+		{"Mixed_100x10", 100, 10},
+		{"Distinct_1000x1", 1000, 1},
+	}
+
+	// Per-record latency models an Aerospike batch read's server-side cost.
+	// 0 isolates record-count + Go overhead; the rest show the wall-clock win.
+	delays := []time.Duration{0, time.Microsecond, 50 * time.Microsecond}
+
+	server := &Server{
+		settings: settings.NewSettings(),
+		logger:   ulogger.TestLogger{},
+	}
+
+	for _, shape := range shapes {
+		levelTxs, resolve := buildLevel(b, shape.parents, shape.childrenPerParent)
+
+		for _, delay := range delays {
+			store := &countingLatencyStore{
+				MockUtxostore:  &utxostore.MockUtxostore{},
+				perRecordDelay: delay,
+				resolve:        resolve,
+			}
+			server.utxoStore = store
+
+			b.Run(fmt.Sprintf("%s/delay=%s/old", shape.name, delay), func(b *testing.B) {
+				store.recordsRead.Store(0)
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					readOldPattern(ctx, store, levelTxs)
+				}
+
+				b.StopTimer()
+				b.ReportMetric(float64(store.recordsRead.Load())/float64(b.N), "reads/op")
+			})
+
+			b.Run(fmt.Sprintf("%s/delay=%s/new", shape.name, delay), func(b *testing.B) {
+				store.recordsRead.Store(0)
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					if _, err := server.prefetchLevelParents(ctx, levelTxs); err != nil {
+						b.Fatalf("prefetchLevelParents: %v", err)
+					}
+				}
+
+				b.StopTimer()
+				b.ReportMetric(float64(store.recordsRead.Load())/float64(b.N), "reads/op")
+			})
+		}
+	}
+}

--- a/services/subtreevalidation/prefetch_level_parents_test.go
+++ b/services/subtreevalidation/prefetch_level_parents_test.go
@@ -1,0 +1,93 @@
+package subtreevalidation
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingParentStore embeds MockUtxostore and records every key passed to
+// BatchDecorate so a test can assert how many distinct parents were actually
+// read from the store.
+type recordingParentStore struct {
+	*utxostore.MockUtxostore
+
+	mu        sync.Mutex
+	requested []chainhash.Hash
+	resolve   map[chainhash.Hash]*meta.Data
+}
+
+func (s *recordingParentStore) BatchDecorate(_ context.Context, items []*utxostore.UnresolvedMetaData, _ ...fields.FieldName) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, it := range items {
+		s.requested = append(s.requested, it.Hash)
+		if d, ok := s.resolve[it.Hash]; ok {
+			it.Data = d
+		}
+	}
+
+	return nil
+}
+
+// Test_prefetchLevelParents_DedupsSharedParent proves the Phase-1 win: when a
+// level has many transactions spending the same parent (the fan-out pattern that
+// dominates the scaling test — one funding tx, many children), the bulk reader
+// asks the store for that parent ONCE, not once per child. Without dedup the
+// store sees N reads of the same record; with it, one.
+func Test_prefetchLevelParents_DedupsSharedParent(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	lockingScript := "76a914000000000000000000000000000000000000000088ac"
+	sharedParentHex := "0000000000000000000000000000000000000000000000000000000000000001"
+	otherParentHex := "0000000000000000000000000000000000000000000000000000000000000002"
+
+	mkTx := func(parentHex string, vout uint32) *bt.Tx {
+		tx := bt.NewTx()
+		require.NoError(t, tx.From(parentHex, vout, lockingScript, 1000))
+		return tx
+	}
+
+	// 5 children of the shared parent + 1 tx spending a different parent.
+	levelTxs := make([]missingTx, 0, 6)
+	for i := 0; i < 5; i++ {
+		levelTxs = append(levelTxs, missingTx{tx: mkTx(sharedParentHex, uint32(i)), idx: i})
+	}
+	levelTxs = append(levelTxs, missingTx{tx: mkTx(otherParentHex, 0), idx: 5})
+
+	sharedParent := *levelTxs[0].tx.Inputs[0].PreviousTxIDChainHash()
+	otherParent := *levelTxs[5].tx.Inputs[0].PreviousTxIDChainHash()
+
+	store := &recordingParentStore{
+		MockUtxostore: &utxostore.MockUtxostore{},
+		resolve: map[chainhash.Hash]*meta.Data{
+			sharedParent: {BlockHeights: []uint32{}},         // in-block / unconfirmed
+			otherParent:  {BlockHeights: []uint32{100, 101}}, // earlier block
+		},
+	}
+	server.utxoStore = store
+
+	prefetched, err := server.prefetchLevelParents(ctx, levelTxs)
+	require.NoError(t, err)
+
+	// Both distinct parents resolved.
+	require.Len(t, prefetched, 2)
+	require.NotNil(t, prefetched[sharedParent])
+	require.NotNil(t, prefetched[otherParent])
+
+	// The dedup contract: each distinct parent read exactly once (2 total),
+	// not once per child (which would be 6).
+	require.Len(t, store.requested, 2,
+		"shared parent must be read once per level, not once per child")
+}

--- a/services/subtreevalidation/prefetch_level_parents_test.go
+++ b/services/subtreevalidation/prefetch_level_parents_test.go
@@ -21,12 +21,15 @@ type recordingParentStore struct {
 
 	mu        sync.Mutex
 	requested []chainhash.Hash
+	fields    []fields.FieldName
 	resolve   map[chainhash.Hash]*meta.Data
 }
 
-func (s *recordingParentStore) BatchDecorate(_ context.Context, items []*utxostore.UnresolvedMetaData, _ ...fields.FieldName) error {
+func (s *recordingParentStore) BatchDecorate(_ context.Context, items []*utxostore.UnresolvedMetaData, f ...fields.FieldName) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	s.fields = f
 
 	for _, it := range items {
 		s.requested = append(s.requested, it.Hash)
@@ -36,6 +39,19 @@ func (s *recordingParentStore) BatchDecorate(_ context.Context, items []*utxosto
 	}
 
 	return nil
+}
+
+func (s *recordingParentStore) hasField(want fields.FieldName) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, f := range s.fields {
+		if f == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Test_prefetchLevelParents_DedupsSharedParent proves the Phase-1 win: when a
@@ -90,4 +106,96 @@ func Test_prefetchLevelParents_DedupsSharedParent(t *testing.T) {
 	// not once per child (which would be 6).
 	require.Len(t, store.requested, 2,
 		"shared parent must be read once per level, not once per child")
+}
+
+// mkExtendedTx builds a fully-extended single-input tx (From sets the input's
+// PreviousTxScript, which is what IsExtended checks).
+func mkExtendedTx(t *testing.T, parentHex string, vout uint32) *bt.Tx {
+	t.Helper()
+
+	const lockingScript = "76a914000000000000000000000000000000000000000088ac"
+
+	tx := bt.NewTx()
+	require.NoError(t, tx.From(parentHex, vout, lockingScript, 1000))
+
+	return tx
+}
+
+// mkNonExtendedTx builds the same tx but clears the input's PreviousTxScript so
+// IsExtended reports false — the validator would then need fields.Tx to extend it.
+func mkNonExtendedTx(t *testing.T, parentHex string, vout uint32) *bt.Tx {
+	t.Helper()
+
+	tx := mkExtendedTx(t, parentHex, vout)
+	tx.Inputs[0].PreviousTxScript = nil
+	require.False(t, tx.IsExtended())
+
+	return tx
+}
+
+// Test_prefetchLevelParents_OmitsTxWhenAllExtended proves the fields-gating fix:
+// when every tx in the level is already extended (e.g. extended via in-block
+// parents), the validator never requests fields.Tx for any parent, so the bulk
+// prefetch must not fetch it either — fetching Tx would trigger a needless
+// external-store round-trip per distinct parent.
+func Test_prefetchLevelParents_OmitsTxWhenAllExtended(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	parentHex := "0000000000000000000000000000000000000000000000000000000000000001"
+
+	levelTxs := []missingTx{
+		{tx: mkExtendedTx(t, parentHex, 0), idx: 0},
+		{tx: mkExtendedTx(t, parentHex, 1), idx: 1},
+	}
+
+	parent := *levelTxs[0].tx.Inputs[0].PreviousTxIDChainHash()
+
+	store := &recordingParentStore{
+		MockUtxostore: &utxostore.MockUtxostore{},
+		resolve:       map[chainhash.Hash]*meta.Data{parent: {BlockHeights: []uint32{100}}},
+	}
+	server.utxoStore = store
+
+	_, err := server.prefetchLevelParents(ctx, levelTxs)
+	require.NoError(t, err)
+
+	require.True(t, store.hasField(fields.BlockIDs), "BlockIDs is always needed")
+	require.True(t, store.hasField(fields.BlockHeights), "BlockHeights is always needed")
+	require.False(t, store.hasField(fields.Tx),
+		"fields.Tx must be omitted when every tx in the level is already extended")
+}
+
+// Test_prefetchLevelParents_IncludesTxWhenAnyNonExtended proves the other side
+// of the gate: a single non-extended tx in the level means the validator will
+// extend it from the parent outputs, so the prefetch must carry fields.Tx.
+func Test_prefetchLevelParents_IncludesTxWhenAnyNonExtended(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	parentHex := "0000000000000000000000000000000000000000000000000000000000000001"
+
+	// One extended, one non-extended — the level still needs Tx for the latter.
+	levelTxs := []missingTx{
+		{tx: mkExtendedTx(t, parentHex, 0), idx: 0},
+		{tx: mkNonExtendedTx(t, parentHex, 1), idx: 1},
+	}
+
+	parent := *levelTxs[0].tx.Inputs[0].PreviousTxIDChainHash()
+
+	store := &recordingParentStore{
+		MockUtxostore: &utxostore.MockUtxostore{},
+		resolve:       map[chainhash.Hash]*meta.Data{parent: {BlockHeights: []uint32{100}}},
+	}
+	server.utxoStore = store
+
+	_, err := server.prefetchLevelParents(ctx, levelTxs)
+	require.NoError(t, err)
+
+	require.True(t, store.hasField(fields.Tx),
+		"fields.Tx must be fetched when any tx in the level is non-extended")
 }

--- a/services/subtreevalidation/prefetch_level_parents_test.go
+++ b/services/subtreevalidation/prefetch_level_parents_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
 	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
@@ -23,6 +24,9 @@ type recordingParentStore struct {
 	requested []chainhash.Hash
 	fields    []fields.FieldName
 	resolve   map[chainhash.Hash]*meta.Data
+	// itemErrs models the Aerospike contract: BatchDecorate returns a nil
+	// function error but records per-record failures on item.Err.
+	itemErrs map[chainhash.Hash]error
 }
 
 func (s *recordingParentStore) BatchDecorate(_ context.Context, items []*utxostore.UnresolvedMetaData, f ...fields.FieldName) error {
@@ -33,6 +37,10 @@ func (s *recordingParentStore) BatchDecorate(_ context.Context, items []*utxosto
 
 	for _, it := range items {
 		s.requested = append(s.requested, it.Hash)
+		if err, ok := s.itemErrs[it.Hash]; ok {
+			it.Err = err
+			continue
+		}
 		if d, ok := s.resolve[it.Hash]; ok {
 			it.Data = d
 		}
@@ -198,4 +206,68 @@ func Test_prefetchLevelParents_IncludesTxWhenAnyNonExtended(t *testing.T) {
 
 	require.True(t, store.hasField(fields.Tx),
 		"fields.Tx must be fetched when any tx in the level is non-extended")
+}
+
+// Test_prefetchLevelParents_OmitsNotFoundParent proves a genuine not-found
+// parent (the cross-subtree parent that lives in a later batch) is omitted from
+// the result map, NOT treated as an error — the validator falls back to a
+// per-parent Get and the existing missing-parent deferral handles it.
+func Test_prefetchLevelParents_OmitsNotFoundParent(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	foundHex := "0000000000000000000000000000000000000000000000000000000000000001"
+	missingHex := "0000000000000000000000000000000000000000000000000000000000000002"
+
+	levelTxs := []missingTx{
+		{tx: mkExtendedTx(t, foundHex, 0), idx: 0},
+		{tx: mkExtendedTx(t, missingHex, 0), idx: 1},
+	}
+
+	found := *levelTxs[0].tx.Inputs[0].PreviousTxIDChainHash()
+	missing := *levelTxs[1].tx.Inputs[0].PreviousTxIDChainHash()
+
+	store := &recordingParentStore{
+		MockUtxostore: &utxostore.MockUtxostore{},
+		resolve:       map[chainhash.Hash]*meta.Data{found: {BlockHeights: []uint32{100}}},
+		itemErrs:      map[chainhash.Hash]error{missing: errors.NewTxNotFoundError("%v not found", missing)},
+	}
+	server.utxoStore = store
+
+	prefetched, err := server.prefetchLevelParents(ctx, levelTxs)
+	require.NoError(t, err, "a not-found parent must not abort the bulk read")
+	require.NotNil(t, prefetched[found])
+	require.Nil(t, prefetched[missing], "not-found parent must be omitted so the validator falls back to Get")
+}
+
+// Test_prefetchLevelParents_AbortsOnRealItemError proves the halt-on-DB-error
+// contract: a per-item error that is NOT a not-found (a store timeout,
+// external-store read failure, decode error — all reported on item.Err while
+// BatchDecorate returns nil) must abort the level, never be silently downgraded
+// to a fallback Get that masks the partial DB failure.
+func Test_prefetchLevelParents_AbortsOnRealItemError(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	failingHex := "0000000000000000000000000000000000000000000000000000000000000003"
+
+	levelTxs := []missingTx{
+		{tx: mkExtendedTx(t, failingHex, 0), idx: 0},
+	}
+
+	failing := *levelTxs[0].tx.Inputs[0].PreviousTxIDChainHash()
+
+	store := &recordingParentStore{
+		MockUtxostore: &utxostore.MockUtxostore{},
+		itemErrs:      map[chainhash.Hash]error{failing: errors.NewStorageError("aerospike timeout")},
+	}
+	server.utxoStore = store
+
+	_, err := server.prefetchLevelParents(ctx, levelTxs)
+	require.Error(t, err, "a real per-item store error must abort the level, not be swallowed")
+	require.True(t, errors.Is(err, errors.ErrStorageError), "abort must surface as a storage error")
 }

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -937,7 +937,7 @@ func (v *Validator) getTransactionInputBlockHeightsAndExtendTx(ctx context.Conte
 	defer endSpan()
 
 	// get the utxo heights for each input
-	utxoHeights, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, txID)
+	utxoHeights, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, txID, validationOptions.PrefetchedParents)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -966,8 +966,10 @@ func (v *Validator) twoPhaseCommitTransaction(ctx context.Context, tx *bt.Tx, tx
 	return nil
 }
 
-// getUtxoBlockHeightsAndExtendTx returns the block heights for each input of the transaction
-func (v *Validator) getUtxoBlockHeightsAndExtendTx(ctx context.Context, tx *bt.Tx, txID string) ([]uint32, error) {
+// getUtxoBlockHeightsAndExtendTx returns the block heights for each input of the transaction.
+// prefetched, when non-nil, supplies parent metadata already read in bulk so per-parent
+// store Gets can be skipped (see Options.PrefetchedParents).
+func (v *Validator) getUtxoBlockHeightsAndExtendTx(ctx context.Context, tx *bt.Tx, txID string, prefetched map[chainhash.Hash]*meta.Data) ([]uint32, error) {
 	// get the block heights of the input transactions of the transaction
 	g, gCtx := errgroup.WithContext(ctx)
 	util.SafeSetLimit(v.logger, g, v.settings.UtxoStore.GetBatcherSize)
@@ -992,7 +994,7 @@ func (v *Validator) getUtxoBlockHeightsAndExtendTx(ctx context.Context, tx *bt.T
 		inputIdxs := idxs
 
 		g.Go(func() error {
-			if err := v.getUtxoBlockHeightAndExtendForParentTx(gCtx, parentTxHash, inputIdxs, utxoHeights, tx, extend); err != nil {
+			if err := v.getUtxoBlockHeightAndExtendForParentTx(gCtx, parentTxHash, inputIdxs, utxoHeights, tx, extend, prefetched); err != nil {
 				if errors.Is(err, errors.ErrTxNotFound) {
 					return errors.NewTxMissingParentError("[Validate][%s] error getting parent transaction %s", txID, parentTxHash, err)
 				}
@@ -1028,7 +1030,7 @@ func (v *Validator) getUtxoBlockHeightsAndExtendTx(ctx context.Context, tx *bt.T
 //     (BDK rejects with bad-txns-unconfirmed-input-in-block) or the candidate
 //     height in policy mode.
 func (v *Validator) getUtxoBlockHeightAndExtendForParentTx(gCtx context.Context, parentTxHash chainhash.Hash, idxs []int,
-	utxoHeights []uint32, tx *bt.Tx, extend bool) error {
+	utxoHeights []uint32, tx *bt.Tx, extend bool, prefetched map[chainhash.Hash]*meta.Data) error {
 	f := []fields.FieldName{fields.BlockIDs, fields.BlockHeights}
 
 	if extend {
@@ -1036,9 +1038,19 @@ func (v *Validator) getUtxoBlockHeightAndExtendForParentTx(gCtx context.Context,
 		f = append(f, fields.Tx)
 	}
 
-	txMeta, err := v.utxoStore.Get(gCtx, &parentTxHash, f...)
-	if err != nil {
-		return err
+	// Use a bulk-prefetched parent if the caller supplied one that carries
+	// everything we need (the parent tx outputs too, when extending). This is a
+	// read-source swap only: the height/sentinel logic below is unchanged, and
+	// any parent not prefetched — or prefetched without the Tx needed for
+	// extension — falls back to a store Get, so correctness is never reduced.
+	var txMeta *meta.Data
+	if pf, ok := prefetched[parentTxHash]; ok && pf != nil && (!extend || pf.Tx != nil) {
+		txMeta = pf
+	} else {
+		var err error
+		if txMeta, err = v.utxoStore.Get(gCtx, &parentTxHash, f...); err != nil {
+			return err
+		}
 	}
 
 	if len(txMeta.BlockHeights) == 0 {

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1047,7 +1047,7 @@ func Test_getUtxoBlockHeights(t *testing.T) {
 			BlockHeights: make([]uint32, 0),
 		}, nil)
 
-		utxoHashes, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, tx.TxID())
+		utxoHashes, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, tx.TxID(), nil)
 		require.NoError(t, err)
 
 		// Fallback writes the unconfirmedParentHeight sentinel instead of
@@ -1088,7 +1088,7 @@ func Test_getUtxoBlockHeights(t *testing.T) {
 			BlockHeights: []uint32{768, 769},
 		}, nil).Once()
 
-		utxoHashes, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, tx.TxID())
+		utxoHashes, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, tx.TxID(), nil)
 		require.NoError(t, err)
 
 		// Middle slot is the unconfirmed-parent fallback: writes the sentinel
@@ -1157,7 +1157,7 @@ func Test_getUtxoBlockHeights(t *testing.T) {
 			},
 		}, nil).Once()
 
-		utxoHashes, err := v.getUtxoBlockHeightsAndExtendTx(ctx, txNonExtended, txNonExtended.TxID())
+		utxoHashes, err := v.getUtxoBlockHeightsAndExtendTx(ctx, txNonExtended, txNonExtended.TxID(), nil)
 		require.NoError(t, err)
 
 		// Middle slot is the unconfirmed-parent fallback: writes the sentinel
@@ -1805,7 +1805,7 @@ func TestGetUtxoBlockHeightAndExtendForParentTx_RecordedHeightFromStore(t *testi
 	utxoHeights := make([]uint32, 1)
 
 	// A parent with recorded BlockHeights resolves to its real stored height.
-	err := v.getUtxoBlockHeightAndExtendForParentTx(ctx, parentTxHash, []int{0}, utxoHeights, tx, false)
+	err := v.getUtxoBlockHeightAndExtendForParentTx(ctx, parentTxHash, []int{0}, utxoHeights, tx, false, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, uint32(999), utxoHeights[0])
@@ -1839,7 +1839,7 @@ func TestGetUtxoBlockHeightAndExtendForParentTx_FallbackWritesUnconfirmedSentine
 	}
 
 	utxoHeights := make([]uint32, 1)
-	err := v.getUtxoBlockHeightAndExtendForParentTx(ctx, parentTxHash, []int{0}, utxoHeights, tx, false)
+	err := v.getUtxoBlockHeightAndExtendForParentTx(ctx, parentTxHash, []int{0}, utxoHeights, tx, false, nil)
 	require.NoError(t, err)
 	require.Equal(t, unconfirmedParentHeight, utxoHeights[0],
 		"fallback must write the teranode-internal sentinel, not blockState.Height+1")

--- a/services/validator/options.go
+++ b/services/validator/options.go
@@ -7,6 +7,11 @@ validation operations.
 */
 package validator
 
+import (
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+)
+
 // Options defines the configuration options for validation operations
 type Options struct {
 	// SkipUtxoCreation determines whether UTXO creation should be skipped
@@ -155,6 +160,22 @@ type Options struct {
 	// runs after ValidateBlock's PoW checks). MUST NOT be set on peer-facing
 	// subtree handling or mempool-admission paths.
 	UnconfirmedParentsAtCandidateHeight bool
+
+	// PrefetchedParents supplies parent-transaction metadata already read in
+	// bulk by the caller (the per-level bulk reader on the catchup path), keyed
+	// by parent tx hash. When a parent is present here the validator uses it
+	// instead of issuing a per-parent utxoStore.Get, which deduplicates the
+	// many reads of a shared parent in fan-out blocks and batches the rest.
+	//
+	// It is a pure read-source swap: the entry must carry exactly what a Get
+	// would return for the requested fields (BlockIDs, BlockHeights, and Tx
+	// when the tx needs extending). The unconfirmed-parent sentinel logic is
+	// unchanged — an entry with empty BlockHeights still resolves to
+	// unconfirmedParentHeight. The validator falls back to a store Get for any
+	// parent absent from this map, or present but missing the Tx needed for
+	// extension, so the prefetch can never reduce correctness. nil = always
+	// read from the store (the non-catchup default).
+	PrefetchedParents map[chainhash.Hash]*meta.Data
 }
 
 // Option defines a function type for setting options

--- a/services/validator/validator_prefetched_parents_test.go
+++ b/services/validator/validator_prefetched_parents_test.go
@@ -1,0 +1,94 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_getUtxoBlockHeightsAndExtendTx_Prefetched is the Phase-1 parity test:
+// when the per-level bulk reader has already fetched a tx's parents, supplying
+// them via PrefetchedParents must yield IDENTICAL block heights to the per-parent
+// store path AND perform ZERO `Get` calls against the store. This is the core
+// correctness contract — the bulk read is a pure read-source swap, not a change
+// in what the validator computes (bitcoin-expert invariants #2/#4: the data and
+// the unconfirmed-parent sentinel logic are unchanged; only the source differs).
+func Test_getUtxoBlockHeightsAndExtendTx_Prefetched(t *testing.T) {
+	ctx := context.Background()
+
+	// Same extended 3-parent tx used by Test_getUtxoBlockHeights.
+	tx, err := bt.NewTxFromString("010000000000000000ef03fe1a25c8774c1e827f9ebdae731fe609ff159d6f7c15094e1d467a99a01e03100000000002012affffffffa086010000000000018253a080075d834402e916390940782236b29d23db6f52dfc940a12b3eff99159c0000000000ffffffffa086010000000000100f5468616e6b7320456c69676975732161e4ed95239756bbb98d11dcf973146be0c17cc1cc94340deb8bc4d44cd88e92000000000a516352676a675168948cffffffff40548900000000000763516751676a680220aa4400000000001976a9149bc0bbdd3024da4d0c38ed1aecf5c68dd1d3fa1288ac20aa4400000000001976a914169ff4804fd6596deb974f360c21584aa1e19c9788ac00000000")
+	require.NoError(t, err)
+
+	parent0, err := chainhash.NewHashFromStr("10031ea0997a461d4e09157c6f9d15ff09e61f73aebd9e7f821e4c77c8251afe")
+	require.NoError(t, err)
+	parent1, err := chainhash.NewHashFromStr("9c1599ff3e2ba140c9df526fdb239db236227840093916e90244835d0780a053")
+	require.NoError(t, err)
+	parent2, err := chainhash.NewHashFromStr("928ed84cd4c48beb0d3494ccc17cc1e06b1473f9dc118db9bb56972395ede461")
+	require.NoError(t, err)
+
+	// Identical data to the "mined parent txs" subtest of Test_getUtxoBlockHeights:
+	// parent1 has empty BlockHeights (unconfirmed → sentinel).
+	prefetched := map[chainhash.Hash]*meta.Data{
+		*parent0: {BlockHeights: []uint32{125, 126}},
+		*parent1: {BlockHeights: []uint32{}},
+		*parent2: {BlockHeights: []uint32{768, 769}},
+	}
+
+	mockUtxoStore := &utxostore.MockUtxostore{}
+	v := &Validator{settings: settings.NewSettings(), utxoStore: mockUtxoStore}
+
+	utxoHeights, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, tx.TxID(), prefetched)
+	require.NoError(t, err)
+
+	require.Equal(t, []uint32{125, unconfirmedParentHeight, 768}, utxoHeights,
+		"prefetched heights must match the per-parent store path exactly")
+
+	mockUtxoStore.AssertNotCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Test_getUtxoBlockHeightsAndExtendTx_PartialPrefetchFallsBackToStore proves the
+// safety invariant: a parent absent from PrefetchedParents falls back to a store
+// Get, so a partial prefetch never reduces correctness — the heights are identical
+// to the all-store path, and only the missing parent is read.
+func Test_getUtxoBlockHeightsAndExtendTx_PartialPrefetchFallsBackToStore(t *testing.T) {
+	ctx := context.Background()
+
+	tx, err := bt.NewTxFromString("010000000000000000ef03fe1a25c8774c1e827f9ebdae731fe609ff159d6f7c15094e1d467a99a01e03100000000002012affffffffa086010000000000018253a080075d834402e916390940782236b29d23db6f52dfc940a12b3eff99159c0000000000ffffffffa086010000000000100f5468616e6b7320456c69676975732161e4ed95239756bbb98d11dcf973146be0c17cc1cc94340deb8bc4d44cd88e92000000000a516352676a675168948cffffffff40548900000000000763516751676a680220aa4400000000001976a9149bc0bbdd3024da4d0c38ed1aecf5c68dd1d3fa1288ac20aa4400000000001976a914169ff4804fd6596deb974f360c21584aa1e19c9788ac00000000")
+	require.NoError(t, err)
+
+	parent0, err := chainhash.NewHashFromStr("10031ea0997a461d4e09157c6f9d15ff09e61f73aebd9e7f821e4c77c8251afe")
+	require.NoError(t, err)
+	parent1, err := chainhash.NewHashFromStr("9c1599ff3e2ba140c9df526fdb239db236227840093916e90244835d0780a053")
+	require.NoError(t, err)
+	parent2, err := chainhash.NewHashFromStr("928ed84cd4c48beb0d3494ccc17cc1e06b1473f9dc118db9bb56972395ede461")
+	require.NoError(t, err)
+
+	// Prefetch covers only parent0 and parent2; parent1 must fall back to the store.
+	prefetched := map[chainhash.Hash]*meta.Data{
+		*parent0: {BlockHeights: []uint32{125, 126}},
+		*parent2: {BlockHeights: []uint32{768, 769}},
+	}
+
+	mockUtxoStore := &utxostore.MockUtxostore{}
+	v := &Validator{settings: settings.NewSettings(), utxoStore: mockUtxoStore}
+
+	// Only parent1 should ever be read from the store.
+	mockUtxoStore.On("Get", mock.Anything, mock.MatchedBy(func(hash *chainhash.Hash) bool {
+		return hash.IsEqual(parent1)
+	}), mock.Anything).Return(&meta.Data{BlockHeights: []uint32{}}, nil).Once()
+
+	utxoHeights, err := v.getUtxoBlockHeightsAndExtendTx(ctx, tx, tx.TxID(), prefetched)
+	require.NoError(t, err)
+
+	require.Equal(t, []uint32{125, unconfirmedParentHeight, 768}, utxoHeights)
+	// parent0 and parent2 came from the prefetch; only parent1 hit the store.
+	mockUtxoStore.AssertNumberOfCalls(t, "Get", 1)
+}


### PR DESCRIPTION
## Problem

When a node is behind and catching up, the subtree-validation txmeta cache is structurally cold, so every transaction's parent lookups fall to the UTXO store. The validator resolves parents **per transaction** (`getUtxoBlockHeightsAndExtendTx` → one `utxoStore.Get` per distinct parent), and `sendGetBatch` **does not deduplicate identical keys**. So a fan-out block — one funding tx spent by many children, the dominant tx-blaster/scaling shape — reads that same parent record **once per child**. At hundreds of millions of txs per block this is a primary reason a behind node can't keep pace with the miner.

This is **Phase 1** of the catchup work: bulk + dedup the parent **reads**, keeping in-order (level) validation, per-tx script validation, and `Spend`/`Create` exactly as they are. (Phase 2 — batched create/spend — is intentionally not included; it carries atomicity risk and should follow measurement.)

## Change

1. **`validator.Options.PrefetchedParents`** (`5d1e56605`): a map of parent hash → already-read `meta.Data`. `getUtxoBlockHeightAndExtendForParentTx` uses it instead of a per-parent `Get`, and **falls back to a `Get` for any parent absent** from the map (or present but missing the `Tx` needed to extend), so correctness is never reduced. The unconfirmed-parent sentinel logic is unchanged — a pure read-source swap.
2. **`prefetchLevelParents`** (`bef11e474`): in `processTransactionsInLevels`, per dependency level, bulk-read the **distinct** parents once and pass them via a per-level `Options` copy. Built after the previous level's transactions are created, so an in-block parent is seen exactly as a per-parent `Get` would see it (empty `BlockHeights` → unconfirmed sentinel → candidate height via the existing flag). A genuine bulk-read store error **aborts** the level (a DB failure must halt, not be swallowed); not-found parents are simply omitted → validator falls back to `Get` → existing missing-parent / deferred-revalidation handling.

The design (level ordering + bulk reads only) was reviewed for consensus safety: ordering, per-tx script validation, `Spend` (the double-spend authority), and `Create` are untouched.

## Benchmarks — `BenchmarkCatchupParentReads` (`b3749c6a5`)

Records read per level (deterministic — this is the Aerospike load):

| Shape | OLD | NEW |
|---|---|---|
| FanOut 1×1000 | 1000 | **1** |
| FanOut 10×100 | 1000 | **10** |
| Mixed 100×10 | 1000 | **100** |
| Distinct 1000×1 (no sharing) | 1000 | 1000 |

Wall-clock at a modelled 50µs/record: FanOut 1×1000 62.3ms → 0.08ms; Distinct 1000×1 ~neutral. The win tracks parent sharing — large on fan-out, a no-op (no regression) when every parent is distinct.

Caveats: records-read is exact (NEW runs the real `prefetchLevelParents`). The ns/op figures use a per-record latency model — they show the win scaling with store latency, not a real-Aerospike measurement. "OLD" faithfully models the validator's per-tx read pattern; the validator parity tests are what prove the new path eliminates those reads. A `-tags aerospike` benchmark is the remaining ground truth.

## Tests

- Validator: parity (prefetched heights == store-path heights, zero Gets) and partial-prefetch fallback (missing parent → exactly one Get).
- Subtreevalidation: dedup (shared parent read once, not once per child).
- Existing `CheckBlockSubtrees` / level-processing / unconfirmed-parent / large-block suites pass unchanged (integration parity); `-race` clean. (The only package failures are pre-existing Docker/redpanda integration tests, `TestPolicyRejectedTx*`.)