### PR TITLE
fix(rpc,settings): complete reflect.Ptr → reflect.Pointer modernization

### DIFF
--- a/services/rpc/bsvjson/cmdparse_test.go
+++ b/services/rpc/bsvjson/cmdparse_test.go
@@ -179,7 +179,7 @@ func TestAssignField(t *testing.T) {
 
 		// Inidirect through to the base types to ensure their values
 		// are the same.
-		for dst.Kind() == reflect.Ptr {
+		for dst.Kind() == reflect.Pointer {
 			dst = dst.Elem()
 		}
 

--- a/services/rpc/bsvjson/help.go
+++ b/services/rpc/bsvjson/help.go
@@ -101,7 +101,7 @@ func resultStructHelp(xT descLookupFunc, rt reflect.Type, indentLevel int) []str
 
 		// Deference pointer if needed.
 		rtfType := rtf.Type
-		if rtfType.Kind() == reflect.Ptr {
+		if rtfType.Kind() == reflect.Pointer {
 			rtfType = rtf.Type.Elem()
 		}
 
@@ -149,7 +149,7 @@ func resultStructHelp(xT descLookupFunc, rt reflect.Type, indentLevel int) []str
 // differently.
 func reflectTypeToJSONExample(xT descLookupFunc, rt reflect.Type, indentLevel int, fieldDescKey string, embeddedStruct bool) ([]string, bool) {
 	// Indirect pointer if needed.
-	if rt.Kind() == reflect.Ptr {
+	if rt.Kind() == reflect.Pointer {
 		rt = rt.Elem()
 	}
 
@@ -315,7 +315,7 @@ func argTypeHelp(xT descLookupFunc, structField reflect.StructField, defaultVal 
 
 	var isOptional bool
 
-	if fieldType.Kind() == reflect.Ptr {
+	if fieldType.Kind() == reflect.Pointer {
 		fieldType = fieldType.Elem()
 		isOptional = true
 	}
@@ -388,7 +388,7 @@ func argHelp(xT descLookupFunc, rtp reflect.Type, defaults map[int]reflect.Value
 		// For types which require a JSON object, or an array of JSON
 		// objects, generate the full syntax for the argument.
 		fieldType := rtf.Type
-		if fieldType.Kind() == reflect.Ptr {
+		if fieldType.Kind() == reflect.Pointer {
 			fieldType = fieldType.Elem()
 		}
 
@@ -567,7 +567,7 @@ func GenerateHelp(method string, descs map[string]string, resultTypes ...interfa
 		}
 
 		rtp := reflect.TypeOf(resultType)
-		if rtp.Kind() != reflect.Ptr {
+		if rtp.Kind() != reflect.Pointer {
 			str := fmt.Sprintf("result #%d (%v) is not a pointer",
 				i, rtp.Kind())
 			return "", makeError(ErrInvalidType, str)

--- a/services/rpc/bsvjson/register.go
+++ b/services/rpc/bsvjson/register.go
@@ -97,7 +97,7 @@ var (
 // indirecting through all pointers.
 func baseKindString(rt reflect.Type) string {
 	numIndirects := 0
-	for rt.Kind() == reflect.Ptr {
+	for rt.Kind() == reflect.Pointer {
 		numIndirects++
 		rt = rt.Elem()
 	}
@@ -118,7 +118,7 @@ func isAcceptableKind(kind reflect.Kind) bool {
 		fallthrough
 	case reflect.Func:
 		fallthrough
-	case reflect.Ptr:
+	case reflect.Pointer:
 		fallthrough
 	case reflect.Interface:
 		return false
@@ -174,7 +174,7 @@ func RegisterCmd(method string, cmd interface{}, flags UsageFlag) error {
 	}
 
 	rtp := reflect.TypeOf(cmd)
-	if rtp.Kind() != reflect.Ptr {
+	if rtp.Kind() != reflect.Pointer {
 		str := fmt.Sprintf("type must be *struct not '%s (%s)'", rtp,
 			rtp.Kind())
 		return makeError(ErrInvalidType, str)
@@ -212,7 +212,7 @@ func RegisterCmd(method string, cmd interface{}, flags UsageFlag) error {
 		var isOptional bool
 
 		switch kind := rtf.Type.Kind(); kind {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			isOptional = true
 			kind = rtf.Type.Elem().Kind()
 

--- a/settings/export.go
+++ b/settings/export.go
@@ -121,7 +121,7 @@ func extractFields(typ reflect.Type, path []int, entries *[]metadataEntry) {
 			fieldType := field.Type
 
 			// Handle pointer to struct (e.g., *PolicySettings)
-			if fieldType.Kind() == reflect.Ptr && fieldType.Elem().Kind() == reflect.Struct {
+			if fieldType.Kind() == reflect.Pointer && fieldType.Elem().Kind() == reflect.Struct {
 				extractFields(fieldType.Elem(), fieldPath, entries)
 			} else if fieldType.Kind() == reflect.Struct {
 				extractFields(fieldType, fieldPath, entries)
@@ -162,7 +162,7 @@ func getValueAtPath(val reflect.Value, path []int) reflect.Value {
 	for _, idx := range path {
 		val = val.Field(idx)
 		// Dereference pointers to access nested struct fields
-		if val.Kind() == reflect.Ptr {
+		if val.Kind() == reflect.Pointer {
 			if val.IsNil() {
 				// Return invalid value for nil pointers
 				return reflect.Value{}
@@ -201,7 +201,7 @@ func formatValue(val reflect.Value) string {
 			return u.String()
 		}
 		return fmt.Sprintf("%v", val.Interface())
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if val.IsNil() {
 			return ""
 		}


### PR DESCRIPTION
## Summary

Follow-up to #1219. That PR only updated the `reflect.Ptr` uses SonarCloud had surfaced in its govet sample; a repo-wide sweep found **13 more** deprecated `reflect.Ptr` uses across `services/rpc/bsvjson/` and `settings/export.go`.

Includes the **3 MAJOR `external_govet:inline` bugs** (`help.go:104/152/318`) that are currently driving the **overall reliability rating to C**, plus the remaining uses that would surface on the next scan (`help.go:391/570`, `register.go:100/121/177/215`, `settings/export.go:124/165/204`, `cmdparse_test.go:182`).

`reflect.Ptr` is a deprecated alias for `reflect.Pointer` — pure rename, no behaviour change.

## Verification

```
go build ./services/rpc/bsvjson/ ./settings/   # ok
go vet   ./services/rpc/bsvjson/ ./settings/    # clean
go test  ./services/rpc/bsvjson/ ./settings/    # ok
```

Once merged and re-scanned, the 3 MAJOR reliability bugs clear → overall reliability rating C → B. (The remaining new-code B, from mistyped filename code-smells, is being addressed separately.)