### PR TITLE
fix(blockassembly): refuse empty-state start past genesis; add tip-lag/stuck metrics (#980)

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -703,9 +703,11 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 	ctxLogger.Debugf("[BlockAssembler] best block header according to block assembly : %d: %s", bestBlockAccordingToBlockAssemblyHeight, bestBlockAccordingToBlockAssembly.Hash())
 
 	// Publish how far block assembly is behind the chain tip so a stall is alertable
-	// without a human watching external chain-tip monitoring (issue #980, Bug B). The
-	// gauge stays elevated whenever a failure path below returns early; it is reset to
-	// zero on the successful-advance path at the end of this function.
+	// without a human watching external chain-tip monitoring (issue #980, Bug B). This
+	// is a pure height delta: it stays elevated while BA lags on a normal catch-up and
+	// is reset to zero on the successful-advance path at the end of this function. It
+	// reads 0 for an equal-height reorg stall (tip hash differs but height matches) —
+	// processing_stuck_total{reason} is the signal for that case.
 	if lag := int64(bestBlockchainBlockHeaderMeta.Height) - int64(bestBlockAccordingToBlockAssemblyHeight); lag > 0 {
 		prometheusBlockAssemblyTipLagBlocks.Set(float64(lag))
 	} else {
@@ -962,8 +964,9 @@ func (b *BlockAssembler) initState(ctx context.Context) error {
 				return errors.NewProcessingError("[BlockAssembler] refusing to start: no persisted BlockAssembler state but chain is at height %d (past genesis); adopting the tip would skip coinbase UTXO creation for blocks below it and corrupt the UTXO set — reseed BlockAssembler state or rebuild", meta.Height)
 			}
 
-			hash, _ := b.CurrentBlock()
-			b.logger.Infof("[BlockAssembler] setting best block header from GetBestBlockHeader: %s", hash.Hash())
+			// Log the header we are adopting (genesis here). b.CurrentBlock() is still
+			// unset on this path, so logging it would nil-deref.
+			b.logger.Infof("[BlockAssembler] setting best block header from GetBestBlockHeader: %s", header.Hash())
 			b.setBestBlockHeader(header, meta.Height)
 			b.subtreeProcessor.InitCurrentBlockHeader(header)
 		}

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -702,6 +702,16 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 	ctxLogger.Debugf("[BlockAssembler] best block header according to blockchain: %d: %s", bestBlockchainBlockHeaderMeta.Height, bestBlockAccordingToBlockchain.Hash())
 	ctxLogger.Debugf("[BlockAssembler] best block header according to block assembly : %d: %s", bestBlockAccordingToBlockAssemblyHeight, bestBlockAccordingToBlockAssembly.Hash())
 
+	// Publish how far block assembly is behind the chain tip so a stall is alertable
+	// without a human watching external chain-tip monitoring (issue #980, Bug B). The
+	// gauge stays elevated whenever a failure path below returns early; it is reset to
+	// zero on the successful-advance path at the end of this function.
+	if lag := int64(bestBlockchainBlockHeaderMeta.Height) - int64(bestBlockAccordingToBlockAssemblyHeight); lag > 0 {
+		prometheusBlockAssemblyTipLagBlocks.Set(float64(lag))
+	} else {
+		prometheusBlockAssemblyTipLagBlocks.Set(0)
+	}
+
 	switch {
 	case bestBlockAccordingToBlockchain.Hash().IsEqual(bestBlockAccordingToBlockAssembly.Hash()):
 		ctxLogger.Infof("[BlockAssembler][%s] best block header is the same as the current best block header: %s", bestBlockchainBlockHeader.Hash(), bestBlockAccordingToBlockAssembly.Hash())
@@ -711,6 +721,7 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 		moveBackBlocksWithMeta, moveForwardBlocksWithMeta, err := b.getReorgBlocks(ctx, bestBlockchainBlockHeader, bestBlockchainBlockHeaderMeta.Height)
 		if err != nil {
 			ctxLogger.Errorf("[BlockAssembler][%s] error fetching blocks for reorg/catch-up decision: %v", bestBlockchainBlockHeader.Hash(), err)
+			prometheusBlockAssemblyProcessingStuck.WithLabelValues("reorg_blocks_fetch").Inc()
 			return
 		}
 
@@ -721,6 +732,7 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 
 			if err = b.handleCatchUp(ctx, moveForwardBlocksWithMeta); err != nil {
 				ctxLogger.Errorf("[BlockAssembler][%s] error catching up: %v", bestBlockchainBlockHeader.Hash(), err)
+				prometheusBlockAssemblyProcessingStuck.WithLabelValues("catchup").Inc()
 				return
 			}
 		} else {
@@ -733,6 +745,7 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 					ctxLogger.Warnf("[BlockAssembler][%s] error handling reorg: %v", bestBlockchainBlockHeader.Hash(), err)
 				} else {
 					ctxLogger.Errorf("[BlockAssembler][%s] error handling reorg: %v", bestBlockchainBlockHeader.Hash(), err)
+					prometheusBlockAssemblyProcessingStuck.WithLabelValues("reorg").Inc()
 				}
 
 				return
@@ -745,6 +758,7 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 
 		if block, err = b.blockchainClient.GetBlock(ctx, bestBlockchainBlockHeader.Hash()); err != nil {
 			ctxLogger.Errorf("[BlockAssembler][%s] error getting block from blockchain: %v", bestBlockchainBlockHeader.Hash(), err)
+			prometheusBlockAssemblyProcessingStuck.WithLabelValues("get_block").Inc()
 			return
 		}
 
@@ -752,11 +766,16 @@ func (b *BlockAssembler) processNewBlockAnnouncement(ctx context.Context) {
 
 		if err = b.subtreeProcessor.MoveForwardBlock(block); err != nil {
 			ctxLogger.Errorf("[BlockAssembler][%s] error moveForwardBlock in subtree processor: %v", bestBlockchainBlockHeader.Hash(), err)
+			prometheusBlockAssemblyProcessingStuck.WithLabelValues("moveforward").Inc()
 			return
 		}
 	}
 
 	b.setBestBlockHeader(bestBlockchainBlockHeader, bestBlockchainBlockHeaderMeta.Height)
+
+	// Block assembly advanced to the chain tip we observed this round: it is no longer
+	// behind, so clear the lag gauge (issue #980, Bug B).
+	prometheusBlockAssemblyTipLagBlocks.Set(0)
 
 	_, height := b.CurrentBlock()
 	prometheusBlockAssemblyCurrentBlockHeight.Set(float64(height))
@@ -928,12 +947,25 @@ func (b *BlockAssembler) initState(ctx context.Context) error {
 			if err != nil {
 				// we must return an error here since we cannot continue without a best block header
 				return errors.NewProcessingError("[BlockAssembler] error getting best block header: %v", err)
-			} else {
-				hash, _ := b.CurrentBlock()
-				b.logger.Infof("[BlockAssembler] setting best block header from GetBestBlockHeader: %s", hash.Hash())
-				b.setBestBlockHeader(header, meta.Height)
-				b.subtreeProcessor.InitCurrentBlockHeader(header)
 			}
+
+			// No persisted checkpoint exists. Adopting the chain tip as the resume
+			// point only safely produces complete state when the chain is itself at
+			// genesis: block assembly is the sole writer of coinbase UTXOs (via
+			// processCoinbaseUtxos during moveForwardBlock), so jumping straight to a
+			// non-genesis tip skips that per-block work for every block below the tip,
+			// leaving permanent UTXO holes that surface as TX_NOT_FOUND ~100 blocks
+			// later (issue #980, Bug A). Refuse to start instead — partial state is
+			// worse than no progress. The operator must reseed the BlockAssembler
+			// state (e.g. via the rewindblockchain tool) or rebuild from scratch.
+			if meta.Height > 0 {
+				return errors.NewProcessingError("[BlockAssembler] refusing to start: no persisted BlockAssembler state but chain is at height %d (past genesis); adopting the tip would skip coinbase UTXO creation for blocks below it and corrupt the UTXO set — reseed BlockAssembler state or rebuild", meta.Height)
+			}
+
+			hash, _ := b.CurrentBlock()
+			b.logger.Infof("[BlockAssembler] setting best block header from GetBestBlockHeader: %s", hash.Hash())
+			b.setBestBlockHeader(header, meta.Height)
+			b.subtreeProcessor.InitCurrentBlockHeader(header)
 		}
 	}
 

