### PR TITLE
perf(utxo): cut allocations on the tx-meta decorate + cache-repopulate hot path

### DIFF
--- a/stores/txmetacache/batchdecorate_pool_test.go
+++ b/stores/txmetacache/batchdecorate_pool_test.go
@@ -86,7 +86,7 @@ func hashFor(g, i int) chainhash.Hash {
 // pooled serialization buffers, every decorated transaction lands in the cache
 // with its own correct metadata (no buffer cross-contamination within a call).
 func Test_TxMetaCache_BatchDecorate_PooledBuffers_Correct(t *testing.T) {
-	for _, bt := range []BucketType{Unallocated, Native} {
+	for _, bt := range []BucketType{Unallocated, Native, Pointer} {
 		cache := newPerHashCache(t, bt)
 		ctx := context.Background()
 
@@ -108,12 +108,39 @@ func Test_TxMetaCache_BatchDecorate_PooledBuffers_Correct(t *testing.T) {
 	}
 }
 
+// Test_putMetaBytesBuf_maxRetainGuard mirrors the guard on putTxMetaCacheReadBuffer:
+// an oversized buffer must be shrunk back to the initial capacity before it is
+// returned to the pool, so an occasional large-parent tx cannot permanently bloat
+// the pooled write buffers and ratchet up process RSS. A normally-sized buffer is
+// retained as-is (only its length reset).
+func Test_putMetaBytesBuf_maxRetainGuard(t *testing.T) {
+	oversized := make([]byte, metaBytesBufMaxRetain+1)
+	op := &oversized
+	putMetaBytesBuf(op)
+	require.LessOrEqual(t, cap(*op), metaBytesBufInitialCapacity, "oversized buffer must be shrunk before returning to pool")
+	require.Len(t, *op, 0)
+
+	normal := make([]byte, 100, metaBytesBufInitialCapacity)
+	np := &normal
+	putMetaBytesBuf(np)
+	require.Equal(t, metaBytesBufInitialCapacity, cap(*np), "normally-sized buffer must be retained")
+	require.Len(t, *np, 0)
+}
+
 // Test_TxMetaCache_BatchDecorate_PooledBuffers_Concurrent stresses the buffer
 // pool: many goroutines run BatchDecorate over disjoint hash sets at once. Each
 // entry must still round-trip to its own hash-derived metadata. Run under -race
-// to catch any cross-goroutine reuse of a pooled buffer.
+// to catch any cross-goroutine reuse of a pooled buffer. Pointer is included
+// because it deserializes each value into a fresh *meta.Data — the path most
+// sensitive to a recycled buffer aliasing another tx's bytes.
 func Test_TxMetaCache_BatchDecorate_PooledBuffers_Concurrent(t *testing.T) {
-	cache := newPerHashCache(t, Unallocated)
+	for _, bt := range []BucketType{Unallocated, Native, Pointer} {
+		testBatchDecoratePooledBuffersConcurrent(t, bt)
+	}
+}
+
+func testBatchDecoratePooledBuffersConcurrent(t *testing.T, bt BucketType) {
+	cache := newPerHashCache(t, bt)
 	ctx := context.Background()
 
 	const (
@@ -122,6 +149,11 @@ func Test_TxMetaCache_BatchDecorate_PooledBuffers_Concurrent(t *testing.T) {
 	)
 
 	var wg sync.WaitGroup
+
+	// require/FailNow must run on the test goroutine (testify contract), so child
+	// goroutines report BatchDecorate errors over a channel and we assert after Wait.
+	errCh := make(chan error, goroutines)
+
 	for g := 0; g < goroutines; g++ {
 		wg.Add(1)
 
@@ -133,19 +165,26 @@ func Test_TxMetaCache_BatchDecorate_PooledBuffers_Concurrent(t *testing.T) {
 				items[i] = &utxo.UnresolvedMetaData{Hash: hashFor(g, i)}
 			}
 
-			require.NoError(t, cache.BatchDecorate(ctx, items, fields.Fee, fields.SizeInBytes, fields.TxInpoints))
+			if err := cache.BatchDecorate(ctx, items, fields.Fee, fields.SizeInBytes, fields.TxInpoints); err != nil {
+				errCh <- err
+			}
 		}(g)
 	}
 
 	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
 
 	for g := 0; g < goroutines; g++ {
 		for i := 0; i < perG; i++ {
 			h := hashFor(g, i)
 			got, found := cache.GetMetaCached(ctx, h)
-			require.True(t, found, "g=%d tx %d missing", g, i)
-			require.Equal(t, feeFor(h), got.Fee, "g=%d tx %d fee", g, i)
-			require.Equal(t, sizeFor(h), got.SizeInBytes, "g=%d tx %d size", g, i)
+			require.True(t, found, "bucket %v: g=%d tx %d missing", bt, g, i)
+			require.Equal(t, feeFor(h), got.Fee, "bucket %v: g=%d tx %d fee", bt, g, i)
+			require.Equal(t, sizeFor(h), got.SizeInBytes, "bucket %v: g=%d tx %d size", bt, g, i)
 		}
 	}
 }

--- a/stores/txmetacache/batchdecorate_pool_test.go
+++ b/stores/txmetacache/batchdecorate_pool_test.go
@@ -1,0 +1,151 @@
+package txmetacache
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtree "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/nullstore"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// perHashDecoratingStore decorates each item with metadata DERIVED FROM ITS HASH
+// (fee and size are functions of the hash). This makes the pooled MetaBytes
+// buffers in BatchDecorate observable: if a recycled buffer ever leaked one tx's
+// bytes into another's cache entry, the round-tripped fee/size would not match
+// the hash and the test would fail.
+type perHashDecoratingStore struct {
+	*nullstore.NullStore
+
+	// A valid, non-empty TxInpoints so the decorated meta is eligible for
+	// caching: TxMetaCache.BatchDecorate refuses to cache a non-coinbase tx with
+	// empty ParentTxHashes (that would poison the cache for subtree validation).
+	inpoints subtree.TxInpoints
+}
+
+func feeFor(h chainhash.Hash) uint64  { return binary.LittleEndian.Uint64(h[0:8]) }
+func sizeFor(h chainhash.Hash) uint64 { return binary.LittleEndian.Uint64(h[8:16]) }
+
+func (s *perHashDecoratingStore) BatchDecorate(_ context.Context, items []*utxo.UnresolvedMetaData, _ ...fields.FieldName) error {
+	for _, it := range items {
+		if it == nil {
+			continue
+		}
+
+		it.Data = &meta.Data{
+			Fee:         feeFor(it.Hash),
+			SizeInBytes: sizeFor(it.Hash),
+			TxInpoints:  s.inpoints,
+			BlockIDs:    make([]uint32, 0), // empty => not yet mined => eligible for caching
+		}
+		it.Err = nil
+	}
+
+	return nil
+}
+
+func newPerHashCache(t testing.TB, bucketType BucketType) *TxMetaCache {
+	t.Helper()
+
+	ns, err := nullstore.NewNullStore()
+	require.NoError(t, err)
+	require.NoError(t, ns.SetBlockHeight(100))
+
+	// A single-parent tx yields a valid, cacheable TxInpoints.
+	tx := bt.NewTx()
+	require.NoError(t, tx.From("0000000000000000000000000000000000000000000000000000000000000001", 0,
+		"76a914000000000000000000000000000000000000000088ac", 1000))
+
+	inpoints, err := subtree.NewTxInpointsFromTx(tx)
+	require.NoError(t, err)
+
+	c, err := NewTxMetaCache(context.Background(), settings.NewSettings(), ulogger.TestLogger{},
+		&perHashDecoratingStore{NullStore: ns, inpoints: inpoints}, bucketType)
+	require.NoError(t, err)
+
+	return c.(*TxMetaCache)
+}
+
+func hashFor(g, i int) chainhash.Hash {
+	var h chainhash.Hash
+	binary.LittleEndian.PutUint32(h[0:4], uint32(g))
+	binary.LittleEndian.PutUint32(h[8:12], uint32(i)) // distinct in both fee and size words
+	return h
+}
+
+// Test_TxMetaCache_BatchDecorate_PooledBuffers_Correct verifies that, with the
+// pooled serialization buffers, every decorated transaction lands in the cache
+// with its own correct metadata (no buffer cross-contamination within a call).
+func Test_TxMetaCache_BatchDecorate_PooledBuffers_Correct(t *testing.T) {
+	for _, bt := range []BucketType{Unallocated, Native} {
+		cache := newPerHashCache(t, bt)
+		ctx := context.Background()
+
+		const n = 500
+		items := make([]*utxo.UnresolvedMetaData, n)
+		for i := range items {
+			items[i] = &utxo.UnresolvedMetaData{Hash: hashFor(0, i)}
+		}
+
+		require.NoError(t, cache.BatchDecorate(ctx, items, fields.Fee, fields.SizeInBytes, fields.TxInpoints))
+
+		for i := 0; i < n; i++ {
+			h := hashFor(0, i)
+			got, found := cache.GetMetaCached(ctx, h)
+			require.True(t, found, "bucket %v: tx %d missing from cache", bt, i)
+			require.Equal(t, feeFor(h), got.Fee, "bucket %v: tx %d fee", bt, i)
+			require.Equal(t, sizeFor(h), got.SizeInBytes, "bucket %v: tx %d size", bt, i)
+		}
+	}
+}
+
+// Test_TxMetaCache_BatchDecorate_PooledBuffers_Concurrent stresses the buffer
+// pool: many goroutines run BatchDecorate over disjoint hash sets at once. Each
+// entry must still round-trip to its own hash-derived metadata. Run under -race
+// to catch any cross-goroutine reuse of a pooled buffer.
+func Test_TxMetaCache_BatchDecorate_PooledBuffers_Concurrent(t *testing.T) {
+	cache := newPerHashCache(t, Unallocated)
+	ctx := context.Background()
+
+	const (
+		goroutines = 8
+		perG       = 300
+	)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+
+		go func(g int) {
+			defer wg.Done()
+
+			items := make([]*utxo.UnresolvedMetaData, perG)
+			for i := range items {
+				items[i] = &utxo.UnresolvedMetaData{Hash: hashFor(g, i)}
+			}
+
+			require.NoError(t, cache.BatchDecorate(ctx, items, fields.Fee, fields.SizeInBytes, fields.TxInpoints))
+		}(g)
+	}
+
+	wg.Wait()
+
+	for g := 0; g < goroutines; g++ {
+		for i := 0; i < perG; i++ {
+			h := hashFor(g, i)
+			got, found := cache.GetMetaCached(ctx, h)
+			require.True(t, found, "g=%d tx %d missing", g, i)
+			require.Equal(t, feeFor(h), got.Fee, "g=%d tx %d fee", g, i)
+			require.Equal(t, sizeFor(h), got.SizeInBytes, "g=%d tx %d size", g, i)
+		}
+	}
+}

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -493,6 +493,36 @@ func (t *TxMetaCache) Get(ctx context.Context, hash *chainhash.Hash, f ...fields
 	return t.utxoStore.Get(ctx, hash, f...)
 }
 
+const (
+	metaBytesBufInitialCapacity = 256
+	metaBytesBufMaxRetain       = 64 * 1024
+)
+
+// metaBytesBufPool recycles the per-transaction MetaBytes serialization buffers
+// used to repopulate the cache in BatchDecorate. The initial capacity covers the
+// common single-parent transaction (17-byte header + a few dozen inpoint bytes)
+// with headroom; larger transactions grow their buffer on first use.
+var metaBytesBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, metaBytesBufInitialCapacity)
+		return &b
+	},
+}
+
+// putMetaBytesBuf returns a buffer to metaBytesBufPool, mirroring the max-retain
+// guard on putTxMetaCacheReadBuffer: an occasional large-parent tx must not pin a
+// hundreds-of-KB backing array in the pool forever and ratchet up process RSS, so
+// any buffer grown past metaBytesBufMaxRetain is dropped for a fresh initial-cap one.
+func putMetaBytesBuf(bp *[]byte) {
+	if cap(*bp) > metaBytesBufMaxRetain {
+		*bp = make([]byte, 0, metaBytesBufInitialCapacity)
+	} else {
+		*bp = (*bp)[:0]
+	}
+
+	metaBytesBufPool.Put(bp)
+}
+
 // BatchDecorate retrieves metadata for multiple transactions in a single batch operation.
 // This is more efficient than calling Get for each transaction individually.
 //
