### PR TITLE
fix(utxo): stamp setMined delete-at-height from the mined block height

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -518,10 +518,24 @@ func (s *Store) GetBlockHeight() uint32 {
 	return s.blockHeight.Load()
 }
 
+// effectiveBlockHeight resolves the block height to use for DAH computation,
+// falling back to the store's current cached block height when the caller did not
+// supply one (blockHeight == 0). Paths that know the operation's block height (the
+// mined block height, or the spend's block height) pass it; paths that don't get
+// the current block height, preserving the historical behaviour.
+func (s *Store) effectiveBlockHeight(blockHeight uint32) uint32 {
+	if blockHeight == 0 {
+		return s.blockHeight.Load()
+	}
+
+	return blockHeight
+}
+
 // deleteAtHeightFor returns the delete-at-height (DAH) to stamp on a record that
 // becomes prunable at blockHeight — blockHeight + the configured retention window —
 // and whether retention is enabled. When retention is 0 ("don't use automatic
-// retention") the second return is false and no DAH should be set.
+// retention") the second return is false and no DAH should be set. A blockHeight of
+// 0 falls back to the current block height (see effectiveBlockHeight).
 //
 // This is the single source of truth for the Go DAH formula and the retention
 // guard, shared by the create, spend and setMined paths so they cannot drift. The
@@ -534,7 +548,7 @@ func (s *Store) deleteAtHeightFor(blockHeight uint32) (uint32, bool) {
 		return 0, false
 	}
 
