### PR TITLE
fix(p2p): keep banlist subscribers across Clear

### DIFF
--- a/internal/banlist/ban_list.go
+++ b/internal/banlist/ban_list.go
@@ -299,7 +299,6 @@ func (b *BanList) Unsubscribe(ch chan BanEvent) {
 func (b *BanList) Clear() {
 	b.mu.Lock()
 	b.bannedPeers = make(map[string]BanInfo)
-	b.subscribers = make(map[chan BanEvent]struct{})
 	b.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/banlist/ban_list_test.go
+++ b/internal/banlist/ban_list_test.go
@@ -109,6 +109,37 @@ func TestBanList_Clear(t *testing.T) {
 	require.False(t, bl.IsBanned("1.2.3.4"))
 }
 
+func TestBanList_ClearKeepsSubscribers(t *testing.T) {
+	bl := newTestBanList(t)
+
+	ch := bl.Subscribe()
+	defer bl.Unsubscribe(ch)
+
+	err := bl.Add(context.Background(), "1.2.3.4", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	select {
+	case event := <-ch:
+		require.Equal(t, "add", event.Action)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event before Clear")
+	}
+
+	bl.Clear()
+	require.Empty(t, bl.ListBanned())
+
+	err = bl.Add(context.Background(), "5.6.7.8", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	select {
+	case event := <-ch:
+		require.Equal(t, "add", event.Action)
+		require.Equal(t, "5.6.7.8", event.IP)
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscriber detached by Clear: no event received after Clear")
+	}
+}
+
 func TestBanList_LoadFromDatabase(t *testing.T) {
 	bl := newTestBanList(t)
 


### PR DESCRIPTION
**Closes #4680.**

### Problem
`BanList.Clear()` recreated the `subscribers` map alongside `bannedPeers`, so every channel previously returned by `Subscribe()` was silently detached. The p2p server subscribes once at startup and consumes ban events in `listenForBanEvents`; since `Clear()` is reachable from the `ClearBanned` gRPC, a single call permanently disabled event-driven ban handling for the rest of the process lifetime.

### Fix
`Clear()` now resets only `bannedPeers` and deletes the DB rows, never `subscribers`. Subscriber lifecycle remains managed exclusively by `Unsubscribe()`.

### Tests
Added `TestBanList_ClearKeepsSubscribers` in `internal/banlist/ban_list_test.go`: a subscriber receives an event, `Clear()` runs, and a subsequent `Add()` must still deliver an event to the same channel (fails by timeout on the old code).