### PR TITLE
refactor(blockchain/sql): rename GenerationalCache.Begin to NewOp

### DIFF
--- a/stores/blockchain/sql/GetBestBlockHeader.go
+++ b/stores/blockchain/sql/GetBestBlockHeader.go
@@ -93,7 +93,7 @@ func (s *SQL) GetBestBlockHeader(ctx context.Context) (*model.BlockHeader, *mode
 
 	// Begin cache-safe query - captures generation to prevent stale writes
 	cacheID := chainhash.HashH([]byte("GetBestBlockHeader"))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBestBlockID.go
+++ b/stores/blockchain/sql/GetBestBlockID.go
@@ -24,7 +24,7 @@ type bestBlockIDResult struct {
 // automatically invalidated by ResetResponseCache().
 func (s *SQL) getBestBlockID(ctx context.Context) (uint32, *chainhash.Hash, error) {
 	cacheID := chainhash.HashH([]byte("getBestBlockID"))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	if cached := cacheOp.Get(); cached != nil {
 		if r, ok := cached.Value().(bestBlockIDResult); ok {

--- a/stores/blockchain/sql/GetBlock.go
+++ b/stores/blockchain/sql/GetBlock.go
@@ -91,7 +91,7 @@ func (s *SQL) GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*model.B
 	// the cache will be invalidated by the StoreBlock function when a new block is added, or after cacheTTL seconds
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlock-%s", blockHash.String())))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().(*getBlockCache); ok && cacheData != nil {

--- a/stores/blockchain/sql/GetBlockByHeight.go
+++ b/stores/blockchain/sql/GetBlockByHeight.go
@@ -86,7 +86,7 @@ func (s *SQL) GetBlockByHeight(ctx context.Context, height uint32) (*model.Block
 	// the cache will be invalidated by the StoreBlock function when a new block is added, or after cacheTTL seconds
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockByHeight-%d", height)))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().(*model.Block); ok && cacheData != nil {

--- a/stores/blockchain/sql/GetBlockByID.go
+++ b/stores/blockchain/sql/GetBlockByID.go
@@ -74,7 +74,7 @@ func (s *SQL) GetBlockByID(ctx context.Context, id uint64) (*model.Block, error)
 	// the cache will be invalidated by the StoreBlock function when a new block is added, or after cacheTTL seconds
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockByID-%d", id)))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().(*model.Block); ok && cacheData != nil {

--- a/stores/blockchain/sql/GetBlockExists.go
+++ b/stores/blockchain/sql/GetBlockExists.go
@@ -68,7 +68,7 @@ func (s *SQL) GetBlockExists(ctx context.Context, blockHash *chainhash.Hash) (bo
 	// Use operation-prefixed key to avoid conflicts with other cached data
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockExists-%s", blockHash.String())))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil {
 		// Check if it's a cached boolean result from previous GetBlockExists call

--- a/stores/blockchain/sql/GetBlockHeader.go
+++ b/stores/blockchain/sql/GetBlockHeader.go
@@ -97,7 +97,7 @@ func (s *SQL) GetBlockHeader(ctx context.Context, blockHash *chainhash.Hash) (*m
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to avoid conflicts with other cached data
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeader-%s", blockHash.String())))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeaderIDs.go
+++ b/stores/blockchain/sql/GetBlockHeaderIDs.go
@@ -105,7 +105,7 @@ func (s *SQL) GetBlockHeaderIDs(ctx context.Context, blockHashFrom *chainhash.Ha
 	}
 
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeaderIDs-%s-%d", blockHashFrom.String(), numberOfHeaders)))
-	cacheOp := cache.Begin(cacheID)
+	cacheOp := cache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeaders.go
+++ b/stores/blockchain/sql/GetBlockHeaders.go
@@ -96,7 +96,7 @@ func (s *SQL) GetBlockHeaders(ctx context.Context, blockHashFrom *chainhash.Hash
 	}
 
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeaders-%s-%d", blockHashFrom.String(), numberOfHeaders)))
-	cacheOp := cache.Begin(cacheID)
+	cacheOp := cache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeadersByHeight.go
+++ b/stores/blockchain/sql/GetBlockHeadersByHeight.go
@@ -60,7 +60,7 @@ func (s *SQL) GetBlockHeadersByHeight(ctx context.Context, startHeight, endHeigh
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeadersByHeight-%d-%d", startHeight, endHeight)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeadersFromHeight.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromHeight.go
@@ -78,7 +78,7 @@ func (s *SQL) GetBlockHeadersFromHeight(ctx context.Context, height, limit uint3
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeadersFromHeight-%d-%d", height, limit)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeadersFromOldest.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromOldest.go
@@ -76,7 +76,7 @@ func (s *SQL) GetBlockHeadersFromOldest(ctx context.Context, chainTipHash, targe
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeadersFromOldest-%s-%s-%d", chainTipHash.String(), targetHash.String(), numberOfHeaders)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeadersFromTill.go
+++ b/stores/blockchain/sql/GetBlockHeadersFromTill.go
@@ -72,7 +72,7 @@ func (s *SQL) GetBlockHeadersFromTill(ctx context.Context, blockHashFrom *chainh
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeadersFromTill-%s-%s", blockHashFrom.String(), blockHashTill.String())))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetBlockHeight.go
+++ b/stores/blockchain/sql/GetBlockHeight.go
@@ -45,7 +45,7 @@ func (s *SQL) GetBlockHeight(ctx context.Context, blockHash *chainhash.Hash) (ui
 	// Use operation-prefixed key to avoid conflicts with other cached data
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockHeight-%s", blockHash.String())))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil {
 		// Check if it's a cached height value

--- a/stores/blockchain/sql/GetBlockInChainByHeight.go
+++ b/stores/blockchain/sql/GetBlockInChainByHeight.go
@@ -57,7 +57,7 @@ func (s *SQL) GetBlockInChainByHeightHash(ctx context.Context, height uint32, st
 	// the cache will be invalidated by the StoreBlock function when a new block is added, or after cacheTTL seconds
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockInChainByHeightHash-%d-%s", height, startHash.String())))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().(*model.Block); ok && cacheData != nil {

--- a/stores/blockchain/sql/GetBlockIsMined.go
+++ b/stores/blockchain/sql/GetBlockIsMined.go
@@ -52,7 +52,7 @@ func (s *SQL) GetBlockIsMined(ctx context.Context, blockHash *chainhash.Hash) (b
 	// Use a derived cache key to avoid conflicts with other cached data
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlockIsMined-%s", blockHash.String())))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().(bool); ok {

--- a/stores/blockchain/sql/GetBlockStats.go
+++ b/stores/blockchain/sql/GetBlockStats.go
@@ -58,7 +58,7 @@ func (s *SQL) GetBlockStats(ctx context.Context) (*model.BlockStats, error) {
 	// Use a fixed cache key for stats since they're global for the entire blockchain
 	statsCacheKey := chainhash.HashH([]byte("GetBlockStats"))
 
-	cacheOp := s.responseCache.Begin(statsCacheKey)
+	cacheOp := s.responseCache.NewOp(statsCacheKey)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().(*model.BlockStats); ok {

--- a/stores/blockchain/sql/GetBlocks.go
+++ b/stores/blockchain/sql/GetBlocks.go
@@ -52,7 +52,7 @@ func (s *SQL) GetBlocks(ctx context.Context, blockHashFrom *chainhash.Hash, numb
 	// Use a derived cache key to avoid conflicts with other cached data
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlocks-%s-%d", blockHashFrom.String(), numberOfHeaders)))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {
 		if cacheData, ok := cached.Value().([]*model.Block); ok {

--- a/stores/blockchain/sql/GetBlocksByHeight.go
+++ b/stores/blockchain/sql/GetBlocksByHeight.go
@@ -67,7 +67,7 @@ func (s *SQL) GetBlocksByHeight(ctx context.Context, startHeight, endHeight uint
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlocksByHeight-%d-%d", startHeight, endHeight)))
 
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 	cached := cacheOp.Get()
 	if cached != nil {
 		if blocks, ok := cached.Value().([]*model.Block); ok {

--- a/stores/blockchain/sql/GetBlocksByTime.go
+++ b/stores/blockchain/sql/GetBlocksByTime.go
@@ -57,7 +57,7 @@ func (s *SQL) GetBlocksByTime(ctx context.Context, fromTime, toTime time.Time) (
 	toTimeString := toTime.Format("2006-01-02 15:04:05 +0000")
 
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetBlocksByTime-%s-%s", fromTimeString, toTimeString)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetChainTips.go
+++ b/stores/blockchain/sql/GetChainTips.go
@@ -26,7 +26,7 @@ func (s *SQL) GetChainTips(ctx context.Context) ([]*model.ChainTip, error) {
 
 	// Try to get from response cache using derived cache key
 	cacheID := chainhash.HashH([]byte("GetChainTips"))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetForkedBlockHeaders.go
+++ b/stores/blockchain/sql/GetForkedBlockHeaders.go
@@ -57,7 +57,7 @@ func (s *SQL) GetForkedBlockHeaders(ctx context.Context, blockHashFrom *chainhas
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetForkedBlockHeaders-%s-%d", blockHashFrom.String(), numberOfHeaders)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetHashOfAncestorBlock.go
+++ b/stores/blockchain/sql/GetHashOfAncestorBlock.go
@@ -53,7 +53,7 @@ func (s *SQL) GetHashOfAncestorBlock(ctx context.Context, hash *chainhash.Hash, 
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetHashOfAncestorBlock-%s-%d", hash.String(), depth)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetHeader.go
+++ b/stores/blockchain/sql/GetHeader.go
@@ -65,7 +65,7 @@ func (s *SQL) GetHeader(ctx context.Context, blockHash *chainhash.Hash) (*model.
 
 	// the cache will be invalidated by the StoreBlock function when a new block is added, or after cacheTTL seconds
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetHeader-%s", blockHash.String())))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {

--- a/stores/blockchain/sql/GetLastNBlocks.go
+++ b/stores/blockchain/sql/GetLastNBlocks.go
@@ -56,7 +56,7 @@ func (s *SQL) GetLastNBlocks(ctx context.Context, n int64, includeOrphans bool, 
 
 	// the cache will be invalidated by the StoreBlock function when a new block is added, or after cacheTTL seconds
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetLastNBlocks-%d-%t-%d", n, includeOrphans, fromHeight)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil && cached.Value() != nil {

--- a/stores/blockchain/sql/GetLastNInvalidBlocks.go
+++ b/stores/blockchain/sql/GetLastNInvalidBlocks.go
@@ -56,7 +56,7 @@ func (s *SQL) GetLastNInvalidBlocks(ctx context.Context, n int64) ([]*model.Bloc
 
 	// Create a unique cache ID for this query
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetLastNInvalidBlocks-%d", n)))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	// Check if we have a cached result
 	cached := cacheOp.Get()

--- a/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
+++ b/stores/blockchain/sql/GetLatestHeaderFromBlockLocator.go
@@ -75,7 +75,7 @@ func (s *SQL) GetLatestBlockHeaderFromBlockLocator(ctx context.Context, bestBloc
 		locatorStrs[i] = hash.String()
 	}
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetLatestHeaderFromBlockLocator-%s-%s", bestBlockHash.String(), strings.Join(locatorStrs, ","))))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/GetSuitableBlock.go
+++ b/stores/blockchain/sql/GetSuitableBlock.go
@@ -55,7 +55,7 @@ func (s *SQL) GetSuitableBlock(ctx context.Context, hash *chainhash.Hash) (*mode
 	// Try to get from response cache using derived cache key
 	// Use operation-prefixed key to be consistent with other operations
 	cacheID := chainhash.HashH([]byte(fmt.Sprintf("GetSuitableBlock-%s", hash.String())))
-	cacheOp := s.responseCache.Begin(cacheID)
+	cacheOp := s.responseCache.NewOp(cacheID)
 
 	cached := cacheOp.Get()
 	if cached != nil {

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -207,7 +207,7 @@ func (s *SQL) StoreBlock(ctx context.Context, block *model.Block, peerID string,
 		s.updateMaxBlockID(newBlockID)
 
 		cacheID := chainhash.HashH([]byte("getBestBlockID"))
-		cacheOp := s.responseCache.Begin(cacheID)
+		cacheOp := s.responseCache.NewOp(cacheID)
 		cacheOp.Set(bestBlockIDResult{id: uint32(newBlockID), hash: block.Hash()}, s.cacheTTL)
 
 		return newBlockID, height, nil

--- a/stores/blockchain/sql/generational_cache.go
+++ b/stores/blockchain/sql/generational_cache.go
@@ -19,7 +19,7 @@ import (
 // 5. Future reads return stale data instead of fresh data
 //
 // With generation tracking:
-// - Begin() captures the current generation in a CacheOperation object
+// - NewOp() captures the current generation in a CacheOperation object
 // - DeleteAll() increments the generation
 // - CacheOperation.Set() only writes if generation matches (query wasn't invalidated)
 // - This ensures stale results from pre-invalidation queries aren't cached
@@ -42,9 +42,9 @@ func NewGenerationalCache() *GenerationalCache {
 	return gc
 }
 
-// Begin starts a cache-safe operation by capturing the current generation.
+// NewOp starts a cache-safe operation by capturing the current generation.
 // Use this for Get→work→Set patterns to prevent stale writes after cache invalidation.
-func (gc *GenerationalCache) Begin(key chainhash.Hash) *CacheOperation {
+func (gc *GenerationalCache) NewOp(key chainhash.Hash) *CacheOperation {
 	return &CacheOperation{
 		generationalCache: gc,
 		key:               key,
@@ -72,7 +72,7 @@ func (gc *GenerationalCache) Stop() {
 //
 // Usage pattern:
 //
-//	op := cache.Begin(key)
+//	op := cache.NewOp(key)
 //	if item := op.Get(); item != nil {
 //	    return item.Value()
 //	}
@@ -81,7 +81,7 @@ func (gc *GenerationalCache) Stop() {
 type CacheOperation struct {
 	generationalCache *GenerationalCache
 	key               chainhash.Hash
-	generation        uint64 // captured at Begin time
+	generation        uint64 // captured at NewOp time
 }
 
 // Get retrieves the cached Item if present, or nil on miss.
@@ -90,7 +90,7 @@ func (co *CacheOperation) Get() *ttlcache.Item[chainhash.Hash, any] {
 	return co.generationalCache.ttlCache.Get(co.key)
 }
 
-// Set writes a value to the cache only if generation hasn't changed since Begin.
+// Set writes a value to the cache only if generation hasn't changed since NewOp.
 // Returns true if cached, false if generation changed (cache was invalidated during operation).
 func (co *CacheOperation) Set(value any, ttl time.Duration) bool {
 	// Only cache if generation matches (cache wasn't invalidated during operation)

--- a/stores/blockchain/sql/generational_cache_test.go
+++ b/stores/blockchain/sql/generational_cache_test.go
@@ -16,7 +16,7 @@ func TestGenerationalCache_PreventStaleWrites(t *testing.T) {
 	key := chainhash.Hash{1, 2, 3}
 
 	// Start an operation (captures generation 0)
-	op := gc.Begin(key)
+	op := gc.NewOp(key)
 
 	// Simulate cache invalidation while operation is in progress
 	gc.DeleteAll()
@@ -28,7 +28,7 @@ func TestGenerationalCache_PreventStaleWrites(t *testing.T) {
 	require.False(t, cached, "stale result should not be cached after invalidation")
 
 	// Verify nothing was cached
-	newOp := gc.Begin(key)
+	newOp := gc.NewOp(key)
 	item := newOp.Get()
 	require.Nil(t, item, "cache should be empty after rejecting stale write")
 }
@@ -40,14 +40,14 @@ func TestGenerationalCache_AllowFreshWrites(t *testing.T) {
 	key := chainhash.Hash{1, 2, 3}
 
 	// Start an operation and immediately cache result (no invalidation)
-	op := gc.Begin(key)
+	op := gc.NewOp(key)
 	cached := op.Set("fresh data", 1*time.Hour)
 
 	// Should cache successfully
 	require.True(t, cached, "fresh result should be cached")
 
 	// Verify data was cached
-	newOp := gc.Begin(key)
+	newOp := gc.NewOp(key)
 	item := newOp.Get()
 	require.NotNil(t, item, "cache should contain the value")
 	require.Equal(t, "fresh data", item.Value())
@@ -60,11 +60,11 @@ func TestGenerationalCache_MultipleInvalidations(t *testing.T) {
 	key := chainhash.Hash{1, 2, 3}
 
 	// Start multiple operations
-	op1 := gc.Begin(key)
+	op1 := gc.NewOp(key)
 	gc.DeleteAll() // Invalidate after op1
-	op2 := gc.Begin(key)
+	op2 := gc.NewOp(key)
 	gc.DeleteAll() // Invalidate after op2
-	op3 := gc.Begin(key)
+	op3 := gc.NewOp(key)
 
 	// Only op3 should be able to cache
 	require.False(t, op1.Set("data1", 1*time.Hour), "op1 should be stale")
@@ -72,7 +72,7 @@ func TestGenerationalCache_MultipleInvalidations(t *testing.T) {
 	require.True(t, op3.Set("data3", 1*time.Hour), "op3 should be fresh")
 
 	// Verify only the latest data was cached
-	newOp := gc.Begin(key)
+	newOp := gc.NewOp(key)
 	item := newOp.Get()
 	require.NotNil(t, item)
 	require.Equal(t, "data3", item.Value())
@@ -93,7 +93,7 @@ func TestGenerationalCache_ConcurrentOperations(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 
-			op := gc.Begin(key)
+			op := gc.NewOp(key)
 			time.Sleep(1 * time.Millisecond) // Simulate work
 
 			// Randomly invalidate cache
@@ -110,7 +110,7 @@ func TestGenerationalCache_ConcurrentOperations(t *testing.T) {
 
 	// Cache should have at most one value (the last successful write)
 	// This test mainly ensures no panics occur with concurrent access
-	newOp := gc.Begin(key)
+	newOp := gc.NewOp(key)
 	item := newOp.Get()
 	if item != nil {
 		t.Logf("Final cached value: %v", item.Value())
@@ -135,7 +135,7 @@ func TestGenerationalCache_GetBeforeSet(t *testing.T) {
 	key := chainhash.Hash{1, 2, 3}
 
 	// Get on empty cache should return nil
-	op := gc.Begin(key)
+	op := gc.NewOp(key)
 	item := op.Get()
 	require.Nil(t, item, "cache miss should return nil")
 }
@@ -147,12 +147,12 @@ func TestGenerationalCache_TTLExpiration(t *testing.T) {
 	key := chainhash.Hash{1, 2, 3}
 
 	// Cache with very short TTL
-	op := gc.Begin(key)
+	op := gc.NewOp(key)
 	cached := op.Set("expiring data", 50*time.Millisecond)
 	require.True(t, cached)
 
 	// Verify it's there immediately
-	newOp := gc.Begin(key)
+	newOp := gc.NewOp(key)
 	item := newOp.Get()
 	require.NotNil(t, item)
 
@@ -160,7 +160,7 @@ func TestGenerationalCache_TTLExpiration(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Should be gone
-	expiredOp := gc.Begin(key)
+	expiredOp := gc.NewOp(key)
 	item = expiredOp.Get()
 	require.Nil(t, item, "item should have expired")
 }
@@ -173,20 +173,20 @@ func TestGenerationalCache_DifferentKeys(t *testing.T) {
 	key2 := chainhash.Hash{2}
 
 	// Cache two different keys
-	op1 := gc.Begin(key1)
+	op1 := gc.NewOp(key1)
 	op1.Set("data1", 1*time.Hour)
 
-	op2 := gc.Begin(key2)
+	op2 := gc.NewOp(key2)
 	op2.Set("data2", 1*time.Hour)
 
 	// Invalidate cache
 	gc.DeleteAll()
 
 	// Both should be cleared
-	newOp1 := gc.Begin(key1)
+	newOp1 := gc.NewOp(key1)
 	require.Nil(t, newOp1.Get(), "key1 should be cleared")
 
-	newOp2 := gc.Begin(key2)
+	newOp2 := gc.NewOp(key2)
 	require.Nil(t, newOp2.Get(), "key2 should be cleared")
 }
 
@@ -197,13 +197,13 @@ func TestGenerationalCache_SetReturnValue(t *testing.T) {
 	key := chainhash.Hash{1, 2, 3}
 
 	t.Run("returns true when cached", func(t *testing.T) {
-		op := gc.Begin(key)
+		op := gc.NewOp(key)
 		result := op.Set("test", 1*time.Hour)
 		require.True(t, result, "Set should return true when value is cached")
 	})
 
 	t.Run("returns false when generation changed", func(t *testing.T) {
-		op := gc.Begin(key)
+		op := gc.NewOp(key)
 		gc.DeleteAll() // Invalidate
 		result := op.Set("test", 1*time.Hour)
 		require.False(t, result, "Set should return false when generation changed")


### PR DESCRIPTION
## What

Renames `GenerationalCache.Begin` → `NewOp` in `stores/blockchain/sql/` (method, all ~30 call sites, tests, and doc comments). Pure mechanical rename via `gopls`, no behaviour change.

## Why

`GenerationalCache` is a response-result cache, not a `database/sql` transaction. Its `Begin()` returns a `*CacheOperation` that exposes only `Get()`/`Set()` and has **no `Rollback()`**.

SonarQube's `godre:S8168` rule pattern-matches the method name `Begin` as a transaction and raises **23 false-positive reliability-HIGH issues** ("add `defer cacheOp.Rollback()`"). The suggested fix would not compile - there is nothing to roll back and no resource to release.

Renaming the constructor to `NewOp` removes the false positives at the source, avoiding per-issue "won't fix" triage or a quality-profile exclusion that would also hide any genuine future issue.

## Verification

- `go build ./stores/blockchain/sql/` - ok
- `go vet ./stores/blockchain/sql/` - clean
- `go test -tags testtxmetacache ./stores/blockchain/sql/` - ok