### PR TITLE
fix(rpc): bound legacy ban RPC calls with a timeout (#591)

### DIFF
--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -1604,15 +1604,13 @@ func calculateMedianTime(ctx context.Context, blockchainClient blockchain.Client
 	return medianTimestampUint32, nil
 }
 
-// isSubscriberActive checks whether a blockchain subscriber whose source
-// contains substr is currently registered. This lets RPC handlers skip
-// expensive calls to services that are not running.
 // isSubscriberActive checks whether source is present in the blockchain
 // subscriber list. This lets RPC handlers skip expensive calls to services
 // that are not running.
 func isSubscriberActive(ctx context.Context, s *RPCServer, source string) bool {
 	subs, err := s.blockchainClient.GetSubscribers(ctx)
 	if err != nil {
+		s.logger.Warnf("[isSubscriberActive] GetSubscribers failed, treating %s as inactive: %v", source, err)
 		return false
 	}
 	for _, src := range subs {

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -1604,13 +1604,15 @@ func calculateMedianTime(ctx context.Context, blockchainClient blockchain.Client
 	return medianTimestampUint32, nil
 }
 
+// isSubscriberActive checks whether a blockchain subscriber whose source
+// contains substr is currently registered. This lets RPC handlers skip
+// expensive calls to services that are not running.
 // isSubscriberActive checks whether source is present in the blockchain
 // subscriber list. This lets RPC handlers skip expensive calls to services
 // that are not running.
 func isSubscriberActive(ctx context.Context, s *RPCServer, source string) bool {
 	subs, err := s.blockchainClient.GetSubscribers(ctx)
 	if err != nil {
-		s.logger.Warnf("[isSubscriberActive] GetSubscribers failed, treating %s as inactive: %v", source, err)
 		return false
 	}
 	for _, src := range subs {
@@ -2116,8 +2118,16 @@ func handleIsBanned(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan
 	// Legacy service only handles IPs
 	var peerBanned bool
 
-	if isIP && s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
-		isBannedLegacy, err := s.legacyP2PClient.IsBanned(ctx, &peer_api.IsBannedRequest{IpOrSubnet: c.IPOrSubnet})
+	if isIP && s.legacyP2PClient != nil {
+		// Bound the call: the legacy peer client is lazily dialed and non-nil
+		// whenever legacy_grpcAddress is configured, so on a node without a
+		// running legacy service this would otherwise block on the parent
+		// context until the RPC's own deadline (see #591).
+		legacyCtx, cancel := context.WithTimeout(ctx, s.settings.RPC.ClientCallTimeout)
+		isBannedLegacy, err := s.legacyP2PClient.IsBanned(legacyCtx, &peer_api.IsBannedRequest{IpOrSubnet: c.IPOrSubnet})
+
+		cancel()
+
 		if err != nil {
 			s.logger.Warnf("Failed to check if banned in legacy peer service: %v", err)
 		} else {
@@ -2199,7 +2209,7 @@ func handleListBanned(ctx context.Context, s *RPCServer, cmd interface{}, _ <-ch
 	}
 
 	// check if legacy peer service is available
-	if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
+	if s.legacyP2PClient != nil {
 		// Create a timeout context for the legacy peer client call
 		legacyCtx, cancel := context.WithTimeout(ctx, clientCallTimeout)
 		defer cancel()
@@ -2276,8 +2286,14 @@ func handleClearBanned(ctx context.Context, s *RPCServer, cmd interface{}, _ <-c
 		}
 	}
 	// check if legacy peer service is available
-	if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
-		_, err := s.legacyP2PClient.ClearBanned(ctx, &emptypb.Empty{})
+	if s.legacyP2PClient != nil {
+		// Bound the call so an absent-but-configured legacy service can't stall
+		// the RPC on the parent context (#591).
+		legacyCtx, cancel := context.WithTimeout(ctx, s.settings.RPC.ClientCallTimeout)
+		_, err := s.legacyP2PClient.ClearBanned(legacyCtx, &emptypb.Empty{})
+
+		cancel()
+
 		if err != nil {
 			s.logger.Warnf("Failed to clear banned list in legacy peer service: %v", err)
 		}
@@ -2342,11 +2358,9 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 	}
 
 	// success tracks whether at least one applicable ban leg actually applied
-	// the ban. It is checked after the switch so the outcome no longer depends
-	// on which legs ran: previously a failed p2p ban was only surfaced as an
-	// error inside the legacy block, so when the legacy leg was skipped (client
-	// absent, or - after the subscriber gate - configured but inactive) a failed
-	// ban silently returned success.
+	// the ban; checked after the switch so the outcome no longer depends on
+	// which legs ran (previously a failed p2p ban was only surfaced when the
+	// legacy leg also ran and failed).
 	var success bool
 
 	// Handle the command
@@ -2383,30 +2397,22 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 		}
 
 		// and ban legacy peers
-		if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
-			until := expirationTimeInt64
+		if s.legacyP2PClient != nil {
+			// Bound the call so an absent-but-configured legacy service can't
+			// stall the RPC on the parent context (#591).
+			legacyCtx, cancel := context.WithTimeout(ctx, s.settings.RPC.ClientCallTimeout)
 
-			resp, err := s.legacyP2PClient.BanPeer(ctx, &peer_api.BanPeerRequest{
+			resp, err := s.legacyP2PClient.BanPeer(legacyCtx, &peer_api.BanPeerRequest{
 				Addr:  c.IPOrSubnet,
-				Until: until,
+				Until: expirationTimeInt64,
 			})
+
+			cancel()
 
 			if err != nil {
 				s.logger.Warnf("Error while trying to ban legacy peer: %v", err)
-
-				if !success {
-					return nil, &bsvjson.RPCError{
-						Code:    bsvjson.ErrRPCInvalidParameter,
-						Message: "Failed to add ban",
-					}
-				}
 			} else if resp == nil || !resp.Ok {
-				if !success {
-					return nil, &bsvjson.RPCError{
-						Code:    bsvjson.ErrRPCInvalidParameter,
-						Message: "Failed to ban peer",
-					}
-				}
+				s.logger.Warnf("Legacy peer service did not apply ban for %s", c.IPOrSubnet)
 			} else {
 				success = true
 				s.logger.Debugf("Added ban for %s until %v", c.IPOrSubnet, expirationTime)
@@ -2423,26 +2429,21 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 		}
 
 		// unban legacy peer
-		if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
-			resp, err := s.legacyP2PClient.UnbanPeer(ctx, &peer_api.UnbanPeerRequest{
+		if s.legacyP2PClient != nil {
+			// Bound the call so an absent-but-configured legacy service can't
+			// stall the RPC on the parent context (#591).
+			legacyCtx, cancel := context.WithTimeout(ctx, s.settings.RPC.ClientCallTimeout)
+
+			resp, err := s.legacyP2PClient.UnbanPeer(legacyCtx, &peer_api.UnbanPeerRequest{
 				Addr: c.IPOrSubnet,
 			})
+
+			cancel()
+
 			if err != nil {
 				s.logger.Errorf("Error while trying to unban legacy peer: %v", err)
-
-				if !success {
-					return nil, &bsvjson.RPCError{
-						Code:    bsvjson.ErrRPCInvalidParameter,
-						Message: "Error while trying to unban peer",
-					}
-				}
 			} else if resp == nil || !resp.Ok {
-				if !success {
-					return nil, &bsvjson.RPCError{
-						Code:    bsvjson.ErrRPCInvalidParameter,
-						Message: "Failed to unban peer",
-					}
-				}
+				s.logger.Warnf("Legacy peer service did not remove ban for %s", c.IPOrSubnet)
 			} else {
 				success = true
 				s.logger.Debugf("Removed ban for %s", c.IPOrSubnet)
@@ -2459,9 +2460,14 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 	// available). setban is an administrative control, so report the failure
 	// rather than silently returning success.
 	if !success {
+		msg := "Failed to apply ban"
+		if c.Command == "remove" {
+			msg = "Failed to remove ban"
+		}
+
 		return nil, &bsvjson.RPCError{
 			Code:    bsvjson.ErrRPCInvalidParameter,
-			Message: "Failed to apply ban",
+			Message: msg,
 		}
 	}
 

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -2118,7 +2118,7 @@ func handleIsBanned(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan
 	// Legacy service only handles IPs
 	var peerBanned bool
 
-	if isIP && s.legacyP2PClient != nil {
+	if isIP && s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
 		isBannedLegacy, err := s.legacyP2PClient.IsBanned(ctx, &peer_api.IsBannedRequest{IpOrSubnet: c.IPOrSubnet})
 		if err != nil {
 			s.logger.Warnf("Failed to check if banned in legacy peer service: %v", err)
@@ -2201,7 +2201,7 @@ func handleListBanned(ctx context.Context, s *RPCServer, cmd interface{}, _ <-ch
 	}
 
 	// check if legacy peer service is available
-	if s.legacyP2PClient != nil {
+	if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
 		// Create a timeout context for the legacy peer client call
 		legacyCtx, cancel := context.WithTimeout(ctx, clientCallTimeout)
 		defer cancel()
@@ -2278,7 +2278,7 @@ func handleClearBanned(ctx context.Context, s *RPCServer, cmd interface{}, _ <-c
 		}
 	}
 	// check if legacy peer service is available
-	if s.legacyP2PClient != nil {
+	if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
 		_, err := s.legacyP2PClient.ClearBanned(ctx, &emptypb.Empty{})
 		if err != nil {
 			s.logger.Warnf("Failed to clear banned list in legacy peer service: %v", err)
@@ -2379,7 +2379,7 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 		}
 
 		// and ban legacy peers
-		if s.legacyP2PClient != nil {
+		if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
 			until := expirationTimeInt64
 
 			resp, err := s.legacyP2PClient.BanPeer(ctx, &peer_api.BanPeerRequest{
@@ -2420,7 +2420,7 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 		}
 
 		// unban legacy peer
-		if s.legacyP2PClient != nil {
+		if s.legacyP2PClient != nil && isSubscriberActive(ctx, s, blockchain.SubscriberLegacy) {
 			resp, err := s.legacyP2PClient.UnbanPeer(ctx, &peer_api.UnbanPeerRequest{
 				Addr: c.IPOrSubnet,
 			})

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -2341,11 +2341,17 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 		}
 	}
 
+	// success tracks whether at least one applicable ban leg actually applied
+	// the ban. It is checked after the switch so the outcome no longer depends
+	// on which legs ran: previously a failed p2p ban was only surfaced as an
+	// error inside the legacy block, so when the legacy leg was skipped (client
+	// absent, or - after the subscriber gate - configured but inactive) a failed
+	// ban silently returned success.
+	var success bool
+
 	// Handle the command
 	switch c.Command {
 	case "add":
-		var success bool
-
 		var expirationTime time.Time
 
 		// If BanTime is nil or 0, use a default ban time (e.g., 24 hours)
@@ -2402,12 +2408,11 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 					}
 				}
 			} else {
+				success = true
 				s.logger.Debugf("Added ban for %s until %v", c.IPOrSubnet, expirationTime)
 			}
 		}
 	case "remove":
-		var success bool
-
 		if s.p2pClient != nil {
 			err := s.p2pClient.UnbanPeer(ctx, c.IPOrSubnet)
 			if err == nil {
@@ -2439,6 +2444,7 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 					}
 				}
 			} else {
+				success = true
 				s.logger.Debugf("Removed ban for %s", c.IPOrSubnet)
 			}
 		}
@@ -2446,6 +2452,16 @@ func handleSetBan(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan s
 		return nil, &bsvjson.RPCError{
 			Code:    bsvjson.ErrRPCInvalidParameter,
 			Message: "Invalid command. Must be 'add' or 'remove'.",
+		}
+	}
+
+	// No applicable ban leg succeeded (every attempted leg failed, or none was
+	// available). setban is an administrative control, so report the failure
+	// rather than silently returning success.
+	if !success {
+		return nil, &bsvjson.RPCError{
+			Code:    bsvjson.ErrRPCInvalidParameter,
+			Message: "Failed to apply ban",
 		}
 	}
 

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -4021,8 +4021,57 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 
 		result, err := handleSetBan(context.Background(), s, cmd, nil)
 
-		require.NoError(t, err)
-		assert.Nil(t, result) // Returns false when ban fails
+		// The p2p ban failed and no other leg applied it, so setban reports the
+		// failure rather than silently returning success.
+		require.Error(t, err)
+		assert.Nil(t, result)
+
+		rpcErr, ok := err.(*bsvjson.RPCError)
+		require.True(t, ok)
+		assert.Contains(t, rpcErr.Message, "Failed to apply ban")
+	})
+
+	t.Run("add ban p2p fails and legacy inactive reports failure", func(t *testing.T) {
+		banTime := int64(3600)
+		legacyCalled := false
+
+		mockP2P := &mockP2PClient{
+			banPeerFunc: func(ctx context.Context, addr string, until int64) error {
+				return errors.New(errors.ERR_ERROR, "ban failed")
+			},
+		}
+		mockPeer := &mockLegacyPeerClient{
+			banPeerFunc: func(ctx context.Context, req *peer_api.BanPeerRequest) (*peer_api.BanPeerResponse, error) {
+				legacyCalled = true
+				return &peer_api.BanPeerResponse{Ok: true}, nil
+			},
+		}
+		// legacy configured but NOT an active subscriber, so the legacy leg is
+		// skipped; the failed p2p leg must still surface as an error.
+		mockBlockchain := &blockchain.Mock{}
+		mockBlockchain.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberP2P}, nil)
+
+		s := &RPCServer{
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: mockBlockchain,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.MainNetParams,
+			},
+		}
+
+		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "add", BanTime: &banTime}
+
+		result, err := handleSetBan(context.Background(), s, cmd, nil)
+
+		require.Error(t, err, "a failed p2p ban with the legacy leg skipped must surface an error, not silent success")
+		assert.Nil(t, result)
+		assert.False(t, legacyCalled, "legacy must not be consulted when inactive")
+
+		rpcErr, ok := err.(*bsvjson.RPCError)
+		require.True(t, ok)
+		assert.Contains(t, rpcErr.Message, "Failed to apply ban")
 	})
 
 	t.Run("add ban with subnet", func(t *testing.T) {

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -3077,16 +3077,6 @@ func TestHandleReconsiderBlockComprehensive(t *testing.T) {
 	})
 }
 
-// newLegacySubscriberMock returns a blockchain mock whose subscriber list
-// includes the legacy manager, so ban RPC handlers treat the legacy peer
-// service as active (mirroring handleGetInfo's isSubscriberActive gate).
-func newLegacySubscriberMock() *blockchain.Mock {
-	m := &blockchain.Mock{}
-	m.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberLegacy}, nil)
-
-	return m
-}
-
 // TestHandleIsBannedComprehensive tests the handleIsBanned handler
 func TestHandleIsBannedComprehensive(t *testing.T) {
 	logger := mocklogger.NewTestLogger()
@@ -3150,10 +3140,9 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3209,9 +3198,8 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3229,42 +3217,6 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		assert.True(t, banned)
 	})
 
-	t.Run("legacy skipped when legacy not an active subscriber", func(t *testing.T) {
-		legacyCalled := false
-		mockPeer := &mockLegacyPeerClient{
-			isBannedFunc: func(ctx context.Context, req *peer_api.IsBannedRequest) (*peer_api.IsBannedResponse, error) {
-				legacyCalled = true
-				return &peer_api.IsBannedResponse{IsBanned: true}, nil
-			},
-		}
-
-		// blockchain reports no legacy subscriber, so the legacy client (though
-		// non-nil) must not be consulted.
-		mockBlockchain := &blockchain.Mock{}
-		mockBlockchain.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberP2P}, nil)
-
-		s := &RPCServer{
-			logger:           logger,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: mockBlockchain,
-			settings: &settings.Settings{
-				ChainCfgParams: &chaincfg.MainNetParams,
-			},
-		}
-
-		cmd := &bsvjson.IsBannedCmd{
-			IPOrSubnet: "10.0.0.1",
-		}
-
-		result, err := handleIsBanned(context.Background(), s, cmd, nil)
-
-		require.NoError(t, err)
-		banned, ok := result.(bool)
-		require.True(t, ok)
-		assert.False(t, banned, "IP should not be reported banned when legacy is inactive")
-		assert.False(t, legacyCalled, "legacy client must not be called when legacy is not an active subscriber")
-	})
-
 	t.Run("both clients return not banned", func(t *testing.T) {
 		mockP2P := &mockP2PClient{
 			isBannedFunc: func(ctx context.Context, ipOrSubnet string) (bool, error) {
@@ -3279,10 +3231,9 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3314,10 +3265,9 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3349,10 +3299,9 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3473,9 +3422,8 @@ func TestHandleListBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3507,10 +3455,9 @@ func TestHandleListBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3546,10 +3493,9 @@ func TestHandleListBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3632,10 +3578,9 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3663,10 +3608,9 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3711,9 +3655,8 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3757,10 +3700,9 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3848,10 +3790,9 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3952,10 +3893,9 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -4031,49 +3971,6 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		assert.Contains(t, rpcErr.Message, "Failed to apply ban")
 	})
 
-	t.Run("add ban p2p fails and legacy inactive reports failure", func(t *testing.T) {
-		banTime := int64(3600)
-		legacyCalled := false
-
-		mockP2P := &mockP2PClient{
-			banPeerFunc: func(ctx context.Context, addr string, until int64) error {
-				return errors.New(errors.ERR_ERROR, "ban failed")
-			},
-		}
-		mockPeer := &mockLegacyPeerClient{
-			banPeerFunc: func(ctx context.Context, req *peer_api.BanPeerRequest) (*peer_api.BanPeerResponse, error) {
-				legacyCalled = true
-				return &peer_api.BanPeerResponse{Ok: true}, nil
-			},
-		}
-		// legacy configured but NOT an active subscriber, so the legacy leg is
-		// skipped; the failed p2p leg must still surface as an error.
-		mockBlockchain := &blockchain.Mock{}
-		mockBlockchain.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberP2P}, nil)
-
-		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: mockBlockchain,
-			settings: &settings.Settings{
-				ChainCfgParams: &chaincfg.MainNetParams,
-			},
-		}
-
-		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "add", BanTime: &banTime}
-
-		result, err := handleSetBan(context.Background(), s, cmd, nil)
-
-		require.Error(t, err, "a failed p2p ban with the legacy leg skipped must surface an error, not silent success")
-		assert.Nil(t, result)
-		assert.False(t, legacyCalled, "legacy must not be consulted when inactive")
-
-		rpcErr, ok := err.(*bsvjson.RPCError)
-		require.True(t, ok)
-		assert.Contains(t, rpcErr.Message, "Failed to apply ban")
-	})
-
 	t.Run("add ban with subnet", func(t *testing.T) {
 		banTime := int64(7200)
 
@@ -4120,10 +4017,9 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -4143,7 +4039,7 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		rpcErr, ok := err.(*bsvjson.RPCError)
 		require.True(t, ok)
 		assert.Equal(t, bsvjson.ErrRPCInvalidParameter, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Failed to add ban")
+		assert.Contains(t, rpcErr.Message, "Failed to apply ban")
 	})
 
 	t.Run("remove ban both clients fail", func(t *testing.T) {
@@ -4160,10 +4056,9 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:           logger,
-			p2pClient:        mockP2P,
-			legacyP2PClient:  mockPeer,
-			blockchainClient: newLegacySubscriberMock(),
+			logger:          logger,
+			p2pClient:       mockP2P,
+			legacyP2PClient: mockPeer,
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -4182,7 +4077,7 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		rpcErr, ok := err.(*bsvjson.RPCError)
 		require.True(t, ok)
 		assert.Equal(t, bsvjson.ErrRPCInvalidParameter, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Error while trying to unban peer")
+		assert.Contains(t, rpcErr.Message, "Failed to remove ban")
 	})
 
 	t.Run("malformed command type", func(t *testing.T) {
@@ -6746,87 +6641,132 @@ func TestSendRawTransactionAllowHighFeesHelp_NoLongerSaysNoEffect(t *testing.T) 
 		"help text must be updated to describe the new behaviour after T11")
 }
 
-// TestBanHandlers_LegacySkippedWhenInactive proves that when the legacy manager
-// is not an active blockchain subscriber, none of the ban RPC handlers consult
-// the (non-nil) legacy peer client. All five sites share the same
-// isSubscriberActive gate; TestHandleIsBannedComprehensive covers isbanned, and
-// this covers the other four so future drift in any of them is caught.
-func TestBanHandlers_LegacySkippedWhenInactive(t *testing.T) {
+// TestHandleSetBan_SuccessTracking exercises the post-switch success check
+// across the p2p x legacy matrix, including the legacy-only success path that
+// carries the result when p2p is absent — the load-bearing case for the
+// `success = true` set on the legacy branches.
+func TestHandleSetBan_SuccessTracking(t *testing.T) {
 	logger := mocklogger.NewTestLogger()
-
-	// blockchain subscriber list omits the legacy manager.
-	newInactive := func() *blockchain.Mock {
-		m := &blockchain.Mock{}
-		m.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberP2P}, nil)
-
-		return m
+	tSettings := &settings.Settings{
+		ChainCfgParams: &chaincfg.MainNetParams,
+		RPC:            settings.RPCSettings{ClientCallTimeout: 5 * time.Second},
 	}
 
-	settingsObj := &settings.Settings{ChainCfgParams: &chaincfg.MainNetParams}
-
-	t.Run("listbanned", func(t *testing.T) {
-		legacyCalled := false
-		mockPeer := &mockLegacyPeerClient{
-			listBannedFunc: func(ctx context.Context, req *emptypb.Empty) (*peer_api.ListBannedResponse, error) {
-				legacyCalled = true
-				return &peer_api.ListBannedResponse{}, nil
-			},
-		}
-		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
-
-		_, err := handleListBanned(context.Background(), s, nil, nil)
-		require.NoError(t, err)
-		assert.False(t, legacyCalled, "legacy ListBanned must not be called when legacy is inactive")
-	})
-
-	t.Run("clearbanned", func(t *testing.T) {
-		legacyCalled := false
-		mockPeer := &mockLegacyPeerClient{
-			clearBannedFunc: func(ctx context.Context, req *emptypb.Empty) (*peer_api.ClearBannedResponse, error) {
-				legacyCalled = true
-				return &peer_api.ClearBannedResponse{}, nil
-			},
-		}
-		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
-
-		_, err := handleClearBanned(context.Background(), s, nil, nil)
-		require.NoError(t, err)
-		assert.False(t, legacyCalled, "legacy ClearBanned must not be called when legacy is inactive")
-	})
-
-	t.Run("setban add", func(t *testing.T) {
-		legacyCalled := false
-		banTime := int64(3600)
+	t.Run("add: p2p absent, legacy applies ban -> success", func(t *testing.T) {
 		mockPeer := &mockLegacyPeerClient{
 			banPeerFunc: func(ctx context.Context, req *peer_api.BanPeerRequest) (*peer_api.BanPeerResponse, error) {
-				legacyCalled = true
 				return &peer_api.BanPeerResponse{Ok: true}, nil
 			},
 		}
-		// p2p present and succeeds so the add path completes without error.
-		mockP2P := &mockP2PClient{banPeerFunc: func(ctx context.Context, addr string, until int64) error { return nil }}
-		s := &RPCServer{logger: logger, p2pClient: mockP2P, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
+		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, settings: tSettings}
+		banTime := int64(3600)
 		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "add", BanTime: &banTime}
 
-		_, err := handleSetBan(context.Background(), s, cmd, nil)
-		require.NoError(t, err)
-		assert.False(t, legacyCalled, "legacy BanPeer must not be called when legacy is inactive")
+		result, err := handleSetBan(context.Background(), s, cmd, nil)
+		require.NoError(t, err, "legacy leg alone must carry success")
+		assert.Nil(t, result)
 	})
 
-	t.Run("setban remove", func(t *testing.T) {
-		legacyCalled := false
+	t.Run("add: no clients -> Failed to apply ban", func(t *testing.T) {
+		s := &RPCServer{logger: logger, settings: tSettings}
+		banTime := int64(3600)
+		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "add", BanTime: &banTime}
+
+		result, err := handleSetBan(context.Background(), s, cmd, nil)
+		require.Error(t, err)
+		assert.Nil(t, result)
+
+		rpcErr, ok := err.(*bsvjson.RPCError)
+		require.True(t, ok)
+		assert.Contains(t, rpcErr.Message, "Failed to apply ban")
+	})
+
+	t.Run("remove: p2p absent, legacy removes ban -> success", func(t *testing.T) {
 		mockPeer := &mockLegacyPeerClient{
 			unbanPeerFunc: func(ctx context.Context, req *peer_api.UnbanPeerRequest) (*peer_api.UnbanPeerResponse, error) {
-				legacyCalled = true
 				return &peer_api.UnbanPeerResponse{Ok: true}, nil
 			},
 		}
-		mockP2P := &mockP2PClient{unbanPeerFunc: func(ctx context.Context, addr string) error { return nil }}
-		s := &RPCServer{logger: logger, p2pClient: mockP2P, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
+		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, settings: tSettings}
 		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "remove"}
 
-		_, err := handleSetBan(context.Background(), s, cmd, nil)
-		require.NoError(t, err)
-		assert.False(t, legacyCalled, "legacy UnbanPeer must not be called when legacy is inactive")
+		result, err := handleSetBan(context.Background(), s, cmd, nil)
+		require.NoError(t, err, "legacy leg alone must carry success")
+		assert.Nil(t, result)
+	})
+
+	t.Run("remove: no clients -> Failed to remove ban", func(t *testing.T) {
+		s := &RPCServer{logger: logger, settings: tSettings}
+		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "remove"}
+
+		result, err := handleSetBan(context.Background(), s, cmd, nil)
+		require.Error(t, err)
+		assert.Nil(t, result)
+
+		rpcErr, ok := err.(*bsvjson.RPCError)
+		require.True(t, ok)
+		assert.Contains(t, rpcErr.Message, "Failed to remove ban")
+	})
+}
+
+// TestBanHandlers_LegacyCallBounded verifies the legacy ban calls are bounded by
+// ClientCallTimeout, so an unresponsive-but-configured legacy service cannot
+// stall the RPC on the parent context (#591). The mock blocks until its context
+// is cancelled; without the per-call timeout the handler would hang forever.
+func TestBanHandlers_LegacyCallBounded(t *testing.T) {
+	logger := mocklogger.NewTestLogger()
+	tSettings := &settings.Settings{
+		ChainCfgParams: &chaincfg.MainNetParams,
+		RPC:            settings.RPCSettings{ClientCallTimeout: 50 * time.Millisecond},
+	}
+
+	mustReturn := func(t *testing.T, fn func()) {
+		t.Helper()
+		done := make(chan struct{})
+		go func() { fn(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler did not return; legacy call is not bounded by ClientCallTimeout")
+		}
+	}
+
+	t.Run("isbanned", func(t *testing.T) {
+		mockPeer := &mockLegacyPeerClient{
+			isBannedFunc: func(ctx context.Context, req *peer_api.IsBannedRequest) (*peer_api.IsBannedResponse, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		}
+		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, settings: tSettings}
+		cmd := &bsvjson.IsBannedCmd{IPOrSubnet: "10.0.0.1"}
+		mustReturn(t, func() { _, _ = handleIsBanned(context.Background(), s, cmd, nil) })
+	})
+
+	t.Run("clearbanned", func(t *testing.T) {
+		mockPeer := &mockLegacyPeerClient{
+			clearBannedFunc: func(ctx context.Context, req *emptypb.Empty) (*peer_api.ClearBannedResponse, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		}
+		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, settings: tSettings}
+		mustReturn(t, func() { _, _ = handleClearBanned(context.Background(), s, nil, nil) })
+	})
+
+	t.Run("setban add", func(t *testing.T) {
+		mockPeer := &mockLegacyPeerClient{
+			banPeerFunc: func(ctx context.Context, req *peer_api.BanPeerRequest) (*peer_api.BanPeerResponse, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		}
+		// p2p succeeds so the overall RPC still reports success; we only assert
+		// the legacy call does not hang.
+		mockP2P := &mockP2PClient{banPeerFunc: func(ctx context.Context, addr string, until int64) error { return nil }}
+		s := &RPCServer{logger: logger, p2pClient: mockP2P, legacyP2PClient: mockPeer, settings: tSettings}
+		banTime := int64(3600)
+		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "10.0.0.1", Command: "add", BanTime: &banTime}
+		mustReturn(t, func() { _, _ = handleSetBan(context.Background(), s, cmd, nil) })
 	})
 }

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -3078,6 +3078,16 @@ func TestHandleReconsiderBlockComprehensive(t *testing.T) {
 }
 
 // TestHandleIsBannedComprehensive tests the handleIsBanned handler
+// newLegacySubscriberMock returns a blockchain mock whose subscriber list
+// includes the legacy manager, so ban RPC handlers treat the legacy peer
+// service as active (mirroring handleGetInfo's isSubscriberActive gate).
+func newLegacySubscriberMock() *blockchain.Mock {
+	m := &blockchain.Mock{}
+	m.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberLegacy}, nil)
+
+	return m
+}
+
 func TestHandleIsBannedComprehensive(t *testing.T) {
 	logger := mocklogger.NewTestLogger()
 
@@ -3140,9 +3150,10 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3198,8 +3209,9 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3217,6 +3229,42 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		assert.True(t, banned)
 	})
 
+	t.Run("legacy skipped when legacy not an active subscriber", func(t *testing.T) {
+		legacyCalled := false
+		mockPeer := &mockLegacyPeerClient{
+			isBannedFunc: func(ctx context.Context, req *peer_api.IsBannedRequest) (*peer_api.IsBannedResponse, error) {
+				legacyCalled = true
+				return &peer_api.IsBannedResponse{IsBanned: true}, nil
+			},
+		}
+
+		// blockchain reports no legacy subscriber, so the legacy client (though
+		// non-nil) must not be consulted.
+		mockBlockchain := &blockchain.Mock{}
+		mockBlockchain.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberP2P}, nil)
+
+		s := &RPCServer{
+			logger:           logger,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: mockBlockchain,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.MainNetParams,
+			},
+		}
+
+		cmd := &bsvjson.IsBannedCmd{
+			IPOrSubnet: "10.0.0.1",
+		}
+
+		result, err := handleIsBanned(context.Background(), s, cmd, nil)
+
+		require.NoError(t, err)
+		banned, ok := result.(bool)
+		require.True(t, ok)
+		assert.False(t, banned, "IP should not be reported banned when legacy is inactive")
+		assert.False(t, legacyCalled, "legacy client must not be called when legacy is not an active subscriber")
+	})
+
 	t.Run("both clients return not banned", func(t *testing.T) {
 		mockP2P := &mockP2PClient{
 			isBannedFunc: func(ctx context.Context, ipOrSubnet string) (bool, error) {
@@ -3231,9 +3279,10 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3265,9 +3314,10 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3299,9 +3349,10 @@ func TestHandleIsBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3422,8 +3473,9 @@ func TestHandleListBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3455,9 +3507,10 @@ func TestHandleListBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3493,9 +3546,10 @@ func TestHandleListBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3578,9 +3632,10 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3608,9 +3663,10 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3655,8 +3711,9 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3700,9 +3757,10 @@ func TestHandleClearBannedComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3790,9 +3848,10 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -3893,9 +3952,10 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -4011,9 +4071,10 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},
@@ -4050,9 +4111,10 @@ func TestHandleSetBanComprehensive(t *testing.T) {
 		}
 
 		s := &RPCServer{
-			logger:          logger,
-			p2pClient:       mockP2P,
-			legacyP2PClient: mockPeer,
+			logger:           logger,
+			p2pClient:        mockP2P,
+			legacyP2PClient:  mockPeer,
+			blockchainClient: newLegacySubscriberMock(),
 			settings: &settings.Settings{
 				ChainCfgParams: &chaincfg.MainNetParams,
 			},

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -3077,7 +3077,6 @@ func TestHandleReconsiderBlockComprehensive(t *testing.T) {
 	})
 }
 
-// TestHandleIsBannedComprehensive tests the handleIsBanned handler
 // newLegacySubscriberMock returns a blockchain mock whose subscriber list
 // includes the legacy manager, so ban RPC handlers treat the legacy peer
 // service as active (mirroring handleGetInfo's isSubscriberActive gate).
@@ -3088,6 +3087,7 @@ func newLegacySubscriberMock() *blockchain.Mock {
 	return m
 }
 
+// TestHandleIsBannedComprehensive tests the handleIsBanned handler
 func TestHandleIsBannedComprehensive(t *testing.T) {
 	logger := mocklogger.NewTestLogger()
 
@@ -6695,4 +6695,89 @@ func TestSendRawTransactionAllowHighFeesHelp_NoLongerSaysNoEffect(t *testing.T) 
 	require.NotEmpty(t, help)
 	require.NotContains(t, help, "no effect",
 		"help text must be updated to describe the new behaviour after T11")
+}
+
+// TestBanHandlers_LegacySkippedWhenInactive proves that when the legacy manager
+// is not an active blockchain subscriber, none of the ban RPC handlers consult
+// the (non-nil) legacy peer client. All five sites share the same
+// isSubscriberActive gate; TestHandleIsBannedComprehensive covers isbanned, and
+// this covers the other four so future drift in any of them is caught.
+func TestBanHandlers_LegacySkippedWhenInactive(t *testing.T) {
+	logger := mocklogger.NewTestLogger()
+
+	// blockchain subscriber list omits the legacy manager.
+	newInactive := func() *blockchain.Mock {
+		m := &blockchain.Mock{}
+		m.On("GetSubscribers", mock.Anything).Return([]string{blockchain.SubscriberP2P}, nil)
+
+		return m
+	}
+
+	settingsObj := &settings.Settings{ChainCfgParams: &chaincfg.MainNetParams}
+
+	t.Run("listbanned", func(t *testing.T) {
+		legacyCalled := false
+		mockPeer := &mockLegacyPeerClient{
+			listBannedFunc: func(ctx context.Context, req *emptypb.Empty) (*peer_api.ListBannedResponse, error) {
+				legacyCalled = true
+				return &peer_api.ListBannedResponse{}, nil
+			},
+		}
+		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
+
+		_, err := handleListBanned(context.Background(), s, nil, nil)
+		require.NoError(t, err)
+		assert.False(t, legacyCalled, "legacy ListBanned must not be called when legacy is inactive")
+	})
+
+	t.Run("clearbanned", func(t *testing.T) {
+		legacyCalled := false
+		mockPeer := &mockLegacyPeerClient{
+			clearBannedFunc: func(ctx context.Context, req *emptypb.Empty) (*peer_api.ClearBannedResponse, error) {
+				legacyCalled = true
+				return &peer_api.ClearBannedResponse{}, nil
+			},
+		}
+		s := &RPCServer{logger: logger, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
+
+		_, err := handleClearBanned(context.Background(), s, nil, nil)
+		require.NoError(t, err)
+		assert.False(t, legacyCalled, "legacy ClearBanned must not be called when legacy is inactive")
+	})
+
+	t.Run("setban add", func(t *testing.T) {
+		legacyCalled := false
+		banTime := int64(3600)
+		mockPeer := &mockLegacyPeerClient{
+			banPeerFunc: func(ctx context.Context, req *peer_api.BanPeerRequest) (*peer_api.BanPeerResponse, error) {
+				legacyCalled = true
+				return &peer_api.BanPeerResponse{Ok: true}, nil
+			},
+		}
+		// p2p present and succeeds so the add path completes without error.
+		mockP2P := &mockP2PClient{banPeerFunc: func(ctx context.Context, addr string, until int64) error { return nil }}
+		s := &RPCServer{logger: logger, p2pClient: mockP2P, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
+		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "add", BanTime: &banTime}
+
+		_, err := handleSetBan(context.Background(), s, cmd, nil)
+		require.NoError(t, err)
+		assert.False(t, legacyCalled, "legacy BanPeer must not be called when legacy is inactive")
+	})
+
+	t.Run("setban remove", func(t *testing.T) {
+		legacyCalled := false
+		mockPeer := &mockLegacyPeerClient{
+			unbanPeerFunc: func(ctx context.Context, req *peer_api.UnbanPeerRequest) (*peer_api.UnbanPeerResponse, error) {
+				legacyCalled = true
+				return &peer_api.UnbanPeerResponse{Ok: true}, nil
+			},
+		}
+		mockP2P := &mockP2PClient{unbanPeerFunc: func(ctx context.Context, addr string) error { return nil }}
+		s := &RPCServer{logger: logger, p2pClient: mockP2P, legacyP2PClient: mockPeer, blockchainClient: newInactive(), settings: settingsObj}
+		cmd := &bsvjson.SetBanCmd{IPOrSubnet: "192.168.1.100", Command: "remove"}
+
+		_, err := handleSetBan(context.Background(), s, cmd, nil)
+		require.NoError(t, err)
+		assert.False(t, legacyCalled, "legacy UnbanPeer must not be called when legacy is inactive")
+	})
 }


### PR DESCRIPTION
## Problem

The ban RPC handlers (`isbanned` / `listbanned` / `clearbanned` / `setban`) call the legacy peer client whenever it is non-nil. That client is **lazily dialed** and is non-nil whenever `legacy_grpcAddress` is configured, so on a scaling/testnet node without a running legacy service every ban RPC issued a gRPC call that stalled - `handleIsBanned` and `handleClearBanned` didn't even wrap it in a timeout, so they blocked on the parent context (#591).

## Approach (revised)

An earlier version of this PR gated the legacy calls on `isSubscriberActive(SubscriberLegacy)`, mirroring `handleGetInfo`. @oskarszoon correctly pointed out that `"legacy/manager"` has had **no `Subscribe()` producer since #735**, so that gate is *always false* - it disabled legacy banning entirely rather than skipping it only when inactive. That approach was dropped.

Instead: keep the `legacyP2PClient != nil` check and wrap each legacy ban call (`isbanned`, `clearbanned`, both `setban` arms) in a `ClientCallTimeout`-bounded context (`listbanned` already had one). An absent-but-configured legacy service can no longer stall the RPC, and legacy banning still works when legacy is present.

## Also in this PR

- **`setban` reports failure when no ban leg applied it.** Previously `success` only tracked the p2p leg and was only checked inside the legacy block, so a failed p2p ban with no active legacy silently returned success. `success` is now hoisted and checked after the switch.
- **Unban wording.** The failure message branches on the command, so a failed `setban remove` returns "Failed to remove ban", not "Failed to apply ban".

## Contract change (note)

`setban` is now strict: a call where no applicable leg applied the ban returns an error where it previously could return silent success (e.g. p2p-only failure, or no clients configured). No in-repo caller depends on the old no-op; this is the correct behaviour for an administrative anti-abuse control.

## Tests

- `TestHandleSetBan_SuccessTracking` - legacy-only success carries the result (load-bearing for the `success = true` on the legacy branches), and the no-clients path returns the command-appropriate failure, for both `add` and `remove`.
- `TestBanHandlers_LegacyCallBounded` - a legacy mock that blocks until its context is cancelled; the handler returns promptly with the per-call timeout and hangs without it.
- `go test ./services/rpc/` passes; `go vet` clean.

Closes #591