### PR TITLE
chore(deps): bump bsv aerospike-client-go fork to v8.7.1-bsv5 (fixes concurrent map read/write crash)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/bitcoin-sv/bdk/module/gobdk v1.2.5-0.20260526081552-cdfa7814ee5d
-	github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv4
+	github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv5
 	github.com/bsv-blockchain/go-bt/v2 v2.6.7
 	github.com/bsv-blockchain/go-chaincfg v1.5.8
 	github.com/bsv-blockchain/go-sdk v1.2.24

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/bitcoinsv/bsvutil v0.0.0-20181216182056-1d77cf353ea9/go.mod h1:p44KuN
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv4 h1:ydeA81l8VFC7FImHkLnaTvsgPh9uOb0YdAw1t44O43o=
-github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv4/go.mod h1:t4MjZ6nitI84mr/KhpPGFCCeCT4+y4hq0di8qOHIIGk=
+github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv5 h1:GNsn4PLzhoU8Vm5PNASTEZriQRrpb6kSg4hDUT0qdRM=
+github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv5/go.mod h1:t4MjZ6nitI84mr/KhpPGFCCeCT4+y4hq0di8qOHIIGk=
 github.com/bsv-blockchain/go-alert-system v0.1.6 h1:pXJqJZVJw4ha46CircxOhcV0iNzohf2nt1l4O3TNtSI=
 github.com/bsv-blockchain/go-alert-system v0.1.6/go.mod h1:3Pwm4O0GcGiYFuofRml7UEWBWt0a4kKLCsvisyOpQps=
 github.com/bsv-blockchain/go-batcher/v2 v2.0.4 h1:u3mEx4W8rufC3W/G3MlJ8Al0pnYsKHe0CZwZAhk6lqs=


### PR DESCRIPTION
Bumps the BSV aerospike-client-go fork **v8.7.1-bsv4 → v8.7.1-bsv5**.

### Why
Production hit a `fatal error: concurrent map read and map write` originating in the client:

```
v8.GetNodeBatchRead(...)            partition.go:128   <- lockless map READ
v8.(*Client).BatchOperate(...)      client.go:971
uaerospike.(*Client).BatchOperate   ...
aerospike.(*Store).BatchDecorate    get.go:632
txmetacache.(*TxMetaCache).BatchDecorate
subtreevalidation.(*Server).processTxMetaUsingStore.func1
```

`Cluster.Close()` mutated the live partition map in place (`cleanup()`) to help the GC, racing an in-flight `BatchOperate`'s lockless snapshot read. Client fix (`bsv-blockchain/aerospike-client-go@55d3b1f`): `Close()` swaps in a fresh empty partition map instead, so in-flight readers keep their immutable snapshot and the old map is GC'd once they drain. Verified upstream with a `-race` regression test reproducing the exact stack.

### Scope
The crash path is the general `BatchOperate` decorate path — **not** native-op specific — so `main` needs the bump independently of #828 (which also carries it). Version-only change; the module's own `go.mod` is unchanged (no transitive churn).

### Not covered here
The client fix stops the *crash* but does not make "close a client during active operations" correct — in-flight ops can still error on close. The teranode-side drain-before-close (Store.Close closes the shared client without waiting for in-flight non-batcher ops like BatchDecorate) is a separate follow-up.

### Verified
- `go build ./...` clean on `main`
- `go vet ./util/uaerospike` clean
