### PR TITLE
fix(asset,blockvalidation): drop chunked terminator on mid-stream failure; classify all-peers-failed as ErrExternal

### DIFF
--- a/services/asset/httpimpl/GetLegacyBlock.go
+++ b/services/asset/httpimpl/GetLegacyBlock.go
@@ -86,7 +86,7 @@ func (h *HTTP) GetLegacyBlock() func(c echo.Context) error {
 
 		prometheusAssetHTTPGetBlockLegacy.WithLabelValues("OK", "200").Inc()
 
-		return c.Stream(http.StatusOK, echo.MIMEOctetStream, r)
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
 	}
 }
 
@@ -142,6 +142,6 @@ func (h *HTTP) GetRestLegacyBlock() func(c echo.Context) error {
 
 		prometheusAssetHTTPGetBlockLegacy.WithLabelValues("OK", "200").Inc()
 
-		return c.Stream(http.StatusOK, echo.MIMEOctetStream, r)
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
 	}
 }

--- a/services/asset/httpimpl/GetSubtree.go
+++ b/services/asset/httpimpl/GetSubtree.go
@@ -183,7 +183,7 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 		defer subtreeReader.Close()
 
 		if mode == BINARY_STREAM {
-			return c.Stream(http.StatusOK, echo.MIMEOctetStream, subtreeReader)
+			return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, subtreeReader)
 		}
 
 		// mode == HEX (validated above)

--- a/services/asset/httpimpl/GetSubtreeData.go
+++ b/services/asset/httpimpl/GetSubtreeData.go
@@ -80,6 +80,6 @@ func (h *HTTP) GetSubtreeData() func(c echo.Context) error {
 
 		prometheusAssetHTTPGetSubtreeData.WithLabelValues("OK", "200").Inc()
 
-		return c.Stream(http.StatusOK, echo.MIMEOctetStream, r)
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
 	}
 }

--- a/services/asset/httpimpl/mining_candidate_legacy_block.go
+++ b/services/asset/httpimpl/mining_candidate_legacy_block.go
@@ -63,5 +63,5 @@ func (h *HTTP) handleMiningCandidateLegacyBlock(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	return c.Stream(http.StatusOK, echo.MIMEOctetStream, r)
+	return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
 }

--- a/services/asset/httpimpl/stream.go
+++ b/services/asset/httpimpl/stream.go
@@ -38,20 +38,26 @@ import (
 //
 // # Caller contract
 //
-// streamOrAbort always returns nil to its echo caller, even on streaming
-// failure — once we hijack the connection we own it, and any further
-// writes from echo's after-handler middleware would either fail or escape
-// our control. Returning nil to echo signals "response already finalised,
-// don't touch it." The error from io.Copy is consumed inside this helper
-// (an abrupt hijack + close is sufficient signalling to the client, which
-// will surface the truncation as io.ErrUnexpectedEOF in its body parse).
+// On the happy path, and on a streaming failure where the hijack succeeds,
+// streamOrAbort returns nil to its echo caller — once we hijack the
+// connection we own it, and any further writes from echo's after-handler
+// middleware would either fail or escape our control. Returning nil to
+// echo signals "response already finalised, don't touch it." The error
+// from io.Copy is consumed inside this helper (an abrupt hijack + close
+// is sufficient signalling to the client, which will surface the
+// truncation as io.ErrUnexpectedEOF in its body parse).
 //
-// The Hijacker assertion succeeds in production: echo's *Response wraps
-// the standard library's http.ResponseWriter, which implements Hijacker
-// on both HTTP/1.x and HTTP/2 (via http2.responseWriter). If for any
-// reason the cast fails, we fall back to letting echo's normal error
-// path run — this is strictly safer than panicking, even if it means
-// the original cache-corruption bug can re-occur on that exotic path.
+// # HTTP/2 limitation
+//
+// Hijacking is only supported on HTTP/1.x. On HTTP/2, echo's
+// Response.Hijack (which delegates to http.ResponseController.Hijack)
+// returns http.ErrNotSupported — it does not panic — and we fall through
+// to returning the io.Copy error. The response is already committed at
+// that point, so echo's error handler only logs it; but the connection is
+// closed cleanly and the cache-bypass guarantee does NOT hold on h2. In
+// production the asset service sits behind an HTTP/1.1 nginx, so the
+// hijack path is the one that runs; only a client (or caching proxy)
+// speaking h2 directly to the asset service hits the fallback.
 func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) error {
 	h := c.Response().Header()
 	h.Set(echo.HeaderContentType, contentType)
@@ -71,9 +77,9 @@ func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) er
 		return nil
 	}
 
