### PR TITLE
test(settings): guard profiler contention-profiling loader wiring

### DIFF
--- a/settings/profiler_settings_test.go
+++ b/settings/profiler_settings_test.go
@@ -1,0 +1,54 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/ordishs/gocore"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProfilerContentionSettings_LoaderReadsBothKeys guards
+// BlockProfileRate/MutexProfileFraction against the field-exists-but-loader-
+// never-reads-it bug: each field has a `key:` tag, but if NewSettings() does
+// not call getInt for it the value stays at Go zero regardless of what's
+// configured, silently leaving contention profiling permanently disabled.
+//
+// Default 0 == Go zero, so a default-value assertion alone would pass
+// spuriously even with a missing loader entry. The honest test is: set a
+// non-zero override, call NewSettings(), assert the field changed.
+func TestProfilerContentionSettings_LoaderReadsBothKeys(t *testing.T) {
+	def := NewSettings()
+	require.Equal(t, 0, def.BlockProfileRate,
+		"default BlockProfileRate must be 0 (disabled); block profiling must not run by default in prod")
+	require.Equal(t, 0, def.MutexProfileFraction,
+		"default MutexProfileFraction must be 0 (disabled); mutex profiling must not run by default in prod")
+
+	type kv struct {
+		key      string
+		override string
+		check    func(t *testing.T, s *Settings)
+	}
+
+	cases := []kv{
+		{
+			key:      "profiler_blockProfileRate",
+			override: "1000000",
+			check:    func(t *testing.T, s *Settings) { require.Equal(t, 1000000, s.BlockProfileRate) },
+		},
+		{
+			key:      "profiler_mutexProfileFraction",
+			override: "100",
+			check:    func(t *testing.T, s *Settings) { require.Equal(t, 100, s.MutexProfileFraction) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			gocore.Config().Set(tc.key, tc.override)
+			t.Cleanup(func() { gocore.Config().Set(tc.key, "") })
+
+			s := NewSettings()
+			tc.check(t, s)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- \`profiler_blockProfileRate\` / \`profiler_mutexProfileFraction\` were already fully wired on \`main\` (struct tags in \`settings/interface.go\`, \`NewSettings()\` loader entries in \`settings/settings.go\`, and the \`runtime.SetBlockProfileRate\`/\`SetMutexProfileFraction\` gating in \`daemon.startProfilerAndMetrics\`) but had no dedicated test proving the loader actually reads them.
- Both default to \`0\`, which is also the Go zero value — so a missing \`getInt()\` entry in \`settings.go\` would silently leave contention profiling permanently disabled in every deployment without any test catching it.
- Adds an override-based loader test (set a non-zero value via \`gocore.Config().Set\`, call \`NewSettings()\`, assert the field changed), following the same pattern already used for this class of bug in \`TestBatcherTickInterval_LoaderReadsAllKeys\`.

No production code changes — this is test-only, closing an observability gap identified while investigating a throughput bottleneck on the dev-scale-1 cluster (mutex/block profiling wasn't enabled, so contention had to be inferred indirectly from CPU/goroutine profiles).

## Test plan

- [x] \`go build ./settings/...\`
- [x] \`go vet ./settings/...\`
- [x] \`go test -race ./settings/...\`
- [x] \`golangci-lint run ./settings/...\` — 0 issues
- [x] \`staticcheck ./settings/...\` — clean