@@ -506,17 +536,6 @@ func (t *TxMetaCache) Get(ctx context.Context, hash *chainhash.Hash, f ...fields
 //
 // The method optimizes retrieval by first checking the cache for each transaction,
 // then batching any cache misses into a single call to the underlying store.
-// metaBytesBufPool recycles the per-transaction MetaBytes serialization buffers
-// used to repopulate the cache in BatchDecorate. The initial capacity covers the
-// common single-parent transaction (17-byte header + a few dozen inpoint bytes)
-// with headroom; larger transactions grow their buffer on first use and keep it.
-var metaBytesBufPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, 0, 256)
-		return &b
-	},
-}
-
 func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.UnresolvedMetaData, fields ...fields.FieldName) error {
 	if err := t.utxoStore.BatchDecorate(ctx, hashes, fields...); err != nil {
 		return err
@@ -538,7 +557,7 @@ func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.Unresolv
 
 	defer func() {
 		for _, bp := range bufPtrs {
-			metaBytesBufPool.Put(bp)
+			putMetaBytesBuf(bp)
 		}
 	}()
 
@@ -574,7 +593,7 @@ func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.Unresolv
 
 		txMetaBytes, err := data.Data.MetaBytesInto((*bufPtr)[:0])
 		if err != nil {
-			metaBytesBufPool.Put(bufPtr)
+			putMetaBytesBuf(bufPtr)
 
 			if errors.Is(err, errors.ErrProcessing) {
 				t.logger.Debugf("error serializing txMeta for [%s]: %v", data.Hash.String(), err)

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -506,6 +506,17 @@ func (t *TxMetaCache) Get(ctx context.Context, hash *chainhash.Hash, f ...fields
 //
 // The method optimizes retrieval by first checking the cache for each transaction,
 // then batching any cache misses into a single call to the underlying store.
+// metaBytesBufPool recycles the per-transaction MetaBytes serialization buffers
+// used to repopulate the cache in BatchDecorate. The initial capacity covers the
+// common single-parent transaction (17-byte header + a few dozen inpoint bytes)
+// with headroom; larger transactions grow their buffer on first use and keep it.
+var metaBytesBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 256)
+		return &b
+	},
+}
+
 func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.UnresolvedMetaData, fields ...fields.FieldName) error {
 	if err := t.utxoStore.BatchDecorate(ctx, hashes, fields...); err != nil {
 		return err
@@ -517,6 +528,19 @@ func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.Unresolv
 	// Note: values are serialized the same way SetCache() does (via MetaBytes).
 	keys := make([][]byte, 0, len(hashes))
 	values := make([][]byte, 0, len(hashes))
+
+	// The per-tx MetaBytes serialization buffers are recycled through a pool:
+	// SetCacheMultiValuesRaw (SetMulti) copies the value bytes into the cache's
+	// own chunk storage before returning, so each buffer is dead afterwards.
+	// They are held in `values` until then, so return them only after the cache
+	// write completes (deferred), not per iteration.
+	bufPtrs := make([]*[]byte, 0, len(hashes))
+
+	defer func() {
+		for _, bp := range bufPtrs {
+			metaBytesBufPool.Put(bp)
+		}
+	}()
 
 	for _, data := range hashes {
 		if data == nil || data.Data == nil {
@@ -545,16 +569,24 @@ func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.Unresolv
 			t.logger.Warnf("stored tx meta maybe too big for txmeta cache, size: %d, parent hash count: %d", data.Data.SizeInBytes, len(data.Data.TxInpoints.ParentTxHashes))
 		}
 
-		// get the metabytes directly here.
-		txMetaBytes, err := data.Data.MetaBytes()
+		// Serialize into a pooled buffer; the cache copies it on insert.
+		bufPtr := metaBytesBufPool.Get().(*[]byte)
+
+		txMetaBytes, err := data.Data.MetaBytesInto((*bufPtr)[:0])
 		if err != nil {
+			metaBytesBufPool.Put(bufPtr)
+
 			if errors.Is(err, errors.ErrProcessing) {
 				t.logger.Debugf("error serializing txMeta for [%s]: %v", data.Hash.String(), err)
 			} else {
 				t.logger.Errorf("error serializing txMeta for [%s]: %v", data.Hash.String(), err)
 			}
+
 			continue
 		}
+
+		*bufPtr = txMetaBytes // keep the (possibly grown) backing array for reuse
+		bufPtrs = append(bufPtrs, bufPtr)
 
 		keys = append(keys, data.Hash.CloneBytes())
 		values = append(values, txMetaBytes)

--- a/stores/utxo/aerospike/build_batch_records_bench_test.go
+++ b/stores/utxo/aerospike/build_batch_records_bench_test.go
@@ -1,0 +1,94 @@
+package aerospike
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/util"
+)
+
+// BenchmarkBuildBatchRecords measures the per-call / per-item allocations of the
+// BatchDecorate setup loop (the network-free construction phase): one
+// aerospike.Key per item, addAbstractedBins expanding the field set per item,
+// FieldNamesToStrings converting it per item, and one aerospike.BatchRead per
+// item. This is the Tier-A allocation surface — Key/BatchRead pooling and
+// hoisting the per-item field-set/string-slice work out of the loop should drop
+// allocs/op here. No live Aerospike is needed; buildBatchRecords does no I/O.
+//
+// Field-set scenarios mirror real callers:
+//   - default: caller passes no fields → the hardcoded default bin set
+//   - prefetch_parents: subtreevalidation's parent prefetch (BlockIDs+Tx)
+//   - tx: block persister / asset (full transaction)
+func BenchmarkBuildBatchRecords(b *testing.B) {
+	tSettings := settings.NewSettings()
+	s := &Store{namespace: "test", setName: "utxo", settings: tSettings}
+	policy := util.GetAerospikeBatchReadPolicy(tSettings)
+
+	scenarios := []struct {
+		name           string
+		optionalFields []fields.FieldName
+	}{
+		{"default", nil},
+		{"prefetch_parents", []fields.FieldName{fields.BlockIDs, fields.BlockHeights, fields.Tx}},
+		{"tx", []fields.FieldName{fields.Tx}},
+	}
+
+	sizes := []int{128, 1024}
+
+	for _, sc := range scenarios {
+		for _, n := range sizes {
+			items := make([]*utxo.UnresolvedMetaData, n)
+			for i := range items {
+				var h chainhash.Hash
+				binary.LittleEndian.PutUint32(h[:], uint32(i+1))
+				items[i] = &utxo.UnresolvedMetaData{Hash: h, Idx: i}
+			}
+
+			b.Run(sc.name+"/"+itoa(n), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					// Each production BatchDecorate call receives fresh items with
+					// no expanded Fields yet; reset to model that (zero-alloc).
+					for _, it := range items {
+						it.Fields = nil
+					}
+
+					recs, err := s.buildBatchRecords(items, policy, sc.optionalFields)
+					if err != nil {
+						b.Fatalf("buildBatchRecords: %v", err)
+					}
+
+					if len(recs) != n {
+						b.Fatalf("expected %d records, got %d", n, len(recs))
+					}
+				}
+
+				b.ReportMetric(float64(n), "records/op")
+			})
+		}
+	}
+}
+
+// itoa avoids a fmt import for the sub-benchmark labels.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	var buf [20]byte
+
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+
+	return string(buf[i:])
+}

