### PR TITLE
MvP-1141 Enforce coinbase scriptSig length in Block.Valid

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -530,6 +530,19 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 		return false, errors.NewBlockInvalidError("[BLOCK][%s] block coinbase tx is not a valid coinbase tx", b.String())
 	}
 
+	// 4b. Check that the coinbase scriptSig (unlocking script) length is within consensus bounds.
+	// Parity with bitcoin-sv CheckCoinbase (bad-cb-length): inclusive 2 <= size <= MaxCoinbaseScriptSigSize.
+	// IsCoinbase() above guarantees exactly one input, so Inputs[0] is safe to index; a nil
+	// UnlockingScript is treated as length 0 and fails the lower bound, matching an empty scriptSig.
+	scriptSigLen := 0
+	if us := b.CoinbaseTx.Inputs[0].UnlockingScript; us != nil {
+		scriptSigLen = len(*us)
+	}
+
+	if scriptSigLen < 2 || scriptSigLen > int(settings.ChainCfgParams.MaxCoinbaseScriptSigSize) {
+		return false, errors.NewBlockInvalidError("[BLOCK][%s] bad coinbase length", b.String())
+	}
+
 	// We can only calculate the height from coinbase transactions in block versions 2 and higher
 
 	// https://en.bitcoin.it/wiki/BIP_0034

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -438,6 +438,88 @@ func TestBlock_Valid_ComprehensiveCoverage(t *testing.T) {
 	})
 }
 
