### PR TITLE
ci(sonar): post Quality Gate result as PR commit status

### DIFF
--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -23,9 +23,8 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
   statuses: write
-  id-token: write
 
 env:
   GO_VERSION: "1.26.0"
@@ -92,7 +91,6 @@ jobs:
             core.setOutput('number', prNumber);
             core.setOutput('base', pr.data.base.ref);
             core.setOutput('head', pr.data.head.ref);
-            core.setOutput('head_sha', pr.data.head.sha);
 
       - name: Checkout base branch
         if: github.event.workflow_run.conclusion == 'success'
@@ -173,9 +171,10 @@ jobs:
       # commit A's result onto B — a stale green on unscanned code, or a spurious
       # red — which is exactly what a required check must never do.
       #
-      # workflow_run runs in base-repo context, so this also works for fork PRs
-      # (their SONAR_TOKEN-less builds never reach here). Mark it a required check
-      # in branch protection under the context "SonarQube Quality Gate".
+      # workflow_run runs in base-repo context where SONAR_TOKEN is available, so
+      # fork PRs are scanned here too — the fork's own token-less test run never
+      # runs this job. Mark it a required check in branch protection under the
+      # context "SonarQube Quality Gate".
       #
       # if: !cancelled() — a self-cancelled sonar run (its own concurrency group)
       # must never post a transient error. On success/failure it resolves every

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -36,14 +36,20 @@ jobs:
     # arm64-safe: only downloads coverage artifacts + runs the sonar scanner CLI
     # (arm64-available); no Go build, no containers.
     runs-on: teranode-runner-4-core-arm
-    # Run for every PR-triggered test outcome (not only success) so the sonar
-    # commit status ALWAYS resolves — a fully skipped job would leave a required
-    # PR check stuck "pending". Only pull_request runs are handled (push-to-main
-    # test runs are filtered out). The analysis steps below are individually
-    # guarded to conclusion == 'success' because they need artifacts that failed
-    # runs never produce; on a non-success run we skip straight to posting a
-    # failure status.
-    if: github.event.workflow_run.event == 'pull_request'
+    # Run for PR-triggered test outcomes other than 'cancelled' so the sonar
+    # commit status resolves instead of leaving a required check stuck "pending".
+    # 'cancelled' is excluded on purpose: teranode_pr_tests uses
+    # cancel-in-progress, so every push to a PR with in-flight tests emits a
+    # cancelled completion for the *superseded* commit. Its successor run reports
+    # on the new head, so acting here would only stamp a spurious failure.
+    # Only pull_request runs are handled (push-to-main test runs are filtered
+    # out). The analysis steps below are individually guarded to
+    # conclusion == 'success' because they need artifacts that failed runs never
+    # produce; on a non-success (but not cancelled) run we skip straight to
+    # posting a failure status.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
 
     steps:
       - name: Get PR number and metadata
@@ -95,11 +101,29 @@ jobs:
           ref: ${{ steps.pr.outputs.base }}
           fetch-depth: 0
 
-      - name: Checkout PR head
+      # Check out the *tested* commit (workflow_run.head_sha), not the live PR
+      # head, so the scanned tree, the downloaded coverage, and the commit status
+      # all describe the same commit. The tested commit is normally an ancestor
+      # of the current head (a later push just adds commits on top), so fetching
+      # pull/N/head brings it into the object store; fall back to fetching the
+      # exact SHA, and bail if it's unreachable (force-push/rebase since the run
+      # — the head has moved, so this analysis is stale and its successor run
+      # will report on the new head).
+      - name: Checkout tested commit
         if: github.event.workflow_run.conclusion == 'success'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          git fetch origin pull/${{ steps.pr.outputs.number }}/head:pr-${{ steps.pr.outputs.number }}
-          git checkout pr-${{ steps.pr.outputs.number }}
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head"
+          if ! git cat-file -e "${TESTED_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${TESTED_SHA}" || true
+          fi
+          if ! git cat-file -e "${TESTED_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Tested commit ${TESTED_SHA} is unreachable (PR head moved since the test run); refusing to scan a different tree."
+            exit 1
+          fi
+          git checkout --detach "${TESTED_SHA}"
 
       - name: Download coverage artifact
         if: github.event.workflow_run.conclusion == 'success'
@@ -141,25 +165,32 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      # Post the Quality Gate result as a commit status on the PR head SHA.
-      # workflow_run runs in base-repo context, so this also works for fork PRs
-      # (their SONAR_TOKEN-less builds never reach here). The status attaches to
-      # the PR head commit and can later be marked a required check in branch
-      # protection under the context "SonarQube Quality Gate".
+      # Post the Quality Gate result as a commit status on the *tested* commit
+      # (github.event.workflow_run.head_sha — the SHA the triggering test run
+      # actually ran and Sonar scanned), NOT the live PR head. If a newer commit
+      # was pushed meanwhile this vouches only for the commit that was scanned;
+      # the newer commit gets its own run. Posting to the live head would stamp
+      # commit A's result onto B — a stale green on unscanned code, or a spurious
+      # red — which is exactly what a required check must never do.
       #
