### PR TITLE
refactor(asset/httpimpl): extract handler bodies to reduce cognitive complexity (S3776)

### DIFF
--- a/services/asset/httpimpl/GetBlock.go
+++ b/services/asset/httpimpl/GetBlock.go
@@ -288,76 +288,81 @@ func (h *HTTP) GetBlockByHeight(mode ReadMode) func(c echo.Context) error {
 //	GET /block/hash/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/hex
 func (h *HTTP) GetBlockByHash(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		hashStr := c.Param("hash")
+		return h.getBlockByHash(c, mode)
+	}
+}
 
-		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockByHash_http",
-			tracing.WithParentStat(AssetStat),
-			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetBlockByHash in %s for %s: %s", mode, c.RealIP(), hashStr),
-		)
+// getBlockByHash serves a single GetBlockByHash request in the given read mode.
+func (h *HTTP) getBlockByHash(c echo.Context, mode ReadMode) error {
+	hashStr := c.Param("hash")
 
-		defer deferFn()
+	ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockByHash_http",
+		tracing.WithParentStat(AssetStat),
+		tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetBlockByHash in %s for %s: %s", mode, c.RealIP(), hashStr),
+	)
 
-		if len(hashStr) != 64 {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash length").Error())
+	defer deferFn()
+
+	if len(hashStr) != 64 {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash length").Error())
+	}
+
+	hash, err := chainhash.NewHashFromStr(c.Param("hash"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
+	}
+
+	block, err := h.repository.GetBlockByHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		} else {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
+	}
 
-		hash, err := chainhash.NewHashFromStr(c.Param("hash"))
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
-		}
+	// sign the response, if the private key is set, ignore error
+	// do this before any output is sent to the client, this adds a signature to the response header
+	_ = h.Sign(c.Response(), hash.CloneBytes())
 
-		block, err := h.repository.GetBlockByHash(ctx, hash)
-		if err != nil {
-			if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
-				return echo.NewHTTPError(http.StatusNotFound, err.Error())
-			} else {
-				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	prometheusAssetHTTPGetBlock.WithLabelValues("OK", "200").Inc()
+
+	if mode == JSON {
+		height := block.Height
+		if height == 0 {
+			_, blockMeta, _ := h.repository.GetBlockHeader(c.Request().Context(), hash)
+			if blockMeta != nil {
+				height = blockMeta.Height
 			}
 		}
 
-		// sign the response, if the private key is set, ignore error
-		// do this before any output is sent to the client, this adds a signature to the response header
-		_ = h.Sign(c.Response(), hash.CloneBytes())
+		// get next hash to include in response
+		var nextBlockHash *chainhash.Hash
 
-		prometheusAssetHTTPGetBlock.WithLabelValues("OK", "200").Inc()
-
-		if mode == JSON {
-			height := block.Height
-			if height == 0 {
-				_, blockMeta, _ := h.repository.GetBlockHeader(c.Request().Context(), hash)
-				if blockMeta != nil {
-					height = blockMeta.Height
-				}
-			}
-
-			// get next hash to include in response
-			var nextBlockHash *chainhash.Hash
-
-			nextBlock, _ := h.repository.GetBlockByHeight(ctx, height+1)
-			if nextBlock != nil {
-				nextBlockHash = nextBlock.Hash()
-			}
-
-			blockExtended := BlockExtended{
-				Block:     block,
-				NextBlock: nextBlockHash,
-			}
-
-			return c.JSONPretty(200, blockExtended, "  ")
+		nextBlock, _ := h.repository.GetBlockByHeight(ctx, height+1)
+		if nextBlock != nil {
+			nextBlockHash = nextBlock.Hash()
 		}
 
-		b, err := block.Bytes()
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		blockExtended := BlockExtended{
+			Block:     block,
+			NextBlock: nextBlockHash,
 		}
 
-		switch mode {
-		case BINARY_STREAM:
-			return c.Blob(200, echo.MIMEOctetStream, b)
-		case HEX:
-			return c.String(200, hex.EncodeToString(b))
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
-		}
+		return c.JSONPretty(200, blockExtended, "  ")
+	}
+
+	b, err := block.Bytes()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	switch mode {
+	case BINARY_STREAM:
+		return c.Blob(200, echo.MIMEOctetStream, b)
+	case HEX:
+		return c.String(200, hex.EncodeToString(b))
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
 	}
 }

--- a/services/asset/httpimpl/GetBlockSubtrees.go
+++ b/services/asset/httpimpl/GetBlockSubtrees.go
@@ -107,91 +107,96 @@ type SubtreeMeta struct {
 //   - The subtree count (total_records) comes from the block's subtree list length
 func (h *HTTP) GetBlockSubtrees(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		hashStr := c.Param("hash")
-
-		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockSubtrees_http",
-			tracing.WithParentStat(AssetStat),
-			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetBlockSubtrees in %s for %s: %s", mode, c.RealIP(), hashStr),
-		)
-
-		defer deferFn()
-
-		if len(hashStr) != 64 {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash length").Error())
-		}
-
-		hash, err := chainhash.NewHashFromStr(hashStr)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
-		}
-
-		block, err := h.repository.GetBlockByHash(ctx, hash)
-		if err != nil {
-			if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
-				return echo.NewHTTPError(http.StatusNotFound, err.Error())
-			} else {
-				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-			}
-		}
-
-		offset, limit, err := h.getLimitOffset(c)
-		if err != nil {
-			// error is already an echo error
-			return err
-		}
-
-		result := ExtendedResponse{
-			Pagination: Pagination{
-				Offset:       offset,
-				Limit:        limit,
-				TotalRecords: len(block.Subtrees),
-			},
-		}
-
-		// get all the subtrees for the block
-		var (
-			subtreeHead *subtree.Subtree
-			numNodes    int
-		)
-
-		data := make([]SubtreeMeta, 0, limit)
-
-		if len(block.Subtrees) > 0 {
-			for i := offset; i < offset+limit; i++ {
-				if i >= len(block.Subtrees) {
-					break
-				}
-
-				subtreeHash := block.Subtrees[i]
-
-				// do not check for error here, we will just return an empty row for the subtree
-				subtreeHead, numNodes, _ = h.repository.GetSubtreeHead(ctx, subtreeHash)
-
-				if subtreeHead != nil {
-					data = append(data, SubtreeMeta{
-						Index:   i,
-						Hash:    subtreeHash.String(),
-						TxCount: numNodes,
-						Fee:     subtreeHead.Fees,
-						Size:    subtreeHead.SizeInBytes,
-					})
-				} else {
-					data = append(data, SubtreeMeta{
-						Index: i,
-						Hash:  subtreeHash.String(),
-					})
-				}
-			}
-		}
-
-		result.Data = data
-
-		prometheusAssetHTTPGetBlock.WithLabelValues("OK", "200").Inc()
-
-		if mode == JSON {
-			return c.JSONPretty(200, result, "  ")
-		}
-
-		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
+		return h.getBlockSubtrees(c, mode)
 	}