-	// Hijack unsupported — fall back to surfacing the io.Copy error so
-	// echo can run its normal error path. In this case the cache-bypass
-	// guarantee no longer holds, but this branch should never fire under
-	// the standard echo + net/http stack in production.
+	// Hijack unsupported (HTTP/2 — see the doc comment) — fall back to
+	// surfacing the io.Copy error so echo logs it. The response is already
+	// committed, so echo's error handler won't write to it; the cache-bypass
+	// guarantee does not hold on this path.
 	return copyErr
 }

--- a/services/asset/httpimpl/stream.go
+++ b/services/asset/httpimpl/stream.go
@@ -1,0 +1,79 @@
+package httpimpl
+
+import (
+	"io"
+
+	"github.com/labstack/echo/v4"
+)
+
+// streamOrAbort is a drop-in replacement for echo.Context.Stream that prevents
+// truncated bodies from being cached by a reverse proxy (nginx in particular)
+// when the source reader fails mid-stream.
+//
+// Background — the bug we're closing
+//
+// echo.Context.Stream commits to a 200 OK status line the moment the first
+// byte is read from the source reader, then io.Copy's the rest of the body
+// to the response. If the source reader fails partway through (e.g. the
+// on-demand subtreeData generation in services/asset/repository can't find
+// some tx in the local store), io.Copy returns the error and the handler
+// returns. So far so good — except Go's net/http server, in finishRequest(),
+// then unconditionally writes the chunked-transfer terminator "0\r\n\r\n"
+// to close the response cleanly. Wire-syntactically the chunked stream
+// looks complete. A caching reverse proxy in front of the asset service
+// (nginx's proxy_cache) takes that at face value and persists the truncated
+// body to the cache. Every subsequent client request hits the bad cache
+// entry, and the catchup loop loses the race against the corruption.
+//
+// # Fix
+//
+// On the happy path, behave exactly like c.Stream — the chunked terminator
+// is written normally and nginx caches the response as today. On the
+// failure path, hijack the underlying TCP connection and close it
+// **without** writing the terminator. nginx detects "upstream prematurely
+// closed connection while reading upstream", refuses to commit the partial
+// response to cache (this is the same path nginx already uses for any
+// truncated chunked response from upstream, documented behaviour), and the
+// next client request goes back to the asset service for a fresh attempt.
+//
+// # Caller contract
+//
+// streamOrAbort always returns nil to its echo caller, even on streaming
+// failure — once we hijack the connection we own it, and any further
+// writes from echo's after-handler middleware would either fail or escape
+// our control. Returning nil to echo signals "response already finalised,
+// don't touch it." The error from io.Copy is consumed inside this helper
+// (an abrupt hijack + close is sufficient signalling to the client, which
+// will surface the truncation as io.ErrUnexpectedEOF in its body parse).
+//
+// The Hijacker assertion succeeds in production: echo's *Response wraps
+// the standard library's http.ResponseWriter, which implements Hijacker
+// on both HTTP/1.x and HTTP/2 (via http2.responseWriter). If for any
+// reason the cast fails, we fall back to letting echo's normal error
+// path run — this is strictly safer than panicking, even if it means
+// the original cache-corruption bug can re-occur on that exotic path.
+func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) error {
+	h := c.Response().Header()
+	h.Set(echo.HeaderContentType, contentType)
+	c.Response().WriteHeader(code)
+
+	_, copyErr := io.Copy(c.Response(), r)
+	if copyErr == nil {
+		// Happy path — let echo / Go finalise the chunked stream normally.
+		return nil
+	}
+
+	// Mid-stream failure. Hijack the connection and close it before Go's
+	// HTTP server has a chance to write the chunked terminator. nginx then
+	// sees an incomplete chunked response and discards its cache file.
+	if conn, _, hjErr := c.Response().Hijack(); hjErr == nil {
+		_ = conn.Close()
+		return nil
+	}
+
+	// Hijack unsupported — fall back to surfacing the io.Copy error so
+	// echo can run its normal error path. In this case the cache-bypass
+	// guarantee no longer holds, but this branch should never fire under
+	// the standard echo + net/http stack in production.
+	return copyErr
+}

