### PR TITLE
fix(utxo): serialize unmined CreatedAt as int64 to prevent UnixMilli truncation

### DIFF
--- a/stores/utxo/unmined_serialization.go
+++ b/stores/utxo/unmined_serialization.go
@@ -17,7 +17,7 @@ var ErrInvalidSerializedData = errors.NewProcessingError("invalid serialized unm
 //   - Hash: 32 bytes
 //   - Fee: 8 bytes (uint64, little-endian)
 //   - SizeInBytes: 8 bytes (uint64, little-endian)
-//   - CreatedAt: 4 bytes (int32, little-endian)
+//   - CreatedAt: 8 bytes (int64, little-endian)
 //   - Flags: 1 byte (bit 0: Locked, bit 1: Skip)
 //   - UnminedSince: 4 bytes (int32, little-endian)
 //   - BlockIDs count: 4 bytes (uint32, little-endian)
@@ -26,7 +26,7 @@ var ErrInvalidSerializedData = errors.NewProcessingError("invalid serialized unm
 func SerializeUnminedTransaction(tx *UnminedTransaction) ([]byte, error) {
 	// Calculate size estimate
 	blockIDsSize := 4 + len(tx.BlockIDs)*4
-	estimatedSize := 32 + 8 + 8 + 4 + 1 + 4 + blockIDsSize + 256 // 256 for TxInpoints estimate
+	estimatedSize := 32 + 8 + 8 + 8 + 1 + 4 + blockIDsSize + 256 // 256 for TxInpoints estimate
 
 	buf := make([]byte, 0, estimatedSize)
 
@@ -42,10 +42,9 @@ func SerializeUnminedTransaction(tx *UnminedTransaction) ([]byte, error) {
 	binary.LittleEndian.PutUint64(b8, tx.Node.SizeInBytes)
 	buf = append(buf, b8...)
 
-	// CreatedAt (4 bytes)
-	b4 := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b4, uint32(tx.CreatedAt))
-	buf = append(buf, b4...)
+	// CreatedAt (8 bytes)
+	binary.LittleEndian.PutUint64(b8, uint64(tx.CreatedAt))
+	buf = append(buf, b8...)
 
 	// Flags (1 byte)
 	var flags byte
@@ -58,6 +57,7 @@ func SerializeUnminedTransaction(tx *UnminedTransaction) ([]byte, error) {
 	buf = append(buf, flags)
 
 	// UnminedSince (4 bytes)
+	b4 := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b4, uint32(tx.UnminedSince))
 	buf = append(buf, b4...)
 
@@ -85,7 +85,7 @@ func SerializeUnminedTransaction(tx *UnminedTransaction) ([]byte, error) {
 
 // DeserializeUnminedTransaction deserializes bytes into an UnminedTransaction.
 func DeserializeUnminedTransaction(data []byte) (*UnminedTransaction, error) {
-	if len(data) < 61 { // Minimum: 32+8+8+4+1+4+4 = 61 bytes
+	if len(data) < 65 { // Minimum: 32+8+8+8+1+4+4 = 65 bytes
 		return nil, ErrInvalidSerializedData
 	}
 
@@ -104,9 +104,9 @@ func DeserializeUnminedTransaction(data []byte) (*UnminedTransaction, error) {
 	sizeInBytes := binary.LittleEndian.Uint64(data[offset : offset+8])
 	offset += 8
 
-	// CreatedAt (4 bytes)
-	createdAt := int(binary.LittleEndian.Uint32(data[offset : offset+4]))
-	offset += 4
+	// CreatedAt (8 bytes)
+	createdAt := int(int64(binary.LittleEndian.Uint64(data[offset : offset+8])))
+	offset += 8
 
 	// Flags (1 byte)
 	flags := data[offset]

--- a/stores/utxo/unmined_serialization_test.go
+++ b/stores/utxo/unmined_serialization_test.go
@@ -2,6 +2,7 @@ package utxo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -62,6 +63,35 @@ func TestSerializeDeserialize_Roundtrip(t *testing.T) {
 	assert.NotNil(t, result.TxInpoints)
 	assert.Equal(t, len(original.TxInpoints.ParentTxHashes), len(result.TxInpoints.ParentTxHashes))
 	assert.Equal(t, original.TxInpoints.ParentTxHashes[0], result.TxInpoints.ParentTxHashes[0])
+}
+
+func TestSerializeDeserialize_CreatedAtUnixMilli(t *testing.T) {
+	hash, err := chainhash.NewHashFromStr("000000000000000000000000000000000000000000000000000000000000000a")
+	require.NoError(t, err)
+
+	// CreatedAt is set from time.Now().UnixMilli() (~1.78e12), far larger than
+	// uint32 max (~4.29e9). Round-tripping must preserve it exactly.
+	createdAt := int(time.Now().UnixMilli())
+	require.Greater(t, createdAt, int(^uint32(0)), "test value must exceed uint32 max")
+
+	original := &UnminedTransaction{
+		Node: &subtree.Node{
+			Hash:        *hash,
+			Fee:         100,
+			SizeInBytes: 200,
+		},
+		CreatedAt:    createdAt,
+		UnminedSince: 1000,
+		BlockIDs:     []uint32{},
+	}
+
+	data, err := SerializeUnminedTransaction(original)
+	require.NoError(t, err)
+
+	result, err := DeserializeUnminedTransaction(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, createdAt, result.CreatedAt)
 }
 
 func TestSerializeDeserialize_EmptyBlockIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1155.

`UnminedTransaction.CreatedAt` holds `time.Now().UnixMilli()` (~1.78e12, set at `stores/utxo/aerospike/create.go:907`), but `unmined_serialization.go` serialized it as a **4-byte uint32** and read it back via `int(Uint32(...))`. Since the value far exceeds the uint32 max (~4.29e9), the high bits were discarded and the round-tripped `CreatedAt` was garbage.

This matters because `CreatedAt` is the first-seen tiebreak in conflict-resolution counter selection (`stores/utxo/process_conflicting.go`) and is relied on for ordering elsewhere.

## Changes

- Serialize `CreatedAt` as an 8-byte little-endian `int64` (was uint32).
- Deserialize reads 8 bytes; bumped the min-length check from 61 to 65 bytes (`32+8+8+8+1+4+4`).
- Updated the format doc comment.
- Added `TestSerializeDeserialize_CreatedAtUnixMilli`, a round-trip regression test using a `UnixMilli` value that exceeds uint32 max.

`UnminedSince` is a block height and fits in uint32 — left unchanged.

## Compatibility

The only caller is `BlockAssembler` (`services/blockassembly/BlockAssembler.go`), which writes to an **ephemeral temp store** consumed within the same `loadUnminedTransactions` run. There is no persisted on-disk format, so the wire-format change is safe.

## Testing

```
go test -race ./stores/utxo/          # ok
go vet ./stores/utxo/                 # clean
go build ./services/blockassembly/... # ok
```

The new test fails against the pre-fix code (`1782897517970` truncated to `486090130`) and passes with the fix.