+}
+
+// getBlockSubtrees serves a single GetBlockSubtrees request in the given read mode.
+func (h *HTTP) getBlockSubtrees(c echo.Context, mode ReadMode) error {
+	hashStr := c.Param("hash")
+
+	ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockSubtrees_http",
+		tracing.WithParentStat(AssetStat),
+		tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetBlockSubtrees in %s for %s: %s", mode, c.RealIP(), hashStr),
+	)
+
+	defer deferFn()
+
+	if len(hashStr) != 64 {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash length").Error())
+	}
+
+	hash, err := chainhash.NewHashFromStr(hashStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
+	}
+
+	block, err := h.repository.GetBlockByHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		} else {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+	}
+
+	offset, limit, err := h.getLimitOffset(c)
+	if err != nil {
+		// error is already an echo error
+		return err
+	}
+
+	result := ExtendedResponse{
+		Pagination: Pagination{
+			Offset:       offset,
+			Limit:        limit,
+			TotalRecords: len(block.Subtrees),
+		},
+	}
+
+	// get all the subtrees for the block
+	var (
+		subtreeHead *subtree.Subtree
+		numNodes    int
+	)
+
+	data := make([]SubtreeMeta, 0, limit)
+
+	if len(block.Subtrees) > 0 {
+		for i := offset; i < offset+limit; i++ {
+			if i >= len(block.Subtrees) {
+				break
+			}
+
+			subtreeHash := block.Subtrees[i]
+
+			// do not check for error here, we will just return an empty row for the subtree
+			subtreeHead, numNodes, _ = h.repository.GetSubtreeHead(ctx, subtreeHash)
+
+			if subtreeHead != nil {
+				data = append(data, SubtreeMeta{
+					Index:   i,
+					Hash:    subtreeHash.String(),
+					TxCount: numNodes,
+					Fee:     subtreeHead.Fees,
+					Size:    subtreeHead.SizeInBytes,
+				})
+			} else {
+				data = append(data, SubtreeMeta{
+					Index: i,
+					Hash:  subtreeHash.String(),
+				})
+			}
+		}
+	}
+
+	result.Data = data
+
+	prometheusAssetHTTPGetBlock.WithLabelValues("OK", "200").Inc()
+
+	if mode == JSON {
+		return c.JSONPretty(200, result, "  ")
+	}
+
+	return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
 }

