### PR TITLE
fix(blockassembly): process all hashes in removeTxsFromSubtrees

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -2721,9 +2721,14 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 
 			// we found the transaction in a subtree
 			if foundSubtreeIndex == -1 {
-				// it was found in the current tree, remove it from there
-				// further processing is not needed, as the subtrees in the chainedSubtrees are older than the current subtree
-				return stp.currentSubtree.Load().RemoveNodeAtIndex(foundIndex)
+				// it was found in the current tree, remove it from there and continue
+				// with the remaining hashes. The trailing reChainSubtrees(0) compacts
+				// every subtree, including the current one, after the loop completes.
+				if err := stp.currentSubtree.Load().RemoveNodeAtIndex(foundIndex); err != nil {
+					return errors.NewProcessingError("[SubtreeProcessor][removeTxsFromSubtrees][%s] error removing node from current subtree", hash.String(), err)
+				}
+
+				continue
 			}
 
 			// it was found in a chained subtree, remove it from there and chain the subtrees again from the point it was removed

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -2649,9 +2649,19 @@ func (stp *SubtreeProcessor) removeTxFromSubtrees(ctx context.Context, hash chai
 
 		// we found the transaction in a subtree
 		if foundSubtreeIndex == -1 {
-			// it was found in the current tree, remove it from there
-			// further processing is not needed, as the subtrees in the chainedSubtrees are older than the current subtree
-			return stp.currentSubtree.Load().RemoveNodeAtIndex(foundIndex)
+			// it was found in the current tree. Duplicate before mutating (mirroring the
+			// chained-subtree branch below) so any precomputed mining-data snapshot holding
+			// the original stays safe for concurrent reads. Further processing is not needed,
+			// as the subtrees in chainedSubtrees are older than the current subtree.
+			currentSubtree := stp.currentSubtree.Load().Duplicate()
+
+			if err := currentSubtree.RemoveNodeAtIndex(foundIndex); err != nil {
+				return errors.NewProcessingError("[SubtreeProcessor][removeTxFromSubtrees][%s] error removing node from current subtree", hash.String(), err)
+			}
+
+			stp.currentSubtree.Store(currentSubtree)
+
+			return nil
 		}
 
 		// it was found in a chained subtree, remove it from there and chain the subtrees again from the point it was removed
@@ -2696,6 +2706,8 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 
 	defer deferFn()
 
+	removedAny := false
+
 	for _, hash := range hashes {
 		// find the transaction in the current and all chained subtrees
 		foundIndex := stp.currentSubtree.Load().NodeIndex(hash)
@@ -2713,6 +2725,8 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 		}
 
 		if foundIndex >= 0 {
+			removedAny = true
+
 			// Save to deleted backup map before removing (for Server fallback during async storage)
 			if txInpoints, found := stp.currentTxMap.Get(hash); found {
 				stp.deletedTxs.Set(hash, *txInpoints)
@@ -2752,6 +2766,12 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 				return errors.NewProcessingError("[SubtreeProcessor][removeTxsFromSubtrees][%s] error removing node from subtree", hash.String(), err)
 			}
 		}
+	}
+
+	// Nothing matched, so there is no hole to fill: skip the O(N) rebuild (which would
+	// also needlessly replace every subtree pointer and invalidate mining snapshots).
+	if !removedAny {
+		return nil
 	}
 
 	// all the chained subtrees should be complete, as we now have a hole in the one we just removed from
@@ -2805,8 +2825,13 @@ func (stp *SubtreeProcessor) reChainSubtrees(fromIndex int) error {
 	}
 	stp.currentSubtree.Store(newSubtree)
 
