### PR TITLE
perf(subtreevalidation): pipeline subtree-batch load with processing

### DIFF
--- a/services/subtreevalidation/arena_pool.go
+++ b/services/subtreevalidation/arena_pool.go
@@ -2,6 +2,7 @@ package subtreevalidation
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 )
@@ -20,9 +21,22 @@ var subtreeArenaPool = sync.Pool{
 	New: func() any { return bt.NewArena(subtreeArenaInitialCap) },
 }
 
+// arenaGets / arenaPuts count lifetime Get/Put calls on the arena pool. They
+// exist to catch arena leaks: every getSubtreeArena must be balanced by a
+// putSubtreeArena. The CheckBlockSubtrees batch pipeline loads batches ahead
+// of processing, so a load-ahead batch whose processing never runs (e.g. an
+// abort mid-block) must still release its arenas — these counters let tests
+// assert that balance, and are cheap enough (one atomic add per subtree decode,
+// not per tx) to leave on in production.
+var (
+	arenaGets atomic.Int64
+	arenaPuts atomic.Int64
+)
+
 // getSubtreeArena returns an arena ready for use. The arena's cursor is at
 // zero on entry.
 func getSubtreeArena() *bt.Arena {
+	arenaGets.Add(1)
 	return subtreeArenaPool.Get().(*bt.Arena)
 }
 
