### PR TITLE
fix(blockvalidation): gate secret-mining verdict on chainwork, not fork depth

### DIFF
--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -3,6 +3,8 @@ package blockvalidation
 
 import (
 	"context"
+	"encoding/binary"
+	"math/big"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -15,6 +17,7 @@ import (
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	"github.com/bsv-blockchain/teranode/services/blockchain/work"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
 	"github.com/bsv-blockchain/teranode/util/blockassemblyutil"
 	"github.com/bsv-blockchain/teranode/util/tracing"
@@ -612,7 +615,18 @@ func (u *Server) validateForkDepth(catchupCtx *CatchupContext) error {
 func (u *Server) checkSecretMining(ctx context.Context, catchupCtx *CatchupContext) error {
 	u.logger.Debugf("[catchup][%s] Step 4: Checking for secret mining", catchupCtx.blockUpTo.Hash().String())
 
-	return u.checkSecretMiningFromCommonAncestor(ctx, catchupCtx.blockUpTo, catchupCtx.peerID, catchupCtx.baseURL, catchupCtx.commonAncestorHash, catchupCtx.commonAncestorMeta)
+	// The headers the peer offers beyond the common ancestor form the candidate chain
+	// whose cumulative work we weigh against our local chain. Not yet filtered at this
+	// point, so slice directly after the common ancestor index.
+	var offeredHeaders []*model.BlockHeader
+	if catchupCtx.headersFetchResult != nil {
+		peerHeaders := catchupCtx.headersFetchResult.Headers
+		if catchupCtx.commonAncestorIndex >= 0 && catchupCtx.commonAncestorIndex+1 < len(peerHeaders) {
+			offeredHeaders = peerHeaders[catchupCtx.commonAncestorIndex+1:]
+		}
+	}
+
+	return u.checkSecretMiningFromCommonAncestor(ctx, catchupCtx.blockUpTo, catchupCtx.peerID, catchupCtx.baseURL, catchupCtx.commonAncestorHash, catchupCtx.commonAncestorMeta, offeredHeaders)
 }
 
 // filterHeaders filters headers to only those after the common ancestor that we don't have.
@@ -1226,7 +1240,14 @@ func getLowestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 }
 
 // checkSecretMiningFromCommonAncestor detects if a peer withheld blocks (secret mining).
-// Checks if common ancestor is too far behind, indicating potential attack.
+//
+// A common ancestor more than SecretMiningThreshold blocks back is a necessary but not
+// sufficient signal: a legitimate reorg carrying more accumulated proof-of-work can fork
+// just as deeply. The malicious verdict is therefore gated on WORK, not depth — a deep
+// fork is only treated as secret mining when the chain the peer offers fails to exceed
+// our local validated chainwork. This keeps the reputation penalty ("peer is malicious")
+// separate from the policy decision of whether to auto-apply a deep reorg, which is
+// enforced independently by validateForkDepth against coinbase maturity.
 //
 // Parameters:
 //   - ctx: Context for cancellation
@@ -1234,10 +1255,11 @@ func getLowestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 //   - baseURL: Peer URL for metrics
 //   - commonAncestorHash: Hash of the common ancestor
 //   - commonAncestorMeta: Metadata of the common ancestor
+//   - offeredHeaders: Peer's headers after the common ancestor (the candidate chain)
 //
 // Returns:
-//   - error: If secret mining is detected
-func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockUpTo *model.Block, peerID, baseURL string, commonAncestorHash *chainhash.Hash, commonAncestorMeta *model.BlockHeaderMeta) error {
+//   - error: If secret mining is detected, or the deep fork cannot be safely followed
+func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockUpTo *model.Block, peerID, baseURL string, commonAncestorHash *chainhash.Hash, commonAncestorMeta *model.BlockHeaderMeta, offeredHeaders []*model.BlockHeader) error {
 	// Check whether the common ancestor is more than X blocks behind our current chain.
 	// This indicates potential secret mining.
 	currentHeight := u.utxoStore.GetBlockHeight()
@@ -1255,7 +1277,23 @@ func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockU
 		return nil
 	}
 
-	// The chain is potentially a secretly mined chain
+	// The fork is deep. Weigh the offered chain's work against our own before penalising.
+	heavier, err := u.offeredChainHasMoreWork(ctx, commonAncestorMeta, offeredHeaders)
+	if err != nil {
+		// We cannot prove the offered chain is heavier, so we must not follow it here; but
+		// we also cannot prove the peer is malicious, so we do NOT touch its reputation.
+		// Abort this catchup and let peer selection try again.
+		u.logger.Warnf("[catchup][%s] deep fork from peer %s (ancestor height %d, %d blocks behind) but chainwork comparison failed: %v - aborting without flagging malicious", blockUpTo.Hash().String(), baseURL, commonAncestorMeta.Height, blocksBehind, err)
+		return errors.NewProcessingError("[catchup][%s] unable to compare chainwork for deep fork from common ancestor at height %d", blockUpTo.Hash().String(), commonAncestorMeta.Height, err)
+	}
+
+	if heavier {
+		// A legitimate heavier chain that happens to fork deep. Follow it; do not penalise the peer.
+		u.logger.Infof("[catchup][%s] deep reorg (%d blocks) from peer %s carries more validated work than local chain - following heavier chain, not flagging secret mining", blockUpTo.Hash().String(), blocksBehind, baseURL)
+		return nil
+	}
+
+	// A deep fork that offers no additional work: potential secret mining (withheld shorter chain).
 	u.logger.Errorf("[catchup][%s] is potentially a secretly mined chain from common ancestor %s at height %d, ignoring", blockUpTo.Hash().String(), commonAncestorHash.String(), commonAncestorMeta.Height)
 
 	// Record error metric for secret mining
@@ -1275,6 +1313,44 @@ func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockU
 	u.logger.Errorf("[catchup][%s] SECURITY: Peer %s attempted secret mining - should be banned (banning not yet implemented)", blockUpTo.Hash().String(), baseURL)
 
 	return errors.NewServiceError("[catchup][%s] is potentially a secretly mined chain from common ancestor at height %d, ignoring", blockUpTo.Hash().String(), commonAncestorMeta.Height)
+}
+
+// offeredChainHasMoreWork reports whether the chain offered by the peer — the common
+// ancestor extended by offeredHeaders — carries strictly more cumulative proof-of-work
+// than our local validated best chain. It distinguishes a legitimate heavier deep reorg
+// from a withheld shorter-work chain ("secret mining").
+//
+// Parameters:
+//   - ctx: Context for the best-block-header lookup
+//   - commonAncestorMeta: Metadata of the common ancestor (supplies its cumulative work)
+//   - offeredHeaders: Peer's headers after the common ancestor
+//
+// Returns:
+//   - bool: True if the offered chain has strictly more cumulative work than the local chain
+//   - error: If the local best block header cannot be retrieved
+func (u *Server) offeredChainHasMoreWork(ctx context.Context, commonAncestorMeta *model.BlockHeaderMeta, offeredHeaders []*model.BlockHeader) (bool, error) {
+	_, bestMeta, err := u.blockchainClient.GetBestBlockHeader(ctx)
+	if err != nil {
+		return false, errors.NewProcessingError("failed to get best block header for chainwork comparison", err)
+	}
+
+	// ChainWork is stored big-endian (see stores/blockchain/sql calculateAndPrepareChainWork),
+	// so SetBytes reconstructs the cumulative work value directly.
+	localWork := new(big.Int).SetBytes(bestMeta.ChainWork)
+
+	// Start from the common ancestor's cumulative work and add each offered block's work,
+	// mirroring work.CalculateWork (work = 2^256 / (target+1)).
+	offeredWork := new(big.Int).SetBytes(commonAncestorMeta.ChainWork)
+	for _, header := range offeredHeaders {
+		if header == nil {
+			continue
+		}
+
+		bits := binary.LittleEndian.Uint32(header.Bits.CloneBytes())
+		offeredWork.Add(offeredWork, work.CalcBlockWork(bits))
+	}
+
+	return offeredWork.Cmp(localWork) > 0, nil
 }
 
 // validateBatchHeaders validates a batch of block headers.

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -1260,12 +1260,20 @@ func getLowestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 // Returns:
 //   - error: If secret mining is detected, or the deep fork cannot be safely followed
 func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockUpTo *model.Block, peerID, baseURL string, commonAncestorHash *chainhash.Hash, commonAncestorMeta *model.BlockHeaderMeta, offeredHeaders []*model.BlockHeader) error {
-	// Check whether the common ancestor is more than X blocks behind our current chain.
-	// This indicates potential secret mining.
-	currentHeight := u.utxoStore.GetBlockHeight()
+	// Read the local best chain tip once, from the same source used for the work comparison
+	// below, so the depth trigger and the work gate reason about the same tip (they can
+	// momentarily disagree during catchup). If it can't be read we cannot evaluate the fork:
+	// abort this catchup without penalising the peer — uncertainty must not be treated as malice.
+	_, bestMeta, err := u.blockchainClient.GetBestBlockHeader(ctx)
+	if err != nil {
+		u.logger.Warnf("[catchup][%s] cannot read best block header for secret-mining check from peer %s: %v - aborting without flagging malicious", blockUpTo.Hash().String(), baseURL, err)
+		return errors.NewProcessingError("[catchup][%s] unable to read best block header for secret-mining check", blockUpTo.Hash().String(), err)
+	}
 
-	// Common ancestor should always be at or below current height due to findCommonAncestor validation
-	// If not, this indicates a bug in the ancestor finding logic
+	currentHeight := bestMeta.Height
+
+	// Common ancestor should always be at or below current height due to findCommonAncestor
+	// validation. If not, we cannot reason about the fork - abort without penalising the peer.
 	if commonAncestorMeta.Height > currentHeight {
 		return errors.NewProcessingError("[catchup][%s] common ancestor height %d is ahead of current height %d - this should not happen", blockUpTo.Hash().String(), commonAncestorMeta.Height, currentHeight)
 	}
@@ -1277,17 +1285,16 @@ func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockU
 		return nil
 	}
 
