### PR TITLE
fix(blockchain): handle malformed n_bits instead of panicking

### DIFF
--- a/stores/blockchain/sql/GetBestBlockHeader.go
+++ b/stores/blockchain/sql/GetBestBlockHeader.go
@@ -174,7 +174,11 @@ func (s *SQL) GetBestBlockHeader(ctx context.Context) (*model.BlockHeader, *mode
 		return nil, nil, errors.NewStorageError("error in GetBestBlockHeader", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, nil, errors.NewStorageError("error in GetBestBlockHeader: malformed n_bits (length %d, expected 4) for block id %d height %d", len(nBits), blockHeaderMeta.ID, blockHeaderMeta.Height, err)
+	}
+
 	blockHeader.Bits = *bits
 
 	blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBestBlockHeader_test.go
+++ b/stores/blockchain/sql/GetBestBlockHeader_test.go
@@ -105,6 +105,37 @@ func TestSqlGetChainTip(t *testing.T) {
 	// TestEqualChainworkTiebreaker verifies that when two chains have equal chainwork,
 	// the tiebreaker uses peer_id ASC (lower peer_id wins, representing "first-seen").
 	// This tests the ORDER BY clause: chain_work DESC, peer_id ASC, id ASC
+	// TestMalformedNBits verifies that a corrupted n_bits column (wrong byte length,
+	// e.g. ASCII-encoded hex stored as bytea) makes GetBestBlockHeader return a clean
+	// storage error instead of panicking with a nil-pointer dereference. See issue #884.
+	t.Run("malformed n_bits returns error instead of panicking", func(t *testing.T) {
+		storeURL, err := url.Parse("sqlitememory:///")
+		require.NoError(t, err)
+
+		s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+		require.NoError(t, err)
+
+		_, _, err = s.StoreBlock(context.Background(), block1, "test_peer")
+		require.NoError(t, err)
+
+		_, _, err = s.StoreBlock(context.Background(), block2, "test_peer")
+		require.NoError(t, err)
+
+		// Corrupt the tip's n_bits to 8 bytes (the length the affected operator's bad
+		// hex-as-ASCII restore produced), mirroring the malformed-bytea condition.
+		_, err = s.db.ExecContext(context.Background(),
+			"UPDATE blocks SET n_bits = ? WHERE height = 2",
+			[]byte{0xff, 0xff, 0x7f, 0x20, 0x00, 0x00, 0x00, 0x00})
+		require.NoError(t, err)
+
+		// Invalidate the response cache so the corrupted row is actually read back.
+		s.responseCache.DeleteAll()
+
+		_, _, err = s.GetBestBlockHeader(context.Background())
+		require.Error(t, err, "GetBestBlockHeader must return an error for malformed n_bits, not panic")
+		require.Contains(t, err.Error(), "n_bits")
+	})
+
 	t.Run("equal chainwork prefers lower peer_id (first-seen rule)", func(t *testing.T) {
 		storeURL, err := url.Parse("sqlitememory:///")
 		require.NoError(t, err)

--- a/stores/blockchain/sql/GetBlock.go
+++ b/stores/blockchain/sql/GetBlock.go
@@ -164,7 +164,11 @@ func (s *SQL) GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*model.B
 		return nil, 0, errors.NewStorageError("error in GetBlock", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, 0, errors.NewStorageError("error in GetBlock: malformed n_bits (length %d, expected 4) for block %s", len(nBits), blockHash.String(), err)
+	}
+
 	block.Header.Bits = *bits
 
 	block.Header.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlockByID.go
+++ b/stores/blockchain/sql/GetBlockByID.go
@@ -146,7 +146,11 @@ func (s *SQL) GetBlockByID(ctx context.Context, id uint64) (*model.Block, error)
 		return nil, errors.NewStorageError("failed to get block by ID", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, errors.NewStorageError("failed to get block by ID: malformed n_bits (length %d, expected 4) for block id %d", len(nBits), id, err)
+	}
+
 	block.Header.Bits = *bits
 
 	block.Header.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlockHeader.go
+++ b/stores/blockchain/sql/GetBlockHeader.go
@@ -179,7 +179,11 @@ func (s *SQL) GetBlockHeader(ctx context.Context, blockHash *chainhash.Hash) (*m
 		return nil, nil, errors.NewStorageError("error in GetBlockHeader", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, nil, errors.NewStorageError("error in GetBlockHeader: malformed n_bits (length %d, expected 4) for block %s height %d", len(nBits), blockHash.String(), blockHeaderMeta.Height, err)
+	}
+
 	blockHeader.Bits = *bits
 
 	blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlockHeaders.go
+++ b/stores/blockchain/sql/GetBlockHeaders.go
@@ -279,7 +279,11 @@ func (s *SQL) processBlockHeadersRows(rows *sql.Rows, numberOfHeaders uint64, ha
 			}
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, nil, errors.NewStorageError("error in GetBlockHeaders: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), blockHeaderMeta.Height, nBitsErr)
+		}
+
 		blockHeader.Bits = *bits
 
 		var err error

--- a/stores/blockchain/sql/GetBlockHeadersByHeight.go
+++ b/stores/blockchain/sql/GetBlockHeadersByHeight.go
@@ -192,7 +192,11 @@ func (s *SQL) GetBlockHeadersByHeight(ctx context.Context, startHeight, endHeigh
 			return nil, nil, errors.NewStorageError("failed to scan row", err)
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, nil, errors.NewStorageError("error in GetBlockHeadersByHeight: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), blockHeaderMeta.Height, nBitsErr)
+		}
+
 		blockHeader.Bits = *bits
 
 		blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlockHeadersFromHeight.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromHeight.go
@@ -160,7 +160,11 @@ func (s *SQL) GetBlockHeadersFromHeight(ctx context.Context, height, limit uint3
 			return nil, nil, errors.NewStorageError("failed to scan row", err)
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, nil, errors.NewStorageError("error in GetBlockHeadersFromHeight: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), blockHeaderMeta.Height, nBitsErr)
+		}
+
 		blockHeader.Bits = *bits
 
 		blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlockHeadersFromTill.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromTill.go
@@ -181,7 +181,11 @@ func (s *SQL) GetBlockHeadersFromTill(ctx context.Context, blockHashFrom *chainh
 			return nil, nil, errors.NewStorageError("failed to scan row", err)
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, nil, errors.NewStorageError("error in GetBlockHeadersFromTill: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), blockHeaderMeta.Height, nBitsErr)
+		}
+
 		blockHeader.Bits = *bits
 
 		blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlockInChainByHeight.go
+++ b/stores/blockchain/sql/GetBlockInChainByHeight.go
@@ -202,7 +202,11 @@ func (s *SQL) GetBlockInChainByHeightHash(ctx context.Context, height uint32, st
 		return nil, false, errors.NewStorageError("[GetBlockInChainByHeightHash][%s:%d] failed to get block in-chain by height", startHash.String(), height, err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, false, errors.NewStorageError("[GetBlockInChainByHeightHash][%s:%d] malformed n_bits (length %d, expected 4)", startHash.String(), height, len(nBits), err)
+	}
+
 	block.Header.Bits = *bits
 
 	block.Header.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlocksNotPersisted.go
+++ b/stores/blockchain/sql/GetBlocksNotPersisted.go
@@ -89,7 +89,11 @@ func (s *SQL) GetBlocksNotPersisted(ctx context.Context, limit int) ([]*model.Bl
 			return nil, errors.NewStorageError("error scanning block row", err)
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, errors.NewStorageError("error in GetBlocksNotPersisted: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), height, nBitsErr)
+		}
+
 		block.Header.Bits = *bits
 
 		block.Header.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetBlocksSubtreesNotSet.go
+++ b/stores/blockchain/sql/GetBlocksSubtreesNotSet.go
@@ -160,7 +160,11 @@ func (s *SQL) getBlocksWithQuery(ctx context.Context, q string) ([]*model.Block,
 			return nil, err
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, errors.NewStorageError("error in GetBlocksSubtreesNotSet: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), height, nBitsErr)
+		}
+
 		block.Header.Bits = *bits
 
 		block.Header.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetForkedBlockHeaders.go
+++ b/stores/blockchain/sql/GetForkedBlockHeaders.go
@@ -164,7 +164,11 @@ func (s *SQL) GetForkedBlockHeaders(ctx context.Context, blockHashFrom *chainhas
 			return nil, nil, errors.NewStorageError("failed to scan row", err)
 		}
 
-		bits, _ := model.NewNBitFromSlice(nBits)
+		bits, nBitsErr := model.NewNBitFromSlice(nBits)
+		if nBitsErr != nil {
+			return nil, nil, errors.NewStorageError("error in GetForkedBlockHeaders: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), blockHeaderMeta.Height, nBitsErr)
+		}
+
 		blockHeader.Bits = *bits
 
 		blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/GetHeader.go
+++ b/stores/blockchain/sql/GetHeader.go
@@ -126,7 +126,11 @@ func (s *SQL) GetHeader(ctx context.Context, blockHash *chainhash.Hash) (*model.
 		return nil, errors.NewProcessingError("failed to convert hashMerkleRoot", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, errors.NewStorageError("error in GetHeader: malformed n_bits (length %d, expected 4) for block %s", len(nBits), blockHash.String(), err)
+	}
+
 	blockHeader.Bits = *bits
 
 	// Cache the result in response cache

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -257,7 +257,11 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		return nil, nil, errors.NewStorageError("error in GetBlockHeader", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, nil, errors.NewStorageError("error in GetLatestBlockHeaderFromBlockLocator: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), blockHeaderMeta.Height, err)
+	}
+
 	blockHeader.Bits = *bits
 
 	blockHeader.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)

--- a/stores/blockchain/sql/block_helpers.go
+++ b/stores/blockchain/sql/block_helpers.go
@@ -68,7 +68,11 @@ func (s *SQL) scanBlockRow(rows *sql.Rows) (*model.BlockInfo, error) {
 	}
 
 	// Process nBits
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, errors.NewStorageError("scanBlockRow: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), info.Height, err)
+	}
+
 	header.Bits = *bits
 
 	// Process previous block hash
@@ -173,7 +177,11 @@ func (s *SQL) scanFullBlockRow(rows *sql.Rows) (*model.Block, error) {
 		return nil, errors.NewStorageError("failed to scan row", err)
 	}
 
-	bits, _ := model.NewNBitFromSlice(nBits)
+	bits, err := model.NewNBitFromSlice(nBits)
+	if err != nil {
+		return nil, errors.NewStorageError("scanFullBlockRow: malformed n_bits (length %d, expected 4) for block height %d", len(nBits), height, err)
+	}
+
 	block.Header.Bits = *bits
 
 	block.Header.HashPrevBlock, err = chainhash.NewHash(hashPrevBlock)


### PR DESCRIPTION
## Summary

Fixes #884.

`GetBestBlockHeader` (and 15 sibling SQL queries in `stores/blockchain/sql/`) ignored the error from `model.NewNBitFromSlice(nBits)` and immediately dereferenced the returned pointer:

```go
bits, _ := model.NewNBitFromSlice(nBits)
blockHeader.Bits = *bits   // panics if bits is nil
```

When a `blocks` row has a non-4-byte `n_bits` column — e.g. an operator restoring a `bytea` column as ASCII-encoded hex rather than binary — `NewNBitFromSlice` returns `(nil, error)` and `*bits` panics with a nil-pointer dereference. The panic fired during `startSubscriptions` early in service startup, crash-looping the blockchain service and cascading through docker-compose `depends_on` (observed: 104 restarts in ~15 minutes, whole stack stalled).

## What changed

Every `NewNBitFromSlice` call site in the package now checks the error and returns a `StorageError` carrying the observed byte length (plus block id/height/hash where available) instead of dereferencing nil. This converts an unrecoverable crash-loop into an actionable operator error.

Call sites hardened: `GetBestBlockHeader`, `GetBlockHeader`, `GetBlock`, `GetBlockByID`, `GetBlockInChainByHeightHash`, `GetHeader`, `GetLatestBlockHeaderFromBlockLocator`, `GetBlockHeaders`, `GetBlockHeadersFromTill`, `GetBlockHeadersFromHeight`, `GetBlockHeadersByHeight`, `GetForkedBlockHeaders`, `GetBlocksNotPersisted`, `GetBlocksSubtreesNotSet`, and both row scanners in `block_helpers.go`.

No function signatures changed, so callers are unaffected.

## Test

Added a regression subtest to `GetBestBlockHeader_test.go` that stores blocks, corrupts the chain tip's `n_bits` to 8 bytes via raw SQL, and asserts `GetBestBlockHeader` returns an error. This subtest panics on the pre-fix code (reproduces the stack trace at `GetBestBlockHeader.go:178`) and passes after.

## Verification

- `go test -race ./stores/blockchain/sql/` → ok (full package)
- `go vet ./stores/blockchain/sql/` → exit 0
- `staticcheck ./stores/blockchain/sql/` → exit 0
- `golangci-lint run ./stores/blockchain/sql/` → 0 issues

## Out of scope

The optional startup table-scan sanity check suggested in the issue is deferred to a separate change.