### PR TITLE
MvP-4491 Enforce BIP68 on non-coinbase txs in NewBlockFromMsgBlock

### DIFF
--- a/daemon/store_subtree_for_block_test.go
+++ b/daemon/store_subtree_for_block_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	bt "github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/test/utils/transactions"
+	"github.com/stretchr/testify/require"
+)
+
+// requireSameTx asserts that got is the same transaction as want. The transaction
+// id is a cryptographic commitment to the whole body, so equal ids prove the body
+// round-tripped intact; the input/output checks are format-independent spot checks
+// on top of that.
+func requireSameTx(t *testing.T, want, got *bt.Tx) {
+	t.Helper()
+
+	require.NotNil(t, got)
+	require.Equal(t, *want.TxIDChainHash(), *got.TxIDChainHash())
+	require.Equal(t, len(want.Inputs), len(got.Inputs))
+	require.Equal(t, len(want.Outputs), len(got.Outputs))
+
+	for i := range want.Outputs {
+		require.Equal(t, want.Outputs[i].Satoshis, got.Outputs[i].Satoshis)
+	}
+}
+
+// TestStoreSubtreeForBlock exercises TestDaemon.StoreSubtreeForBlock against an
+// in-memory subtree store. The helper only touches the exported Ctx and
+// SubtreeStore fields, so it can be driven from a minimally-populated TestDaemon
+// without standing up a full daemon, its dependencies, or any containers.
+func TestStoreSubtreeForBlock(t *testing.T) {
+	privKey, _ := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+
+	td := TestDaemon{
+		privKey:      privKey,
+		Ctx:          context.Background(),
+		SubtreeStore: memory.New(),
+	}
+
+	// A parent transaction with two spendable outputs, then two children that each
+	// spend one of them. The children are the non-coinbase transactions placed in
+	// the subtree after the coinbase placeholder.
+	parentTx := td.CreateTransactionWithOptions(t,
+		transactions.WithCoinbaseData(100, "/Test miner/"),
+		transactions.WithP2PKHOutputs(2, 1e8),
+	)
+
+	tx1 := td.CreateTransactionWithOptions(t,
+		transactions.WithInput(parentTx, 0),
+		transactions.WithP2PKHOutputs(1, 1000),
+	)
+	tx2 := td.CreateTransactionWithOptions(t,
+		transactions.WithInput(parentTx, 1),
+		transactions.WithP2PKHOutputs(1, 1000),
+	)
+
+	txs := []*bt.Tx{tx1, tx2}
+	parentHash := *parentTx.TxIDChainHash()
+
+	const deleteAtHeight = uint32(100)
+
+	rootHash := td.StoreSubtreeForBlock(t, txs, deleteAtHeight)
+	require.NotNil(t, rootHash)
+
+	// The subtree blob must round-trip to the expected leaf layout: a coinbase
+	// placeholder followed by the two child tx hashes in block order, and the same
+	// root hash the helper returned.
+	subtreeBytes, err := td.SubtreeStore.Get(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeToCheck)
+	require.NoError(t, err)
+
+	parsedSubtree, err := subtreepkg.NewSubtreeFromBytes(subtreeBytes)
+	require.NoError(t, err)
+	require.Equal(t, 3, parsedSubtree.Length())
+	require.True(t, parsedSubtree.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue))
+	require.Equal(t, *tx1.TxIDChainHash(), parsedSubtree.Nodes[1].Hash)
+	require.Equal(t, *tx2.TxIDChainHash(), parsedSubtree.Nodes[2].Hash)
+	require.Equal(t, *rootHash, *parsedSubtree.RootHash())
+
+	// The subtree data blob must round-trip to the two child tx bodies in order.
+	// Index 0 is the coinbase placeholder slot and carries no body.
+	dataBytes, err := td.SubtreeStore.Get(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeData)
+	require.NoError(t, err)
+
+	parsedData, err := subtreepkg.NewSubtreeDataFromBytes(parsedSubtree, dataBytes)
+	require.NoError(t, err)
+	require.Len(t, parsedData.Txs, 3)
+	require.Nil(t, parsedData.Txs[0])
+	requireSameTx(t, tx1, parsedData.Txs[1])
+	requireSameTx(t, tx2, parsedData.Txs[2])
+
+	// The subtree meta blob must round-trip to each child's parent inpoints. Both
+	// children spend the same parent, so each records that single parent tx hash.
+	metaBytes, err := td.SubtreeStore.Get(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeMeta)
+	require.NoError(t, err)
+
+	parsedMeta, err := subtreepkg.NewSubtreeMetaFromBytes(parsedSubtree, metaBytes)
+	require.NoError(t, err)
+
+	parents1, err := parsedMeta.GetParentTxHashes(1)
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{parentHash}, parents1)
+
+	parents2, err := parsedMeta.GetParentTxHashes(2)
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{parentHash}, parents2)
+
+	// Storing the same transaction set again must succeed (overwrite is allowed) and
+	// must yield the same deterministic root hash.
+	rootHashAgain := td.StoreSubtreeForBlock(t, txs, deleteAtHeight)
+	require.NotNil(t, rootHashAgain)
+	require.Equal(t, *rootHash, *rootHashAgain)
+}