--- a/services/asset/httpimpl/GetTransaction.go
+++ b/services/asset/httpimpl/GetTransaction.go
@@ -132,70 +132,75 @@ import (
 //	GET /tx/{hash}/hex
 func (h *HTTP) GetTransaction(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		hashStr := c.Param("hash")
+		return h.getTransaction(c, mode)
+	}
+}
 
-		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetTransaction_http",
-			tracing.WithParentStat(AssetStat),
-			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetTransaction in %s for %s: %s", mode, c.RealIP(), hashStr),
-		)
+// getTransaction serves a single GetTransaction request in the given read mode.
+func (h *HTTP) getTransaction(c echo.Context, mode ReadMode) error {
+	hashStr := c.Param("hash")
 
-		defer deferFn()
+	ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetTransaction_http",
+		tracing.WithParentStat(AssetStat),
+		tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetTransaction in %s for %s: %s", mode, c.RealIP(), hashStr),
+	)
 
-		if len(hashStr) != 64 {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash length").Error())
+	defer deferFn()
+
+	if len(hashStr) != 64 {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash length").Error())
+	}
+
+	hash, err := chainhash.NewHashFromStr(hashStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
+	}
+
+	b, err := h.repository.GetTransaction(ctx, hash)
+	if err != nil {
+		if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		} else {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
+	}
 
-		hash, err := chainhash.NewHashFromStr(hashStr)
+	// sign the response, if the private key is set, ignore error
+	// do this before any output is sent to the client, this adds a signature to the response header
+	_ = h.Sign(c.Response(), hash.CloneBytes())
+
+	prometheusAssetHTTPGetTransaction.WithLabelValues("OK", "200").Inc()
+
+	switch mode {
+	case BINARY_STREAM:
+		return c.Blob(200, echo.MIMEOctetStream, b)
+
+	case HEX:
+		return c.String(200, hex.EncodeToString(b))
+
+	case JSON:
+		tx, err := bt.NewTxFromBytes(b)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
+			return echo.NewHTTPError(http.StatusInternalServerError, errors.NewProcessingError("error parsing transaction", err).Error())
 		}
 
-		b, err := h.repository.GetTransaction(ctx, hash)
-		if err != nil {
-			if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
-				return echo.NewHTTPError(http.StatusNotFound, err.Error())
-			} else {
-				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-			}
-		}
+		// Debug logging for extended transaction format
+		h.logger.Debugf("[Asset_http] GetTransaction: Transaction %s - IsExtended: %v, IsCoinbase: %v",
+			hash.String(), tx.IsExtended(), tx.IsCoinbase())
 
-		// sign the response, if the private key is set, ignore error
-		// do this before any output is sent to the client, this adds a signature to the response header
-		_ = h.Sign(c.Response(), hash.CloneBytes())
-
-		prometheusAssetHTTPGetTransaction.WithLabelValues("OK", "200").Inc()
-
-		switch mode {
-		case BINARY_STREAM:
-			return c.Blob(200, echo.MIMEOctetStream, b)
-
-		case HEX:
-			return c.String(200, hex.EncodeToString(b))
-
-		case JSON:
-			tx, err := bt.NewTxFromBytes(b)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, errors.NewProcessingError("error parsing transaction", err).Error())
-			}
-
-			// Debug logging for extended transaction format
-			h.logger.Debugf("[Asset_http] GetTransaction: Transaction %s - IsExtended: %v, IsCoinbase: %v",
-				hash.String(), tx.IsExtended(), tx.IsCoinbase())
-
-			if len(tx.Inputs) > 0 {
-				// Log details about the first few inputs
-				for i, input := range tx.Inputs {
-					if i < 3 { // Log first 3 inputs
-						h.logger.Debugf("[Asset_http] GetTransaction: Tx %s - Input[%d] PreviousTxSatoshis: %d",
-							hash.String(), i, input.PreviousTxSatoshis)
-					}
+		if len(tx.Inputs) > 0 {
+			// Log details about the first few inputs
+			for i, input := range tx.Inputs {
+				if i < 3 { // Log first 3 inputs
+					h.logger.Debugf("[Asset_http] GetTransaction: Tx %s - Input[%d] PreviousTxSatoshis: %d",
+						hash.String(), i, input.PreviousTxSatoshis)
 				}
 			}
-
-			return c.JSONPretty(200, tx, "  ")
-
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
 		}
+
+		return c.JSONPretty(200, tx, "  ")
+
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
 	}
 }

