### PR TITLE
fix(blockvalidation): port legacy hardening to quick validation (chunked SetMinedMulti #936, transient spend retry)

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -241,6 +241,10 @@ type BlockValidation struct {
 
 	// mmapDir, when non-empty, enables mmap-backed subtree loading.
 	mmapDir string
+
+	// spendRetryBackoff overrides the pause between quick-validate spend retry
+	// attempts; zero means spendRetryBackoffDefault. Settable in tests.
+	spendRetryBackoff time.Duration
 }
 
 // subtreeFromBytesWithMmap creates a subtree from bytes, using mmap if dir is non-empty.

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1284,9 +1284,13 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 	}
 
 	// Phase 1.5: Update mined info for transactions that already existed
-	// This handles the case where a previous attempt created UTXOs with a different block ID
+	// This handles the case where a previous attempt created UTXOs with a different
+	// block ID. Chunked via the shared helper (issue 936): on a fat-batch retry every tx
+	// in the batch already exists, and a single unchunked SetMinedMulti call would
+	// overrun the aerospike client connection pool.
 	if len(existingTxHashes) > 0 {
-		if _, err := u.utxoStore.SetMinedMulti(ctx, existingTxHashes, minedBlockInfo); err != nil {
+		if err := utxo.SetMinedMultiChunked(ctx, u.logger, u.utxoStore, existingTxHashes, minedBlockInfo,
+			u.settings.UtxoStore.MaxMinedBatchSize, u.settings.UtxoStore.MaxMinedRoutines); err != nil {
 			return errors.NewProcessingError("[createAndSpendUTXOsForBatch][%s] failed to update mined info for %d existing txs", block.Hash().String(), len(existingTxHashes), err)
 		}
 	}

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1295,21 +1295,99 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 		}
 	}
 
-	// Phase 2: Spend all transactions in parallel
-	spendG, spendCtx := errgroup.WithContext(ctx)
-	util.SafeSetLimit(u.logger, spendG, u.settings.UtxoStore.SpendBatcherSize*u.settings.UtxoStore.SpendBatcherConcurrency*2)
+	// Phase 2: Spend all transactions, with the same hardening the legacy path has
+	// (services/legacy/netsync PreValidateTransactions): tolerate ErrTxConflicting
+	// (the block is checkpoint-certified, so its txs take precedence and conflicts
+	// are resolved at block acceptance), retry transient store errors with backoff
+	// and progress detection, hard-fail everything else.
+	return u.spendBatchWithRetry(ctx, block, batch.batchTxs, outpointOnly)
+}
 
