### PR TITLE
fix(util/aerospike): set MaxBufferSize once in init to fix data race

### DIFF
--- a/util/aerospike.go
+++ b/util/aerospike.go
@@ -67,6 +67,14 @@ var aerospikeHistogramLastBuckets = *safemap.New[string, []uint64]()
 
 func init() {
 	aerospikeConnections = make(map[string]*uaerospike.Client)
+
+	// Raise the aerospike client's read buffer to 512MB for large records.
+	// aerospike.MaxBufferSize is a package-global in the client library that its
+	// batch/read commands consult concurrently. Writing it here in init (once,
+	// before main and before any client or batch read exists) establishes a
+	// happens-before edge with those reads; writing it on every GetAerospikeClient
+	// call instead raced with in-flight batch reads on already-running clients.
+	aerospike.MaxBufferSize = 1024 * 1024 * 512 // 512MB
 }
 
 // GetAerospikeClient creates or retrieves a cached Aerospike client for the given URL.
@@ -93,9 +101,6 @@ func GetAerospikeClient(logger ulogger.Logger, url *url.URL, tSettings *settings
 	} else {
 		logger.Infof("[AEROSPIKE] Reusing aerospike client: %v", url.Host)
 	}
-
-	// increase buffer size to 256MB for large records
-	aerospike.MaxBufferSize = 1024 * 1024 * 512 // 512MB
 
 	return client, nil
 }

--- a/util/aerospike_test.go
+++ b/util/aerospike_test.go
@@ -841,21 +841,17 @@ func TestAerospikeBufferSize(t *testing.T) {
 	u, err := url.Parse("aerospike://localhost:9999/test?Timeout=100ms&LoginTimeout=100ms")
 	require.NoError(t, err)
 
-	// Store original buffer size
-	originalBufferSize := aerospike.MaxBufferSize
+	// MaxBufferSize is set exactly once in this package's init (not per
+	// GetAerospikeClient call, which raced with in-flight batch reads on already
+	// running clients). So by the time any test runs it must already be 512MB.
+	const expectedBufferSize = 1024 * 1024 * 512 // 512MB
+	require.Equal(t, 536870912, expectedBufferSize, "Buffer size constant should be 512MB")
+	require.Equal(t, expectedBufferSize, aerospike.MaxBufferSize, "init must set MaxBufferSize to 512MB")
 
-	// The GetAerospikeClient will fail to connect but that's expected
-	// The buffer size is only set upon successful client creation
+	// A GetAerospikeClient that fails to connect must not touch MaxBufferSize.
 	_, err = GetAerospikeClient(logger, u, testSettings)
-	assert.Error(t, err, "Expected connection error since no Aerospike server running")
-
-	// Since connection failed, buffer size should remain unchanged
-	// This tests that the function doesn't crash and handles connection failures gracefully
-	assert.Equal(t, originalBufferSize, aerospike.MaxBufferSize, "Buffer size should remain unchanged on connection failure")
-
-	// Test that we can at least validate the buffer size constant value
-	expectedBufferSize := 1024 * 1024 * 512 // 512MB
-	assert.Equal(t, 536870912, expectedBufferSize, "Buffer size constant should be 512MB")
+	require.Error(t, err, "Expected connection error since no Aerospike server running")
+	require.Equal(t, expectedBufferSize, aerospike.MaxBufferSize, "Buffer size must stay 512MB after a failed connection")
 }
 
 // Test initStats function with minimal testing to improve coverage


### PR DESCRIPTION
## What

`aerospike.MaxBufferSize` is a package-global in the aerospike client library that its batch/read commands consult concurrently. `GetAerospikeClient` wrote it (to a constant, 512MB) on **every** call. When a new node's daemon startup calls `GetAerospikeClient`, that write races with in-flight batch reads on already-running nodes' clients.

The race detector catches this intermittently in the multi-node `chainintegrity` E2E test:

```
WARNING: DATA RACE
Write at util/aerospike.go:98  ->  aerospike.MaxBufferSize = 1024 * 1024 * 512
   (GetAerospikeClient, during a new node's daemon startup)
Previous read by aerospike-client-go batchCommandOperate.parseRecord
   (an in-flight batch read on an already-running node)
```

## Fix

The value never changes, so hoist the assignment into package `init()`. It runs exactly once, before `main` and before any client or batch read can exist, giving a clean happens-before edge with the library's reads. Behaviorally equivalent (previously the value was set on the first `GetAerospikeClient` call, before any batch read against that freshly-created client) minus the repeated racy write.

## Test

`TestAerospikeBufferSize` updated to assert the new invariant: `init` sets `MaxBufferSize` to 512MB, and a failed `GetAerospikeClient` leaves it untouched. Verified load-bearing (removing the `init` write drops `MaxBufferSize` to the library default of 120MB and fails the test). `go test -race ./util/` passes.