### PR TITLE
fix(utxo/sql): don't clear parent locked flag on unflagged Unspend

### DIFF
--- a/stores/utxo/logger/logger.go
+++ b/stores/utxo/logger/logger.go
@@ -201,7 +201,7 @@ func (s *Store) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignore
 }
 
 func (s *Store) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked ...bool) error {
-	err := s.store.Unspend(ctx, spends, false)
+	err := s.store.Unspend(ctx, spends, flagAsLocked...)
 	spendDetails := make([]string, len(spends))
 
 	for i, spend := range spends {

--- a/stores/utxo/logger/logger_test.go
+++ b/stores/utxo/logger/logger_test.go
@@ -528,23 +528,50 @@ func TestSpend(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+// TestUnspend proves the decorator forwards flagAsLocked unchanged (#1154).
+// Dropping it and hardcoding false defeats the SQL fix on the ?logging=true path
+// (a no-flag rollback would still write locked=false) and inverts
+// ProcessConflicting's Unspend(..., true) lock-set into a lock-clear.
 func TestUnspend(t *testing.T) {
-	logger := ulogger.TestLogger{}
-	mockStore := &MockStore{}
-	store := New(context.Background(), logger, mockStore).(*Store)
-
 	ctx := context.Background()
 	spends := []*utxo.Spend{createTestSpend(1), createTestSpend(2)}
 	expectedErr := errors.NewError("unspend error")
 
-	// Note: The implementation always passes false as the third argument (ignoring variadic parameter)
-	// The mock receives it as []bool{false} due to variadic expansion
-	mockStore.On("Unspend", ctx, spends, []bool{false}).Return(expectedErr)
+	t.Run("no flag is forwarded as no flag", func(t *testing.T) {
+		mockStore := &MockStore{}
+		store := New(ctx, ulogger.TestLogger{}, mockStore).(*Store)
 
-	err := store.Unspend(ctx, spends, true) // flagAsLocked is ignored in implementation
+		mockStore.On("Unspend", ctx, spends, []bool(nil)).Return(expectedErr)
 
-	assert.Equal(t, expectedErr, err)
-	mockStore.AssertExpectations(t)
+		err := store.Unspend(ctx, spends)
+
+		assert.Equal(t, expectedErr, err)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("explicit true is forwarded unchanged", func(t *testing.T) {
+		mockStore := &MockStore{}
+		store := New(ctx, ulogger.TestLogger{}, mockStore).(*Store)
+
+		mockStore.On("Unspend", ctx, spends, []bool{true}).Return(expectedErr)
+
+		err := store.Unspend(ctx, spends, true)
+
+		assert.Equal(t, expectedErr, err)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("explicit false is forwarded unchanged", func(t *testing.T) {
+		mockStore := &MockStore{}
+		store := New(ctx, ulogger.TestLogger{}, mockStore).(*Store)
+
+		mockStore.On("Unspend", ctx, spends, []bool{false}).Return(expectedErr)
+
+		err := store.Unspend(ctx, spends, false)
+
+		assert.Equal(t, expectedErr, err)
+		mockStore.AssertExpectations(t)
+	})
 }
 
 func TestDelete(t *testing.T) {

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -2966,12 +2966,10 @@ func (s *Store) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked 
 	// qFindTxID runs after q1 returns 0 rows. Unspend is idempotent: if the output
 	// row exists but our caller doesn't own the spend (stored data is NULL or
 	// belongs to someone else), we no-op on spending_data but still need the
-	// transaction_id to apply the locked/DAH housekeeping below — callers like
-	// ProcessConflicting rely on the parent transaction's locked state being
-	// updated regardless of whether the spend was the loser's. Only a missing
-	// row is a real error (NotFound). Mirrors stores/utxo/aerospike/teranode.lua
-	// where the unspend UDF returns STATUS_OK with no bin mutation for the same
-	// non-owning cases.
+	// transaction_id to apply the DAH housekeeping below. Only a missing row is a
+	// real error (NotFound). Mirrors stores/utxo/aerospike/teranode.lua where the
+	// unspend UDF returns STATUS_OK with no bin mutation for the same non-owning
+	// cases.
 	qFindTxID := `
 		SELECT transaction_id FROM outputs
 		WHERE transaction_id IN (
@@ -2980,8 +2978,17 @@ func (s *Store) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked 
 		AND idx = $2
 	`
 
+	// Only touch the parent's locked flag when the caller explicitly supplies one.
+	// The Aerospike unspend UDF never mutates locked (it is cleared on setMined),
+	// so a plain spend-rollback (no flagAsLocked) must leave locked untouched here
+	// too — otherwise an overlapping rollback would clear an independently-set 2PC
+	// locked flag and make a parent's outputs spendable before 2PC completes.
+	// Callers that intend to change locked pass it explicitly: ProcessConflicting
+	// locks affected parents (true) and ReverseProcessConflicting unlocks them (false).
+	flagLockedProvided := len(flagAsLocked) > 0
+
 	locked := false
-	if len(flagAsLocked) > 0 {
+	if flagLockedProvided {
 		locked = flagAsLocked[0]
 	}
 
@@ -3026,8 +3033,10 @@ func (s *Store) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked 
 				}
 			}
 
-			if _, err = txn.ExecContext(ctx, q2, transactionID, locked); err != nil {
-				return errors.NewStorageError("[Unspend] error removing tombstone for %s:%d", spend.TxID, spend.Vout, err)
+			if flagLockedProvided {
+				if _, err = txn.ExecContext(ctx, q2, transactionID, locked); err != nil {
+					return errors.NewStorageError("[Unspend] error removing tombstone for %s:%d", spend.TxID, spend.Vout, err)
+				}
 			}
 
 			if err = s.setDAH(ctx, txn, transactionID); err != nil {

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -409,6 +409,55 @@ func TestUnspend(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestUnspendLockedFlag proves the #1154 fix: a spend-rollback (Unspend with no
+// flagAsLocked) must not clear a parent's independently-set 2PC locked flag, matching
+// the Aerospike unspend UDF which never touches locked. It also proves the deliberate
+// semantics are retained: an explicit false clears locked, an explicit true keeps it set.
+func TestUnspendLockedFlag(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	utxoStore, tx := setup(ctx, t)
+
+	// Parent created with the 2PC locked flag set.
+	_, err := utxoStore.Create(ctx, tx, 0, utxo.WithLocked(true))
+	require.NoError(t, err)
+
+	lockedNow := func() bool {
+		m := &meta.Data{}
+		require.NoError(t, utxoStore.GetMeta(ctx, tx.TxIDChainHash(), m))
+		return m.Locked
+	}
+	require.True(t, lockedNow(), "parent should be locked after Create(WithLocked(true))")
+
+	// Spend a child of the locked parent. The parent is locked, so IgnoreLocked is required.
+	spendTx := utxo2.GetSpendingTx(tx, 0)
+	_, err = utxoStore.Spend(ctx, spendTx, utxoStore.GetBlockHeight()+1, utxo.IgnoreFlags{IgnoreLocked: true})
+	require.NoError(t, err)
+
+	utxohash, err := util.UTXOHashFromOutput(tx.TxIDChainHash(), tx.Outputs[0], 0)
+	require.NoError(t, err)
+
+	spend := &utxo.Spend{
+		TxID:         tx.TxIDChainHash(),
+		Vout:         0,
+		UTXOHash:     utxohash,
+		SpendingData: spendpkg.NewSpendingData(spendTx.TxIDChainHash(), 0),
+	}
+
+	// No flag: the parent's locked flag must be left untouched.
+	require.NoError(t, utxoStore.Unspend(ctx, []*utxo.Spend{spend}))
+	require.True(t, lockedNow(), "Unspend without a flag must not clear the parent's locked flag")
+
+	// Explicit true: still locked.
+	require.NoError(t, utxoStore.Unspend(ctx, []*utxo.Spend{spend}, true))
+	require.True(t, lockedNow(), "Unspend(true) must keep the parent locked")
+
+	// Explicit false: locked is cleared (ReverseProcessConflicting semantics).
+	require.NoError(t, utxoStore.Unspend(ctx, []*utxo.Spend{spend}, false))
+	require.False(t, lockedNow(), "Unspend(false) must clear the parent's locked flag")
+}
+
 func TestGetSpend(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Fixes #1154

## Problem
`stores/utxo/sql/sql.go` `Unspend` ran `UPDATE transactions SET locked = $2` for **every** spend, with `locked` defaulting to `false` when no `flagAsLocked` was supplied. A plain spend-rollback therefore cleared a parent's independently-set two-phase-commit `locked` flag, making its outputs spendable before 2PC completed.

This diverged from Aerospike: the `unspend` UDF (`teranode.lua:484-555`) never touches `locked` (it is cleared on `setMined`), and the Aerospike Go wrapper ignores `flagAsLocked` entirely. The dangerous no-flag callers are `services/validator/Validator.go:1461` (`reverseSpends`), the batched-spend rollback (`sql.go:1951`), and `cmd/rewindblockchain`.

## Fix
Apply the `locked` update **only when `flagAsLocked` is explicitly supplied**. When no flag is passed, `locked` is left untouched, matching Aerospike. `setDAH` housekeeping still runs unconditionally, and the deliberate lock/unlock semantics of `ProcessConflicting` (`true`) and `ReverseProcessConflicting` (`false`) are preserved.

## Tests
Added `TestUnspendLockedFlag` (`stores/utxo/sql/sql_test.go`):
- `Create(parent, WithLocked(true))` → spend a child with `IgnoreLocked` → `Unspend(no flag)` asserts parent `Locked` is still `true`.
- Also asserts `Unspend(true)` keeps it locked and `Unspend(false)` clears it (retained semantics).

Verified the test fails against the pre-fix code and passes with the fix.

```
go test -race -tags "testtxmetacache" ./stores/utxo/sql/... ./stores/utxo/
ok  	github.com/bsv-blockchain/teranode/stores/utxo/sql	21.689s
ok  	github.com/bsv-blockchain/teranode/stores/utxo/sql/pruner	1.572s
ok  	github.com/bsv-blockchain/teranode/stores/utxo	2.912s
```
`go vet ./stores/utxo/sql/...` clean.