--- a/services/asset/httpimpl/GetUTXOsByTXID.go
+++ b/services/asset/httpimpl/GetUTXOsByTXID.go
@@ -122,107 +122,112 @@ type UTXOItem struct {
 //   - UTXOs can be in various states (spent, unspent, frozen, etc.)
 func (h *HTTP) GetUTXOsByTxID(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		hashStr := c.Param("hash")
+		return h.getUTXOsByTxID(c, mode)
+	}
+}
 
-		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetUTXOsByTxID_http",
-			tracing.WithParentStat(AssetStat),
-			tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetUTXOsByTxID in %s for %s: %s", mode, c.RealIP(), hashStr),
-		)
+// getUTXOsByTxID serves a single GetUTXOsByTxID request in the given read mode.
+func (h *HTTP) getUTXOsByTxID(c echo.Context, mode ReadMode) error {
+	hashStr := c.Param("hash")
 
-		defer deferFn()
+	ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetUTXOsByTxID_http",
+		tracing.WithParentStat(AssetStat),
+		tracing.WithDebugLogMessage(h.logger, "[Asset_http] GetUTXOsByTxID in %s for %s: %s", mode, c.RealIP(), hashStr),
+	)
 
-		if len(hashStr) != 64 {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.NewInvalidArgumentError("invalid transaction hash length").Error())
-		}
+	defer deferFn()
 
-		hash, err := chainhash.NewHashFromStr(hashStr)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.NewInvalidArgumentError("invalid transaction hash format", err).Error())
-		}
+	if len(hashStr) != 64 {
+		return echo.NewHTTPError(http.StatusInternalServerError, errors.NewInvalidArgumentError("invalid transaction hash length").Error())
+	}
 
-		b, err := h.repository.GetTransaction(ctx, hash)
-		if err != nil {
-			h.logger.Errorf("[Asset_http][%s] GetUTXOsByTxID error getting transaction: %s", hash.String(), err.Error())
+	hash, err := chainhash.NewHashFromStr(hashStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, errors.NewInvalidArgumentError("invalid transaction hash format", err).Error())
+	}
 
