### PR TITLE
fix(ci): resolve SonarCloud security hotspots in CI/build config

### DIFF
--- a/.github/workflows/benchmark-compare.yaml
+++ b/.github/workflows/benchmark-compare.yaml
@@ -153,7 +153,7 @@ jobs:
           build_cache: 'false'
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260615155930-9e4b9ddef5b6
 
       - name: Download all benchmark results
         uses: actions/download-artifact@v4

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install MkDocs
-        run: pip install mkdocs-material
+        run: "pip install --only-binary :all: mkdocs-material==9.7.6"
 
       - name: Configure Git for deployment
         run: |

--- a/.github/workflows/teranode_main_build.yaml
+++ b/.github/workflows/teranode_main_build.yaml
@@ -12,12 +12,15 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  id-token: write
 
 jobs:
   # Tests and code lint
   test_and_lint:
     uses: ./.github/workflows/teranode_main_tests.yaml
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
     secrets: inherit
 
   # Calculate version information

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GIT_VERSION="${GIT_VERSI
 
 # This could be run in the ${BASE_IMG} so we don't have to do it on every build, but it's not a big deal and this is pretty quick
 ENV GOPATH=/go
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.27.0
 
 # RUN_IMG should be overritten by --build-args
 FROM ${RUN_IMG}

