### PR TITLE
chore(sonar): exclude test files from cognitive complexity rule

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,3 +19,11 @@ sonar.cpd.exclusions=poc/**,ui/dashboard/**,cmd/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.python.version=3.12
+
+# Don't raise Cognitive Complexity (go:S3776) on test files. Table-driven test
+# setup inflates the metric without signalling real maintainability debt, and it
+# dominates the issue list (e.g. sign_test.go). Keep the rule active for
+# production code only.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S3776
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go


### PR DESCRIPTION
## Summary

Excludes test files (`**/*_test.go`) from SonarQube's Cognitive Complexity rule (`go:S3776`).

## Why

`go:S3776` currently fires on **99 test files — ~29% of the open S3776 issues** — including the single worst offender in the whole project, `services/legacy/txscript/sign_test.go` (complexity **435**). Table-driven test setup naturally inflates cognitive complexity (big literal tables, nested case builders) without signalling any real maintainability debt, and it can't be cleared by tuning the threshold because it's a *file class*, not a complexity level.

With the threshold recently raised to 25, S3776 sits at 345 open issues:

| Category | Count |
|---|---|
| Production | 220 |
| Test files | 99 |
| cmd/compose tooling | 26 |

This change drops the list to **246** (production + tooling) and removes the permanent 435 outlier from the top of the list, so the remaining issues reflect actual production code.

## Change

A `sonar.issue.ignore.multicriteria` entry scoping `go:S3776` to exclude `**/*_test.go`. The rule stays fully active for all non-test code. No source or behaviour changes.

## Verification

Config-only change. Takes effect on the next SonarCloud analysis; the 99 test-file S3776 issues will auto-resolve.