### PR TITLE
fix(scripts): shell hygiene — errors to stderr + [[ ]] conditionals

### DIFF
--- a/compose/scripts/generate-blocks.sh
+++ b/compose/scripts/generate-blocks.sh
@@ -53,7 +53,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ -z "$HOST" ]; then
-  echo "Error: --host is a required argument."
+  echo "Error: --host is a required argument." >&2
   echo "Usage: $0 --host <host> [--port <port>] [--stopHeight <height>] [--generate] [--initialBlocks <count>]"
   exit 1
 fi

--- a/deploy/docker/base/aerospike-asmt-wrapper.sh
+++ b/deploy/docker/base/aerospike-asmt-wrapper.sh
@@ -25,7 +25,7 @@ log_warn() {
 }
 
 log_error() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ ERROR: $*"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ ERROR: $*" >&2
 }
 
 # Install ASMT tool if not present

--- a/scripts/clean_datadir.sh
+++ b/scripts/clean_datadir.sh
@@ -4,18 +4,18 @@ set -e
 
 # Parse arguments
 FORCE=false
-if [ "$1" == "--force" ] || [ "$1" == "-f" ]; then
+if [[ "$1" == "--force" ]] || [[ "$1" == "-f" ]]; then
     FORCE=true
 fi
 
 # Check if DATADIR is set
-if [ -z "$DATADIR" ]; then
+if [[ -z "$DATADIR" ]]; then
     echo "Error: DATADIR environment variable is not set" >&2
     exit 1
 fi
 
 # Check if DATADIR exists
-if [ ! -d "$DATADIR" ]; then
+if [[ ! -d "$DATADIR" ]]; then
     echo "Error: DATADIR '$DATADIR' does not exist" >&2
     exit 1
 fi
@@ -23,9 +23,9 @@ fi
 echo "Cleaning folders in: $DATADIR"
 echo "This will delete all subdirectories but preserve p2p.key in the root"
 
-if [ "$FORCE" = false ]; then
+if [[ "$FORCE" = false ]]; then
     read -p "Are you sure you want to continue? (yes/no): " confirm
-    if [ "$confirm" != "yes" ]; then
+    if [[ "$confirm" != "yes" ]]; then
         echo "Operation cancelled"
         exit 0
     fi

--- a/scripts/clean_datadir.sh
+++ b/scripts/clean_datadir.sh
@@ -10,13 +10,13 @@ fi
 
 # Check if DATADIR is set
 if [ -z "$DATADIR" ]; then
-    echo "Error: DATADIR environment variable is not set"
+    echo "Error: DATADIR environment variable is not set" >&2
     exit 1
 fi
 
 # Check if DATADIR exists
 if [ ! -d "$DATADIR" ]; then
-    echo "Error: DATADIR '$DATADIR' does not exist"
+    echo "Error: DATADIR '$DATADIR' does not exist" >&2
     exit 1
 fi
 

--- a/scripts/dev-stack-macos.sh
+++ b/scripts/dev-stack-macos.sh
@@ -95,10 +95,10 @@ is_container_running() {
     local container_name=$1
     local inspect_output
     inspect_output=$($CONTAINER_BINARY inspect "$container_name" 2>/dev/null || echo "[]")
-    if [ "$inspect_output" != "[]" ]; then
+    if [[ "$inspect_output" != "[]" ]]; then
         local state
         state=$(echo "$inspect_output" | grep -o '"status":"[^"]*"' | cut -d'"' -f4 || echo "")
-        [ "$state" = "running" ] && return 0
+        [[ "$state" = "running" ]] && return 0
     fi
     return 1
 }
