### PR TITLE
fix(reliability): fix context handling flagged by SonarQube

### DIFF
--- a/services/alert/server.go
+++ b/services/alert/server.go
@@ -247,7 +247,7 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) (err error)
 
 	// Ensure that RPC connection is valid
 	if !s.appConfig.DisableRPCVerification {
-		if _, err = s.appConfig.Services.Node.BestBlockHash(context.Background()); err != nil {
+		if _, err = s.appConfig.Services.Node.BestBlockHash(ctx); err != nil {
 			return errors.NewServiceError("error talking to Bitcoin node with supplied RPC credentials", err)
 		}
 	}

--- a/services/asset/centrifuge_impl/centrifuge.go
+++ b/services/asset/centrifuge_impl/centrifuge.go
@@ -237,12 +237,15 @@ func (c *Centrifuge) Start(ctx context.Context, addr string) error {
 	_ = c.httpServer.AddHTTPHandler("/connection/websocket", c.authMiddleware(websocketHandler))
 	_ = c.httpServer.AddHTTPHandler("/client/", http.FileServer(http.Dir("./client")))
 
-	shutdownContext, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	_ = shutdownCancel
-
 	<-ctx.Done()
 
 	c.logger.Infof("[AssetService] Centrifuge (impl) service shutting down")
+
+	// Derive the graceful-shutdown timeout here, after ctx is already Done. Using
+	// WithoutCancel keeps ctx's values (e.g. tracing) while giving shutdown its own
+	// 5s budget; deriving it earlier would let the timer expire during the wait above.
+	shutdownContext, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer shutdownCancel()
 
 	if err = c.centrifugeNode.Shutdown(shutdownContext); err != nil {
 		c.logger.Errorf("[AssetService] Centrifuge (impl) node service shutdown error: %s", err)

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -1551,7 +1551,7 @@ func (stp *SubtreeProcessor) reset(blockHeader *model.BlockHeader, moveBackBlock
 }
 
 func (stp *SubtreeProcessor) getConflictingNodes(ctx context.Context, block *model.Block) ([]chainhash.Hash, error) {
-	_, _, deferFn := tracing.Tracer("subtreeprocessor").Start(context.Background(), "getConflictingNodes",
+	_, _, deferFn := tracing.Tracer("subtreeprocessor").Start(ctx, "getConflictingNodes",
 		tracing.WithParentStat(stp.stats),
 		tracing.WithDebugLogMessage(stp.logger, "[SubtreeProcessor][getConflictingNodes][%s] getting conflicting nodes", block.String()),
 	)

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -591,7 +591,7 @@ func (s *Server) logPeerStats(ctx context.Context) {
 					p.GetAddr(), p.GetId(), p.GetServices(), p.GetInbound(), p.GetBytesSent(), p.GetBytesReceived(), p.GetPingTime(), lastSendElapsed, lastRecvElapsed, p.GetCurrentHeight(), p.GetBanscore())
 			}
 
-			state, err := s.blockchainClient.GetFSMCurrentState(context.Background())
+			state, err := s.blockchainClient.GetFSMCurrentState(ctx)
 			if err != nil {
 				ctxLogger.Debugf("Peer stats - Connected: %d, Current FSM State: unknown, error: %v", len(peers), err)
 			} else {

--- a/util/kafka/kafka_listener.go
+++ b/util/kafka/kafka_listener.go
@@ -70,9 +70,14 @@ func StartKafkaListener(ctx context.Context, logger ulogger.Logger, kafkaURL *ur
 	client, err := NewKafkaConsumerGroupFromURL(logger, kafkaURL, groupID, autoCommit, kafkaSettings)
 	if err != nil {
 		logger.Errorf("failed to start Kafka listener for %s: %v", kafkaURL.String(), err)
+		return
 	}
 
-	// create a new context for the consumer, so we are able to stop the consumer gracefully
+	// create a new context for the consumer, so we are able to stop the consumer gracefully.
+	// kCtx is deliberately detached (rooted at Background) and outlives this function:
+	// client.Start is non-blocking, so the only thing that should cancel kCtx is the
+	// goroutine below, tied to the parent ctx. A defer kCancel() here would cancel the
+	// consumer the instant this function returns, before it processes any messages.
 	kCtx, kCancel := context.WithCancel(context.Background())
 
 	// start a go routine to close the client when the context is done


### PR DESCRIPTION
## Summary

Addresses SonarQube reliability issues (`godre:S8188` "defer cancel" and `godre:S8239` "use available ctx"). Contains two genuine bugs plus context-propagation cleanups. Intentional detached-context sites (documented isolation in blockvalidation, `DecoupleTracingSpan`, SQL rollback paths, rebuild timeouts, the kafka consumer lifecycle) are deliberately left as-is and should be marked False Positive in SonarCloud.

## Changes

### Genuine bugs

- **`asset/centrifuge_impl` — graceful shutdown never worked.** The 5s shutdown timeout was created at `Start()` time with its cancel discarded (`_ = shutdownCancel`), then the code blocked on `<-ctx.Done()` indefinitely. By the time `centrifugeNode.Shutdown()` ran, the timer had long expired, so the node got **zero** shutdown grace and the context leaked. Now the timeout is derived *after* `ctx` is Done, via `context.WithoutCancel(ctx)` (keeps ctx values e.g. tracing, drops the already-fired cancellation), with `defer shutdownCancel()`.

- **`util/kafka/kafka_listener` — nil-deref guard.** `return` after a failed consumer-group construction instead of falling through to `Close()`/`Start()` on a nil client.

### Context propagation (`S8239`)

- **`subtreeprocessor/getConflictingNodes`** — start the trace span from the `ctx` parameter, not `context.Background()`, so the span links to the caller's trace instead of orphaning.
- **`alert/Start`** and **`legacy/logPeerStats`** — thread the in-scope `ctx` into the `BestBlockHash` and `GetFSMCurrentState` calls, matching the sibling calls already using `ctx` in the same block.

### Not changed (false positive, documented)

- **`kafka_listener.go` `kCtx` (S8188)** — `client.Start` is **non-blocking** (it spawns the consume loop in a goroutine and returns), so `StartKafkaListener` returns immediately. `kCtx` is deliberately detached (rooted at `Background`) and outlives the function; the only thing meant to cancel it is the parent-ctx goroutine (`<-ctx.Done(); client.Close(); kCancel()`). A `defer kCancel()` would cancel every consumer microseconds after it starts, before it processes a single message. This is now documented in a comment; the S8188 issue should be marked False Positive.

## Testing

```
go build ./util/kafka/ ./services/asset/centrifuge_impl/ ./services/blockassembly/subtreeprocessor/ ./services/alert/ ./services/legacy/   # ok
go vet   (same packages)                                                                                                                  # clean
go test ./util/kafka/ ./services/asset/centrifuge_impl/ ./services/blockassembly/subtreeprocessor/ ./services/alert/                      # ok
```