-	if len(originalSubtrees) == 0 {
-		// we must add the coinbase tx if we have no original subtrees
+	if fromIndex == 0 {
+		// Rebuilding from index 0 means the block's first subtree (which carries the
+		// coinbase placeholder at Nodes[0]) is part of the rebuild. The re-add loop below
+		// skips placeholder nodes, so re-assert the placeholder on the fresh first subtree;
+		// otherwise the first real transaction would slide into Nodes[0] and corrupt the
+		// coinbase commitment. For fromIndex > 0 the preserved chainedSubtrees[:fromIndex]
+		// still hold the placeholder, so the rebuilt tail must not add another one.
 		if err = stp.currentSubtree.Load().AddCoinbaseNode(); err != nil {
 			return errors.NewProcessingError("error adding coinbase node to new current subtree", err)
 		}
@@ -3867,16 +3892,20 @@ func (stp *SubtreeProcessor) moveBackBlock(ctx context.Context, block *model.Blo
 		deferFn()
 	}()
 
-	lastIncompleteSubtree := stp.currentSubtree.Load()
-	chainedSubtrees := stp.chainedSubtrees
-
-	// process coinbase utxos
+	// process coinbase utxos. This may remove this block's coinbase child-spends from
+	// the assembly, which rebuilds and Closes the chained/current subtrees via
+	// reChainSubtrees. Capture the previous subtree state AFTER this call so the bulk
+	// build folds live, post-removal subtrees back in — capturing beforehand would read
+	// Closed (mmap-unmapped) subtrees and re-add the just-removed spends.
 	if err = stp.removeCoinbaseUtxos(ctx, block); err != nil {
 		// no need to error out if the key doesn't exist anyway
 		if !errors.Is(err, errors.ErrTxNotFound) {
 			return nil, nil, errors.NewProcessingError("[moveBackBlock][%s] error removing coinbase utxo", block.String(), err)
 		}
 	}
+
+	lastIncompleteSubtree := stp.currentSubtree.Load()
+	chainedSubtrees := stp.chainedSubtrees
 
 	// Bulk build: get block subtrees, collect all nodes, then build subtrees in parallel
 	if subtreesNodes, conflictingHashes, err = stp.moveBackBlockBulkBuild(ctx, block, createProperlySizedSubtrees, chainedSubtrees, lastIncompleteSubtree); err != nil {

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -2721,13 +2721,22 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 
 			// we found the transaction in a subtree
 			if foundSubtreeIndex == -1 {
-				// it was found in the current tree, remove it from there and continue
-				// with the remaining hashes. The trailing reChainSubtrees(0) compacts
-				// every subtree, including the current one, after the loop completes.
-				if err := stp.currentSubtree.Load().RemoveNodeAtIndex(foundIndex); err != nil {
+				// it was found in the current subtree. Duplicate before mutating (mirroring
+				// the chained-subtree branch) so any precomputed mining-data snapshot holding
+				// the original stays safe for concurrent reads, and so the duplicate's node
+				// index is rebuilt fresh on the next lookup: RemoveNodeAtIndex leaves the index
+				// map stale for nodes after the removed one, which would otherwise corrupt the
+				// index used to remove a subsequent hash from the same subtree.
+				currentSubtree := stp.currentSubtree.Load().Duplicate()
+
+				if err := currentSubtree.RemoveNodeAtIndex(foundIndex); err != nil {
 					return errors.NewProcessingError("[SubtreeProcessor][removeTxsFromSubtrees][%s] error removing node from current subtree", hash.String(), err)
 				}
 
+				stp.currentSubtree.Store(currentSubtree)
+
+				// the trailing reChainSubtrees(0) compacts every subtree, including the
+				// current one, after the loop completes
 				continue
 			}
 

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -3303,6 +3303,25 @@ func TestRemoveTxsFromSubtreesBasic(t *testing.T) {
 	})
 }
 
+// requireCoinbasePlaceholderIntact asserts that the block's first subtree still
+// carries the coinbase placeholder at Nodes[0]. reChainSubtrees rebuilds the
+// chain from a fresh subtree and skips placeholder nodes in its re-add loop, so a
+// regression that fails to re-assert the placeholder lets the first real tx slide
+// into Nodes[0] — a corrupt coinbase commitment.
+func requireCoinbasePlaceholderIntact(t *testing.T, stp *SubtreeProcessor) {
+	t.Helper()
+
+	first := stp.currentSubtree.Load()
+	if len(stp.chainedSubtrees) > 0 {
+		first = stp.chainedSubtrees[0]
+	}
+
+	require.NotNil(t, first, "block's first subtree must exist")
+	require.Greater(t, first.Length(), 0, "block's first subtree must not be empty")
+	require.True(t, first.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue),
+		"block's first subtree must retain the coinbase placeholder at Nodes[0], got %s", first.Nodes[0].Hash.String())
+}
+
 // TestRemoveTxsFromSubtreesOrdering reproduces the coinbase-spend ordering bug
 // where removeTxsFromSubtrees early-returned on the first hash found in the
 // current subtree, leaving later hashes (and the trailing reChainSubtrees(0)
@@ -3385,6 +3404,8 @@ func TestRemoveTxsFromSubtreesOrdering(t *testing.T) {
 		for i, cs := range stp.chainedSubtrees {
 			require.True(t, cs.IsComplete(), "chained subtree %d must be complete after recompaction", i)
 		}
+
+		requireCoinbasePlaceholderIntact(t, stp)
 	})
 
 	t.Run("removes all hashes when a chained-subtree hash precedes a current-subtree hash", func(t *testing.T) {
@@ -3427,6 +3448,8 @@ func TestRemoveTxsFromSubtreesOrdering(t *testing.T) {
 		for i, cs := range stp.chainedSubtrees {
 			require.True(t, cs.IsComplete(), "chained subtree %d must be complete after recompaction", i)
 		}
+
+		requireCoinbasePlaceholderIntact(t, stp)
 	})
 
 	t.Run("removes multiple hashes that all live in the current subtree", func(t *testing.T) {
@@ -3492,7 +3515,215 @@ func TestRemoveTxsFromSubtreesOrdering(t *testing.T) {
 		for _, l := range []string{"A", "B", "C"} {
 			require.Equal(t, 1, occurrences(hashes[l]), "%s must remain present exactly once", l)
 		}
+
+		requireCoinbasePlaceholderIntact(t, stp)
 	})
+}
+
+// TestRemoveTxFromSubtreesCurrentSnapshotSafety verifies the singular
+// removeTxFromSubtrees duplicates the current subtree before removing a node from
+// it, mirroring removeTxsFromSubtrees. Mutating the live current subtree in place
+// would corrupt any precomputed mining-data snapshot still holding the original
+// pointer.
+func TestRemoveTxFromSubtreesCurrentSnapshotSafety(t *testing.T) {
+	ctx := context.Background()
+	stp := setupTestSubtreeProcessor(t)
+
+	h := chainhash.HashH([]byte("singular_current_tx"))
+	require.NoError(t, stp.AddDirectly(&subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}, &subtreepkg.TxInpoints{}, true))
+
+	before := stp.currentSubtree.Load()
+	require.GreaterOrEqual(t, before.NodeIndex(h), 0, "precondition: tx in current subtree")
+
+	require.NoError(t, stp.removeTxFromSubtrees(ctx, h))
+
+	after := stp.currentSubtree.Load()
+	require.Equal(t, -1, after.NodeIndex(h), "tx must be removed from the live current subtree")
+	require.NotSame(t, before, after, "current subtree must be duplicated before mutation, not mutated in place")
+	require.GreaterOrEqual(t, before.NodeIndex(h), 0, "the pre-removal snapshot must remain untouched")
+}
+
+// TestRemoveTxsFromSubtreesNoMatchSkipsRechain verifies that removeTxsFromSubtrees
+// does not run reChainSubtrees(0) when no hash matched. An unconditional rebuild on
+// a no-op call needlessly replaces every subtree pointer (invalidating mining
+// snapshots) and burns an O(N) rebuild, matching the singular path's foundIndex>=0
+// gate.
+func TestRemoveTxsFromSubtreesNoMatchSkipsRechain(t *testing.T) {
+	ctx := context.Background()
+	stp := setupTestSubtreeProcessor(t)
+
+	for _, l := range []string{"A", "B", "C", "D"} {
+		h := chainhash.HashH([]byte("nomatch_" + l))
+		require.NoError(t, stp.AddDirectly(&subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}, &subtreepkg.TxInpoints{}, true))
+	}
+
+	require.GreaterOrEqual(t, len(stp.chainedSubtrees), 1, "expected at least one chained subtree")
+
+	beforeCurrent := stp.currentSubtree.Load()
+	beforeChained := append([]*subtreepkg.Subtree(nil), stp.chainedSubtrees...)
+
+	err := stp.removeTxsFromSubtrees(ctx, []chainhash.Hash{
+		chainhash.HashH([]byte("ghost_1")),
+		chainhash.HashH([]byte("ghost_2")),
+	})
+	require.NoError(t, err)
+
+	require.Same(t, beforeCurrent, stp.currentSubtree.Load(), "no-match removal must not rebuild the current subtree")
+	require.Equal(t, len(beforeChained), len(stp.chainedSubtrees), "no-match removal must not change the chained subtree count")
+
+	for i := range beforeChained {
+		require.Same(t, beforeChained[i], stp.chainedSubtrees[i], "no-match removal must not rebuild chained subtree %d", i)
+	}
+}
+
+// TestMoveBackBlockDoesNotResurrectRemovedCoinbaseSpends drives the full
+// moveBackBlock path for a block whose coinbase has child-spends sitting in the
+// mempool assembly. moveBackBlock captured the previous chained/current subtrees
+// BEFORE removeCoinbaseUtxos, which rebuilds (and Closes) those subtrees via
+// reChainSubtrees. moveBackBlockBulkBuild then folded the stale pre-removal
+// subtrees back in — resurrecting the just-removed coinbase child-spends (and, for
+// mmap-backed subtrees, reading Closed/unmapped memory). The captured refs must be
+// taken from live state after removeCoinbaseUtxos.
+func TestMoveBackBlockDoesNotResurrectRemovedCoinbaseSpends(t *testing.T) {
+	ctx := context.Background()
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockAssembly.InitialMerkleItemsPerSubtree = 4
+
+	utxoStore, err := sql.New(ctx, ulogger.TestLogger{}, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+	require.NoError(t, utxoStore.SetBlockHeight(4))
+
+	blobStore := blob_memory.New()
+
+	blockchainClient := &blockchain.Mock{}
+	blockchainClient.On("SetBlockProcessedAt", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 10)
+	go func() {
+		for req := range newSubtreeChan {
+			if req.ErrChan != nil {
+				req.ErrChan <- nil
+			}
+		}
+	}()
+	defer close(newSubtreeChan)
+
+	// NOTE: Start() is intentionally not called so moveBackBlock can be driven
+	// directly without racing the background goroutine (nodes added via addNode).
+	stp, err := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, tSettings, blobStore, blockchainClient, utxoStore, newSubtreeChan)
+	require.NoError(t, err)
+
+	// Coinbase with a child and grandchild spend, wired up in the utxo store so
+	// GetAndLockChildren returns them.
+	coinbase := coinbaseTx
+	_, err = utxoStore.Create(ctx, coinbase, 1)
+	require.NoError(t, err)
+
+	childTx := bt.NewTx()
+	require.NoError(t, childTx.From(coinbase.TxIDChainHash().String(), 0, coinbase.Outputs[0].LockingScript.String(), uint64(coinbase.Outputs[0].Satoshis)))
+	require.NoError(t, childTx.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 400000000))
+	childTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
+
+	grandchildTx := bt.NewTx()
+	require.NoError(t, grandchildTx.From(childTx.TxIDChainHash().String(), 0, childTx.Outputs[0].LockingScript.String(), uint64(childTx.Outputs[0].Satoshis)))
+	require.NoError(t, grandchildTx.AddP2PKHOutputFromAddress("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2", 300000000))
+	grandchildTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
+
+	_, err = utxoStore.Create(ctx, childTx, 1)
+	require.NoError(t, err)
+	_, err = utxoStore.Create(ctx, grandchildTx, 1)
+	require.NoError(t, err)
+
+	spends, err := utxoStore.Spend(ctx, childTx, 2, utxo.IgnoreFlags{})
+	require.NoError(t, err)
+	for _, spend := range spends {
+		require.NoError(t, spend.Err)
+	}
+
+	spends, err = utxoStore.Spend(ctx, grandchildTx, 2, utxo.IgnoreFlags{})
+	require.NoError(t, err)
+	for _, spend := range spends {
+		require.NoError(t, spend.Err)
+	}
+
+	childHash := *childTx.TxIDChainHash()
+	grandchildHash := *grandchildTx.TxIDChainHash()
+
+	// Lay the assembly out so the coinbase child-spends sit in a CHAINED subtree
+	// while the current (incomplete) subtree holds other mempool txs. itemsPerSubtree
+	// is 4, and the first subtree carries the coinbase placeholder, so:
+	//   [coinbase, child, grandchild, f0]  -> chained[0]
+	//   [f1, f2]                           -> current (non-empty)
+	// removeCoinbaseUtxos removes child+grandchild from chained[0] and reChains, which
+	// Closes the live current subtree. moveBackBlock captured that current subtree
+	// before the removal, so folding the stale copy back duplicates f1/f2.
+	require.NoError(t, stp.addNode(subtreepkg.Node{Hash: childHash, Fee: 1}, &subtreepkg.TxInpoints{ParentTxHashes: []chainhash.Hash{childHash}}, true))
+	require.NoError(t, stp.addNode(subtreepkg.Node{Hash: grandchildHash, Fee: 1}, &subtreepkg.TxInpoints{ParentTxHashes: []chainhash.Hash{grandchildHash}}, true))
+
+	var fillers []chainhash.Hash
+	for i := 0; i < 3; i++ {
+		fh := chainhash.HashH([]byte("mbb_filler_" + string(rune('0'+i))))
+		fillers = append(fillers, fh)
+		require.NoError(t, stp.addNode(subtreepkg.Node{Hash: fh, Fee: 1}, &subtreepkg.TxInpoints{ParentTxHashes: []chainhash.Hash{fh}}, true))
+	}
+
+	occurrences := func(h chainhash.Hash) int {
+		count := 0
+		if stp.currentSubtree.Load().NodeIndex(h) >= 0 {
+			count++
+		}
+
+		for _, cs := range stp.chainedSubtrees {
+			if cs.NodeIndex(h) >= 0 {
+				count++
+			}
+		}
+
+		return count
+	}
+	inAssembly := func(h chainhash.Hash) bool { return occurrences(h) > 0 }
+
+	// Sanity: both child-spends are in a chained subtree and the current subtree is non-empty.
+	require.GreaterOrEqual(t, len(stp.chainedSubtrees), 1, "precondition: expected a chained subtree")
+	require.GreaterOrEqual(t, stp.chainedSubtrees[0].NodeIndex(childHash), 0, "precondition: child in chained subtree")
+	require.GreaterOrEqual(t, stp.chainedSubtrees[0].NodeIndex(grandchildHash), 0, "precondition: grandchild in chained subtree")
+	require.Greater(t, stp.currentSubtree.Load().Length(), 0, "precondition: current subtree must be non-empty")
+
+	childrenBefore, err := utxo.GetAndLockChildren(ctx, utxoStore, *coinbase.TxIDChainHash())
+	require.NoError(t, err)
+	require.Len(t, childrenBefore, 2, "coinbase should have two descendant spends")
+
+	stp.InitCurrentBlockHeader(blockHeader)
+
+	block := &model.Block{
+		Header:     prevBlockHeader,
+		CoinbaseTx: coinbase,
+		Subtrees:   []*chainhash.Hash{},
+	}
+
+	_, _, err = stp.moveBackBlock(ctx, block, true)
+	require.NoError(t, err)
+
+	// The removed coinbase child-spends must NOT be folded back into the assembly.
+	require.False(t, inAssembly(childHash), "child spend must not be resurrected into the assembly")
+	require.False(t, inAssembly(grandchildHash), "grandchild spend must not be resurrected into the assembly")
+
+	_, childInMap := stp.currentTxMap.Get(childHash)
+	require.False(t, childInMap, "child spend must not be resurrected into currentTxMap")
+	_, grandchildInMap := stp.currentTxMap.Get(grandchildHash)
+	require.False(t, grandchildInMap, "grandchild spend must not be resurrected into currentTxMap")
+
+	// Non-coinbase mempool txs must survive the move-back exactly once: folding a
+	// stale pre-removal current-subtree copy back in would duplicate them.
+	for _, fh := range fillers {
+		require.Equal(t, 1, occurrences(fh), "filler tx %s must survive move-back exactly once (no duplication)", fh.String())
+	}
+
+	requireCoinbasePlaceholderIntact(t, stp)
 }
 
 // TestRemoveTxsFromSubtreesIntegration tests the function in a more realistic scenario

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -3303,6 +3303,133 @@ func TestRemoveTxsFromSubtreesBasic(t *testing.T) {
 	})
 }
 