-	return blockHeight + retention, true
+	return s.effectiveBlockHeight(blockHeight) + retention, true
 }
 
 func (s *Store) SetMedianBlockTime(medianTime uint32) error {

--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -518,6 +518,25 @@ func (s *Store) GetBlockHeight() uint32 {
 	return s.blockHeight.Load()
 }
 
+// deleteAtHeightFor returns the delete-at-height (DAH) to stamp on a record that
+// becomes prunable at blockHeight — blockHeight + the configured retention window —
+// and whether retention is enabled. When retention is 0 ("don't use automatic
+// retention") the second return is false and no DAH should be set.
+//
+// This is the single source of truth for the Go DAH formula and the retention
+// guard, shared by the create, spend and setMined paths so they cannot drift. The
+// Aerospike filter-expression path (buildDeleteAtHeightExpression) and the Lua
+// setDeleteAtHeight UDF compute the same blockHeight + retention and MUST be kept
+// in sync with this function.
+func (s *Store) deleteAtHeightFor(blockHeight uint32) (uint32, bool) {
+	retention := s.settings.GetUtxoStoreBlockHeightRetention()
+	if retention == 0 {
+		return 0, false
+	}
+
+	return blockHeight + retention, true
+}
+
 func (s *Store) SetMedianBlockTime(medianTime uint32) error {
 	s.logger.Debugf("setting median block time to %d", medianTime)
 	s.medianBlockTime.Store(medianTime)

--- a/stores/utxo/aerospike/aerospike_server_test.go
+++ b/stores/utxo/aerospike/aerospike_server_test.go
@@ -600,7 +600,10 @@ func TestAerospike(t *testing.T) {
 		value, err = client.Get(util.GetAerospikeReadPolicy(tSettings), txKey)
 		require.NoError(t, err)
 
-		assert.Equal(t, 11, value.Bins[fields.DeleteAtHeight.String()])
+		// setMined stamps the DAH relative to the height of the block the tx is mined
+		// into (BlockHeight=123), plus the retention window — not the store's cached
+		// chain tip.
+		assert.Equal(t, int(123+tSettings.GetUtxoStoreBlockHeightRetention()), value.Bins[fields.DeleteAtHeight.String()])
 
 		// try to spend with different txid
 		spends, err = store.Spend(ctx, spendTx3, 1)

--- a/stores/utxo/aerospike/aerospike_server_test.go
+++ b/stores/utxo/aerospike/aerospike_server_test.go
@@ -1006,7 +1006,7 @@ func TestAerospike(t *testing.T) {
 		assert.Nil(t, rec.Bins["creating"])
 
 		// Increment via multi API
-		require.NoError(t, store.IncrementSpentRecordsMulti([]*chainhash.Hash{bigTx.TxIDChainHash()}, 1))
+		require.NoError(t, store.IncrementSpentRecordsMulti([]*chainhash.Hash{bigTx.TxIDChainHash()}, 1, 0))
 
 		rec2, err := client.Get(util.GetAerospikeReadPolicy(tSettings), bigTxKey)
 		require.NoError(t, err)
@@ -1065,7 +1065,7 @@ func TestAerospike(t *testing.T) {
 		var invalid chainhash.Hash // zero hash, not present
 		ids := []*chainhash.Hash{valid, &invalid}
 
-		aggErr := store.IncrementSpentRecordsMulti(ids, 1)
+		aggErr := store.IncrementSpentRecordsMulti(ids, 1, 0)
 		require.Error(t, aggErr)
 		t.Logf("Error: %v", aggErr)
 
@@ -1319,7 +1319,7 @@ func TestIncrementSpentRecords(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 0, totalExtraRecs)
 
-	res, err := store.IncrementSpentRecords(tx.TxIDChainHash(), 1)
+	res, err := store.IncrementSpentRecords(tx.TxIDChainHash(), 1, 0)
 	require.NoError(t, err)
 
 	// Lua now clamps spentExtraRecs to [0, totalExtraRecs] instead of erroring.
@@ -1951,7 +1951,7 @@ func TestAerospikeWithBatchSize(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, 2, totalExtraRecs)
 
-		_, err = store.IncrementSpentRecords(tx.TxIDChainHash(), 1)
+		_, err = store.IncrementSpentRecords(tx.TxIDChainHash(), 1, 0)
 		require.NoError(t, err)
 
 		resp, err = client.Get(nil, txKey)
@@ -1965,7 +1965,7 @@ func TestAerospikeWithBatchSize(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, 1, spentExtraRecs)
 
-		_, err = store.IncrementSpentRecords(tx.TxIDChainHash(), -1)
+		_, err = store.IncrementSpentRecords(tx.TxIDChainHash(), -1, 0)
 		require.NoError(t, err)
 
 		resp, err = client.Get(nil, txKey)

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -498,8 +498,9 @@ func (s *Store) sendStoreBatch(batch []*BatchStoreItem) {
 		}
 
 		if bItem.conflicting {
-			dah := bItem.blockHeight + s.settings.GetUtxoStoreBlockHeightRetention()
-			putOps = append(putOps, aerospike.PutOp(aerospike.NewBin(fields.DeleteAtHeight.String(), dah)))
+			if dah, ok := s.deleteAtHeightFor(bItem.blockHeight); ok {
+				putOps = append(putOps, aerospike.PutOp(aerospike.NewBin(fields.DeleteAtHeight.String(), dah)))
+			}
 		}
 
 		batchRecords[idx] = aerospike.NewBatchWrite(batchWritePolicy, key, putOps...)
@@ -897,8 +898,8 @@ func (s *Store) GetBinsToStore(tx *bt.Tx, blockHeight uint32, blockIDs, blockHei
 		}
 
 		if spendableUtxos == 0 {
-			if retention := s.settings.GetUtxoStoreBlockHeightRetention(); retention > 0 {
-				batches[0] = append(batches[0], aerospike.NewBin(fields.DeleteAtHeight.String(), aerospike.NewIntegerValue(int(blockHeight+retention))))
+			if dah, ok := s.deleteAtHeightFor(blockHeight); ok {
+				batches[0] = append(batches[0], aerospike.NewBin(fields.DeleteAtHeight.String(), aerospike.NewIntegerValue(int(dah))))
 			}
 		}
 	}
@@ -1081,8 +1082,9 @@ func (s *Store) storeExternallyWithLock(
 		}
 
 		if idx == 0 && bItem.conflicting {
-			dah := bItem.blockHeight + s.settings.GetUtxoStoreBlockHeightRetention()
-			putOps = append(putOps, aerospike.PutOp(aerospike.NewBin(fields.DeleteAtHeight.String(), dah)))
+			if dah, ok := s.deleteAtHeightFor(bItem.blockHeight); ok {
+				putOps = append(putOps, aerospike.PutOp(aerospike.NewBin(fields.DeleteAtHeight.String(), dah)))
+			}
 		}
 
 		batchRecords[idx] = aerospike.NewBatchWrite(batchWritePolicy, key, putOps...)

--- a/stores/utxo/aerospike/delete_at_height_test.go
+++ b/stores/utxo/aerospike/delete_at_height_test.go
@@ -1,0 +1,30 @@
+package aerospike
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteAtHeightFor pins the single source of truth for the Go DAH formula and
+// the retention guard shared by the create, spend and setMined paths. The
+// filter-expression path (buildDeleteAtHeightExpression) and the Lua
+// setDeleteAtHeight UDF must compute the same value.
+func TestDeleteAtHeightFor(t *testing.T) {
+	t.Run("retention enabled returns blockHeight + retention", func(t *testing.T) {
+		s := &Store{settings: &settings.Settings{GlobalBlockHeightRetention: 288}}
+
+		dah, ok := s.deleteAtHeightFor(1000)
+		require.True(t, ok)
+		require.Equal(t, uint32(1288), dah)
+	})
+
+	t.Run("retention disabled (0) stamps no DAH", func(t *testing.T) {
+		s := &Store{settings: &settings.Settings{GlobalBlockHeightRetention: 0}}
+
+		dah, ok := s.deleteAtHeightFor(1000)
+		require.False(t, ok, "no DAH must be stamped when retention is disabled")
+		require.Equal(t, uint32(0), dah)
+	})
+}

--- a/stores/utxo/aerospike/set_mined.go
+++ b/stores/utxo/aerospike/set_mined.go
@@ -432,7 +432,7 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 	var postErr error
 
 	if len(extraRecords) > 0 {
-		if err := s.IncrementSpentRecordsMulti(extraRecords, 1); err != nil {
+		if err := s.IncrementSpentRecordsMulti(extraRecords, 1, minedBlockInfo.BlockHeight); err != nil {
 			postErr = errors.Join(postErr, err)
 		}
 	}

--- a/stores/utxo/aerospike/set_mined.go
+++ b/stores/utxo/aerospike/set_mined.go
@@ -348,7 +348,14 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 	retention := s.settings.GetUtxoStoreBlockHeightRetention()
 	var dahHeight uint32
 	if retention > 0 {
-		dahHeight = thisBlockHeight + retention
+		// DAH is relative to the height of the block the tx is mined into
+		// (minedBlockInfo.BlockHeight), NOT the store's cached chain tip
+		// (thisBlockHeight). The cached tip lags behind the block being validated
+		// during catchup/sync; using it stamped the DAH too low and let the pruner
+		// delete the record before the retention window elapsed. This value is used
+		// for the child/pagination records and must match the master DAH set by the
+		// setMined UDF (which now also uses the mined block height).
+		dahHeight = minedBlockInfo.BlockHeight + retention
 	}
 
 	// Reuse a single LuaMapResponse across all per-record parses in this batch.

--- a/stores/utxo/aerospike/set_mined.go
+++ b/stores/utxo/aerospike/set_mined.go
@@ -233,7 +233,7 @@ func (s *Store) SetMinedMulti(ctx context.Context, hashes []*chainhash.Hash, min
 	}
 
 	// Process batch results
-	blockIDs, work, err := s.processBatchResultsForSetMined(ctx, batchRecords, hashes, thisBlockHeight, minedBlockInfo)
+	blockIDs, work, err := s.processBatchResultsForSetMined(ctx, batchRecords, hashes, minedBlockInfo)
 
 	// #1037: clear the lock on the pagination records of successfully-mined
 	// external txs. Done here (not inside the result processor) so the processor
@@ -314,7 +314,7 @@ func (s *Store) executeBatchOperation(batchRecords []aerospike.BatchRecordIfc) e
 // (SetMinedMulti) so this function stays free of follow-up writes for the
 // lock-clear path — keeping it unit-testable without a live client.
 func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords []aerospike.BatchRecordIfc,
-	hashes []*chainhash.Hash, thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo) (map[chainhash.Hash][]uint32, lockClearWork, error) {
+	hashes []*chainhash.Hash, minedBlockInfo utxo.MinedBlockInfo) (map[chainhash.Hash][]uint32, lockClearWork, error) {
 	var errs error
 	okUpdates := 0
 	nrErrors := 0
@@ -336,27 +336,14 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 	// `locked` flag must be cleared (the master-keyed setMined only clears the
 	// master). Populated from the setMined response's childCount (= totalExtraRecs).
 	var work lockClearWork
-	// DAH timing assumption:
-	// - thisBatch operates under a fixed block-processing context.
-	// - thisBlockHeight and retention are immutable for the duration of SetMinedMulti() execution.
-	// Therefore, computing DeleteAtHeight (DAH) once is safe and consistent across all signals in this batch.
-	// If this assumption ever changes (e.g., SetBlockHeight or retention can mutate concurrently),
-	// DAH must be computed per-record at signal time to avoid stale values.
-	//
-	// Only calculate DAH if BlockHeightRetention is configured (> 0)
-	// When retention is 0, it means "don't use automatic retention"
-	retention := s.settings.GetUtxoStoreBlockHeightRetention()
-	var dahHeight uint32
-	if retention > 0 {
-		// DAH is relative to the height of the block the tx is mined into
-		// (minedBlockInfo.BlockHeight), NOT the store's cached chain tip
-		// (thisBlockHeight). The cached tip lags behind the block being validated
-		// during catchup/sync; using it stamped the DAH too low and let the pruner
-		// delete the record before the retention window elapsed. This value is used
-		// for the child/pagination records and must match the master DAH set by the
-		// setMined UDF (which now also uses the mined block height).
-		dahHeight = minedBlockInfo.BlockHeight + retention
-	}
+	// DAH is relative to the height of the block the tx is mined into
+	// (minedBlockInfo.BlockHeight), NOT the store's cached chain tip — the cached
+	// tip lags behind the block being validated during catchup/sync, which would
+	// stamp the DAH too low and let the pruner delete the record before the
+	// retention window elapsed. Computed once for the batch (block height and
+	// retention are fixed for the duration of SetMinedMulti) and used for the
+	// child/pagination records; it matches the master DAH set by the setMined UDF.
+	dahHeight, dahEnabled := s.deleteAtHeightFor(minedBlockInfo.BlockHeight)
 
 	// Reuse a single LuaMapResponse across all per-record parses in this batch.
 	// The struct's fields (status, signal, BlockIDs cap, Errors map buckets) are
@@ -366,7 +353,7 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 
 	for idx, batchRecord := range batchRecords {
 		pooledRes.Reset()
-		result, res, err := s.processSingleBatchRecordPooled(ctx, batchRecord, hashes[idx], thisBlockHeight, minedBlockInfo, pooledRes)
+		result, res, err := s.processSingleBatchRecordPooled(ctx, batchRecord, hashes[idx], minedBlockInfo, pooledRes)
 		if err != nil {
 			if errs == nil {
 				errs = err
@@ -412,7 +399,7 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 				extraRecords = append(extraRecords, hashes[idx])
 			case LuaSignalDAHSet:
 				// Only set DAH if retention is configured
-				if retention > 0 {
+				if dahEnabled {
 					dahSetItems = append(dahSetItems, struct {
 						TxID           *chainhash.Hash
 						ChildCount     int
@@ -476,9 +463,9 @@ func (s *Store) processBatchResultsForSetMined(ctx context.Context, batchRecords
 // fresh LuaMapResponse. Retained for callers outside the hot path; SetMinedMulti
 // uses processSingleBatchRecordPooled to share a pooled response.
 func (s *Store) processSingleBatchRecord(ctx context.Context, batchRecord aerospike.BatchRecordIfc, hash *chainhash.Hash,
-	thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo) (bool, *LuaMapResponse, error) {
+	minedBlockInfo utxo.MinedBlockInfo) (bool, *LuaMapResponse, error) {
 	res := &LuaMapResponse{}
-	ok, returnedRes, err := s.processSingleBatchRecordPooled(ctx, batchRecord, hash, thisBlockHeight, minedBlockInfo, res)
+	ok, returnedRes, err := s.processSingleBatchRecordPooled(ctx, batchRecord, hash, minedBlockInfo, res)
 	if returnedRes == nil {
 		return ok, nil, err
 	}
@@ -491,7 +478,7 @@ func (s *Store) processSingleBatchRecord(ctx context.Context, batchRecord aerosp
 // error) or `res` itself. Callers must not retain the returned *LuaMapResponse
 // past the next Reset/Put of `res`.
 func (s *Store) processSingleBatchRecordPooled(ctx context.Context, batchRecord aerospike.BatchRecordIfc, hash *chainhash.Hash,
-	thisBlockHeight uint32, minedBlockInfo utxo.MinedBlockInfo, res *LuaMapResponse) (bool, *LuaMapResponse, error) {
+	minedBlockInfo utxo.MinedBlockInfo, res *LuaMapResponse) (bool, *LuaMapResponse, error) {
 	batchErr := batchRecord.BatchRec().Err
 	if batchErr != nil {
 		return false, nil, s.handleBatchRecordError(batchErr, hash, minedBlockInfo.UnsetMined)
@@ -535,38 +522,6 @@ func (s *Store) handleBatchRecordError(err error, hash *chainhash.Hash, unsetMin
 		return errors.NewTxNotFoundError("transaction not found: %s", hash.String())
 	}
 	return errors.NewStorageError("aerospike batchRecord error", hash.String(), err)
-}
-
-// handleSetMinedSignal handles signals from the setMined operation
-func (s *Store) handleSetMinedSignal(ctx context.Context, signal LuaSignal, hash *chainhash.Hash, childCount int, thisBlockHeight uint32) error {
-	var errs error
-
-	switch signal {
-	case LuaSignalAllSpent:
-		if err := s.handleExtraRecords(ctx, hash, 1); err != nil {
-			errs = errors.Join(errs, err)
-		}
-
-	case LuaSignalDAHSet:
-		// Only set DAH if BlockHeightRetention is configured (> 0)
-		// When retention is 0, it means "don't use automatic retention"
-		if retention := s.settings.GetUtxoStoreBlockHeightRetention(); retention > 0 {
-			dahHeight := thisBlockHeight + retention
-
-			if err := s.SetDAHForChildRecords(hash, childCount, dahHeight); err != nil {
-				errs = errors.Join(errs, err)
-			}
-			// External store DAH is disabled - lifecycle managed by pruner service
-		}
-
-	case LuaSignalDAHUnset:
-		if err := s.SetDAHForChildRecords(hash, childCount, 0); err != nil {
-			errs = errors.Join(errs, err)
-		}
-		// External store DAH is disabled - lifecycle managed by pruner service
-	}
-
-	return errs
 }
 
 // lockClearItem identifies a transaction whose pagination/extra records must

--- a/stores/utxo/aerospike/set_mined_dah_test.go
+++ b/stores/utxo/aerospike/set_mined_dah_test.go
@@ -1,0 +1,130 @@
+package aerospike_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/uaerospike"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetMinedStampsDAHAtMinedBlockHeight is a regression test for the early-pruning
+// bug where setMined computed deleteAtHeight from the store's cached chain tip
+// (s.blockHeight) rather than the height of the block the transaction was actually
+// mined into (minedBlockInfo.BlockHeight).
+//
+// s.blockHeight is maintained by an asynchronous blockchain-notification
+// subscription, so during catchup / sync / high load it lags behind the block being
+// validated. When a transaction that was spent while still unmined is later marked
+// mined, setMined stamps the DAH. Using the lagging cached height stamped the DAH far
+// too low, so the pruner (which deletes records with deleteAtHeight <= currentHeight)
+// removed the record long before the retention window had elapsed.
+//
+// Covers both the Lua UDF path and the filter-expression path.
+func TestSetMinedStampsDAHAtMinedBlockHeight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Aerospike integration test in short mode")
+	}
+
+	for _, useExpressions := range []bool{false, true} {
+		name := "lua"
+		if useExpressions {
+			name = "expressions"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := ulogger.NewErrorTestLogger(t)
+			tSettings := test.CreateBaseTestSettings(t)
+			tSettings.Aerospike.EnableSetMinedFilterExpressions = useExpressions
+			// Small batch size so the tx spans the master plus a pagination record;
+			// the master DAH and the pagination-record DAH are stamped by different
+			// code paths and must agree.
+			tSettings.UtxoStore.UtxoBatchSize = 4
+
+			retention := tSettings.GetUtxoStoreBlockHeightRetention()
+			require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+			client, store, _, cleanup := initAerospike(t, tSettings, logger)
+			defer cleanup()
+			cleanDB(t, client)
+
+			// Cached chain tip lags far behind the block being validated — the
+			// catchup / sync condition that triggered the bug.
+			const cachedTip uint32 = 100
+			const minedHeight uint32 = 900_000
+			require.NoError(t, store.SetBlockHeight(cachedTip))
+
+			// Create the parent UNMINED with 6 spendable outputs (master holds 4,
+			// pagination record 1 holds 2). A non-zero previous txid keeps this from
+			// being treated as a coinbase (whose outputs would be subject to maturity
+			// and could not be spent here).
+			parent := bt.NewTx()
+			require.NoError(t, parent.From(
+				"1111111111111111111111111111111111111111111111111111111111111111",
+				0,
+				"76a914000000000000000000000000000000000000000088ac",
+				100000,
+			))
+			parent.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x6a})
+			for range 6 {
+				require.NoError(t, parent.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
+			}
+			parentHash := parent.TxIDChainHash()
+			_, err := store.Create(ctx, parent, cachedTip)
+			require.NoError(t, err)
+
+			// Spend every output while the parent is still UNMINED. The parent becomes
+			// fully spent but gets NO deleteAtHeight (the spend path only stamps a DAH
+			// on already-mined txs). The DAH is therefore stamped later, by setMined.
+			for i, out := range parent.Outputs {
+				child := bt.NewTx()
+				require.NoError(t, child.From(parentHash.String(), uint32(i), out.LockingScript.String(), out.Satoshis))
+				require.NoError(t, child.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 500))
+				_, err = store.Spend(ctx, child, cachedTip)
+				require.NoError(t, err, "spending output %d while unmined should succeed", i)
+			}
+
+			// Mark the parent mined at a height far above the cached tip — block
+			// validation always knows and passes this height in minedBlockInfo.BlockHeight.
+			_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{parentHash}, utxo.MinedBlockInfo{
+				BlockID:        100,
+				BlockHeight:    minedHeight,
+				SubtreeIdx:     0,
+				OnLongestChain: true,
+			})
+			require.NoError(t, err)
+
+			// Both the master record and every pagination record must carry the same
+			// deleteAtHeight, computed from the mined block height — not the lagging
+			// cached tip.
+			readDAH := func(recordIdx uint32) (interface{}, bool) {
+				key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), uaerospike.CalculateKeySourceInternal(parentHash, recordIdx))
+				require.NoError(t, err)
+				rec, err := client.Get(nil, key)
+				require.NoError(t, err)
+				require.NotNil(t, rec, "record %d must exist", recordIdx)
+				v, ok := rec.Bins[fields.DeleteAtHeight.String()]
+				return v, ok
+			}
+
+			masterDAH, ok := readDAH(0)
+			require.True(t, ok, "setMined must stamp a deleteAtHeight on a fully-spent, mined tx")
+			require.Equal(t, int(minedHeight+retention), masterDAH,
+				"master deleteAtHeight must be minedBlockInfo.BlockHeight + retention, not the lagging cachedTip + 1 + retention")
+
+			childDAH, ok := readDAH(1)
+			require.True(t, ok, "pagination record must carry a deleteAtHeight")
+			require.Equal(t, int(minedHeight+retention), childDAH,
+				"pagination-record deleteAtHeight must match the master (minedBlockInfo.BlockHeight + retention)")
+		})
+	}
+}

--- a/stores/utxo/aerospike/set_mined_expressions.go
+++ b/stores/utxo/aerospike/set_mined_expressions.go
@@ -297,10 +297,15 @@ func (s *Store) SetMinedMultiWithExpressions(ctx context.Context, hashes []*chai
 	// Set deleteAtHeight to nil initially (will be updated by expression if needed)
 	ops = append(ops, aerospike.PutOp(aerospike.NewBin(fields.DeleteAtHeight.String(), nil)))
 
-	// Add deleteAtHeight expression if retention is enabled
+	// Add deleteAtHeight expression if retention is enabled.
+	// Stamp the DAH relative to the height of the block the tx is mined into
+	// (minedBlockInfo.BlockHeight), NOT the store's cached chain tip (thisBlockHeight).
+	// The cached tip lags behind the block being validated during catchup/sync; using
+	// it stamped the DAH too low and let the pruner delete the record before the
+	// retention window elapsed.
 	blockHeightRetention := s.settings.GetUtxoStoreBlockHeightRetention()
 	if blockHeightRetention > 0 {
-		dahExp := s.buildDeleteAtHeightExpression(thisBlockHeight, blockHeightRetention, minedBlockInfo.OnLongestChain, false)
+		dahExp := s.buildDeleteAtHeightExpression(minedBlockInfo.BlockHeight, blockHeightRetention, minedBlockInfo.OnLongestChain, false)
 		ops = append(ops, aerospike.ExpWriteOp(
 			fields.DeleteAtHeight.String(),
 			dahExp,

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -799,9 +799,7 @@ func (s *Store) handleSpendSignal(ctx context.Context, signal LuaSignal, txID *c
 	case LuaSignalDAHSet:
 		// Only set DAH if BlockHeightRetention is configured (> 0)
 		// When retention is 0, it means "don't use automatic retention"
-		if retention := s.settings.GetUtxoStoreBlockHeightRetention(); retention > 0 {
-			dahHeight := thisBlockHeight + retention
-
+		if dahHeight, ok := s.deleteAtHeightFor(thisBlockHeight); ok {
 			if err := s.SetDAHForChildRecords(txID, childCount, dahHeight); err != nil {
 				s.logger.Errorf("Failed to set DAH for child records: %v", err)
 			}
@@ -1002,7 +1000,7 @@ func (s *Store) handleExtraRecords(ctx context.Context, txID *chainhash.Hash, in
 			case LuaSignalDAHSet:
 				// Only set DAH if BlockHeightRetention is configured (> 0)
 				// When retention is 0, it means "don't use automatic retention"
-				if retention := s.settings.GetUtxoStoreBlockHeightRetention(); retention > 0 {
+				if dah, ok := s.deleteAtHeightFor(s.blockHeight.Load()); ok {
 					// Sanity check: verify all children are actually spent before
 					// setting DAH. The spentExtraRecs counter can drift due to
 					// interrupted rollbacks, so we don't trust it blindly.
@@ -1029,9 +1027,6 @@ func (s *Store) handleExtraRecords(ctx context.Context, txID *chainhash.Hash, in
 							return nil
 						}
 					}
-
-					thisBlockHeight := s.blockHeight.Load()
-					dah := thisBlockHeight + retention
 
 					if err := s.SetDAHForChildRecords(txID, ret.ChildCount, dah); err != nil {
 						return err

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -107,15 +107,13 @@ type batchSpend struct {
 
 // IncrementSpentRecordsMulti performs a single BatchOperate to increment spent-extra-records for many txids.
 // This avoids enqueueing each increment through the batcher and waiting per-item.
-func (s *Store) IncrementSpentRecordsMulti(txids []*chainhash.Hash, increment int) error {
+func (s *Store) IncrementSpentRecordsMulti(txids []*chainhash.Hash, increment int, blockHeight uint32) error {
 	if len(txids) == 0 {
 		return nil
 	}
 
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
 	batchUDFPolicy := aerospike.NewBatchUDFPolicy()
-
-	currentBlockHeight := s.blockHeight.Load()
 
 	batchRecordsPtr := getBatchRecordsSlice(len(txids))
 	batchRecords := (*batchRecordsPtr)[:0]
@@ -130,7 +128,7 @@ func (s *Store) IncrementSpentRecordsMulti(txids []*chainhash.Hash, increment in
 
 		batchRecords = append(batchRecords, aerospike.NewBatchUDF(batchUDFPolicy, key, LuaPackage, "incrementSpentExtraRecs",
 			aerospike.NewIntegerValue(increment),
-			aerospike.NewIntegerValue(int(currentBlockHeight)),
+			aerospike.NewIntegerValue(int(s.effectiveBlockHeight(blockHeight))),
 			aerospike.NewValue(s.settings.GetUtxoStoreBlockHeightRetention()),
 		))
 	}
@@ -228,9 +226,10 @@ func (s *Store) SetDAHForChildRecordsMulti(items []struct {
 
 // batchIncrement handles record count updates for paginated transactions
 type batchIncrement struct {
-	txID      *chainhash.Hash               // Transaction hash
-	increment int                           // Count adjustment
-	res       chan incrementSpentRecordsRes // Result channel
+	txID        *chainhash.Hash               // Transaction hash
+	increment   int                           // Count adjustment
+	blockHeight uint32                        // Height of the operation, for DAH = blockHeight + retention
+	res         chan incrementSpentRecordsRes // Result channel
 }
 
 type batchDAH struct {
@@ -792,7 +791,7 @@ func (s *Store) handleParseError(batchByKey []aerospike.MapValue, batch []*batch
 func (s *Store) handleSpendSignal(ctx context.Context, signal LuaSignal, txID *chainhash.Hash, childCount int, thisBlockHeight uint32) {
 	switch signal {
 	case LuaSignalAllSpent:
-		if err := s.handleExtraRecords(ctx, txID, 1); err != nil {
+		if err := s.handleExtraRecords(ctx, txID, 1, thisBlockHeight); err != nil {
 			s.logger.Errorf("Failed to handle extra records: %v", err)
 		}
 
@@ -981,8 +980,8 @@ func (s *Store) SetDAHForChildRecords(txID *chainhash.Hash, childCount int, dah 
 //
 // Returns:
 //   - error: Any error encountered during the record count update
-func (s *Store) handleExtraRecords(ctx context.Context, txID *chainhash.Hash, increment int) error {
-	res, err := s.IncrementSpentRecords(txID, increment) // This is a batch operation
+func (s *Store) handleExtraRecords(ctx context.Context, txID *chainhash.Hash, increment int, blockHeight uint32) error {
+	res, err := s.IncrementSpentRecords(txID, increment, blockHeight) // This is a batch operation
 	if err != nil {
 		return err
 	}
@@ -1000,7 +999,7 @@ func (s *Store) handleExtraRecords(ctx context.Context, txID *chainhash.Hash, in
 			case LuaSignalDAHSet:
 				// Only set DAH if BlockHeightRetention is configured (> 0)
 				// When retention is 0, it means "don't use automatic retention"
-				if dah, ok := s.deleteAtHeightFor(s.blockHeight.Load()); ok {
+				if dah, ok := s.deleteAtHeightFor(blockHeight); ok {
 					// Sanity check: verify all children are actually spent before
 					// setting DAH. The spentExtraRecs counter can drift due to
 					// interrupted rollbacks, so we don't trust it blindly.
@@ -1117,14 +1116,15 @@ type incrementSpentRecordsRes struct {
 
 // IncrementSpentRecords updates the record count for paginated transactions.
 // Used for cleanup management of large transactions.
-func (s *Store) IncrementSpentRecords(txid *chainhash.Hash, increment int) (interface{}, error) {
+func (s *Store) IncrementSpentRecords(txid *chainhash.Hash, increment int, blockHeight uint32) (interface{}, error) {
 	res := make(chan incrementSpentRecordsRes, 1)
 
 	go func() {
 		s.incrementBatcher.Put(&batchIncrement{
-			txID:      txid,
-			increment: increment,
-			res:       res,
+			txID:        txid,
+			increment:   increment,
+			blockHeight: blockHeight,
+			res:         res,
 		})
 	}()
 
@@ -1165,8 +1165,6 @@ func (s *Store) sendIncrementBatch(batch []*batchIncrement) {
 	batchRecords := make([]aerospike.BatchRecordIfc, len(batch))
 	handled := make([]bool, len(batch))
 
-	currentBlockHeight := s.blockHeight.Load()
-
 	for i, item := range batch {
 		aeroKey, err := aerospike.NewKey(s.namespace, s.setName, item.txID[:])
 		if err != nil {
@@ -1180,7 +1178,7 @@ func (s *Store) sendIncrementBatch(batch []*batchIncrement) {
 
 		batchRecords[i] = aerospike.NewBatchUDF(batchUDFPolicy, aeroKey, LuaPackage, "incrementSpentExtraRecs",
 			aerospike.NewIntegerValue(item.increment),
-			aerospike.NewIntegerValue(int(currentBlockHeight)),
+			aerospike.NewIntegerValue(int(s.effectiveBlockHeight(item.blockHeight))),
 			aerospike.NewValue(s.settings.GetUtxoStoreBlockHeightRetention()),
 		)
 	}

--- a/stores/utxo/aerospike/spend_expressions.go
+++ b/stores/utxo/aerospike/spend_expressions.go
@@ -392,8 +392,10 @@ func (s *Store) processSpendBatchResultsExpressions(
 	// (missing parent during catch-up) or FILTERED_OUT — issue #953.
 	infraErrCount := 0
 
-	// Collect follow-up actions
-	extraRecords := make([]*chainhash.Hash, 0)
+	// Collect follow-up actions. Extra-record increments are grouped by the spend's
+	// block height so each tx's delete-at-height is stamped from its own spend
+	// height (a single batch may aggregate spends from different blocks).
+	extraRecordsByHeight := make(map[uint32][]*chainhash.Hash)
 	dahSetItems := make([]struct {
 		TxID           *chainhash.Hash
 		ChildCount     int
@@ -464,7 +466,7 @@ func (s *Store) processSpendBatchResultsExpressions(
 		if state.TotalExtraRecs == nil {
 			// Pagination record - check if all spent
 			if state.RecordUtxos > 0 && state.SpentUtxos == state.RecordUtxos {
-				extraRecords = append(extraRecords, bItem.spend.TxID)
+				extraRecordsByHeight[bItem.blockHeight] = append(extraRecordsByHeight[bItem.blockHeight], bItem.spend.TxID)
 			}
 		} else if state.TotalExtraRecs != nil {
 			// Master record - check DAH changes for external transactions
@@ -525,8 +527,8 @@ func (s *Store) processSpendBatchResultsExpressions(
 	// Execute follow-up actions
 	var postErr error
 
-	if len(extraRecords) > 0 {
-		if err := s.IncrementSpentRecordsMulti(extraRecords, 1); err != nil {
+	for bh, txids := range extraRecordsByHeight {
+		if err := s.IncrementSpentRecordsMulti(txids, 1, bh); err != nil {
 			postErr = errors.Join(postErr, err)
 		}
 	}

--- a/stores/utxo/aerospike/spend_paginated_dah_test.go
+++ b/stores/utxo/aerospike/spend_paginated_dah_test.go
@@ -1,0 +1,101 @@
+package aerospike_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/uaerospike"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpendPaginatedStampsDAHAtSpendBlockHeight is a regression test for the
+// early-pruning bug on the spend path for PAGINATED transactions.
+//
+// A non-paginated tx gets its delete-at-height from the spend UDF / expression
+// using the per-call spend block height (correct). But for a paginated tx the
+// final "all spent" transition is detected while accounting the extra records
+// (incrementSpentExtraRecs), and that path stamped the master DAH from the store's
+// cached chain tip (s.blockHeight) instead of the spend's block height. During
+// catchup/sync the cached tip lags behind the block being validated, so the DAH
+// was stamped too low and the pruner deleted large/paginated txs before the
+// retention window elapsed.
+//
+// Uses the Lua spend path (utxoBatchSize > 1). The same increment-path fix also
+// covers IncrementSpentRecordsMulti, used by the filter-expression spend path and
+// the setMined extra-records accounting.
+func TestSpendPaginatedStampsDAHAtSpendBlockHeight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Aerospike integration test in short mode")
+	}
+
+	const addr = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+	const numOutputs = 6 // with utxoBatchSize=4 => master(4) + one pagination record(2)
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.UtxoStore.UtxoBatchSize = 4
+
+	retention := tSettings.GetUtxoStoreBlockHeightRetention()
+	require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+	client, store, _, cleanup := initAerospike(t, tSettings, logger)
+	defer cleanup()
+	cleanDB(t, client)
+
+	// Cached chain tip lags far behind the block doing the spends — the catchup /
+	// sync condition that triggered the bug.
+	const cachedTip uint32 = 100
+	const spendHeight uint32 = 900_000
+	require.NoError(t, store.SetBlockHeight(cachedTip))
+
+	// Mined, on-longest-chain, paginated parent with spendable outputs (still
+	// unspent, so no DAH yet). Non-zero previous txid keeps it from being a coinbase.
+	parent := bt.NewTx()
+	require.NoError(t, parent.From(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		0,
+		"76a914000000000000000000000000000000000000000088ac",
+		1_000_000,
+	))
+	parent.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x6a})
+	for range numOutputs {
+		require.NoError(t, parent.PayToAddress(addr, 1000))
+	}
+	parentHash := parent.TxIDChainHash()
+	_, err := store.Create(ctx, parent, 500, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+		BlockID: 1, BlockHeight: 500, SubtreeIdx: 0, OnLongestChain: true,
+	}))
+	require.NoError(t, err)
+
+	// Spend every output, each in its own tx and in vout order: the master record's
+	// outputs first, then the pagination record. Spending the last extra-record
+	// output triggers the increment-path "all spent" transition that stamps the DAH.
+	for i := 0; i < numOutputs; i++ {
+		child := bt.NewTx()
+		require.NoError(t, child.From(parentHash.String(), uint32(i), parent.Outputs[i].LockingScript.String(), parent.Outputs[i].Satoshis))
+		require.NoError(t, child.PayToAddress(addr, 500))
+		_, err := store.Spend(ctx, child, spendHeight)
+		require.NoError(t, err, "spending output %d should succeed", i)
+	}
+
+	// The master record's DAH must be relative to the spend block height, not the
+	// lagging cached tip.
+	key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), uaerospike.CalculateKeySourceInternal(parentHash, 0))
+	require.NoError(t, err)
+	rec, err := client.Get(nil, key)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	dah, ok := rec.Bins[fields.DeleteAtHeight.String()]
+	require.True(t, ok, "a fully-spent, mined, paginated tx must have a deleteAtHeight")
+	require.Equal(t, int(spendHeight+retention), dah,
+		"master deleteAtHeight must be spendHeight + retention, not the lagging cachedTip + retention")
+}

--- a/stores/utxo/aerospike/spend_test.go
+++ b/stores/utxo/aerospike/spend_test.go
@@ -300,7 +300,7 @@ func TestStore_IncrementSpentRecords(t *testing.T) {
 		require.NoError(t, err)
 
 		// Increment spentExtraRecs by 1
-		res, err := store.IncrementSpentRecords(txID, 1)
+		res, err := store.IncrementSpentRecords(txID, 1, 0)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
@@ -317,7 +317,7 @@ func TestStore_IncrementSpentRecords(t *testing.T) {
 		assert.Equal(t, 1, resp.Bins[fields.SpentExtraRecs.String()])
 
 		// Decrement spentExtraRecs by 1
-		res, err = store.IncrementSpentRecords(txID, -1)
+		res, err = store.IncrementSpentRecords(txID, -1, 0)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
@@ -364,7 +364,7 @@ func TestStore_IncrementSpentRecords(t *testing.T) {
 		assert.Equal(t, []interface{}{101}, rec.Bins[fields.BlockIDs.String()])
 
 		// Increment spentExtraRecs by 1
-		res, err := store.IncrementSpentRecords(txID, 1)
+		res, err := store.IncrementSpentRecords(txID, 1, 0)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
@@ -382,7 +382,7 @@ func TestStore_IncrementSpentRecords(t *testing.T) {
 		assert.Equal(t, 1, rec.Bins[fields.SpentExtraRecs.String()])
 		assert.Equal(t, []interface{}{101}, rec.Bins[fields.BlockIDs.String()])
 
-		res, err = store.IncrementSpentRecords(txID, 1)
+		res, err = store.IncrementSpentRecords(txID, 1, 0)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
@@ -417,7 +417,7 @@ func TestStore_IncrementSpentRecords(t *testing.T) {
 		// We have a master record and 2 extra records
 		for i := 0; i < 2; i++ {
 			// Increment spentExtraRecs by 1
-			res, err := store.IncrementSpentRecords(txID, 1)
+			res, err := store.IncrementSpentRecords(txID, 1, 0)
 			require.NoError(t, err)
 			require.NotNil(t, res)
 		}
@@ -449,7 +449,7 @@ func TestStore_IncrementSpentRecords_Timeout(t *testing.T) {
 	// Set an extremely short timeout so the batcher can't respond in time
 	tSettings.UtxoStore.SpendWaitTimeout = time.Nanosecond
 
-	_, err = store.IncrementSpentRecords(tx.TxIDChainHash(), 1)
+	_, err = store.IncrementSpentRecords(tx.TxIDChainHash(), 1, 0)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errors.ErrServiceUnavailable), "expected service unavailable error, got: %v", err)
 }

--- a/stores/utxo/aerospike/teranode.go
+++ b/stores/utxo/aerospike/teranode.go
@@ -72,7 +72,7 @@ import (
 var teranodeLUA []byte
 
 var (
-	LuaPackage      = "teranode_v60" // N.B. Do not have any "." in this string
+	LuaPackage      = "teranode_v61" // N.B. Do not have any "." in this string
 	LuaPackageMined = LuaPackage + "_mined"
 )
 

--- a/stores/utxo/aerospike/teranode.lua
+++ b/stores/utxo/aerospike/teranode.lua
@@ -654,7 +654,13 @@ function setMined(rec, blockID, blockHeight, subtreeIdx, currentBlockHeight, blo
         rec[BIN_CREATING] = nil
     end
 
-    local signal, childCount = setDeleteAtHeight(rec, currentBlockHeight, blockHeightRetention)
+    -- Stamp the DAH relative to the height of the block this tx is mined into
+    -- (blockHeight), NOT the caller's cached chain tip (currentBlockHeight). The
+    -- cached tip lags behind the block being validated during catchup/sync; using
+    -- it stamped the DAH too low and let the pruner delete the record before the
+    -- retention window elapsed. currentBlockHeight is still used above for the
+    -- unmined_since marker, which legitimately wants the current height.
+    local signal, childCount = setDeleteAtHeight(rec, blockHeight, blockHeightRetention)
 
     -- Update the record to save changes
     aerospike:update(rec)

--- a/stores/utxo/aerospike/un_spend.go
+++ b/stores/utxo/aerospike/un_spend.go
@@ -193,7 +193,10 @@ func (s *Store) unspendLua(ctx context.Context, spend *utxo.Spend) error {
 			// Decrement spentExtraRecs on the master record since this child
 			// record transitioned from ALLSPENT back to NOTALLSPENT.
 			// This mirrors the +1 increment done in handleSpendSignal for ALLSPENT.
-			if err := s.handleExtraRecords(ctx, spend.TxID, -1); err != nil {
+			// Pass 0 so the DAH height falls back to the current block height; a
+			// decrement clears the DAH (tx no longer all-spent) rather than setting
+			// it, so the height is not actually used here.
+			if err := s.handleExtraRecords(ctx, spend.TxID, -1, 0); err != nil {
 				return err
 			}
 		}

--- a/stores/utxo/aerospike/verify_children_test.go
+++ b/stores/utxo/aerospike/verify_children_test.go
@@ -101,7 +101,7 @@ func TestHandleExtraRecords_DAHSetWithDrift(t *testing.T) {
 
 	// Call handleExtraRecords(+1) → this will increment spentExtraRecs to 2 == totalExtraRecs
 	// Lua returns DAHSET → Go verifies children → finds not-all-spent → clears DAH
-	err = store.handleExtraRecords(ctx, txID, 1)
+	err = store.handleExtraRecords(ctx, txID, 1, 0)
 	require.NoError(t, err)
 
 	// Verify DAH was cleared (drift detected)
@@ -163,7 +163,7 @@ func TestHandleExtraRecords_DAHSetAllSpent(t *testing.T) {
 
 	// Call handleExtraRecords(+1) → spentExtraRecs goes from 0 to 1 == totalExtraRecs(1)
 	// Lua returns DAHSET → Go verifies child1 → all spent → DAH should be set
-	err = store.handleExtraRecords(ctx, txID, 1)
+	err = store.handleExtraRecords(ctx, txID, 1, 0)
 	require.NoError(t, err)
 
 	// Verify DAH was set (all children genuinely spent)

--- a/stores/utxo/sql/set_mined_dah_test.go
+++ b/stores/utxo/sql/set_mined_dah_test.go
@@ -1,0 +1,74 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetMinedStampsDAHAtMinedBlockHeight is a regression test for the early-pruning
+// bug where setMined computed delete_at_height from the store's cached chain tip
+// (s.blockHeight) rather than the height of the block the transaction was actually
+// mined into (minedBlockInfo.BlockHeight).
+//
+// The store's cached height is maintained by an asynchronous blockchain-notification
+// subscription, so during catchup / sync / high load it lags behind the block being
+// validated. When a transaction that was spent while still unmined is later marked
+// mined, setMined stamps the DAH. Using the lagging cached height stamped the DAH far
+// too low, so the pruner (which deletes records with delete_at_height <= currentHeight)
+// removed the record long before the retention window had elapsed.
+//
+// The mined block height is always known to block validation and passed in
+// minedBlockInfo.BlockHeight, so the DAH must be computed from it.
+func TestSetMinedStampsDAHAtMinedBlockHeight(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, parent := setup(ctx, t)
+
+	retention := store.settings.GetUtxoStoreBlockHeightRetention()
+	require.Greater(t, retention, uint32(0), "test requires a non-zero block height retention")
+
+	// The store's cached chain-tip height lags far behind the block actually being
+	// validated — exactly the catchup / sync condition that triggered the bug.
+	const cachedTip uint32 = 100
+	const minedHeight uint32 = 900_000
+	require.NoError(t, store.SetBlockHeight(cachedTip))
+
+	// Create the parent UNMINED.
+	parentHash := parent.TxIDChainHash()
+	_, err := store.Create(ctx, parent, cachedTip)
+	require.NoError(t, err)
+
+	// Spend every output while the parent is still UNMINED. The parent becomes fully
+	// spent but gets NO delete_at_height (the spend path only stamps a DAH on
+	// already-mined txs). The DAH is therefore stamped later, by setMined.
+	for i, out := range parent.Outputs {
+		child := bt.NewTx()
+		require.NoError(t, child.From(parentHash.String(), uint32(i), out.LockingScript.String(), out.Satoshis))
+		require.NoError(t, child.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 500))
+		_, err = store.Spend(ctx, child, cachedTip)
+		require.NoError(t, err, "spending output %d while unmined should succeed", i)
+	}
+
+	// Mark the parent mined at a height far above the cached tip — block validation
+	// always knows and passes this height in minedBlockInfo.BlockHeight.
+	_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{parentHash}, utxo.MinedBlockInfo{
+		BlockID:        100,
+		BlockHeight:    minedHeight,
+		SubtreeIdx:     0,
+		OnLongestChain: true,
+	})
+	require.NoError(t, err)
+
+	var dah *int64
+	err = store.db.QueryRowContext(ctx, "SELECT delete_at_height FROM transactions WHERE hash = $1", parentHash[:]).Scan(&dah)
+	require.NoError(t, err)
+	require.NotNil(t, dah, "setMined must stamp a delete_at_height on a fully-spent, mined tx")
+	require.Equal(t, int64(minedHeight+retention), *dah,
+		"delete_at_height must be minedBlockInfo.BlockHeight + retention, not the lagging cachedTip + 1 + retention")
+}

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -3265,8 +3265,12 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 	if s.settings != nil {
 		retention = s.settings.GetUtxoStoreBlockHeightRetention()
 	}
-	// +1 because blockHeight lags during block processing (mirrors aerospike set_mined.go:162)
-	newDAH := int64(s.blockHeight.Load() + 1 + retention)
+	// Stamp the DAH relative to the height of the block the tx is mined into
+	// (minedBlockInfo.BlockHeight), NOT the store's cached chain tip. s.blockHeight
+	// is updated asynchronously via blockchain notifications and lags behind the
+	// block being validated during catchup/sync; using it stamped the DAH too low
+	// and let the pruner delete the record before the retention window elapsed.
+	newDAH := int64(minedBlockInfo.BlockHeight) + int64(retention)
 
 	if minedBlockInfo.OnLongestChain {
 		if retention > 0 {


### PR DESCRIPTION
## Problem

On the scaling environment, transactions were disappearing from the UTXO store **before** the configured retention window (`utxostore_blockHeightRetention`, default 288 blocks) had elapsed.

## Root cause

The pruner is correct — it deletes records whose `deleteAtHeight (DAH) <= currentHeight`. The bug is in how the DAH is **stamped** during `setMined`.

Both the Aerospike and SQL UTXO stores computed the DAH during `setMined` from the store's **cached chain tip** (`s.blockHeight + 1`) instead of the height of the block the transaction is actually mined into (`minedBlockInfo.BlockHeight`):

- aerospike: `set_mined.go`, `set_mined_expressions.go`, `teranode.lua` (`setMined` UDF)
- sql: `setMinedMultiChunk` in `sql.go`

`s.blockHeight` is refreshed asynchronously by a blockchain-notification subscription (`stores/utxo/factory/utxo.go`), so during catchup/sync and under high block throughput it lags behind the block being validated. When a transaction that was spent while still unmined is later marked mined, `setMined` stamps the DAH. Using the lagging cached height stamped it far too low — once the lag reached the retention window the DAH was already `<= currentHeight`, so the pruner deleted the record almost immediately.

The spend path was already correct (it uses the per-call block height). Block validation already passes the correct height in `minedBlockInfo.BlockHeight` (it is even used to populate the `blockHeights` bin/column), so the DAH is now computed from it. The `unset` and `unmined_since` paths intentionally keep using the current height, which is correct there.

## Fix

Compute the setMined DAH from `minedBlockInfo.BlockHeight + retention` in both backends:

- **aerospike** — master DAH (Lua UDF + filter-expression path) and child/pagination-record DAH
- **sql** — `setMinedMultiChunk`

## Tests

New regression tests for both backends (`set_mined_dah_test.go`) that reproduce the catchup condition (cached tip far below the mined block height) and assert `DAH == minedBlockInfo.BlockHeight + retention`:

- SQLite (in-memory)
- Aerospike (testcontainers) — covers both the Lua and filter-expression paths, and both the master and a pagination record

Updated one existing Aerospike test (`aerospike_spend_all_and_expire`) that had encoded the buggy value.

Verified locally: `go build ./...`, `go vet`, SQL tests (incl. `-race`), Aerospike integration tests (`TestAerospike`, setMined/DAH suites).

## Notes

- The Teraslab store is out of scope (it owns the DAH lifecycle server-side); the scaling environment uses Aerospike.
- The Aerospike Lua UDF changed, so it is re-registered from `teranode.lua` on startup.