--- a/services/asset/httpimpl/stream_test.go
+++ b/services/asset/httpimpl/stream_test.go
@@ -3,7 +3,6 @@ package httpimpl
 import (
 	"bytes"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,15 +19,12 @@ import (
 // supplied error on the next Read. Used to drive streamOrAbort's
 // failure path with a deterministic mid-stream error.
 type errReader struct {
-	prefix    []byte
-	err       error
-	consumed  bool
-	readCalls int
+	prefix   []byte
+	err      error
+	consumed bool
 }
 
 func (e *errReader) Read(p []byte) (int, error) {
-	e.readCalls++
-
 	if !e.consumed {
 		n := copy(p, e.prefix)
 		e.consumed = true
@@ -172,8 +168,3 @@ func TestStreamOrAbort_FailureConnIsActuallyClosed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "still alive", string(body2))
 }
-
-// ensureNetConnSentinel keeps the imports used so the file's intent is
-// explicit — net.Conn is what Hijack returns, and httptest.NewServer
-// gives us a real TCP listener the server runs against.
-var _ net.Conn = (net.Conn)(nil)

--- a/services/asset/httpimpl/stream_test.go
+++ b/services/asset/httpimpl/stream_test.go
@@ -1,0 +1,179 @@
+package httpimpl
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errReader returns the supplied prefix bytes once, then fails with the
+// supplied error on the next Read. Used to drive streamOrAbort's
+// failure path with a deterministic mid-stream error.
+type errReader struct {
+	prefix    []byte
+	err       error
+	consumed  bool
+	readCalls int
+}
+
+func (e *errReader) Read(p []byte) (int, error) {
+	e.readCalls++
+
+	if !e.consumed {
+		n := copy(p, e.prefix)
+		e.consumed = true
+		return n, nil
+	}
+
+	return 0, e.err
+}
+
+// TestStreamOrAbort_HappyPath verifies that on a successful copy
+// streamOrAbort returns nil and lets the HTTP framework finalise the
+// response (i.e. emit the chunked terminator) so a caching reverse
+// proxy would accept the response.
+func TestStreamOrAbort_HappyPath(t *testing.T) {
+	body := strings.Repeat("payload-", 1024)
+
+	e := echo.New()
+	e.GET("/x", func(c echo.Context) error {
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, strings.NewReader(body))
+	})
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/x")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(got))
+}
+
+// TestStreamOrAbort_MidStreamFailure_ClientSeesUnexpectedEOF verifies that
+// when the source reader fails mid-stream, the helper closes the
+// underlying TCP connection without the chunked terminator. The client
+// observes the truncation as an io.ErrUnexpectedEOF on the next read of
+// the body — the signal a caching proxy uses to decide not to cache the
+// response.
+func TestStreamOrAbort_MidStreamFailure_ClientSeesUnexpectedEOF(t *testing.T) {
+	prefix := bytes.Repeat([]byte{0xAB}, 256)
+
+	e := echo.New()
+	e.GET("/x", func(c echo.Context) error {
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, &errReader{
+			prefix: prefix,
+			err:    errors.NewProcessingError("simulated mid-stream failure"),
+		})
+	})
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/x")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The handler had already committed to 200 OK before the failure, so
+	// the wire-level status is still 200.
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Reading the body must surface a non-clean termination — a clean
+	// io.EOF would mean Go wrote the chunked terminator, which is what
+	// we're explicitly preventing. The exact error varies (io.ErrUnexpectedEOF
+	// from the chunked decoder if any chunks arrived, or a net error if
+	// the connection dropped before any body bytes hit the wire) — both
+	// are acceptable; both make a caching proxy refuse to store the
+	// response.
+	_, readErr := io.ReadAll(resp.Body)
+
+	require.Error(t, readErr, "client must see a non-clean termination so caches refuse to store the truncated body")
+	assert.NotErrorIs(t, readErr, io.EOF,
+		"clean io.EOF would imply Go wrote the chunked terminator — this would let caching proxies store the truncated body")
+}
+
+// TestStreamOrAbort_NoHeaderOverwriteAfterCommit guards against a regression
+// where the helper might try to mutate headers after WriteHeader was
+// called — which Go silently drops and would mask other bugs. We assert
+// that the Content-Type set by streamOrAbort is what shows up on the wire.
+func TestStreamOrAbort_NoHeaderOverwriteAfterCommit(t *testing.T) {
+	body := "small payload"
+
+	e := echo.New()
+	e.GET("/x", func(c echo.Context) error {
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, strings.NewReader(body))
+	})
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/x")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, echo.MIMEOctetStream, resp.Header.Get(echo.HeaderContentType))
+}
+
+// TestStreamOrAbort_FailureConnIsActuallyClosed exercises a low-level
+// invariant: after the mid-stream failure, the TCP connection from the
+// server side is no longer open for additional writes. We can't easily
+// observe Go's "did it write the chunked terminator" decision from the
+// outside, but we can check that the connection is dead after the
+// failed response by attempting a second HTTP request on a fresh
+// connection while the first is in flight — and confirming the server
+// is responsive (i.e. the per-connection abort didn't bring the listener
+// down with it).
+func TestStreamOrAbort_FailureConnIsActuallyClosed(t *testing.T) {
+	prefix := bytes.Repeat([]byte{0xCD}, 64)
+
+	e := echo.New()
+	e.GET("/fail", func(c echo.Context) error {
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, &errReader{
+			prefix: prefix,
+			err:    errors.NewProcessingError("simulated"),
+		})
+	})
+	e.GET("/ok", func(c echo.Context) error {
+		return c.String(http.StatusOK, "still alive")
+	})
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	// Failing request first
+	resp, err := http.Get(srv.URL + "/fail")
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Follow-up request must succeed — the listener and other connections
+	// must be unaffected by the previous request's hijack-and-close.
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp2, err := client.Get(srv.URL + "/ok")
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+	body2, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "still alive", string(body2))
+}
+
+// ensureNetConnSentinel keeps the imports used so the file's intent is
+// explicit — net.Conn is what Hijack returns, and httptest.NewServer
+// gives us a real TCP listener the server runs against.
+var _ net.Conn = (net.Conn)(nil)

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1735,29 +1735,32 @@ func (u *Server) processCatchupChItem(ctx context.Context, c processBlockCatchup
 			return
 		}
 