-	for _, tx := range batch.batchTxs {
-		tx := tx
-		spendG.Go(func() error {
-			if _, err := u.utxoStore.Spend(spendCtx, tx, block.Height, utxo.IgnoreFlags{IgnoreLocked: true, SkipUTXOHashCheck: outpointOnly}); err != nil {
-				return errors.NewProcessingError("[createAndSpendUTXOsForBatch][%s] failed to spend tx %s", block.Hash().String(), tx.TxIDChainHash().String(), err)
-			}
-			return nil
-		})
+// spendRetryBackoffDefault is the pause between spend retry attempts. Matches the
+// legacy path's retryBackoff (services/legacy/netsync PreValidateTransactions).
+const spendRetryBackoffDefault = 2 * time.Second
+
+// spendBatchWithRetry spends txs in parallel with bounded retries. Per attempt:
+// ErrTxConflicting is tolerated (block txs take precedence below checkpoint-certified
+// blocks; resolution happens at block acceptance), retryable errors (transient store
+// overload) queue the tx for the next attempt, anything else fails hard immediately.
+// Gives up early when an attempt makes no progress. Mirrors the legacy path's
+// PreValidateTransactions retry semantics (maxRetries=10, 2s backoff) so both
+// below-checkpoint implementations converge identically after dirty restarts.
+func (u *BlockValidation) spendBatchWithRetry(ctx context.Context, block *model.Block, txs []*bt.Tx, outpointOnly bool) error {
+	const maxRetries = 10
+
+	backoff := u.spendRetryBackoff
+	if backoff <= 0 {
+		backoff = spendRetryBackoffDefault
 	}
 
-	return spendG.Wait()
+	pending := txs
+	total := len(txs)
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return errors.NewProcessingError("[spendBatchWithRetry][%s] context cancelled", block.Hash().String())
+		}
+
+		if attempt > 0 {
+			u.logger.Infof("[spendBatchWithRetry][%s] retry %d/%d: %d of %d transactions remaining", block.Hash().String(), attempt, maxRetries, len(pending), total)
+			time.Sleep(backoff)
+		}
+
+		spendG, spendCtx := errgroup.WithContext(ctx)
+		util.SafeSetLimit(u.logger, spendG, u.settings.UtxoStore.SpendBatcherSize*u.settings.UtxoStore.SpendBatcherConcurrency*2)
+
+		var (
+			mu        sync.Mutex
+			retryable []*bt.Tx
+			lastErr   error
+			hardFail  error
+		)
+
+		for _, tx := range pending {
+			tx := tx
+			spendG.Go(func() error {
+				if _, err := u.utxoStore.Spend(spendCtx, tx, block.Height, utxo.IgnoreFlags{IgnoreLocked: true, SkipUTXOHashCheck: outpointOnly}); err != nil {
+					if errors.Is(err, errors.ErrTxConflicting) {
+						return nil
+					}
+					if errors.IsRetryableError(err) {
+						mu.Lock()
+						retryable = append(retryable, tx)
+						lastErr = err
+						mu.Unlock()
+						return nil
+					}
+					mu.Lock()
+					hardFail = errors.NewProcessingError("[spendBatchWithRetry][%s] failed to spend tx %s", block.Hash().String(), tx.TxIDChainHash().String(), err)
+					mu.Unlock()
+				}
+				return nil
+			})
+		}
+
+		_ = spendG.Wait()
+
+		if hardFail != nil {
+			return hardFail
+		}
+
+		if len(retryable) == 0 {
+			if attempt > 0 {
+				u.logger.Infof("[spendBatchWithRetry][%s] all spends succeeded after %d retries", block.Hash().String(), attempt)
+			}
+			return nil
+		}
+
+		if attempt > 0 && len(retryable) >= len(pending) {
+			return errors.NewProcessingError("[spendBatchWithRetry][%s] %d of %d spends failed with no progress, giving up", block.Hash().String(), len(retryable), total, lastErr)
+		}
+
+		pending = retryable
+	}
+
+	return errors.NewProcessingError("[spendBatchWithRetry][%s] %d of %d spends still failing after %d retries", block.Hash().String(), len(pending), total, maxRetries)
 }
 
 // writeSubtreeFilesForBatch writes the full subtree files (.subtree) for a batch.

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1295,11 +1295,15 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 		}
 	}
 
-	// Phase 2: Spend all transactions, with the same hardening the legacy path has
-	// (services/legacy/netsync PreValidateTransactions): tolerate ErrTxConflicting
-	// (the block is checkpoint-certified, so its txs take precedence and conflicts
-	// are resolved at block acceptance), retry transient store errors with backoff
-	// and progress detection, hard-fail everything else.
+	// Phase 2: Spend all transactions, retrying transient store errors the way the
+	// legacy path does (services/legacy/netsync PreValidateTransactions). Unlike
+	// legacy, conflicts are NOT tolerated here: legacy runs the validator with
+	// WithCreateConflicting so block assembly's ProcessConflicting later reconciles
+	// the loser, but the quick path never writes conflicting subtree nodes and has
+	// no such resolver — tolerating ErrTxConflicting would leave an output's spend
+	// permanently attributed to a non-canonical tx. Hard-fail instead (fail-closed).
+	// Dirty-restart replay does not need conflict tolerance: re-spending an output
+	// with the same spender is the store's idempotent success path.
 	return u.spendBatchWithRetry(ctx, block, batch.batchTxs, outpointOnly)
 }
 
@@ -1308,12 +1312,13 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 const spendRetryBackoffDefault = 2 * time.Second
 
 // spendBatchWithRetry spends txs in parallel with bounded retries. Per attempt:
