### PR TITLE
fix(model): overflow-safe coinbase reward/fee check

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -765,22 +765,45 @@ func (b *Block) checkBlockRewardAndFees(params *chaincfg.Params, storeSupportsOu
 		return nil
 	}
 
+	// Accumulate with overflow detection. A uint64 wraparound in any of these
+	// sums could make the no-inflation comparison below pass on a block that is
+	// actually inflating supply, so a sum that overflows is itself invalid.
+	// These overflows cannot occur in a valid block (total value is far below
+	// 2^64 satoshis), so this only rejects impossible values and does not change
+	// the result for any real block.
 	coinbaseOutputSatoshis := uint64(0)
+
 	for _, tx := range b.CoinbaseTx.Outputs {
-		coinbaseOutputSatoshis += tx.Satoshis
+		sum := coinbaseOutputSatoshis + tx.Satoshis
+		if sum < coinbaseOutputSatoshis {
+			return errors.NewBlockInvalidError("[checkBlockRewardAndFees][%s] coinbase output satoshis overflow uint64", b.String())
+		}
+
+		coinbaseOutputSatoshis = sum
 	}
 
 	subtreeFees := uint64(0)
 
 	for i := 0; i < len(b.SubtreeSlices); i++ {
 		subtree := b.SubtreeSlices[i]
-		subtreeFees += subtree.Fees
+
+		sum := subtreeFees + subtree.Fees
+		if sum < subtreeFees {
+			return errors.NewBlockInvalidError("[checkBlockRewardAndFees][%s] subtree fees overflow uint64", b.String())
+		}
+
+		subtreeFees = sum
 	}
 
 	coinbaseReward := util.GetBlockSubsidyForHeight(b.Height, params)
 
-	if coinbaseOutputSatoshis > subtreeFees+coinbaseReward {
-		return errors.NewBlockInvalidError("[checkBlockRewardAndFees][%s] coinbase output (%d) is greater than the fees + block subsidy (%d)", b.String(), coinbaseOutputSatoshis, subtreeFees+coinbaseReward)
+	allowedReward := subtreeFees + coinbaseReward
+	if allowedReward < subtreeFees {
+		return errors.NewBlockInvalidError("[checkBlockRewardAndFees][%s] fees + block subsidy overflow uint64", b.String())
+	}
+
+	if coinbaseOutputSatoshis > allowedReward {
+		return errors.NewBlockInvalidError("[checkBlockRewardAndFees][%s] coinbase output (%d) is greater than the fees + block subsidy (%d)", b.String(), coinbaseOutputSatoshis, allowedReward)
 	}
 
 	return nil

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -2023,6 +2023,31 @@ func TestBlock_CheckBlockRewardAndFees(t *testing.T) {
 		err = block.checkBlockRewardAndFees(params, true, true)
 		require.NoError(t, err)
 	})
+
+	t.Run("coinbase output satoshi sum overflow is rejected", func(t *testing.T) {
+		blockHeaderBytes, _ := hex.DecodeString(block1Header)
+		blockHeader, err := NewBlockHeaderFromBytes(blockHeaderBytes)
+		require.NoError(t, err)
+
+		coinbase, err := bt.NewTxFromString(CoinbaseHex)
+		require.NoError(t, err)
+
+		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, 1, 0)
+		require.NoError(t, err)
+
+		// Two coinbase outputs whose satoshi sum wraps uint64. Without the
+		// overflow guard the wrapped total (0) would slip past the
+		// no-inflation comparison; it must be rejected as an invalid block.
+		block.CoinbaseTx.Outputs = []*bt.Output{
+			{Satoshis: ^uint64(0)},
+			{Satoshis: 1},
+		}
+
+		params := &chaincfg.Params{SubsidyReductionInterval: 210000}
+		err = block.checkBlockRewardAndFees(params, true, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "overflow")
+	})
 }
 
 // newBlockWithCoinbaseRewardAndZeroSubtreeFees builds a Block at the given height


### PR DESCRIPTION
## Problem

`Block.checkBlockRewardAndFees` accumulated the coinbase output total and the subtree fees with plain unchecked `uint64` additions, and compared against an unchecked `subtreeFees + coinbaseReward`:

```go
coinbaseOutputSatoshis += tx.Satoshis   // unchecked
subtreeFees += subtree.Fees             // unchecked
if coinbaseOutputSatoshis > subtreeFees+coinbaseReward { ... }   // RHS unchecked
```

A `uint64` wraparound in any of these sums could make the no-inflation comparison pass on a block that is actually inflating supply. SV Node enforces `MoneyRange` on these values; Teranode had no overflow/range guard here.

Reported as [TN-009] in #1148.

## Fix

Detect overflow on each accumulation (`sum < prev`) and on the `fees + subsidy` sum, returning `BlockInvalidError`.

This is **purely additive**: for every real block the sums are far below `2^64` satoshis, so `allowedReward == subtreeFees + coinbaseReward` and the comparison is identical to before. Only impossible, overflowing values are newly rejected. As the issue notes, wrapping `uint64` would require ~184 quintillion satoshis, so this is defense-in-depth, not a reachable exploit today.

## Test

New subtest `coinbase output satoshi sum overflow is rejected` sets two coinbase outputs whose satoshi sum wraps `uint64` and asserts the block is rejected. Verified: without the guard the wrapped total (0) slips past the comparison and the block is wrongly accepted (test fails); with the guard it's rejected. All existing `checkBlockRewardAndFees` / checkpoint-skip tests still pass; `go vet` clean.

Closes #1148