--- a/daemon/test_daemon.go
+++ b/daemon/test_daemon.go
@@ -1712,7 +1712,7 @@ func createAndSaveSubtrees(ctx context.Context, subtreeStore blob.Store, txs []*
 		}
 	}
 
-	if err = storeSubtreeFiles(ctx, subtreeStore, subtree, subtreeData, subtreeMeta); err != nil {
+	if err = storeSubtreeFiles(ctx, subtreeStore, subtree, subtreeData, subtreeMeta, 100); err != nil {
 		return nil, err
 	}
 
@@ -1720,7 +1720,7 @@ func createAndSaveSubtrees(ctx context.Context, subtreeStore blob.Store, txs []*
 }
 
 // storeSubtreeFiles serializes and stores the subtree, subtree data, and subtree meta in the provided subtree store.
-func storeSubtreeFiles(ctx context.Context, subtreeStore blob.Store, subtree *subtreepkg.Subtree, subtreeData *subtreepkg.Data, subtreeMeta *subtreepkg.Meta) error {
+func storeSubtreeFiles(ctx context.Context, subtreeStore blob.Store, subtree *subtreepkg.Subtree, subtreeData *subtreepkg.Data, subtreeMeta *subtreepkg.Meta, deleteAtHeight uint32) error {
 	subtreeBytes, err := subtree.Serialize()
 	if err != nil {
 		return err
@@ -1731,7 +1731,7 @@ func storeSubtreeFiles(ctx context.Context, subtreeStore blob.Store, subtree *su
 		subtree.RootHash()[:],
 		fileformat.FileTypeSubtreeToCheck, // this needs to be FileTypeSubtreeToCheck for tx processing to occur
 		subtreeBytes,
-		options.WithDeleteAt(100),
+		options.WithDeleteAt(deleteAtHeight),
 		options.WithAllowOverwrite(true),
 	)
 	if err != nil {
@@ -1748,7 +1748,7 @@ func storeSubtreeFiles(ctx context.Context, subtreeStore blob.Store, subtree *su
 		subtreeData.RootHash()[:],
 		fileformat.FileTypeSubtreeData,
 		subtreeDataBytes,
-		options.WithDeleteAt(100),
+		options.WithDeleteAt(deleteAtHeight),
 		options.WithAllowOverwrite(true),
 	)
 	if err != nil {
@@ -1765,7 +1765,7 @@ func storeSubtreeFiles(ctx context.Context, subtreeStore blob.Store, subtree *su
 		subtree.RootHash()[:],
 		fileformat.FileTypeSubtreeMeta,
 		subtreeMetaBytes,
-		options.WithDeleteAt(100),
+		options.WithDeleteAt(deleteAtHeight),
 		options.WithAllowOverwrite(true),
 	)
 	if err != nil {
@@ -1809,25 +1809,11 @@ func (td *TestDaemon) StoreSubtreeForBlock(t *testing.T, txs []*bt.Tx, deleteAtH
 
 	rootHash := subtree.RootHash()
 
-	subtreeBytes, err := subtree.Serialize()
-	require.NoError(t, err)
-
-	// FileTypeSubtreeToCheck (rather than FileTypeSubtree) is required so the
+	// Delegate the persist path to storeSubtreeFiles. subtreeData.RootHash() equals
+	// subtree.RootHash() for a NewSubtreeData(subtree), so the stored keys are unchanged.
+	// FileTypeSubtreeToCheck (set by storeSubtreeFiles) is required so the
 	// subtree-validation pass treats the transactions as pending and validates them.
-	require.NoError(t, td.SubtreeStore.Set(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes,
-		options.WithDeleteAt(deleteAtHeight), options.WithAllowOverwrite(true)))
-
-	subtreeDataBytes, err := subtreeData.Serialize()
-	require.NoError(t, err)
-
-	require.NoError(t, td.SubtreeStore.Set(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeData, subtreeDataBytes,
-		options.WithDeleteAt(deleteAtHeight), options.WithAllowOverwrite(true)))
-
-	subtreeMetaBytes, err := subtreeMeta.Serialize()
-	require.NoError(t, err)
-
-	require.NoError(t, td.SubtreeStore.Set(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeMeta, subtreeMetaBytes,
-		options.WithDeleteAt(deleteAtHeight), options.WithAllowOverwrite(true)))
+	require.NoError(t, storeSubtreeFiles(td.Ctx, td.SubtreeStore, subtree, subtreeData, subtreeMeta, deleteAtHeight))
 
 	return rootHash
 }

--- a/daemon/test_daemon.go
+++ b/daemon/test_daemon.go
@@ -1775,6 +1775,63 @@ func storeSubtreeFiles(ctx context.Context, subtreeStore blob.Store, subtree *su
 	return nil
 }
 
+// StoreSubtreeForBlock builds the single subtree for a block whose only
+// non-coinbase transactions are those given (a coinbase placeholder followed by
+// the supplied transactions, in order), then persists the subtree, its data and
+// its meta to the subtree store. This makes the transactions locally available
+// to the block-validation subtree pass, which fetches the subtree data and
+// consensus-validates every non-coinbase transaction.
+//
+// It is the test-side complement to model.NewBlockFromMsgBlock: that constructor
+// records the subtree root on the block, but the transaction bodies (carried only
+// in the original wire block) are not part of the serialised block and must be
+// supplied to the store separately for validation to reach them.
+//
+// deleteAtHeight controls blob retention and must be above the height of the
+// block being validated so the subtree is not pruned before validation runs.
+// The returned root hash matches block.Subtrees[0] for a block built from the
+// same coinbase-plus-transactions set.
+func (td *TestDaemon) StoreSubtreeForBlock(t *testing.T, txs []*bt.Tx, deleteAtHeight uint32) *chainhash.Hash {
+	subtree, err := subtreepkg.NewIncompleteTreeByLeafCount(len(txs) + 1)
+	require.NoError(t, err)
+
+	subtreeData := subtreepkg.NewSubtreeData(subtree)
+	subtreeMeta := subtreepkg.NewSubtreeMeta(subtree)
+
+	require.NoError(t, subtree.AddCoinbaseNode())
+
+	for i, tx := range txs {
+		require.NoError(t, subtree.AddNode(*tx.TxIDChainHash(), 0, uint64(tx.Size()))) //nolint:gosec
+		// node index is i+1 because index 0 is the coinbase placeholder
+		require.NoError(t, subtreeData.AddTx(tx, i+1))
+		require.NoError(t, subtreeMeta.SetTxInpointsFromTx(tx))
+	}
+
+	rootHash := subtree.RootHash()
+
+	subtreeBytes, err := subtree.Serialize()
+	require.NoError(t, err)
+
+	// FileTypeSubtreeToCheck (rather than FileTypeSubtree) is required so the
+	// subtree-validation pass treats the transactions as pending and validates them.
+	require.NoError(t, td.SubtreeStore.Set(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes,
+		options.WithDeleteAt(deleteAtHeight), options.WithAllowOverwrite(true)))
+
+	subtreeDataBytes, err := subtreeData.Serialize()
+	require.NoError(t, err)
+
+	require.NoError(t, td.SubtreeStore.Set(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeData, subtreeDataBytes,
+		options.WithDeleteAt(deleteAtHeight), options.WithAllowOverwrite(true)))
+
+	subtreeMetaBytes, err := subtreeMeta.Serialize()
+	require.NoError(t, err)
+
+	require.NoError(t, td.SubtreeStore.Set(td.Ctx, rootHash[:], fileformat.FileTypeSubtreeMeta, subtreeMetaBytes,
+		options.WithDeleteAt(deleteAtHeight), options.WithAllowOverwrite(true)))
+
+	return rootHash
+}
+
 // ResetServiceManagerContext resets the ServiceManager context to allow for a fresh start.
 func (td *TestDaemon) ResetServiceManagerContext(t *testing.T) {
 	err := td.d.ServiceManager.ResetContext()

--- a/model/Block.go
+++ b/model/Block.go
@@ -218,7 +218,7 @@ func NewBlockFromMsgBlock(msgBlock *wire.MsgBlock, optionalSettings *settings.Se
 
 		txSize, sizeErr := safeconversion.IntToUint64(tx.Size())
 		if sizeErr != nil {
-			return nil, sizeErr
+			return nil, errors.NewProcessingError("failed to compute size for transaction %d", i, sizeErr)
 		}
 
 		if addErr := subtree.AddNode(*tx.TxIDChainHash(), 0, txSize); addErr != nil {

--- a/model/Block.go
+++ b/model/Block.go
@@ -118,7 +118,13 @@ func NewBlock(header *BlockHeader, coinbase *bt.Tx, subtrees []*chainhash.Hash, 
 	}, nil
 }
 
-// NewBlockFromMsgBlock creates a new model.Block from a wire.MsgBlock
+// NewBlockFromMsgBlock creates a new model.Block from a wire.MsgBlock.
+//
+// All non-coinbase transactions are packed into a single subtree sized to the
+// transaction count. This is intended for the genesis block and the small
+// offline/test blocks that are this constructor's only callers; it is NOT
+// subtree-size-limit aware and must not be used to assemble real, full-sized
+// blocks (which split transactions across multiple bounded subtrees).
 func NewBlockFromMsgBlock(msgBlock *wire.MsgBlock, optionalSettings *settings.Settings) (*Block, error) {
 	if msgBlock == nil {
 		return nil, errors.NewInvalidArgumentError("msgBlock is nil")
@@ -182,15 +188,67 @@ func NewBlockFromMsgBlock(msgBlock *wire.MsgBlock, optionalSettings *settings.Se
 	if err = subtree.AddCoinbaseNode(); err != nil {
 		return nil, errors.NewSubtreeError("failed to add coinbase placeholder", err)
 	}
-	// TODO: support more than coinbase tx in the subtree
-	// if txCount > 1 {
-	// 	// loop through the transactions ignoring the first coinbase tx and add them to the subtrees list
 
-	// 	// subtrees = append(subtrees, subtree.RootHash())
-	// }
+	// Add every non-coinbase transaction to the subtree so the resulting block
+	// exposes its full transaction set, not just the coinbase. Without this,
+	// block.Valid() and the block-validation service skip all per-transaction
+	// checks for a block built from a wire.MsgBlock, because they gate those
+	// checks on the block carrying at least one subtree root.
+	//
+	// Transaction input values are not available from a raw (non-extended) block,
+	// so the per-node fee is recorded as 0 here. That is enough to place the
+	// transaction in the subtree and to validate consensus rules that do not depend
+	// on fees (e.g. sequence locks): the subtree-validation/store path recomputes and
+	// rewrites fee metadata when it persists and validates the subtree. Note that
+	// model.Block.Valid()'s block-reward check sums the SubtreeSlices fees directly
+	// and does not recompute them, so validating a block in memory straight from this
+	// constructor is only sound for offline blocks whose coinbase claims no fees
+	// (subsidy only). A single subtree holds the whole block, which is sufficient for
+	// the offline blocks this constructor handles.
+	for i := 1; i < len(msgBlock.Transactions); i++ {
+		var txBuf bytes.Buffer
+		if serializeErr := msgBlock.Transactions[i].Serialize(&txBuf); serializeErr != nil {
+			return nil, errors.NewProcessingError("failed to serialize transaction %d", i, serializeErr)
+		}
 
-	// Create and return the new Block
-	return NewBlock(header, coinbaseTx, subtrees, txCount, sizeInBytes, 0, 0)
+		tx, txErr := bt.NewTxFromBytes(txBuf.Bytes())
+		if txErr != nil {
+			return nil, errors.NewProcessingError("failed to create bt.Tx for transaction %d", i, txErr)
+		}
+
+		txSize, sizeErr := safeconversion.IntToUint64(tx.Size())
+		if sizeErr != nil {
+			return nil, sizeErr
+		}
+
+		if addErr := subtree.AddNode(*tx.TxIDChainHash(), 0, txSize); addErr != nil {
+			return nil, errors.NewSubtreeError("failed to add transaction %d to subtree", i, addErr)
+		}
+	}
+
+	// Only a block that carries transactions beyond the coinbase gets a subtree
+	// root recorded on the block. A coinbase-only block (e.g. the genesis block)
+	// keeps an empty subtree list, preserving the historical behaviour of this
+	// function and its callers.
+	var subtreeSlices []*subtreepkg.Subtree
+
+	if txCount > 1 {
+		subtrees = append(subtrees, subtree.RootHash())
+		subtreeSlices = []*subtreepkg.Subtree{subtree}
+	}
+
+	// Create the new Block
+	block, err := NewBlock(header, coinbaseTx, subtrees, txCount, sizeInBytes, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Retain the in-memory subtree so in-process callers can validate the block
+	// without a subtree-store round trip. This field is not serialised, so it is
+	// dropped when the block is sent over the wire.
+	block.SubtreeSlices = subtreeSlices
+
+	return block, nil
 }
 
 func NewBlockFromBytes(blockBytes []byte) (block *Block, err error) {

--- a/model/Block.go
+++ b/model/Block.go
@@ -206,22 +206,16 @@ func NewBlockFromMsgBlock(msgBlock *wire.MsgBlock, optionalSettings *settings.Se
 	// (subsidy only). A single subtree holds the whole block, which is sufficient for
 	// the offline blocks this constructor handles.
 	for i := 1; i < len(msgBlock.Transactions); i++ {
-		var txBuf bytes.Buffer
-		if serializeErr := msgBlock.Transactions[i].Serialize(&txBuf); serializeErr != nil {
-			return nil, errors.NewProcessingError("failed to serialize transaction %d", i, serializeErr)
-		}
+		// The transaction hash is the canonical double-SHA256 of the wire
+		// serialization, identical to the value the subtree/merkle path expects.
+		hash := msgBlock.Transactions[i].TxHash()
 
-		tx, txErr := bt.NewTxFromBytes(txBuf.Bytes())
-		if txErr != nil {
-			return nil, errors.NewProcessingError("failed to create bt.Tx for transaction %d", i, txErr)
-		}
-
-		txSize, sizeErr := safeconversion.IntToUint64(tx.Size())
+		txSize, sizeErr := safeconversion.IntToUint64(msgBlock.Transactions[i].SerializeSize())
 		if sizeErr != nil {
 			return nil, errors.NewProcessingError("failed to compute size for transaction %d", i, sizeErr)
 		}
 
-		if addErr := subtree.AddNode(*tx.TxIDChainHash(), 0, txSize); addErr != nil {
+		if addErr := subtree.AddNode(hash, 0, txSize); addErr != nil {
 			return nil, errors.NewSubtreeError("failed to add transaction %d to subtree", i, addErr)
 		}
 	}
@@ -237,11 +231,9 @@ func NewBlockFromMsgBlock(msgBlock *wire.MsgBlock, optionalSettings *settings.Se
 		subtreeSlices = []*subtreepkg.Subtree{subtree}
 	}
 
-	// Create the new Block
-	block, err := NewBlock(header, coinbaseTx, subtrees, txCount, sizeInBytes, 0, 0)
-	if err != nil {
-		return nil, err
-	}
+	// Create the new Block. NewBlock never returns an error, so the result is
+	// used directly.
+	block, _ := NewBlock(header, coinbaseTx, subtrees, txCount, sizeInBytes, 0, 0)
 
 	// Retain the in-memory subtree so in-process callers can validate the block
 	// without a subtree-store round trip. This field is not serialised, so it is

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -1554,6 +1554,76 @@ func TestNewBlockFromMsgBlock(t *testing.T) {
 	})
 }
 
+func TestNewBlockFromMsgBlock_MultiTransactionSubtree(t *testing.T) {
+	// A coinbase plus one ordinary transaction. Two leaves is a power of two, so the
+	// single subtree the constructor builds is full and its root equals the canonical
+	// Bitcoin merkle root DSHA(coinbaseHash || txHash) with no padding involved.
+	coinbaseTx := &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+			SignatureScript:  []byte{0x03, 0x01, 0x02, 0x03},
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{Value: 5000000000, PkScript: []byte{0x51}}},
+	}
+
+	spendTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.DoubleHashH([]byte{0x01}), Index: 0},
+			SignatureScript:  []byte{0x47, 0x30, 0x44},
+			Sequence:         0xfffffffe,
+		}},
+		TxOut: []*wire.TxOut{{Value: 4999990000, PkScript: []byte{0x76, 0xa9, 0x14}}},
+	}
+
+	coinbaseHash := coinbaseTx.TxHash()
+	spendHash := spendTx.TxHash()
+
+	// Canonical merkle root for two leaves, computed independently of the subtree package.
+	buf := make([]byte, 0, 2*chainhash.HashSize)
+	buf = append(buf, coinbaseHash[:]...)
+	buf = append(buf, spendHash[:]...)
+	merkleRoot := chainhash.DoubleHashH(buf)
+
+	msgBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    2,
+			PrevBlock:  chainhash.Hash{},
+			MerkleRoot: merkleRoot,
+			Timestamp:  time.Unix(1640995200, 0),
+			Bits:       0x1d00ffff,
+			Nonce:      42,
+		},
+		Transactions: []*wire.MsgTx{coinbaseTx, spendTx},
+	}
+
+	block, err := NewBlockFromMsgBlock(msgBlock, nil)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+
+	// transaction count includes the coinbase
+	require.Equal(t, uint64(2), block.TransactionCount)
+
+	// exactly one subtree root is recorded and the in-memory slice is populated
+	require.Len(t, block.Subtrees, 1)
+	require.Len(t, block.SubtreeSlices, 1)
+	require.NotNil(t, block.SubtreeSlices[0])
+
+	// node 0 is the coinbase placeholder, node 1 is the non-coinbase tx hash in block order
+	subtree := block.SubtreeSlices[0]
+	require.Equal(t, 2, len(subtree.Nodes))
+	require.True(t, subtree.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue))
+	require.Equal(t, spendHash, subtree.Nodes[1].Hash)
+
+	// the recorded root matches the subtree's own root
+	require.Equal(t, *subtree.RootHash(), *block.Subtrees[0])
+
+	// the single-subtree representation reconciles to the header merkle root
+	require.NoError(t, block.CheckMerkleRoot(context.Background()))
+}
+
 func TestNewBlockFromMsgBlockAndModelBlock(t *testing.T) {
 	blockHeaderBytes, err := hex.DecodeString(block1Header)
 	require.NoError(t, err)

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -1624,6 +1624,153 @@ func TestNewBlockFromMsgBlock_MultiTransactionSubtree(t *testing.T) {
 	require.NoError(t, block.CheckMerkleRoot(context.Background()))
 }
 
+// canonicalBlockMerkleRoot computes the Bitcoin merkle root for the given leaves
+// (coinbase first, then transactions in block order) using the duplicate-when-odd
+// rule applied at every level. It is deliberately independent of the subtree
+// package so it can serve as an oracle for CheckMerkleRoot.
+func canonicalBlockMerkleRoot(leaves []chainhash.Hash) chainhash.Hash {
+	level := make([]chainhash.Hash, len(leaves))
+	copy(level, leaves)
+
+	for len(level) > 1 {
+		if len(level)%2 != 0 {
+			level = append(level, level[len(level)-1])
+		}
+
+		next := make([]chainhash.Hash, 0, len(level)/2)
+
+		for i := 0; i < len(level); i += 2 {
+			buf := make([]byte, 0, 2*chainhash.HashSize)
+			buf = append(buf, level[i][:]...)
+			buf = append(buf, level[i+1][:]...)
+			next = append(next, chainhash.DoubleHashH(buf))
+		}
+
+		level = next
+	}
+
+	return level[0]
+}
+
+func TestNewBlockFromMsgBlock_OddNonCoinbaseSubtree(t *testing.T) {
+	// A coinbase plus two ordinary transactions: three leaves. Three is not a power
+	// of two, so building the single subtree's root exercises the duplicate-when-odd
+	// merkle path (the last leaf is hashed against itself), which the coinbase-plus-one
+	// case never reaches.
+	coinbaseTx := &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+			SignatureScript:  []byte{0x03, 0x01, 0x02, 0x03},
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{Value: 5000000000, PkScript: []byte{0x51}}},
+	}
+
+	spendTx1 := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.DoubleHashH([]byte{0x01}), Index: 0},
+			SignatureScript:  []byte{0x47, 0x30, 0x44},
+			Sequence:         0xfffffffe,
+		}},
+		TxOut: []*wire.TxOut{{Value: 4999990000, PkScript: []byte{0x76, 0xa9, 0x14}}},
+	}
+
+	spendTx2 := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.DoubleHashH([]byte{0x02}), Index: 1},
+			SignatureScript:  []byte{0x47, 0x30, 0x45},
+			Sequence:         0xfffffffd,
+		}},
+		TxOut: []*wire.TxOut{{Value: 4999980000, PkScript: []byte{0x76, 0xa9, 0x15}}},
+	}
+
+	coinbaseHash := coinbaseTx.TxHash()
+	spendHash1 := spendTx1.TxHash()
+	spendHash2 := spendTx2.TxHash()
+
+	merkleRoot := canonicalBlockMerkleRoot([]chainhash.Hash{coinbaseHash, spendHash1, spendHash2})
+
+	msgBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    2,
+			PrevBlock:  chainhash.Hash{},
+			MerkleRoot: merkleRoot,
+			Timestamp:  time.Unix(1640995200, 0),
+			Bits:       0x1d00ffff,
+			Nonce:      7,
+		},
+		Transactions: []*wire.MsgTx{coinbaseTx, spendTx1, spendTx2},
+	}
+
+	block, err := NewBlockFromMsgBlock(msgBlock, nil)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+
+	// transaction count includes the coinbase
+	require.Equal(t, uint64(3), block.TransactionCount)
+
+	// exactly one subtree root is recorded and the in-memory slice is populated
+	require.Len(t, block.Subtrees, 1)
+	require.Len(t, block.SubtreeSlices, 1)
+	require.NotNil(t, block.SubtreeSlices[0])
+
+	// node 0 is the coinbase placeholder; nodes 1 and 2 are the non-coinbase txs in block order
+	subtree := block.SubtreeSlices[0]
+	require.Equal(t, 3, len(subtree.Nodes))
+	require.True(t, subtree.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue))
+	require.Equal(t, spendHash1, subtree.Nodes[1].Hash)
+	require.Equal(t, spendHash2, subtree.Nodes[2].Hash)
+
+	// the recorded root matches the subtree's own root
+	require.Equal(t, *subtree.RootHash(), *block.Subtrees[0])
+
+	// the odd-leaf single-subtree representation reconciles to the canonical merkle root
+	require.NoError(t, block.CheckMerkleRoot(context.Background()))
+}
+
+func TestNewBlockFromMsgBlock_CoinbaseOnlyNoSubtree(t *testing.T) {
+	// A coinbase-only block (genesis-like) must keep an empty subtree list and an
+	// empty in-memory subtree slice, so block validation skips the per-transaction
+	// pass exactly as it did before non-coinbase transactions were threaded in.
+	coinbaseTx := &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+			SignatureScript:  []byte{0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04},
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{Value: 5000000000, PkScript: []byte{0x51}}},
+	}
+
+	coinbaseHash := coinbaseTx.TxHash()
+
+	msgBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    1,
+			PrevBlock:  chainhash.Hash{},
+			MerkleRoot: coinbaseHash,
+			Timestamp:  time.Unix(1231006505, 0),
+			Bits:       0x1d00ffff,
+			Nonce:      2083236893,
+		},
+		Transactions: []*wire.MsgTx{coinbaseTx},
+	}
+
+	block, err := NewBlockFromMsgBlock(msgBlock, nil)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+
+	require.Equal(t, uint64(1), block.TransactionCount)
+	require.Empty(t, block.Subtrees)
+	require.Empty(t, block.SubtreeSlices)
+
+	// with a single transaction the merkle root is the coinbase hash itself
+	require.NoError(t, block.CheckMerkleRoot(context.Background()))
+}
+
 func TestNewBlockFromMsgBlockAndModelBlock(t *testing.T) {
 	blockHeaderBytes, err := hex.DecodeString(block1Header)
 	require.NoError(t, err)

--- a/test/e2e/daemon/ready/bip68_test.go
+++ b/test/e2e/daemon/ready/bip68_test.go
@@ -221,12 +221,7 @@ func TestBIP68_HeightBased_Accept(t *testing.T) {
 
 // TestBIP68_HeightBased_Reject verifies that a block containing a tx with an unsatisfied
 // height-based sequence lock is rejected by Teranode.
-//
-// NOTE: Skipped because model.NewBlockFromMsgBlock (model/Block.go:161) only populates the
-// coinbase subtree — non-coinbase txs are invisible to block.Valid() and therefore to
-// ValidateBlock. Fix that TODO first, then remove the t.Skip.
 func TestBIP68_HeightBased_Reject(t *testing.T) {
-	t.Skip("BIP68 reject: model.NewBlockFromMsgBlock (model/Block.go:161) only populates the coinbase subtree, so ValidateBlock never sees non-coinbase txs and cannot enforce BIP68 sequence locks on them")
 	legacySyncTestLock.Lock()
 	defer legacySyncTestLock.Unlock()
 
@@ -271,8 +266,11 @@ func TestBIP68_HeightBased_Reject(t *testing.T) {
 	initialTDHeight := initialTDMeta.Height
 	require.Equal(t, fundingBlockHeight, initialTDHeight)
 
-	// Submit to Teranode via ValidateBlock — the correct full-validation path (calls block.Valid()
-	// with UTXO store and subtree store). Should reject because the sequence lock is not satisfied.
+	// Submit to Teranode via ProcessBlock — the full validation path that runs the
+	// subtree-validation pass and therefore consensus-validates every non-coinbase
+	// transaction, including the BIP68 sequence-lock check. block.Valid() alone does
+	// not evaluate sequence locks, so the lighter ValidateBlock RPC cannot reject on
+	// this rule. The block must be rejected because the sequence lock is not satisfied.
 	blockBytes, err := hex.DecodeString(block.Hex)
 	require.NoError(t, err)
 	msgBlock := &wire.MsgBlock{}
@@ -282,8 +280,19 @@ func TestBIP68_HeightBased_Reject(t *testing.T) {
 	require.NoError(t, err)
 	modelBlock.Height = fundingBlockHeight + 1
 
-	err = td.BlockValidationClient.ValidateBlock(ctx, modelBlock, nil)
+	// The serialised block carries the subtree root but not the transaction bodies,
+	// so persist the subtree (coinbase placeholder + the sequence-locked tx) to the
+	// subtree store for validation to reach the transaction.
+	td.StoreSubtreeForBlock(t, []*bt.Tx{tx}, modelBlock.Height+1000)
+
+	err = td.BlockValidationClient.ProcessBlock(ctx, modelBlock, modelBlock.Height, "test", "", 0)
 	require.Error(t, err, "Teranode should reject block with unsatisfied height-based sequence lock (sequence=%d, UTXO age=1 block)", sequence)
+	// Assert the rejection is the height-based sequence-lock failure specifically, so the
+	// test cannot pass on an unrelated error (missing subtree data, merkle mismatch, fees).
+	// The validator surfaces this as a tx-invalid error reading "transaction sequence lock
+	// height not satisfied: ..." (services/validator/TxValidator.go).
+	require.ErrorContains(t, err, "sequence lock height not satisfied",
+		"rejection must be the BIP68 height-based sequence-lock failure, not an unrelated validation error")
 	t.Logf("Teranode rejected block as expected: %v", err)
 
 	// Verify Teranode height is unchanged
@@ -377,12 +386,7 @@ func TestBIP68_TimeBased_Accept(t *testing.T) {
 
 // TestBIP68_TimeBased_Reject verifies that a block containing a tx with an unsatisfied
 // time-based sequence lock is rejected by Teranode.
-//
-// NOTE: Same prerequisite as TestBIP68_HeightBased_Reject — model.NewBlockFromMsgBlock
-// (model/Block.go:161) only populates the coinbase subtree, so ValidateBlock never sees
-// non-coinbase txs. Fix that TODO first, then remove the t.Skip.
 func TestBIP68_TimeBased_Reject(t *testing.T) {
-	t.Skip("BIP68 reject: model.NewBlockFromMsgBlock (model/Block.go:161) only populates the coinbase subtree, so ValidateBlock never sees non-coinbase txs and cannot enforce BIP68 sequence locks on them")
 	legacySyncTestLock.Lock()
 	defer legacySyncTestLock.Unlock()
 
@@ -427,8 +431,11 @@ func TestBIP68_TimeBased_Reject(t *testing.T) {
 	initialTDHeight := initialTDMeta.Height
 	require.Equal(t, fundingBlockHeight, initialTDHeight)
 
-	// Submit to Teranode via ValidateBlock — the correct full-validation path (calls block.Valid()
-	// with UTXO store and subtree store). Should reject because the time lock is not satisfied.
+	// Submit to Teranode via ProcessBlock — the full validation path that runs the
+	// subtree-validation pass and therefore consensus-validates every non-coinbase
+	// transaction, including the BIP68 sequence-lock check. block.Valid() alone does
+	// not evaluate sequence locks, so the lighter ValidateBlock RPC cannot reject on
+	// this rule. The block must be rejected because the time lock is not satisfied.
 	blockBytes, err := hex.DecodeString(block.Hex)
 	require.NoError(t, err)
 	msgBlock := &wire.MsgBlock{}
@@ -438,8 +445,19 @@ func TestBIP68_TimeBased_Reject(t *testing.T) {
 	require.NoError(t, err)
 	modelBlock.Height = fundingBlockHeight + 1
 
-	err = td.BlockValidationClient.ValidateBlock(ctx, modelBlock, nil)
+	// The serialised block carries the subtree root but not the transaction bodies,
+	// so persist the subtree (coinbase placeholder + the sequence-locked tx) to the
+	// subtree store for validation to reach the transaction.
+	td.StoreSubtreeForBlock(t, []*bt.Tx{tx}, modelBlock.Height+1000)
+
+	err = td.BlockValidationClient.ProcessBlock(ctx, modelBlock, modelBlock.Height, "test", "", 0)
 	require.Error(t, err, "Teranode should reject block with unsatisfied time-based sequence lock (1000 × 512 seconds not elapsed)")
+	// Assert the rejection is the time-based sequence-lock failure specifically, so the
+	// test cannot pass on an unrelated error (missing subtree data, merkle mismatch, fees).
+	// The validator surfaces this as a tx-invalid error reading "transaction sequence lock
+	// time not satisfied: ..." (services/validator/TxValidator.go).
+	require.ErrorContains(t, err, "sequence lock time not satisfied",
+		"rejection must be the BIP68 time-based sequence-lock failure, not an unrelated validation error")
 	t.Logf("Teranode rejected block as expected: %v", err)
 
 	// Verify Teranode height is unchanged

--- a/test/e2e/daemon/ready/bip68_test.go
+++ b/test/e2e/daemon/ready/bip68_test.go
@@ -227,7 +227,12 @@ func TestBIP68_HeightBased_Reject(t *testing.T) {
 
 	ctx := t.Context()
 
-	// Setup: CSV active at height 10, start with 110 initial blocks
+	// Setup: CSV active at height 10, start with 110 initial blocks.
+	// This test only proves enforcement while the block height sits in the window
+	// CSVHeight <= height < GenesisActivationHeight; past Genesis, relative-locktime
+	// enforcement is dropped and this check becomes a no-op. If a future regtest config
+	// lowers GenesisActivationHeight below the heights here, this test would silently
+	// stop proving anything — keep the window in mind when changing those heights.
 	td, sv, txCreator := setupBIP68Test(t, 10, 110)
 	defer func() {
 		td.Stop(t)
@@ -392,7 +397,12 @@ func TestBIP68_TimeBased_Reject(t *testing.T) {
 
 	ctx := t.Context()
 
-	// Setup: CSV active at height 10, start with 110 initial blocks
+	// Setup: CSV active at height 10, start with 110 initial blocks.
+	// This test only proves enforcement while the block height sits in the window
+	// CSVHeight <= height < GenesisActivationHeight; past Genesis, relative-locktime
+	// enforcement is dropped and this check becomes a no-op. If a future regtest config
+	// lowers GenesisActivationHeight below the heights here, this test would silently
+	// stop proving anything — keep the window in mind when changing those heights.
 	td, sv, txCreator := setupBIP68Test(t, 10, 110)
 	defer func() {
 		td.Stop(t)

--- a/test/e2e/daemon/ready/legacy_sync_test.go
+++ b/test/e2e/daemon/ready/legacy_sync_test.go
@@ -1760,6 +1760,12 @@ func TestFloatingBlock_SubmitToTeranodeFirst(t *testing.T) {
 	require.NoError(t, err, "Should create model block from wire.MsgBlock")
 
 	expectedHeight := fundingBlockHeight + 1
+
+	// model.NewBlockFromMsgBlock records the subtree root on the block but not the
+	// transaction bodies, so persist the subtree (coinbase placeholder + the spending
+	// tx) to the subtree store for validation to reach the transaction.
+	td.StoreSubtreeForBlock(t, []*bt.Tx{tx}, expectedHeight+1000)
+
 	err = td.BlockValidationClient.ProcessBlock(ctx, modelBlock, expectedHeight, "test", "", 0)
 	require.NoError(t, err, "Teranode should accept the floating block")
 	t.Logf("Submitted floating block to Teranode at height %d", expectedHeight)


### PR DESCRIPTION
This resolve [[fix(model): enforce BIP68 on non-coinbase txs in NewBlockFromMsgBlock](https://github.com/bitcoin-sv/teranode/issues/4491)](https://github.com/bitcoin-sv/teranode/issues/4491)