### PR TITLE
fix(blockchain): init maxBlockID at startup to stop false-negative chain-membership during cold-cache catchup

### DIFF
--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain.go
@@ -41,6 +41,20 @@ func (s *SQL) CheckBlockIsInCurrentChain(ctx context.Context, blockIDs []uint32)
 
 	maxID := uint32(s.maxBlockID.Load())
 
+	// Fail safe when maxBlockID is uninitialised. It is loaded synchronously at
+	// New() and refreshed by rebuildOffChainSet, but is held in an atomic that
+	// starts at 0. Genesis is committed with id 1 before either runs, so a real
+	// chain never has a committed MAX(id) of 0 — maxID==0 unambiguously means
+	// "not yet initialised" (e.g. the synchronous load errored and the first
+	// async rebuild has not completed). With maxID==0 the id<=maxID filter below
+	// would drop EVERY committed candidate as "dangling" and return a (false, nil)
+	// false negative — which checkOldBlockIDs escalates into a PERMANENT block
+	// invalidation. Defer to the authoritative, flag-free parent_id CTE instead;
+	// it needs no maxBlockID and cannot produce that false negative.
+	if maxID == 0 {
+		return s.checkBlockIsInCurrentChainSQL(ctx, blockIDs)
+	}
+
 	// Drop ids above the highest committed id. These are allocated-but-uncommitted
 	// (GetNextBlockID writes a tx's BlockIDs before AddBlock bumps maxBlockID), so
 	// they have no committed row and are definitively not on the main chain. This

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
@@ -211,6 +211,44 @@ func TestCheckBlockIsInCurrentChain_InMemory_PhantomBelowMaxID(t *testing.T) {
 	assert.True(t, result)
 }
 
+// TestCheckBlockIsInCurrentChain_InMemory_UninitialisedMaxBlockID reproduces the
+// 2026-06-18 betfair-pc mainnet cascade. On a restart mid-catchup the startup
+// rebuildOffChainSet timed out on a cold cache and returned before setting
+// maxBlockID, leaving the atomic at 0 once the rebuild guard was released. With
+// maxID==0 the in-memory path dropped every committed parent id as "above the
+// highest id" and returned (false, nil) — a false negative that checkOldBlockIDs
+// escalates into a PERMANENT block invalidation, which froze the chain. A real
+// chain's MAX(id) is never 0 (genesis is committed as id 1), so maxID==0 means
+// "uninitialised" and must fall through to the authoritative parent_id CTE rather
+// than reject. Pre-fix this returned false; post-fix it returns true.
+func TestCheckBlockIsInCurrentChain_InMemory_UninitialisedMaxBlockID(t *testing.T) {
+	s := newStoreWithInMemoryChainCheck(t)
+	defer s.Close()
+
+	_, _, err := s.StoreBlock(context.Background(), block1, "")
+	require.NoError(t, err)
+
+	block2ID, _, err := s.StoreBlock(context.Background(), block2, "")
+	require.NoError(t, err)
+
+	// Precondition: block2 is genuinely on the main chain (maxBlockID populated).
+	ok, err := s.CheckBlockIsInCurrentChain(context.Background(), []uint32{uint32(block2ID)})
+	require.NoError(t, err)
+	require.True(t, ok, "precondition: block2 must be on the main chain")
+
+	// Simulate the post-timeout startup window: the rebuild guard is released (so
+	// the in-memory path is active) but maxBlockID was never set.
+	require.Zero(t, s.mainChainRebuilding.Load(), "in-memory path requires guard==0")
+	s.maxBlockID.Store(0)
+
+	// A committed, on-chain parent id must NOT be reported off-chain just because
+	// maxBlockID is uninitialised. Pre-fix this returned (false, nil) and the
+	// caller permanently invalidated the block.
+	ok, err = s.CheckBlockIsInCurrentChain(context.Background(), []uint32{uint32(block2ID)})
+	require.NoError(t, err)
+	require.True(t, ok, "uninitialised maxBlockID (0) must fall through to the CTE, not reject an on-chain block")
+}
+
 func TestCheckBlockIsInCurrentChain_MixedOnChainAndOffChain(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 	storeURL, err := url.Parse("sqlitememory:///")

--- a/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
+++ b/stores/blockchain/sql/CheckBlockIsInCurrentChain_test.go
@@ -212,7 +212,7 @@ func TestCheckBlockIsInCurrentChain_InMemory_PhantomBelowMaxID(t *testing.T) {
 }
 
 // TestCheckBlockIsInCurrentChain_InMemory_UninitialisedMaxBlockID reproduces the
-// 2026-06-18 betfair-pc mainnet cascade. On a restart mid-catchup the startup
+// 2026-06-18 mainnet cascade. On a restart mid-catchup the startup
 // rebuildOffChainSet timed out on a cold cache and returned before setting
 // maxBlockID, leaving the atomic at 0 once the rebuild guard was released. With
 // maxID==0 the in-memory path dropped every committed parent id as "above the

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -293,6 +293,28 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		return nil, errors.NewStorageError("failed to insert genesis transaction", err)
 	}
 
