### PR TITLE
MvP-1140 Add Go-side satoshi-range/no-inflation backstop on SkipScriptValidati…

### DIFF
--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -157,7 +157,8 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 		// ERA-DEPENDENT order that mirrors BDK: pre-Genesis the sentinel first,
 		// post-Genesis the input/inflation check first. See the era switch below
 		// for why (bdk/core/txvalidator.cpp).
-		if err := tv.checkOutputValues(tx); err != nil {
+		totalOut, err := tv.checkOutputValues(tx)
+		if err != nil {
 			return err
 		}
 
@@ -190,11 +191,11 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 			if err := sentinelGuard(); err != nil {
 				return err
 			}
-			if err := tv.checkInputValuesAndInflation(tx); err != nil {
+			if err := tv.checkInputValuesAndInflation(tx, totalOut); err != nil {
 				return err
 			}
 		} else {
-			if err := tv.checkInputValuesAndInflation(tx); err != nil {
+			if err := tv.checkInputValuesAndInflation(tx, totalOut); err != nil {
 				return err
 			}
 			if err := sentinelGuard(); err != nil {
@@ -220,31 +221,32 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 // check. The running total is bounded after each addition, which also makes the
 // accumulation overflow-safe: every addend is within [0, MaxSatoshis], so the
 // total cannot wrap uint64 before it is rejected.
-func (tv *TxValidator) checkOutputValues(tx *bt.Tx) error {
+func (tv *TxValidator) checkOutputValues(tx *bt.Tx) (uint64, error) {
 	totalOut := uint64(0)
 
 	for _, out := range tx.Outputs {
 		if out.Satoshis > math.MaxInt64 {
-			return errors.NewTxInvalidError("bad-txns-vout-negative")
+			return 0, errors.NewTxInvalidError("bad-txns-vout-negative")
 		}
 
 		if out.Satoshis > MaxSatoshis {
-			return errors.NewTxInvalidError("bad-txns-vout-toolarge")
+			return 0, errors.NewTxInvalidError("bad-txns-vout-toolarge")
 		}
 
 		totalOut += out.Satoshis
 		if totalOut > MaxSatoshis {
-			return errors.NewTxInvalidError("bad-txns-txouttotal-toolarge")
+			return 0, errors.NewTxInvalidError("bad-txns-txouttotal-toolarge")
 		}
 	}
 
-	return nil
+	return totalOut, nil
 }
 
 // checkInputValuesAndInflation enforces the input money-range and no-inflation
 // invariants that BDK applies in implCheckInputValues: each input value and the
 // running total must be within [0, MaxSatoshis], and the sum of inputs must be at
-// least the sum of outputs (equality is allowed, i.e. a zero-fee transaction).
+// least totalOut (the output total already computed and bounded by
+// checkOutputValues; equality is allowed, i.e. a zero-fee transaction).
 // A high-bit or over-range input value both map to bad-txns-inputvalues-outofrange,
 // matching how the money-range predicate collapses the two cases.
 //
@@ -252,7 +254,7 @@ func (tv *TxValidator) checkOutputValues(tx *bt.Tx) error {
 // this holds for every caller that reaches ValidateTransaction. If a value-less
 // transaction were passed, the sum of inputs would be zero and the check fails
 // closed (bad-txns-in-belowout) rather than admitting coins from nothing.
-func (tv *TxValidator) checkInputValuesAndInflation(tx *bt.Tx) error {
+func (tv *TxValidator) checkInputValuesAndInflation(tx *bt.Tx, totalOut uint64) error {
 	totalIn := uint64(0)
 
 	for _, in := range tx.Inputs {
@@ -264,11 +266,6 @@ func (tv *TxValidator) checkInputValuesAndInflation(tx *bt.Tx) error {
 		if totalIn > MaxSatoshis {
 			return errors.NewTxInvalidError("bad-txns-inputvalues-outofrange")
 		}
-	}
-
-	totalOut := uint64(0)
-	for _, out := range tx.Outputs {
-		totalOut += out.Satoshis
 	}
 
 	if totalIn < totalOut {

--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -149,23 +149,57 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 	// scripts is pure overhead. The caller is responsible for ensuring the block
 	// is actually trusted (see SyncManager.quickValidationAllowed).
 	if validationOptions.SkipScriptValidation {
-		// The normal path leans on BDK to reject MEMPOOL_HEIGHT in consensus mode
-		// (bdk/core/txvalidator.cpp:779), but skipping script validation bypasses
-		// BDK entirely. Without this guard the unconfirmedParentHeight sentinel
-		// would propagate to BIP68. With the int64 height arithmetic in
-		// sequenceLocks the sentinel now evaluates to 4294967295 (not the old
-		// int32 wrap to -1), so an unguarded sentinel would FAIL the height check
-		// rather than be silently accepted; we still reject explicitly here to
-		// mirror BDK's UnconfirmedInputInBlock with the correct error instead of a
-		// generic BIP68 height failure (the MTP lookup in
-		// Validator.readMTPsLocked clamps to blockMTP).
-		if validationOptions.SkipPolicyChecks {
-			for _, h := range utxoHeights {
-				if h == unconfirmedParentHeight {
-					return errors.NewTxInvalidError("bad-txns-unconfirmed-input-in-block")
+		// Skipping script validation bypasses BDK entirely, so the money-range and
+		// no-inflation invariants BDK normally enforces are applied here as a
+		// Go-side backstop. The check order mirrors BDK's ValidateTransaction
+		// sequence: output money-range/total first (implCheckTransactionCommon),
+		// then the unconfirmed-parent sentinel, then input money-range and
+		// inflation (implCheckInputValues).
+		if err := tv.checkOutputValues(tx); err != nil {
+			return err
+		}
+
+		// The unconfirmed-parent sentinel guard mirrors BDK's UnconfirmedInputInBlock
+		// rejection, which only applies in consensus mode. Without it the
+		// unconfirmedParentHeight sentinel would propagate to BIP68: with the int64
+		// height arithmetic in sequenceLocks the sentinel evaluates to 4294967295
+		// (not the old int32 wrap to -1), so an unguarded sentinel would FAIL the
+		// height check rather than be silently accepted; we still reject explicitly
+		// here to surface the correct error instead of a generic BIP68 height
+		// failure (the MTP lookup in Validator.readMTPsLocked clamps to blockMTP).
+		sentinelGuard := func() error {
+			if validationOptions.SkipPolicyChecks {
+				for _, h := range utxoHeights {
+					if h == unconfirmedParentHeight {
+						return errors.NewTxInvalidError("bad-txns-unconfirmed-input-in-block")
+					}
 				}
 			}
+			return nil
 		}
+
+		// The sentinel is placed before or after the input/inflation check
+		// depending on protocol era, matching BDK: pre-Genesis the MEMPOOL_HEIGHT
+		// rejection runs in the consensus sigops check before input values, while
+		// post-Genesis that check returns early and the sentinel is only reached
+		// after input values during script verification. The >= boundary matches
+		// the Genesis comparison used in sequenceLocks.
+		if blockHeight < tv.settings.ChainCfgParams.GenesisActivationHeight {
+			if err := sentinelGuard(); err != nil {
+				return err
+			}
+			if err := tv.checkInputValuesAndInflation(tx); err != nil {
+				return err
+			}
+		} else {
+			if err := tv.checkInputValuesAndInflation(tx); err != nil {
+				return err
+			}
+			if err := sentinelGuard(); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
 
@@ -175,6 +209,71 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 	// SkipPolicyChecks is equivalent to BDK consensus=true.
 	// https://github.com/bsv-blockchain/teranode/issues/2367
 	return tv.bdk.ValidateTransaction(tx, blockHeight, validationOptions.SkipPolicyChecks, utxoHeights)
+}
+
+// checkOutputValues enforces the per-output and total-output money-range
+// invariants that BDK applies in implCheckTransactionCommon. Bitcoin reads each
+// 8-byte output value into a signed 64-bit amount, so a uint64 with the high bit
+// set is negative and rejected as bad-txns-vout-negative before the upper-bound
+// check. The running total is bounded after each addition, which also makes the
+// accumulation overflow-safe: every addend is within [0, MaxSatoshis], so the
+// total cannot wrap uint64 before it is rejected.
+func (tv *TxValidator) checkOutputValues(tx *bt.Tx) error {
+	totalOut := uint64(0)
+
+	for _, out := range tx.Outputs {
+		if out.Satoshis > math.MaxInt64 {
+			return errors.NewTxInvalidError("bad-txns-vout-negative")
+		}
+
+		if out.Satoshis > MaxSatoshis {
+			return errors.NewTxInvalidError("bad-txns-vout-toolarge")
+		}
+
+		totalOut += out.Satoshis
+		if totalOut > MaxSatoshis {
+			return errors.NewTxInvalidError("bad-txns-txouttotal-toolarge")
+		}
+	}
+
+	return nil
+}
+
+// checkInputValuesAndInflation enforces the input money-range and no-inflation
+// invariants that BDK applies in implCheckInputValues: each input value and the
+// running total must be within [0, MaxSatoshis], and the sum of inputs must be at
+// least the sum of outputs (equality is allowed, i.e. a zero-fee transaction).
+// A high-bit or over-range input value both map to bad-txns-inputvalues-outofrange,
+// matching how the money-range predicate collapses the two cases.
+//
+// Precondition: tx is in extended format so previous-output values are populated;
+// this holds for every caller that reaches ValidateTransaction. If a value-less
+// transaction were passed, the sum of inputs would be zero and the check fails
+// closed (bad-txns-in-belowout) rather than admitting coins from nothing.
+func (tv *TxValidator) checkInputValuesAndInflation(tx *bt.Tx) error {
+	totalIn := uint64(0)
+
+	for _, in := range tx.Inputs {
+		if in.PreviousTxSatoshis > MaxSatoshis {
+			return errors.NewTxInvalidError("bad-txns-inputvalues-outofrange")
+		}
+
+		totalIn += in.PreviousTxSatoshis
+		if totalIn > MaxSatoshis {
+			return errors.NewTxInvalidError("bad-txns-inputvalues-outofrange")
+		}
+	}
+
+	totalOut := uint64(0)
+	for _, out := range tx.Outputs {
+		totalOut += out.Satoshis
+	}
+
+	if totalIn < totalOut {
+		return errors.NewTxInvalidError("bad-txns-in-belowout")
+	}
+
+	return nil
 }
 
 // ValidateBIP68 verifies that BIP68 relative lock-time constraints are satisfied.

--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -151,10 +151,12 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 	if validationOptions.SkipScriptValidation {
 		// Skipping script validation bypasses BDK entirely, so the money-range and
 		// no-inflation invariants BDK normally enforces are applied here as a
-		// Go-side backstop. The check order mirrors BDK's ValidateTransaction
-		// sequence: output money-range/total first (implCheckTransactionCommon),
-		// then the unconfirmed-parent sentinel, then input money-range and
-		// inflation (implCheckInputValues).
+		// Go-side backstop. Output money-range/total is always checked first
+		// (implCheckTransactionCommon). The unconfirmed-parent sentinel and the
+		// input money-range/inflation check (implCheckInputValues) then run in an
+		// ERA-DEPENDENT order that mirrors BDK: pre-Genesis the sentinel first,
+		// post-Genesis the input/inflation check first. See the era switch below
+		// for why (bdk/core/txvalidator.cpp).
 		if err := tv.checkOutputValues(tx); err != nil {
 			return err
 		}

--- a/services/validator/TxValidator.go
+++ b/services/validator/TxValidator.go
@@ -181,6 +181,21 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 			return nil
 		}
 
+		// The input money-range/inflation check needs previous-output values. The
+		// OutpointOnlySpend fast path intentionally leaves the transaction un-extended
+		// and reads no parent values (Validator.validateInternal skips parent extension
+		// below the highest checkpoint, where PoW + checkpoint linkage already establish
+		// canonicality). Skip the check there, matching the parent-value-dependent extend
+		// and BIP68 guards which are gated on OutpointOnlySpend for the same reason. Every
+		// other skip-path caller supplies an extended transaction, so the backstop still
+		// runs (and still fails closed on a value-less non-OutpointOnlySpend transaction).
+		inflationGuard := func() error {
+			if validationOptions.OutpointOnlySpend {
+				return nil
+			}
+			return tv.checkInputValuesAndInflation(tx, totalOut)
+		}
+
 		// The sentinel is placed before or after the input/inflation check
 		// depending on protocol era, matching BDK: pre-Genesis the MEMPOOL_HEIGHT
 		// rejection runs in the consensus sigops check before input values, while
@@ -191,11 +206,11 @@ func (tv *TxValidator) ValidateTransaction(tx *bt.Tx, blockHeight uint32, utxoHe
 			if err := sentinelGuard(); err != nil {
 				return err
 			}
-			if err := tv.checkInputValuesAndInflation(tx, totalOut); err != nil {
+			if err := inflationGuard(); err != nil {
 				return err
 			}
 		} else {
-			if err := tv.checkInputValuesAndInflation(tx, totalOut); err != nil {
+			if err := inflationGuard(); err != nil {
 				return err
 			}
 			if err := sentinelGuard(); err != nil {

--- a/services/validator/TxValidator_test.go
+++ b/services/validator/TxValidator_test.go
@@ -20,6 +20,7 @@ Usage:
 package validator
 
 import (
+	"math"
 	"os"
 	"testing"
 
@@ -183,6 +184,316 @@ func TestTxValidator_SkipScriptValidation_AcceptsConfirmedHeightsInConsensus(t *
 	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
 	require.NoError(t, txValidator.ValidateTransaction(aTx, 100, []uint32{99, 99}, validationOptions))
 	require.Equal(t, 0, counter.calls)
+}
+
+// newSkipScriptTxValidator builds a TxValidator whose BDK adapter is a counter,
+// so the SkipScriptValidation path can be exercised without invoking BDK.
+func newSkipScriptTxValidator(t *testing.T) (*TxValidator, *countingBDKValidator) {
+	t.Helper()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	counter := &countingBDKValidator{}
+
+	return &TxValidator{
+		logger:   ulogger.TestLogger{},
+		settings: tSettings,
+		bdk:      counter,
+	}, counter
+}
+
+// opFalseReturnScript builds a minimal provably-unspendable OP_FALSE OP_RETURN
+// locking script, used for zero-value outputs.
+func opFalseReturnScript(t *testing.T) *bscript.Script {
+	t.Helper()
+
+	s := &bscript.Script{}
+	require.NoError(t, s.AppendOpcodes(bscript.OpFALSE, bscript.OpRETURN))
+
+	return s
+}
+
+// When BDK is bypassed, a transaction whose outputs exceed its inputs must be
+// rejected as coins-from-nothing rather than silently accepted.
+func TestTxValidator_SkipScriptValidation_RejectsInflation(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	for _, in := range tx.Inputs {
+		in.PreviousTxSatoshis = 1
+	}
+	tx.Outputs[0].Satoshis = 1_000_000
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-in-belowout")
+	require.Equal(t, 0, counter.calls)
+}
+
+// A uint64 output value with the high bit set deserializes as a negative signed
+// amount, which must be rejected as bad-txns-vout-negative (not too-large).
+func TestTxValidator_SkipScriptValidation_RejectsOutputNegative(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	tx.Outputs[0].Satoshis = uint64(math.MaxInt64) + 1
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-vout-negative")
+	require.Equal(t, 0, counter.calls)
+}
+
+// A single output above the money limit (but still a positive signed amount)
+// must be rejected as bad-txns-vout-toolarge.
+func TestTxValidator_SkipScriptValidation_RejectsOutputOverMaxMoney(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	tx.Outputs[0].Satoshis = MaxSatoshis + 1
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-vout-toolarge")
+	require.Equal(t, 0, counter.calls)
+}
+
+// Two individually in-range outputs whose total exceeds the money limit must be
+// rejected as bad-txns-txouttotal-toolarge.
+func TestTxValidator_SkipScriptValidation_RejectsOutputTotalOverMaxMoney(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	tx.Outputs = []*bt.Output{
+		{Satoshis: MaxSatoshis, LockingScript: tx.Outputs[0].LockingScript},
+		{Satoshis: MaxSatoshis, LockingScript: tx.Outputs[0].LockingScript},
+	}
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-txouttotal-toolarge")
+	require.Equal(t, 0, counter.calls)
+}
+
+// An input value out of the money range must be rejected as
+// bad-txns-inputvalues-outofrange, both above the limit and with the high bit set.
+func TestTxValidator_SkipScriptValidation_RejectsInputOverMaxMoney(t *testing.T) {
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+
+	for name, value := range map[string]uint64{
+		"over-max": MaxSatoshis + 1,
+		"high-bit": uint64(math.MaxInt64) + 1,
+	} {
+		t.Run(name, func(t *testing.T) {
+			txValidator, counter := newSkipScriptTxValidator(t)
+
+			tx := aTx.Clone()
+			tx.Inputs[0].PreviousTxSatoshis = value
+
+			err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "bad-txns-inputvalues-outofrange")
+			require.Equal(t, 0, counter.calls)
+		})
+	}
+}
+
+// A zero-fee transaction (sum of inputs equal to sum of outputs) with a
+// zero-value OP_RETURN output must be accepted.
+func TestTxValidator_SkipScriptValidation_AcceptsZeroFeeAndZeroValueOutputs(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	tx.Inputs[0].PreviousTxSatoshis = 500
+	tx.Inputs[1].PreviousTxSatoshis = 500
+	tx.Outputs = []*bt.Output{
+		{Satoshis: 1000, LockingScript: tx.Outputs[0].LockingScript},
+		{Satoshis: 0, LockingScript: opFalseReturnScript(t)},
+	}
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	require.NoError(t, txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions))
+	require.Equal(t, 0, counter.calls)
+}
+
+// The inflation backstop is consensus-level and must fire in policy mode too
+// (SkipPolicyChecks=false), proving it is not wired only to the consensus branch.
+func TestTxValidator_SkipScriptValidation_InflationRejectedInPolicyMode(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	for _, in := range tx.Inputs {
+		in.PreviousTxSatoshis = 1
+	}
+	tx.Outputs[0].Satoshis = 1_000_000
+
+	validationOptions := &Options{SkipPolicyChecks: false, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-in-belowout")
+	require.Equal(t, 0, counter.calls)
+}
+
+// A value-less (non-extended) transaction violates the extended-tx precondition;
+// the backstop must fail closed (reject as inflation) rather than accept.
+func TestTxValidator_SkipScriptValidation_NonExtendedFailsClosed(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	for _, in := range tx.Inputs {
+		in.PreviousTxScript = nil
+		in.PreviousTxSatoshis = 0
+	}
+	tx.Outputs[0].Satoshis = 1000
+
+	require.False(t, tx.IsExtended())
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, 100, []uint32{99, 99}, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-in-belowout")
+	require.Equal(t, 0, counter.calls)
+}
+
+// For a transaction that is both inflationary and carries an unconfirmed-parent
+// sentinel input, the surfaced error is era-dependent. Pre-Genesis the sentinel
+// is checked before input values, so the unconfirmed-input error wins.
+func TestTxValidator_SkipScriptValidation_MixedDefect_PreGenesis_SentinelWins(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	for _, in := range tx.Inputs {
+		in.PreviousTxSatoshis = 1
+	}
+	tx.Outputs[0].Satoshis = 1_000_000
+
+	blockHeight := txValidator.settings.ChainCfgParams.GenesisActivationHeight - 1
+	utxoHeights := []uint32{unconfirmedParentHeight, 99}
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, blockHeight, utxoHeights, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-unconfirmed-input-in-block")
+	require.Equal(t, 0, counter.calls)
+}
+
+// Post-Genesis the sentinel is only reached after input values, so the inflation
+// error wins for the same doubly-invalid transaction.
+func TestTxValidator_SkipScriptValidation_MixedDefect_PostGenesis_InflationWins(t *testing.T) {
+	txValidator, counter := newSkipScriptTxValidator(t)
+
+	tx := aTx.Clone()
+	for _, in := range tx.Inputs {
+		in.PreviousTxSatoshis = 1
+	}
+	tx.Outputs[0].Satoshis = 1_000_000
+
+	blockHeight := txValidator.settings.ChainCfgParams.GenesisActivationHeight
+	utxoHeights := []uint32{unconfirmedParentHeight, 99}
+
+	validationOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+	err := txValidator.ValidateTransaction(tx, blockHeight, utxoHeights, validationOptions)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-in-belowout")
+	require.Equal(t, 0, counter.calls)
+}
+
+// The Go-side backstop must surface the same reject markers as the real BDK path
+// for each representative value failure — this is the drift guard between the two
+// implementations. For every case the same mutated transaction is run through both
+// the skip path (Go backstop, BDK bypassed) and the real gobdk validator, and both
+// errors must carry the same bad-txns-* marker.
+//
+// The real BDK validator uses the gobdk cgo binding, which is a non-test import of
+// this package (ScriptVerifierGoBDK.go); the package cannot build or run its tests
+// without it, so the BDK assertions below always execute when these tests run
+// (identically to TestScriptVerifierGoBDK). No build tag or conditional skip is
+// used because there is no build of this package in which BDK is absent.
+//
+// The BDK validator runs on the same mainnet configuration where the unmutated
+// fixture validates cleanly (see TestScriptVerifierGoBDK), and BDK evaluates output
+// and input money ranges before script verification, so each mutation surfaces its
+// money error rather than a signature failure.
+func TestSkipPath_MoneyChecks_MatchBDKPath(t *testing.T) {
+	skipOptions := &Options{SkipPolicyChecks: true, SkipScriptValidation: true}
+
+	mainnetParams, err := chaincfg.GetChainParams("mainnet")
+	require.NoError(t, err)
+
+	bdkValidator := newScriptVerifierGoBDK(ulogger.TestLogger{}, settings.NewPolicySettings(), mainnetParams)
+
+	const bdkBlockHeight = uint32(110300)
+
+	bdkUTXOHeights := []uint32{631924, 631924}
+
+	tests := []struct {
+		name   string
+		mutate func(tx *bt.Tx)
+		marker string
+	}{
+		{
+			name:   "output high-bit negative",
+			mutate: func(tx *bt.Tx) { tx.Outputs[0].Satoshis = uint64(math.MaxInt64) + 1 },
+			marker: "bad-txns-vout-negative",
+		},
+		{
+			name:   "output over max",
+			mutate: func(tx *bt.Tx) { tx.Outputs[0].Satoshis = MaxSatoshis + 1 },
+			marker: "bad-txns-vout-toolarge",
+		},
+		{
+			name: "output total over max",
+			mutate: func(tx *bt.Tx) {
+				tx.Outputs = []*bt.Output{
+					{Satoshis: MaxSatoshis, LockingScript: tx.Outputs[0].LockingScript},
+					{Satoshis: MaxSatoshis, LockingScript: tx.Outputs[0].LockingScript},
+				}
+			},
+			marker: "bad-txns-txouttotal-toolarge",
+		},
+		{
+			name:   "input over max",
+			mutate: func(tx *bt.Tx) { tx.Inputs[0].PreviousTxSatoshis = MaxSatoshis + 1 },
+			marker: "bad-txns-inputvalues-outofrange",
+		},
+		{
+			name: "inputs below outputs",
+			mutate: func(tx *bt.Tx) {
+				for _, in := range tx.Inputs {
+					in.PreviousTxSatoshis = 1
+				}
+				tx.Outputs[0].Satoshis = 1_000_000
+			},
+			marker: "bad-txns-in-belowout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Skip path: Go backstop, BDK bypassed. Pins the skip-path marker.
+			txValidator, counter := newSkipScriptTxValidator(t)
+
+			skipTx := aTx.Clone()
+			tt.mutate(skipTx)
+
+			skipErr := txValidator.ValidateTransaction(skipTx, 100, []uint32{99, 99}, skipOptions)
+			require.Error(t, skipErr)
+			require.Contains(t, skipErr.Error(), tt.marker)
+			require.Equal(t, 0, counter.calls)
+
+			// Real BDK path: same mutation, consensus mode. The returned error must
+			// carry the same marker, proving the Go backstop has not drifted.
+			bdkTx := aTx.Clone()
+			tt.mutate(bdkTx)
+
+			bdkErr := bdkValidator.ValidateTransaction(bdkTx, bdkBlockHeight, true, bdkUTXOHeights)
+			require.Error(t, bdkErr)
+			require.Contains(t, bdkErr.Error(), tt.marker)
+		})
+	}
 }
 
 // policy settings tests


### PR DESCRIPTION
This resolve https://github.com/bsv-blockchain/teranode/issues/1140

## Problem

The "no inflation" and satoshi-range invariants — `sum(outputs) ≤ sum(inputs)` and every output/total within `[0, MaxSatoshis]` — were enforced **only inside GoBDK**. Two consequences:

- On the `SkipScriptValidation` path, `TxValidator.ValidateTransaction` returns after only an unconfirmed-parent guard and **never calls BDK**, so there was *no* value or inflation check at all on that path. A future caller setting `SkipScriptValidation` on an untrusted path would accept coins-from-nothing with zero Go-side backstop.
- The `MaxSatoshis` constant was dead code (referenced only at its own definition), which misleads readers into thinking Teranode enforces the supply cap itself.

Today the only production setter of the flag is checkpoint/PoW-trusted catchup sync, so this is a defense-in-depth gap rather than a live exploit — but the gap is real and the misleading constant should be resolved.

## Solution

Add an overflow-safe, Go-side value/inflation backstop that runs on the `SkipScriptValidation` path (where BDK is bypassed), designed to be a strict **subset of BDK's checks** so it can never reject a transaction that BDK/legacy bitcoin-sv would accept:

- `checkOutputValues` — per output: `> math.MaxInt64` → `bad-txns-vout-negative` (matching BDK reading values into a signed `Amount`), then `> MaxSatoshis` → `bad-txns-vout-toolarge`; running total `> MaxSatoshis` → `bad-txns-txouttotal-toolarge`.
- `checkInputValuesAndInflation` — per input/total range → `bad-txns-inputvalues-outofrange`; `sum(inputs) < sum(outputs)` → `bad-txns-in-belowout`.
- **Reject strings, boundary conditions, and check ordering mirror BDK exactly.** The skip-path ordering is era-aware to match BDK's control flow for a transaction that is both money-invalid and carries an unconfirmed-parent sentinel: outputs first; pre-Genesis sentinel → inflation; post-Genesis inflation → sentinel.
- `MaxSatoshis` is now **wired in** as the money bound (rather than deleted).
- The path continues to rely on the documented extended-transaction precondition and **fails closed** — no fail-open branch for value-less transactions.

## Tests

11 new unit tests in `TxValidator_test.go`, including:

- Inflation, output-negative (high-bit), output-over-max, output-total-over-max, and input-over-max rejections, each asserting the exact reject string.
- Zero-fee / zero-value outputs accepted; non-extended input fails closed.
- Policy-mode (`SkipPolicyChecks=false`) rejection, proving the backstop is not consensus-branch-only.
- Mixed-defect ordering tests on both sides of the Genesis boundary.
- A parity table that runs each mutated transaction through **both** the skip path and the real GoBDK path and asserts both return the same marker — a genuine drift guard.

## Verification

`go build ./...`, `go vet`, and `golangci-lint run` on the validator package are clean; all validator unit tests pass (the one skipped failure is a pre-existing Aerospike/Docker integration test unrelated to this change).