-			if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
-				return echo.NewHTTPError(http.StatusNotFound, err.Error())
-			} else {
-				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-			}
-		}
+	b, err := h.repository.GetTransaction(ctx, hash)
+	if err != nil {
+		h.logger.Errorf("[Asset_http][%s] GetUTXOsByTxID error getting transaction: %s", hash.String(), err.Error())
 
-		tx, err := bt.NewTxFromBytes(b)
-		if err != nil {
-			h.logger.Errorf("[Asset_http][%s] GetUTXOsByTxID error creating transaction: %s", hash.String(), err.Error())
+		if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		} else {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
+	}
 
-		// Go through all the outputs and get the UTXOHash for each one
-		// and then look up the UTXO by that hash.  This is done in parallel
-		// to help speed things up.
+	tx, err := bt.NewTxFromBytes(b)
+	if err != nil {
+		h.logger.Errorf("[Asset_http][%s] GetUTXOsByTxID error creating transaction: %s", hash.String(), err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 
-		g, ctx := errgroup.WithContext(c.Request().Context())
+	// Go through all the outputs and get the UTXOHash for each one
+	// and then look up the UTXO by that hash.  This is done in parallel
+	// to help speed things up.
 
-		// Create a channel to receive the results from the goroutines
-		// that will be created.
-		utxos := make([]*UTXOItem, len(tx.Outputs))
+	g, ctx := errgroup.WithContext(c.Request().Context())
 
-		// Create a goroutine for each output in the transaction.
-		for i, output := range tx.Outputs {
-			safeI, safeOutput := i, output
+	// Create a channel to receive the results from the goroutines
+	// that will be created.
+	utxos := make([]*UTXOItem, len(tx.Outputs))
 
-			g.Go(func() error {
-				// Get the UTXOHash for this output.
-				//nolint:gosec
-				utxoHash, err := util.UTXOHash(hash, uint32(safeI), safeOutput.LockingScript, safeOutput.Satoshis)
-				if err != nil {
-					return err
-				}
+	// Create a goroutine for each output in the transaction.
+	for i, output := range tx.Outputs {
+		safeI, safeOutput := i, output
 
-				//nolint:gosec
-				utxoItem := &UTXOItem{
-					Txid:          hash,
-					Vout:          uint32(safeI),
-					LockingScript: safeOutput.LockingScript,
-					Satoshis:      safeOutput.Satoshis,
-					UtxoHash:      utxoHash,
-				}
+		g.Go(func() error {
+			// Get the UTXOHash for this output.
+			//nolint:gosec
+			utxoHash, err := util.UTXOHash(hash, uint32(safeI), safeOutput.LockingScript, safeOutput.Satoshis)
+			if err != nil {
+				return err
+			}
 
-				// Get the UTXO for this output.
-				//nolint:gosec
-				utxoRes, _ := h.repository.GetUtxo(ctx, &utxo.Spend{
-					UTXOHash: utxoHash,
-					TxID:     tx.TxIDChainHash(),
-					Vout:     uint32(safeI),
-				})
+			//nolint:gosec
+			utxoItem := &UTXOItem{
+				Txid:          hash,
+				Vout:          uint32(safeI),
+				LockingScript: safeOutput.LockingScript,
+				Satoshis:      safeOutput.Satoshis,
+				UtxoHash:      utxoHash,
+			}
 
-				//nolint:gosec
-				if utxoRes != nil && utxoRes.Status != int(utxo.Status_NOT_FOUND) {
-					utxoItem.Status = utxo.Status(utxoRes.Status).String()
-					utxoItem.SpendingData = utxoRes.SpendingData
-					utxoItem.LockTime = utxoRes.LockTime
-				} else {
-					utxoItem.Status = utxo.Status_NOT_FOUND.String()
-				}
-
-				// this can be set here, but only directly by index
-				utxos[safeI] = utxoItem
-
-				return nil
+			// Get the UTXO for this output.
+			//nolint:gosec
+			utxoRes, _ := h.repository.GetUtxo(ctx, &utxo.Spend{
+				UTXOHash: utxoHash,
+				TxID:     tx.TxIDChainHash(),
+				Vout:     uint32(safeI),
 			})
-		}
 
-		if err = g.Wait(); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.NewProcessingError("[Asset_http][%s] error getting utxos", hash.String(), err).Error())
-		}
+			//nolint:gosec
+			if utxoRes != nil && utxoRes.Status != int(utxo.Status_NOT_FOUND) {
+				utxoItem.Status = utxo.Status(utxoRes.Status).String()
+				utxoItem.SpendingData = utxoRes.SpendingData
+				utxoItem.LockTime = utxoRes.LockTime
+			} else {
+				utxoItem.Status = utxo.Status_NOT_FOUND.String()
+			}
 
-		prometheusAssetHTTPGetUTXO.WithLabelValues("OK", "200").Inc()
+			// this can be set here, but only directly by index
+			utxos[safeI] = utxoItem
 
-		switch mode {
-		case JSON:
-			return c.JSONPretty(200, utxos, "  ")
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
-		}
+			return nil
+		})
+	}
+
+	if err = g.Wait(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, errors.NewProcessingError("[Asset_http][%s] error getting utxos", hash.String(), err).Error())
+	}
+
+	prometheusAssetHTTPGetUTXO.WithLabelValues("OK", "200").Inc()
+
+	switch mode {
+	case JSON:
+		return c.JSONPretty(200, utxos, "  ")
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
 	}
 }


### PR DESCRIPTION
## Summary

The four asset `Get*` handlers each wrap their entire body in a returned `func(c echo.Context) error` closure. Because everything sits inside that lambda, every branch carries a nesting penalty that pushed cognitive complexity over the threshold (25). This moves each closure body into a private method and has the closure just delegate.

| Handler | Extracted method | complexity after |
|---|---|---|
| `GetBlockByHash` | `getBlockByHash` | 17 |
| `GetTransaction` | `getTransaction` | 19 |
| `GetBlockSubtrees` | `getBlockSubtrees` | 19 |
| `GetUTXOsByTxID` | `getUTXOsByTxID` | 19 |

(the outer handlers become trivial; measured with `gocognit`)

## No behaviour or performance change

Pure structural extraction — a **whitespace-ignoring diff (`git diff -w`) shows only the added delegating call + method signature per file; the moved bodies are byte-identical**. Control flow, error paths, tracing spans, the `errgroup` fan-out in `GetUTXOsByTxID` (captured vars and all) are unchanged. The only runtime cost is one extra function call per request on these HTTP read-path handlers — negligible, and off the tx/block pipeline. Public handler signatures and routes are untouched.

## Verification

```
gofmt -l (4 files)                       # clean
go vet  ./services/asset/httpimpl/        # clean
go test ./services/asset/httpimpl/        # ok
gocognit: all four extracted methods < 25; outer handlers trivial
```