### PR TITLE
p2p: require admin API key for all state-mutating p2p admin RPCs

### DIFF
--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -668,18 +668,14 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 		if err != nil {
 			return errors.NewServiceError("error generating random API key", err)
 		}
-	}
 
-	// Define protected methods - use the full gRPC method path
-	protectedMethods := map[string]bool{
-		"/p2p_api.PeerService/BanPeer":   true,
-		"/p2p_api.PeerService/UnbanPeer": true,
+		s.logger.Warnf("[P2P] grpc_admin_api_key is not set; a random key was generated so admin RPCs (ban, unban, clear bans, ban score, reputation reset, connect/disconnect peer) are unreachable until a key is configured")
 	}
 
 	// Create auth options
 	authOptions := &util.AuthOptions{
 		APIKey:           apiKey,
-		ProtectedMethods: protectedMethods,
+		ProtectedMethods: adminProtectedMethods(),
 	}
 
 	// this will block
@@ -845,6 +841,25 @@ func (s *Server) rejectedTxHandler(ctx context.Context) func(msg *kafka.KafkaMes
 func (s *Server) disconnectPreExistingBannedPeers(ctx context.Context) {
 	for _, banned := range s.banList.ListBanned() {
 		s.handleBanEvent(ctx, BanEvent{Action: banActionAdd, IP: banned})
+	}
+}
+
+// adminProtectedMethods returns the full gRPC method paths of every
+// state-mutating admin RPC on the PeerService; the auth interceptor requires
+// the admin API key for these. Read-only queries and internal data-plane
+// reporting RPCs (catchup metrics, valid block/subtree reports, bytes
+// downloaded) stay unauthenticated because other services call them without
+// admin credentials. Any new mutating admin RPC must be added here; the
+// classification is enforced by TestAdminProtectedMethodsCoverAllRPCs.
+func adminProtectedMethods() map[string]bool {
+	return map[string]bool{
+		"/p2p_api.PeerService/BanPeer":         true,
+		"/p2p_api.PeerService/UnbanPeer":       true,
+		"/p2p_api.PeerService/ClearBanned":     true,
+		"/p2p_api.PeerService/AddBanScore":     true,
+		"/p2p_api.PeerService/ResetReputation": true,
+		"/p2p_api.PeerService/ConnectPeer":     true,
+		"/p2p_api.PeerService/DisconnectPeer":  true,
 	}
 }
 

--- a/services/p2p/server_auth_test.go
+++ b/services/p2p/server_auth_test.go
@@ -1,0 +1,127 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/services/p2p/p2p_api"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// publicPeerServiceMethods are the PeerService RPCs deliberately reachable
+// without the admin API key: read-only queries and internal data-plane
+// reporting calls made by other services (block/subtree validation) that do
+// not carry admin credentials. Adding an RPC to neither this list nor
+// adminProtectedMethods fails TestAdminProtectedMethodsCoverAllRPCs.
+var publicPeerServiceMethods = map[string]bool{
+	// Read-only queries
+	"/p2p_api.PeerService/GetPeers":           true,
+	"/p2p_api.PeerService/IsBanned":           true,
+	"/p2p_api.PeerService/ListBanned":         true,
+	"/p2p_api.PeerService/GetPeersForCatchup": true,
+	"/p2p_api.PeerService/IsPeerMalicious":    true,
+	"/p2p_api.PeerService/IsPeerUnhealthy":    true,
+	"/p2p_api.PeerService/GetPeerRegistry":    true,
+	"/p2p_api.PeerService/GetPeer":            true,
+	// Internal data-plane reporting
+	"/p2p_api.PeerService/RecordCatchupAttempt":    true,
+	"/p2p_api.PeerService/RecordCatchupSuccess":    true,
+	"/p2p_api.PeerService/RecordCatchupFailure":    true,
+	"/p2p_api.PeerService/RecordCatchupMalicious":  true,
+	"/p2p_api.PeerService/UpdateCatchupReputation": true,
+	"/p2p_api.PeerService/UpdateCatchupError":      true,
+	"/p2p_api.PeerService/ReportValidSubtree":      true,
+	"/p2p_api.PeerService/ReportValidBlock":        true,
+	"/p2p_api.PeerService/RecordBytesDownloaded":   true,
+}
+
+// TestAdminProtectedMethodsCoverAllRPCs forces every PeerService RPC to be
+// classified as either admin-protected or explicitly public, so new mutating
+// RPCs cannot ship unauthenticated by omission.
+func TestAdminProtectedMethodsCoverAllRPCs(t *testing.T) {
+	protected := adminProtectedMethods()
+
+	for _, m := range p2p_api.PeerService_ServiceDesc.Methods {
+		fullMethod := "/" + p2p_api.PeerService_ServiceDesc.ServiceName + "/" + m.MethodName
+
+		isProtected := protected[fullMethod]
+		isPublic := publicPeerServiceMethods[fullMethod]
+
+		require.False(t, isProtected && isPublic, "%s is both protected and public", fullMethod)
+		require.True(t, isProtected || isPublic,
+			"%s is not classified: add it to adminProtectedMethods (state-mutating admin RPC) or publicPeerServiceMethods (read-only or internal data-plane)", fullMethod)
+	}
+
+	// Every protected/public entry must correspond to a real RPC (catches typos).
+	registered := make(map[string]bool)
+	for _, m := range p2p_api.PeerService_ServiceDesc.Methods {
+		registered["/"+p2p_api.PeerService_ServiceDesc.ServiceName+"/"+m.MethodName] = true
+	}
+
+	for method := range protected {
+		require.True(t, registered[method], "protected method %s is not a registered PeerService RPC", method)
+	}
+
+	for method := range publicPeerServiceMethods {
+		require.True(t, registered[method], "public method %s is not a registered PeerService RPC", method)
+	}
+
+	// The auth interceptor is unary-only (util.StartGRPCServer installs no
+	// stream auth interceptor), so a streaming RPC would bypass authentication
+	// entirely. Adding one requires wiring stream auth first.
+	require.Empty(t, p2p_api.PeerService_ServiceDesc.Streams,
+		"PeerService has streaming RPCs but the auth interceptor only covers unary methods; add stream auth before registering streams")
+}
+
+// TestAuthInterceptorProtectsAdminMethods exercises the auth interceptor with
+// the p2p protected-method set: admin RPCs must be rejected without a valid
+// API key while public RPCs pass through untouched.
+func TestAuthInterceptorProtectsAdminMethods(t *testing.T) {
+	const apiKey = "test-admin-key"
+
+	interceptor := util.CreateAuthInterceptor(apiKey, adminProtectedMethods())
+
+	handlerCalled := false
+	handler := func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "ok", nil
+	}
+
+	call := func(ctx context.Context, fullMethod string) error {
+		handlerCalled = false
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: fullMethod}, handler)
+
+		return err
+	}
+
+	for method := range adminProtectedMethods() {
+		// No metadata at all
+		err := call(context.Background(), method)
+		require.Equal(t, codes.Unauthenticated, status.Code(err), "%s without metadata must be rejected", method)
+		require.False(t, handlerCalled, "%s handler must not run without a key", method)
+
+		// Wrong key
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-api-key", "wrong-key"))
+		err = call(ctx, method)
+		require.Equal(t, codes.Unauthenticated, status.Code(err), "%s with a wrong key must be rejected", method)
+		require.False(t, handlerCalled, "%s handler must not run with a wrong key", method)
+
+		// Correct key
+		ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-api-key", apiKey))
+		err = call(ctx, method)
+		require.NoError(t, err, "%s with the correct key must succeed", method)
+		require.True(t, handlerCalled, "%s handler must run with the correct key", method)
+	}
+
+	// Public methods pass through without any key.
+	for method := range publicPeerServiceMethods {
+		err := call(context.Background(), method)
+		require.NoError(t, err, "public method %s must not require a key", method)
+		require.True(t, handlerCalled, "public method %s handler must run", method)
+	}
+}