--- a/services/blockassembly/BlockAssembler_test.go
+++ b/services/blockassembly/BlockAssembler_test.go
@@ -236,6 +236,57 @@ func TestBlockAssembly_Start(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Start with no state but non-genesis chain refuses", func(t *testing.T) {
+		// Bug A (issue #980): if no BlockAssembler checkpoint is persisted but the
+		// chain has already advanced past genesis, adopting the tip as the resume
+		// point silently skips processCoinbaseUtxos for every missed block, leaving
+		// permanent UTXO holes. A running node must refuse to start instead.
+		initPrometheusMetrics()
+
+		tSettings := createTestSettings(t)
+
+		utxoStoreURL, err := url.Parse("sqlitememory:///test")
+		require.NoError(t, err)
+
+		utxoStore, err := utxostoresql.New(t.Context(), ulogger.TestLogger{}, tSettings, utxoStoreURL)
+		require.NoError(t, err)
+
+		stats := gocore.NewStat("test")
+
+		// A non-genesis tip header that the node would otherwise silently adopt.
+		tipHeader := &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  model.GenesisBlockHeader.Hash(),
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      uint32(time.Now().Unix()),
+			Bits:           model.NBit{0xff, 0xff, 0x7f, 0x20},
+			Nonce:          1,
+		}
+
+		blockchainClient := &blockchain.Mock{}
+		// No persisted BlockAssembler state.
+		blockchainClient.On("GetState", mock.Anything, mock.Anything).Return([]byte{}, sql.ErrNoRows)
+		blockchainClient.On("SetState", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		// Chain tip is well past genesis.
+		blockchainClient.On("GetBestBlockHeader", mock.Anything).Return(tipHeader, &model.BlockHeaderMeta{Height: 100}, nil)
+		blockchainClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return([]*model.BlockHeader{model.GenesisBlockHeader}, []*model.BlockHeaderMeta{{Height: 0}}, nil)
+		blockchainClient.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{0}, nil)
+		blockchainClient.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
+		blockchainClient.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.ErrNotFound)
+		runningState := blockchain.FSMStateRUNNING
+		blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&runningState, nil)
+		subChan := make(chan *blockchain_api.Notification, 1)
+		blockchainClient.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
+
+		blockAssembler, err := NewBlockAssembler(t.Context(), ulogger.TestLogger{}, tSettings, stats, utxoStore, nil, blockchainClient, nil)
+		require.NoError(t, err)
+		require.NotNil(t, blockAssembler)
+
+		err = blockAssembler.Start(t.Context())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "refusing to start")
+	})
+
 	t.Run("Start with existing state in blockchain", func(t *testing.T) {
 		initPrometheusMetrics()
 

--- a/services/blockassembly/block_assembler_catchup_test.go
+++ b/services/blockassembly/block_assembler_catchup_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockassembly/subtreeprocessor"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +54,63 @@ func injectMockStp(t *testing.T, items *baTestItems, mockStp *subtreeprocessor.M
 	// Stop is called by t.Cleanup registered in setupBlockAssemblyTest.
 	mockStp.On("Stop", mock.Anything).Return()
 	items.blockAssembler.subtreeProcessor = mockStp
+}
+
+// TestProcessNewBlockAnnouncement_StuckMetrics covers the observability added for issue
+// #980 Bug B: when block assembly cannot advance, the only detection mechanism was a
+// human watching external chain-tip monitoring. A tip-lag gauge and a processing-stuck
+// counter make the stall alertable.
+func TestProcessNewBlockAnnouncement_StuckMetrics(t *testing.T) {
+	initPrometheusMetrics()
+
+	// A catch-up that keeps failing must leave the tip-lag gauge elevated and bump the
+	// processing-stuck counter, instead of silently logging and returning.
+	t.Run("failed catch-up records lag and stuck counter", func(t *testing.T) {
+		items := setupBlockAssemblyTest(t)
+		genesis := genesisHeader(t, items)
+
+		chain := buildChain(genesis, 5, 700)
+		addChain(t, items, chain)
+
+		mockStp := &subtreeprocessor.MockSubtreeProcessor{}
+		// Catch-up delegates to Reorg(empty, blocks); make it fail like ProcessConflicting did.
+		mockStp.On("Reorg", mock.Anything, mock.Anything).
+			Return(errors.NewProcessingError("tx is not conflicting"))
+		injectMockStp(t, items, mockStp)
+
+		// BA stuck at genesis; tip is at height 5 → lag of 5.
+		items.blockAssembler.setBestBlockHeader(genesis, 0)
+
+		stuckBefore := testutil.ToFloat64(prometheusBlockAssemblyProcessingStuck.WithLabelValues("catchup"))
+
+		items.blockAssembler.processNewBlockAnnouncement(t.Context())
+
+		require.Equal(t, float64(5), testutil.ToFloat64(prometheusBlockAssemblyTipLagBlocks),
+			"tip-lag gauge must reflect blocks behind the chain tip")
+		stuckAfter := testutil.ToFloat64(prometheusBlockAssemblyProcessingStuck.WithLabelValues("catchup"))
+		require.Equal(t, float64(1), stuckAfter-stuckBefore,
+			"processing-stuck counter must increment on a failed catch-up")
+	})
+
+	// A successful advance to the tip must clear the lag gauge.
+	t.Run("successful catch-up clears lag", func(t *testing.T) {
+		items := setupBlockAssemblyTest(t)
+		genesis := genesisHeader(t, items)
+
+		chain := buildChain(genesis, 3, 800)
+		addChain(t, items, chain)
+
+		mockStp := &subtreeprocessor.MockSubtreeProcessor{}
+		mockStp.On("Reorg", mock.Anything, mock.Anything).Return(nil)
+		injectMockStp(t, items, mockStp)
+
+		items.blockAssembler.setBestBlockHeader(genesis, 0)
+
+		items.blockAssembler.processNewBlockAnnouncement(t.Context())
+
+		require.Equal(t, float64(0), testutil.ToFloat64(prometheusBlockAssemblyTipLagBlocks),
+			"tip-lag gauge must return to zero once caught up")
+	})
 }
 
 // TestProcessNewBlockAnnouncement_CatchupVsReorg covers the routing logic introduced

--- a/services/blockassembly/metrics.go
+++ b/services/blockassembly/metrics.go
@@ -49,6 +49,8 @@ var (
 	prometheusBlockAssemblerUpdateBestBlock             prometheus.Histogram
 	prometheusBlockAssemblyBestBlockHeight              prometheus.Gauge
 	prometheusBlockAssemblyCurrentBlockHeight           prometheus.Gauge
+	prometheusBlockAssemblyTipLagBlocks                 prometheus.Gauge
+	prometheusBlockAssemblyProcessingStuck              *prometheus.CounterVec
 	prometheusBlockAssemblerCurrentState                prometheus.Gauge
 	prometheusBlockAssemblerStateTransitions            *prometheus.CounterVec
 	prometheusBlockAssemblerStateDuration               *prometheus.HistogramVec
@@ -271,6 +273,25 @@ func _initPrometheusMetrics() {
 			Name:      "current_block_height",
 			Help:      "Current block height in block assembly",
 		},
+	)
+
+	prometheusBlockAssemblyTipLagBlocks = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "teranode",
+			Subsystem: "blockassembly",
+			Name:      "tip_lag_blocks",
+			Help:      "Number of blocks block assembly is behind the blockchain tip (0 when caught up). Sustained non-zero values indicate block assembly is stuck (issue #980).",
+		},
+	)
+
+	prometheusBlockAssemblyProcessingStuck = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockassembly",
+			Name:      "processing_stuck_total",
+			Help:      "Count of block assembly catch-up/reorg/move-forward failures that left the assembler behind the tip, labelled by reason (issue #980).",
+		},
+		[]string{"reason"},
 	)
 
 	prometheusBlockAssemblerCurrentState = promauto.NewGauge(


### PR DESCRIPTION
## Summary

Addresses two of the three block-assembly failure modes reported in #980. Both left a mainnet node (`v0.15.2-beta-2`) wedged with **no exit condition and no operator visibility** — the chain tip kept advancing while block assembly silently stopped making progress.

### Bug A — empty/stale-checkpoint catch-up leaves UTXO holes
Block assembly is the **sole writer of coinbase UTXOs** (`processCoinbaseUtxos` runs only inside `SubtreeProcessor`). When `initState` found no persisted `BlockAssembler` checkpoint, it adopted the chain tip directly — skipping the per-block coinbase work for every block below the tip and producing a corrupt UTXO set that surfaces as `TX_NOT_FOUND` ~100 blocks later (exactly the incident's intervention-5 failure).

`initState` now **refuses to start** when no checkpoint exists *and* the chain is past genesis (height > 0). A genuinely fresh node (genesis only) still starts normally. Partial state is worse than no progress — the operator must reseed `BlockAssembler` state (e.g. via `rewindblockchain`) or rebuild. No automated flow leaves the state empty on a non-genesis chain, so this only triggers on manual `DELETE`, DB corruption, or a snapshot missing BA state.

### Bug B — stalls were invisible
`processNewBlockAnnouncement` now publishes:
- `blockassembly_tip_lag_blocks` — gauge, blocks behind the chain tip (0 when caught up); stays elevated while stuck, cleared on a successful advance.
- `blockassembly_processing_stuck_total{reason}` — counter over catch-up / reorg / move-forward / block-fetch failures.

The lag gauge alone would have paged operators ~20h earlier than external chain-tip monitoring did in the incident. This is the cheapest detection improvement requested in the issue's open questions.

> Scoped to **metrics only** per design discussion — the catch-up retry is now *visible* but still unbounded. Bounding the retry + FSM escalation is a deliberately separate, larger change.

### Bug C — not included
The pruner already gates both prune phases and the blob-deletion worker on block-assembly state (`checkBlockAssemblySafeForPruner`), and that gate predates the incident by ~6 months. Investigation found no unconditional hole in the default-config path; the only real gaps are config-gated (`pruner_utxoSetTTL=true` autonomous Aerospike expiry) and a latent `nil`-client no-op. Left for a separate change pending direction.

## Tests
- `TestBlockAssembly_Start/Start_with_no_state_but_non-genesis_chain_refuses` — TDD for Bug A (genesis-only fresh node still starts).
- `TestProcessNewBlockAnnouncement_StuckMetrics` — failed catch-up leaves lag gauge elevated + bumps the stuck counter; successful catch-up clears the gauge.
- `go test ./services/blockassembly/` green; `go test -race` on the affected tests clean; `go vet` clean.