-      # runs on always() and resolves every path: tests passed + gate PASSED or
-      # FAILED, tests passed but scan errored, or upstream tests did not succeed
-      # (analysis skipped) -> failure. This keeps a required check from hanging
-      # "pending". One case no workflow_run job can cover: if "Teranode PR tests"
-      # never runs at all (path filter, draft PR) this workflow never triggers,
-      # so require the tests check alongside this one when enforcing.
+      # workflow_run runs in base-repo context, so this also works for fork PRs
+      # (their SONAR_TOKEN-less builds never reach here). Mark it a required check
+      # in branch protection under the context "SonarQube Quality Gate".
+      #
+      # if: !cancelled() — a self-cancelled sonar run (its own concurrency group)
+      # must never post a transient error. On success/failure it resolves every
+      # path: gate PASSED/WARN -> success, FAILED -> failure, scan errored ->
+      # error, upstream tests failed/skipped -> failure. ('cancelled' upstream is
+      # already excluded at the job level.) One case no workflow_run job can
+      # cover: if "Teranode PR tests" never runs at all (path filter, draft PR)
+      # this never triggers, so require the tests check alongside this one.
       - name: Report Quality Gate as commit status
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           QG_STATUS: ${{ steps.qg.outputs.quality-gate-status }}
           TESTS_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
@@ -167,10 +198,11 @@ jobs:
             const testsConclusion = process.env.TESTS_CONCLUSION || '';
             const sha = process.env.HEAD_SHA;
             const pr = process.env.PR_NUMBER;
+            // Keep in sync with sonar.projectKey in sonar-project.properties.
             const projectKey = 'bsv-blockchain_teranode';
 
             if (!sha) {
-              core.setFailed('No PR head SHA resolved; cannot post commit status.');
+              core.setFailed('No tested commit SHA on the workflow_run payload; cannot post commit status.');
               return;
             }
 
@@ -184,6 +216,9 @@ jobs:
             } else if (qg === 'PASSED') {
               state = 'success';
               description = 'Quality Gate passed';
+            } else if (qg === 'WARN') {
+              state = 'success';
+              description = 'Quality Gate passed with warnings';
             } else if (qg === 'FAILED') {
               state = 'failure';
               description = 'Quality Gate failed';

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -24,6 +24,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
   id-token: write
 
 env:
@@ -35,12 +36,14 @@ jobs:
     # arm64-safe: only downloads coverage artifacts + runs the sonar scanner CLI
     # (arm64-available); no Go build, no containers.
     runs-on: teranode-runner-4-core-arm
-    # Only run if:
-    # 1. The triggering workflow succeeded (ensures all artifacts were generated)
-    # 2. It was triggered by a pull_request event (not push to main)
-    if: |
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    # Run for every PR-triggered test outcome (not only success) so the sonar
+    # commit status ALWAYS resolves — a fully skipped job would leave a required
+    # PR check stuck "pending". Only pull_request runs are handled (push-to-main
+    # test runs are filtered out). The analysis steps below are individually
+    # guarded to conclusion == 'success' because they need artifacts that failed
+    # runs never produce; on a non-success run we skip straight to posting a
+    # failure status.
+    if: github.event.workflow_run.event == 'pull_request'
 
     steps:
       - name: Get PR number and metadata
@@ -86,17 +89,20 @@ jobs:
             core.setOutput('head_sha', pr.data.head.sha);
 
       - name: Checkout base branch
+        if: github.event.workflow_run.conclusion == 'success'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           ref: ${{ steps.pr.outputs.base }}
           fetch-depth: 0
 
       - name: Checkout PR head
+        if: github.event.workflow_run.conclusion == 'success'
         run: |
           git fetch origin pull/${{ steps.pr.outputs.number }}/head:pr-${{ steps.pr.outputs.number }}
           git checkout pr-${{ steps.pr.outputs.number }}
 
       - name: Download coverage artifact
+        if: github.event.workflow_run.conclusion == 'success'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: coverage-report
@@ -104,6 +110,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download golangci-lint report
+        if: github.event.workflow_run.conclusion == 'success'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: golangci-lint-report
@@ -111,6 +118,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download filename check report
+        if: github.event.workflow_run.conclusion == 'success'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sonar-filename-report
@@ -118,6 +126,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: SonarQube Scan
+        if: github.event.workflow_run.conclusion == 'success'
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -125,7 +134,72 @@ jobs:
           args: "-Dsonar.pullrequest.key=${{ steps.pr.outputs.number }} -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head }} -Dsonar.pullrequest.base=${{ steps.pr.outputs.base }}"
 
       - name: SonarQube Quality Gate check
+        id: qg
+        if: github.event.workflow_run.conclusion == 'success'
         uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
         timeout-minutes: 10
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # Post the Quality Gate result as a commit status on the PR head SHA.
+      # workflow_run runs in base-repo context, so this also works for fork PRs
+      # (their SONAR_TOKEN-less builds never reach here). The status attaches to
+      # the PR head commit and can later be marked a required check in branch
+      # protection under the context "SonarQube Quality Gate".
+      #
+      # runs on always() and resolves every path: tests passed + gate PASSED or
+      # FAILED, tests passed but scan errored, or upstream tests did not succeed
+      # (analysis skipped) -> failure. This keeps a required check from hanging
+      # "pending". One case no workflow_run job can cover: if "Teranode PR tests"
+      # never runs at all (path filter, draft PR) this workflow never triggers,
+      # so require the tests check alongside this one when enforcing.
+      - name: Report Quality Gate as commit status
+        if: always()
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          QG_STATUS: ${{ steps.qg.outputs.quality-gate-status }}
+          TESTS_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const qg = process.env.QG_STATUS || '';
+            const testsConclusion = process.env.TESTS_CONCLUSION || '';
+            const sha = process.env.HEAD_SHA;
+            const pr = process.env.PR_NUMBER;
+            const projectKey = 'bsv-blockchain_teranode';
+
+            if (!sha) {
+              core.setFailed('No PR head SHA resolved; cannot post commit status.');
+              return;
+            }
+
+            let state, description;
+            if (testsConclusion !== 'success') {
+              // Upstream "Teranode PR tests" did not pass, so the analysis steps
+              // were skipped and no Quality Gate ran. Post failure so the
+              // required check resolves instead of hanging "pending".
+              state = 'failure';
+              description = `Upstream tests ${testsConclusion || 'did not succeed'} — Sonar not run`;
+            } else if (qg === 'PASSED') {
+              state = 'success';
+              description = 'Quality Gate passed';
+            } else if (qg === 'FAILED') {
+              state = 'failure';
+              description = 'Quality Gate failed';
+            } else {
+              state = 'error';
+              description = 'Quality Gate did not complete (analysis failed)';
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state,
+              context: 'SonarQube Quality Gate',
+              description,
+              target_url: `https://sonarcloud.io/summary/new_code?id=${projectKey}&pullRequest=${pr}`,
+            });
+
+            core.info(`Posted commit status '${state}' (tests=${testsConclusion || 'none'}, qg=${qg || 'none'}) to ${sha}`);