@@ -202,7 +202,7 @@ stop_container() {
     local container_name=$1
     local inspect_output
     inspect_output=$($CONTAINER_BINARY inspect "$container_name" 2>/dev/null || echo "[]")
-    if [ "$inspect_output" = "[]" ]; then
+    if [[ "$inspect_output" = "[]" ]]; then
         return 0
     fi
 
@@ -278,7 +278,7 @@ show_status() {
 show_logs() {
     local follow="${1:-false}"
 
-    if [ "$follow" = "true" ]; then
+    if [[ "$follow" = "true" ]]; then
         echo "📜 Following Container Logs (Ctrl+C to stop):"
         echo ""
 
@@ -304,7 +304,7 @@ show_logs() {
             fi
         done
 
-        if [ ${#pids[@]} -eq 0 ]; then
+        if [[ ${#pids[@]} -eq 0 ]]; then
             echo "No running containers found"
             return 1
         fi
@@ -337,7 +337,7 @@ clean_data() {
         fi
     done
 
-    if [ ${#running_containers[@]} -gt 0 ]; then
+    if [[ ${#running_containers[@]} -gt 0 ]]; then
         echo "❌ Error: Cannot clean data while containers are running" >&2
         echo "" >&2
         echo "Running containers:" >&2
@@ -359,7 +359,7 @@ clean_data() {
 
     # Ask for confirmation
     read -p "Are you sure you want to delete all data? (yes/no): " confirmation
-    if [ "$confirmation" != "yes" ]; then
+    if [[ "$confirmation" != "yes" ]]; then
         echo "Cancelled."
         return 0
     fi
@@ -368,14 +368,14 @@ clean_data() {
     echo ""
     echo "Deleting data directories..."
 
-    if [ -d "${DATA_PATH}/aerospike" ]; then
+    if [[ -d "${DATA_PATH}/aerospike" ]]; then
         rm -rf "${DATA_PATH}/aerospike"
         echo "✅ Deleted ${DATA_PATH}/aerospike"
     else
         echo "  ${DATA_PATH}/aerospike does not exist"
     fi
 
-    if [ -d "${DATA_PATH}/postgres" ]; then
+    if [[ -d "${DATA_PATH}/postgres" ]]; then
         rm -rf "${DATA_PATH}/postgres"
         echo "✅ Deleted ${DATA_PATH}/postgres"
     else
@@ -389,12 +389,12 @@ clean_data() {
 # Main execution
 ACTION="${1:-}"
 
-if [ -z "$ACTION" ]; then
+if [[ -z "$ACTION" ]]; then
     usage
 fi
 
 # Only allow a single sub-command
-if [ $# -gt 1 ]; then
+if [[ $# -gt 1 ]]; then
     echo "Error: Only one command allowed at a time. Got: $*" >&2
     echo "" >&2
     usage

--- a/scripts/kafka.sh
+++ b/scripts/kafka.sh
@@ -11,7 +11,7 @@ docker_service_init
 # Check if /etc/hosts entry exists
 if ! grep -q "kafka-shared" /etc/hosts 2>/dev/null; then
     echo ""
-    echo "❌ ERROR: Missing required /etc/hosts entry!"
+    echo "❌ ERROR: Missing required /etc/hosts entry!" >&2
     echo ""
     echo "IMPORTANT: Add this to /etc/hosts (required for all developers):"
     echo "127.0.0.1	kafka-shared"

--- a/scripts/monitoring.sh
+++ b/scripts/monitoring.sh
@@ -21,7 +21,7 @@ case "$ACTION" in
     up|down|restart)
         ;;
     *)
-        echo "Error: Invalid action '$ACTION'"
+        echo "Error: Invalid action '$ACTION'" >&2
         usage
         ;;
 esac

--- a/scripts/nginx-cache.sh
+++ b/scripts/nginx-cache.sh
@@ -43,7 +43,7 @@ case "$ACTION" in
         docker rm "$CONTAINER_NAME" 2>/dev/null || true
 
         # Check if the nginx config exists
-        if [ ! -f "${NGINX_CONF}" ]; then
+        if [[ ! -f "${NGINX_CONF}" ]]; then
             echo "Error: nginx config not found at ${NGINX_CONF}" >&2
             exit 1
         fi

--- a/scripts/nginx-cache.sh
+++ b/scripts/nginx-cache.sh
@@ -30,7 +30,7 @@ case "$ACTION" in
     up|down|restart)
         ;;
     *)
-        echo "Error: Invalid action '$ACTION'"
+        echo "Error: Invalid action '$ACTION'" >&2
         usage
         ;;
 esac
@@ -44,7 +44,7 @@ case "$ACTION" in
 
         # Check if the nginx config exists
         if [ ! -f "${NGINX_CONF}" ]; then
-            echo "Error: nginx config not found at ${NGINX_CONF}"
+            echo "Error: nginx config not found at ${NGINX_CONF}" >&2
             exit 1
         fi
 

--- a/scripts/run-teranode-with-logrotate.sh
+++ b/scripts/run-teranode-with-logrotate.sh
@@ -8,7 +8,7 @@ fi
 
 # Check if SETTINGS_CONTEXT is set
 if [ -z "$SETTINGS_CONTEXT" ]; then
-    echo "Error: SETTINGS_CONTEXT environment variable is not set"
+    echo "Error: SETTINGS_CONTEXT environment variable is not set" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two related SonarCloud shell-lint cleanups across a set of dev/ops scripts. Two commits:

### 1. Redirect error messages to stderr (`shelldre:S7677`, 9 findings)
Error messages were printed to **stdout**, which pollutes output when a script's stdout is piped or captured. Append `>&2` to each flagged error echo in: `generate-blocks.sh`, `aerospike-asmt-wrapper.sh` (`log_error()`), `clean_datadir.sh` (x2), `kafka.sh`, `monitoring.sh`, `nginx-cache.sh` (x2), `run-teranode-with-logrotate.sh`. Only Sonar-flagged error lines are redirected; trailing usage/instruction text Sonar treats as informational is left on stdout.

### 2. Use `[[ ]]` instead of `[ ]` (`shelldre:S7688`, remaining 18 findings)
The bulk of S7688 (144, in the two diag scripts) was fixed in #1183. This clears the remaining 18 in `dev-stack-macos.sh` (11), `clean_datadir.sh` (6), `nginx-cache.sh` (1). All three are bash. Mechanical bracket-token swap only - operands and quoting untouched; quoted literals like `"[]"`, array lengths like `${#pids[@]}`, globs, and pre-existing `[[ ]]` are preserved. The single unquoted RHS (`clean_datadir.sh`: `= false`) has no glob metacharacters, so `[[ ]]` matches it identically.

## Why both rules in one PR

`clean_datadir.sh` and `nginx-cache.sh` are touched by both fixes. Keeping them in one PR avoids merge conflicts between two branches editing the same files on adjacent lines.

## Testing

`bash -n` passes on every changed file. Post-conversion scan: zero single-bracket test tokens remain in the three S7688 files. Diffs reviewed line by line.