### PR TITLE
blockvalidation: low-risk micro-optimizations (IsEqual, redundant mutex, defensive copy, dead nil-check)

### DIFF
--- a/services/blockvalidation/catchup/header_chain_cache.go
+++ b/services/blockvalidation/catchup/header_chain_cache.go
@@ -171,10 +171,10 @@ func (hc *HeaderChainCache) GetValidationHeaders(blockHash *chainhash.Hash) ([]*
 		return nil, false
 	}
 
-	// Return a copy to prevent modification
-	result := make([]*model.BlockHeader, len(headers))
-	copy(result, headers)
-	return result, true
+	// Read-only contract: callers (the catchup validation path) only read the
+	// returned slice, so we return the stored slice directly under the RLock
+	// rather than copying it on every block. Do not mutate the result.
+	return headers, true
 }
 
 // HasBlock checks if a block hash exists in the chain index.

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -112,10 +112,6 @@ func (u *Server) fetchBlocksConcurrently(ctx context.Context, catchupCtx *Catchu
 		defer close(workQueue)
 
 		// In production, commonAncestorMeta is always set during catchup initialization
-		if catchupCtx == nil {
-			return errors.NewProcessingError("[catchup:fetchBlocksConcurrently][%s] catchupCtx must not be nil", blockUpTo.Hash().String())
-		}
-
 		if catchupCtx.commonAncestorMeta == nil {
 			return errors.NewProcessingError("[catchup:fetchBlocksConcurrently][%s] commonAncestorMeta must not be nil", blockUpTo.Hash().String())
 		}
@@ -909,7 +905,7 @@ func reverseBlocks(blocks []*model.Block) {
 // verifyBlockHeaders checks that each fetched block's hash matches the expected header.
 func verifyBlockHeaders(blocks []*model.Block, headers []*model.BlockHeader, blockUpTo *model.Block) error {
 	for j, block := range blocks {
-		if block.Hash().String() != headers[j].Hash().String() {
+		if !block.Hash().IsEqual(headers[j].Hash()) {
 			return errors.NewProcessingError("[catchup:batchFetchAndDistribute][%s] block hash mismatch at index %d: expected %s, got %s",
 				blockUpTo.Hash().String(), j, headers[j].Hash().String(), block.Hash().String())
 		}

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1296,7 +1296,6 @@ func (u *BlockValidation) buildSubtreeJobsForBatch(ctx context.Context, block *m
 
 	batchSize := batch.batchEnd - batch.batchStart
 	jobs := make([]*SubtreeWriteJob, batchSize)
-	var jobsMu sync.Mutex
 
 	for i := 0; i < batchSize; i++ {
 		globalIdx := batch.batchStart + i
@@ -1312,9 +1311,9 @@ func (u *BlockValidation) buildSubtreeJobsForBatch(ctx context.Context, block *m
 			if err != nil {
 				return err
 			}
-			jobsMu.Lock()
+			// Each goroutine writes a distinct index; buildG.Wait() below
+			// provides the happens-before that makes these writes visible.
 			jobs[localIdx] = job
-			jobsMu.Unlock()
 			return nil
 		})
 	}

--- a/services/blockvalidation/verify_block_headers_test.go
+++ b/services/blockvalidation/verify_block_headers_test.go
@@ -1,0 +1,36 @@
+package blockvalidation
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyBlockHeaders guards the hash comparison in verifyBlockHeaders, which uses
+// the zero-alloc chainhash.Hash.IsEqual instead of string conversion.
+func TestVerifyBlockHeaders(t *testing.T) {
+	blocks := testhelpers.CreateTestBlockChain(t, 5)
+	blockUpTo := blocks[len(blocks)-1]
+
+	headers := make([]*model.BlockHeader, len(blocks))
+	for i, b := range blocks {
+		headers[i] = b.Header
+	}
+
+	t.Run("all hashes match", func(t *testing.T) {
+		require.NoError(t, verifyBlockHeaders(blocks, headers, blockUpTo))
+	})
+
+	t.Run("mismatch is detected", func(t *testing.T) {
+		mismatched := make([]*model.BlockHeader, len(headers))
+		copy(mismatched, headers)
+		// Swap two distinct headers so positions 0 and 1 no longer match their blocks.
+		mismatched[0], mismatched[1] = mismatched[1], mismatched[0]
+
+		err := verifyBlockHeaders(blocks, mismatched, blockUpTo)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "block hash mismatch at index 0")
+	})
+}


### PR DESCRIPTION
Closes #4662.

Problem

A bundle of small, independent, low-risk cleanups in the blockvalidation package. All four items in the issue were confirmed still valid at the cited locations; none had been fixed already.

Fix

1. get_blocks.go:912 (verifyBlockHeaders) — replaced per-block block.Hash().String() != headers[j].Hash().String() with the zero-alloc !block.Hash().IsEqual(headers[j].Hash()). Runs in a per-block catchup loop, so this drops two hex-encode allocations per block.
2. quick_validate.go (buildSubtreeJobsForBatch) — removed the jobsMu mutex around jobs[localIdx] = job. Each goroutine writes a distinct index and buildG.Wait() provides the happens-before, so the lock was pure overhead and false cache-line contention. Added a comment documenting the memory-safety reasoning.
3. catchup/header_chain_cache.go (GetValidationHeaders) — return the stored slice directly under the existing RLock instead of allocating + copying on every block during catchup. Verified the read-only contract: the sole production caller (catchup.go:1083) passes the slice into ValidateBlockOptions.CachedHeaders, where it is only read and ultimately handed to waitForPreviousBlocksToBeProcessed (whose parameter is in fact unused). Documented the read-only contract in a comment.
4. get_blocks.go (fetchBlocksConcurrently) — removed the dead if catchupCtx == nil guard. catchupCtx is already dereferenced at the top of the function (lines 64-67), so the guard nested inside a later goroutine was unreachable as a guard. The adjacent commonAncestorMeta == nil check (which the existing comment actually describes) is retained.