-		// Local infrastructure/service failure (e.g. blockchain service unavailable) — not a peer issue
-		if errors.Is(err, errors.ErrServiceError) {
-			// #1057: count this cycle toward the per-block cap (unless it made
-			// progress) so a persistent local service error cannot drive unbounded
-			// re-entry.
-			attempts := u.recordCatchupAttemptUnlessProgress(c.block.Hash())
-			u.logger.Warnf("[catchup] Local service error during catchup for block %s (attempt %d/%d), clearing markers to allow retry: %v", c.block.Hash().String(), attempts, u.settings.BlockValidation.CatchupMaxAttemptsPerBlock, err)
-			u.processBlockNotify.Delete(*c.block.Hash())
-			u.catchupAlternatives.Delete(*c.block.Hash())
-			return
-		}
-
-		// Peer-side data-quality failure: every peer we tried (primary +
-		// alternatives) returned bad/incomplete data. Distinguished from
-		// ErrServiceError so the silent "clear markers, retry" loop above
-		// doesn't absorb peer issues. We clear markers (so future P2P
-		// notifications for this block can re-trigger catchup), report
-		// peer failure for the originating peer (so P2P routes the next
-		// attempt to a different peer), and log loudly. This avoids the
+		// Peer-side failure: every peer we tried (primary + alternatives)
+		// returned bad/incomplete data or rejected/failed the request.
+		// Distinguished from ErrServiceError so the silent "clear markers,
+		// retry" loop below doesn't absorb peer issues. We clear markers (so
+		// future P2P notifications for this block can re-trigger catchup),
+		// report peer failure for the originating peer (so P2P routes the
+		// next attempt to a different peer), and log loudly. This avoids the
 		// hot-loop where the same peer keeps being asked for the same
 		// missing subtree data.
