### PR TITLE
fix(ci): harden gitleaks workflow (template injection + HTTPS enforcement)

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -28,7 +28,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/bin"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz" \
+          curl -sSfL --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz" \
             | tar -xz -C "${RUNNER_TEMP}/bin" gitleaks
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
           "${RUNNER_TEMP}/bin/gitleaks" version

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -34,6 +34,11 @@ jobs:
           "${RUNNER_TEMP}/bin/gitleaks" version
 
       - name: Scan PR commits for secrets
+        # SHAs are passed via env, never interpolated directly into the script,
+        # to avoid GitHub Actions template injection.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           gitleaks detect \
@@ -42,4 +47,4 @@ jobs:
             --redact \
             --no-banner \
             --exit-code 1 \
-            --log-opts="--no-merges ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+            --log-opts="--no-merges ${BASE_SHA}..${HEAD_SHA}"


### PR DESCRIPTION
## Summary

Two security hardenings to the secret-scan workflow added in #1238:

1. **`githubactions:S6506` (HTTPS enforcement)** — the `curl -sSfL` install used `-L` (follow redirects) without pinning the protocol, so a redirect could downgrade to HTTP. Added `--proto '=https' --proto-redir '=https' --tlsv1.2` so both the initial request and any redirect must stay HTTPS. *This is the finding currently failing the SonarCloud gate.*

2. **Template injection** — the scan step interpolated `${{ github.event.pull_request.*.sha }}` directly into a `run:` shell. Moved to the `env:` context and referenced as shell vars (`${BASE_SHA}..${HEAD_SHA}`), so GitHub never substitutes context text into the script.

## Verification

- YAML valid.
- No `${{ github.event.* }}` interpolation inside any `run:` block (only in `env:`).
- Download restricted to HTTPS on request + redirect.
- Scan semantics unchanged (same `base..head` range, pinned gitleaks 8.18.4).

Once merged and re-scanned, the security rating returns to A and the gate goes green.