### PR TITLE
fix(blockassembly): stable-sort unmined reload with parents-first tiebreak

### DIFF
--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -2285,6 +2285,141 @@ func (b *BlockAssembler) validateParentChain(
 	return validTxs, nil
 }
 
+// stableSortUnminedByCreatedAt orders unmined transactions by CreatedAt (oldest
+// first) with a topological tiebreak: when transactions share the same
+// CreatedAt, any parent that is also in the set is placed before its children.
+//
+// CreatedAt is stamped independently per transaction with no enforced gap, and
+// has coarse resolution — millisecond on the Aerospike store and one-second on
+// the SQLite store (its CURRENT_TIMESTAMP default emits "YYYY-MM-DD HH:MM:SS").
+// A parent and child created close together therefore routinely share a
+// CreatedAt value. An unstable sort could then emit the child before its
+// parent, and validateParentChain treats parent-after-child as invalid ordering
+// and drops the child (cascading to its descendants). The stable base sort
+// preserves iterator order on ties, and the per-run reorder guarantees parents
+// precede their children regardless of iterator order.
+func stableSortUnminedByCreatedAt(txs []*utxo.UnminedTransaction) {
+	sort.SliceStable(txs, func(i, j int) bool {
+		return txs[i].CreatedAt < txs[j].CreatedAt
+	})
+
+	// Reorder within each maximal run of equal CreatedAt so in-set parents come
+	// before their children. Only same-timestamp transactions can be misordered,
+	// so unrelated timestamps are left untouched.
+	for start := 0; start < len(txs); {
+		end := start + 1
+		for end < len(txs) && txs[end].CreatedAt == txs[start].CreatedAt {
+			end++
+		}
+
+		if end-start > 1 {
+			orderRunParentsFirst(txs[start:end])
+		}
+
+		start = end
+	}
+}
+
+// orderRunParentsFirst reorders, in place, a run of transactions that all share
+// the same CreatedAt so any transaction which is a parent of another in the run
+// appears before its children. Transactions with no parent/child relationship
+// inside the run keep their incoming relative order (the sort is stable), which
+// preserves the iterator's ordering for unrelated transactions.
+func orderRunParentsFirst(run []*utxo.UnminedTransaction) {
+	n := len(run)
+
+	// Map each hash in the run to its slot so intra-run parent edges can be found.
+	pos := make(map[chainhash.Hash]int, n)
+	for i, tx := range run {
+		pos[tx.Node.Hash] = i
+	}
+
+	// parents[i] = slots within the run whose outputs transaction i spends.
+	parents := make([][]int, n)
+	for i, tx := range run {
+		if tx.TxInpoints == nil {
+			continue
+		}
+
+		for _, parentHash := range tx.TxInpoints.GetParentTxHashes() {
+			if p, ok := pos[parentHash]; ok && p != i {
+				parents[i] = append(parents[i], p)
+			}
+		}
+	}
+
+	// depth[i] = length of the longest in-run ancestor chain ending at i. A
+	// parent always has a strictly smaller depth than its child, so ordering by
+	// depth places parents before children. Computed iteratively (explicit
+	// stack) to avoid deep recursion on long dependency chains.
+	const (
+		unvisited int8 = iota
+		active
+		done
+	)
+
+	depth := make([]int, n)
+	state := make([]int8, n)
+	stack := make([]int, 0, n)
+
+	for i := 0; i < n; i++ {
+		if state[i] != unvisited {
+			continue
+		}
+
+		stack = append(stack, i)
+
+		for len(stack) > 0 {
+			v := stack[len(stack)-1]
+
+			if state[v] == unvisited {
+				state[v] = active
+				for _, p := range parents[v] {
+					if state[p] == unvisited {
+						stack = append(stack, p)
+					}
+				}
+
+				continue
+			}
+
+			stack = stack[:len(stack)-1]
+			if state[v] == done {
+				continue
+			}
+
+			d := 0
+			for _, p := range parents[v] {
+				// Parents still active indicate a cycle (impossible for a tx
+				// DAG); skip them so this terminates rather than looping.
+				if state[p] == done && depth[p]+1 > d {
+					d = depth[p] + 1
+				}
+			}
+
+			depth[v] = d
+			state[v] = done
+		}
+	}
+
+	// Stable-sort slot indices by depth; equal depths keep original order.
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+
+	sort.SliceStable(order, func(a, b int) bool {
+		return depth[order[a]] < depth[order[b]]
+	})
+
+	reordered := make([]*utxo.UnminedTransaction, n)
+	for k, idx := range order {
+		reordered[k] = run[idx]
+	}
+
+	copy(run, reordered)
+}
+
 // fixUnminedSinceInconsistencies performs a lightweight scan of all records in the UTXO store
 // to detect and fix unmined_since inconsistencies: transactions that have block_ids on the
 // main chain but still have unmined_since set. This can happen from previous bugs, crashes,
