### PR TITLE
test(blockvalidation): fix broken main — catch-all GetBlockHeader mock in catchup fork scenario

### DIFF
--- a/services/blockvalidation/catchup_fork_handling_test.go
+++ b/services/blockvalidation/catchup_fork_handling_test.go
@@ -690,8 +690,12 @@ func TestCatchup_NoMinedSetChurnOnRejectedFork(t *testing.T) {
 		// Metadata for the common ancestor.
 		mockBlockchainClient.On("GetBlockHeader", mock.Anything, ancestorHeader.Hash()).
 			Return(ancestorHeader, &model.BlockHeaderMeta{Height: ancestorHeight, ID: 1, ChainWork: ancestorChainWork.Bytes()}, nil).Maybe()
+		// Any other header (the peer's fork blocks) is absent from our chain, so
+		// GetBlockHeader reports not found and the common-ancestor walk stops at the
+		// divergence point, leaving the fork blocks as offered headers.
 		mockBlockchainClient.On("GetBlockHeader", mock.Anything, mock.Anything).
-			Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: ancestorHeight, ChainWork: ancestorChainWork.Bytes()}, nil).Maybe()
+			Return((*model.BlockHeader)(nil), (*model.BlockHeaderMeta)(nil),
+				errors.NewBlockNotFoundError("block not found")).Maybe()
 
 		// Header-fetch plumbing.
 		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).


### PR DESCRIPTION
## What

Fixes `TestCatchup_NoMinedSetChurnOnRejectedFork/SecretMiningDepth`, which has been failing on `main` since #1094 merged (breaks the `Teranode main test build push` Go test job).

## Root cause — semantic merge conflict

Two blockvalidation PRs collided:

- #1197 (`gate secret-mining verdict on chainwork`) added this test plus a guard that bails with `"no offered headers to compare chainwork"` when the peer offers no headers past the common ancestor. Its `buildForkScenario` mocks `GetBlockHeader` to return a valid header (nil error) for **any** hash — correct against the *old* `findCommonAncestor`, which detected block absence through a separate `GetBlockExists` call (true only for the ancestor).
- #1094 (`collapse redundant RPCs in findCommonAncestor`) refactored the walk to drop `GetBlockExists` and detect absence purely from `GetBlockHeader` returning `ErrBlockNotFound`. It branched **before** #1197, so it never saw that test; its own test updates use `NewBlockNotFoundError` catch-alls.

The merge was textually clean (disjoint hunks) but semantically broken. With the refactored walk, the test's catch-all `GetBlockHeader` never returns not-found, so every fork header looks present → the common ancestor lands on the **last** peer header → `offeredHeaders` is empty → the code trips the `"no offered headers"` guard instead of reaching the `"secretly mined"` verdict the test asserts.

**Production code was already correct** — a real blockchain client returns `ErrBlockNotFound` for the peer's fork blocks. Only the test mock modeled reality wrong.

## Fix

Test-only. The catch-all `GetBlockHeader` mock in `buildForkScenario` now returns `NewBlockNotFoundError` for non-ancestor hashes, matching:
- the real blockchain client,
- the `GetBlockExists`=false mock already in the same scenario,
- the sibling `catchup_test.go` mocks updated in #1094.

Walk now stops at the first fork header → `offeredHeaders` holds the 5 fork headers → local chain outweighs the fork → `"secretly mined"` verdict. Both subtests pass.

## Verification

```
go test -tags testtxmetacache -run TestCatchup_NoMinedSetChurnOnRejectedFork ./services/blockvalidation/   # ok
go test -tags testtxmetacache ./services/blockvalidation/                                                  # ok, 278s
```
