### PR TITLE
fix(blockvalidation): drop throwaway BlockPriorityQueue in updateQueueSizeMetrics

### DIFF
--- a/services/blockvalidation/block_priority.go
+++ b/services/blockvalidation/block_priority.go
@@ -343,7 +343,7 @@ func (pq *BlockPriorityQueue) GetAlternativeSource(blockHash *chainhash.Hash) (p
 }
 
 // getQueueStats returns statistics about the queue without locking
-func (pq *BlockPriorityQueue) getQueueStats(items []*PrioritizedBlock) (chainExtending, nearFork, deepFork int) {
+func getQueueStats(items []*PrioritizedBlock) (chainExtending, nearFork, deepFork int) {
 	for _, item := range items {
 		switch item.priority {
 		case PriorityChainExtending:
@@ -361,7 +361,7 @@ func (pq *BlockPriorityQueue) GetQueueStats() (chainExtending, nearFork, deepFor
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 
-	return pq.getQueueStats(pq.items)
+	return getQueueStats(pq.items)
 }
 
 func (pq *BlockPriorityQueue) Clear() {
@@ -477,8 +477,7 @@ func updateQueueSizeMetrics(items []*PrioritizedBlock) {
 		return
 	}
 
-	pq := &BlockPriorityQueue{items: items}
-	chainExtending, nearFork, deepFork := pq.getQueueStats(items)
+	chainExtending, nearFork, deepFork := getQueueStats(items)
 	prometheusBlockPriorityQueueSize.WithLabelValues("chain_extending").Set(float64(chainExtending))
 	prometheusBlockPriorityQueueSize.WithLabelValues("near_fork").Set(float64(nearFork))
 	prometheusBlockPriorityQueueSize.WithLabelValues("deep_fork").Set(float64(deepFork))


### PR DESCRIPTION
Closes #4664


updateQueueSizeMetrics heap-allocated a throwaway BlockPriorityQueue struct on every queue mutation (Add, removeItem, RequeueForRetry) solely to call getQueueStats, which reads only the items slice and no field of the receiver. Make getQueueStats a plain package-level function and call it directly, removing the allocation from the block-scheduling hot path.