+// TestBlock_Valid_CoinbaseScriptSigLength pins the coinbase scriptSig length check in Block.Valid.
+// Parity with bitcoin-sv CheckCoinbase (bad-cb-length): valid iff 2 <= size <= MaxCoinbaseScriptSigSize,
+// inclusive. See GitHub issue #1141.
+func TestBlock_Valid_CoinbaseScriptSigLength(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	maxLen := int(tSettings.ChainCfgParams.MaxCoinbaseScriptSigSize)
+
+	// buildBlock returns a coinbase-only, otherwise-valid block whose coinbase scriptSig is
+	// either a controlled byte length (setNil == false) or a nil UnlockingScript (setNil == true).
+	// Height 0 skips BIP-34 and the reward/fee checks; nil subtreeStore/txMetaStore skip the
+	// subtree and order/blessed checks; empty currentChain skips the median-time-past check.
+	buildBlock := func(t *testing.T, n int, setNil bool) *Block {
+		t.Helper()
+
+		blockHeaderBytes, err := hex.DecodeString(block1Header)
+		require.NoError(t, err)
+
+		blockHeader, err := NewBlockHeaderFromBytes(blockHeaderBytes)
+		require.NoError(t, err)
+
+		coinbase, err := bt.NewTxFromString(CoinbaseHex)
+		require.NoError(t, err)
+
+		if setNil {
+			coinbase.Inputs[0].UnlockingScript = nil
+		} else {
+			coinbase.Inputs[0].UnlockingScript = bscript.NewFromBytes(make([]byte, n))
+		}
+
+		// The swapped coinbase must still be recognised as a coinbase for step 4b to fire.
+		require.True(t, coinbase.IsCoinbase())
+
+		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, 0, 0)
+		require.NoError(t, err)
+
+		return block
+	}
+
+	callValid := func(t *testing.T, block *Block) (bool, error) {
+		t.Helper()
+
+		return block.Valid(context.Background(), ulogger.TestLogger{}, nil, nil,
+			txmap.NewSyncedMap[chainhash.Hash, []uint32](), []*BlockHeader{}, []uint32{}, tSettings, nil)
+	}
+
+	t.Run("too short (length 1) is rejected", func(t *testing.T) {
+		valid, err := callValid(t, buildBlock(t, 1, false))
+		require.False(t, valid)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad coinbase length")
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	})
+
+	t.Run("too long (length Max+1) is rejected", func(t *testing.T) {
+		valid, err := callValid(t, buildBlock(t, maxLen+1, false))
+		require.False(t, valid)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad coinbase length")
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	})
+
+	t.Run("boundary low (length exactly 2) passes", func(t *testing.T) {
+		valid, err := callValid(t, buildBlock(t, 2, false))
+		require.NoError(t, err)
+		require.True(t, valid)
+	})
+
+	t.Run("boundary high (length exactly Max) passes", func(t *testing.T) {
+		valid, err := callValid(t, buildBlock(t, maxLen, false))
+		require.NoError(t, err)
+		require.True(t, valid)
+	})
+
+	t.Run("nil unlocking script is rejected", func(t *testing.T) {
+		valid, err := callValid(t, buildBlock(t, 0, true))
+		require.False(t, valid)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad coinbase length")
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	})
+}
+
 // TestBlock_NewBlockFromMsgBlock_ComprehensiveCoverage tests various paths in NewBlockFromMsgBlock
 func TestBlock_NewBlockFromMsgBlock_ComprehensiveCoverage(t *testing.T) {
 	t.Run("nil msgBlock error", func(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/bsv-blockchain/teranode/issues/1141

## Summary

The consensus rule that a coinbase transaction's scriptSig must be between 2 and
`MaxCoinbaseScriptSigSize` bytes (inclusive) was enforced only in the block-validation
and block-assembly services, not in `model/Block.Valid()` where the other structural
coinbase checks live. This PR centralizes the check into `Block.Valid`, closing a latent
gap on the code paths that reach `Block.Valid` without an independent length guard.

## The gap

`Block.Valid()` already checks coinbase presence, `IsCoinbase()`, and the BIP-34 height,
but not the scriptSig length. The length check existed in two other places:

- `services/blockvalidation/BlockValidation.go` — `ValidateBlockWithOptions`
- `services/blockassembly/Server.go` — `submitMiningSolution`

Both run their check *before* calling `Block.Valid`, so the main peer-block and
self-built-block paths were covered. But two callers reached `Block.Valid` without any
independent length guard:

- `BlockValidation.reValidateBlock`
- the gRPC `blockvalidation.Server.ValidateBlock` entry point

A future or existing caller validating an external block through `Block.Valid` without the
service-layer guard would accept an out-of-range coinbase scriptSig. Latent today, but a
consensus-relevant robustness hole.

## The change

Add the coinbase scriptSig length check inside `Block.Valid`, immediately after the
`IsCoinbase()` check and before the BIP-34 height block:

- **Inclusive bounds**, matching bitcoin-sv `CheckCoinbase` (`bad-cb-length`): reject iff
  `size < 2 || size > MaxCoinbaseScriptSigSize`. `size == 2` and `size == Max` both pass.
- The bound is read from **per-network chain config**
  (`settings.ChainCfgParams.MaxCoinbaseScriptSigSize`), never hard-coded.
- **Nil-safe**: a nil unlocking script is treated as length 0 and rejected (an empty
  scriptSig fails the lower bound). `Inputs[0]` is safe to index because `IsCoinbase()`
  above guarantees exactly one input.
- Error class is `BlockInvalidError` (hard-invalid), matching the reference node's
  `REJECT_INVALID` / DoS-100 semantics for this rule.

### Why the existing checks are kept (defense-in-depth, not removed)

The service-layer checks are intentionally retained rather than removed, because they
carry behavior `Block.Valid` neither has nor should reproduce:

- `ValidateBlockWithOptions` distinguishes a *missing/empty* coinbase
  (`BlockIncompleteError`, so the block can be re-fetched from another peer) from a
  *bad-length* coinbase (`BlockInvalidError` + `storeInvalidBlock`).
- `submitMiningSolution` returns a `ProcessingError` for the node's own mining-solution
  submission — a different error class appropriate to that RPC.

Removing them would change error-class and side-effect behavior on consensus-relevant
paths. Once the check is centralized in `Block.Valid`, those checks become genuine
defense-in-depth (they short-circuit earlier with richer semantics) with **zero
behavioral change** to their paths, while the new check closes the gap on the
revalidation and gRPC `ValidateBlock` paths.

## Consensus parity

This matches the reference bitcoin-sv node's `CheckCoinbase` rule
(`MAX_COINBASE_SCRIPTSIG_SIZE = 100`, `bad-cb-length`, DoS 100). Teranode's configured
`MaxCoinbaseScriptSigSize` is 100 on every network, so the enforced bound is identical.
No coinbase the reference node would accept is now rejected (no off-by-one; existing
in-range fixtures continue to pass).

## Tests

Added `TestBlock_Valid_CoinbaseScriptSigLength` in `model/Block_test.go`, covering:

- scriptSig length 1 (too short) → rejected
- scriptSig length Max+1 (too long) → rejected
- scriptSig length exactly 2 (lower boundary) → passes
- scriptSig length exactly Max (upper boundary) → passes
- nil unlocking script → rejected

The passing boundary cases use a minimal coinbase-only block setup so unrelated validation
(header difficulty, BIP-34, subtree, reward) does not interfere.

## Files changed

- `model/Block.go` — the centralized length check
- `model/Block_test.go` — the new test cases

No changes to `services/blockvalidation/*` or `services/blockassembly/*`.

## Verification

- `go build ./model/...` — pass
- `go vet ./model/...` — pass
- `go test ./model/...` — pass (full package)
- `go test -race ./model/` — pass
- `golangci-lint run` (changed files vs `main`) — 0 issues