+// TestRemoveTxsFromSubtreesOrdering reproduces the coinbase-spend ordering bug
+// where removeTxsFromSubtrees early-returned on the first hash found in the
+// current subtree, leaving later hashes (and the trailing reChainSubtrees(0)
+// compaction) unprocessed. This mirrors removeCoinbaseUtxos removing N child
+// spends where children[0] sits in the current subtree and children[1..] span a
+// chained subtree.
+func TestRemoveTxsFromSubtreesOrdering(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("removes all hashes when a current-subtree hash precedes a chained-subtree hash", func(t *testing.T) {
+		stp := setupTestSubtreeProcessor(t) // InitialMerkleItemsPerSubtree = 4
+
+		// Add A,B,C: first subtree fills to [coinbase,A,B,C] and chains.
+		// Add D,E: these land in the current subtree.
+		labels := []string{"A", "B", "C", "D", "E"}
+		hashes := make(map[string]chainhash.Hash, len(labels))
+
+		for _, l := range labels {
+			h := chainhash.HashH([]byte("cbspend_" + l))
+			hashes[l] = h
+			node := &subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}
+			require.NoError(t, stp.AddDirectly(node, &subtreepkg.TxInpoints{}, true))
+		}
+
+		// Sanity: A is in a chained subtree, D is in the current subtree.
+		require.GreaterOrEqual(t, len(stp.chainedSubtrees), 1, "expected at least one chained subtree")
+		require.GreaterOrEqual(t, stp.chainedSubtrees[0].NodeIndex(hashes["A"]), 0, "A should be in chained subtree 0")
+		require.GreaterOrEqual(t, stp.currentSubtree.Load().NodeIndex(hashes["D"]), 0, "D should be in current subtree")
+
+		// Remove D (current subtree, listed first) then A (chained subtree).
+		// Pre-fix, the D hit triggers an early return, so A is never removed and
+		// reChainSubtrees(0) never runs.
+		err := stp.removeTxsFromSubtrees(ctx, []chainhash.Hash{hashes["D"], hashes["A"]})
+		require.NoError(t, err)
+
+		nodeIndexAnywhere := func(h chainhash.Hash) int {
+			if idx := stp.currentSubtree.Load().NodeIndex(h); idx >= 0 {
+				return idx
+			}
+
+			for _, cs := range stp.chainedSubtrees {
+				if idx := cs.NodeIndex(h); idx >= 0 {
+					return idx
+				}
+			}
+
+			return -1
+		}
+
+		// Both targeted hashes must be gone from every subtree and from currentTxMap.
+		for _, l := range []string{"D", "A"} {
+			require.Equal(t, -1, nodeIndexAnywhere(hashes[l]), "%s must be removed from all subtrees", l)
+
+			_, exists := stp.currentTxMap.Get(hashes[l])
+			require.False(t, exists, "%s must be removed from currentTxMap", l)
+		}
+
+		// The untouched hashes must survive, exactly once each.
+		occurrences := func(h chainhash.Hash) int {
+			count := 0
+			if stp.currentSubtree.Load().NodeIndex(h) >= 0 {
+				count++
+			}
+
+			for _, cs := range stp.chainedSubtrees {
+				if cs.NodeIndex(h) >= 0 {
+					count++
+				}
+			}
+
+			return count
+		}
+
+		for _, l := range []string{"B", "C", "E"} {
+			require.Equal(t, 1, occurrences(hashes[l]), "%s must remain present exactly once", l)
+		}
+
+		// reChainSubtrees(0) must have recompacted the chain: every chained subtree
+		// is full (no hole left by the in-place removal from a chained subtree).
+		for i, cs := range stp.chainedSubtrees {
+			require.True(t, cs.IsComplete(), "chained subtree %d must be complete after recompaction", i)
+		}
+	})
+
+	t.Run("removes all hashes when a chained-subtree hash precedes a current-subtree hash", func(t *testing.T) {
+		stp := setupTestSubtreeProcessor(t)
+
+		labels := []string{"A", "B", "C", "D", "E"}
+		hashes := make(map[string]chainhash.Hash, len(labels))
+
+		for _, l := range labels {
+			h := chainhash.HashH([]byte("cbspend2_" + l))
+			hashes[l] = h
+			node := &subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}
+			require.NoError(t, stp.AddDirectly(node, &subtreepkg.TxInpoints{}, true))
+		}
+
+		// Remove A (chained) then D (current). Pre-fix, A removal leaves a hole in
+		// the chained subtree, then the D hit early-returns before reChainSubtrees(0),
+		// leaving the chain uncompacted.
+		err := stp.removeTxsFromSubtrees(ctx, []chainhash.Hash{hashes["A"], hashes["D"]})
+		require.NoError(t, err)
+
+		nodeIndexAnywhere := func(h chainhash.Hash) int {
+			if idx := stp.currentSubtree.Load().NodeIndex(h); idx >= 0 {
+				return idx
+			}
+
+			for _, cs := range stp.chainedSubtrees {
+				if idx := cs.NodeIndex(h); idx >= 0 {
+					return idx
+				}
+			}
+
+			return -1
+		}
+
+		for _, l := range []string{"A", "D"} {
+			require.Equal(t, -1, nodeIndexAnywhere(hashes[l]), "%s must be removed from all subtrees", l)
+		}
+
+		for i, cs := range stp.chainedSubtrees {
+			require.True(t, cs.IsComplete(), "chained subtree %d must be complete after recompaction", i)
+		}
+	})
+}
+
 // TestRemoveTxsFromSubtreesIntegration tests the function in a more realistic scenario
 func TestRemoveTxsFromSubtreesIntegration(t *testing.T) {
 	ctx := context.Background()

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor_test.go
@@ -3428,6 +3428,71 @@ func TestRemoveTxsFromSubtreesOrdering(t *testing.T) {
 			require.True(t, cs.IsComplete(), "chained subtree %d must be complete after recompaction", i)
 		}
 	})
