### PR TITLE
docs(blockassembly): document post-Genesis any-order queue assumption (TN-019)

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1049,6 +1049,21 @@ func (stp *SubtreeProcessor) Start(ctx context.Context) {
 
 					// Phase 3: Bulk insert valid nodes into subtrees (single-threaded)
 					// Only nodes with non-zero Hash passed the filters
+					//
+					// Ordering note (post-Genesis any-order assumption):
+					// Nodes are appended to subtrees strictly in dequeue order; this loop
+					// never reorders a child behind its parent. Because the validator
+					// creates the parent UTXO (Validator.go CreateInUtxoStore) and enqueues
+					// to block assembly (sendToBlockAssembler) as separate steps, and
+					// concurrent validator goroutines race on the MPSC queue's tail.Swap
+					// (queue.go enqueueBatch), a child's batch can be enqueued — and so
+					// placed in an earlier subtree slot — ahead of its parent's. That is
+					// valid post-Genesis: TTOR was removed at ChainCfgParams.
+					// GenesisActivationHeight (620,538 on mainnet), so any in-block order
+					// is accepted as long as the parent is present in the same block and
+					// there is no double-spend. If strict parent-before-child ordering is
+					// ever required (e.g. for pre-Genesis history), add a parent-presence
+					// hold here or set BlockAssembly.DoubleSpendWindow > 0 to delay batches.
 					nrAddedInBatch := 0
 					for _, batch := range dequeueBatches {
 						for _, node := range batch.nodes {

--- a/services/blockassembly/subtreeprocessor/queue.go
+++ b/services/blockassembly/subtreeprocessor/queue.go
@@ -53,6 +53,13 @@ func (q *LockFreeQueue) length() int64 {
 // It uses atomic operations to ensure thread safety during concurrent enqueue operations.
 // The entire batch receives a single timestamp when enqueued.
 //
+// Ordering: concurrent producers linearise on tail.Swap, so the order in which
+// two batches land is whichever producer wins that swap — it is NOT guaranteed to
+// match parent-before-child causal order. A child enqueued from one validator
+// goroutine may precede its parent enqueued from another. The consumer appends in
+// dequeue order without reordering; see the post-Genesis any-order assumption
+// documented at the dequeue loop in SubtreeProcessor.go.
+//
 // Parameters:
 //   - nodes: The transaction nodes to add
 //   - txInpoints: Parent transaction references for each node

--- a/services/blockassembly/subtreeprocessor/queue_test.go
+++ b/services/blockassembly/subtreeprocessor/queue_test.go
@@ -456,6 +456,135 @@ func Test_queueLarge(t *testing.T) {
 	assert.Equal(t, 10_000_000, batches)
 }
 
+// Test_queueDoesNotHoldChildBeforeParent documents and verifies the post-Genesis
+// any-order assumption (issue TN-019): the queue performs no parent-presence
+// reordering. When a child batch is enqueued ahead of its parent's batch — as can
+// happen when concurrent validator goroutines race on tail.Swap — the consumer
+// dequeues the child first. The queue never holds a child back to wait for its
+// parent. This is intentional and valid post-Genesis (TTOR removed), so long as
+// the parent is present in the same block and there is no double-spend.
+func Test_queueDoesNotHoldChildBeforeParent(t *testing.T) {
+	q := NewLockFreeQueue()
+
+	parentHash := chainhash.Hash{0x01}
+	childHash := chainhash.Hash{0x02}
+
+	// Child is enqueued FIRST, parent SECOND — the adverse ordering the queue
+	// does not correct. The child references the parent via its inpoints.
+	q.enqueueBatch(
+		[]subtree.Node{{Hash: childHash}},
+		[]*subtree.TxInpoints{{ParentTxHashes: []chainhash.Hash{parentHash}}},
+	)
+	q.enqueueBatch(
+		[]subtree.Node{{Hash: parentHash}},
+		[]*subtree.TxInpoints{{}},
+	)
+
+	// DoubleSpendWindow disabled (validFromMillis == 0): no batches are held back.
+	first, found := q.dequeueBatch(0)
+	require.True(t, found)
+	require.Len(t, first.nodes, 1)
+	require.Equal(t, childHash, first.nodes[0].Hash,
+		"child must dequeue first; the queue must not hold it back for its parent")
+
+	second, found := q.dequeueBatch(0)
+	require.True(t, found)
+	require.Len(t, second.nodes, 1)
+	require.Equal(t, parentHash, second.nodes[0].Hash)
+
+	_, found = q.dequeueBatch(0)
+	require.False(t, found)
+	require.True(t, q.IsEmpty())
+}
+
+// Test_queueParentChildConcurrentLossless enqueues a parent and its child from two
+// separate goroutines, repeatedly, exactly as concurrent validator Store() calls
+// do. The producers race on tail.Swap, so neither parent-before-child nor
+// child-before-parent ordering is guaranteed. The invariant that MUST hold is that
+// every enqueued transaction survives to the consumer — no batch is dropped,
+// duplicated, or corrupted under contention.
+func Test_queueParentChildConcurrentLossless(t *testing.T) {
+	const rounds = 5_000
+
+	q := NewLockFreeQueue()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Producer A: parents. Producer B: children. Hashes are unique per round and
+	// disjoint between producers so we can detect any loss or duplication.
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < rounds; i++ {
+			h := chainhash.Hash{}
+			h[0] = 0xAA
+			binaryPut(h[1:], uint64(i))
+			q.enqueueBatch(
+				[]subtree.Node{{Hash: h}},
+				[]*subtree.TxInpoints{{}},
+			)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < rounds; i++ {
+			parent := chainhash.Hash{}
+			parent[0] = 0xAA
+			binaryPut(parent[1:], uint64(i))
+
+			h := chainhash.Hash{}
+			h[0] = 0xBB
+			binaryPut(h[1:], uint64(i))
+			q.enqueueBatch(
+				[]subtree.Node{{Hash: h}},
+				[]*subtree.TxInpoints{{ParentTxHashes: []chainhash.Hash{parent}}},
+			)
+		}
+	}()
+
+	wg.Wait()
+
+	seen := make(map[chainhash.Hash]int, rounds*2)
+
+	for {
+		batch, found := q.dequeueBatch(0)
+		if !found {
+			break
+		}
+
+		for _, node := range batch.nodes {
+			seen[node.Hash]++
+		}
+	}
+
+	require.Len(t, seen, rounds*2, "every parent and child must survive exactly once")
+
+	for i := 0; i < rounds; i++ {
+		parent := chainhash.Hash{}
+		parent[0] = 0xAA
+		binaryPut(parent[1:], uint64(i))
+
+		child := chainhash.Hash{}
+		child[0] = 0xBB
+		binaryPut(child[1:], uint64(i))
+
+		require.Equal(t, 1, seen[parent], "parent %d lost or duplicated", i)
+		require.Equal(t, 1, seen[child], "child %d lost or duplicated", i)
+	}
+
+	require.True(t, q.IsEmpty())
+}
+
+// binaryPut writes v into b in little-endian order (b must be at least 8 bytes).
+func binaryPut(b []byte, v uint64) {
+	for i := 0; i < 8; i++ {
+		b[i] = byte(v >> (8 * i))
+	}
+}
+
 // enqueueBatches adds test batches to a queue for testing.
 // Each batch contains a single transaction for testing simplicity.
 //


### PR DESCRIPTION
## Summary

Addresses #1158 (TN-019, low severity). The block-assembly MPSC queue does not guarantee parent-before-child ordering across concurrent validator `Store()` calls, and the code relied implicitly on the post-Genesis any-order rule without documenting it. Per the issue, **no consensus fix is required** — this PR documents the assumption and adds the suggested concurrency test.

## Why ordering is not guaranteed

- `queue.go` `enqueueBatch`: concurrent producers linearise on `tail.Swap`, so whichever producer wins the swap lands first — not parent-before-child.
- The validator creates the parent UTXO (`CreateInUtxoStore`) and enqueues to block assembly (`sendToBlockAssembler`) as **separate** steps, so concurrent validator goroutines can interleave a child ahead of its parent.
- The consumer (`SubtreeProcessor.go` Phase 3) appends in dequeue order with no parent reorder.

This is valid post-Genesis — TTOR was removed at `ChainCfgParams.GenesisActivationHeight` (620,538 on mainnet); any in-block order is accepted as long as the parent is present in the same block and there is no double-spend.

## Changes

- **`SubtreeProcessor.go`** — "Ordering note" comment at the Phase 3 dequeue/insert loop documenting the post-Genesis any-order assumption and the escape hatches (parent-presence hold, or `DoubleSpendWindow > 0`) if strict ordering is ever needed.
- **`queue.go`** — ordering note on `enqueueBatch` explaining the `tail.Swap` linearisation, cross-referencing the dequeue-loop comment.
- **`queue_test.go`** — two tests:
  - `Test_queueDoesNotHoldChildBeforeParent` — deterministic proof a child enqueued ahead of its parent dequeues first (no parent-presence hold).
  - `Test_queueParentChildConcurrentLossless` — two goroutines enqueue parent/child across 5,000 rounds; asserts every tx survives exactly once under `tail.Swap` contention.

The two source edits are comment-only; runtime behaviour is unchanged.

## Testing

- `go test -race -tags testtxmetacache -run 'Test_queue' ./services/blockassembly/subtreeprocessor/` — ok
- `go vet -tags testtxmetacache ./services/blockassembly/subtreeprocessor/` — clean

Closes #1158