### PR DESCRIPTION
**Closes #4678.**

### Problem
Only `BanPeer` and `UnbanPeer` were in the p2p gRPC auth allowlist (`services/p2p/Server.go`), so `ClearBanned`, `AddBanScore`, `ResetReputation`, `ConnectPeer`, and `DisconnectPeer` were reachable without the admin API key - enough to wipe the ban list, reset reputations, or ban arbitrary peers from any client that can reach the port. Additionally, when `grpc_admin_api_key` was unset, a random key was silently generated, making protected methods uncallable with no operator-visible signal. Both cited code locations were confirmed still present.

### Fix
- Extracted the protected set into `adminProtectedMethods()`, now covering all seven state-mutating admin RPCs: `BanPeer`, `UnbanPeer`, `ClearBanned`, `AddBanScore`, `ResetReputation`, `ConnectPeer`, `DisconnectPeer`. Legitimate callers (RPC service, asset HTTP, test daemon) go through the p2p `Client`, which already attaches `GRPCAdminAPIKey` from settings, so no caller changes are needed.
- Internal data-plane RPCs (`RecordCatchup*`, `UpdateCatchup*`, `ReportValidSubtree/Block`, `RecordBytesDownloaded`) deliberately stay unauthenticated: block/subtree validation call them continuously and protecting them would break reputation tracking wherever the admin key is empty. Instead of inverting the interceptor model at runtime, a classification test forces every PeerService RPC to be explicitly listed as protected or public, so new mutating RPCs are caught at test time rather than shipping open by omission.
- The coverage test also asserts `PeerService_ServiceDesc.Streams` is empty: the auth interceptor is unary-only, so a future streaming RPC would bypass authentication entirely; the test forces stream auth to be wired first.
- When `grpc_admin_api_key` is unset, the server still fails closed with a random key but now logs a warning that admin RPCs are unreachable until a key is configured (the key itself is never logged).

### Tests
- `TestAdminProtectedMethodsCoverAllRPCs` - enumerates `PeerService_ServiceDesc` and requires every RPC to be classified exactly once (protected or public), every listed entry to be a real RPC, and no streaming RPCs to exist while auth is unary-only.
- `TestAuthInterceptorProtectsAdminMethods` - runs `util.CreateAuthInterceptor` with the p2p protected set: each admin RPC is rejected with `Unauthenticated` when the key is missing or wrong and succeeds with the correct key; public RPCs pass through with no key.

Commands run (affected package only):
```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```
All green, including the pre-existing p2p suite.
