### PR TITLE
fix(txmetacache): never cache or trust partial inpoints-less tx meta

### DIFF
--- a/services/subtreevalidation/processTxMetaUsingCache.go
+++ b/services/subtreevalidation/processTxMetaUsingCache.go
@@ -113,7 +113,12 @@ func (p *TxMetaProcessor) processTxMetaUsingCache(i int) error {
 		}
 
 		txMeta, found := p.cache.GetMetaCached(p.ctx, txHash)
-		if found {
+		// Defensively reject a partial cache entry: a non-coinbase tx with no
+		// parent tx hashes is incomplete (TxInpoints was never populated) and
+		// would later fail subtree-meta serialization and wedge the block. Treat
+		// it as a miss so the store fallback — which can reconstruct inpoints from
+		// the tx inputs — resolves it and self-heals the cache.
+		if found && (txMeta.IsCoinbase || len(txMeta.TxInpoints.ParentTxHashes) > 0) {
 			p.txMetaSlice[i+j] = metaSliceItem{
 				fee:         txMeta.Fee,
 				sizeInBytes: txMeta.SizeInBytes,

--- a/services/subtreevalidation/processTxMetaUsingCache_test.go
+++ b/services/subtreevalidation/processTxMetaUsingCache_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/errors"
@@ -59,10 +60,19 @@ func generateTestHashes(count int) []chainhash.Hash {
 
 func populateCache(t testing.TB, cache *txmetacache.TxMetaCache, hashes []chainhash.Hash) {
 	t.Helper()
+	// Seed complete entries: a non-coinbase tx always has at least one parent, so
+	// a real cache entry carries a non-empty ParentTxHashes. (An empty one is a
+	// partial entry that the cache read-path now correctly treats as a miss.)
+	parent := chainhash.HashH([]byte("test-parent"))
+	in := &bt.Input{PreviousTxOutIndex: 0}
+	require.NoError(t, in.PreviousTxIDAdd(&parent))
+	ti, err := subtree.NewTxInpointsFromInputs([]*bt.Input{in})
+	require.NoError(t, err)
+
 	testMeta := &meta.Data{
 		Fee:         100,
 		SizeInBytes: 250,
-		TxInpoints:  subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{}},
+		TxInpoints:  ti,
 		BlockIDs:    []uint32{},
 	}
 
@@ -70,6 +80,59 @@ func populateCache(t testing.TB, cache *txmetacache.TxMetaCache, hashes []chainh
 		err := cache.SetCache(&hashes[i], testMeta)
 		require.NoError(t, err)
 	}
+}
+
+func TestProcessTxMetaUsingCache_PartialEntryTreatedAsMiss(t *testing.T) {
+	cache := setupTestCache(t)
+	server := setupCacheTestServer(t, cache, 1024, 4, 1000)
+	ctx := context.Background()
+
+	// Simulate a poisoned cache entry: a non-coinbase tx cached with empty
+	// ParentTxHashes (as a reduced-field BatchDecorate path would write). This
+	// is the entry that wedges block validation when trusted verbatim.
+	hash := chainhash.HashH([]byte("partial-cache-entry"))
+	partial := &meta.Data{
+		Fee:         100,
+		SizeInBytes: 250,
+		TxInpoints:  subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{}},
+		BlockIDs:    []uint32{},
+	}
+	require.NoError(t, cache.SetCache(&hash, partial))
+
+	txHashes := []chainhash.Hash{hash}
+	txMetaSlice := make([]metaSliceItem, 1)
+
+	missed, err := server.processTxMetaUsingCache(ctx, txHashes, txMetaSlice, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, missed, "partial entry (non-coinbase, empty ParentTxHashes) must be treated as a miss so the store fallback can self-heal it")
+	require.False(t, txMetaSlice[0].isSet, "partial entry must not be marked as set")
+}
+
+func TestProcessTxMetaUsingCache_CoinbaseEntryWithNoParentsIsHit(t *testing.T) {
+	cache := setupTestCache(t)
+	server := setupCacheTestServer(t, cache, 1024, 4, 1000)
+	ctx := context.Background()
+
+	// A coinbase tx legitimately has no parents; an empty-ParentTxHashes entry
+	// flagged IsCoinbase is complete and must still be served from the cache.
+	hash := chainhash.HashH([]byte("coinbase-cache-entry"))
+	coinbaseMeta := &meta.Data{
+		Fee:         0,
+		SizeInBytes: 100,
+		IsCoinbase:  true,
+		TxInpoints:  subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{}},
+		BlockIDs:    []uint32{},
+	}
+	require.NoError(t, cache.SetCache(&hash, coinbaseMeta))
+
+	txHashes := []chainhash.Hash{hash}
+	txMetaSlice := make([]metaSliceItem, 1)
+
+	missed, err := server.processTxMetaUsingCache(ctx, txHashes, txMetaSlice, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, missed, "a coinbase entry with no parents is complete and must be a hit")
+	require.True(t, txMetaSlice[0].isSet)
+	require.True(t, txMetaSlice[0].coinbase)
 }
 
 func TestProcessTxMetaUsingCache_MismatchedSliceLengths(t *testing.T) {

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -528,6 +528,19 @@ func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.Unresolv
 			continue
 		}
 
+		// Never cache a partial meta. A cached entry must be complete enough to
+		// serialize for subtree validation, which requires TxInpoints (the parent
+		// tx hashes). A reduced-field BatchDecorate — e.g. the {BlockIDs,
+		// BlockHeights} parent prefetch in subtree validation — leaves TxInpoints
+		// empty, so caching it would poison the cache: a later subtree-meta
+		// serialize rejects the inpoints-less node and the block wedges forever.
+		// Every non-coinbase tx has at least one parent, so empty ParentTxHashes
+		// here means the field was not populated; skip caching it and let the
+		// store (which can reconstruct inpoints from its inputs) serve the read.
+		if !data.Data.IsCoinbase && len(data.Data.TxInpoints.ParentTxHashes) == 0 {
+			continue
+		}
+
 		if len(data.Data.TxInpoints.ParentTxHashes) > 48 {
 			t.logger.Warnf("stored tx meta maybe too big for txmeta cache, size: %d, parent hash count: %d", data.Data.SizeInBytes, len(data.Data.TxInpoints.ParentTxHashes))
 		}

--- a/stores/txmetacache/txmetacache_test.go
+++ b/stores/txmetacache/txmetacache_test.go
@@ -892,6 +892,82 @@ func Test_TxMetaCache_BatchDecorate(t *testing.T) {
 
 // Note: GetSpend test skipped due to type compatibility issues
 
+// TestBatchDecorate_DoesNotCachePartialInpoints pins the producer-side root-cause
+// fix: BatchDecorate must never cache a partial meta — a non-coinbase tx whose
+// TxInpoints (parent tx hashes) was not populated, as a reduced-field
+// BatchDecorate ({BlockIDs, BlockHeights}) yields. Caching it poisons the cache
+// and wedges block validation because subtree-meta serialization rejects an
+// inpoints-less non-coinbase node.
+func TestBatchDecorate_DoesNotCachePartialInpoints(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+
+	ns, err := nullstore.NewNullStore()
+	require.NoError(t, err)
+	require.NoError(t, ns.SetBlockHeight(100))
+
+	// The store returns a partial meta: non-coinbase but no parent tx hashes.
+	partial := &meta.Data{
+		Fee:         100,
+		SizeInBytes: 111,
+		TxInpoints:  subtree.TxInpoints{ParentTxHashes: []chainhash.Hash{}},
+		BlockIDs:    make([]uint32, 0),
+	}
+	store := &decoratingNullStore{NullStore: ns, metaData: partial}
+
+	c, err := NewTxMetaCache(ctx, settings.NewSettings(), logger, store, Unallocated)
+	require.NoError(t, err)
+	cache := c.(*TxMetaCache)
+
+	h := chainhash.HashH([]byte("partial-batchdecorate"))
+	items := []*utxo.UnresolvedMetaData{{Hash: h}}
+
+	err = cache.BatchDecorate(ctx, items, fields.BlockIDs, fields.BlockHeights)
+	require.NoError(t, err)
+
+	_, found := cache.GetMetaCached(ctx, h)
+	require.False(t, found, "BatchDecorate must not cache a partial (inpoints-less) non-coinbase meta")
+}
+
+// TestBatchDecorate_CachesCompleteInpoints is the positive counterpart: a meta
+// with populated parent tx hashes is complete and must be cached as before.
+func TestBatchDecorate_CachesCompleteInpoints(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+
+	ns, err := nullstore.NewNullStore()
+	require.NoError(t, err)
+	require.NoError(t, ns.SetBlockHeight(100))
+
+	parent := chainhash.HashH([]byte("parent"))
+	in := &bt.Input{PreviousTxOutIndex: 0}
+	require.NoError(t, in.PreviousTxIDAdd(&parent))
+	ti, err := subtree.NewTxInpointsFromInputs([]*bt.Input{in})
+	require.NoError(t, err)
+
+	complete := &meta.Data{
+		Fee:         100,
+		SizeInBytes: 111,
+		TxInpoints:  ti,
+		BlockIDs:    make([]uint32, 0),
+	}
+	store := &decoratingNullStore{NullStore: ns, metaData: complete}
+
+	c, err := NewTxMetaCache(ctx, settings.NewSettings(), logger, store, Unallocated)
+	require.NoError(t, err)
+	cache := c.(*TxMetaCache)
+
+	h := chainhash.HashH([]byte("complete-batchdecorate"))
+	items := []*utxo.UnresolvedMetaData{{Hash: h}}
+
+	err = cache.BatchDecorate(ctx, items, fields.Fee, fields.SizeInBytes, fields.TxInpoints)
+	require.NoError(t, err)
+
+	cached, found := cache.GetMetaCached(ctx, h)
+	require.True(t, found, "BatchDecorate must cache a complete meta")
+	require.Len(t, cached.TxInpoints.ParentTxHashes, 1)
+}
+
 func Test_TxMetaCache_MiningOperations(t *testing.T) {
 	ctx := context.Background()
 	logger := ulogger.NewErrorTestLogger(t)


### PR DESCRIPTION
## Problem

A node can **permanently wedge on block validation** when the txmeta cache holds a *partial* entry for a non-coinbase transaction — one cached with empty `TxInpoints` (no parent tx hashes). Subtree validation trusts the cache hit, never falls back to the store (which has the correct data), and subtree-meta serialization rejects the inpoints-less node. The block fails validation, retries forever (~once/second with an identical error), and the node stops advancing. Observed during scaling tests; node-local and deterministic, requiring a cache flush / restart to recover.

## Root cause

`TxMetaCache.BatchDecorate` cached **every** decorated unmined/non-conflicting result, gated only on `BlockIDs`/`Conflicting` — never on whether `TxInpoints` was actually populated. A reduced-field parent prefetch (`{BlockIDs, BlockHeights}` in `check_block_subtrees.go`) produces a meta with empty `TxInpoints`; `MetaBytes()` happily serializes the empty value and the wrapper wrote that partial meta into the very cache subtree validation later reads. The consumer (`processTxMetaUsingCache`) then trusts any hit verbatim and short-circuits the store fallback.

## Fix (two parts)

1. **Producer (root):** `BatchDecorate` skips caching a non-coinbase meta with empty `ParentTxHashes`. Every non-coinbase tx has at least one parent, so an empty value here means the field was not populated — i.e. an incomplete entry that must not enter the cache. (Gating on data-completeness rather than the requested field set is more robust: only an explicit `fields.TxInpoints` request populates `Data.TxInpoints`, and this catches *any* partial-producing path.)
2. **Consumer (defensive):** `processTxMetaUsingCache` treats a cache hit with empty `ParentTxHashes` on a non-coinbase tx as a **miss**, falling through to the store — which reconstructs inpoints from the tx inputs — so any partial entry that slips through self-heals instead of wedging the block.

## Tests

- New regression tests (TDD, confirmed failing before the fix):
  - `stores/txmetacache`: a partial (inpoints-less, non-coinbase) meta is **not** cached; a complete meta **is** cached.
  - `services/subtreevalidation`: a partial cache entry is treated as a **miss**; a coinbase entry with no parents is still a **hit**.
- Updated the `populateCache` test helper to seed complete entries (it previously seeded empty-`ParentTxHashes` entries, which encoded the buggy behavior).
- `go test` (both packages), `go test -race` (new tests), and `go vet` all pass.

## Risk

`BatchDecorate` no longer caches reduced-field results lacking inpoints. The only such caller (parent prefetch) uses the returned map directly, not the cache, so its path is unaffected — it just no longer poisons the cache. `TxMetaCache.BatchDecorate` always reads through to the underlying store, so a consumer "miss" reliably re-fetches full inpoints.

Closes #1168