+	if useInMemory {
+		// Initialise maxBlockID synchronously, before any query can be served.
+		// maxBlockID is otherwise only set at the end of rebuildOffChainSet, which
+		// runs asynchronously below and can time out on a cold cache during catchup —
+		// leaving maxBlockID at 0 once the startup guard is released. A zero
+		// maxBlockID makes CheckBlockIsInCurrentChain's in-memory path drop every
+		// committed parent id as "above the highest id" and return a (false, nil)
+		// false negative that checkOldBlockIDs escalates into a PERMANENT block
+		// invalidation. This cheap MAX(id) query (an index-only scan, unlike the
+		// timeout-prone off-chain CTE) closes that startup window. Best-effort: on
+		// error the CTE fallback in CheckBlockIsInCurrentChain still keeps results
+		// correct, so do not fail startup over it.
+		maxIDCtx, maxIDCancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
+		var maxID uint32
+		if scanErr := s.db.QueryRowContext(maxIDCtx, `SELECT COALESCE(MAX(id), 0) FROM blocks`).Scan(&maxID); scanErr != nil {
+			s.logger.Warnf("startup: failed to initialise maxBlockID (will be set by first rebuild): %v", scanErr)
+		} else {
+			s.updateMaxBlockID(uint64(maxID))
+		}
+		maxIDCancel()
+	}
+
 	// Hold the rebuild guard synchronously until the background goroutine has started
 	// and incremented it itself. This ensures concurrent queries fall back to the CTE
 	// from the moment New() returns, even before the goroutine is scheduled — without
@@ -1656,6 +1678,21 @@ func (s *SQL) rebuildOffChainSet(ctx context.Context) error {
 		err  error
 	)
 
