### PR TITLE
fix(asset/centrifuge): bidirectional protocol — negotiate protobuf + dashboard pong

### DIFF
--- a/services/asset/centrifuge_impl/centrifuge_test.go
+++ b/services/asset/centrifuge_impl/centrifuge_test.go
@@ -402,6 +402,46 @@ func TestNewWebsocketHandler(t *testing.T) {
 	})
 }
 
+// TestWebsocketHandler_SubprotocolNegotiation verifies the handler advertises
+// the centrifuge-protobuf subprotocol so a protobuf client negotiates it (rather
+// than being silently served JSON and disconnected with "bad request"), while a
+// client that requests no subprotocol still gets JSON (empty negotiated value).
+func TestWebsocketHandler_SubprotocolNegotiation(t *testing.T) {
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+
+	node.OnConnecting(func(_ context.Context, _ centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+		return centrifuge.ConnectReply{}, nil
+	})
+
+	require.NoError(t, node.Run())
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	// Permissive origin check: this test exercises subprotocol negotiation, not
+	// the same-host origin guard (which would otherwise reject the test dialer).
+	srv := httptest.NewServer(NewWebsocketHandler(node, WebsocketConfig{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	t.Run("protobuf requested is negotiated", func(t *testing.T) {
+		d := websocket.Dialer{Subprotocols: []string{"centrifuge-protobuf"}}
+		conn, _, derr := d.Dial(wsURL, nil)
+		require.NoError(t, derr)
+		defer conn.Close()
+		require.Equal(t, "centrifuge-protobuf", conn.Subprotocol())
+	})
+
+	t.Run("no subprotocol stays JSON", func(t *testing.T) {
+		conn, _, derr := websocket.DefaultDialer.Dial(wsURL, nil)
+		require.NoError(t, derr)
+		defer conn.Close()
+		require.Equal(t, "", conn.Subprotocol())
+	})
+}
+
 func TestCheckSameHost(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/services/asset/centrifuge_impl/websocket.go
+++ b/services/asset/centrifuge_impl/websocket.go
@@ -89,6 +89,12 @@ func NewWebsocketHandler(n *centrifuge.Node, c WebsocketConfig) *WebsocketHandle
 	upgrade := &websocket.Upgrader{
 		ReadBufferSize:    c.ReadBufferSize,
 		EnableCompression: c.Compression,
+		// Advertise the Centrifuge protobuf subprotocol so a client requesting it
+		// (Sec-WebSocket-Protocol: centrifuge-protobuf) negotiates protobuf rather
+		// than being silently served JSON. Clients that request no subprotocol
+		// (e.g. the dashboard's raw WebSocket) continue to use JSON. Matches the
+		// upstream centrifuge WebsocketHandler.
+		Subprotocols: []string{"centrifuge-protobuf"},
 	}
 	if c.UseWriteBufferPool {
 		upgrade.WriteBufferPool = writeBufferPool
@@ -161,13 +167,23 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// Negotiate the protocol from the subprotocol the upgrader selected. Defaults
+	// to JSON (no/other subprotocol); protobuf only when the client requested and
+	// the upgrader echoed "centrifuge-protobuf". The transport then reads AND
+	// writes in the matching codec — hardcoding JSON here would decode a protobuf
+	// client's frames as JSON, disconnecting it with "bad request".
+	protoType := centrifuge.ProtocolTypeJSON
+	if conn.Subprotocol() == "centrifuge-protobuf" {
+		protoType = centrifuge.ProtocolTypeProtobuf
+	}
+
 	// Separate goroutine for better GC of caller's data.
 	go func() {
 		opts := websocketTransportOptions{
 			pingInterval:       pingInterval,
 			writeTimeout:       writeTimeout,
 			compressionMinSize: compressionMinSize,
-			protoType:          centrifuge.ProtocolTypeJSON,
+			protoType:          protoType,
 		}
 
 		graceCh := make(chan struct{})

--- a/ui/dashboard/src/internal/stores/p2pStore.ts
+++ b/ui/dashboard/src/internal/stores/p2pStore.ts
@@ -144,8 +144,14 @@ export async function connectToP2PServer() {
             const data = await event.data
             const json: any = JSON.parse(data)
 
-            // Centrifuge server ping arrives as an empty reply object — ignore it.
+            // Centrifuge server ping arrives as an empty reply object. The
+            // bidirectional protocol requires a pong (an empty command) in reply;
+            // without it the server disconnects us after its PongTimeout
+            // (~8s), churning the connection and dropping live updates. Reply
+            // with an empty command, then ignore. Only ever sent in response to a
+            // server ping, so it can never be an "unnecessary pong".
             if (!json || Object.keys(json).length === 0) {
+              socket.send('{}')
               return
             }
 


### PR DESCRIPTION
## Problem

Asset-service WebSocket clients are disconnected with `bad request`, and the dashboard's live updates churn:

```
[Centrifuge] disconnect after handling command: reason:bad request
```

## Root cause

The bidirectional Centrifuge handler (added in #944) has two protocol defects:

1. **Protocol forced to JSON.** `websocket.go` hardcoded `ProtocolTypeJSON` and the upgrader did not advertise the `centrifuge-protobuf` subprotocol. A client negotiating protobuf was silently served JSON; its binary frames decoded to a zero-value `Command`, which centrifuge treats as an unsolicited pong (`isPong` + `lastPing <= 0`) and rejects with `DisconnectBadRequest` — exactly the logged line, with an empty `command`.

2. **Dashboard never pongs.** The transport sets `PingPongConfig` (25s ping / ~8s `PongTimeout`) on a bidirectional connection, but the dashboard's raw-WebSocket store ignored the server's empty-object ping. With no pong, centrifuge disconnects with `DisconnectNoPong` every ~33s, dropping live updates.

## Fix

- **Server** (`services/asset/centrifuge_impl/websocket.go`): advertise `centrifuge-protobuf` and derive `protoType` from the negotiated subprotocol (matching upstream centrifuge). No-subprotocol clients (the dashboard) still use JSON, so this is a no-op for them.
- **Dashboard** (`ui/dashboard/src/internal/stores/p2pStore.ts`): reply to each server ping with an empty command (pong). Only ever sent in response to a ping, so it can never be an "unnecessary pong".

## Tests

- Added `TestWebsocketHandler_SubprotocolNegotiation`: a protobuf-requesting client negotiates `centrifuge-protobuf`; a no-subprotocol client stays JSON. Verified red→green (without the upgrader advertisement the protobuf case fails).
- `go vet` + existing centrifuge tests pass.

## Notes

- Branched off `main` (the defects are in `main`'s #944 handler, unrelated to any feature branch).
- Dashboard lint/typecheck not run locally (fresh worktree, no `node_modules`); the change is a single call on an `any`-typed socket — CI covers the TS toolchain.
