### PR TITLE
refactor: reduce cognitive complexity in two functions (S3776)

### DIFF
--- a/internal/profiling/memory_analyzer.go
+++ b/internal/profiling/memory_analyzer.go
@@ -120,42 +120,8 @@ func parseSmaps(breakdown *MemoryBreakdown) error {
 			continue
 		}
 
-		// Parse memory statistics for current region
-		var value int64
-		if strings.HasPrefix(line, "Size:") {
-			_, _ = fmt.Sscanf(line, "Size: %d kB", &value)
-			currentRegion.Size = value * 1024
-			breakdown.TotalVirtual += value * 1024
-		} else if strings.HasPrefix(line, "Rss:") {
-			_, _ = fmt.Sscanf(line, "Rss: %d kB", &value)
-			currentRegion.Rss = value * 1024
-			breakdown.TotalRss += value * 1024
-		} else if strings.HasPrefix(line, "Pss:") {
-			_, _ = fmt.Sscanf(line, "Pss: %d kB", &value)
-			currentRegion.Pss = value * 1024
-			breakdown.TotalPss += value * 1024
-		} else if strings.HasPrefix(line, "Shared_Clean:") {
-			_, _ = fmt.Sscanf(line, "Shared_Clean: %d kB", &value)
-			currentRegion.SharedClean = value * 1024
-		} else if strings.HasPrefix(line, "Shared_Dirty:") {
-			_, _ = fmt.Sscanf(line, "Shared_Dirty: %d kB", &value)
-			currentRegion.SharedDirty = value * 1024
-		} else if strings.HasPrefix(line, "Private_Clean:") {
-			_, _ = fmt.Sscanf(line, "Private_Clean: %d kB", &value)
-			currentRegion.PrivateClean = value * 1024
-		} else if strings.HasPrefix(line, "Private_Dirty:") {
-			_, _ = fmt.Sscanf(line, "Private_Dirty: %d kB", &value)
-			currentRegion.PrivateDirty = value * 1024
-		} else if strings.HasPrefix(line, "Referenced:") {
-			_, _ = fmt.Sscanf(line, "Referenced: %d kB", &value)
-			currentRegion.Referenced = value * 1024
-		} else if strings.HasPrefix(line, "Anonymous:") {
-			_, _ = fmt.Sscanf(line, "Anonymous: %d kB", &value)
-			currentRegion.Anonymous = value * 1024
-		} else if strings.HasPrefix(line, "Swap:") {
-			_, _ = fmt.Sscanf(line, "Swap: %d kB", &value)
-			currentRegion.Swap = value * 1024
-		}
+		// Parse memory statistics for current region.
+		parseRegionStat(line, currentRegion, breakdown)
 	}
 
 	// Don't forget the last region
@@ -165,6 +131,48 @@ func parseSmaps(breakdown *MemoryBreakdown) error {
 	}
 
 	return scanner.Err()
+}
+
+// parseRegionStat parses a single smaps statistic line into region, and
+// accumulates the aggregate totals (virtual/rss/pss) into breakdown.
+func parseRegionStat(line string, region *MemoryRegion, breakdown *MemoryBreakdown) {
+	var value int64
+
+	switch {
+	case strings.HasPrefix(line, "Size:"):
+		_, _ = fmt.Sscanf(line, "Size: %d kB", &value)
+		region.Size = value * 1024
+		breakdown.TotalVirtual += value * 1024
+	case strings.HasPrefix(line, "Rss:"):
+		_, _ = fmt.Sscanf(line, "Rss: %d kB", &value)
+		region.Rss = value * 1024
+		breakdown.TotalRss += value * 1024
+	case strings.HasPrefix(line, "Pss:"):
+		_, _ = fmt.Sscanf(line, "Pss: %d kB", &value)
+		region.Pss = value * 1024
+		breakdown.TotalPss += value * 1024
+	case strings.HasPrefix(line, "Shared_Clean:"):
+		_, _ = fmt.Sscanf(line, "Shared_Clean: %d kB", &value)
+		region.SharedClean = value * 1024
+	case strings.HasPrefix(line, "Shared_Dirty:"):
+		_, _ = fmt.Sscanf(line, "Shared_Dirty: %d kB", &value)
+		region.SharedDirty = value * 1024
+	case strings.HasPrefix(line, "Private_Clean:"):
+		_, _ = fmt.Sscanf(line, "Private_Clean: %d kB", &value)
+		region.PrivateClean = value * 1024
+	case strings.HasPrefix(line, "Private_Dirty:"):
+		_, _ = fmt.Sscanf(line, "Private_Dirty: %d kB", &value)
+		region.PrivateDirty = value * 1024
+	case strings.HasPrefix(line, "Referenced:"):
+		_, _ = fmt.Sscanf(line, "Referenced: %d kB", &value)
+		region.Referenced = value * 1024
+	case strings.HasPrefix(line, "Anonymous:"):
+		_, _ = fmt.Sscanf(line, "Anonymous: %d kB", &value)
+		region.Anonymous = value * 1024
+	case strings.HasPrefix(line, "Swap:"):
+		_, _ = fmt.Sscanf(line, "Swap: %d kB", &value)
+		region.Swap = value * 1024
+	}
 }
 
 // categorizeRegion places a memory region into the appropriate category.