+	// Refresh maxBlockID BEFORE the (potentially slow, timeout-prone) off-chain
+	// query below. maxBlockID is the authoritative upper bound consulted by
+	// CheckBlockIsInCurrentChain's in-memory path. The off-chain query can be a
+	// full-chain recursive CTE that times out on a cold cache during catchup; if
+	// it does, this function returns early. Doing the cheap MAX(id) query up front
+	// guarantees maxBlockID is still refreshed rather than left at a stale/zero
+	// value — a zero maxBlockID makes every committed parent id look "above the
+	// highest id", a false negative that checkOldBlockIDs escalates into a
+	// PERMANENT block invalidation.
+	var maxID uint32
+	if err = s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM blocks`).Scan(&maxID); err != nil {
+		return errors.NewStorageError("rebuildOffChainSet: failed to query max block ID", err)
+	}
+	s.updateMaxBlockID(uint64(maxID))
+
 	if s.mainChainRebuilding.Load() > 0 {
 		// on_main_chain flags may be mid-update — fall back to the authoritative CTE walk.
 		// Walk the main chain from bestBlockID backward to genesis via parent_id,
@@ -1701,15 +1738,6 @@ func (s *SQL) rebuildOffChainSet(ctx context.Context) error {
 	s.offChainBlockIDsMu.Lock()
 	s.offChainBlockIDs = offChain
 	s.offChainBlockIDsMu.Unlock()
-
-	// Update maxBlockID from the database. This is the authoritative upper bound
-	// for block IDs — any ID above this cannot exist and should not be treated as
-	// on-chain by CheckBlockIsInCurrentChain.
-	var maxID uint32
-	if err = s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM blocks`).Scan(&maxID); err != nil {
-		return errors.NewStorageError("rebuildOffChainSet: failed to query max block ID", err)
-	}
-	s.updateMaxBlockID(uint64(maxID))
 
 	if len(offChain) > 0 {
 		s.logger.Infof("rebuildOffChainSet: %d off-chain block IDs, maxBlockID=%d", len(offChain), maxID)

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -306,11 +306,8 @@ func New(logger ulogger.Logger, storeURL *url.URL, tSettings *settings.Settings)
 		// error the CTE fallback in CheckBlockIsInCurrentChain still keeps results
 		// correct, so do not fail startup over it.
 		maxIDCtx, maxIDCancel := s.shutdownAwareContext(rebuildOffChainSetTimeout)
-		var maxID uint32
-		if scanErr := s.db.QueryRowContext(maxIDCtx, `SELECT COALESCE(MAX(id), 0) FROM blocks`).Scan(&maxID); scanErr != nil {
+		if scanErr := s.refreshMaxBlockID(maxIDCtx); scanErr != nil {
 			s.logger.Warnf("startup: failed to initialise maxBlockID (will be set by first rebuild): %v", scanErr)
-		} else {
-			s.updateMaxBlockID(uint64(maxID))
 		}
 		maxIDCancel()
 	}
@@ -1679,19 +1676,14 @@ func (s *SQL) rebuildOffChainSet(ctx context.Context) error {
 	)
 
 	// Refresh maxBlockID BEFORE the (potentially slow, timeout-prone) off-chain
-	// query below. maxBlockID is the authoritative upper bound consulted by
-	// CheckBlockIsInCurrentChain's in-memory path. The off-chain query can be a
-	// full-chain recursive CTE that times out on a cold cache during catchup; if
-	// it does, this function returns early. Doing the cheap MAX(id) query up front
-	// guarantees maxBlockID is still refreshed rather than left at a stale/zero
-	// value — a zero maxBlockID makes every committed parent id look "above the
-	// highest id", a false negative that checkOldBlockIDs escalates into a
-	// PERMANENT block invalidation.
-	var maxID uint32
-	if err = s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM blocks`).Scan(&maxID); err != nil {
-		return errors.NewStorageError("rebuildOffChainSet: failed to query max block ID", err)
+	// query below. The off-chain query can be a full-chain recursive CTE that times
+	// out on a cold cache during catchup; if it does, this function returns early.
+	// Doing the cheap MAX(id) query up front guarantees maxBlockID is still refreshed
+	// rather than left at a stale/zero value. See refreshMaxBlockID for why a zero
+	// bound is dangerous.
+	if err = s.refreshMaxBlockID(ctx); err != nil {
+		return errors.NewStorageError("rebuildOffChainSet: failed to refresh max block ID", err)
 	}
-	s.updateMaxBlockID(uint64(maxID))
 
 	if s.mainChainRebuilding.Load() > 0 {
 		// on_main_chain flags may be mid-update — fall back to the authoritative CTE walk.
@@ -1740,8 +1732,26 @@ func (s *SQL) rebuildOffChainSet(ctx context.Context) error {
 	s.offChainBlockIDsMu.Unlock()
 
 	if len(offChain) > 0 {
-		s.logger.Infof("rebuildOffChainSet: %d off-chain block IDs, maxBlockID=%d", len(offChain), maxID)
+		s.logger.Infof("rebuildOffChainSet: %d off-chain block IDs, maxBlockID=%d", len(offChain), s.maxBlockID.Load())
 	}
+
+	return nil
+}
+
+// refreshMaxBlockID reads the highest committed block id (an index-only scan on
+// the primary key) and advances maxBlockID to it. It is the cheap, timeout-resistant
+// counterpart to the off-chain CTE rebuild: maxBlockID is the authoritative upper
+// bound consulted by CheckBlockIsInCurrentChain's in-memory path, and a stale/zero
+// value there makes every committed parent id look "above the highest id" — a false
+// negative that checkOldBlockIDs escalates into a PERMANENT block invalidation. Run
+// it before anything that can serve a query (New) and before any timeout-prone work
+// (rebuildOffChainSet) so the bound is always populated.
+func (s *SQL) refreshMaxBlockID(ctx context.Context) error {
+	var maxID uint32
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM blocks`).Scan(&maxID); err != nil {
+		return errors.NewStorageError("failed to query max block ID", err)
+	}
+	s.updateMaxBlockID(uint64(maxID))
 
 	return nil
 }