-// ErrTxConflicting is tolerated (block txs take precedence below checkpoint-certified
-// blocks; resolution happens at block acceptance), retryable errors (transient store
-// overload) queue the tx for the next attempt, anything else fails hard immediately.
-// Gives up early when an attempt makes no progress. Mirrors the legacy path's
-// PreValidateTransactions retry semantics (maxRetries=10, 2s backoff) so both
-// below-checkpoint implementations converge identically after dirty restarts.
+// retryable errors (transient store overload) queue the tx for the next attempt;
+// anything else — including ErrTxConflicting and ErrSpent — fails hard immediately
+// (fail-closed: the quick path has no ProcessConflicting pipeline to reconcile a
+// tolerated conflict; see the phase-2 call site). Gives up early when an attempt
+// makes no progress. Retry cadence mirrors the legacy path's PreValidateTransactions
+// (maxRetries=10, 2s backoff) so both below-checkpoint implementations converge
+// identically after dirty restarts.
 func (u *BlockValidation) spendBatchWithRetry(ctx context.Context, block *model.Block, txs []*bt.Tx, outpointOnly bool) error {
 	const maxRetries = 10
 
@@ -1349,9 +1354,6 @@ func (u *BlockValidation) spendBatchWithRetry(ctx context.Context, block *model.
 			tx := tx
 			spendG.Go(func() error {
 				if _, err := u.utxoStore.Spend(spendCtx, tx, block.Height, utxo.IgnoreFlags{IgnoreLocked: true, SkipUTXOHashCheck: outpointOnly}); err != nil {
-					if errors.Is(err, errors.ErrTxConflicting) {
-						return nil
-					}
 					if errors.IsRetryableError(err) {
 						mu.Lock()
 						retryable = append(retryable, tx)

--- a/services/blockvalidation/quick_validate_spend_retry_test.go
+++ b/services/blockvalidation/quick_validate_spend_retry_test.go
@@ -1,0 +1,127 @@
+package blockvalidation
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/nullstore"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// spendRetrySpyStore wraps NullStore; Spend behaviour is scripted per tx hash.
+type spendRetrySpyStore struct {
+	*nullstore.NullStore
+	mu sync.Mutex
+	// failuresLeft[txid] = how many times Spend should fail with failErr[txid]
+	failuresLeft map[chainhash.Hash]int
+	failErr      map[chainhash.Hash]error
+	spendCalls   atomic.Int64
+}
+
+func (s *spendRetrySpyStore) Spend(_ context.Context, tx *bt.Tx, _ uint32, _ ...utxo.IgnoreFlags) ([]*utxo.Spend, error) {
+	s.spendCalls.Add(1)
+	h := *tx.TxIDChainHash()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n, ok := s.failuresLeft[h]; ok && n > 0 {
+		s.failuresLeft[h] = n - 1
+		return nil, s.failErr[h]
+	}
+	return nil, nil
+}
+
+func newSpendRetryHarness(t *testing.T, spy *spendRetrySpyStore) (*BlockValidation, *model.Block, []*bt.Tx) {
+	t.Helper()
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	u := &BlockValidation{
+		logger:            ulogger.TestLogger{},
+		settings:          tSettings,
+		utxoStore:         spy,
+		spendRetryBackoff: time.Millisecond,
+	}
+
+	// three distinct txs (coinbase-style, distinct via locktime)
+	txs := make([]*bt.Tx, 3)
+	for i := range txs {
+		tx := bt.NewTx()
+		tx.LockTime = uint32(i + 1)
+		txs[i] = tx
+	}
+
+	block := &model.Block{Height: 100, Header: model.GenesisBlockHeader}
+
+	return u, block, txs
+}
+
+func TestSpendBatchWithRetry(t *testing.T) {
+	t.Run("clean spends: one call each, no retries", func(t *testing.T) {
+		spy := &spendRetrySpyStore{failuresLeft: map[chainhash.Hash]int{}, failErr: map[chainhash.Hash]error{}}
+		u, block, txs := newSpendRetryHarness(t, spy)
+
+		require.NoError(t, u.spendBatchWithRetry(context.Background(), block, txs, false))
+		require.Equal(t, int64(3), spy.spendCalls.Load())
+	})
+
+	t.Run("transient failure converges: retried tx succeeds on attempt 2", func(t *testing.T) {
+		spy := &spendRetrySpyStore{failuresLeft: map[chainhash.Hash]int{}, failErr: map[chainhash.Hash]error{}}
+		u, block, txs := newSpendRetryHarness(t, spy)
+
+		h := *txs[1].TxIDChainHash()
+		spy.failuresLeft[h] = 1
+		spy.failErr[h] = errors.NewStorageError("transient device overload") // retryable class
+
+		require.NoError(t, u.spendBatchWithRetry(context.Background(), block, txs, false))
+		// 3 first-attempt + 1 retry
+		require.Equal(t, int64(4), spy.spendCalls.Load())
+	})
+
+	t.Run("conflicting spend tolerated, never retried", func(t *testing.T) {
+		spy := &spendRetrySpyStore{failuresLeft: map[chainhash.Hash]int{}, failErr: map[chainhash.Hash]error{}}
+		u, block, txs := newSpendRetryHarness(t, spy)
+
+		h := *txs[0].TxIDChainHash()
+		spy.failuresLeft[h] = 999
+		spy.failErr[h] = errors.NewTxConflictingError("conflicting")
+
+		require.NoError(t, u.spendBatchWithRetry(context.Background(), block, txs, false))
+		require.Equal(t, int64(3), spy.spendCalls.Load()) // no retry for the conflicting tx
+	})
+
+	t.Run("non-retryable error fails hard on first attempt", func(t *testing.T) {
+		spy := &spendRetrySpyStore{failuresLeft: map[chainhash.Hash]int{}, failErr: map[chainhash.Hash]error{}}
+		u, block, txs := newSpendRetryHarness(t, spy)
+
+		h := *txs[2].TxIDChainHash()
+		spy.failuresLeft[h] = 1
+		spy.failErr[h] = errors.NewTxInvalidError("bad tx") // not retryable
+
+		require.Error(t, u.spendBatchWithRetry(context.Background(), block, txs, false))
+	})
+
+	t.Run("no progress: permanently-retryable tx gives up with error", func(t *testing.T) {
+		spy := &spendRetrySpyStore{failuresLeft: map[chainhash.Hash]int{}, failErr: map[chainhash.Hash]error{}}
+		u, block, txs := newSpendRetryHarness(t, spy)
+
+		h := *txs[1].TxIDChainHash()
+		spy.failuresLeft[h] = 999
+		spy.failErr[h] = errors.NewStorageError("still overloaded")
+
+		err := u.spendBatchWithRetry(context.Background(), block, txs, false)
+		require.Error(t, err)
+		// gave up on no-progress after attempt 1 (same 1 tx failing), NOT after 10 attempts:
+		// 3 first-attempt calls + 1 retry call = 4
+		require.Equal(t, int64(4), spy.spendCalls.Load())
+	})
+}

--- a/services/blockvalidation/quick_validate_spend_retry_test.go
+++ b/services/blockvalidation/quick_validate_spend_retry_test.go
@@ -87,7 +87,7 @@ func TestSpendBatchWithRetry(t *testing.T) {
 		require.Equal(t, int64(4), spy.spendCalls.Load())
 	})
 
-	t.Run("conflicting spend tolerated, never retried", func(t *testing.T) {
+	t.Run("conflicting spend fails hard, never retried", func(t *testing.T) {
 		spy := &spendRetrySpyStore{failuresLeft: map[chainhash.Hash]int{}, failErr: map[chainhash.Hash]error{}}
 		u, block, txs := newSpendRetryHarness(t, spy)
 
@@ -95,8 +95,10 @@ func TestSpendBatchWithRetry(t *testing.T) {
 		spy.failuresLeft[h] = 999
 		spy.failErr[h] = errors.NewTxConflictingError("conflicting")
 
-		require.NoError(t, u.spendBatchWithRetry(context.Background(), block, txs, false))
-		require.Equal(t, int64(3), spy.spendCalls.Load()) // no retry for the conflicting tx
+		err := u.spendBatchWithRetry(context.Background(), block, txs, false)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errors.ErrTxConflicting) || errors.Is(err, errors.ErrProcessing), "hard fail must surface the conflict")
+		require.Equal(t, int64(3), spy.spendCalls.Load()) // first attempt only — never retried
 	})
 
 	t.Run("non-retryable error fails hard on first attempt", func(t *testing.T) {

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1043,24 +1043,10 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 	// Merge our blockID into any tx that already existed. Without this, those txs
 	// keep their stale (or empty) BlockIDs and the next block's validOrderAndBlessed
 	// check fails in model/Block.go getParentTxMetaBlockIDs.
-	//
-	// Chunk the merge across a worker pool (#936). A single SetMinedMulti call with
-	// every existing tx in the block overruns the aerospike client connection pool
-	// on fat blocks (e.g. mainnet 755880 = 2.87M txs). Pattern mirrors
-	// stores/utxo/aerospike/longest_chain.go:MarkTransactionsOnLongestChain.
+	// Chunked via the shared helper (issue 936): a single SetMinedMulti call with every
+	// existing tx in the block overruns the aerospike client connection pool on fat
+	// blocks (e.g. mainnet 755880 = 2.87M txs).
 	if len(existingTxHashes) > 0 {
-		sm.logger.Debugf("[createUtxos] merging blockID %d into %d pre-existing tx(s)", blockID, len(existingTxHashes))
-
-		batchSize := sm.settings.UtxoStore.MaxMinedBatchSize
-		if batchSize < 1 {
-			batchSize = 1
-		}
-		numChunks := (len(existingTxHashes) + batchSize - 1) / batchSize
-		numWorkers := min(sm.settings.UtxoStore.MaxMinedRoutines, numChunks)
-		if numWorkers < 1 {
-			numWorkers = 1
-		}
-
 		minedBlockInfo := utxo.MinedBlockInfo{
 			BlockID:        blockID,
 			BlockHeight:    blockHeightUint32,
@@ -1068,32 +1054,9 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 			OnLongestChain: true,
 		}
 
-		rangeSize := (len(existingTxHashes) + numWorkers - 1) / numWorkers
-
-		mergeG, mergeCtx := errgroup.WithContext(ctx)
-
-		for w := 0; w < numWorkers && w*rangeSize < len(existingTxHashes); w++ {
-			workerStart := w * rangeSize
-			workerEnd := min(workerStart+rangeSize, len(existingTxHashes))
-			workerHashes := existingTxHashes[workerStart:workerEnd]
-
-			mergeG.Go(func() error {
-				for i := 0; i < len(workerHashes); i += batchSize {
-					if mergeCtx.Err() != nil {
-						return mergeCtx.Err()
-					}
-					chunkEnd := min(i+batchSize, len(workerHashes))
-					chunk := workerHashes[i:chunkEnd]
-					if _, err := sm.utxoStore.SetMinedMulti(mergeCtx, chunk, minedBlockInfo); err != nil {
-						return err
-					}
-				}
-				return nil
-			})
-		}
-
-		if err = mergeG.Wait(); err != nil {
-			return errors.NewProcessingError("failed to merge blockID into %d pre-existing txs", len(existingTxHashes), err)
+		if err = utxo.SetMinedMultiChunked(ctx, sm.logger, sm.utxoStore, existingTxHashes, minedBlockInfo,
+			sm.settings.UtxoStore.MaxMinedBatchSize, sm.settings.UtxoStore.MaxMinedRoutines); err != nil {
+			return err
 		}
 	}
 

--- a/stores/utxo/set_mined_multi_chunked.go
+++ b/stores/utxo/set_mined_multi_chunked.go
@@ -1,0 +1,69 @@
+package utxo
+
+import (
+	"context"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"golang.org/x/sync/errgroup"
+)
+
+// SetMinedMultiChunked merges mined-block info into pre-existing transactions in
+// bounded chunks across a small worker pool. A single SetMinedMulti call with every
+// existing tx in a block overruns the aerospike client connection pool on fat blocks
+// (e.g. mainnet 755880 = 2.87M txs, issue 936). Pattern mirrors
+// stores/utxo/aerospike/longest_chain.go:MarkTransactionsOnLongestChain.
+//
+// Extracted from services/legacy/netsync createUtxos so the legacy and
+// quick-validation paths share one implementation. batchSize and maxWorkers are
+// floored to 1; info is passed through verbatim (callers differ deliberately in
+// SubtreeIdx/OnLongestChain — do not normalise here).
+func SetMinedMultiChunked(ctx context.Context, logger ulogger.Logger, store Store, hashes []*chainhash.Hash, info MinedBlockInfo, batchSize, maxWorkers int) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	logger.Debugf("[SetMinedMultiChunked] merging blockID %d into %d pre-existing tx(s)", info.BlockID, len(hashes))
+
+	if batchSize < 1 {
+		batchSize = 1
+	}
+
+	numChunks := (len(hashes) + batchSize - 1) / batchSize
+
+	numWorkers := min(maxWorkers, numChunks)
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	rangeSize := (len(hashes) + numWorkers - 1) / numWorkers
+
+	mergeG, mergeCtx := errgroup.WithContext(ctx)
+
+	for w := 0; w < numWorkers && w*rangeSize < len(hashes); w++ {
+		workerStart := w * rangeSize
+		workerEnd := min(workerStart+rangeSize, len(hashes))
+		workerHashes := hashes[workerStart:workerEnd]
+
+		mergeG.Go(func() error {
+			for i := 0; i < len(workerHashes); i += batchSize {
+				if mergeCtx.Err() != nil {
+					return mergeCtx.Err()
+				}
+				chunkEnd := min(i+batchSize, len(workerHashes))
+				chunk := workerHashes[i:chunkEnd]
+				if _, err := store.SetMinedMulti(mergeCtx, chunk, info); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := mergeG.Wait(); err != nil {
+		return errors.NewProcessingError("failed to merge blockID into %d pre-existing txs", len(hashes), err)
+	}
+
+	return nil
+}

--- a/stores/utxo/set_mined_multi_chunked_test.go
+++ b/stores/utxo/set_mined_multi_chunked_test.go
@@ -1,0 +1,92 @@
+package utxo
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// chunkSpyStore records every SetMinedMulti call's chunk size and hashes.
+// Embeds Store as a nil interface: any OTHER method call panics, proving the
+// helper touches nothing but SetMinedMulti.
+type chunkSpyStore struct {
+	Store
+	mu     sync.Mutex
+	calls  [][]*chainhash.Hash
+	info   []MinedBlockInfo
+	failOn int // 1-based call number to fail on; 0 = never fail
+}
+
+func (s *chunkSpyStore) SetMinedMulti(_ context.Context, hashes []*chainhash.Hash, info MinedBlockInfo) (map[chainhash.Hash][]uint32, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, hashes)
+	s.info = append(s.info, info)
+	if s.failOn > 0 && len(s.calls) == s.failOn {
+		return nil, errors.NewStorageError("boom")
+	}
+	return nil, nil
+}
+
+func makeHashes(n int) []*chainhash.Hash {
+	out := make([]*chainhash.Hash, n)
+	for i := 0; i < n; i++ {
+		h := chainhash.Hash{}
+		h[0] = byte(i)
+		h[1] = byte(i >> 8)
+		out[i] = &h
+	}
+	return out
+}
+
+func TestSetMinedMultiChunked(t *testing.T) {
+	info := MinedBlockInfo{BlockID: 42, BlockHeight: 100, OnLongestChain: true}
+
+	t.Run("empty input: no calls, no error", func(t *testing.T) {
+		spy := &chunkSpyStore{}
+		require.NoError(t, SetMinedMultiChunked(context.Background(), ulogger.TestLogger{}, spy, nil, info, 10, 4))
+		require.Empty(t, spy.calls)
+	})
+
+	t.Run("25 hashes, batch 10, workers 2: every hash exactly once, no chunk over 10", func(t *testing.T) {
+		spy := &chunkSpyStore{}
+		hashes := makeHashes(25)
+		require.NoError(t, SetMinedMultiChunked(context.Background(), ulogger.TestLogger{}, spy, hashes, info, 10, 2))
+
+		seen := map[chainhash.Hash]int{}
+		for _, call := range spy.calls {
+			require.LessOrEqual(t, len(call), 10, "chunk exceeds batchSize")
+			require.NotEmpty(t, call)
+			for _, h := range call {
+				seen[*h]++
+			}
+		}
+		require.Len(t, seen, 25)
+		for h, n := range seen {
+			require.Equal(t, 1, n, "hash %s sent %d times", h.String(), n)
+		}
+		// every call carries the caller's exact info (incl. OnLongestChain)
+		for _, gotInfo := range spy.info {
+			require.Equal(t, info, gotInfo)
+		}
+	})
+
+	t.Run("floors: batchSize 0 and maxWorkers 0 behave as 1", func(t *testing.T) {
+		spy := &chunkSpyStore{}
+		hashes := makeHashes(3)
+		require.NoError(t, SetMinedMultiChunked(context.Background(), ulogger.TestLogger{}, spy, hashes, info, 0, 0))
+		require.Len(t, spy.calls, 3) // batchSize floored to 1 => one call per hash
+	})
+
+	t.Run("store error propagates wrapped", func(t *testing.T) {
+		spy := &chunkSpyStore{failOn: 1}
+		hashes := makeHashes(5)
+		err := SetMinedMultiChunked(context.Background(), ulogger.TestLogger{}, spy, hashes, info, 2, 1)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Two hardening fixes that exist in the legacy netsync path but were missing from the quick-validation path (`quick_validate.go`), closing verified drift between the two below-checkpoint block-processing implementations:

1. **Chunked `SetMinedMulti` (#936 port).** Legacy chunks the pre-existing-tx blockID merge across a bounded worker pool because a single call with every existing tx overran the Aerospike client connection pool on fat blocks (mainnet 755880 = 2.87M txs). Quick validation still made one unchunked call — a latent fat-batch hazard on dirty-restart retries during catchup (on retry, every tx in the batch already exists). Extracted to a shared `utxo.SetMinedMultiChunked` helper used by both paths. Legacy behaviour is byte-identical (same chunk math, floors, worker fan-out; the one observable delta is the debug-log prefix, now `[SetMinedMultiChunked]`).
   - Reviewer note: the two callers deliberately keep different `MinedBlockInfo` values — legacy sets `OnLongestChain: true, SubtreeIdx: 0`, quick validation passes zero values. That divergence pre-exists this PR; the helper passes `info` through verbatim rather than silently unifying. Flagging for confirmation that quick validation's `OnLongestChain: false` is intended.
2. **Transient spend retry.** Quick validation's spend phase hard-failed on ANY spend error. Legacy (`PreValidateTransactions`) retries transient store errors (`errors.IsRetryableError`, maxRetries=10, 2s backoff) with no-progress give-up. Ported the same retry semantics into a new `spendBatchWithRetry` so both paths converge identically after dirty restarts and under transient store overload (e.g. Aerospike DEVICE_OVERLOAD).
   - **Deliberately NOT ported: legacy's `ErrTxConflicting` tolerance.** Consensus review during development established that legacy's tolerance is only safe because legacy runs the validator with `WithCreateConflicting`, so block assembly's `ProcessConflicting` reconciles the loser at block acceptance. The quick path never writes conflicting subtree nodes and has no such resolver — tolerating there would leave an output's spend permanently attributed to a non-canonical tx. Quick validation therefore fails closed on conflicts (and dirty-restart replay needs no tolerance: re-spending with the same spender is the store's idempotent success path). The comments in the code document this asymmetry.

No new flags, no consensus-rule changes — error-handling parity where safe, fail-closed where the legacy mechanism doesn't exist.

## Tests

- `TestSetMinedMultiChunked` — chunk-size ceiling, exactly-once hash coverage, floors, error propagation, caller-info passthrough (spy store proves the helper touches nothing but SetMinedMulti)
- `TestSpendBatchWithRetry` — clean path / transient-converges / conflicting-fails-hard-never-retried / non-retryable-hard-fail / no-progress-give-up
- Full `stores/utxo`, `services/legacy/netsync`, `services/blockvalidation`, `catchup` packages green incl. `-race`; `go vet` clean; lint findings limited to pre-existing untouched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQajKfjjWRAVoTaPHvZFDH