### PR TITLE
fix(util): avoid input aliasing in BuildMerkleRootFromCoinbase

### DIFF
--- a/util/build_merkle_root_from_coinbase.go
+++ b/util/build_merkle_root_from_coinbase.go
@@ -6,7 +6,13 @@ func BuildMerkleRootFromCoinbase(coinbaseHash []byte, merkleBranches [][]byte) [
 	acc := coinbaseHash
 
 	for _, branch := range merkleBranches {
-		concat := append(acc, branch...)
+		// Build the concatenation in a freshly allocated buffer rather than
+		// append(acc, branch...): on the first iteration acc still aliases the
+		// caller's coinbaseHash backing array, so a spare-capacity slice would be
+		// mutated in place (corrupting the caller and the merkle root).
+		concat := make([]byte, 0, len(acc)+len(branch))
+		concat = append(concat, acc...)
+		concat = append(concat, branch...)
 		hash := Sha256d(concat)
 		acc = hash
 	}

--- a/util/build_merkle_root_from_coinbase_test.go
+++ b/util/build_merkle_root_from_coinbase_test.go
@@ -44,6 +44,56 @@ func TestBuildMerkleRootFromCoinbase(t *testing.T) {
 	})
 }
 
+func TestBuildMerkleRootFromCoinbaseDoesNotMutateInput(t *testing.T) {
+	// Same branches/coinbase/root as the block 797330 case above, but the
+	// coinbase hash is passed as a slice with spare capacity (cap > len). The
+	// old append(acc, branch...) aliased that backing array on the first
+	// iteration and wrote branch bytes into the spare region; the result was
+	// still correct, but the caller's buffer was silently corrupted.
+	merkleBranchesStr := []string{
+		"e736164db06b4ca5e1020bca8ddba837ecaa029d2caef7e57cf84e4383d66cad",
+		"19dd8d4640891daef573cdf059c7539ff5d9dd8e06697c000925fd2015cee7d4",
+		"10f00d867168e4e51bbe2800706d3acf7d8a8fd53bbe3e8388a45d8b3fadf265",
+		"7fb48c2d1fe6fb6e1dfe411695e1297f3603dda9e1976cb3f931132aab59c0c9",
+		"c3a387dc2f98da4f7706290e78714f904770a0be1e509a8f9cc4f19a4ab39d57",
+		"6f27cd328e23e676a3d94c1dc55ded5a1d38905c0079c9f2ca4a467d810705d4",
+		"b321f9bcd334766be8188524a9bb454d8f41129f2b48f82dd6084b9722e234a7",
+		"e005abf2adbc22bdadda8da0eb79aae08627b1e07411c51c5fd58c63da0c6032",
+		"881fe6b97fc34f6f4a4bb1ed3d5912108edb29dec69ac4eb2436f2345c31abd0",
+		"cc6da767edfd473466d70a747348eee48f649d3173f762be0f41ac3bd418e681",
+		"d8920119ca681be1d616ce0079edc0eb2664c389bcde81e7ca4d32993bd83180",
+	}
+
+	merkleBranches := make([][]byte, len(merkleBranchesStr))
+
+	for i, s := range merkleBranchesStr {
+		hash, err := chainhash.NewHashFromStr(s)
+		require.NoError(t, err)
+
+		merkleBranches[i] = hash.CloneBytes()
+	}
+
+	coinbaseHash, err := chainhash.NewHashFromStr("ddee6d8fb3cf03276e3ffcb25ccb34a7dacf733cea1b40ba3fa7a716426e93cd")
+	require.NoError(t, err)
+
+	cb := coinbaseHash.CloneBytes()
+
+	// Backing array with spare capacity, so a first-iteration in-place append
+	// would land in backing[len:cap].
+	backing := make([]byte, len(cb), len(cb)*2)
+	copy(backing, cb)
+
+	snapshot := make([]byte, cap(backing))
+	copy(snapshot, backing[:cap(backing)])
+
+	merkleRoot := BuildMerkleRootFromCoinbase(backing, merkleBranches)
+	merkleRootHash, err := chainhash.NewHash(merkleRoot)
+	require.NoError(t, err)
+
+	assert.Equal(t, "596907991495a39471b16d4d69804372d7dc2d7d64bf9255767db34f36f5669f", merkleRootHash.String())
+	assert.Equal(t, snapshot, backing[:cap(backing)], "input backing array (incl. spare capacity) must not be mutated")
+}
+
 func TestBuildMerkleRootFromCoinbaseOnlyTransaction(t *testing.T) {
 	t.Run("ternanode block 1 - coinbase only", func(t *testing.T) {
 		merkleBranchesStr := []string{}


### PR DESCRIPTION
## Problem

`BuildMerkleRootFromCoinbase` built each step's concatenation with:

```go
concat := append(acc, branch...)
```

On the **first** iteration `acc` still aliases the caller's `coinbaseHash` backing array. If that slice has spare capacity (`cap > len`), `append` writes `branch` into the backing array **in place** instead of allocating - silently corrupting the caller's buffer (and, in consensus-critical merkle code, risking a wrong root for whoever reuses that buffer).

Reported as [TN-004] in #1143.

## Fix

Build the concatenation in a freshly allocated buffer:

```go
concat := make([]byte, 0, len(acc)+len(branch))
concat = append(concat, acc...)
concat = append(concat, branch...)
```

This is **latent, not active**: every current caller passes a length-32, capacity-32 slice (from `chainhash.Hash[:]`), so `append` always reallocates and no input is mutated today. The change just removes the hazard for any future caller passing a spare-capacity slice. No behavior change for existing callers (the existing block-797330 and coinbase-only root tests still pass).

## Test

`TestBuildMerkleRootFromCoinbaseDoesNotMutateInput` passes the coinbase hash as a spare-capacity slice and asserts (a) the merkle root is still correct and (b) the caller's backing array - including its spare capacity - is untouched. Verified: it fails on the mutation assertion without the fix and passes with it.

Closes #1143