@@ -2683,10 +2818,7 @@ func (b *BlockAssembler) loadUnminedTransactions(ctx context.Context, validateIn
 
 	b.logger.Infof("[loadUnminedTransactions] sorting %d unmined transactions by createdAt", len(unminedTransactions))
 
-	sort.Slice(unminedTransactions, func(i, j int) bool {
-		// sort by createdAt, oldest first
-		return unminedTransactions[i].CreatedAt < unminedTransactions[j].CreatedAt
-	})
+	stableSortUnminedByCreatedAt(unminedTransactions)
 
 	txCount := len(unminedTransactions)
 
@@ -3172,7 +3304,15 @@ func (b *BlockAssembler) loadUnminedTransactionsWithDiskSort(ctx context.Context
 	// Sort the lightweight entries in memory
 	sortStart := time.Now()
 	sort.Slice(sortEntries, func(i, j int) bool {
-		return sortEntries[i].CreatedAt < sortEntries[j].CreatedAt
+		if sortEntries[i].CreatedAt != sortEntries[j].CreatedAt {
+			return sortEntries[i].CreatedAt < sortEntries[j].CreatedAt
+		}
+		// Deterministic tiebreak on equal CreatedAt: Sequence is the iterator
+		// yield order, which places parents before children where the iterator
+		// itself is ordered. This path does not run validateParentChain (it is
+		// gated on OnRestartValidateParentChain being false), so it never drops
+		// on misordering; the tiebreak removes non-determinism between restarts.
+		return sortEntries[i].Sequence < sortEntries[j].Sequence
 	})
 	txCount := len(sortEntries)
 	var countBucket string

--- a/services/blockassembly/unmined_sort_test.go
+++ b/services/blockassembly/unmined_sort_test.go
@@ -1,0 +1,288 @@
+// Package blockassembly provides functionality for assembling Bitcoin blocks in Teranode.
+package blockassembly
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// txHash returns a deterministic, unique hash for a given id (0-255).
+func txHash(id byte) chainhash.Hash {
+	var h chainhash.Hash
+	for i := range h {
+		h[i] = id
+	}
+
+	return h
+}
+
+// minedParent is a hash that never appears in the unmined set, standing in for a
+// parent that is already mined on the best chain.
+var minedParent = chainhash.Hash{}
+
+// multiParentInpointsPtr builds a *TxInpoints spending vout 0 of each parent.
+func multiParentInpointsPtr(parents ...chainhash.Hash) *subtree.TxInpoints {
+	inputs := make([]*bt.Input, 0, len(parents))
+
+	for _, p := range parents {
+		in := &bt.Input{PreviousTxOutIndex: 0}
+		if err := in.PreviousTxIDAdd(&p); err != nil {
+			panic(err)
+		}
+
+		inputs = append(inputs, in)
+	}
+
+	ti, err := subtree.NewTxInpointsFromInputs(inputs)
+	if err != nil {
+		panic(err)
+	}
+
+	return &ti
+}
+
+// mkUnmined builds an unmined transaction with the given id, CreatedAt and parents.
+func mkUnmined(id byte, createdAt int, parents ...chainhash.Hash) *utxo.UnminedTransaction {
+	if len(parents) == 0 {
+		parents = []chainhash.Hash{minedParent}
+	}
+
+	return &utxo.UnminedTransaction{
+		Node: &subtree.Node{
+			Hash:        txHash(id),
+			Fee:         1000,
+			SizeInBytes: 250,
+		},
+		TxInpoints:   multiParentInpointsPtr(parents...),
+		CreatedAt:    createdAt,
+		UnminedSince: 1,
+	}
+}
+
+// permutations invokes fn with every permutation of the input slice.
+func permutations(txs []*utxo.UnminedTransaction, fn func([]*utxo.UnminedTransaction)) {
+	var permute func(k int)
+
+	permute = func(k int) {
+		if k == len(txs) {
+			cp := make([]*utxo.UnminedTransaction, len(txs))
+			copy(cp, txs)
+			fn(cp)
+
+			return
+		}
+
+		for i := k; i < len(txs); i++ {
+			txs[k], txs[i] = txs[i], txs[k]
+			permute(k + 1)
+			txs[k], txs[i] = txs[i], txs[k]
+		}
+	}
+
+	permute(0)
+}
+
+// indexOf returns the position of the transaction with the given id, or -1.
+func indexOf(txs []*utxo.UnminedTransaction, id byte) int {
+	want := txHash(id)
+	for i, tx := range txs {
+		if tx.Node.Hash.IsEqual(&want) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func TestStableSortUnminedByCreatedAt(t *testing.T) {
+	t.Run("same timestamp parent/child - all permutations keep parent first", func(t *testing.T) {
+		// parent (id 1) and child (id 2) share CreatedAt=100; child spends parent.
+		base := []*utxo.UnminedTransaction{
+			mkUnmined(1, 100),
+			mkUnmined(2, 100, txHash(1)),
+		}
+
+		count := 0
+
+		permutations(base, func(perm []*utxo.UnminedTransaction) {
+			count++
+			stableSortUnminedByCreatedAt(perm)
+
+			require.Len(t, perm, 2, "no transaction may be dropped")
+			require.Less(t, indexOf(perm, 1), indexOf(perm, 2), "parent must sort before child")
+		})
+
+		require.Equal(t, 2, count)
+	})
+
+	t.Run("same timestamp 3-deep chain - all permutations topologically ordered", func(t *testing.T) {
+		// A(1) <- B(2) <- C(3), all CreatedAt=100.
+		base := []*utxo.UnminedTransaction{
+			mkUnmined(1, 100),
+			mkUnmined(2, 100, txHash(1)),
+			mkUnmined(3, 100, txHash(2)),
+		}
+
+		permutations(base, func(perm []*utxo.UnminedTransaction) {
+			stableSortUnminedByCreatedAt(perm)
+
+			require.Len(t, perm, 3)
+			require.Less(t, indexOf(perm, 1), indexOf(perm, 2))
+			require.Less(t, indexOf(perm, 2), indexOf(perm, 3))
+		})
+	})
+
+	t.Run("same timestamp diamond - both parents before shared child", func(t *testing.T) {
+		// A(1) is parent of B(2) and C(3); D(4) spends both B and C. All CreatedAt=100.
+		base := []*utxo.UnminedTransaction{
+			mkUnmined(1, 100),
+			mkUnmined(2, 100, txHash(1)),
+			mkUnmined(3, 100, txHash(1)),
+			mkUnmined(4, 100, txHash(2), txHash(3)),
+		}
+
+		permutations(base, func(perm []*utxo.UnminedTransaction) {
+			stableSortUnminedByCreatedAt(perm)
+
+			require.Len(t, perm, 4)
+			require.Less(t, indexOf(perm, 1), indexOf(perm, 2))
+			require.Less(t, indexOf(perm, 1), indexOf(perm, 3))
+			require.Less(t, indexOf(perm, 2), indexOf(perm, 4))
+			require.Less(t, indexOf(perm, 3), indexOf(perm, 4))
+		})
+	})
+
+	t.Run("cross-timestamp ordering is by CreatedAt", func(t *testing.T) {
+		// Child (id 2) has an EARLIER CreatedAt than parent (id 1). The primary
+		// sort key is CreatedAt, so ordering follows CreatedAt across different
+		// timestamps; the topological tiebreak only applies within equal values.
+		in := []*utxo.UnminedTransaction{
+			mkUnmined(1, 200),
+			mkUnmined(2, 100, txHash(1)),
+		}
+
+		stableSortUnminedByCreatedAt(in)
+
+		require.Equal(t, 100, in[0].CreatedAt)
+		require.Equal(t, 200, in[1].CreatedAt)
+	})
+
+	t.Run("unrelated same-timestamp transactions keep iterator order", func(t *testing.T) {
+		// ids 10,11,12 are mutually unrelated and share CreatedAt=100; a stable
+		// sort must preserve their incoming order.
+		in := []*utxo.UnminedTransaction{
+			mkUnmined(10, 100),
+			mkUnmined(11, 100),
+			mkUnmined(12, 100),
+		}
+
+		stableSortUnminedByCreatedAt(in)
+
+		require.Equal(t, 0, indexOf(in, 10))
+		require.Equal(t, 1, indexOf(in, 11))
+		require.Equal(t, 2, indexOf(in, 12))
+	})
+
+	t.Run("SQLite-style: many identical CreatedAt with embedded parent/child", func(t *testing.T) {
+		// The SQLite store stamps CreatedAt at one-second resolution, so a whole
+		// second of transactions collides. Bury a child (id 2) BEFORE its parent
+		// (id 1) inside a large equal-timestamp run and confirm it is reordered.
+		in := make([]*utxo.UnminedTransaction, 0, 100)
+		in = append(in, mkUnmined(2, 100, txHash(1))) // child first (worst case)
+
+		for id := byte(50); id < 148; id++ {
+			in = append(in, mkUnmined(id, 100)) // filler, unrelated
+		}
+
+		in = append(in, mkUnmined(1, 100)) // parent last
+
+		stableSortUnminedByCreatedAt(in)
+
+		require.Len(t, in, 100)
+		require.Less(t, indexOf(in, 1), indexOf(in, 2), "parent must be reordered before child")
+	})
+}
+
+// TestStableSortPreventsValidateParentChainDrop is the end-to-end regression
+// test for issue 1157: a same-timestamp parent/child fed child-first must be
+// reordered so validateParentChain retains both rather than dropping the child.
+func TestStableSortPreventsValidateParentChainDrop(t *testing.T) {
+	ctx := context.Background()
+
+	newAssembler := func() (*BlockAssembler, *utxo.MockUtxostore) {
+		mockStore := new(utxo.MockUtxostore)
+
+		testSettings := &settings.Settings{}
+		testSettings.BlockAssembly.ParentValidationBatchSize = 50
+		testSettings.BlockAssembly.OnRestartValidateParentChain = true
+		testSettings.BlockAssembly.OnRestartRemoveInvalidParentChainTxs = true
+
+		ba := &BlockAssembler{
+			utxoStore: mockStore,
+			settings:  testSettings,
+			logger:    ulogger.TestLogger{},
+		}
+
+		// Parent (id 1) references a mined parent (empty hash, on best chain);
+		// child (id 2) references the in-list parent (id 1).
+		mockStore.On("BatchDecorate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				for _, unresolved := range args.Get(1).([]*utxo.UnresolvedMetaData) {
+					if unresolved.Hash.IsEqual(&minedParent) {
+						unresolved.Data = &meta.Data{BlockIDs: []uint32{1}, UnminedSince: 0}
+					} else {
+						// in-list unmined parent (id 1)
+						unresolved.Data = &meta.Data{BlockIDs: []uint32{}, UnminedSince: 1}
+					}
+				}
+			}).
+			Return(nil)
+
+		return ba, mockStore
+	}
+
+	bestChain := map[uint32]bool{1: true}
+
+	t.Run("child-first without sort is dropped (demonstrates the bug)", func(t *testing.T) {
+		ba, _ := newAssembler()
+
+		// Deliberately unsorted: child before parent, same CreatedAt.
+		unsorted := []*utxo.UnminedTransaction{
+			mkUnmined(2, 100, txHash(1)),
+			mkUnmined(1, 100),
+		}
+
+		valid, err := ba.validateParentChain(ctx, unsorted, bestChain)
+		require.NoError(t, err)
+
+		// The child is dropped because its parent appears after it.
+		require.Equal(t, -1, indexOf(valid, 2), "child is dropped when parent sorts after it")
+	})
+
+	t.Run("stable sort then validate retains both", func(t *testing.T) {
+		ba, _ := newAssembler()
+
+		txs := []*utxo.UnminedTransaction{
+			mkUnmined(2, 100, txHash(1)),
+			mkUnmined(1, 100),
+		}
+
+		stableSortUnminedByCreatedAt(txs)
+
+		valid, err := ba.validateParentChain(ctx, txs, bestChain)
+		require.NoError(t, err)
+
+		require.Len(t, valid, 2, "no transaction dropped after stable sort")
+		require.Less(t, indexOf(valid, 1), indexOf(valid, 2))
+	})
+}


### PR DESCRIPTION
Closes #1157

## Problem

On startup, Block Assembly reloads unmined transactions ordered by `CreatedAt` using an unstable `sort.Slice` with no tiebreak. `CreatedAt` is stamped per transaction with **no enforced gap** and **coarse resolution**:

- **Aerospike** (`create.go:907`): `time.Now().UnixMilli()` per `Create` — millisecond resolution.
- **SQLite** (`sql.go`): `inserted_at` defaults to `CURRENT_TIMESTAMP`, emitted as second-precision `"YYYY-MM-DD HH:MM:SS"` — **every transaction created in the same second shares a `CreatedAt`**.
- **Postgres**: `TIMESTAMPTZ` truncated by `UnixMilli()` — same-ms collisions under load.

The tx dependency only guarantees `parent.CreatedAt ≤ child.CreatedAt` in wall-clock; it does **not** guarantee a gap. So a same-timestamp parent/child can sort child-first. `validateParentChain` (`BlockAssembler.go:2222`) then treats parent-after-child as invalid ordering and, with the default flags `OnRestartValidateParentChain=true` / `OnRestartRemoveInvalidParentChainTxs=true`, **drops the child and cascades to its descendants** (`:2232-2247`) — silently shedding part of the mining candidate until a later restart or resubmit.

Not consensus-unsafe (any in-block order is valid post-Genesis; txs remain in the UTXO store), but a real timing-dependent mining-candidate completeness regression.

## Fix

- **In-memory path** (`BlockAssembler.go:2686`): replace the unstable sort with `stableSortUnminedByCreatedAt` — a stable sort by `CreatedAt` followed by a per-run topological reorder that places in-set parents before their children on equal timestamps. The reorder is independent of iterator order (works on both SQL and Aerospike), touches only same-timestamp runs, and uses an iterative longest-ancestor-chain depth (no recursion) with a cycle guard.
- **Disk-sort path** (`BlockAssembler.go:3174`): add a deterministic `Sequence` tiebreak. This path is gated on `OnRestartValidateParentChain=false`, so it never runs `validateParentChain` and never drops — the tiebreak removes non-determinism between restarts.

## Tests

New `services/blockassembly/unmined_sort_test.go`:

- Same-timestamp parent/child, 3-deep chain, and diamond — **all permutations** asserted parent-before-child with nothing dropped.
- Cross-timestamp ordering still follows `CreatedAt`; unrelated same-timestamp txs keep iterator order.
- SQLite-style large equal-timestamp run with an embedded child-before-parent — asserted reordered.
- End-to-end regression: child-first fed to `validateParentChain` **is** dropped (demonstrates the bug); after `stableSortUnminedByCreatedAt` both are retained.

## Verification

- `go test -race -tags testtxmetacache ./services/blockassembly/` — ok (99s)
- `go vet ./services/blockassembly/` — clean
- `golangci-lint run ./services/blockassembly/...` — no new issues (4 remaining are pre-existing `prealloc` hints in untouched files)
