### PR TITLE
feat(uaerospike): wrap Execute for overload retry + semaphore

### DIFF
--- a/util/uaerospike/client.go
+++ b/util/uaerospike/client.go
@@ -452,6 +452,36 @@ func (c *Client) Operate(policy *aerospike.WritePolicy, key *aerospike.Key, oper
 	return record, err
 }
 
+// Execute is a wrapper around aerospike.Client.Execute that uses the semaphore
+// to limit concurrent connections and retries server-overload rejections.
+//
+// Without this wrapper a call to client.Execute would resolve to the embedded
+// *aerospike.Client method, bypassing both the connection semaphore and the
+// overload-retry layer. The store's single UDF write path (un_spend.go's
+// "unspend") goes through here, so it now participates in the same backpressure
+// and DEVICE_OVERLOAD / MAX_ERROR_RATE retry as the other write methods.
+func (c *Client) Execute(policy *aerospike.WritePolicy, key *aerospike.Key, packageName string, functionName string, args ...aerospike.Value) (any, aerospike.Error) {
+	if err := c.acquirePermit(policy); err != nil {
+		return nil, err
+	}
+	defer c.releasePermit()
+
+	start := gocore.CurrentTime()
+	defer func() {
+		c.stats.stat.NewStat("Execute: " + functionName).AddTime(start)
+	}()
+
+	var ret any
+
+	err := c.retryOnOverload(func() aerospike.Error {
+		var aerr aerospike.Error
+		ret, aerr = c.Client.Execute(policy, key, packageName, functionName, args...)
+		return aerr
+	})
+
+	return ret, err
+}
+
 // BatchOperate is a wrapper around aerospike.Client.BatchOperate that uses semaphore to limit concurrent connections.
 func (c *Client) BatchOperate(policy *aerospike.BatchPolicy, records []aerospike.BatchRecordIfc) aerospike.Error {
 	if err := c.acquirePermit(policy); err != nil {

--- a/util/uaerospike/client_test.go
+++ b/util/uaerospike/client_test.go
@@ -55,6 +55,33 @@ func TestClient_Put(t *testing.T) {
 	})
 }
 
+// TestClient_Execute_AcquiresPermit verifies the Execute wrapper participates
+// in the connection semaphore. When no permit is available it must fail closed
+// with a timeout from acquirePermit, before the (here nil) embedded client is
+// ever touched. This is the behaviour finding #1 adds: the unspend UDF path
+// previously called the embedded Execute directly and bypassed the semaphore
+// (and the overload-retry layer) entirely.
+func TestClient_Execute_AcquiresPermit(t *testing.T) {
+	client := &Client{
+		Client:        nil,                    // must NOT be dereferenced when the permit acquire fails
+		connSemaphore: make(chan struct{}, 1), // capacity 1
+		stats:         NewClientStats(),
+	}
+
+	// Saturate the semaphore so the next acquire cannot succeed.
+	client.connSemaphore <- struct{}{}
+
+	policy := aerospike.NewWritePolicy(0, 0)
+	policy.TotalTimeout = 50 * time.Millisecond
+
+	ret, err := client.Execute(policy, nil, "pkg", "fn")
+
+	require.Nil(t, ret)
+	require.NotNil(t, err, "Execute must fail closed when no permit is available")
+	require.True(t, err.Matches(types.TIMEOUT),
+		"acquirePermit timeout must surface as TIMEOUT, got %v", err)
+}
+
 func TestCalculateKeySource(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -528,6 +555,15 @@ func TestClientWrapperMethods_WithLocalAerospike(t *testing.T) {
 		record := aerospike.NewBatchWrite(writePolicy, key, aerospike.GetOp())
 
 		_ = client.BatchOperate(policy, []aerospike.BatchRecordIfc{record})
+	})
+
+	t.Run("test execute wrapper", func(t *testing.T) {
+		policy := aerospike.NewWritePolicy(0, 0)
+		key, _ := aerospike.NewKey("test", "test", "test-key")
+
+		// No UDF module is registered on the test server, so this returns an
+		// error; the point is to exercise the wrapper's permit + retry path.
+		_, _ = client.Execute(policy, key, "pkg", "fn")
 	})
 }
 


### PR DESCRIPTION
## Problem

The overload-retry layer added in #1085 wraps `Put`, `PutBins`, `Delete`, `Get`, `Operate` and `BatchOperate` in `util/uaerospike.Client`, but not `Execute`. Since `uaerospike.Client` embeds `*aerospike.Client`, a call to `client.Execute(...)` resolved to the embedded method and bypassed **both** the connection semaphore and the `DEVICE_OVERLOAD` / `MAX_ERROR_RATE` retry.

The UTXO store has exactly one UDF write path through `Execute`:

- `stores/utxo/aerospike/un_spend.go` — the `"unspend"` UDF that un-spends a UTXO during reorg/rollback.

Under sustained Aerospike overload while a reorg unwinds spends, that UDF could be rejected with `DEVICE_OVERLOAD` and propagate immediately as a hard `StorageError` — no retry. And because #1085 removed `DEVICE_OVERLOAD` from the spend circuit breaker's infrastructure-failure list, it no longer even trips the breaker; it just surfaces as a failure on the unspend path. Lower frequency than the IBD spend path (reorgs are rarer), but a genuine overload-bearing write left uncovered by #1085's six-method scope.

`Query` (reads) and `GetNodes` / `CreateIndex` (admin) are the other embedded methods the store touches; none produce `DEVICE_OVERLOAD`. No `BatchExecute` / `ExecuteUDF` call sites exist. `Execute` is the only gap.

## Change

Add an `Execute` wrapper to `util/uaerospike/client.go`, mirroring `Operate`: `acquirePermit` → `retryOnOverload` → per-function stat (`Execute: <fn>`). Because `uaerospike.Client` now defines `Execute`, `s.client.Execute(...)` in `un_spend.go` resolves to the wrapper (the explicit method shadows the promoted embedded one) — no call-site edit.

### Behaviour note

`unspend` previously did not take a connection-semaphore permit (the embedded method doesn't touch the semaphore). It now does, so it participates in the same backpressure and overload retry as every other write. That is the intended effect.

## Out of scope

Two other items from a re-review of #1085, deliberately not addressed here:

- Overload-induced `MAX_ERROR_RATE` can still trip the spend breaker after the retry budget is spent. `MAX_ERROR_RATE` is ambiguous (also fires on genuine node failure) and #1085 kept it as an infra signal on purpose; no clean way to distinguish at the breaker.
- The 2m retry budget can out-wait a caller's gRPC deadline (the wrapper has no `context`). Acknowledged in #1085; plumbing context through the wrapper API is a larger change.

## Testing

- New unit test `TestClient_Execute_AcquiresPermit` (no live Aerospike): capacity-1 semaphore pre-filled, `WritePolicy` with a short `TotalTimeout`; `Execute` must return `TIMEOUT` from `acquirePermit` without dereferencing the (nil) embedded client — proves semaphore participation and fail-closed before the call. Verified red→green (pre-change it panics calling the embedded nil-receiver `Execute`).
- Added an `Execute` sub-test to `TestClientWrapperMethods_WithLocalAerospike` for real-call coverage parity (skips when no local Aerospike).
- Retry semantics themselves are already unit-tested via `retryOnOverload` in `overload_retry_test.go`; `Execute` routes through the same helper.
- `go test -race ./util/uaerospike/`, `go vet` (uaerospike + aerospike store), `golangci-lint run`, `staticcheck`, `go build ./...` — all green.