+		//
+		// ORDER IS LOAD-BEARING: this check must run before the
+		// ErrServiceError check. errors.Is matches by code across the whole
+		// wrapped chain, and the ERR_EXTERNAL classification from
+		// fetchAndStoreSubtreeAndSubtreeData arrives buried mid-chain — it
+		// wraps the per-peer ServiceError, and is itself re-wrapped by
+		// fetchSubtreeDataForBlock (ServiceError) and orderedDelivery
+		// (ProcessingError) on the way up. So errors.Is(err, ErrServiceError)
+		// is also true for these errors, and matching on the outermost code
+		// would see ERR_PROCESSING. ERR_EXTERNAL anywhere in the chain means
+		// a peer-side failure was classified, which is what we dispatch on.
 		if errors.Is(err, errors.ErrExternal) {
-			u.logger.Warnf("[catchup] All peers failed for block %s, clearing markers and reporting peer failure to allow retry from a different peer: %v", c.block.Hash().String(), err)
+			// #1057: count this cycle toward the per-block cap (unless it made
+			// progress) so persistently failing peers cannot drive unbounded
+			// re-entry via repeated P2P notifications.
+			attempts := u.recordCatchupAttemptUnlessProgress(c.block.Hash())
+			u.logger.Warnf("[catchup] All peers failed for block %s (attempt %d/%d), clearing markers and reporting peer failure to allow retry from a different peer: %v", c.block.Hash().String(), attempts, u.settings.BlockValidation.CatchupMaxAttemptsPerBlock, err)
 			u.processBlockNotify.Delete(*c.block.Hash())
 			u.catchupAlternatives.Delete(*c.block.Hash())
 			u.reportCatchupFailure(ctx, c.peerID)
@@ -1766,6 +1769,19 @@ func (u *Server) processCatchupChItem(ctx context.Context, c processBlockCatchup
 				u.logger.Errorf("[catchup] failed to report peer failure for block %s peer %s: %v", c.block.Hash().String(), c.peerID, reportErr)
 			}
 
+			return
+		}
+
+		// Local infrastructure/service failure (e.g. blockchain service unavailable) — not a peer issue.
+		// Must run after the ErrExternal check above (see the ordering note there).
+		if errors.Is(err, errors.ErrServiceError) {
+			// #1057: count this cycle toward the per-block cap (unless it made
+			// progress) so a persistent local service error cannot drive unbounded
+			// re-entry.
+			attempts := u.recordCatchupAttemptUnlessProgress(c.block.Hash())
+			u.logger.Warnf("[catchup] Local service error during catchup for block %s (attempt %d/%d), clearing markers to allow retry: %v", c.block.Hash().String(), attempts, u.settings.BlockValidation.CatchupMaxAttemptsPerBlock, err)
+			u.processBlockNotify.Delete(*c.block.Hash())
+			u.catchupAlternatives.Delete(*c.block.Hash())
 			return
 		}
 

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1747,6 +1747,28 @@ func (u *Server) processCatchupChItem(ctx context.Context, c processBlockCatchup
 			return
 		}
 
+		// Peer-side data-quality failure: every peer we tried (primary +
+		// alternatives) returned bad/incomplete data. Distinguished from
+		// ErrServiceError so the silent "clear markers, retry" loop above
+		// doesn't absorb peer issues. We clear markers (so future P2P
+		// notifications for this block can re-trigger catchup), report
+		// peer failure for the originating peer (so P2P routes the next
+		// attempt to a different peer), and log loudly. This avoids the
+		// hot-loop where the same peer keeps being asked for the same
+		// missing subtree data.
+		if errors.Is(err, errors.ErrExternal) {
+			u.logger.Warnf("[catchup] All peers failed for block %s, clearing markers and reporting peer failure to allow retry from a different peer: %v", c.block.Hash().String(), err)
+			u.processBlockNotify.Delete(*c.block.Hash())
+			u.catchupAlternatives.Delete(*c.block.Hash())
+			u.reportCatchupFailure(ctx, c.peerID)
+
+			if reportErr := u.blockchainClient.ReportPeerFailure(ctx, c.block.Hash(), c.peerID, "catchup", err.Error()); reportErr != nil {
+				u.logger.Errorf("[catchup] failed to report peer failure for block %s peer %s: %v", c.block.Hash().String(), c.peerID, reportErr)
+			}
+
+			return
+		}
+
 		// Report catchup failure to P2P service
 		u.reportCatchupFailure(ctx, c.peerID)
 

