### PR TITLE
fix(blob/file): cast stat.Bavail to uint64 for FreeBSD portability

### DIFF
--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -602,7 +602,7 @@ func (s *File) Health(ctx context.Context, _ bool) (int, string, error) {
 		return http.StatusInternalServerError, "File Store: Unable to check disk space", err
 	}
 
-	availableBytes := stat.Bavail * uint64(stat.Bsize)
+	availableBytes := uint64(stat.Bavail) * uint64(stat.Bsize)
 	totalBytes := stat.Blocks * uint64(stat.Bsize)
 
 	const minAvailableBytes = 1 << 30 // 1 GiB


### PR DESCRIPTION
## Summary
- On FreeBSD, `syscall.Statfs_t.Bavail` is a **signed** integer, so `stat.Bavail * uint64(stat.Bsize)` in the blob file store's disk-space health check fails to compile.
- On Linux and macOS `Bavail` is already unsigned, so the explicit `uint64()` conversion is a harmless no-op there.
- Adding the cast makes the line build on all POSIX platforms — purely a portability fix, no behaviour change.

```diff
-    availableBytes := stat.Bavail * uint64(stat.Bsize)
+    availableBytes := uint64(stat.Bavail) * uint64(stat.Bsize)
```

## Test plan
- [x] `go build ./stores/blob/file/` — passes
- [x] `go vet ./stores/blob/file/` — clean
- [ ] Cross-compile / build on FreeBSD confirms the previous compile error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)