### PR DESCRIPTION
## Problem

Follow-up to #1086. That PR closed the spurious-invalidation path where a transiently-false `on_main_chain` flag (off-chain set) caused `checkOldBlockIDs` to permanently invalidate an on-chain block. A second, distinct trigger of the **same** false-negative-becomes-permanent-invalidation hazard remained.

`CheckBlockIsInCurrentChain`'s in-memory path (`blockchain_use_in_memory_chain_check=true`) drops parent block ids `> maxBlockID` as dangling/uncommitted, then returns `(false, nil)` if nothing survives. But `maxBlockID` is **only ever set at the end of `rebuildOffChainSet`**, which runs asynchronously at startup. On a restart mid-catchup with a cold cache, that rebuild's off-chain query (a full-chain recursive CTE) **times out** and returns *before* the trailing `SELECT MAX(id)` — so `maxBlockID` stays `0` once the startup rebuild guard (`mainChainRebuilding`) is released.

With `maxBlockID == 0`, every committed parent id is filtered out → `CheckBlockIsInCurrentChain` returns `(false, nil)` → `checkOldBlockIDs` escalates it into a **permanent `BLOCK_INVALID`**, freezing the chain.

Observed on a mainnet node 2026-06-18: cascade rooted at height 250580 (`block is not valid. Transaction's (...) parent blocks ([249371]) are not from current chain`), with `rebuildOffChainSet ... context deadline exceeded` in the same startup window. There is no `maxBlockID` initialisation at `New()` — only the timeout-prone async rebuild populates it.

## Fix

Three complementary changes, all targeting the single root cause:

1. **`New()`** — load `maxBlockID` synchronously (cheap `MAX(id)` index-only scan) before any query can be served. Best-effort: on error the CTE fallback keeps results correct, so it never fails startup.
2. **`rebuildOffChainSet`** — refresh `maxBlockID` *before* the timeout-prone off-chain query, so a timed-out rebuild still updates it.
3. **`CheckBlockIsInCurrentChain`** — fail safe: when `maxBlockID == 0` (a real chain's `MAX(id)` is never 0 — genesis is id 1 — so 0 unambiguously means "uninitialised"), fall through to the authoritative flag-free `parent_id` CTE instead of rejecting.

The consensus-critical dangling-id reject (ids genuinely `> maxBlockID`) is unchanged for an initialised `maxBlockID`.

## Test

`TestCheckBlockIsInCurrentChain_InMemory_UninitialisedMaxBlockID` forces `maxBlockID=0` with the rebuild guard released and asserts a committed on-chain id is **not** reported off-chain. **Fails before this change** (returns false), passes after.

## Verification

- `go build`, `go vet`, `golangci-lint` — clean
- `go test -race -tags testtxmetacache ./stores/blockchain/sql/` — 551 pass
- New regression test verified fail-before / pass-after