--- a/services/blockvalidation/block_processing_retry_test.go
+++ b/services/blockvalidation/block_processing_retry_test.go
@@ -296,6 +296,61 @@ func TestProcessCatchupChItem(t *testing.T) {
 		require.Nil(t, u.catchupAlternatives.Get(*b.Hash()), "alternatives cleared on success")
 	})
 
+	// ChiR1 regression: the ErrExternal classification from
+	// fetchAndStoreSubtreeAndSubtreeData reaches processCatchupChItem buried in
+	// the middle of the chain — fetchSubtreeDataForBlock wraps it in a
+	// ServiceError (get_blocks.go) and orderedDelivery wraps that in a
+	// ProcessingError. errors.Is matches by code across the whole chain, so
+	// errors.Is(err, ErrServiceError) is ALSO true for this error; the handler
+	// must check ErrExternal before ErrServiceError or the peer-failure path is
+	// never taken for peer-unreachable/HTTP-error failures.
+	t.Run("external error buried under service and processing wraps takes the peer-failure path", func(t *testing.T) {
+		// Reconstruct the real catchup-path chain, innermost first:
+		// fetchSubtreeFromPeer(HTTP failure) -> ExternalError(all peers failed)
+		// -> ServiceError(fetchSubtreeDataForBlock) -> ProcessingError(orderedDelivery).
+		httpErr := errors.NewServiceError("failed to fetch subtree from http://peer/subtree/aa")
+		allPeersErr := errors.NewExternalError("all peers failed to fetch subtree aa", httpErr)
+		svcWrap := errors.NewServiceError("failed to fetch subtree data for block bb", allPeersErr)
+		chain := errors.NewProcessingError("worker failed for block bb", svcWrap)
+
+		require.True(t, errors.Is(chain, errors.ErrServiceError), "precondition: the chain also matches ErrServiceError — that is the trap")
+		require.True(t, errors.Is(chain, errors.ErrExternal))
+
+		u, _ := newServer(3, chain)
+		b := testBlock()
+		u.processBlockNotify.Set(*b.Hash(), true, ttlcache.DefaultTTL)
+		u.catchupAlternatives.Set(*b.Hash(), []processBlockCatchup{{block: b, peerID: "altpeer"}}, ttlcache.DefaultTTL)
+
+		u.processCatchupChItem(ctx, item(b))
+
+		require.Nil(t, u.processBlockNotify.Get(*b.Hash()), "peer-failure path must clear the processing guard")
+		require.Nil(t, u.catchupAlternatives.Get(*b.Hash()), "peer-failure path must clear cached alternatives")
+
+		it := u.blockCatchupAttempts.Get(*b.Hash())
+		require.NotNil(t, it, "an all-peers-failed cycle must count toward the #1057 cap")
+		require.Equal(t, 1, it.Value())
+
+		mockBC := u.blockchainClient.(*blockchain.Mock)
+		mockBC.AssertCalled(t, "ReportPeerFailure", mock.Anything, mock.Anything, mock.Anything, "catchup", mock.Anything)
+	})
+
+	t.Run("plain external error takes the peer-failure path", func(t *testing.T) {
+		u, _ := newServer(3, errors.NewExternalError("all peers failed"))
+		b := testBlock()
+		u.processBlockNotify.Set(*b.Hash(), true, ttlcache.DefaultTTL)
+
+		u.processCatchupChItem(ctx, item(b))
+
+		require.Nil(t, u.processBlockNotify.Get(*b.Hash()))
+
+		it := u.blockCatchupAttempts.Get(*b.Hash())
+		require.NotNil(t, it)
+		require.Equal(t, 1, it.Value())
+
+		mockBC := u.blockchainClient.(*blockchain.Mock)
+		mockBC.AssertCalled(t, "ReportPeerFailure", mock.Anything, mock.Anything, mock.Anything, "catchup", mock.Anything)
+	})
+
 	t.Run("invalid block clears notify without counting toward cap", func(t *testing.T) {
 		u, _ := newServer(3, errors.NewBlockInvalidError("bad block"))
 		b := testBlock()

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -697,11 +697,18 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	}
 
 	// All peers failed. Classify as ErrExternal — every peer we tried returned bad data
-	// or rejected the request, but none of the local infrastructure (subtree store,
-	// blockchain client, context) failed. ErrServiceError is reserved for genuine local
-	// failures and the catchup top-level handler short-circuits ErrServiceError into a
-	// silent "clear markers, retry" loop that hides peer-data-quality issues. With
-	// ErrExternal the handler reports peer failure and lets P2P switch peers instead.
+	// or rejected/failed the request, but none of the local infrastructure (subtree
+	// store, blockchain client, context) failed. ErrServiceError is reserved for genuine
+	// local failures and the catchup top-level handler short-circuits ErrServiceError
+	// into a silent "clear markers, retry" loop that hides peer-data-quality issues.
+	// With ErrExternal the handler reports peer failure and lets P2P switch peers instead.
+	//
+	// Note on detection: lastErr usually carries ERR_SERVICE_ERROR (the per-peer HTTP
+	// fetch wrappers), and callers wrap this error further (fetchSubtreeDataForBlock
+	// adds a ServiceError, orderedDelivery a ProcessingError), so by the time it
+	// reaches processCatchupChItem the ERR_EXTERNAL code sits mid-chain and
+	// errors.Is(err, ErrServiceError) is also true. The handler therefore checks
+	// ErrExternal before ErrServiceError — see processCatchupChItem.
 	//
 	// errors.NewExternalError extracts the trailing error param as the wrapped error,
 	// so a "%v" placeholder for lastErr would render as %!v(MISSING). The wrapped error

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -696,10 +696,17 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 		}
 	}
 
