### PR TITLE
fix(sonar): stop mistyped code-smells inflating the reliability rating

### DIFF
--- a/cmd/settings/Settings.go
+++ b/cmd/settings/Settings.go
@@ -56,7 +56,7 @@ func sortValue(v interface{}) interface{} {
 
 	// Additional check: if the pointer type implements json.Marshaler, create a pointer
 	// This matches Go's JSON marshaling behavior which automatically takes addresses when needed
-	ptrType := reflect.PtrTo(typ)
+	ptrType := reflect.PointerTo(typ)
 	if ptrType.Implements(reflect.TypeOf((*json.Marshaler)(nil)).Elem()) {
 		// Create a new pointer to this value to enable custom marshaling
 		newVal := reflect.New(typ)
@@ -71,7 +71,7 @@ func sortValue(v interface{}) interface{} {
 	}
 
 	// Handle pointers
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil
 		}

--- a/cmd/settings/settings_sort_test.go
+++ b/cmd/settings/settings_sort_test.go
@@ -290,7 +290,7 @@ func TestChainHashPreservation(t *testing.T) {
 	// Test our reflection-based detection
 	typ := reflect.TypeOf(hash)
 	val := reflect.ValueOf(hash)
-	ptrType := reflect.PtrTo(typ)
+	ptrType := reflect.PointerTo(typ)
 	if ptrType.Implements(reflect.TypeOf((*json.Marshaler)(nil)).Elem()) {
 		t.Logf("Reflection detects that *chainhash.Hash implements json.Marshaler")
 	} else {

--- a/scripts/check_filenames.sh
+++ b/scripts/check_filenames.sh
@@ -52,8 +52,8 @@ find $SEARCH_DIR -type f -name "*.go" | while read -r file; do
         "message": "Filename does not follow snake_case.go convention",
         "filePath": "$normalized_file"
     },
-    "severity":"MAJOR",
-    "type":"BUG",
+    "severity":"MINOR",
+    "type":"CODE_SMELL",
     "textRange": {
       "startLine": 1
     }

--- a/services/blockchain/Difficulty_block910479_test.go
+++ b/services/blockchain/Difficulty_block910479_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -48,7 +48,7 @@ func TestBlock910479Difficulty(t *testing.T) {
 	}
 
 	for _, height := range heights {
-		data, err := ioutil.ReadFile(fmt.Sprintf("../../block_%d_info.json", height))
+		data, err := os.ReadFile(fmt.Sprintf("../../block_%d_info.json", height))
 		if err != nil {
 			t.Skipf("Skipping test - block data files not found. Run the curl commands to download them first.")
 			return

--- a/services/rpc/bsvjson/cmdinfo.go
+++ b/services/rpc/bsvjson/cmdinfo.go
@@ -148,7 +148,7 @@ func fieldUsage(structField reflect.StructField, defaultVal *reflect.Value) stri
 
 	// Indirect the pointer if needed.
 	fieldType := structField.Type
-	if fieldType.Kind() == reflect.Ptr {
+	if fieldType.Kind() == reflect.Pointer {
 		fieldType = fieldType.Elem()
 	}
 
@@ -204,7 +204,7 @@ func methodUsageText(rtp reflect.Type, defaults map[int]reflect.Value, method st
 
 		var isOptional bool
 
-		if kind := rtf.Type.Kind(); kind == reflect.Ptr {
+		if kind := rtf.Type.Kind(); kind == reflect.Pointer {
 			isOptional = true
 		}
 

--- a/services/rpc/bsvjson/cmdparse.go
+++ b/services/rpc/bsvjson/cmdparse.go
@@ -25,7 +25,7 @@ func makeParams(rt reflect.Type, rv reflect.Value) []interface{} {
 		rtf := rt.Field(i)
 		rvf := rv.Field(i)
 
-		if rtf.Type.Kind() == reflect.Ptr {
+		if rtf.Type.Kind() == reflect.Pointer {
 			if rvf.IsNil() {
 				break
 			}
@@ -240,7 +240,7 @@ func typesMaybeCompatible(dest reflect.Type, src reflect.Type) bool {
 func baseType(arg reflect.Type) (reflect.Type, int) {
 	var numIndirects int
 
-	for arg.Kind() == reflect.Ptr {
+	for arg.Kind() == reflect.Pointer {
 		arg = arg.Elem()
 		numIndirects++
 	}
@@ -307,7 +307,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 	}
 
 	// Indirect through to the base source value.
-	for src.Kind() == reflect.Ptr {
+	for src.Kind() == reflect.Pointer {
 		src = src.Elem()
 	}
 

--- a/test/consensus/script_json_test.go
+++ b/test/consensus/script_json_test.go
@@ -3,7 +3,7 @@ package consensus
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -269,7 +269,7 @@ func TestLoadJSONTests(t *testing.T) {
 
 	// This shows how you would load tests from a JSON file
 	testFile := filepath.Join("testdata", "script_tests.json")
-	data, err := ioutil.ReadFile(testFile)
+	data, err := os.ReadFile(testFile)
 	if err != nil {
 		t.Skipf("Test file not found: %v", err)
 		return


### PR DESCRIPTION
## Summary

SonarCloud's **reliability rating is C** even though there are **zero real reliability issues** open. The rating is driven by `type=BUG` issues, and there are **327 open BUG-typed MAJOR issues that are actually maintainability concerns mistyped as bugs**. This PR retypes/fixes all of them so the rating returns to **A**.

Root cause breakdown:

| Count | Source | Nature |
|---|---|---|
| 320 | `scripts/check_filenames.sh` | filename-convention violations hard-coded as `type:BUG, severity:MAJOR` |
| 7 | `external_govet:inline` | deprecated-stdlib hints imported as BUG |

Neither is a reliability defect. Because Standard-mode reliability rating = `≥1 MAJOR bug → C`, **both** groups have to be cleared to move the grade — fixing one alone leaves the other holding it at C.

## Changes

**1. Filename check → CODE_SMELL (clears 320)**
`scripts/check_filenames.sh` emitted `"type":"BUG","severity":"MAJOR"` for a snake_case naming check. Retyped to `CODE_SMELL / MINOR` so the issues land under maintainability where they belong. Verified the script still emits valid JSON (369 issues, all now `CODE_SMELL/MINOR`).

**2. go vet modernizations → fix the code (clears 7)**
Behaviour-preserving stdlib updates:
- `reflect.PtrTo` → `reflect.PointerTo`
- `reflect.Ptr` → `reflect.Pointer`
- `ioutil.ReadFile` → `os.ReadFile` (import `io/ioutil` → `os`)

Also updates 3 further `reflect.Ptr` uses in the same files (`Settings.go:74`, `cmdparse.go:243/310`) that weren't yet flagged, so they don't resurface. These are pure aliases — no behaviour change.

## Verification

```
go build ./cmd/settings/ ./services/rpc/bsvjson/         # ok
go vet ./cmd/settings/ ./services/rpc/bsvjson/ ./services/blockchain/ ./test/consensus/   # clean
bash scripts/check_filenames.sh                          # valid JSON, all CODE_SMELL/MINOR
```

Once merged and re-scanned, no `type=BUG` issues remain → reliability rating returns to A.