+
+	t.Run("removes multiple hashes that all live in the current subtree", func(t *testing.T) {
+		stp := setupTestSubtreeProcessor(t)
+
+		// A,B,C fill and chain the first subtree; D,E remain in the current subtree.
+		labels := []string{"A", "B", "C", "D", "E"}
+		hashes := make(map[string]chainhash.Hash, len(labels))
+
+		for _, l := range labels {
+			h := chainhash.HashH([]byte("cbspend3_" + l))
+			hashes[l] = h
+			node := &subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}
+			require.NoError(t, stp.AddDirectly(node, &subtreepkg.TxInpoints{}, true))
+		}
+
+		require.GreaterOrEqual(t, stp.currentSubtree.Load().NodeIndex(hashes["D"]), 0, "D should be in current subtree")
+		require.GreaterOrEqual(t, stp.currentSubtree.Load().NodeIndex(hashes["E"]), 0, "E should be in current subtree")
+
+		// Removing two current-subtree hashes in one call exercises the index map:
+		// RemoveNodeAtIndex leaves a stale index for E after D is removed, so an
+		// in-place removal would use a stale index and remove the wrong node or fail.
+		err := stp.removeTxsFromSubtrees(ctx, []chainhash.Hash{hashes["D"], hashes["E"]})
+		require.NoError(t, err)
+
+		nodeIndexAnywhere := func(h chainhash.Hash) int {
+			if idx := stp.currentSubtree.Load().NodeIndex(h); idx >= 0 {
+				return idx
+			}
+
+			for _, cs := range stp.chainedSubtrees {
+				if idx := cs.NodeIndex(h); idx >= 0 {
+					return idx
+				}
+			}
+
+			return -1
+		}
+
+		for _, l := range []string{"D", "E"} {
+			require.Equal(t, -1, nodeIndexAnywhere(hashes[l]), "%s must be removed from all subtrees", l)
+
+			_, exists := stp.currentTxMap.Get(hashes[l])
+			require.False(t, exists, "%s must be removed from currentTxMap", l)
+		}
+
+		// A,B,C must be untouched and still present exactly once.
+		occurrences := func(h chainhash.Hash) int {
+			count := 0
+			if stp.currentSubtree.Load().NodeIndex(h) >= 0 {
+				count++
+			}
+
+			for _, cs := range stp.chainedSubtrees {
+				if cs.NodeIndex(h) >= 0 {
+					count++
+				}
+			}
+
+			return count
+		}
+
+		for _, l := range []string{"A", "B", "C"} {
+			require.Equal(t, 1, occurrences(hashes[l]), "%s must remain present exactly once", l)
+		}
+	})
 }
 
 // TestRemoveTxsFromSubtreesIntegration tests the function in a more realistic scenario


