### PR TITLE
fix(expiringmap): make TTL clean() eviction send non-blocking

### DIFF
--- a/util/expiringmap/expiringmap.go
+++ b/util/expiringmap/expiringmap.go
@@ -84,9 +84,9 @@ func (m *ExpiringMap[K, V]) WithEvictionFunction(f func(K, V) bool) *ExpiringMap
 // cap is always honored. A value of 0 (the default) disables the cap and
 // preserves the original unbounded behaviour.
 //
-// Note: cap-eviction's eviction-channel send is non-blocking (the notification
-// is dropped if the channel is full), since cap-eviction runs synchronously
-// inside Set. The TTL clean() path's eviction-channel send remains blocking.
+// Note: the eviction-channel send is non-blocking on both the cap-eviction
+// path (inside Set) and the TTL clean() path (the ticker) — the notification
+// is dropped if the channel is full — so eviction never blocks under m.mu.
 func (m *ExpiringMap[K, V]) WithMaxSize(n int) *ExpiringMap[K, V] {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -258,6 +258,13 @@ func (m *ExpiringMap[K, V]) clean() {
 	}
 
 	if m.evictionCh != nil && len(expiredItems) > 0 {
-		m.evictionCh <- expiredItems
+		// Non-blocking send: clean() holds m.mu, so a blocking send to a full
+		// (or unconsumed) eviction channel would stall the ticker under the
+		// write lock and deadlock all Get/Set/Delete/Len. Drop the notification
+		// if the consumer can't keep up, matching the cap-eviction path.
+		select {
+		case m.evictionCh <- expiredItems:
+		default:
+		}
 	}
 }

--- a/util/expiringmap/expiringmap_test.go
+++ b/util/expiringmap/expiringmap_test.go
@@ -158,3 +158,42 @@ func TestExpiringMap_NoMaxSize_DefaultUnbounded(t *testing.T) {
 
 	require.Equal(t, 100, m.Len())
 }
+
+// TestExpiringMap_CleanEvictionSendDoesNotBlockUnderLock guards against the TTL
+// clean() path performing a blocking eviction-channel send while holding m.mu.
+// With an unbuffered, unconsumed eviction channel, a blocking send would stall
+// clean() under the write lock and deadlock all Get/Set/Delete/Len. The send
+// must be non-blocking (drop-on-full), so clean() always returns.
+func TestExpiringMap_CleanEvictionSendDoesNotBlockUnderLock(t *testing.T) {
+	// expire != 0 would start the hourly ticker; use a long expiry so the
+	// background goroutine never fires during the test and we drive clean()
+	// directly.
+	ch := make(chan []int) // unbuffered, no reader
+	m := New[string, int](time.Hour).WithEvictionChannel(ch)
+
+	// Insert an already-expired item so clean() selects it for eviction.
+	m.mu.Lock()
+	m.items["k"] = &itemWrapper[int]{
+		item:    1,
+		expiry:  time.Now().Add(-time.Hour).UnixNano(),
+		addedAt: time.Now().Add(-time.Hour).UnixNano(),
+	}
+	m.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		m.clean()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("clean() blocked on eviction-channel send while holding m.mu")
+	}
+
+	// The expired item must still have been removed even though the
+	// notification was dropped.
+	_, ok := m.Get("k")
+	require.False(t, ok, "expired item should be evicted")
+}


### PR DESCRIPTION
## Problem

`ExpiringMap.clean()` (the TTL ticker path) sent expired items to the eviction channel with a **blocking** send while holding `m.mu`:

```go
if m.evictionCh != nil && len(expiredItems) > 0 {
    m.evictionCh <- expiredItems   // blocking, under m.mu
}
```

If a configured eviction channel were ever full or unconsumed, the ticker goroutine would block on this send while holding the write lock, deadlocking every `Get`/`Set`/`Delete`/`Len`. The sibling cap-eviction path (`evictOldestLocked`) already uses a non-blocking send; only `clean()` was left blocking.

Reported as [TN-013] in #1152.

## Fix

Use a non-blocking `select { case m.evictionCh <- expiredItems: default: }`, matching the cap-eviction path, so eviction never blocks under `m.mu`. The `WithMaxSize` doc note (which previously stated the clean() send "remains blocking") is updated to match.

This is **latent today** — no production code wires `WithEvictionChannel` — so there is no behavior change for current callers; it removes the deadlock hazard for any future consumer.

## Test

`TestExpiringMap_CleanEvictionSendDoesNotBlockUnderLock` configures an unbuffered, unread eviction channel, inserts an already-expired item, and asserts `clean()` returns within a timeout (and still evicts the item). Verified: it hangs → fails on the 2s timeout without the fix, passes with it. Full package passes under `-race`.

Closes #1152