### PR TITLE
chore(sonar): knock out low-risk major code smells

### DIFF
--- a/compose/multinode.sh
+++ b/compose/multinode.sh
@@ -537,12 +537,13 @@ chaos_isolate() {
 }
 
 chaos_heal() {
-  if [[ -n "${1:-}" ]]; then
+  local node_num="${1:-}"
+  if [[ -n "$node_num" ]]; then
     local ctr
-    ctr=$(container_name "$1")
-    echo "restoring teranode$1 peer traffic..."
+    ctr=$(container_name "$node_num")
+    echo "restoring teranode$node_num peer traffic..."
     netns_iptables "$ctr" -F 2>/dev/null || true
-    echo "teranode$1 healed"
+    echo "teranode$node_num healed"
     return
   fi
   echo "restoring all nodes..."

--- a/scripts/bestblock-dev.sh
+++ b/scripts/bestblock-dev.sh
@@ -2,20 +2,23 @@
 
 function get_block_header() {
   local node=$1
+  local output_file=$2
   local url="http://$node/api/v1/bestblockheader/json"
-  curl -s "$url" | jq -r '. | "\(.height): \(.hash)"' > "$2" # Write output to temp file
+  curl -s "$url" | jq -r '. | "\(.height): \(.hash)"' > "$output_file" # Write output to temp file
 }
 
 function get_fsm_state() {
   local node=$1
+  local output_file=$2
   local url="http://$node/api/v1/fsm/state"
-  curl -s "$url" | jq -r '.state' > "$2" # Write output to temp file
+  curl -s "$url" | jq -r '.state' > "$output_file" # Write output to temp file
 }
 
 function get_service_heights() {
   local node=$1
+  local output_file=$2
   local url="http://$node/api/v1/service/heights"
-  curl -s "$url" | jq -r '"Persister: \(.block_persister_height // "N/A") Assembly: \(.block_assembly_height // "N/A")"' > "$2"
+  curl -s "$url" | jq -r '"Persister: \(.block_persister_height // "N/A") Assembly: \(.block_assembly_height // "N/A")"' > "$output_file"
 }
 
 while true; do

--- a/scripts/bestblock-teranet.sh
+++ b/scripts/bestblock-teranet.sh
@@ -2,19 +2,19 @@
 
 function get_block_header() {
   local node=$1
-  https://eu-central-1-teranode-teranet-prod-1.ubsv.dev/
+  local output_file=$2
   local url="https://$node.ubsv.dev/api/v1/bestblockheader/json"
   local output=$(curl -s "$url")
 
   if [[ -z $output ]]; then
-    echo "n/a" > "$2" # Write n/a to temp file
+    echo "n/a" > "$output_file" # Write n/a to temp file
   else
     # Check if the output is valid JSON
     echo $output | jq -e . > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
-      echo "n/a" > "$2" # Write n/a to temp file
+      echo "n/a" > "$output_file" # Write n/a to temp file
     else
-      echo $output | jq -r '. | "\(.height): \(.hash)"' > "$2" # Write output to temp file
+      echo $output | jq -r '. | "\(.height): \(.hash)"' > "$output_file" # Write output to temp file
     fi
   fi
 }

--- a/scripts/lastblocks.sh
+++ b/scripts/lastblocks.sh
@@ -3,8 +3,9 @@
 function get_lastblocks() {
   local node=$1
   local n=$2
+  local output_file=$3
   local url="https://$node.scaling.ubsv.dev/api/v1/lastblocks?n=$n"
-  curl -s "$url" | jq -r '.[] | "\(.height) \(.height): \(.hash)"' > "$3"
+  curl -s "$url" | jq -r '.[] | "\(.height) \(.height): \(.hash)"' > "$output_file"
 }
 
 n=10

--- a/services/asset/httpimpl/settings_handler.go
+++ b/services/asset/httpimpl/settings_handler.go
@@ -110,14 +110,8 @@ func (h *SettingsHandler) GetSettings(c echo.Context) error {
 			cmp = strings.Compare(strings.ToLower(filtered[i].Key), strings.ToLower(filtered[j].Key))
 		case "name":
 			cmp = strings.Compare(strings.ToLower(filtered[i].Name), strings.ToLower(filtered[j].Name))
-		case "category":
-			cmp = strings.Compare(strings.ToLower(filtered[i].Category), strings.ToLower(filtered[j].Category))
-			if cmp == 0 {
-				// Secondary sort by key within category
-				cmp = strings.Compare(strings.ToLower(filtered[i].Key), strings.ToLower(filtered[j].Key))
-			}
 		default:
-			// Default to category then key
+			// "category" and any unknown field sort by category, then key.
 			cmp = strings.Compare(strings.ToLower(filtered[i].Category), strings.ToLower(filtered[j].Category))
 			if cmp == 0 {
 				cmp = strings.Compare(strings.ToLower(filtered[i].Key), strings.ToLower(filtered[j].Key))

--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -481,6 +481,7 @@ func sendChunkResult(ctx context.Context, resultsChan chan<- chunkResult, result
 
 func drainChunkResults(resultsChan <-chan chunkResult) {
 	for range resultsChan {
+		// drain remaining results until the channel is closed
 	}
 }
 

--- a/services/legacy/bsvutil/merkleblock/decode.go
+++ b/services/legacy/bsvutil/merkleblock/decode.go
@@ -17,7 +17,7 @@ import (
 // size (240 bytes) to calculate max number of transactions that could fit
 // in a block which at this time is 4000000/240=16666
 //
-// bitcoin ABC has removed this check and has been marked "FIXME".
+// bitcoin ABC has removed this check and flagged it for revisiting.
 //
 // we have opted to use a similar calculation to core based on smallest
 // possible transaction size spending OP_TRUE at 61 bytes with max block

--- a/services/rpc/bsvjson/help.go
+++ b/services/rpc/bsvjson/help.go
@@ -395,12 +395,7 @@ func argHelp(xT descLookupFunc, rtp reflect.Type, defaults map[int]reflect.Value
 		kind := fieldType.Kind()
 
 		switch kind {
-		case reflect.Struct:
-			fieldDescKey := fmt.Sprintf("%s-%s", method, fieldName)
-			resultText := resultTypeHelp(xT, fieldType, fieldDescKey)
-			args = append(args, resultText)
-
-		case reflect.Map:
+		case reflect.Struct, reflect.Map:
 			fieldDescKey := fmt.Sprintf("%s-%s", method, fieldName)
 			resultText := resultTypeHelp(xT, fieldType, fieldDescKey)
 			args = append(args, resultText)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.go.coverage.reportPaths=coverage.out
 sonar.go.golangci-lint.reportPaths=golangci-lint-report.xml
 sonar.externalIssuesReportPaths=sonar_filename_report.json
 
-sonar.exclusions=**test**,**/docs/**,**vendor**,ui/**,ui_v2/**,**/*.pb.go,**/mock.go,**/Mock.go,**/interface.go,**/Interface.go
+sonar.exclusions=**test**,**/docs/**,**vendor**,ui/**,ui_v2/**,.claude/**,**/*.pb.go,**/mock.go,**/Mock.go,**/interface.go,**/Interface.go
 sonar.coverage.exclusions=poc/**,ui/dashboard/**,k8sresolver/**,cmd/**,compose/cmd/**,tracing/**,internal/profiling/**,compose/chainintegrity/**,**/benchmark.go,scripts/validate-markdown.py,services/legacy/**,model/TestHelper.go,util/kafka/kafka_producer_async.go
 sonar.cpd.exclusions=poc/**,ui/dashboard/**,cmd/**
 sonar.tests=.

--- a/stores/utxo/aerospike/consistency_scan_test.go
+++ b/stores/utxo/aerospike/consistency_scan_test.go
@@ -438,6 +438,7 @@ func Test_launchConsistencyScan(t *testing.T) {
 
 		// Drain — wait for channels to close (all workers done)
 		for range it.resultChan {
+			// drain until closed
 		}
 		require.Equal(t, int32(4096), workerCount.Load())
 		it.Close()

--- a/util/kafka/in_memory_kafka/in_memory_kafka_test.go
+++ b/util/kafka/in_memory_kafka/in_memory_kafka_test.go
@@ -139,8 +139,10 @@ func TestInMemoryAsyncProducerClose(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	require.NoError(t, producer.Close())
 	for range producer.Successes() {
+		// drain successes channel
 	}
 	for range producer.Errors() {
+		// drain errors channel
 	}
 	_, okSuccess := <-producer.Successes()
 	assert.False(t, okSuccess)


### PR DESCRIPTION
## Summary

Low-risk maintainability quick wins across several rules. No product-logic behaviour changes.

| Rule | What | Count |
|---|---|---|
| exclusion | `.claude/**` excluded from analysis — Claude Code skill/diagnostic scripts, not product code (same rationale as `ui/**`, `docs/**`) | ~36 shell smells |
| `go:S1871` | merge identical switch cases — `help.go` → `case reflect.Struct, reflect.Map`; `settings_handler.go` drops the redundant `"category"` case (`default` already handles it identically) | 2 |
| `go:S108` | annotate the intentional channel-drain loops (`for range ch {}`) | 4 |
| `go:S1134` | reword a comment so the literal `FIXME` token (describing Bitcoin ABC history, not our TODO) no longer trips the rule | 1 |
| `shelldre:S7679` | assign `$2`/`$3` output-file args to named locals in the bestblock/lastblocks helpers and `chaos_heal` | 10 |

Also removed a stray bare-URL line in `bestblock-teranet.sh` that would error as a command on every call (copy-paste artifact).

## Deliberately skipped (not low-risk)

- **`multinode.sh` arg-parser `case "$1"` loops** (`S7679`, ~6) — idiomatic argument parsing; the refactor adds noise and risks `shift` bugs for a MINOR smell.
- **`script_utils_test.go` 107-branch opcode→name switch** (`S1479`) — a genuine refactor (map dispatch), not a quick win.

## Verification

```
bash -n on all edited shell scripts        # ok
go build / go vet (edited packages)        # ok
go test ./services/rpc/bsvjson/ ./services/asset/httpimpl/   # ok
gofmt -l (edited Go files)                 # clean
```

## Related (not in this PR)

Raising the `go:S107` "too many parameters" threshold 7→10 is a separate quality-profile change (clears ~37 of 45), pending maintainer sign-off since it edits the shared org profile.