### PR TITLE
blockvalidation: avoid full queue copy in BlockPriorityQueue.Get steady-state path

### DIFF
--- a/services/blockvalidation/block_priority.go
+++ b/services/blockvalidation/block_priority.go
@@ -159,6 +159,28 @@ func (pq *BlockPriorityQueue) Add(blockFound processBlockFound, priority BlockPr
 	updateQueueSizeMetrics(pq.items)
 }
 
+// takeIfPresent removes and returns the block matching hash if it is still queued,
+// reporting whether it was found. Used by Get's fast path to claim the front block
+// without copying the whole queue.
+func (pq *BlockPriorityQueue) takeIfPresent(hash *chainhash.Hash) (processBlockFound, bool) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	for i, currentItem := range pq.items {
+		if currentItem.blockFound.hash.IsEqual(hash) {
+			if blockQueueWaitTime != nil {
+				blockQueueWaitTime.Observe(time.Since(currentItem.timestamp).Seconds())
+			}
+
+			pq.removeItem(i)
+
+			return currentItem.blockFound, true
+		}
+	}
+
+	return processBlockFound{}, false
+}
+
 func (pq *BlockPriorityQueue) Get(ctx context.Context, bp BlockProcessor) (block processBlockFound, status GetStatus) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -176,6 +198,31 @@ func (pq *BlockPriorityQueue) Get(ctx context.Context, bp BlockProcessor) (block
 
 	if pq.needsSort {
 		pq.sortItems()
+	}
+
+	// Fast path: in steady state the highest-priority (front) block is immediately
+	// processable, so probe it first without copying the whole queue. Only fall back
+	// to the full scan below when the front block is blocked or already taken.
+	front := pq.items[0]
+	pq.mu.Unlock()
+
+	if ctx.Err() != nil {
+		return processBlockFound{}, GetEmpty
+	}
+
+	if canProcess, err := bp.CanProcessBlock(ctx, front.blockFound.hash); err == nil && canProcess {
+		if takenBlock, ok := pq.takeIfPresent(front.blockFound.hash); ok {
+			return takenBlock, GetOK
+		}
+	}
+
+	// Slow path: the front block was blocked or taken by another worker. Copy the
+	// queue once so the CanProcessBlock round-trips below run without holding the lock.
+	pq.mu.Lock()
+
+	if len(pq.items) == 0 {
+		pq.mu.Unlock()
+		return processBlockFound{}, GetEmpty
 	}
 
 	itemsCopy := make([]*PrioritizedBlock, len(pq.items))

--- a/services/blockvalidation/block_priority_get_test.go
+++ b/services/blockvalidation/block_priority_get_test.go
@@ -95,6 +95,72 @@ func TestBlockPriorityQueue_Get_SingleProcessableBlock(t *testing.T) {
 	assert.Equal(t, 0, pq.Size(), "Block should be removed from queue")
 }
 
+// TestBlockPriorityQueue_Get_FastPathDeepQueue verifies the steady-state fast path:
+// when the highest-priority (front) block is processable, Get claims it after probing
+// only that one block, without scanning the rest of a deep queue.
+func TestBlockPriorityQueue_Get_FastPathDeepQueue(t *testing.T) {
+	initPrometheusMetrics()
+	logger := ulogger.TestLogger{}
+	pq := NewBlockPriorityQueue(logger)
+	mockBP := NewMockBlockProcessor()
+	ctx := context.Background()
+
+	// Highest-priority (front) block is processable.
+	front := &chainhash.Hash{}
+	front[0] = 1
+	pq.Add(processBlockFound{hash: front}, PriorityChainExtending, 1000)
+	mockBP.SetCanProcess(front, true)
+
+	// Many lower-priority followers queued behind it.
+	for i := 2; i <= 100; i++ {
+		h := &chainhash.Hash{}
+		h[0] = byte(i)
+		pq.Add(processBlockFound{hash: h}, PriorityDeepFork, uint32(1000+i))
+		mockBP.SetCanProcess(h, false)
+	}
+
+	block, status := pq.Get(ctx, mockBP)
+	require.Equal(t, GetOK, status)
+	require.Equal(t, front, block.hash)
+	require.Equal(t, 99, pq.Size(), "only the front block should be removed")
+	require.Equal(t, 1, mockBP.GetCallCount(), "fast path should probe only the front block")
+}
+
+// TestBlockPriorityQueue_Get_SlowPathFallbackDeepQueue verifies the fallback: when the
+// front block is blocked, Get still scans the rest of the queue and returns a deeper
+// processable block.
+func TestBlockPriorityQueue_Get_SlowPathFallbackDeepQueue(t *testing.T) {
+	initPrometheusMetrics()
+	logger := ulogger.TestLogger{}
+	pq := NewBlockPriorityQueue(logger)
+	mockBP := NewMockBlockProcessor()
+	ctx := context.Background()
+
+	// Front block is blocked, forcing the slow-path scan.
+	front := &chainhash.Hash{}
+	front[0] = 1
+	pq.Add(processBlockFound{hash: front}, PriorityChainExtending, 1000)
+	mockBP.SetCanProcess(front, false)
+
+	// Followers sorted by height; only the last (deepest) one is processable.
+	var processable *chainhash.Hash
+	for i := 2; i <= 20; i++ {
+		h := &chainhash.Hash{}
+		h[0] = byte(i)
+		pq.Add(processBlockFound{hash: h}, PriorityNearFork, uint32(1000+i))
+		last := i == 20
+		mockBP.SetCanProcess(h, last)
+		if last {
+			processable = h
+		}
+	}
+
+	block, status := pq.Get(ctx, mockBP)
+	require.Equal(t, GetOK, status)
+	require.Equal(t, processable, block.hash)
+	require.Equal(t, 19, pq.Size(), "only the processable block should be removed")
+}
+
 // TestBlockPriorityQueue_Get_AllBlocksBlocked tests Get when all blocks are blocked
 func TestBlockPriorityQueue_Get_AllBlocksBlocked(t *testing.T) {
 	initPrometheusMetrics()


### PR DESCRIPTION
**Closes #4667.**

### Problem
`BlockPriorityQueue.Get` copied the entire `items` slice on every call before releasing the lock (`block_priority.go:181-183`), an O(N) allocation + copy paid unconditionally by every worker on every scheduling iteration via `WaitForBlock`. In steady state the front item (the chain-extending block) is immediately processable, so the full copy was wasted.

### Fix
Added a fast path: after sorting, probe only the front (highest-priority) block via `CanProcessBlock` without copying, and claim it with a new `takeIfPresent` helper that re-verifies presence under the lock (concurrency-safe against another worker taking it). The existing full-copy scan is kept intact as a slow-path fallback, entered only when the front block is blocked or already taken. This preserves all prior behavior (empty, all-blocked skip-count batching, context cancellation, panic recovery). The only cost is one extra `CanProcessBlock` on the front block in the fallback case; that call is a cheap in-memory check (atomic load + map lookups in `ForkManager`), so it is negligible.

### Tests
Added to `block_priority_get_test.go`:
- `TestBlockPriorityQueue_Get_FastPathDeepQueue` — front processable behind 99 blocked followers: returns the front, removes only it, probes exactly one block.
- `TestBlockPriorityQueue_Get_SlowPathFallbackDeepQueue` — front blocked, only the deepest follower processable: fallback scan still returns it.

