### PR TITLE
docs(propagation,validator): correct non-existent mempool service references

### DIFF
--- a/services/propagation/Client.go
+++ b/services/propagation/Client.go
@@ -21,9 +21,13 @@
 //   - Batch processing for high-volume transaction scenarios
 //
 // Integration:
-// This package integrates with other Teranode services including the mempool, validator,
-// and P2P services to ensure transactions are properly validated and distributed across
-// the network according to Bitcoin protocol specifications.
+// This package integrates with other Teranode services including the validator
+// (which validates transactions and forwards them to block assembly for inclusion
+// in subtrees) and the P2P service, ensuring transactions are properly validated and
+// distributed across the network according to Bitcoin protocol specifications.
+// Teranode has no separate mempool service: validated-but-unmined transactions are
+// assembled into subtrees by the block assembly service, with their unmined state
+// tracked in the UTXO store.
 package propagation
 
 import (

--- a/services/validator/Interface.go
+++ b/services/validator/Interface.go
@@ -3,8 +3,9 @@ Package validator implements BSV Blockchain transaction validation functionality
 
 This package provides a comprehensive transaction validation framework that implements
 the Bitcoin consensus and policy rules. It serves as a critical component in the
-Teranode architecture, ensuring that only valid transactions are accepted into the
-mempool and blocks.
+Teranode architecture, ensuring that only valid transactions are passed to block
+assembly for inclusion in subtrees and, ultimately, blocks. Teranode has no separate
+mempool service.
 
 This file defines the core interfaces for the validator service, providing the contract
 that all validator implementations must fulfill. The Interface type establishes the


### PR DESCRIPTION
## Summary

Fixes #635. The package documentation in `services/propagation/Client.go` and `services/validator/Interface.go` referenced a `mempool` service that does not exist in Teranode.

Teranode deliberately has **no mempool service**. There is no `mempool` directory under `services/`, and `propagation` integrates with the **validator** (which forwards transactions to **block assembly** for inclusion in subtrees/blocks), plus the **P2P** service. The conceptual mempool role is split between block assembly (subtrees) and the UTXO store (unmined-state tracking).

## Changes

- `services/propagation/Client.go` — corrected the package Integration doc to describe the real flow (validator → block assembly) and note that Teranode has no separate mempool service.
- `services/validator/Interface.go` — corrected the package doc: valid transactions are passed to block assembly for inclusion in subtrees and blocks, not "into the mempool".

Documentation-only change; no logic, signatures, or behaviour altered.

## Verification

```
go vet ./services/propagation/ ./services/validator/   # exit 0
```