--- a/compose/cmd/gennodes/main.go
+++ b/compose/cmd/gennodes/main.go
@@ -419,7 +419,7 @@ func writeAll(outDir string, s spec) error {
 		if err := renderToFile("templates/"+name+".tmpl", p, s); err != nil {
 			return err
 		}
-		if err := os.Chmod(p, 0o755); err != nil {
+		if err := os.Chmod(p, 0o750); err != nil {
 			return err
 		}
 	}

--- a/util/cuckoo/cuckoo_h32_test.go
+++ b/util/cuckoo/cuckoo_h32_test.go
@@ -123,6 +123,20 @@ func TestH32_SaturationLatchesAndShortCircuits(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Measure a per-Insert floor on THIS machine so the bound auto-scales to
+	// the runner's speed instead of assuming a fast dev box (the old fixed 1s
+	// bound flaked on slow/contended CI runners). extract() is the hashing work
+	// every Insert does before the short-circuit; it's the cheapest honest
+	// proxy for irreducible per-op cost and scales with machine speed.
+	floorStart := time.Now()
+	var sink uint64
+	for i := 0; i < n; i++ {
+		fp, idx := cf.extract(&hashes[i])
+		sink += uint64(fp) + idx
+	}
+	floor := time.Since(floorStart)
+	require.NotZero(t, sink+1) // keep the loop from being optimised away
+
 	// Time a batch of Inserts that we expect to fail. With saturation
 	// latched, these should all return immediately (no eviction churn).
 	start := time.Now()
@@ -131,10 +145,15 @@ func TestH32_SaturationLatchesAndShortCircuits(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	// Sanity bound: if the short-circuit is broken and eviction runs for
-	// every Insert, we'd see ~100K × 500 kicks × ~30 ns = ~1.5 s. With
-	// the short-circuit, this loop should complete in well under 100 ms
-	// even on a modest machine. Allow generous slack for CI variance.
-	require.Less(t, elapsed, time.Second,
-		"saturated Insert short-circuit appears broken: %d Inserts took %v", n, elapsed)
+	// The saturated short-circuit does extract + two failed CAS probes
+	// (2 × bucketSize atomic loads) + an atomic flag load: a small constant
+	// multiple of the extract floor. A broken short-circuit would run the full
+	// eviction loop (up to maxKicks=500 kicks per Insert), i.e. ~2 orders of
+	// magnitude more work. A 50× floor bound (plus a small constant to absorb
+	// timer noise) sits comfortably between the two and rides the machine's
+	// speed, so it catches a broken short-circuit without flaking on slow CI.
+	bound := 50*floor + 100*time.Millisecond
+	require.Less(t, elapsed, bound,
+		"saturated Insert short-circuit appears broken: %d Inserts took %v (floor %v, bound %v)",
+		n, elapsed, floor, bound)
 }


### PR DESCRIPTION
## Summary

Resolves six SonarCloud SECURITY findings in CI/build configuration. All are hardening / supply-chain hygiene - none are exploitable vulnerabilities in application code.

| Rule | Location | Change |
|------|----------|--------|
| `githubactions:S8233` | `teranode_main_build.yaml` | Move `id-token: write` from workflow level to the `test_and_lint` job that needs it, so `calculate-version` no longer gets OIDC token-minting power |
| `githubactions:S8545` | `benchmark-compare.yaml:156` | Pin `benchstat` to a fixed pseudo-version instead of `@latest` |
| `docker:S8545` | `Dockerfile:43` | Pin delve `dlv` to `v1.27.0` instead of `@latest` |
| `githubactions:S8541` + `S8544` | `docs-deploy.yml:34` | Pin `mkdocs-material==9.7.6` and add `--only-binary :all:` to block sdist setup-script execution |
| `go:S2612` | `compose/cmd/gennodes/main.go:422` | Tighten generated helper-script perms `0o755` -> `0o750` to drop world access |

## Behaviour-preserving notes

- `test_and_lint` keeps `id-token: write` via a new job-level `permissions` block, so OIDC behaviour is unchanged; only `calculate-version` loses the unneeded grant.
- Pinned versions are the current latest at commit time. They will need periodic bumps (Dependabot/Renovate would automate this) - the expected tradeoff for reproducibility over `@latest`.
- `benchstat` has no upstream semver tags, so a pseudo-version is the only available pin.

## Testing

- `go build ./compose/cmd/gennodes/`: OK
- `python3 yaml.safe_load` on all three edited workflows: OK
- CI workflows not executed locally; first CI run on this PR is the real confirmation (notably that a manylinux wheel exists for `mkdocs-material==9.7.6`, which it does on PyPI).

## Not included

Other open SonarCloud SECURITY findings are being resolved as Safe / Won't-Fix in the SonarCloud UI rather than via code, because they are false positives or local-only dev tooling:
- 13x `go:S2077` in `stores/utxo/sql/sql.go` - parameterized queries; only `$N` placeholders are interpolated, all values are bound (false positive)
- 2x `pythonsecurity:S8707` in `scripts/validate-markdown.py` - local docs linter over trusted repo paths
- 1x `javascript:S5332` in `centrifuge_impl/client/index.html` - localhost-only demo client (`ws://` is the only endpoint)

The `secrets:S6698` BLOCKER (hardcoded Postgres password in `teranode-configmap.yaml`) is intentionally out of scope for this PR and tracked separately.

---

## Added: flaky-test stabilisation (commit 963697583)

CI on this branch tripped a pre-existing flaky timing test unrelated to the SonarCloud changes: `util/cuckoo/TestH32_SaturationLatchesAndShortCircuits` asserted 100K saturated Inserts finish in a hardcoded < 1s. That bound was tuned to a fast dev box; on a slow/contended CI runner under `-race` it flaked (observed 1.053s), because the short-circuit path still does a hash extract + two failed atomic CAS probes per Insert and `-race` instruments those atomics heavily.

Replaced the fixed bound with a self-calibrating one: measure the per-Insert `extract()` floor on the runner, then assert `elapsed < 50*floor + 100ms`. The legitimate short-circuit runs at ~5-6x the floor (stable with and without `-race`); a broken short-circuit runs the full eviction loop (up to maxKicks=500 kicks/Insert), ~100x+ the floor, so the 50x bound still catches the regression the test exists to detect. Verified: `go vet` clean, 8x green under `-race` locally.

Folded into this PR rather than split out because it's the change that turns this branch's CI green and the PR is already CI-reliability-themed.