-	// The fork is deep. Weigh the offered chain's work against our own before penalising.
-	heavier, err := u.offeredChainHasMoreWork(ctx, commonAncestorMeta, offeredHeaders)
-	if err != nil {
-		// We cannot prove the offered chain is heavier, so we must not follow it here; but
-		// we also cannot prove the peer is malicious, so we do NOT touch its reputation.
-		// Abort this catchup and let peer selection try again.
-		u.logger.Warnf("[catchup][%s] deep fork from peer %s (ancestor height %d, %d blocks behind) but chainwork comparison failed: %v - aborting without flagging malicious", blockUpTo.Hash().String(), baseURL, commonAncestorMeta.Height, blocksBehind, err)
-		return errors.NewProcessingError("[catchup][%s] unable to compare chainwork for deep fork from common ancestor at height %d", blockUpTo.Hash().String(), commonAncestorMeta.Height, err)
+	// The fork is deep. Without any offered headers we cannot weigh the candidate chain, so we
+	// can prove neither that it is heavier nor that it is a withheld shorter chain. Treat this
+	// like any other uncertainty: abort without penalising the peer.
+	if len(offeredHeaders) == 0 {
+		u.logger.Warnf("[catchup][%s] deep fork from peer %s (%d blocks behind) but no offered headers to weigh - aborting without flagging malicious", blockUpTo.Hash().String(), baseURL, blocksBehind)
+		return errors.NewProcessingError("[catchup][%s] deep fork with no offered headers to compare chainwork from common ancestor at height %d", blockUpTo.Hash().String(), commonAncestorMeta.Height)
 	}
 
-	if heavier {
+	// Weigh the offered chain's cumulative work against our own before penalising.
+	if offeredChainHasMoreWork(bestMeta.ChainWork, commonAncestorMeta, offeredHeaders) {
 		// A legitimate heavier chain that happens to fork deep. Follow it; do not penalise the peer.
 		u.logger.Infof("[catchup][%s] deep reorg (%d blocks) from peer %s carries more validated work than local chain - following heavier chain, not flagging secret mining", blockUpTo.Hash().String(), blocksBehind, baseURL)
 		return nil
@@ -1317,26 +1324,21 @@ func (u *Server) checkSecretMiningFromCommonAncestor(ctx context.Context, blockU
 
 // offeredChainHasMoreWork reports whether the chain offered by the peer — the common
 // ancestor extended by offeredHeaders — carries strictly more cumulative proof-of-work
-// than our local validated best chain. It distinguishes a legitimate heavier deep reorg
-// from a withheld shorter-work chain ("secret mining").
+// than our local validated best chain (localChainWork, the best block header's cumulative
+// work). It distinguishes a legitimate heavier deep reorg from a withheld shorter-work
+// chain ("secret mining").
 //
 // Parameters:
-//   - ctx: Context for the best-block-header lookup
+//   - localChainWork: Cumulative work of the local best chain tip (big-endian bytes)
 //   - commonAncestorMeta: Metadata of the common ancestor (supplies its cumulative work)
 //   - offeredHeaders: Peer's headers after the common ancestor
 //
 // Returns:
 //   - bool: True if the offered chain has strictly more cumulative work than the local chain
-//   - error: If the local best block header cannot be retrieved
-func (u *Server) offeredChainHasMoreWork(ctx context.Context, commonAncestorMeta *model.BlockHeaderMeta, offeredHeaders []*model.BlockHeader) (bool, error) {
-	_, bestMeta, err := u.blockchainClient.GetBestBlockHeader(ctx)
-	if err != nil {
-		return false, errors.NewProcessingError("failed to get best block header for chainwork comparison", err)
-	}
-
+func offeredChainHasMoreWork(localChainWork []byte, commonAncestorMeta *model.BlockHeaderMeta, offeredHeaders []*model.BlockHeader) bool {
 	// ChainWork is stored big-endian (see stores/blockchain/sql calculateAndPrepareChainWork),
 	// so SetBytes reconstructs the cumulative work value directly.
-	localWork := new(big.Int).SetBytes(bestMeta.ChainWork)
+	localWork := new(big.Int).SetBytes(localChainWork)
 
 	// Start from the common ancestor's cumulative work and add each offered block's work,
 	// mirroring work.CalculateWork (work = 2^256 / (target+1)).
@@ -1350,7 +1352,7 @@ func (u *Server) offeredChainHasMoreWork(ctx context.Context, commonAncestorMeta
 		offeredWork.Add(offeredWork, work.CalcBlockWork(bits))
 	}
 
-	return offeredWork.Cmp(localWork) > 0, nil
+	return offeredWork.Cmp(localWork) > 0
 }
 
 // validateBatchHeaders validates a batch of block headers.

--- a/services/blockvalidation/catchup_fork_handling_test.go
+++ b/services/blockvalidation/catchup_fork_handling_test.go
@@ -3,7 +3,9 @@ package blockvalidation
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"math/big"
 	"net/http"
 	"strings"
 	"sync"
@@ -14,6 +16,7 @@ import (
 	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockchain/work"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/jarcoal/httpmock"
@@ -627,6 +630,14 @@ func TestCatchup_NoMinedSetChurnOnRejectedFork(t *testing.T) {
 		ancestorHeader.Bits = *nBits
 		testhelpers.MineHeader(ancestorHeader)
 
+		// Cumulative work of each chain tip, proportional to its height, so the secret-mining
+		// work gate sees the local chain (currentHeight blocks) as heavier than the peer's short
+		// fork (ancestorHeight + a few fork blocks). Without this the mock's zero chainwork would
+		// make any offered fork look heavier and bypass the check.
+		perBlockWork := work.CalcBlockWork(binary.LittleEndian.Uint32(nBits.CloneBytes()))
+		ancestorChainWork := new(big.Int).Mul(perBlockWork, big.NewInt(int64(ancestorHeight)))
+		localChainWork := new(big.Int).Mul(perBlockWork, big.NewInt(int64(currentHeight)))
+
 		// Peer's fork: a few blocks built on top of the common ancestor.
 		forkHeaders := testhelpers.CreateSyntheticChainFrom(ancestorHeader, 5)
 		targetBlock := &model.Block{
@@ -642,13 +653,13 @@ func TestCatchup_NoMinedSetChurnOnRejectedFork(t *testing.T) {
 
 		// Metadata for the common ancestor.
 		mockBlockchainClient.On("GetBlockHeader", mock.Anything, ancestorHeader.Hash()).
-			Return(ancestorHeader, &model.BlockHeaderMeta{Height: ancestorHeight, ID: 1}, nil).Maybe()
+			Return(ancestorHeader, &model.BlockHeaderMeta{Height: ancestorHeight, ID: 1, ChainWork: ancestorChainWork.Bytes()}, nil).Maybe()
 		mockBlockchainClient.On("GetBlockHeader", mock.Anything, mock.Anything).
-			Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: ancestorHeight}, nil).Maybe()
+			Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: ancestorHeight, ChainWork: ancestorChainWork.Bytes()}, nil).Maybe()
 
 		// Header-fetch plumbing.
 		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).
-			Return(ancestorHeader, &model.BlockHeaderMeta{Height: currentHeight}, nil).Maybe()
+			Return(ancestorHeader, &model.BlockHeaderMeta{Height: currentHeight, ChainWork: localChainWork.Bytes()}, nil).Maybe()
 		mockBlockchainClient.On("GetBlockLocator", mock.Anything, mock.Anything, mock.Anything).
 			Return([]*chainhash.Hash{ancestorHeader.Hash()}, nil).Maybe()
 		mockBlockchainClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -1092,8 +1092,8 @@ func TestCatchup(t *testing.T) {
 		// Mock GetBlockHeight to return our current height
 		mockUTXOStore.On("GetBlockHeight").Return(currentHeight)
 
-		// Local chain carries far more validated work than the deep fork offers,
-		// so the deep fork with no extra work is genuine secret mining.
+		// Local chain carries far more validated work than the deep fork offers, and the
+		// depth trigger reads its tip from this same best header (height = currentHeight).
 		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).Return(
 			&model.BlockHeader{},
 			&model.BlockHeaderMeta{Height: currentHeight, ChainWork: new(big.Int).SetInt64(1_000_000).Bytes()},
@@ -1111,8 +1111,9 @@ func TestCatchup(t *testing.T) {
 			ChainWork: new(big.Int).SetInt64(1_000).Bytes(),
 		}
 
-		// Peer offers no additional work beyond the ancestor: shorter-work deep chain.
-		err := server.checkSecretMiningFromCommonAncestor(ctx, blockUpTo, "", "http://test-peer", commonAncestorHash, commonAncestorMeta, nil)
+		// Peer offers a deep fork whose few blocks add negligible work: a shorter-work deep chain.
+		offered := testhelpers.CreateTestHeaders(t, 5)
+		err := server.checkSecretMiningFromCommonAncestor(ctx, blockUpTo, "", "http://test-peer", commonAncestorHash, commonAncestorMeta, offered)
 
 		// Should return an error because the deep fork carries less work than our chain
 		require.Error(t, err)
@@ -1266,6 +1267,20 @@ func TestCheckSecretMiningWorkGating(t *testing.T) {
 		require.Contains(t, err.Error(), "secretly mined chain")
 		require.True(t, rec.maliciousCalled(), "a withheld shorter-work deep chain must be flagged malicious")
 		require.Equal(t, "peer-bad", rec.peer())
+	})
+
+	t.Run("deep fork with no offered headers aborts without flagging malicious", func(t *testing.T) {
+		rec := &recordingP2PClient{}
+
+		// Local chain is heavier, but with no offered headers we cannot weigh the candidate
+		// chain: uncertainty must abort without penalising the peer, not flag it malicious.
+		srv, ancestorHash, ancestorMeta := newServer(t, big.NewInt(1_000_000), rec)
+
+		err := srv.checkSecretMiningFromCommonAncestor(context.Background(), blockUpTo, "peer-empty", "http://empty-peer", ancestorHash, ancestorMeta, nil)
+
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secretly mined chain")
+		require.False(t, rec.maliciousCalled(), "an unweighable fork must not penalise the peer")
 	})
 
 	t.Run("chainwork lookup failure aborts without flagging malicious", func(t *testing.T) {

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -3,6 +3,7 @@ package blockvalidation
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -1091,20 +1092,29 @@ func TestCatchup(t *testing.T) {
 		// Mock GetBlockHeight to return our current height
 		mockUTXOStore.On("GetBlockHeight").Return(currentHeight)
 
+		// Local chain carries far more validated work than the deep fork offers,
+		// so the deep fork with no extra work is genuine secret mining.
+		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).Return(
+			&model.BlockHeader{},
+			&model.BlockHeaderMeta{Height: currentHeight, ChainWork: new(big.Int).SetInt64(1_000_000).Bytes()},
+			nil,
+		)
+
 		// Create test blocks
 		blocks := testhelpers.CreateTestBlockChain(t, 2)
 		blockUpTo := blocks[1]
 
-		// Create common ancestor hash and meta
+		// Create common ancestor hash and meta (tiny cumulative work)
 		commonAncestorHash := blocks[0].Header.Hash()
 		commonAncestorMeta := &model.BlockHeaderMeta{
-			Height: commonAncestorHeight,
+			Height:    commonAncestorHeight,
+			ChainWork: new(big.Int).SetInt64(1_000).Bytes(),
 		}
 
-		// Call the secret mining check function directly
-		err := server.checkSecretMiningFromCommonAncestor(ctx, blockUpTo, "", "http://test-peer", commonAncestorHash, commonAncestorMeta)
+		// Peer offers no additional work beyond the ancestor: shorter-work deep chain.
+		err := server.checkSecretMiningFromCommonAncestor(ctx, blockUpTo, "", "http://test-peer", commonAncestorHash, commonAncestorMeta, nil)
 
-		// Should return an error because 180 blocks behind > 100 threshold
+		// Should return an error because the deep fork carries less work than our chain
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "secretly mined chain")
 	})
@@ -1135,11 +1145,157 @@ func TestCatchup(t *testing.T) {
 		}
 
 		// Call the secret mining check function directly
-		err := server.checkSecretMiningFromCommonAncestor(ctx, blockUpTo, "", "http://test-peer", commonAncestorHash, commonAncestorMeta)
+		err := server.checkSecretMiningFromCommonAncestor(ctx, blockUpTo, "", "http://test-peer", commonAncestorHash, commonAncestorMeta, nil)
 
 		// Should return an error because common ancestor is ahead of current height
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "ahead of current height")
+	})
+}
+
+// recordingP2PClient records whether malicious behaviour was reported for a peer,
+// so tests can distinguish the reputation penalty from a mere policy-driven abort.
+type recordingP2PClient struct {
+	P2PClientI
+
+	mu     sync.Mutex
+	called bool
+	peerID string
+}
+
+func (r *recordingP2PClient) RecordCatchupMalicious(_ context.Context, peerID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.called = true
+	r.peerID = peerID
+
+	return nil
+}
+
+func (r *recordingP2PClient) maliciousCalled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.called
+}
+
+func (r *recordingP2PClient) peer() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.peerID
+}
+
+// TestCheckSecretMiningWorkGating verifies that the secret-mining check gates the
+// malicious verdict on cumulative work, not fork depth: an honest peer serving a
+// heavier deep reorg is followed and left unpenalised (issue #1160), while a deep
+// fork that carries no additional work is still flagged.
+func TestCheckSecretMiningWorkGating(t *testing.T) {
+	initPrometheusMetrics()
+
+	const (
+		currentHeight        = uint32(200)
+		commonAncestorHeight = uint32(20) // 180 blocks behind, exceeds the threshold of 100
+	)
+
+	newServer := func(t *testing.T, localChainWork *big.Int, rec *recordingP2PClient) (*Server, *chainhash.Hash, *model.BlockHeaderMeta) {
+		t.Helper()
+
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.BlockValidation.SecretMiningThreshold = 100
+
+		mockUTXOStore := &utxo.MockUtxostore{}
+		mockUTXOStore.On("GetBlockHeight").Return(currentHeight)
+
+		mockBlockchainClient := &blockchain.Mock{}
+		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).Return(
+			&model.BlockHeader{},
+			&model.BlockHeaderMeta{Height: currentHeight, ChainWork: localChainWork.Bytes()},
+			nil,
+		)
+
+		srv := &Server{
+			logger:           ulogger.TestLogger{},
+			settings:         tSettings,
+			blockchainClient: mockBlockchainClient,
+			utxoStore:        mockUTXOStore,
+			stats:            gocore.NewStat("test"),
+		}
+		if rec != nil {
+			srv.p2pClient = rec
+		}
+
+		ancestorHash := testhelpers.CreateTestHeaders(t, 1)[0].Hash()
+		ancestorMeta := &model.BlockHeaderMeta{
+			Height:    commonAncestorHeight,
+			ChainWork: big.NewInt(1_000).Bytes(),
+		}
+
+		return srv, ancestorHash, ancestorMeta
+	}
+
+	blockUpTo := testhelpers.CreateTestBlockChain(t, 2)[1]
+
+	t.Run("heavier deep reorg is followed and not flagged malicious", func(t *testing.T) {
+		rec := &recordingP2PClient{}
+
+		// Local best work equals the common ancestor work (1000): any positive work the
+		// peer's offered headers add makes the offered chain strictly heavier.
+		srv, ancestorHash, ancestorMeta := newServer(t, big.NewInt(1_000), rec)
+
+		offered := testhelpers.CreateTestHeaders(t, 5)
+
+		err := srv.checkSecretMiningFromCommonAncestor(context.Background(), blockUpTo, "peer-good", "http://good-peer", ancestorHash, ancestorMeta, offered)
+
+		require.NoError(t, err)
+		require.False(t, rec.maliciousCalled(), "honest peer serving a heavier deep chain must not be flagged malicious")
+	})
+
+	t.Run("deep fork with no extra work is flagged malicious", func(t *testing.T) {
+		rec := &recordingP2PClient{}
+
+		// Local best work dwarfs the offered chain: the deep fork carries no extra work.
+		srv, ancestorHash, ancestorMeta := newServer(t, big.NewInt(1_000_000), rec)
+
+		offered := testhelpers.CreateTestHeaders(t, 5)
+
+		err := srv.checkSecretMiningFromCommonAncestor(context.Background(), blockUpTo, "peer-bad", "http://bad-peer", ancestorHash, ancestorMeta, offered)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secretly mined chain")
+		require.True(t, rec.maliciousCalled(), "a withheld shorter-work deep chain must be flagged malicious")
+		require.Equal(t, "peer-bad", rec.peer())
+	})
+
+	t.Run("chainwork lookup failure aborts without flagging malicious", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.BlockValidation.SecretMiningThreshold = 100
+
+		mockUTXOStore := &utxo.MockUtxostore{}
+		mockUTXOStore.On("GetBlockHeight").Return(currentHeight)
+
+		mockBlockchainClient := &blockchain.Mock{}
+		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).Return(nil, nil, errors.NewProcessingError("boom"))
+
+		rec := &recordingP2PClient{}
+		srv := &Server{
+			logger:           ulogger.TestLogger{},
+			settings:         tSettings,
+			blockchainClient: mockBlockchainClient,
+			utxoStore:        mockUTXOStore,
+			stats:            gocore.NewStat("test"),
+			p2pClient:        rec,
+		}
+
+		ancestorHash := testhelpers.CreateTestHeaders(t, 1)[0].Hash()
+		ancestorMeta := &model.BlockHeaderMeta{Height: commonAncestorHeight, ChainWork: big.NewInt(1_000).Bytes()}
+
+		err := srv.checkSecretMiningFromCommonAncestor(context.Background(), blockUpTo, "peer-x", "http://x", ancestorHash, ancestorMeta, testhelpers.CreateTestHeaders(t, 3))
+
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secretly mined chain")
+		require.False(t, rec.maliciousCalled(), "an internal lookup failure must not penalise the peer")
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes #1160.