### PR DESCRIPTION
## Summary

Fixes #1156.

`removeTxsFromSubtrees(hashes)` iterated the slice but, when a hash was found in the **current** subtree, it `return`ed out of the whole function — skipping every remaining hash *and* the trailing `reChainSubtrees(0)` compaction.

It is called from `removeCoinbaseUtxos`, which has already deleted those txs' parent (coinbase) UTXOs. So on a reorg/reset that orphans a block whose matured coinbase outputs were spent, with ≥2 such child-spends where the first sits in the current subtree, the remaining children stayed in the mining candidate while spending non-existent UTXOs → the node could build/mine a **consensus-invalid block**. The skipped `reChainSubtrees(0)` also left a hole whenever a chained removal preceded a current-subtree removal.

## Fix

In the current-subtree branch, remove the node (with an error check) and `continue` the loop instead of `return`ing. The loop then falls through to the existing `reChainSubtrees(0)`, which now always runs and recompacts every subtree.

## Tests

Added `TestRemoveTxsFromSubtreesOrdering` with both hash orderings the existing tests missed:
- current-subtree hash before chained-subtree hash (the primary bug: later hash never removed)
- chained-subtree hash before current-subtree hash (the skipped-recompaction hole)

Each asserts all targeted hashes are gone from every subtree and `currentTxMap`, untouched hashes survive exactly once, and every chained subtree is `IsComplete()` (no hole).

Verified red against the old code, green after the fix.

```
go test -race -tags testtxmetacache -run TestRemoveTxsFromSubtreesOrdering ./services/blockassembly/subtreeprocessor/   # ok
go test -race -tags testtxmetacache ./services/blockassembly/subtreeprocessor/                                          # ok  157.702s
go vet -tags testtxmetacache ./services/blockassembly/subtreeprocessor/                                                 # exit 0
```