### PR TITLE
fix(model): clamp disk-map capacity to 1 for empty (coinbase-only) blocks

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -745,10 +745,16 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 	}
 
 	if len(diskMapDirs) > 0 {
+		// An empty (coinbase-only) block has TransactionCount == 0, but the
+		// mmap-backed table rejects a zero capacity — clamp to 1.
+		filterCapacity := b.TransactionCount
+		if filterCapacity == 0 {
+			filterCapacity = 1
+		}
 		diskMap, diskErr := NewDiskTxMapUint64(DiskTxMapUint64Options{
 			BasePaths:      diskMapDirs,
 			Prefix:         "bv-txmap",
-			FilterCapacity: uint(b.TransactionCount),
+			FilterCapacity: uint(filterCapacity),
 		})
 		if diskErr != nil {
 			return errors.NewProcessingError("[checkDuplicateTransactions][%s] failed to create disk tx map", b.String(), diskErr)
@@ -852,6 +858,11 @@ func (b *Block) validOrderAndBlessed(ctx context.Context, logger ulogger.Logger,
 		parentSpendsCapacityMultiplier = 1
 	}
 	expectedInpoints := b.TransactionCount * parentSpendsCapacityMultiplier
+	if expectedInpoints == 0 {
+		// Empty (coinbase-only) block: TransactionCount == 0, but the
+		// mmap-backed table rejects a zero capacity — clamp to 1.
+		expectedInpoints = 1
+	}
 
 	var psMap ParentSpendsMap
 	if len(diskMapDirs) > 0 {

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -3421,19 +3421,34 @@ func (m *mockSubtreeStore) GetIoReader(ctx context.Context, key []byte, fileType
 	return nil, errors.NewBlobNotFoundError("mock error")
 }
 
-// createValidSubtreeMetadata creates valid subtree metadata that won't trigger retries
+// createValidSubtreeMetadata creates valid subtree metadata that won't trigger retries.
+// Non-coinbase nodes get a dummy parent because go-subtree v1.4.0's SubtreeMeta.Serialize
+// rejects empty TxInpoints on non-coinbase entries ("parent tx hashes are not set for node N").
+// The coinbase placeholder at index 0 keeps an empty TxInpoints, matching the on-wire shape.
 func createValidSubtreeMetadata(subtree *subtreepkg.Subtree) ([]byte, error) {
-	// Create SubtreeMeta with proper structure
 	subtreeMeta := subtreepkg.NewSubtreeMeta(subtree)
 
-	// Initialize TxInpoints array for all nodes up to Length()
-	for i := 0; i < subtree.Length(); i++ {
-		// Create empty TxInpoints for all nodes (including root)
-		txInpoints := subtreepkg.NewTxInpoints()
-		subtreeMeta.TxInpoints[i] = txInpoints
+	var dummyParent chainhash.Hash
+	dummyParent[0] = 0xde
+
+	dummyInput := &bt.Input{PreviousTxOutIndex: 0}
+	if err := dummyInput.PreviousTxIDAdd(&dummyParent); err != nil {
+		return nil, err
 	}
 
-	// Serialize the metadata
+	dummyInpoints, err := subtreepkg.NewTxInpointsFromInputs([]*bt.Input{dummyInput})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < subtree.Length(); i++ {
+		if i == 0 && len(subtree.Nodes) > 0 && subtree.Nodes[0].Hash == *subtreepkg.CoinbasePlaceholderHash {
+			subtreeMeta.TxInpoints[i] = subtreepkg.NewTxInpoints()
+			continue
+		}
+		subtreeMeta.TxInpoints[i] = dummyInpoints
+	}
+
 	return subtreeMeta.Serialize()
 }
 
@@ -5030,6 +5045,59 @@ func TestBlock_Valid_DupTxDetected_DiskMapDirs(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, errors.Is(err, errors.ErrBlockInvalid), "expected ErrBlockInvalid, got %v", err)
 			require.Contains(t, err.Error(), "duplicate transaction")
+		})
+	}
+}
+
+// TestBlock_EmptyBlock_DiskMapDirs verifies a coinbase-only block — whose
+// TransactionCount is 0, since GetAndValidateSubtrees derives it from subtree
+// lengths and an empty block has no subtrees — passes checkDuplicateTransactions
+// and validOrderAndBlessed when block_diskMapDirs is set. The mmap-backed maps
+// reject FilterCapacity == 0, so the call sites must clamp the derived capacity
+// to a floor of 1; without the clamp every empty block fails validation on
+// nodes configured with disk-backed maps.
+func TestBlock_EmptyBlock_DiskMapDirs(t *testing.T) {
+	cases := []struct {
+		name string
+		dirs func(t *testing.T) []string
+	}{
+		{"in_memory", func(*testing.T) []string { return nil }},
+		{"single_disk", func(t *testing.T) []string { return []string{t.TempDir()} }},
+		{"multi_disk", func(t *testing.T) []string { return []string{t.TempDir(), t.TempDir()} }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tSettings := test.CreateBaseTestSettings(t)
+
+			blockHeaderBytes, _ := hex.DecodeString(block1Header)
+			blockHeader, err := NewBlockHeaderFromBytes(blockHeaderBytes)
+			require.NoError(t, err)
+
+			coinbase, err := bt.NewTxFromString(CoinbaseHex)
+			require.NoError(t, err)
+
+			block, err := NewBlock(blockHeader, coinbase, nil, 0, 123, 0, 0)
+			require.NoError(t, err)
+			require.Zero(t, block.TransactionCount)
+
+			ctx := context.Background()
+			logger := ulogger.TestLogger{}
+			dirs := tc.dirs(t)
+
+			err = block.checkDuplicateTransactions(ctx, logger, tSettings.Block.CheckDuplicateTransactionsConcurrency, dirs)
+			require.NoError(t, err)
+
+			deps := &validationDependencies{
+				txMetaStore:           createTestUTXOStore(t),
+				subtreeStore:          &mockSubtreeStore{shouldError: true},
+				currentChain:          []*BlockHeader{},
+				currentBlockHeaderIDs: []uint32{},
+				oldBlockIDsMap:        txmap.NewSyncedMap[chainhash.Hash, []uint32](),
+			}
+
+			err = block.validOrderAndBlessed(ctx, logger, deps, tSettings.Block.ValidOrderAndBlessedConcurrency, dirs, tSettings.Block.ParentSpendsCapacityMultiplier)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -3421,34 +3421,19 @@ func (m *mockSubtreeStore) GetIoReader(ctx context.Context, key []byte, fileType
 	return nil, errors.NewBlobNotFoundError("mock error")
 }
 
-// createValidSubtreeMetadata creates valid subtree metadata that won't trigger retries.
-// Non-coinbase nodes get a dummy parent because go-subtree v1.4.0's SubtreeMeta.Serialize
-// rejects empty TxInpoints on non-coinbase entries ("parent tx hashes are not set for node N").
-// The coinbase placeholder at index 0 keeps an empty TxInpoints, matching the on-wire shape.
+// createValidSubtreeMetadata creates valid subtree metadata that won't trigger retries
 func createValidSubtreeMetadata(subtree *subtreepkg.Subtree) ([]byte, error) {
+	// Create SubtreeMeta with proper structure
 	subtreeMeta := subtreepkg.NewSubtreeMeta(subtree)
 
-	var dummyParent chainhash.Hash
-	dummyParent[0] = 0xde
-
-	dummyInput := &bt.Input{PreviousTxOutIndex: 0}
-	if err := dummyInput.PreviousTxIDAdd(&dummyParent); err != nil {
-		return nil, err
-	}
-
-	dummyInpoints, err := subtreepkg.NewTxInpointsFromInputs([]*bt.Input{dummyInput})
-	if err != nil {
-		return nil, err
-	}
-
+	// Initialize TxInpoints array for all nodes up to Length()
 	for i := 0; i < subtree.Length(); i++ {
-		if i == 0 && len(subtree.Nodes) > 0 && subtree.Nodes[0].Hash == *subtreepkg.CoinbasePlaceholderHash {
-			subtreeMeta.TxInpoints[i] = subtreepkg.NewTxInpoints()
-			continue
-		}
-		subtreeMeta.TxInpoints[i] = dummyInpoints
+		// Create empty TxInpoints for all nodes (including root)
+		txInpoints := subtreepkg.NewTxInpoints()
+		subtreeMeta.TxInpoints[i] = txInpoints
 	}
 
+	// Serialize the metadata
 	return subtreeMeta.Serialize()
 }
 
@@ -5080,6 +5065,11 @@ func TestBlock_EmptyBlock_DiskMapDirs(t *testing.T) {
 			block, err := NewBlock(blockHeader, coinbase, nil, 0, 123, 0, 0)
 			require.NoError(t, err)
 			require.Zero(t, block.TransactionCount)
+
+			// checkDuplicateTransactions allocates block.txMap (mmap-backed
+			// DiskTxMapUint64 when dirs are set); release it on all paths so
+			// the mmap files/fds are freed and TempDir cleanup stays reliable.
+			defer block.releaseTxMap()
 
 			ctx := context.Background()
 			logger := ulogger.TestLogger{}


### PR DESCRIPTION
Extracted from #828 (feat/teranode-native-ops); independent of native ops.

An empty (coinbase-only) block has `TransactionCount == 0`, but the mmap-backed `DiskTxMapUint64` rejects a zero capacity. Clamp `FilterCapacity` and `expectedInpoints` to a minimum of 1 so `Block.Valid` works for empty blocks when disk-backed tx maps are configured.

Adds `TestBlock_EmptyBlock_DiskMapDirs`.

### Verified
- `go build ./...` clean against `main`
- `go test -race ./model -run TestBlock_EmptyBlock_DiskMapDirs` passes