--- a/internal/profiling/memory_analyzer_test.go
+++ b/internal/profiling/memory_analyzer_test.go
@@ -3,7 +3,6 @@ package profiling
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +25,7 @@ func TestParseRegionStat(t *testing.T) {
 		"Referenced:            7 kB",
 		"Anonymous:             9 kB",
 		"Swap:                 10 kB",
-		"VmFlags: rd wr mr mw me ac", // unrecognised -> no-op
+		"VmFlags: rd wr mr mw me ac",  // unrecognised -> no-op
 		"KernelPageSize:        4 kB", // unrecognised (not a tracked prefix)
 	}
 	for _, l := range lines {
@@ -35,21 +34,21 @@ func TestParseRegionStat(t *testing.T) {
 
 	const kB = int64(1024)
 	// Per-region fields (value * 1024).
-	assert.Equal(t, 8*kB, region.Size)
-	assert.Equal(t, 4*kB, region.Rss)
-	assert.Equal(t, 2*kB, region.Pss)
-	assert.Equal(t, 1*kB, region.SharedClean)
-	assert.Equal(t, 3*kB, region.SharedDirty)
-	assert.Equal(t, 5*kB, region.PrivateClean)
-	assert.Equal(t, 6*kB, region.PrivateDirty)
-	assert.Equal(t, 7*kB, region.Referenced)
-	assert.Equal(t, 9*kB, region.Anonymous)
-	assert.Equal(t, 10*kB, region.Swap)
+	require.Equal(t, 8*kB, region.Size)
+	require.Equal(t, 4*kB, region.Rss)
+	require.Equal(t, 2*kB, region.Pss)
+	require.Equal(t, 1*kB, region.SharedClean)
+	require.Equal(t, 3*kB, region.SharedDirty)
+	require.Equal(t, 5*kB, region.PrivateClean)
+	require.Equal(t, 6*kB, region.PrivateDirty)
+	require.Equal(t, 7*kB, region.Referenced)
+	require.Equal(t, 9*kB, region.Anonymous)
+	require.Equal(t, 10*kB, region.Swap)
 
 	// Aggregate totals (only Size/Rss/Pss accumulate).
-	assert.Equal(t, 8*kB, breakdown.TotalVirtual)
-	assert.Equal(t, 4*kB, breakdown.TotalRss)
-	assert.Equal(t, 2*kB, breakdown.TotalPss)
+	require.Equal(t, 8*kB, breakdown.TotalVirtual)
+	require.Equal(t, 4*kB, breakdown.TotalRss)
+	require.Equal(t, 2*kB, breakdown.TotalPss)
 
 	// Unrecognised prefixes (KernelPageSize also mentions "kB") must not leak
 	// into any tracked field — nothing above should have been overwritten.
@@ -70,10 +69,10 @@ func TestParseRegionStat_Accumulates(t *testing.T) {
 	parseRegionStat("Rss: 1 kB", r2, breakdown)
 
 	const kB = int64(1024)
-	assert.Equal(t, 10*kB, breakdown.TotalVirtual)
-	assert.Equal(t, 5*kB, breakdown.TotalRss)
-	assert.Equal(t, int64(0), breakdown.TotalPss)
+	require.Equal(t, 10*kB, breakdown.TotalVirtual)
+	require.Equal(t, 5*kB, breakdown.TotalRss)
+	require.Equal(t, int64(0), breakdown.TotalPss)
 	// Each region keeps only its own value.
-	assert.Equal(t, 8*kB, r1.Size)
-	assert.Equal(t, 2*kB, r2.Size)
+	require.Equal(t, 8*kB, r1.Size)
+	require.Equal(t, 2*kB, r2.Size)
 }

--- a/internal/profiling/memory_analyzer_test.go
+++ b/internal/profiling/memory_analyzer_test.go
@@ -1,0 +1,79 @@
+package profiling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseRegionStat verifies the smaps statistic parser extracted from
+// parseSmaps: each recognised line sets the matching region field (in bytes),
+// Size/Rss/Pss also accumulate into the breakdown totals, and unrecognised
+// lines are a no-op.
+func TestParseRegionStat(t *testing.T) {
+	region := &MemoryRegion{}
+	breakdown := &MemoryBreakdown{}
+
+	lines := []string{
+		"Size:                  8 kB",
+		"Rss:                   4 kB",
+		"Pss:                   2 kB",
+		"Shared_Clean:          1 kB",
+		"Shared_Dirty:          3 kB",
+		"Private_Clean:         5 kB",
+		"Private_Dirty:         6 kB",
+		"Referenced:            7 kB",
+		"Anonymous:             9 kB",
+		"Swap:                 10 kB",
+		"VmFlags: rd wr mr mw me ac", // unrecognised -> no-op
+		"KernelPageSize:        4 kB", // unrecognised (not a tracked prefix)
+	}
+	for _, l := range lines {
+		parseRegionStat(l, region, breakdown)
+	}
+
+	const kB = int64(1024)
+	// Per-region fields (value * 1024).
+	assert.Equal(t, 8*kB, region.Size)
+	assert.Equal(t, 4*kB, region.Rss)
+	assert.Equal(t, 2*kB, region.Pss)
+	assert.Equal(t, 1*kB, region.SharedClean)
+	assert.Equal(t, 3*kB, region.SharedDirty)
+	assert.Equal(t, 5*kB, region.PrivateClean)
+	assert.Equal(t, 6*kB, region.PrivateDirty)
+	assert.Equal(t, 7*kB, region.Referenced)
+	assert.Equal(t, 9*kB, region.Anonymous)
+	assert.Equal(t, 10*kB, region.Swap)
+
+	// Aggregate totals (only Size/Rss/Pss accumulate).
+	assert.Equal(t, 8*kB, breakdown.TotalVirtual)
+	assert.Equal(t, 4*kB, breakdown.TotalRss)
+	assert.Equal(t, 2*kB, breakdown.TotalPss)
+
+	// Unrecognised prefixes (KernelPageSize also mentions "kB") must not leak
+	// into any tracked field — nothing above should have been overwritten.
+	require.Equal(t, 8*kB, region.Size, "unrecognised KernelPageSize line must not affect Size")
+}
+
+// TestParseRegionStat_Accumulates confirms Size/Rss/Pss sum across regions,
+// matching the running-total behaviour parseSmaps relies on.
+func TestParseRegionStat_Accumulates(t *testing.T) {
+	breakdown := &MemoryBreakdown{}
+
+	r1 := &MemoryRegion{}
+	parseRegionStat("Size: 8 kB", r1, breakdown)
+	parseRegionStat("Rss: 4 kB", r1, breakdown)
+
+	r2 := &MemoryRegion{}
+	parseRegionStat("Size: 2 kB", r2, breakdown)
+	parseRegionStat("Rss: 1 kB", r2, breakdown)
+
+	const kB = int64(1024)
+	assert.Equal(t, 10*kB, breakdown.TotalVirtual)
+	assert.Equal(t, 5*kB, breakdown.TotalRss)
+	assert.Equal(t, int64(0), breakdown.TotalPss)
+	// Each region keeps only its own value.
+	assert.Equal(t, 8*kB, r1.Size)
+	assert.Equal(t, 2*kB, r2.Size)
+}

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -271,7 +271,7 @@ func handleGetBlockHeader(ctx context.Context, s *RPCServer, cmd interface{}, _ 
 
 // getBlockHeaderVerboseResult builds the verbose getblockheader reply from the
 // block header and its metadata.
-func (s *RPCServer) getBlockHeaderVerboseResult(ctx context.Context, b *model.BlockHeader, meta *model.BlockHeaderMeta) (interface{}, error) {
+func (s *RPCServer) getBlockHeaderVerboseResult(ctx context.Context, b *model.BlockHeader, meta *model.BlockHeaderMeta) (*bsvjson.GetBlockHeaderVerboseResult, error) {
 	versionInt32, err := safeconversion.Uint32ToInt32(b.Version)
 	if err != nil {
 		return nil, err
@@ -365,7 +365,6 @@ func (s *RPCServer) getBlockHeaderVerboseResult(ctx context.Context, b *model.Bl
 
 	if !isOnMainChain {
 		headerReply.Confirmations = -1
-		return headerReply, nil
 	}
 
 	return headerReply, nil

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -262,107 +262,113 @@ func handleGetBlockHeader(ctx context.Context, s *RPCServer, cmd interface{}, _ 
 		return nil, err
 	}
 
-	if *c.Verbose {
-		versionInt32, err := safeconversion.Uint32ToInt32(b.Version)
-		if err != nil {
-			return nil, err
-		}
+	if !*c.Verbose {
+		return fmt.Sprintf("%x", b.Bytes()), nil
+	}
 
-		nonceUint64, err := safeconversion.Uint32ToUint64(b.Nonce)
-		if err != nil {
-			return nil, err
-		}
+	return s.getBlockHeaderVerboseResult(ctx, b, meta)
+}
 
-		timeInt64, err := safeconversion.Uint32ToInt64(b.Timestamp)
-		if err != nil {
-			return nil, err
-		}
+// getBlockHeaderVerboseResult builds the verbose getblockheader reply from the
+// block header and its metadata.
+func (s *RPCServer) getBlockHeaderVerboseResult(ctx context.Context, b *model.BlockHeader, meta *model.BlockHeaderMeta) (interface{}, error) {
+	versionInt32, err := safeconversion.Uint32ToInt32(b.Version)
+	if err != nil {
+		return nil, err
+	}
 
-		heightInt32, err := safeconversion.Uint32ToInt32(meta.Height)
-		if err != nil {
-			return nil, err
-		}
+	nonceUint64, err := safeconversion.Uint32ToUint64(b.Nonce)
+	if err != nil {
+		return nil, err
+	}
 
-		diff := b.Bits.CalculateDifficulty()
-		diffFloat, _ := diff.Float64()
+	timeInt64, err := safeconversion.Uint32ToInt64(b.Timestamp)
+	if err != nil {
+		return nil, err
+	}
 
-		// Get best block header for confirmations calculation
-		_, bestBlockMeta, err := s.blockchainClient.GetBestBlockHeader(ctx)
-		if err != nil {
-			return nil, err
-		}
+	heightInt32, err := safeconversion.Uint32ToInt32(meta.Height)
+	if err != nil {
+		return nil, err
+	}
 
-		// Calculate median time for this block
-		medianTime, err := calculateMedianTime(ctx, s.blockchainClient, b.Hash())
-		if err != nil {
-			// If we can't calculate median time, use block time
-			s.logger.Warnf("Failed to calculate median time for block %s: %v, falling back to block timestamp", b.Hash(), err)
-			medianTime = b.Timestamp
-		}
+	diff := b.Bits.CalculateDifficulty()
+	diffFloat, _ := diff.Float64()
 
-		// Handle previousblockhash for genesis block
-		previousBlockHash := b.HashPrevBlock.String()
-		if meta.Height == 0 {
-			// For genesis block, return empty string instead of zeros
-			previousBlockHash = ""
-		}
+	// Get best block header for confirmations calculation
+	_, bestBlockMeta, err := s.blockchainClient.GetBestBlockHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-		// Get next block hash unless there are none
-		nextBlock, err := s.blockchainClient.GetBlockByHeight(ctx, meta.Height+1)
-		var nextBlockHash string
-		if err == nil && nextBlock != nil {
-			nextBlockHash = nextBlock.Hash().String()
-		}
+	// Calculate median time for this block
+	medianTime, err := calculateMedianTime(ctx, s.blockchainClient, b.Hash())
+	if err != nil {
+		// If we can't calculate median time, use block time
+		s.logger.Warnf("Failed to calculate median time for block %s: %v, falling back to block timestamp", b.Hash(), err)
+		medianTime = b.Timestamp
+	}
 
-		// Get block size
-		blockBytes := b.Bytes()
-		blockSizeInt32, err := safeconversion.IntToInt32(len(blockBytes))
-		if err != nil {
-			return nil, err
-		}
+	// Handle previousblockhash for genesis block
+	previousBlockHash := b.HashPrevBlock.String()
+	if meta.Height == 0 {
+		// For genesis block, return empty string instead of zeros
+		previousBlockHash = ""
+	}
 
-		// Get transaction count from the block at this height
-		block, err := s.blockchainClient.GetBlockByHeight(ctx, meta.Height)
-		var numTx int
-		if err == nil && block != nil {
-			numTx = int(block.TransactionCount)
-		}
+	// Get next block hash unless there are none
+	nextBlock, err := s.blockchainClient.GetBlockByHeight(ctx, meta.Height+1)
+	var nextBlockHash string
+	if err == nil && nextBlock != nil {
+		nextBlockHash = nextBlock.Hash().String()
+	}
 
-		headerReply := &bsvjson.GetBlockHeaderVerboseResult{
-			Hash:          b.Hash().String(),
-			Version:       versionInt32,
-			VersionHex:    fmt.Sprintf("%08x", b.Version),
-			PreviousHash:  previousBlockHash,
-			Nonce:         nonceUint64,
-			Time:          timeInt64,
-			Bits:          b.Bits.String(),
-			Difficulty:    diffFloat,
-			MerkleRoot:    b.HashMerkleRoot.String(),
-			Confirmations: int64(1 + bestBlockMeta.Height - meta.Height),
-			Height:        heightInt32,
-			Size:          blockSizeInt32,
-			NumTx:         numTx,
-			MedianTime:    int64(medianTime),
-			ChainWork:     hex.EncodeToString(meta.ChainWork),
-			NextHash:      nextBlockHash,
-			Status:        "active",
-		}
+	// Get block size
+	blockBytes := b.Bytes()
+	blockSizeInt32, err := safeconversion.IntToInt32(len(blockBytes))
+	if err != nil {
+		return nil, err
+	}
 
-		// Check if this block is on the main chain
-		isOnMainChain, err := s.blockchainClient.CheckBlockIsInCurrentChain(ctx, []uint32{meta.ID})
-		if err != nil {
-			return nil, err
-		}
+	// Get transaction count from the block at this height
+	block, err := s.blockchainClient.GetBlockByHeight(ctx, meta.Height)
+	var numTx int
+	if err == nil && block != nil {
+		numTx = int(block.TransactionCount)
+	}
 
-		if !isOnMainChain {
-			headerReply.Confirmations = -1
-			return headerReply, nil
-		}
+	headerReply := &bsvjson.GetBlockHeaderVerboseResult{
+		Hash:          b.Hash().String(),
+		Version:       versionInt32,
+		VersionHex:    fmt.Sprintf("%08x", b.Version),
+		PreviousHash:  previousBlockHash,
+		Nonce:         nonceUint64,
+		Time:          timeInt64,
+		Bits:          b.Bits.String(),
+		Difficulty:    diffFloat,
+		MerkleRoot:    b.HashMerkleRoot.String(),
+		Confirmations: int64(1 + bestBlockMeta.Height - meta.Height),
+		Height:        heightInt32,
+		Size:          blockSizeInt32,
+		NumTx:         numTx,
+		MedianTime:    int64(medianTime),
+		ChainWork:     hex.EncodeToString(meta.ChainWork),
+		NextHash:      nextBlockHash,
+		Status:        "active",
+	}
 
+	// Check if this block is on the main chain
+	isOnMainChain, err := s.blockchainClient.CheckBlockIsInCurrentChain(ctx, []uint32{meta.ID})
+	if err != nil {
+		return nil, err
+	}
+
+	if !isOnMainChain {
+		headerReply.Confirmations = -1
 		return headerReply, nil
 	}
 
-	return fmt.Sprintf("%x", b.Bytes()), nil
+	return headerReply, nil
 }
 
 // blockToJSON converts a block to JSON format based on verbosity level.


### PR DESCRIPTION
## Summary

Two behaviour-preserving extractions to bring functions under the cognitive-complexity threshold (25). No logic changes.

| Function | Before | After |
|---|---|---|
| `rpc.handleGetBlockHeader` | 29 | **3** |
| `rpc.getBlockHeaderVerboseResult` (new) | — | **14** |
| `profiling.parseSmaps` | 27 | **16** |
| `profiling.parseRegionStat` (new) | — | **1** |

(measured with `gocognit`)

## Changes

- **`handleGetBlockHeader`**: invert to a guard clause for the non-verbose path (`if !*c.Verbose { return hex }`) and extract the verbose-reply construction into a `getBlockHeaderVerboseResult` method. The main handler is now a trivial dispatch.
- **`parseSmaps`**: extract the 10-branch smaps statistic parser into `parseRegionStat`, rewritten as a `switch`. Field assignments and the running virtual/rss/pss totals are unchanged.

The large line count in `handlers.go` is the verbose block moving into the new method (indentation), not logic churn.

## Verification

```
gofmt -l           # clean
go build/vet ./services/rpc/ ./internal/profiling/   # ok
go test ./services/rpc/                              # ok
gocognit: all four functions < 25
```