--- a/stores/utxo/aerospike/build_batch_records_test.go
+++ b/stores/utxo/aerospike/build_batch_records_test.go
@@ -1,0 +1,112 @@
+package aerospike
+
+import (
+	"encoding/binary"
+	"testing"
+
+	aerospike "github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/stretchr/testify/require"
+)
+
+func newBuildRecordsStore() *Store {
+	tSettings := settings.NewSettings()
+	return &Store{namespace: "test", setName: "utxo", settings: tSettings}
+}
+
+func makeItems(n int) []*utxo.UnresolvedMetaData {
+	items := make([]*utxo.UnresolvedMetaData, n)
+	for i := range items {
+		var h chainhash.Hash
+		binary.LittleEndian.PutUint32(h[:], uint32(i+1))
+		items[i] = &utxo.UnresolvedMetaData{Hash: h, Idx: i}
+	}
+
+	return items
+}
+
+func binNamesOf(t *testing.T, rec aerospike.BatchRecordIfc) []string {
+	t.Helper()
+	br, ok := rec.(*aerospike.BatchRead)
+	require.True(t, ok, "record is not a *BatchRead")
+
+	return br.BinNames
+}
+
+// Test_buildBatchRecords_UniformDefault verifies the shared-field-set path: with
+// no caller fields, every item gets the expanded default field set and the same
+// wire BinNames, the per-item key digest matches NewKey, and (the hoist's point)
+// every item shares ONE backing array for the expanded fields rather than a
+// fresh allocation each.
+func Test_buildBatchRecords_UniformDefault(t *testing.T) {
+	s := newBuildRecordsStore()
+	policy := aerospike.NewBatchReadPolicy()
+
+	items := makeItems(4)
+
+	recs, err := s.buildBatchRecords(items, policy, nil)
+	require.NoError(t, err)
+	require.Len(t, recs, 4)
+
+	wantFields := s.addAbstractedBins(defaultDecorateBins)
+	wantNames := fields.FieldNamesToStrings(wantFields)
+
+	for i, item := range items {
+		require.Equal(t, wantFields, item.Fields, "item %d expanded fields", i)
+		require.Equal(t, wantNames, binNamesOf(t, recs[i]), "item %d bin names", i)
+
+		wantKey, kerr := aerospike.NewKey(s.namespace, s.setName, item.Hash[:])
+		require.NoError(t, kerr)
+		require.Equal(t, wantKey.Digest(), recs[i].(*aerospike.BatchRead).Key.Digest(), "item %d key digest", i)
+	}
+
+	// Hoist invariant: all uniform items share the same backing array for the
+	// expanded fields (no per-item re-allocation).
+	require.Same(t, &items[0].Fields[0], &items[1].Fields[0],
+		"uniform items must share one expanded-fields backing array")
+}
+
+// Test_buildBatchRecords_OptionalFields verifies a uniform caller-supplied field
+// set is expanded once and applied to every item.
+func Test_buildBatchRecords_OptionalFields(t *testing.T) {
+	s := newBuildRecordsStore()
+	policy := aerospike.NewBatchReadPolicy()
+
+	items := makeItems(3)
+
+	recs, err := s.buildBatchRecords(items, policy, []fields.FieldName{fields.Tx})
+	require.NoError(t, err)
+
+	wantFields := s.addAbstractedBins([]fields.FieldName{fields.Tx})
+	for i, item := range items {
+		require.Equal(t, wantFields, item.Fields)
+		require.Equal(t, fields.FieldNamesToStrings(wantFields), binNamesOf(t, recs[i]))
+	}
+}
+
+// Test_buildBatchRecords_PerItemFieldsOverride verifies an item carrying its own
+// Fields is expanded individually and does not pick up the shared set, while the
+// other items still use the shared set.
+func Test_buildBatchRecords_PerItemFieldsOverride(t *testing.T) {
+	s := newBuildRecordsStore()
+	policy := aerospike.NewBatchReadPolicy()
+
+	items := makeItems(3)
+	items[1].Fields = []fields.FieldName{fields.BlockIDs}
+
+	recs, err := s.buildBatchRecords(items, policy, []fields.FieldName{fields.Tx})
+	require.NoError(t, err)
+
+	sharedFields := s.addAbstractedBins([]fields.FieldName{fields.Tx})
+	overrideFields := s.addAbstractedBins([]fields.FieldName{fields.BlockIDs})
+
+	require.Equal(t, sharedFields, items[0].Fields)
+	require.Equal(t, overrideFields, items[1].Fields)
+	require.Equal(t, sharedFields, items[2].Fields)
+
+	require.Equal(t, fields.FieldNamesToStrings(overrideFields), binNamesOf(t, recs[1]))
+	require.NotEqual(t, binNamesOf(t, recs[0]), binNamesOf(t, recs[1]))
+}

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -570,22 +570,20 @@ func (s *Store) addAbstractedBins(bins []fields.FieldName) []fields.FieldName {
 //   - ctx: Context for cancellation
 //   - items: Transactions to fetch
 //   - fields: Optional fields to retrieve
-func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaData, optionalFields ...fields.FieldName) error {
-	var err error
-
-	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
-	// we only want to read from the master for tx metadata, due to blockIDs being updated
-	// however we still want to read from the replica for the utxos in case of aerospike failures
-	batchPolicy.ReplicaPolicy = aerospike.SEQUENCE
-
-	policy := util.GetAerospikeBatchReadPolicy(s.settings)
-
+//
+// buildBatchRecords constructs the per-item aerospike BatchRead records for a
+// BatchDecorate call: one aerospike.Key per item (digest of the tx hash) plus
+// the expanded field-name set to read. It also records the expanded field set
+// back onto each item (item.Fields) so the result-parsing pass knows which bins
+// were requested. This is pure construction — no network I/O — which makes it
+// the unit the allocation benchmark targets.
+func (s *Store) buildBatchRecords(items []*utxo.UnresolvedMetaData, policy *aerospike.BatchReadPolicy, optionalFields []fields.FieldName) ([]aerospike.BatchRecordIfc, error) {
 	batchRecords := make([]aerospike.BatchRecordIfc, len(items))
 
 	for idx, item := range items {
 		key, err := aerospike.NewKey(s.namespace, s.setName, item.Hash[:])
 		if err != nil {
-			return errors.NewProcessingError("failed to init new aerospike key for txMeta", err)
+			return nil, errors.NewProcessingError("failed to init new aerospike key for txMeta", err)
 		}
 
 		// Default fields - optimized for common use cases without scripts
@@ -602,6 +600,22 @@ func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaD
 		record := aerospike.NewBatchRead(policy, key, fields.FieldNamesToStrings(item.Fields))
 		// Add to batch
 		batchRecords[idx] = record
+	}
+
+	return batchRecords, nil
+}
+
+func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaData, optionalFields ...fields.FieldName) error {
+	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
+	// we only want to read from the master for tx metadata, due to blockIDs being updated
+	// however we still want to read from the replica for the utxos in case of aerospike failures
+	batchPolicy.ReplicaPolicy = aerospike.SEQUENCE
+
+	policy := util.GetAerospikeBatchReadPolicy(s.settings)
+
+	batchRecords, err := s.buildBatchRecords(items, policy, optionalFields)
+	if err != nil {
+		return err
 	}
 
 	if len(batchRecords) == 0 {

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -559,18 +559,6 @@ func (s *Store) addAbstractedBins(bins []fields.FieldName) []fields.FieldName {
 	return newBins
 }
 
-// BatchDecorate efficiently fetches metadata for multiple transactions.
-// It optimizes database access by:
-//   - Batching multiple queries
-//   - Deduplicating requests
-//   - Managing external storage access
-//   - Handling partial responses
-//
-// Parameters:
-//   - ctx: Context for cancellation
-//   - items: Transactions to fetch
-//   - fields: Optional fields to retrieve
-//
 // buildBatchRecords constructs the per-item aerospike BatchRead records for a
 // BatchDecorate call: one aerospike.Key per item (digest of the tx hash) plus
 // the expanded field-name set to read. It also records the expanded field set
@@ -629,6 +617,17 @@ func (s *Store) buildBatchRecords(items []*utxo.UnresolvedMetaData, policy *aero
 // package-level so the common path does not re-allocate it per item.
 var defaultDecorateBins = []fields.FieldName{fields.Fee, fields.SizeInBytes, fields.TxInpoints, fields.BlockIDs, fields.IsCoinbase}
 
+// BatchDecorate efficiently fetches metadata for multiple transactions.
+// It optimizes database access by:
+//   - Batching multiple queries
+//   - Deduplicating requests
+//   - Managing external storage access
+//   - Handling partial responses
+//
+// Parameters:
+//   - ctx: Context for cancellation
+//   - items: Transactions to fetch
+//   - fields: Optional fields to retrieve
 func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaData, optionalFields ...fields.FieldName) error {
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)
 	// we only want to read from the master for tx metadata, due to blockIDs being updated

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -580,30 +580,54 @@ func (s *Store) addAbstractedBins(bins []fields.FieldName) []fields.FieldName {
 func (s *Store) buildBatchRecords(items []*utxo.UnresolvedMetaData, policy *aerospike.BatchReadPolicy, optionalFields []fields.FieldName) ([]aerospike.BatchRecordIfc, error) {
 	batchRecords := make([]aerospike.BatchRecordIfc, len(items))
 
+	// Most BatchDecorate calls request a uniform field set for every item:
+	// callers either pass optionalFields or rely on the default and leave
+	// item.Fields nil. Expand that shared set and convert it to wire names ONCE
+	// and reuse the (read-only) results across every such item, instead of
+	// re-expanding and re-allocating per item. Items that carry their own
+	// item.Fields (the rare per-item path) are expanded individually below.
+	//
+	// The shared slices are only read downstream: the result-parsing pass ranges
+	// over item.Fields, and the aerospike client only reads BatchRead BinNames
+	// (it never sorts or mutates them in place), so sharing one backing array
+	// across records is safe.
+	sharedBins := optionalFields
+	if len(sharedBins) == 0 {
+		sharedBins = defaultDecorateBins
+	}
+
+	sharedExpanded := s.addAbstractedBins(sharedBins)
+	sharedNames := fields.FieldNamesToStrings(sharedExpanded)
+
 	for idx, item := range items {
 		key, err := aerospike.NewKey(s.namespace, s.setName, item.Hash[:])
 		if err != nil {
 			return nil, errors.NewProcessingError("failed to init new aerospike key for txMeta", err)
 		}
 
-		// Default fields - optimized for common use cases without scripts
-		// Services that need full transaction (persister, API) explicitly request fields.Tx
-		bins := []fields.FieldName{fields.Fee, fields.SizeInBytes, fields.TxInpoints, fields.BlockIDs, fields.IsCoinbase}
+		expanded := sharedExpanded
+		names := sharedNames
+
 		if len(item.Fields) > 0 {
-			bins = item.Fields
-		} else if len(optionalFields) > 0 {
-			bins = optionalFields
+			// Item-specific field set: expand and convert it on its own.
+			expanded = s.addAbstractedBins(item.Fields)
+			names = fields.FieldNamesToStrings(expanded)
 		}
 
-		item.Fields = s.addAbstractedBins(bins)
+		item.Fields = expanded
 
-		record := aerospike.NewBatchRead(policy, key, fields.FieldNamesToStrings(item.Fields))
 		// Add to batch
-		batchRecords[idx] = record
+		batchRecords[idx] = aerospike.NewBatchRead(policy, key, names)
 	}
 
 	return batchRecords, nil
 }
+
+// defaultDecorateBins is the field set BatchDecorate reads when the caller
+// requests none — optimized for common use cases without scripts. Services that
+// need the full transaction (persister, API) explicitly request fields.Tx. Kept
+// package-level so the common path does not re-allocate it per item.
+var defaultDecorateBins = []fields.FieldName{fields.Fee, fields.SizeInBytes, fields.TxInpoints, fields.BlockIDs, fields.IsCoinbase}
 
 func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaData, optionalFields ...fields.FieldName) error {
 	batchPolicy := util.GetAerospikeBatchPolicy(s.settings)

--- a/stores/utxo/fields/fields_bench_test.go
+++ b/stores/utxo/fields/fields_bench_test.go
@@ -1,0 +1,27 @@
+package fields
+
+import "testing"
+
+// sinkStrings forces the FieldNamesToStrings result to escape so the benchmark
+// measures the real heap allocation (in production the slice escapes into the
+// aerospike BatchRead record); without the sink, escape analysis stack-
+// allocates the discarded result and reports a misleading 0 allocs/op.
+var sinkStrings []string
+
+// BenchmarkFieldNamesToStrings measures the allocation of converting a field
+// set to its wire string names. BatchDecorate calls this once per item even
+// though every item in a call usually requests the same field set, so the
+// per-call cost is N times this. Tier A hoists it to once per distinct field
+// set per call; this benchmark is the per-conversion baseline.
+func BenchmarkFieldNamesToStrings(b *testing.B) {
+	// Representative expanded set (BlockIDs prefetch expands to ~4 fields; Tx
+	// expands to ~8). Use the larger to bound the cost.
+	fieldSet := []FieldName{Fee, SizeInBytes, TxInpoints, Inputs, Outputs, Version, LockTime, External}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sinkStrings = FieldNamesToStrings(fieldSet)
+	}
+}

--- a/stores/utxo/meta/data.go
+++ b/stores/utxo/meta/data.go
@@ -299,6 +299,20 @@ func (d *Data) Bytes() ([]byte, error) {
 // Use this method when you need to efficiently store or transmit just the
 // metadata portion of a transaction record.
 func (d *Data) MetaBytes() ([]byte, error) {
+	return d.MetaBytesInto(nil)
+}
+
+// MetaBytesInto is MetaBytes that serializes into the caller-provided buffer's
+// backing array when it is large enough, reusing its capacity instead of
+// allocating a fresh slice. The caller passes dst[:0] (any length is reset) and
+// uses the returned slice; dst may be nil (equivalent to MetaBytes). This lets a
+// hot caller — notably the txmetacache cache-repopulate path, which serializes
+// one buffer per transaction and discards it after the cache copies it — recycle
+// the buffer through a sync.Pool and avoid the per-tx outer-buffer allocation.
+//
+// The returned slice's length bounds exactly the bytes written, so stale
+// capacity from a recycled buffer never leaks into the result.
+func (d *Data) MetaBytesInto(dst []byte) ([]byte, error) {
 	// Serialize the TxInpoints first so we can size the outer buffer exactly.
 	// The previous fixed cap of 1024 over-allocated ~10x for the common case
 	// (single-parent tx) and dominated allocator pressure on hot paths (profile
@@ -311,10 +325,20 @@ func (d *Data) MetaBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	buf := make([]byte, 17, 17+len(txInpointsBytes))
+	need := 17 + len(txInpointsBytes)
+
+	buf := dst[:0]
+	if cap(buf) < need {
+		buf = make([]byte, 0, need)
+	}
+
+	buf = buf[:17]
 
 	binary.LittleEndian.PutUint64(buf[:8], d.Fee)
 	binary.LittleEndian.PutUint64(buf[8:16], d.SizeInBytes)
+
+	// Reset the flags byte: a recycled buffer may carry stale bits here.
+	buf[16] = 0
 
 	if d.IsCoinbase {
 		buf[16] |= 0b01

--- a/stores/utxo/meta/data_metabytes_bench_test.go
+++ b/stores/utxo/meta/data_metabytes_bench_test.go
@@ -1,0 +1,44 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	subtree "github.com/bsv-blockchain/go-subtree"
+)
+
+// BenchmarkMetaBytes measures the allocations of serializing tx metadata to its
+// cache-wire form. The txmetacache cache-repopulate path (TxMetaCache.
+// BatchDecorate) calls MetaBytes once per transaction to produce a buffer it
+// then copies into the cache backend and discards — so the buffer is poolable
+// (Tier C). This benchmark is the per-tx baseline for that allocation.
+func BenchmarkMetaBytes(b *testing.B) {
+	// Common case the MetaBytes buffer sizing is tuned for: a single-parent tx.
+	tx := bt.NewTx()
+	if err := tx.From("0000000000000000000000000000000000000000000000000000000000000001", 0,
+		"76a914000000000000000000000000000000000000000088ac", 1000); err != nil {
+		b.Fatalf("build tx: %v", err)
+	}
+
+	inpoints, err := subtree.NewTxInpointsFromTx(tx)
+	if err != nil {
+		b.Fatalf("inpoints: %v", err)
+	}
+
+	d := &Data{
+		Fee:          1000,
+		SizeInBytes:  250,
+		TxInpoints:   inpoints,
+		BlockIDs:     []uint32{100, 101},
+		BlockHeights: []uint32{100, 101},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := d.MetaBytes(); err != nil {
+			b.Fatalf("MetaBytes: %v", err)
+		}
+	}
+}

--- a/stores/utxo/meta/data_metabytesinto_test.go
+++ b/stores/utxo/meta/data_metabytesinto_test.go
@@ -1,0 +1,78 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	subtree "github.com/bsv-blockchain/go-subtree"
+	"github.com/stretchr/testify/require"
+)
+
+func metaBytesIntoFixtures(t *testing.T) []*Data {
+	t.Helper()
+
+	tx := bt.NewTx()
+	require.NoError(t, tx.From("0000000000000000000000000000000000000000000000000000000000000001", 0,
+		"76a914000000000000000000000000000000000000000088ac", 1000))
+
+	inpoints, err := subtree.NewTxInpointsFromTx(tx)
+	require.NoError(t, err)
+
+	return []*Data{
+		{Fee: 1000, SizeInBytes: 250, TxInpoints: inpoints},
+		{Fee: 0, SizeInBytes: 0, IsCoinbase: true}, // empty inpoints, coinbase
+		{Fee: 5, SizeInBytes: 9, Frozen: true, Conflicting: true, Locked: true, InBlock: true, TxInpoints: inpoints},
+	}
+}
+
+// Test_MetaBytesInto_ParityWithMetaBytes verifies MetaBytesInto produces exactly
+// the same bytes as MetaBytes for nil, an empty, and a dirty oversized buffer —
+// i.e. recycling a buffer never changes or leaks into the output.
+func Test_MetaBytesInto_ParityWithMetaBytes(t *testing.T) {
+	for i, d := range metaBytesIntoFixtures(t) {
+		want, err := d.MetaBytes()
+		require.NoError(t, err)
+
+		gotNil, err := d.MetaBytesInto(nil)
+		require.NoError(t, err)
+		require.Equal(t, want, gotNil, "fixture %d: nil buffer", i)
+
+		// A dirty, oversized buffer pre-filled with 0xFF must not leak stale
+		// bytes (especially into the flags byte) and must reuse the backing.
+		dirty := make([]byte, 0, len(want)+64)
+		for j := 0; j < cap(dirty); j++ {
+			dirty = append(dirty, 0xFF)
+		}
+
+		gotDirty, err := d.MetaBytesInto(dirty[:0])
+		require.NoError(t, err)
+		require.Equal(t, want, gotDirty, "fixture %d: dirty reused buffer", i)
+	}
+}
+
+// Test_MetaBytesInto_ReuseSavesOuterAlloc verifies that reusing a sufficiently
+// sized buffer removes the outer-buffer allocation that MetaBytes makes fresh
+// each call. (The separate TxInpoints serialization allocation is in go-subtree
+// and out of scope, so this asserts the delta rather than zero.)
+func Test_MetaBytesInto_ReuseSavesOuterAlloc(t *testing.T) {
+	d := &Data{Fee: 1000, SizeInBytes: 250}
+
+	fresh := testing.AllocsPerRun(100, func() {
+		if _, err := d.MetaBytes(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	buf := make([]byte, 0, 256)
+
+	reused := testing.AllocsPerRun(100, func() {
+		out, err := d.MetaBytesInto(buf[:0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf = out
+	})
+
+	require.Less(t, reused, fresh,
+		"reusing a sized buffer must allocate less than MetaBytes (fresh=%v reused=%v)", fresh, reused)
+}


### PR DESCRIPTION
## Problem

A CPU profile of the `subtree-validator` on a following node showed ~26% of CPU in `runtime.mallocgc`, concentrated in the tx-metadata **decorate + cache-repopulate** path — not transaction validation. On large-block catch-up this is pure GC pressure on a hot path.

This PR removes the bulk of those allocations with two safe, measured changes, each behind allocation benchmarks.

## Changes

**Baseline** — extract the network-free record-construction loop of `aerospike.BatchDecorate` into `buildBatchRecords` (behaviour-preserving) so its allocations can be benchmarked without a live cluster; add allocation benchmarks for the decorate path (`BenchmarkBuildBatchRecords`, `BenchmarkFieldNamesToStrings`, `BenchmarkMetaBytes`).

**Hoist decorate field-set expansion out of the per-item loop** (`stores/utxo/aerospike`) — `BatchDecorate` re-expanded the field set (`addAbstractedBins`), re-converted it to wire names (`FieldNamesToStrings`), and allocated the default-bins literal *per item*, even though every item in a call almost always requests the same fields. Expand + convert the shared set **once** and reuse the read-only result across uniform items; items carrying their own `Fields` still expand individually. Verified the aerospike client only reads `BinNames` (never mutates them), so one backing array is safe to share.

**Pool the `MetaBytes` buffer on the cache-repopulate path** (`stores/txmetacache` + `stores/utxo/meta`) — `TxMetaCache.BatchDecorate` serializes one `MetaBytes` buffer per tx, then discards it once the cache has copied the bytes into its own chunk storage (`SetMulti` appends k/v into bucket chunks). Add `Data.MetaBytesInto(dst)` and recycle the per-tx buffers through a `sync.Pool`, returning them only after the cache write completes. The returned slice length bounds exactly the bytes written, so a recycled buffer never leaks stale bytes; the flags byte is explicitly reset.

## Benchmark results

| Benchmark | Before | After |
|---|---|---|
| `BuildBatchRecords` (1024 records, default fields) | ~7 allocs/record, 772 KB | **~4 allocs/record, 379 KB** |
| `BuildBatchRecords` (tx fields) | ~9 allocs/record | **~4 allocs/record** |
| `txMetaCache_BatchDecorate_1k` | 6801 allocs/op, 212 KB | **5803 allocs/op, 198 KB** (−1 alloc/tx) |

## What was evaluated and deliberately NOT included

The plan also included pooling the per-record `*meta.Data` (the 232-byte struct) via a caller-provided buffer. **I implemented it and reverted it**: pre-setting `item.Data` to a pooled non-nil buffer breaks the pipeline's `Data == nil` ⇒ "not found in store" contract, so any `BatchDecorate` implementation that signals not-found by leaving `Data` untouched (mocks; potentially non-aerospike stores) causes transactions to be misclassified as already-validated and **skipped from validation**. Existing tests caught it (`TestProcessTransactionsInLevels`, `AssembledPath`, `FloaterParent`, `SubtreesHandler`). Making it safe needs an explicit `Found` flag on every `BatchDecorate` implementation — too broad for a ~1-struct/tx win (the inner slices still allocate). Left out.

Also assessed and rejected: pooling the `aerospike.Key`/`BatchRead` structs — `BatchRead` has no reset API and embeds an unexported-constructed record, and `Key` keeps the `NewValue` boxing allocation and must survive the parse loop.

## Tests

- `buildBatchRecords` correctness (shared vs per-item field sets, key digests, shared-backing invariant).
- `MetaBytesInto` parity with `MetaBytes` (incl. dirty reused buffer) and reuse-saves-alloc.
- Pooled `TxMetaCache.BatchDecorate` round-trips each tx's own metadata, including concurrent callers under `-race`.
- Full `stores/utxo/aerospike` (testcontainer) and `stores/txmetacache -race` green; `go vet`, `staticcheck` clean.

Rebased on latest `main`.