-	// All peers failed. errors.NewServiceError extracts the trailing error param as
-	// the wrapped error, so a "%v" placeholder for lastErr would render as
-	// %!v(MISSING). The wrapped error is preserved in the chain.
-	return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s", subtreeHash.String(), lastErr)
+	// All peers failed. Classify as ErrExternal — every peer we tried returned bad data
+	// or rejected the request, but none of the local infrastructure (subtree store,
+	// blockchain client, context) failed. ErrServiceError is reserved for genuine local
+	// failures and the catchup top-level handler short-circuits ErrServiceError into a
+	// silent "clear markers, retry" loop that hides peer-data-quality issues. With
+	// ErrExternal the handler reports peer failure and lets P2P switch peers instead.
+	//
+	// errors.NewExternalError extracts the trailing error param as the wrapped error,
+	// so a "%v" placeholder for lastErr would render as %!v(MISSING). The wrapped error
+	// is preserved in the chain.
+	return "", errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s", subtreeHash.String(), lastErr)
 }
 
 // fetchSubtreeFromPeer fetches subtree (for subtreeToCheck) from a peer via HTTP


### PR DESCRIPTION
Extracted from #828 (feat/teranode-native-ops); independent of native ops.

Two halves of one fix for **catchup wedging on truncated subtree data**:

- **asset:** on a mid-stream failure, abort the connection instead of finishing the HTTP chunked stream. A finished chunk stream looks complete to a caching proxy/client, so a truncated `subtree_data` body would be cached as if whole — poisoning every downstream fetch.
- **blockvalidation:** when *every* peer fails to fetch a subtree, classify the result as `ErrExternal`, not `ErrServiceError`. The catchup top-level handler short-circuits `ErrServiceError` into a silent clear-markers/retry loop that hides peer data-quality issues; `ErrExternal` reports peer failure and lets P2P switch peers.

`services/blockvalidation/get_blocks.go` was applied via 3-way merge over #1200 (already on `main`); no line overlap.

### Verified
- `go build ./...` clean against `main`
- `go test -race ./services/asset/httpimpl -run TestStreamOrAbort` passes
