### PR TITLE
fix(blockvalidation): build orphan fork ID from full block hash

### DIFF
--- a/services/blockvalidation/fork_manager.go
+++ b/services/blockvalidation/fork_manager.go
@@ -557,8 +557,10 @@ func (fm *ForkManager) DetermineForkID(ctx context.Context, block *model.Block, 
 	}
 
 	if err != nil {
-		blockHashStr := block.Hash().String()
-		forkID := "orphan-" + blockHashStr[len(blockHashStr)-8:]
+		// Use the full block hash (256 bits) so distinct orphan blocks never collide
+		// onto the same ForkBranch. Truncating to the last 8 hex chars (32 bits) allowed
+		// two different orphans to alias onto one fork and corrupt its bookkeeping.
+		forkID := "orphan-" + block.Hash().String()
 
 		if _, exists := fm.forks[forkID]; !exists {
 			now := time.Now()

--- a/services/blockvalidation/fork_manager_orphan_test.go
+++ b/services/blockvalidation/fork_manager_orphan_test.go
@@ -1,0 +1,142 @@
+package blockvalidation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	blockchain_store "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// orphanTestBlock builds a block whose parent is unknown to the store, forcing
+// DetermineForkID down the orphan path. nonce/prev vary the full block hash.
+func orphanTestBlock(t *testing.T, nonce uint32) *model.Block {
+	t.Helper()
+
+	prev := &chainhash.Hash{}
+	prev[0] = byte(nonce)
+	prev[1] = 0xAB
+
+	merkleRoot := &chainhash.Hash{}
+	merkleRoot[0] = byte(nonce)
+
+	return &model.Block{
+		Height: 100,
+		Header: &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  prev,
+			HashMerkleRoot: merkleRoot,
+			Timestamp:      1700000000,
+			Bits:           model.NBit{0xff, 0xff, 0x00, 0x1d},
+			Nonce:          nonce,
+		},
+	}
+}
+
+// TestDetermineForkID_OrphanUsesFullHash verifies that the orphan fork ID is
+// derived from the full block hash (256 bits) rather than a truncated suffix.
+// Truncating to the last 8 hex chars (32 bits) allowed two distinct orphan
+// blocks to alias onto a single ForkBranch and corrupt its bookkeeping. See
+// issue #4663.
+func TestDetermineForkID_OrphanUsesFullHash(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.MaxParallelForks = 10
+
+	// A best block that no orphan parent matches, so DetermineForkID never
+	// short-circuits to "main".
+	store := blockchain_store.NewMockStore()
+	store.BestBlock = &model.Block{
+		Height: 1,
+		Header: &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: &chainhash.Hash{0xFF},
+			Timestamp:      1700000000,
+			Bits:           model.NBit{0xff, 0xff, 0x00, 0x1d},
+			Nonce:          1,
+		},
+	}
+
+	client, err := blockchain.NewLocalClient(logger, tSettings, store, nil, nil)
+	require.NoError(t, err)
+
+	fm := NewForkManager(logger, tSettings)
+
+	block := orphanTestBlock(t, 1)
+	forkID, err := fm.DetermineForkID(ctx, block, client)
+	require.NoError(t, err)
+
+	fullHash := block.Hash().String()
+
+	// The fork ID must carry the full hash, not a truncated suffix.
+	require.Equal(t, "orphan-"+fullHash, forkID)
+	require.True(t, strings.Contains(forkID, fullHash),
+		"orphan fork ID must embed the full block hash to avoid collisions")
+	require.Greater(t, len(forkID), len("orphan-")+8,
+		"orphan fork ID must use more than the truncated 8-char suffix")
+
+	// The block and its parent are mapped to this fork.
+	fm.mu.RLock()
+	require.Equal(t, forkID, fm.blockToFork[*block.Hash()])
+	require.Equal(t, forkID, fm.blockToFork[*block.Header.HashPrevBlock])
+	_, ok := fm.forks[forkID]
+	fm.mu.RUnlock()
+	require.True(t, ok, "fork must be registered")
+}
+
+// TestDetermineForkID_DistinctOrphansDistinctForks verifies that two distinct
+// orphan blocks produce two distinct ForkBranches, each tracking its own block.
+func TestDetermineForkID_DistinctOrphansDistinctForks(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.MaxParallelForks = 10
+
+	store := blockchain_store.NewMockStore()
+	store.BestBlock = &model.Block{
+		Height: 1,
+		Header: &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: &chainhash.Hash{0xFF},
+			Timestamp:      1700000000,
+			Bits:           model.NBit{0xff, 0xff, 0x00, 0x1d},
+			Nonce:          1,
+		},
+	}
+
+	client, err := blockchain.NewLocalClient(logger, tSettings, store, nil, nil)
+	require.NoError(t, err)
+
+	fm := NewForkManager(logger, tSettings)
+
+	blockA := orphanTestBlock(t, 1)
+	blockB := orphanTestBlock(t, 2)
+	require.False(t, blockA.Hash().IsEqual(blockB.Hash()), "test blocks must differ")
+
+	forkA, err := fm.DetermineForkID(ctx, blockA, client)
+	require.NoError(t, err)
+
+	forkB, err := fm.DetermineForkID(ctx, blockB, client)
+	require.NoError(t, err)
+
+	require.NotEqual(t, forkA, forkB, "distinct orphan blocks must not alias onto one fork")
+
+	fm.mu.RLock()
+	require.Equal(t, forkA, fm.blockToFork[*blockA.Hash()])
+	require.Equal(t, forkB, fm.blockToFork[*blockB.Hash()])
+	require.Len(t, fm.forks, 2, "each distinct orphan must create its own fork")
+	fm.mu.RUnlock()
+}


### PR DESCRIPTION
**Closes #4663.**

### Problem
`DetermineForkID` derived the orphan fork ID from only the last 8 hex chars of the block hash (`fork_manager.go:559-561`) — 32 bits of entropy. Two distinct orphan blocks sharing those 8 chars collide onto one `ForkBranch`: the `!exists` branch is skipped, so the second orphan reuses the first fork's branch and is tracked under the wrong fork's lifecycle. A ~1-in-4-billion accidental collision, and trivially forced on a public network.

### Fix
Use the full block hash (256 bits) for the orphan fork ID, so distinct orphan blocks can never alias onto the same fork.