`checkSecretMiningFromCommonAncestor` (`services/blockvalidation/catchup.go`) treated a common ancestor more than `SecretMiningThreshold` (~99) blocks back as an attack, pinning the peer's reputation to 5.0 (excluded from selection) and aborting catchup. A **legitimate deeper reorg carrying more validated work is indistinguishable to a depth-only check**, so every honest peer serving a better deep chain was flagged malicious and the node refused to follow the heavier chain.

## What changed

- The secret-mining verdict is now **gated on cumulative proof-of-work, not fork depth**. When the depth threshold is exceeded, the offered chain's work (common-ancestor chainwork + Σ per-header work of the peer's offered headers) is compared against the local validated best-chain work:
  - **Offered work > local work** → legitimate heavier chain: follow it, return `nil`, and **do not** touch the peer's reputation.
  - **Offered work ≤ local work** → deep fork with no extra work (withheld shorter chain): flag malicious and abort, as before.
- If the local best block header can't be read, the catchup aborts **without** penalising the peer — separating the "refuse to auto-apply this reorg" policy decision from the "this peer is malicious" reputation decision. Deep-reorg depth policy remains independently enforced by `validateForkDepth` against coinbase maturity.
- New helper `offeredChainHasMoreWork` computes the comparison using the existing `work.CalcBlockWork` and the big-endian `ChainWork` convention already used in `services/blockchain/Difficulty.go`.

## Tests

`TestCheckSecretMiningWorkGating` (new) asserts the reputation distinction via a recording P2P client:
- heavier deep reorg → no error, `RecordCatchupMalicious` **not** called;
- deep fork with no extra work → error `secretly mined chain`, `RecordCatchupMalicious` **called** for the peer;
- best-block-header lookup failure → aborts without flagging malicious.

The existing `TestCatchup` "Too Far Behind" case was updated to set up the work comparison (local chain heavier) so it continues to exercise the malicious path.

### Verification
- `go build ./services/blockvalidation/` — clean
- `go vet ./services/blockvalidation/` — pass
- `go test -race -tags testtxmetacache ./services/blockvalidation/` — `ok` (full package)
- `golangci-lint run --new-from-rev=upstream/main ./services/blockvalidation/` — 0 issues