@@ -31,6 +45,7 @@ func getSubtreeArena() *bt.Arena {
 // decode calls before invoking putSubtreeArena — script bytes will be
 // reused or freed by subsequent pool consumers.
 func putSubtreeArena(a *bt.Arena) {
+	arenaPuts.Add(1)
 	a.ResetAndShrink(subtreeArenaShrinkCap)
 	subtreeArenaPool.Put(a)
 }

--- a/services/subtreevalidation/batch_pipeline.go
+++ b/services/subtreevalidation/batch_pipeline.go
@@ -1,0 +1,120 @@
+package subtreevalidation
+
+import (
+	"context"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+// runLoadProcessPipeline drives CheckBlockSubtrees' per-batch work as a
+// producer/consumer pipeline: it loads batch N+1 while batch N is being
+// processed, but calls process strictly serially and in batch order.
+//
+// This shape exists because the LOAD phase (loadSubtreeBatch) is read-only with
+// respect to the UTXO set — it only fetches and decodes subtree transactions —
+// whereas PROCESS (processTransactionsInLevels) performs the Spend/Create
+// mutations and MUST stay in-order: a child in batch N+1 may spend a parent
+// created in batch N. Overlapping the next batch's load with the current
+// batch's process reclaims the otherwise-idle gap between batches without
+// changing validation ordering.
+//
+// Contract:
+//   - process is never called concurrently with itself and is called for
+//     batches 0..numBatches-1 in ascending order, stopping at the first error.
+//   - load runs at most one batch ahead of process (unbuffered hand-off), so at
+//     most two batches' transactions are resident at once.
+//   - On any load or process error the run is aborted: the producer is
+//     cancelled and release is called exactly once for every batch whose arenas
+//     were loaded but whose normal post-process release did not run (i.e. the
+//     batches the producer loaded ahead). A batch that fails to load is expected
+//     to have already released its own arenas (loadSubtreeBatch does this), so
+//     it must return nil arenas.
+//
+// release is always invoked for a successfully processed batch's arenas
+// (success or process-error) and for any loaded-ahead batch left in flight on
+// abort.
+func runLoadProcessPipeline(
+	ctx context.Context,
+	numBatches int,
+	load func(ctx context.Context, batchIdx int) ([]*bt.Tx, []*bt.Arena, error),
+	process func(batchIdx int, txs []*bt.Tx, arenas []*bt.Arena) error,
+	release func(arenas []*bt.Arena),
+) error {
+	if numBatches <= 0 {
+		return nil
+	}
+
+	type loadedBatch struct {
+		idx    int
+		txs    []*bt.Tx
+		arenas []*bt.Arena
+		err    error
+	}
+
+	pctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Unbuffered: the producer blocks on send until the consumer takes the
+	// previous batch, so it runs exactly one batch ahead — bounding resident
+	// memory to two batches.
+	ch := make(chan loadedBatch)
+
+	go func() {
+		defer close(ch)
+
+		for i := 0; i < numBatches; i++ {
+			txs, arenas, err := load(pctx, i)
+
+			select {
+			case ch <- loadedBatch{idx: i, txs: txs, arenas: arenas, err: err}:
+			case <-pctx.Done():
+				// Consumer aborted before taking this batch; it never reaches
+				// the drain loop, so release here to avoid a leak.
+				if err == nil {
+					release(arenas)
+				}
+
+				return
+			}
+
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	var retErr error
+
+	for b := range ch {
+		if retErr != nil {
+			// Draining loaded-ahead batches after an abort: release their
+			// arenas (a failed-load batch carries none).
+			if b.err == nil {
+				release(b.arenas)
+			}
+
+			continue
+		}
+
+		if b.err != nil {
+			retErr = b.err
+
+			cancel()
+
+			continue
+		}
+
+		perr := process(b.idx, b.txs, b.arenas)
+		release(b.arenas)
+
+		if perr != nil {
+			retErr = perr
+
+			cancel()
+
+			continue
+		}
+	}
+
+	return retErr
+}

--- a/services/subtreevalidation/batch_pipeline.go
+++ b/services/subtreevalidation/batch_pipeline.go
@@ -104,8 +104,13 @@ func runLoadProcessPipeline(
 			continue
 		}
 
-		perr := process(b.idx, b.txs, b.arenas)
-		release(b.arenas)
+		// Release via defer so the batch's arenas return to the pool even if
+		// process panics (the panic unwinds through here to the recover in
+		// CheckBlockSubtrees); a plain post-call release would be skipped.
+		perr := func() error {
+			defer release(b.arenas)
+			return process(b.idx, b.txs, b.arenas)
+		}()
 
 		if perr != nil {
 			retErr = perr

--- a/services/subtreevalidation/batch_pipeline_bench_test.go
+++ b/services/subtreevalidation/batch_pipeline_bench_test.go
@@ -1,0 +1,62 @@
+package subtreevalidation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+// BenchmarkBatchPipeline contrasts the wall-clock of the old sequential
+// per-batch shape (load then process, no overlap) with runLoadProcessPipeline
+// for a range of LOAD/PROCESS latency mixes. LOAD models the read-only subtree
+// fetch+decode; PROCESS models processTransactionsInLevels. The pipeline
+// overlaps LOAD(N+1) with PROCESS(N), so its wall-clock approaches
+// loadDelay + numBatches*max(load,process) instead of numBatches*(load+process).
+//
+// The injected latencies are a modelling choice; the deterministic win is that
+// the inter-batch LOAD no longer serializes in front of PROCESS. Run with
+// -benchtime=1x for a clean single-pass wall-clock comparison.
+func BenchmarkBatchPipeline(b *testing.B) {
+	const numBatches = 16
+
+	mixes := []struct {
+		name        string
+		loadDelay   time.Duration
+		processTime time.Duration
+	}{
+		{"load_lt_process", 2 * time.Millisecond, 6 * time.Millisecond},
+		{"load_eq_process", 4 * time.Millisecond, 4 * time.Millisecond},
+		{"load_gt_process", 6 * time.Millisecond, 2 * time.Millisecond},
+	}
+
+	for _, m := range mixes {
+		load := func(_ context.Context, _ int) ([]*bt.Tx, []*bt.Arena, error) {
+			time.Sleep(m.loadDelay)
+			return nil, nil, nil
+		}
+		process := func(_ int, _ []*bt.Tx, _ []*bt.Arena) error {
+			time.Sleep(m.processTime)
+			return nil
+		}
+		noopRelease := func([]*bt.Arena) {}
+
+		b.Run(fmt.Sprintf("%s/sequential", m.name), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for batch := 0; batch < numBatches; batch++ {
+					txs, arenas, _ := load(context.Background(), batch)
+					_ = process(batch, txs, arenas)
+					noopRelease(arenas)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("%s/pipelined", m.name), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = runLoadProcessPipeline(context.Background(), numBatches, load, process, noopRelease)
+			}
+		})
+	}
+}

--- a/services/subtreevalidation/batch_pipeline_test.go
+++ b/services/subtreevalidation/batch_pipeline_test.go
@@ -31,10 +31,7 @@ func TestRunLoadProcessPipeline_ProcessesInOrderSerially(t *testing.T) {
 		overlap   bool
 	)
 
-	loaded := make([]bool, numBatches)
-
-	load := func(_ context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
-		loaded[idx] = true
+	load := func(_ context.Context, _ int) ([]*bt.Tx, []*bt.Arena, error) {
 		return nil, nil, nil
 	}
 
@@ -75,6 +72,7 @@ func TestRunLoadProcessPipeline_ProcessErrorReleasesPendingBatches(t *testing.T)
 		mu          sync.Mutex
 		loadedCount int
 		released    = map[int]int{}
+		processed   []int
 	)
 
 	wantErr := errors.NewProcessingError("process boom")
@@ -102,6 +100,10 @@ func TestRunLoadProcessPipeline_ProcessErrorReleasesPendingBatches(t *testing.T)
 	}
 
 	process := func(idx int, _ []*bt.Tx, _ []*bt.Arena) error {
+		mu.Lock()
+		processed = append(processed, idx)
+		mu.Unlock()
+
 		if idx == 1 {
 			return wantErr
 		}
@@ -122,6 +124,14 @@ func TestRunLoadProcessPipeline_ProcessErrorReleasesPendingBatches(t *testing.T)
 
 	mu.Lock()
 	defer mu.Unlock()
+
+	// PROCESS must stop at the failing batch: batch 0 succeeds, batch 1 errors,
+	// and no later batch is processed. This is the consensus-relevant property —
+	// no UTXO mutation may run after a fatal error — and it is what guards the
+	// drain check in runLoadProcessPipeline. Asserting only the arena balance
+	// below would still pass if the abort guard were removed and batches 2..N
+	// were processed (and released) after the error.
+	require.Equal(t, []int{0, 1}, processed, "process must stop at the failing batch; no batch may be processed after the error")
 
 	// Every batch the producer loaded must have had its arenas released exactly
 	// once — no leak, no double release.
@@ -183,7 +193,7 @@ func TestRunLoadProcessPipeline_LoadErrorAborts(t *testing.T) {
 	require.Equal(t, []int{0, 1, 2}, processed)
 	// Every non-failing batch that was loaded contributes one arena; all must
 	// be released (processed ones after process, the failing batch none).
-	require.Equal(t, releasedN, countNonFailingLoaded(loadCalls, 3))
+	require.Equal(t, countNonFailingLoaded(loadCalls, 3), releasedN)
 }
 
 // countNonFailingLoaded returns how many loaded batches carried a (releasable)
@@ -199,34 +209,94 @@ func countNonFailingLoaded(loadCalls, failIdx int) int {
 	return n
 }
 
-// TestRunLoadProcessPipeline_OverlapsLoadWithProcess proves the speed-up: with
-// a per-batch LOAD delay and PROCESS delay, the pipeline wall-clock must be
-// well below the sequential sum (load+process per batch), because LOAD of
-// batch N+1 overlaps PROCESS of batch N.
+// TestRunLoadProcessPipeline_OverlapsLoadWithProcess proves the overlap
+// deterministically (no wall-clock thresholds): while process(N) runs, it
+// blocks until load(N+1) has started. If LOAD did not run a batch ahead of
+// PROCESS this would deadlock on the timeout and the test would fail — so a
+// success is positive proof that load(N+1) overlaps process(N).
 func TestRunLoadProcessPipeline_OverlapsLoadWithProcess(t *testing.T) {
-	const (
-		numBatches  = 8
-		loadDelay   = 8 * time.Millisecond
-		processTime = 8 * time.Millisecond
+	const numBatches = 4
+
+	loadStarted := make([]chan struct{}, numBatches)
+	for i := range loadStarted {
+		loadStarted[i] = make(chan struct{})
+	}
+
+	var (
+		mu       sync.Mutex
+		overlaps int
 	)
 
-	load := func(_ context.Context, _ int) ([]*bt.Tx, []*bt.Arena, error) {
-		time.Sleep(loadDelay)
+	load := func(_ context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
+		close(loadStarted[idx])
 		return nil, nil, nil
 	}
-	process := func(_ int, _ []*bt.Tx, _ []*bt.Arena) error {
-		time.Sleep(processTime)
+
+	process := func(idx int, _ []*bt.Tx, _ []*bt.Arena) error {
+		// While processing batch idx, the producer must already be loading
+		// batch idx+1 (one batch ahead). Wait for that load to start; the
+		// timeout only guards against a hang if the overlap never happens.
+		if idx+1 < numBatches {
+			select {
+			case <-loadStarted[idx+1]:
+				mu.Lock()
+				overlaps++
+				mu.Unlock()
+			case <-time.After(2 * time.Second):
+				t.Errorf("load of batch %d did not start during process of batch %d — no overlap", idx+1, idx)
+			}
+		}
+
 		return nil
 	}
 
-	start := time.Now()
 	err := runLoadProcessPipeline(context.Background(), numBatches, load, process, func([]*bt.Arena) {})
-	elapsed := time.Since(start)
 	require.NoError(t, err)
 
-	sequential := numBatches * (loadDelay + processTime)
-	// Pipeline lower bound ≈ loadDelay (first load) + numBatches*processTime.
-	// Require a clear win over sequential (allow scheduling slack).
-	require.Less(t, elapsed, sequential*3/4,
-		"pipeline (%s) should be well below sequential (%s)", elapsed, sequential)
+	require.Equal(t, numBatches-1, overlaps, "every process(N) must overlap load(N+1)")
+}
+
+// TestRunLoadProcessPipeline_ProcessPanicReleasesBatch asserts that if process
+// panics, the panicking batch's arenas are still released (the release is
+// deferred), and the panic propagates to the caller. Without the deferred
+// release the arenas would leak from the pool on a process panic.
+func TestRunLoadProcessPipeline_ProcessPanicReleasesBatch(t *testing.T) {
+	const numBatches = 4
+
+	panicArena := bt.NewArena(1)
+
+	var (
+		mu       sync.Mutex
+		released = map[*bt.Arena]bool{}
+	)
+
+	load := func(_ context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
+		if idx == 0 {
+			return nil, []*bt.Arena{panicArena}, nil
+		}
+		return nil, []*bt.Arena{bt.NewArena(1)}, nil
+	}
+
+	process := func(idx int, _ []*bt.Tx, _ []*bt.Arena) error {
+		if idx == 0 {
+			panic("process boom")
+		}
+		return nil
+	}
+
+	release := func(arenas []*bt.Arena) {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, a := range arenas {
+			released[a] = true
+		}
+	}
+
+	require.Panics(t, func() {
+		_ = runLoadProcessPipeline(context.Background(), numBatches, load, process, release)
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, released[panicArena], "panicking batch's arenas must be released via defer")
 }

--- a/services/subtreevalidation/batch_pipeline_test.go
+++ b/services/subtreevalidation/batch_pipeline_test.go
@@ -1,0 +1,232 @@
+package subtreevalidation
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// runLoadProcessPipeline overlaps the read-only LOAD of each batch with the
+// PROCESS of the previous batch while keeping PROCESS strictly serial and
+// in-order. These tests pin that contract (it is the consensus-safety property
+// of the CheckBlockSubtrees batch pipeline) plus the arena-release guarantee on
+// the abort paths.
+
+// TestRunLoadProcessPipeline_ProcessesInOrderSerially asserts process is called
+// once per batch, in batch order, and never concurrently with itself — even
+// though load runs ahead. The injected per-process sleep means an overlapping
+// (buggy) implementation would be caught by the concurrency guard.
+func TestRunLoadProcessPipeline_ProcessesInOrderSerially(t *testing.T) {
+	const numBatches = 6
+
+	var (
+		mu        sync.Mutex
+		order     []int
+		inProcess bool
+		overlap   bool
+	)
+
+	loaded := make([]bool, numBatches)
+
+	load := func(_ context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
+		loaded[idx] = true
+		return nil, nil, nil
+	}
+
+	process := func(idx int, _ []*bt.Tx, _ []*bt.Arena) error {
+		mu.Lock()
+		if inProcess {
+			overlap = true
+		}
+		inProcess = true
+		order = append(order, idx)
+		mu.Unlock()
+
+		time.Sleep(5 * time.Millisecond)
+
+		mu.Lock()
+		inProcess = false
+		mu.Unlock()
+
+		return nil
+	}
+
+	err := runLoadProcessPipeline(context.Background(), numBatches, load, process, func([]*bt.Arena) {})
+	require.NoError(t, err)
+
+	require.False(t, overlap, "process must never run concurrently with itself")
+	require.Equal(t, []int{0, 1, 2, 3, 4, 5}, order, "process must be called in batch order")
+}
+
+// TestRunLoadProcessPipeline_ProcessErrorReleasesPendingBatches is the core
+// new-risk guard: when process fails on an early batch, every batch the
+// producer already loaded ahead must be released exactly once, and the process
+// error must propagate. A naive pipeline that drops the load-ahead batches on
+// the floor would leak their arenas here.
+func TestRunLoadProcessPipeline_ProcessErrorReleasesPendingBatches(t *testing.T) {
+	const numBatches = 8
+
+	var (
+		mu          sync.Mutex
+		loadedCount int
+		released    = map[int]int{}
+	)
+
+	wantErr := errors.NewProcessingError("process boom")
+
+	load := func(_ context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
+		mu.Lock()
+		loadedCount++
+		mu.Unlock()
+		// One sentinel arena per batch so release can be attributed by identity.
+		return nil, []*bt.Arena{bt.NewArena(1)}, nil
+	}
+
+	// Track which loaded batch each arena belongs to via a side map keyed on
+	// pointer identity captured at load time.
+	arenaToBatch := map[*bt.Arena]int{}
+
+	loadTracking := func(ctx context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
+		txs, arenas, err := load(ctx, idx)
+		mu.Lock()
+		for _, a := range arenas {
+			arenaToBatch[a] = idx
+		}
+		mu.Unlock()
+		return txs, arenas, err
+	}
+
+	process := func(idx int, _ []*bt.Tx, _ []*bt.Arena) error {
+		if idx == 1 {
+			return wantErr
+		}
+		time.Sleep(2 * time.Millisecond)
+		return nil
+	}
+
+	release := func(arenas []*bt.Arena) {
+		mu.Lock()
+		for _, a := range arenas {
+			released[arenaToBatch[a]]++
+		}
+		mu.Unlock()
+	}
+
+	err := runLoadProcessPipeline(context.Background(), numBatches, loadTracking, process, release)
+	require.ErrorIs(t, err, wantErr)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Every batch the producer loaded must have had its arenas released exactly
+	// once — no leak, no double release.
+	for b := 0; b < loadedCount; b++ {
+		require.Equal(t, 1, released[b], "batch %d arenas must be released exactly once (loaded=%d)", b, loadedCount)
+	}
+	require.Equal(t, loadedCount, len(released), "released set must equal loaded set")
+}
+
+// TestRunLoadProcessPipeline_LoadErrorAborts asserts a LOAD failure aborts the
+// run, returns that error, and releases any batches already processed/loaded
+// without leaking. loadSubtreeBatch releases its own arenas on failure, so the
+// failing batch contributes nil arenas (modelled here by returning nil).
+func TestRunLoadProcessPipeline_LoadErrorAborts(t *testing.T) {
+	const numBatches = 6
+
+	wantErr := errors.NewStorageError("load boom")
+
+	var (
+		mu        sync.Mutex
+		processed []int
+		releasedN int
+		loadCalls int
+	)
+
+	load := func(_ context.Context, idx int) ([]*bt.Tx, []*bt.Arena, error) {
+		mu.Lock()
+		loadCalls++
+		mu.Unlock()
+		if idx == 3 {
+			// Mirror loadSubtreeBatch: it releases its own arenas before
+			// returning an error, so the failing batch yields nil arenas.
+			return nil, nil, wantErr
+		}
+		return nil, []*bt.Arena{bt.NewArena(1)}, nil
+	}
+
+	process := func(idx int, _ []*bt.Tx, _ []*bt.Arena) error {
+		mu.Lock()
+		processed = append(processed, idx)
+		mu.Unlock()
+		return nil
+	}
+
+	release := func(arenas []*bt.Arena) {
+		mu.Lock()
+		releasedN += len(arenas)
+		mu.Unlock()
+	}
+
+	err := runLoadProcessPipeline(context.Background(), numBatches, load, process, release)
+	require.ErrorIs(t, err, wantErr)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Batches before the failing one are processed in order; the failing batch
+	// and everything after it are not processed.
+	require.Equal(t, []int{0, 1, 2}, processed)
+	// Every non-failing batch that was loaded contributes one arena; all must
+	// be released (processed ones after process, the failing batch none).
+	require.Equal(t, releasedN, countNonFailingLoaded(loadCalls, 3))
+}
+
+// countNonFailingLoaded returns how many loaded batches carried a (releasable)
+// arena given the failing batch index — every loaded batch except the failing
+// one contributes exactly one arena.
+func countNonFailingLoaded(loadCalls, failIdx int) int {
+	n := 0
+	for i := 0; i < loadCalls; i++ {
+		if i != failIdx {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRunLoadProcessPipeline_OverlapsLoadWithProcess proves the speed-up: with
+// a per-batch LOAD delay and PROCESS delay, the pipeline wall-clock must be
+// well below the sequential sum (load+process per batch), because LOAD of
+// batch N+1 overlaps PROCESS of batch N.
+func TestRunLoadProcessPipeline_OverlapsLoadWithProcess(t *testing.T) {
+	const (
+		numBatches  = 8
+		loadDelay   = 8 * time.Millisecond
+		processTime = 8 * time.Millisecond
+	)
+
+	load := func(_ context.Context, _ int) ([]*bt.Tx, []*bt.Arena, error) {
+		time.Sleep(loadDelay)
+		return nil, nil, nil
+	}
+	process := func(_ int, _ []*bt.Tx, _ []*bt.Arena) error {
+		time.Sleep(processTime)
+		return nil
+	}
+
+	start := time.Now()
+	err := runLoadProcessPipeline(context.Background(), numBatches, load, process, func([]*bt.Arena) {})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+
+	sequential := numBatches * (loadDelay + processTime)
+	// Pipeline lower bound ≈ loadDelay (first load) + numBatches*processTime.
+	// Require a clear win over sequential (allow scheduling slack).
+	require.Less(t, elapsed, sequential*3/4,
+		"pipeline (%s) should be well below sequential (%s)", elapsed, sequential)
+}

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -69,7 +69,17 @@ func (c *countingReadCloser) Close() error {
 // release the arenas (putSubtreeArena) once processTransactionsInLevels has
 // consumed the txs. On error it releases any arenas it allocated before
 // returning, so the caller never has to clean up after a failed load.
-func (u *Server) loadSubtreeBatch(ctx context.Context, request *subtreevalidation_api.CheckBlockSubtreesRequest, batchSubtrees []chainhash.Hash, peerID string, dah uint32) (allTransactions []*bt.Tx, batchArenas []*bt.Arena, err error) {
+//
+// ctx governs the batch load itself (errgroup, store reads) and is the
+// pipeline's cancellable per-load context — when CheckBlockSubtrees aborts
+// (a later batch's processing fails) this ctx is cancelled to stop the load.
+// fetchCtx is the durable top-level request context, deliberately NOT derived
+// from the pipeline's load-abort context: it governs only the on-demand peer
+// subtree_data download (see the rationale at the fetch site) so that a
+// cross-batch abort does not cancel an in-flight peer fetch and trigger the
+// peer's storer.Abort. Pass the same context for both only when there is no
+// pipeline (e.g. tests).
+func (u *Server) loadSubtreeBatch(ctx, fetchCtx context.Context, request *subtreevalidation_api.CheckBlockSubtreesRequest, batchSubtrees []chainhash.Hash, peerID string, dah uint32) (allTransactions []*bt.Tx, batchArenas []*bt.Arena, err error) {
 	// Load transactions for this batch of subtrees in parallel
 	subtreeTxs := make([][]*bt.Tx, len(batchSubtrees))
 	batchArenas = make([]*bt.Arena, len(batchSubtrees))
@@ -252,19 +262,21 @@ func (u *Server) loadSubtreeBatch(ctx context.Context, request *subtreevalidatio
 					// Retry on 503 — peer's asset service may reject under admission control
 					// while it generates the file on-demand from Aerospike.
 					//
-					// IMPORTANT: pass the parent ctx, NOT gCtx, to the HTTP fetch and the
-					// stream processor. gCtx is the errgroup's cancellable context — using
-					// it here means a single sibling failure cancels every in-flight
-					// subtree_data download in this batch. Because each cancellation closes
-					// the upstream connection, the peer aborts its on-demand creation
-					// (storer.Abort), discarding work that was already paid for in Aerospike
-					// reads. Detaching from gCtx lets each fetch complete (or hit its own
-					// http_streaming_timeout) so the peer can finish writing its subtreeData
-					// file — converting wasted Aerospike work into a pre-warmed cache for
-					// the next retry. The trade-off is that batch failure detection waits
-					// for in-flight peers instead of cancelling early; acceptable here
-					// because the per-fetch streaming timeout still bounds it.
-					body, subtreeDataErr := util.DoHTTPRequestBodyReaderWithRetry(ctx, url)
+					// IMPORTANT: pass fetchCtx, NOT ctx or gCtx, to the HTTP fetch and the
+					// stream processor. Both ctx (the pipeline's per-load context) and gCtx
+					// (the errgroup's child of ctx) are cancelled when this load is aborted —
+					// either by a sibling subtree failing in this batch (gCtx) or by a LATER
+					// batch's processing failing, which cancels the pipeline load context
+					// (ctx). Cancelling here closes the upstream connection, so the peer
+					// aborts its on-demand creation (storer.Abort), discarding work already
+					// paid for in Aerospike reads. fetchCtx is the durable top-level request
+					// context, independent of both abort paths, so each fetch completes (or
+					// hits its own http_streaming_timeout) and the peer finishes writing its
+					// subtreeData file — converting otherwise-wasted Aerospike work into a
+					// pre-warmed cache for the next retry. The trade-off is that abort
+					// detection waits for in-flight peers instead of cancelling early;
+					// acceptable here because the per-fetch streaming timeout still bounds it.
+					body, subtreeDataErr := util.DoHTTPRequestBodyReaderWithRetry(fetchCtx, url)
 					if subtreeDataErr != nil {
 						return errors.NewServiceError("[CheckBlockSubtrees][%s] failed to get subtree data from %s", subtreeHash.String(), url, subtreeDataErr)
 					}
@@ -277,8 +289,8 @@ func (u *Server) loadSubtreeBatch(ctx context.Context, request *subtreevalidatio
 					}
 
 					// Process transactions directly from the stream while storing to disk.
-					// Same rationale as above for using ctx instead of gCtx.
-					err = u.processSubtreeDataStream(ctx, subtreeToCheck, countingBody, &subtreeTxs[subtreeIdx], dah, arena)
+					// Same rationale as above for using fetchCtx instead of ctx/gCtx.
+					err = u.processSubtreeDataStream(fetchCtx, subtreeToCheck, countingBody, &subtreeTxs[subtreeIdx], dah, arena)
 					_ = countingBody.Close()
 
 					// Track bytes downloaded from peer after stream is consumed
@@ -324,7 +336,7 @@ func (u *Server) loadSubtreeBatch(ctx context.Context, request *subtreevalidatio
 			}
 		}
 
-		return nil, nil, errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to get subtree tx hashes", err)
+		return nil, nil, errors.NewProcessingError("[CheckBlockSubtrees] failed to load subtree transactions", err)
 	}
 
 	// Collect all transactions from this batch of subtrees
@@ -561,7 +573,18 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 			batchSubtrees := missingSubtrees[batchStart:batchEnd]
 			u.logger.Debugf("[CheckBlockSubtrees] Loading subtree batch %d/%d with %d subtrees for block %s", batchIdx+1, numBatches, len(batchSubtrees), block.Hash().String())
 
-			return u.loadSubtreeBatch(loadCtx, request, batchSubtrees, peerID, dah)
+			// loadCtx (the pipeline's per-load context) governs the load and is
+			// cancelled on abort; ctx is the durable top-level request context
+			// passed as fetchCtx so an in-flight peer subtree_data download is not
+			// cancelled by a later batch's failure. See loadSubtreeBatch.
+			txs, arenas, loadErr := u.loadSubtreeBatch(loadCtx, ctx, request, batchSubtrees, peerID, dah)
+			if loadErr != nil {
+				// Restore the batch context the pre-pipeline loop carried — with
+				// loads running ahead, knowing which batch failed matters more.
+				return nil, nil, errors.NewProcessingError("[CheckBlockSubtrees] failed to load subtree batch %d/%d", batchIdx+1, numBatches, loadErr)
+			}
+
+			return txs, arenas, nil
 		},
 		func(batchIdx int, allTransactions []*bt.Tx, _ []*bt.Arena) error {
 			batchTxCount := len(allTransactions)

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -56,6 +56,294 @@ func (c *countingReadCloser) Close() error {
 // CheckBlockSubtrees validates that all subtrees referenced in a block exist in storage.
 //
 // subtree information for blocks that reference unavailable subtrees.
+// loadSubtreeBatch fetches and deserializes the transactions for one batch of
+// subtrees. It is the read-only LOAD phase of CheckBlockSubtrees: it reads
+// subtree files (or fetches them from a peer), writes the content-addressed
+// FileTypeSubtreeToCheck marker, and decodes the subtree's transactions into
+// memory. It performs NO UTXO Spend/Create, so it is safe to run ahead of — and
+// concurrently with — the PROCESS phase (processTransactionsInLevels) of an
+// earlier batch. See the producer/consumer pipeline in CheckBlockSubtrees.
+//
+// On success it returns the batch's transactions consolidated into a single
+// slice plus the per-subtree arenas backing their script data. The caller MUST
+// release the arenas (putSubtreeArena) once processTransactionsInLevels has
+// consumed the txs. On error it releases any arenas it allocated before
+// returning, so the caller never has to clean up after a failed load.
+func (u *Server) loadSubtreeBatch(ctx context.Context, request *subtreevalidation_api.CheckBlockSubtreesRequest, batchSubtrees []chainhash.Hash, peerID string, dah uint32) (allTransactions []*bt.Tx, batchArenas []*bt.Arena, err error) {
+	// Load transactions for this batch of subtrees in parallel
+	subtreeTxs := make([][]*bt.Tx, len(batchSubtrees))
+	batchArenas = make([]*bt.Arena, len(batchSubtrees))
+	g, gCtx := errgroup.WithContext(ctx)
+	util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
+
+	for subtreeIdx, subtreeHash := range batchSubtrees {
+		subtreeHash := subtreeHash
+		subtreeIdx := subtreeIdx
+
+		g.Go(func() (err error) {
+			// A subtree may be available locally under either:
+			//   - FileTypeSubtreeToCheck — fetched from a peer, pending validation
+			//   - FileTypeSubtree        — already validated (e.g. legacy catch-up's
+			//                               quickValidationMode validated txs inline
+			//                               before writing the subtree)
+			// We must consult both before falling back to an HTTP fetch. Otherwise
+			// CheckBlockSubtrees will try to HTTP-download a subtree we already have
+			// — and for baseURL="legacy" the synthetic URL has no scheme, so the
+			// request fails outright.
+			localFileType, localExists, err := u.findLocalSubtreeFile(gCtx, subtreeHash)
+			if err != nil {
+				return errors.NewStorageError("[CheckBlockSubtrees][%s] failed to check if subtree exists in store", subtreeHash.String(), err)
+			}
+
+			var subtreeToCheck *subtreepkg.Subtree
+
+			if localExists {
+				// read from whichever local file we found
+				subtreeReader, err := u.subtreeStore.GetIoReader(gCtx, subtreeHash[:], localFileType)
+				if err != nil {
+					return errors.NewStorageError("[CheckBlockSubtrees][%s] failed to get subtree from store", subtreeHash.String(), err)
+				}
+				defer subtreeReader.Close()
+
+				// Use pooled bufio.Reader to reduce allocations (eliminates 50% of GC pressure)
+				bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
+				bufferedReader.Reset(subtreeReader)
+				defer func() {
+					bufferedReader.Reset(nil) // Clear reference before returning to pool
+					bufioReaderPool.Put(bufferedReader)
+				}()
+
+				subtreeToCheck, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
+				if err != nil {
+					return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to deserialize subtree", subtreeHash.String(), err)
+				}
+			} else {
+				// get the subtree from the peer
+				url := fmt.Sprintf("%s/subtree/%s", request.BaseUrl, subtreeHash.String())
+
+				// Bound the body at the receive-side policy cap (MaxIncomingSubtreeBytes) so a
+				// malicious peer can't OOM us by streaming oversized responses. This must be
+				// independent of local BlockAssembly.MaximumMerkleItemsPerSubtree, which only
+				// controls what *this node* assembles; peers may legitimately produce larger subtrees.
+				maxSubtreeBytes := u.settings.SubtreeValidation.MaxIncomingSubtreeBytes
+
+				subtreeNodeBytes, err := util.DoHTTPRequestBounded(gCtx, url, maxSubtreeBytes)
+				if err != nil {
+					return errors.NewServiceError("[CheckBlockSubtrees][%s] failed to get subtree from %s", subtreeHash.String(), url, err)
+				}
+
+				// Track bytes downloaded from peer
+				if u.p2pClient != nil && peerID != "" {
+					if err := u.p2pClient.RecordBytesDownloaded(gCtx, peerID, uint64(len(subtreeNodeBytes))); err != nil {
+						u.logger.Warnf("[CheckBlockSubtrees][%s] failed to record %d bytes downloaded from peer %s: %v", subtreeHash.String(), len(subtreeNodeBytes), peerID, err)
+					}
+				}
+
+				// Bound the leaf count by the receive-side cap (same rationale as the body cap above):
+				// peers may legitimately produce subtrees larger than the local assembly policy. The
+				// bounded HTTP read already enforces this, but we keep the explicit check as a guard
+				// before subtreepkg.NewIncompleteTreeByLeafCount allocates against the count.
+				leafCount := len(subtreeNodeBytes) / chainhash.HashSize
+				maxIncomingLeaves := int(maxSubtreeBytes / int64(chainhash.HashSize))
+				if err := validateSubtreeLeafCount(subtreeHash, leafCount, maxIncomingLeaves); err != nil {
+					return err
+				}
+
+				subtreeToCheck, err = subtreepkg.NewIncompleteTreeByLeafCount(leafCount)
+				if err != nil {
+					return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to create subtree structure", subtreeHash.String(), err)
+				}
+
+				var nodeHash chainhash.Hash
+				for i := 0; i < len(subtreeNodeBytes)/chainhash.HashSize; i++ {
+					copy(nodeHash[:], subtreeNodeBytes[i*chainhash.HashSize:(i+1)*chainhash.HashSize])
+
+					if nodeHash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
+						if err = subtreeToCheck.AddCoinbaseNode(); err != nil {
+							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to add coinbase node to subtree", subtreeHash.String(), err)
+						}
+					} else {
+						if err = subtreeToCheck.AddNode(nodeHash, 0, 0); err != nil {
+							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to add node to subtree", subtreeHash.String(), err)
+						}
+					}
+				}
+
+				if !subtreeHash.Equal(*subtreeToCheck.RootHash()) {
+					return errors.NewProcessingError("[CheckBlockSubtrees][%s] subtree root hash mismatch: %s", subtreeHash.String(), subtreeToCheck.RootHash().String())
+				}
+
+				subtreeBytes, err := subtreeToCheck.Serialize()
+				if err != nil {
+					return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to serialize subtree", subtreeHash.String(), err)
+				}
+
+				// Store the subtreeToCheck marker for later processing, with a DAH of
+				// current block height + subtree-validation retention (set above).
+				if err = u.subtreeStore.Set(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes, options.WithDeleteAt(dah)); err != nil {
+					// ErrBlobAlreadyExists is benign: the subtree filename is its content
+					// hash (verified above), so an existing file holds identical bytes. This
+					// happens when the same block is validated concurrently (announced by two
+					// peers) or retried after a partial attempt — racing on this content-
+					// addressed write must not fail the block. Mirrors the same handling for
+					// FileTypeSubtree/FileTypeSubtreeMeta in ValidateSubtreeInternal.
+					if errors.Is(err, errors.ErrBlobAlreadyExists) {
+						u.logger.Warnf("[CheckBlockSubtrees][%s] subtreeToCheck already exists in store", subtreeHash.String())
+					} else {
+						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to store subtreeToCheck", subtreeHash.String(), err)
+					}
+				}
+			}
+
+			// Adaptive-fetch gate: when optimistic, skip subtreeData entirely.
+			//
+			// What this skip is: the work below is only a prewarm. It bulk-loads
+			// the subtree's txs from subtreeData so the real validation step
+			// (ValidateSubtreeInternal, run for every subtree further down) finds
+			// them already cached. Skipping it leaves subtreeTxs[subtreeIdx] nil,
+			// so the bulk processTransactionsInLevels does nothing for this subtree.
+			//
+			// What this skip is NOT: it does not skip validation. Every subtree
+			// still goes through ValidateSubtreeInternal below, which checks the
+			// UTXO store for each tx and fetches anything genuinely missing from
+			// peers on demand (getSubtreeMissingTxs → processMissingTransactions).
+			// So if the optimistic assumption is wrong — a tx was not delivered by
+			// propagation — that tx is still recovered and validated normally. The
+			// only cost of a wrong guess is bandwidth (the tx is fetched during
+			// validation instead of being prewarmed here); correctness and data
+			// integrity are never at risk.
+			//
+			// Capture the live mode (not just the boolean) so the
+			// observation we record below can be tagged with the mode
+			// the work was actually performed in. Subtree workers run
+			// concurrently via the errgroup and the mode can transition
+			// between sample and Record; tagging the observation lets
+			// the state machine drop cross-mode samples instead of
+			// applying them to the wrong window.
+			modeAtSample := u.adaptiveFetch.Mode()
+			optimistic := modeAtSample == adaptivefetch.ModeOptimistic
+
+			if !optimistic {
+				// PHASE 2: Exact pre-allocation. Only sized when we will actually
+				// populate the slice (pessimistic path). In optimistic mode we
+				// leave subtreeTxs[subtreeIdx] as nil to avoid allocating a
+				// large *bt.Tx-pointer backing array that would never be filled —
+				// downstream consolidation handles nil/empty entries naturally.
+				subtreeTxs[subtreeIdx] = make([]*bt.Tx, 0, subtreeToCheck.Length())
+
+				// Allocate a per-subtree arena for zero-copy script decoding.
+				// The arena is stored in batchArenas[subtreeIdx] so it can be released
+				// after processTransactionsInLevels consumes the batch's txs.
+				// Only allocated on the pessimistic path; in optimistic mode no
+				// subtreeData is fetched, so no arena is needed and
+				// batchArenas[subtreeIdx] stays nil (the release loops guard on nil).
+				arena := getSubtreeArena()
+				batchArenas[subtreeIdx] = arena
+
+				subtreeDataExists, err := u.subtreeStore.Exists(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeData)
+				if err != nil {
+					return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to check if subtree data exists in store", subtreeHash.String(), err)
+				}
+
+				if !subtreeDataExists {
+					// get the subtree data from the peer and process it directly
+					url := fmt.Sprintf("%s/subtree_data/%s", request.BaseUrl, subtreeHash.String())
+
+					// Retry on 503 — peer's asset service may reject under admission control
+					// while it generates the file on-demand from Aerospike.
+					//
+					// IMPORTANT: pass the parent ctx, NOT gCtx, to the HTTP fetch and the
+					// stream processor. gCtx is the errgroup's cancellable context — using
+					// it here means a single sibling failure cancels every in-flight
+					// subtree_data download in this batch. Because each cancellation closes
+					// the upstream connection, the peer aborts its on-demand creation
+					// (storer.Abort), discarding work that was already paid for in Aerospike
+					// reads. Detaching from gCtx lets each fetch complete (or hit its own
+					// http_streaming_timeout) so the peer can finish writing its subtreeData
+					// file — converting wasted Aerospike work into a pre-warmed cache for
+					// the next retry. The trade-off is that batch failure detection waits
+					// for in-flight peers instead of cancelling early; acceptable here
+					// because the per-fetch streaming timeout still bounds it.
+					body, subtreeDataErr := util.DoHTTPRequestBodyReaderWithRetry(ctx, url)
+					if subtreeDataErr != nil {
+						return errors.NewServiceError("[CheckBlockSubtrees][%s] failed to get subtree data from %s", subtreeHash.String(), url, subtreeDataErr)
+					}
+
+					// Wrap with counting reader to track bytes downloaded
+					var bytesRead uint64
+					countingBody := &countingReadCloser{
+						reader:    body,
+						bytesRead: &bytesRead,
+					}
+
+					// Process transactions directly from the stream while storing to disk.
+					// Same rationale as above for using ctx instead of gCtx.
+					err = u.processSubtreeDataStream(ctx, subtreeToCheck, countingBody, &subtreeTxs[subtreeIdx], dah, arena)
+					_ = countingBody.Close()
+
+					// Track bytes downloaded from peer after stream is consumed
+					// Decouple the context to ensure tracking completes even if parent context is cancelled
+					if u.p2pClient != nil && peerID != "" {
+						trackCtx, _, deferFn := tracing.DecoupleTracingSpan(gCtx, "subtreevalidation", "recordBytesDownloaded")
+						defer deferFn()
+						if err := u.p2pClient.RecordBytesDownloaded(trackCtx, peerID, bytesRead); err != nil {
+							u.logger.Warnf("[CheckBlockSubtrees][%s] failed to record %d bytes downloaded from peer %s: %v", subtreeHash.String(), bytesRead, peerID, err)
+						}
+					}
+
+					if err != nil {
+						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to process subtree data stream", subtreeHash.String(), err)
+					}
+				} else {
+					// SubtreeData exists, extract transactions from stored file
+					err = u.extractAndCollectTransactions(gCtx, subtreeToCheck, &subtreeTxs[subtreeIdx], arena)
+					if err != nil {
+						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to extract transactions", subtreeHash.String(), err)
+					}
+				}
+			}
+
+			// Record a synthetic warm-up observation for the adaptive-fetch
+			// state machine. The rationale (why MissingFetches is 0 today,
+			// why that is safe, and the TODO to plumb real counts) lives
+			// once on adaptivefetch.State.RecordSyntheticWarmup. The State is
+			// armed on first FSM RUNNING (see Server), so a node stays
+			// pessimistic through cold-start IBD and only earns optimism once
+			// proven synced.
+			u.adaptiveFetch.RecordSyntheticWarmup(modeAtSample, subtreeToCheck.Length(), 0)
+
+			return nil
+		})
+	}
+
+	if err = g.Wait(); err != nil {
+		// Release arenas allocated by goroutines that completed before the error.
+		for i := range batchArenas {
+			if batchArenas[i] != nil {
+				putSubtreeArena(batchArenas[i])
+			}
+		}
+
+		return nil, nil, errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to get subtree tx hashes", err)
+	}
+
+	// Collect all transactions from this batch of subtrees
+	// Calculate exact capacity needed across all subtrees in this batch to avoid reallocations
+	totalTxCapacity := 0
+	for _, txs := range subtreeTxs {
+		totalTxCapacity += len(txs)
+	}
+
+	allTransactions = make([]*bt.Tx, 0, totalTxCapacity)
+	for _, txs := range subtreeTxs {
+		if len(txs) > 0 {
+			allTransactions = append(allTransactions, txs...)
+		}
+	}
+
+	return allTransactions, batchArenas, nil
+}
+
 func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidation_api.CheckBlockSubtreesRequest) (*subtreevalidation_api.CheckBlockSubtreesResponse, error) {
 	block, err := model.NewBlockFromBytes(request.Block)
 	if err != nil {
@@ -244,329 +532,58 @@ func (u *Server) CheckBlockSubtrees(ctx context.Context, request *subtreevalidat
 			block.TransactionCount, len(block.Subtrees))
 	}
 
-	// Process subtrees in batches to limit memory usage
-	// Each batch loads subtree data, processes transactions, then GCs before next batch
-	for batchStart := 0; batchStart < totalSubtrees; batchStart += subtreesBatchSize {
-		batchEnd := batchStart + subtreesBatchSize
-		if batchEnd > totalSubtrees {
-			batchEnd = totalSubtrees
-		}
+	// Process subtrees in batches to limit memory usage. The read-only LOAD of
+	// each batch (loadSubtreeBatch) is pipelined one batch ahead of the
+	// ordered, UTXO-mutating PROCESS (processTransactionsInLevels) so the
+	// otherwise-idle inter-batch gap overlaps with validation — see
+	// runLoadProcessPipeline for the ordering and arena-release contract.
+	numBatches := (totalSubtrees + subtreesBatchSize - 1) / subtreesBatchSize
 
-		batchNum := (batchStart / subtreesBatchSize) + 1
-		batchSubtrees := missingSubtrees[batchStart:batchEnd]
-		u.logger.Debugf("[CheckBlockSubtrees] Processing subtree batch %d/%d with %d subtrees for block %s", batchNum, (totalSubtrees+subtreesBatchSize-1)/subtreesBatchSize, len(batchSubtrees), block.Hash().String())
-
-		// Load transactions for this batch of subtrees in parallel
-		subtreeTxs := make([][]*bt.Tx, len(batchSubtrees))
-		batchArenas := make([]*bt.Arena, len(batchSubtrees))
-		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(u.logger, g, u.settings.SubtreeValidation.CheckBlockSubtreesConcurrency)
-
-		for subtreeIdx, subtreeHash := range batchSubtrees {
-			subtreeHash := subtreeHash
-			subtreeIdx := subtreeIdx
-
-			g.Go(func() (err error) {
-				// A subtree may be available locally under either:
-				//   - FileTypeSubtreeToCheck — fetched from a peer, pending validation
-				//   - FileTypeSubtree        — already validated (e.g. legacy catch-up's
-				//                               quickValidationMode validated txs inline
-				//                               before writing the subtree)
-				// We must consult both before falling back to an HTTP fetch. Otherwise
-				// CheckBlockSubtrees will try to HTTP-download a subtree we already have
-				// — and for baseURL="legacy" the synthetic URL has no scheme, so the
-				// request fails outright.
-				localFileType, localExists, err := u.findLocalSubtreeFile(gCtx, subtreeHash)
-				if err != nil {
-					return errors.NewStorageError("[CheckBlockSubtrees][%s] failed to check if subtree exists in store", subtreeHash.String(), err)
-				}
-
-				var subtreeToCheck *subtreepkg.Subtree
-
-				if localExists {
-					// read from whichever local file we found
-					subtreeReader, err := u.subtreeStore.GetIoReader(gCtx, subtreeHash[:], localFileType)
-					if err != nil {
-						return errors.NewStorageError("[CheckBlockSubtrees][%s] failed to get subtree from store", subtreeHash.String(), err)
-					}
-					defer subtreeReader.Close()
-
-					// Use pooled bufio.Reader to reduce allocations (eliminates 50% of GC pressure)
-					bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
-					bufferedReader.Reset(subtreeReader)
-					defer func() {
-						bufferedReader.Reset(nil) // Clear reference before returning to pool
-						bufioReaderPool.Put(bufferedReader)
-					}()
-
-					subtreeToCheck, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
-					if err != nil {
-						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to deserialize subtree", subtreeHash.String(), err)
-					}
-				} else {
-					// get the subtree from the peer
-					url := fmt.Sprintf("%s/subtree/%s", request.BaseUrl, subtreeHash.String())
-
-					// Bound the body at the receive-side policy cap (MaxIncomingSubtreeBytes) so a
-					// malicious peer can't OOM us by streaming oversized responses. This must be
-					// independent of local BlockAssembly.MaximumMerkleItemsPerSubtree, which only
-					// controls what *this node* assembles; peers may legitimately produce larger subtrees.
-					maxSubtreeBytes := u.settings.SubtreeValidation.MaxIncomingSubtreeBytes
-
-					subtreeNodeBytes, err := util.DoHTTPRequestBounded(gCtx, url, maxSubtreeBytes)
-					if err != nil {
-						return errors.NewServiceError("[CheckBlockSubtrees][%s] failed to get subtree from %s", subtreeHash.String(), url, err)
-					}
-
-					// Track bytes downloaded from peer
-					if u.p2pClient != nil && peerID != "" {
-						if err := u.p2pClient.RecordBytesDownloaded(gCtx, peerID, uint64(len(subtreeNodeBytes))); err != nil {
-							u.logger.Warnf("[CheckBlockSubtrees][%s] failed to record %d bytes downloaded from peer %s: %v", subtreeHash.String(), len(subtreeNodeBytes), peerID, err)
-						}
-					}
-
-					// Bound the leaf count by the receive-side cap (same rationale as the body cap above):
-					// peers may legitimately produce subtrees larger than the local assembly policy. The
-					// bounded HTTP read already enforces this, but we keep the explicit check as a guard
-					// before subtreepkg.NewIncompleteTreeByLeafCount allocates against the count.
-					leafCount := len(subtreeNodeBytes) / chainhash.HashSize
-					maxIncomingLeaves := int(maxSubtreeBytes / int64(chainhash.HashSize))
-					if err := validateSubtreeLeafCount(subtreeHash, leafCount, maxIncomingLeaves); err != nil {
-						return err
-					}
-
-					subtreeToCheck, err = subtreepkg.NewIncompleteTreeByLeafCount(leafCount)
-					if err != nil {
-						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to create subtree structure", subtreeHash.String(), err)
-					}
-
-					var nodeHash chainhash.Hash
-					for i := 0; i < len(subtreeNodeBytes)/chainhash.HashSize; i++ {
-						copy(nodeHash[:], subtreeNodeBytes[i*chainhash.HashSize:(i+1)*chainhash.HashSize])
-
-						if nodeHash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
-							if err = subtreeToCheck.AddCoinbaseNode(); err != nil {
-								return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to add coinbase node to subtree", subtreeHash.String(), err)
-							}
-						} else {
-							if err = subtreeToCheck.AddNode(nodeHash, 0, 0); err != nil {
-								return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to add node to subtree", subtreeHash.String(), err)
-							}
-						}
-					}
-
-					if !subtreeHash.Equal(*subtreeToCheck.RootHash()) {
-						return errors.NewProcessingError("[CheckBlockSubtrees][%s] subtree root hash mismatch: %s", subtreeHash.String(), subtreeToCheck.RootHash().String())
-					}
-
-					subtreeBytes, err := subtreeToCheck.Serialize()
-					if err != nil {
-						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to serialize subtree", subtreeHash.String(), err)
-					}
-
-					// Store the subtreeToCheck marker for later processing, with a DAH of
-					// current block height + subtree-validation retention (set above).
-					if err = u.subtreeStore.Set(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes, options.WithDeleteAt(dah)); err != nil {
-						// ErrBlobAlreadyExists is benign: the subtree filename is its content
-						// hash (verified above), so an existing file holds identical bytes. This
-						// happens when the same block is validated concurrently (announced by two
-						// peers) or retried after a partial attempt — racing on this content-
-						// addressed write must not fail the block. Mirrors the same handling for
-						// FileTypeSubtree/FileTypeSubtreeMeta in ValidateSubtreeInternal.
-						if errors.Is(err, errors.ErrBlobAlreadyExists) {
-							u.logger.Warnf("[CheckBlockSubtrees][%s] subtreeToCheck already exists in store", subtreeHash.String())
-						} else {
-							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to store subtreeToCheck", subtreeHash.String(), err)
-						}
-					}
-				}
-
-				// Adaptive-fetch gate: when optimistic, skip subtreeData entirely.
-				//
-				// What this skip is: the work below is only a prewarm. It bulk-loads
-				// the subtree's txs from subtreeData so the real validation step
-				// (ValidateSubtreeInternal, run for every subtree further down) finds
-				// them already cached. Skipping it leaves subtreeTxs[subtreeIdx] nil,
-				// so the bulk processTransactionsInLevels does nothing for this subtree.
-				//
-				// What this skip is NOT: it does not skip validation. Every subtree
-				// still goes through ValidateSubtreeInternal below, which checks the
-				// UTXO store for each tx and fetches anything genuinely missing from
-				// peers on demand (getSubtreeMissingTxs → processMissingTransactions).
-				// So if the optimistic assumption is wrong — a tx was not delivered by
-				// propagation — that tx is still recovered and validated normally. The
-				// only cost of a wrong guess is bandwidth (the tx is fetched during
-				// validation instead of being prewarmed here); correctness and data
-				// integrity are never at risk.
-				//
-				// Capture the live mode (not just the boolean) so the
-				// observation we record below can be tagged with the mode
-				// the work was actually performed in. Subtree workers run
-				// concurrently via the errgroup and the mode can transition
-				// between sample and Record; tagging the observation lets
-				// the state machine drop cross-mode samples instead of
-				// applying them to the wrong window.
-				modeAtSample := u.adaptiveFetch.Mode()
-				optimistic := modeAtSample == adaptivefetch.ModeOptimistic
-
-				if !optimistic {
-					// PHASE 2: Exact pre-allocation. Only sized when we will actually
-					// populate the slice (pessimistic path). In optimistic mode we
-					// leave subtreeTxs[subtreeIdx] as nil to avoid allocating a
-					// large *bt.Tx-pointer backing array that would never be filled —
-					// downstream consolidation handles nil/empty entries naturally.
-					subtreeTxs[subtreeIdx] = make([]*bt.Tx, 0, subtreeToCheck.Length())
-
-					// Allocate a per-subtree arena for zero-copy script decoding.
-					// The arena is stored in batchArenas[subtreeIdx] so it can be released
-					// after processTransactionsInLevels consumes the batch's txs.
-					// Only allocated on the pessimistic path; in optimistic mode no
-					// subtreeData is fetched, so no arena is needed and
-					// batchArenas[subtreeIdx] stays nil (the release loops guard on nil).
-					arena := getSubtreeArena()
-					batchArenas[subtreeIdx] = arena
-
-					subtreeDataExists, err := u.subtreeStore.Exists(gCtx, subtreeHash[:], fileformat.FileTypeSubtreeData)
-					if err != nil {
-						return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to check if subtree data exists in store", subtreeHash.String(), err)
-					}
-
-					if !subtreeDataExists {
-						// get the subtree data from the peer and process it directly
-						url := fmt.Sprintf("%s/subtree_data/%s", request.BaseUrl, subtreeHash.String())
-
-						// Retry on 503 — peer's asset service may reject under admission control
-						// while it generates the file on-demand from Aerospike.
-						//
-						// IMPORTANT: pass the parent ctx, NOT gCtx, to the HTTP fetch and the
-						// stream processor. gCtx is the errgroup's cancellable context — using
-						// it here means a single sibling failure cancels every in-flight
-						// subtree_data download in this batch. Because each cancellation closes
-						// the upstream connection, the peer aborts its on-demand creation
-						// (storer.Abort), discarding work that was already paid for in Aerospike
-						// reads. Detaching from gCtx lets each fetch complete (or hit its own
-						// http_streaming_timeout) so the peer can finish writing its subtreeData
-						// file — converting wasted Aerospike work into a pre-warmed cache for
-						// the next retry. The trade-off is that batch failure detection waits
-						// for in-flight peers instead of cancelling early; acceptable here
-						// because the per-fetch streaming timeout still bounds it.
-						body, subtreeDataErr := util.DoHTTPRequestBodyReaderWithRetry(ctx, url)
-						if subtreeDataErr != nil {
-							return errors.NewServiceError("[CheckBlockSubtrees][%s] failed to get subtree data from %s", subtreeHash.String(), url, subtreeDataErr)
-						}
-
-						// Wrap with counting reader to track bytes downloaded
-						var bytesRead uint64
-						countingBody := &countingReadCloser{
-							reader:    body,
-							bytesRead: &bytesRead,
-						}
-
-						// Process transactions directly from the stream while storing to disk.
-						// Same rationale as above for using ctx instead of gCtx.
-						err = u.processSubtreeDataStream(ctx, subtreeToCheck, countingBody, &subtreeTxs[subtreeIdx], dah, arena)
-						_ = countingBody.Close()
-
-						// Track bytes downloaded from peer after stream is consumed
-						// Decouple the context to ensure tracking completes even if parent context is cancelled
-						if u.p2pClient != nil && peerID != "" {
-							trackCtx, _, deferFn := tracing.DecoupleTracingSpan(gCtx, "subtreevalidation", "recordBytesDownloaded")
-							defer deferFn()
-							if err := u.p2pClient.RecordBytesDownloaded(trackCtx, peerID, bytesRead); err != nil {
-								u.logger.Warnf("[CheckBlockSubtrees][%s] failed to record %d bytes downloaded from peer %s: %v", subtreeHash.String(), bytesRead, peerID, err)
-							}
-						}
-
-						if err != nil {
-							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to process subtree data stream", subtreeHash.String(), err)
-						}
-					} else {
-						// SubtreeData exists, extract transactions from stored file
-						err = u.extractAndCollectTransactions(gCtx, subtreeToCheck, &subtreeTxs[subtreeIdx], arena)
-						if err != nil {
-							return errors.NewProcessingError("[CheckBlockSubtrees][%s] failed to extract transactions", subtreeHash.String(), err)
-						}
-					}
-				}
-
-				// Record a synthetic warm-up observation for the adaptive-fetch
-				// state machine. The rationale (why MissingFetches is 0 today,
-				// why that is safe, and the TODO to plumb real counts) lives
-				// once on adaptivefetch.State.RecordSyntheticWarmup. The State is
-				// armed on first FSM RUNNING (see Server), so a node stays
-				// pessimistic through cold-start IBD and only earns optimism once
-				// proven synced.
-				u.adaptiveFetch.RecordSyntheticWarmup(modeAtSample, subtreeToCheck.Length(), 0)
-
-				return nil
-			})
-		}
-
-		if err = g.Wait(); err != nil {
-			// Release arenas allocated by goroutines that completed before the error.
-			for i := range batchArenas {
-				if batchArenas[i] != nil {
-					putSubtreeArena(batchArenas[i])
-				}
-			}
-			return nil, errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to get subtree tx hashes for batch %d", batchNum, err)
-		}
-
-		// Collect all transactions from this batch of subtrees
-		// Calculate exact capacity needed across all subtrees in this batch to avoid reallocations
-		totalTxCapacity := 0
-		for _, txs := range subtreeTxs {
-			totalTxCapacity += len(txs)
-		}
-		allTransactions := make([]*bt.Tx, 0, totalTxCapacity)
-		for _, txs := range subtreeTxs {
-			if len(txs) > 0 {
-				allTransactions = append(allTransactions, txs...)
+	// releaseArenas returns a batch's per-subtree arenas to the pool. Called for
+	// every batch whose txs are no longer referenced (after processing, or for a
+	// loaded-ahead batch abandoned on abort).
+	releaseArenas := func(arenas []*bt.Arena) {
+		for i := range arenas {
+			if arenas[i] != nil {
+				putSubtreeArena(arenas[i])
 			}
 		}
-
-		// Release 2D subtree transaction slice after consolidation
-		// All transactions now in allTransactions, original 2D structure no longer needed
-		subtreeTxs = nil //nolint:ineffassign // Intentional early GC hint
-
-		batchTxCount := len(allTransactions)
-		totalBatches := (totalSubtrees + subtreesBatchSize - 1) / subtreesBatchSize
-		u.logger.Debugf("[CheckBlockSubtrees] Batch %d/%d loaded %d transactions for block %s, now processing", batchNum, totalBatches, batchTxCount, block.Hash().String())
-
-		// Process transactions for this batch
-		if batchTxCount > 0 {
-			if err = u.processTransactionsInLevels(ctx, allTransactions, *block.Hash(), chainhash.Hash{}, block.Height, candidateBlockTime, candidateParentMedianTime, blockIds, addTXToBlockAssembly); err != nil {
-				// Release arenas before returning — txs won't be consumed further.
-				for i := range batchArenas {
-					if batchArenas[i] != nil {
-						putSubtreeArena(batchArenas[i])
-					}
-				}
-				return nil, errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to process transactions in batch %d", batchNum, err)
-			}
-			totalProcessedTxs += batchTxCount
-
-			// Release transaction slice after processing completes
-			// Transactions are now in UTXO store and validator cache, original slice no longer needed
-			allTransactions = nil //nolint:ineffassign // Intentional early GC hint
-		}
-
-		// Release per-subtree arenas: all *bt.Tx pointers were consumed by
-		// processTransactionsInLevels above, so the arena-backed script slices
-		// are no longer referenced and the arenas can be returned to the pool.
-		for i := range batchArenas {
-			if batchArenas[i] != nil {
-				putSubtreeArena(batchArenas[i])
-				batchArenas[i] = nil
-			}
-		}
-		batchArenas = nil //nolint:ineffassign // Intentional early GC hint
-
-		batchSubtrees = nil //nolint:ineffassign // Intentional early GC hint for batch slice view
-		u.logger.Debugf("[CheckBlockSubtrees] Batch %d/%d complete for block %s (%d txs processed, %d total), memory reclaimed", batchNum, totalBatches, block.Hash().String(), batchTxCount, totalProcessedTxs)
 	}
 
-	u.logger.Infof("[CheckBlockSubtrees] Completed processing %d transactions across %d subtree batches", totalProcessedTxs, (totalSubtrees+subtreesBatchSize-1)/subtreesBatchSize)
+	err = runLoadProcessPipeline(ctx, numBatches,
+		func(loadCtx context.Context, batchIdx int) ([]*bt.Tx, []*bt.Arena, error) {
+			batchStart := batchIdx * subtreesBatchSize
+			batchEnd := batchStart + subtreesBatchSize
+			if batchEnd > totalSubtrees {
+				batchEnd = totalSubtrees
+			}
+
+			batchSubtrees := missingSubtrees[batchStart:batchEnd]
+			u.logger.Debugf("[CheckBlockSubtrees] Loading subtree batch %d/%d with %d subtrees for block %s", batchIdx+1, numBatches, len(batchSubtrees), block.Hash().String())
+
+			return u.loadSubtreeBatch(loadCtx, request, batchSubtrees, peerID, dah)
+		},
+		func(batchIdx int, allTransactions []*bt.Tx, _ []*bt.Arena) error {
+			batchTxCount := len(allTransactions)
+			u.logger.Debugf("[CheckBlockSubtrees] Batch %d/%d loaded %d transactions for block %s, now processing", batchIdx+1, numBatches, batchTxCount, block.Hash().String())
+
+			if batchTxCount > 0 {
+				if procErr := u.processTransactionsInLevels(ctx, allTransactions, *block.Hash(), chainhash.Hash{}, block.Height, candidateBlockTime, candidateParentMedianTime, blockIds, addTXToBlockAssembly); procErr != nil {
+					return errors.NewProcessingError("[CheckBlockSubtreesRequest] Failed to process transactions in batch %d", batchIdx+1, procErr)
+				}
+
+				totalProcessedTxs += batchTxCount
+			}
+
+			return nil
+		},
+		releaseArenas,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	u.logger.Infof("[CheckBlockSubtrees] Completed processing %d transactions across %d subtree batches", totalProcessedTxs, numBatches)
 
 	// validateSubtree is the per-subtree action used by both the parallel and
 	// sequential passes below. Extracted as a closure so the phase-2/phase-3

--- a/services/subtreevalidation/check_block_subtrees_pipeline_test.go
+++ b/services/subtreevalidation/check_block_subtrees_pipeline_test.go
@@ -95,9 +95,11 @@ func wireMultiBatchMocks(server *Server) {
 	server.blockchainClient.(*blockchain.Mock).On("GetBlockHeaderIDs",
 		mock.Anything, mock.Anything, mock.Anything).
 		Return([]uint32{1, 2, 3}, nil).Maybe()
-	server.blockchainClient.(*blockchain.Mock).On("IsFSMCurrentState",
-		mock.Anything, mock.Anything).
-		Return(true, nil).Maybe()
+	// CheckBlockSubtrees gates optimistic fetch on GetFSMCurrentState (not
+	// IsFSMCurrentState); mock the method actually on the code path.
+	runningState := blockchain.FSMStateRUNNING
+	server.blockchainClient.(*blockchain.Mock).On("GetFSMCurrentState", mock.Anything).
+		Return(&runningState, nil).Maybe()
 }
 
 // TestCheckBlockSubtrees_MultiBatch_BalancesArenas drives the real batch
@@ -119,6 +121,10 @@ func TestCheckBlockSubtrees_MultiBatch_BalancesArenas(t *testing.T) {
 	blockBytes, err := block.Bytes()
 	require.NoError(t, err)
 
+	// arenaGets/arenaPuts are package-global; the pre/post delta is only valid
+	// because subtreevalidation tests run sequentially (no t.Parallel, per
+	// .claude/rules/testing.md). A concurrent test touching the pool would
+	// perturb these deltas.
 	gets0, puts0 := arenaGets.Load(), arenaPuts.Load()
 
 	_, err = server.CheckBlockSubtrees(context.Background(), &subtreevalidation_api.CheckBlockSubtreesRequest{

--- a/services/subtreevalidation/check_block_subtrees_pipeline_test.go
+++ b/services/subtreevalidation/check_block_subtrees_pipeline_test.go
@@ -1,0 +1,175 @@
+package subtreevalidation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation/subtreevalidation_api"
+	"github.com/bsv-blockchain/teranode/services/validator"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMultiBatchBlock creates n single-tx subtrees, stores each one's
+// FileTypeSubtreeToCheck marker and FileTypeSubtreeData locally (so the batch
+// loader resolves them without any HTTP fetch), and returns a block whose
+// per-subtree tx count forces the configured TxBatchSize to one subtree per
+// batch — i.e. n sequential batches through the pipeline.
+func buildMultiBatchBlock(t *testing.T, server *Server, n int) *model.Block {
+	t.Helper()
+
+	subtreeHashes := make([]*chainhash.Hash, 0, n)
+
+	for i := 0; i < n; i++ {
+		// Build a genuinely unique tx per subtree (distinct input outpoint +
+		// distinct OP_RETURN) so each subtree has its own root hash.
+		tx := bt.NewTx()
+		require.NoError(t, tx.From(fmt.Sprintf("%064x", i+1), 0,
+			"76a914000000000000000000000000000000000000000088ac", 1000))
+		require.NoError(t, tx.AddOpReturnOutput([]byte(fmt.Sprintf("pipeline_tx_%d", i))))
+
+		s, err := subtreepkg.NewIncompleteTreeByLeafCount(2)
+		require.NoError(t, err)
+		require.NoError(t, s.AddCoinbaseNode())
+		require.NoError(t, s.AddNode(*tx.TxIDChainHash(), 0, 0))
+
+		serialized, err := s.Serialize()
+		require.NoError(t, err)
+
+		// FileTypeSubtreeToCheck present (so findLocalSubtreeFile resolves it)
+		// but FileTypeSubtree absent (so the subtree is "missing" and enters the
+		// batch loop).
+		require.NoError(t, server.subtreeStore.Set(context.Background(),
+			s.RootHash()[:], fileformat.FileTypeSubtreeToCheck, serialized))
+
+		// SubtreeData stream omits the coinbase placeholder; first tx is the
+		// non-coinbase. Stored locally so loadSubtreeBatch extracts without HTTP.
+		subtreeData := bytes.Buffer{}
+		subtreeData.Write(tx.Bytes())
+		require.NoError(t, server.subtreeStore.Set(context.Background(),
+			s.RootHash()[:], fileformat.FileTypeSubtreeData, subtreeData.Bytes()))
+
+		subtreeHashes = append(subtreeHashes, s.RootHash())
+	}
+
+	header := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()),
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}
+
+	coinbaseTx := &bt.Tx{Version: 1}
+	// TransactionCount == len(subtrees) => txsPerSubtree == 1, so with
+	// TxBatchSize == 1 each batch holds exactly one subtree.
+	block, err := model.NewBlock(header, coinbaseTx, subtreeHashes, uint64(n), 500, 0, 0)
+	require.NoError(t, err)
+
+	return block
+}
+
+func wireMultiBatchMocks(server *Server) {
+	server.settings.SubtreeValidation.TxBatchSize = 1
+
+	server.blockchainClient.(*blockchain.Mock).On("GetBestBlockHeader", mock.Anything).
+		Return(&model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      uint32(time.Now().Unix()),
+			Bits:           model.NBit{},
+			Nonce:          0,
+		}, &model.BlockHeaderMeta{ID: 100}, nil).Maybe()
+	server.blockchainClient.(*blockchain.Mock).On("GetBlockHeaderIDs",
+		mock.Anything, mock.Anything, mock.Anything).
+		Return([]uint32{1, 2, 3}, nil).Maybe()
+	server.blockchainClient.(*blockchain.Mock).On("IsFSMCurrentState",
+		mock.Anything, mock.Anything).
+		Return(true, nil).Maybe()
+}
+
+// TestCheckBlockSubtrees_MultiBatch_BalancesArenas drives the real batch
+// pipeline across several batches and asserts every per-subtree arena that was
+// acquired is returned to the pool — no leak through the pipelined load-ahead /
+// process / release path.
+func TestCheckBlockSubtrees_MultiBatch_BalancesArenas(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	wireMultiBatchMocks(server)
+
+	mockValidator := server.validatorClient.(*validator.MockValidatorClient)
+	mockValidator.UtxoStore = server.utxoStore
+
+	const numSubtrees = 5
+	block := buildMultiBatchBlock(t, server, numSubtrees)
+
+	blockBytes, err := block.Bytes()
+	require.NoError(t, err)
+
+	gets0, puts0 := arenaGets.Load(), arenaPuts.Load()
+
+	_, err = server.CheckBlockSubtrees(context.Background(), &subtreevalidation_api.CheckBlockSubtreesRequest{
+		Block:   blockBytes,
+		BaseUrl: "http://test.com",
+	})
+	require.NoError(t, err)
+
+	getsDelta := arenaGets.Load() - gets0
+	putsDelta := arenaPuts.Load() - puts0
+
+	require.GreaterOrEqual(t, getsDelta, int64(numSubtrees),
+		"the batch loop must have acquired an arena per missing subtree")
+	require.Equal(t, getsDelta, putsDelta,
+		"every acquired arena must be released (no leak): gets=%d puts=%d", getsDelta, putsDelta)
+}
+
+// TestCheckBlockSubtrees_MultiBatch_ProcessErrorBalancesArenas injects a
+// validation failure so an early batch's PROCESS errors. The pipeline must
+// abort, surface the error, and still release the arenas of any batch the
+// producer had already loaded ahead — the central risk of the load-ahead
+// design.
+func TestCheckBlockSubtrees_MultiBatch_ProcessErrorBalancesArenas(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	wireMultiBatchMocks(server)
+
+	mockValidator := server.validatorClient.(*validator.MockValidatorClient)
+	mockValidator.UtxoStore = server.utxoStore
+	// Fail the very first transaction validated, forcing an early batch's
+	// processTransactionsInLevels to error while later batches are in flight.
+	mockValidator.Errors = []error{errors.NewProcessingError("injected validation failure")}
+
+	const numSubtrees = 5
+	block := buildMultiBatchBlock(t, server, numSubtrees)
+
+	blockBytes, err := block.Bytes()
+	require.NoError(t, err)
+
+	gets0, puts0 := arenaGets.Load(), arenaPuts.Load()
+
+	_, err = server.CheckBlockSubtrees(context.Background(), &subtreevalidation_api.CheckBlockSubtreesRequest{
+		Block:   blockBytes,
+		BaseUrl: "http://test.com",
+	})
+	require.Error(t, err)
+
+	getsDelta := arenaGets.Load() - gets0
+	putsDelta := arenaPuts.Load() - puts0
+
+	require.Equal(t, getsDelta, putsDelta,
+		"arenas must balance even when a batch fails mid-pipeline: gets=%d puts=%d", getsDelta, putsDelta)
+}

--- a/services/subtreevalidation/check_block_subtrees_test.go
+++ b/services/subtreevalidation/check_block_subtrees_test.go
@@ -288,7 +288,7 @@ func TestCheckBlockSubtrees(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, response)
 		// The error message will vary depending on network conditions, but it should be a processing error
-		assert.Contains(t, err.Error(), "CheckBlockSubtreesRequest")
+		assert.Contains(t, err.Error(), "failed to load subtree batch")
 	})
 
 	t.Run("SubtreeExistsError", func(t *testing.T) {
@@ -424,7 +424,7 @@ func TestCheckBlockSubtrees(t *testing.T) {
 		response, err := server.CheckBlockSubtrees(context.Background(), request)
 		require.Error(t, err)
 		assert.Nil(t, response)
-		assert.Contains(t, err.Error(), "Failed to get subtree tx hashes")
+		assert.Contains(t, err.Error(), "failed to load subtree transactions")
 	})
 }
 
@@ -924,7 +924,7 @@ func TestCheckBlockSubtrees_WithQuorum(t *testing.T) {
 		// from http://127.0.0.1:0, which fails deterministically because nothing listens there. The important thing is it detected missing via quorum.
 		_, err = server.CheckBlockSubtrees(context.Background(), request)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "Failed to get subtree tx hashes")
+		assert.Contains(t, err.Error(), "failed to load subtree transactions")
 	})
 
 	t.Run("QuorumTimeout_TreatsAsMissing", func(t *testing.T) {
@@ -998,7 +998,7 @@ func TestCheckBlockSubtrees_WithQuorum(t *testing.T) {
 		_, err = server.CheckBlockSubtrees(context.Background(), request)
 		require.Error(t, err)
 		// The error should be from the HTTP fetch, not from quorum timeout
-		assert.Contains(t, err.Error(), "Failed to get subtree tx hashes")
+		assert.Contains(t, err.Error(), "failed to load subtree transactions")
 		assert.NotContains(t, err.Error(), "quorum lock")
 	})
 


### PR DESCRIPTION
## Problem

On the scaling cluster, follower nodes trail the miner by several blocks on large (~365-535M-tx) blocks. A CPU profile of the `subtree-validator` showed it sustaining only ~24 of 192 cores with the UTXO store idle — not CPU- or store-bound, but **serialized**.

`CheckBlockSubtrees` chunks a block into subtree batches and runs them strictly sequentially:

```
LOAD (read-only subtree fetch + deserialize)  →  PROCESS (processTransactionsInLevels: Spend/Create)  →  repeat
```

There is no overlap — while a batch is being validated, the next batch's subtree data sits unfetched, and the box idles in the inter-batch gap.

## Change

Extract the LOAD phase into `loadSubtreeBatch` and drive batches through a producer/consumer pipeline (`runLoadProcessPipeline`): the producer **loads batch N+1 while the consumer processes batch N**, but PROCESS stays **strictly serial and in batch order**.

### Why this is consensus-safe

- `PROCESS` (`processTransactionsInLevels`) performs the only UTXO mutations and is never overlapped with itself or reordered. A child in batch N+1 may spend a parent created in batch N — that parent's `Create` still completes before N+1 is processed.
- `LOAD` is read-only with respect to the UTXO set (it fetches/decodes subtree transactions and writes the content-addressed `FileTypeSubtreeToCheck` marker only), so running it one batch ahead cannot change any validation result.
- The hand-off is unbuffered → at most two batches resident at once (bounded memory).
- On any load/process error the run aborts, cancels the producer, and **releases the arenas of every batch loaded ahead**. Added `arena` get/put counters to assert this balance in tests.

## Benchmark

`BenchmarkBatchPipeline` (16 batches, modelled per-batch latencies), `-benchtime=1x`:

| load vs process mix | sequential | pipelined | speed-up |
|---|---|---|---|
| load < process (2ms/6ms) | 134.7ms | 100.5ms | 25% |
| load = process (4ms/4ms) | 132.2ms | 70.2ms | **47%** |
| load > process (6ms/2ms) | 133.8ms | 99.6ms | 26% |

Pipelined wall-clock ≈ `loadDelay + N·max(load, process)` vs sequential `N·(load + process)`. The injected latencies are a modelling choice; the deterministic win is that the read-only LOAD no longer serializes in front of PROCESS.

## Tests

- `batch_pipeline_test.go` — pipeline unit tests under `-race`: in-order serial processing (overlap guard), process-error releases all load-ahead batches, load-error aborts, and the load/process overlap timing.
- `check_block_subtrees_pipeline_test.go` — multi-batch integration through the real `CheckBlockSubtrees`: arena balance on the success path and on a mid-pipeline validation failure.
- Full `services/subtreevalidation` package green under `-race`; `go vet`, `staticcheck` clean.

## Scope / follow-ups

This overlaps LOAD with PROCESS. It does not change `processTransactionsInLevels` itself; the decorate/cache-repopulate allocation cost (~26% GC observed in the same profile) is a separate PR.