### PR DESCRIPTION
## What

`sonar-pr-analyze.yaml` runs via `workflow_run`, so its Quality Gate result never
became a PR check and couldn't be marked required. This adds a `github-script` step
that posts the gate result as a commit status on the **tested commit** under the
context **`SonarQube Quality Gate`**, which can then be required in branch protection.

## Why this route (not the SonarCloud App)

`workflow_run` is kept deliberately: fork PRs can't read `SONAR_TOKEN`, so the scan
must run in base-repo context. A commit status stays entirely inside that fork-safe
flow — no App install, no analysis-method change, coverage/lint imports untouched.

## Status resolves on every path that runs

Everything — checkout, coverage, scan, and the posted status — describes the same
commit (`github.event.workflow_run.head_sha`), so the check vouches only for the tree
that was actually scanned.

| Upstream tests | Analysis | Status posted to tested commit |
|---|---|---|
| success | gate PASSED / WARN | `success` |
| success | gate FAILED | `failure` |
| success | scan errored (gate skipped) | `error` |
| failed / skipped / timed_out | steps guarded off | `failure` — "Upstream tests … — Sonar not run" |
| cancelled (superseded by a newer push) | job excluded at `if:` | none — the successor run reports on the new head |
| tests never triggered, or a manual cancel on the current head | this workflow never runs | none — uncoverable via `workflow_run` |

Implementation:
- **Posts to `workflow_run.head_sha`** (the tested commit), not the live PR head — and
  the `Checkout tested commit` step is pinned to the same SHA, so scan + coverage +
  status all agree. Posting to the live head would stamp commit A's result onto B.
- **Job `if:` excludes `cancelled`** upstream runs: `teranode_pr_tests` uses
  `cancel-in-progress`, so a push to an active PR cancels the superseded commit's run;
  its successor reports on the new head, so acting here would only post a spurious red.
- **Status step `if: ${{ !cancelled() }}`** — a self-cancelled sonar run never posts a
  transient error. It reads the gate output + upstream conclusion, and guards `if (!sha)`
  so it fails loud instead of posting a false green. The `WARN` gate outcome is treated
  as `success` ("passed with warnings").
- Analysis steps are guarded to `conclusion == 'success'` (they need artifacts a failed
  run never produces); GitHub implicitly ANDs `success()` onto a custom step `if:`, so a
  mid-job scan failure also skips the gate and is caught as `error`.
- Permissions: `statuses: write` (+ `contents`/`pull-requests: read`) only.

## Enforcing later

1. Mark **`SonarQube Quality Gate`** a required status check.
2. Require the tests check alongside it — the uncoverable case is the tests workflow
   never triggering (or a manual cancel on the current head), which also never triggers
   this one, so a required sonar status alone could hang.