### PR TITLE
ci(sonar): bind Quality Gate to tested merge

### DIFF
--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -17,10 +17,6 @@ on:
     types:
       - completed
 
-concurrency:
-  group: sonar-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: read
@@ -30,98 +26,155 @@ env:
   GO_VERSION: "1.26.0"
 
 jobs:
-  sonarqube:
-    name: SonarQube Analysis
-    # arm64-safe: only downloads coverage artifacts + runs the sonar scanner CLI
-    # (arm64-available); no Go build, no containers.
-    runs-on: teranode-runner-4-core-arm
-    # Run for PR-triggered test outcomes other than 'cancelled' so the sonar
-    # commit status resolves instead of leaving a required check stuck "pending".
-    # 'cancelled' is excluded on purpose: teranode_pr_tests uses
-    # cancel-in-progress, so every push to a PR with in-flight tests emits a
-    # cancelled completion for the *superseded* commit. Its successor run reports
-    # on the new head, so acting here would only stamp a spurious failure.
-    # Only pull_request runs are handled (push-to-main test runs are filtered
-    # out). The analysis steps below are individually guarded to
-    # conclusion == 'success' because they need artifacts that failed runs never
-    # produce; on a non-success (but not cancelled) run we skip straight to
-    # posting a failure status.
+  resolve-pr:
+    name: Resolve tested PR identity
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion != 'cancelled'
-
+    runs-on: ubuntu-latest
+    outputs:
+      active: ${{ steps.resolve.outputs.active }}
+      number: ${{ steps.resolve.outputs.number }}
+      head_ref: ${{ steps.resolve.outputs.head_ref }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      base_ref: ${{ steps.resolve.outputs.base_ref }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
+      merge_sha: ${{ steps.resolve.outputs.merge_sha }}
     steps:
-      - name: Get PR number and metadata
-        id: pr
+      - name: Parse and validate tested PR identity
+        id: resolve
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            // Try to get PR number from workflow_run.pull_requests first
-            let prNumber;
-            if (context.payload.workflow_run.pull_requests && context.payload.workflow_run.pull_requests.length > 0) {
-              prNumber = context.payload.workflow_run.pull_requests[0].number;
-            } else {
-              // Fallback: search for PR by head SHA (needed for fork PRs where pull_requests array is empty)
-              const headSha = context.payload.workflow_run.head_sha;
-              core.info(`pull_requests array is empty, searching for PR by head SHA: ${headSha}`);
+            const run = context.payload.workflow_run;
+            const title = run.display_title || '';
+            const pattern = /^sonar-pr\/([1-9][0-9]*)\/merge\/([0-9a-f]{40})\/base\/([0-9a-f]{40})\/ref\/(.+)$/;
+            const match = pattern.exec(title);
 
-              const { data: prs } = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                sort: 'updated',
-                direction: 'desc',
-                per_page: 100
-              });
-
-              const pr = prs.find(p => p.head.sha === headSha);
-              if (!pr) {
-                core.setFailed(`Could not find PR for head SHA: ${headSha}`);
-                return;
-              }
-              prNumber = pr.number;
+            if (!match) {
+              core.setFailed(`Invalid Teranode PR tests run-name: ${title || '<empty>'}`);
+              return;
             }
 
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
+            const [, numberText, mergeSha, baseSha, baseRef] = match;
+            const prNumber = Number(numberText);
+            const runHeadRepo = run.head_repository?.full_name || '';
 
-            core.setOutput('number', prNumber);
-            core.setOutput('base', pr.data.base.ref);
-            core.setOutput('head', pr.data.head.ref);
+            if (!runHeadRepo) {
+              core.setFailed('workflow_run has no head repository; refusing unbound PR identity.');
+              return;
+            }
 
+            let pr;
+            try {
+              ({ data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              }));
+            } catch (error) {
+              core.setFailed(`Could not load PR ${prNumber}: ${error.message}`);
+              return;
+            }
+
+            if (pr.state !== 'open') {
+              core.info(`PR ${prNumber} is ${pr.state}; no current gate status required.`);
+              core.setOutput('active', 'false');
+              return;
+            }
+
+            const prHeadRepo = pr.head.repo?.full_name || '';
+            if (prHeadRepo !== runHeadRepo) {
+              core.setFailed(`PR ${prNumber} head repository does not match workflow_run.`);
+              return;
+            }
+            if (pr.head.ref !== run.head_branch) {
+              core.setFailed(`PR ${prNumber} head branch does not match workflow_run.`);
+              return;
+            }
+
+            if (pr.head.sha !== run.head_sha) {
+              core.info(`PR ${prNumber} head moved; successor source run owns the current status.`);
+              core.setOutput('active', 'false');
+              return;
+            }
+            if (pr.base.ref !== baseRef) {
+              core.info(`PR ${prNumber} was retargeted; successor edited run owns the current status.`);
+              core.setOutput('active', 'false');
+              return;
+            }
+
+            let mergeCommit;
+            try {
+              ({ data: mergeCommit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: mergeSha,
+              }));
+            } catch (error) {
+              core.setFailed(`Could not load tested merge ${mergeSha}: ${error.message}`);
+              return;
+            }
+
+            const parents = mergeCommit.parents || [];
+            if (parents.length !== 2 || parents[0].sha !== baseSha || parents[1].sha !== run.head_sha) {
+              core.setFailed(`Tested merge ${mergeSha} does not match base ${baseSha} and head ${run.head_sha}.`);
+              return;
+            }
+
+            core.setOutput('active', 'true');
+            core.setOutput('number', String(prNumber));
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', run.head_sha);
+            core.setOutput('base_ref', baseRef);
+            core.setOutput('base_sha', baseSha);
+            core.setOutput('merge_sha', mergeSha);
+
+  sonarqube:
+    name: SonarQube Analysis
+    needs: resolve-pr
+    if: needs.resolve-pr.outputs.active == 'true'
+    concurrency:
+      group: sonar-pr-${{ needs.resolve-pr.outputs.number }}
+      cancel-in-progress: true
+    # arm64-safe: only downloads coverage artifacts + runs the sonar scanner CLI
+    # (arm64-available); no Go build, no containers.
+    runs-on: teranode-runner-4-core-arm
+
+    steps:
       - name: Checkout base branch
         if: github.event.workflow_run.conclusion == 'success'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
-          ref: ${{ steps.pr.outputs.base }}
+          ref: ${{ needs.resolve-pr.outputs.base_ref }}
           fetch-depth: 0
 
-      # Check out the *tested* commit (workflow_run.head_sha), not the live PR
-      # head, so the scanned tree, the downloaded coverage, and the commit status
-      # all describe the same commit. The tested commit is normally an ancestor
-      # of the current head (a later push just adds commits on top), so fetching
-      # pull/N/head brings it into the object store; fall back to fetching the
-      # exact SHA, and bail if it's unreachable (force-push/rebase since the run
-      # — the head has moved, so this analysis is stale and its successor run
-      # will report on the new head).
-      - name: Checkout tested commit
+      - name: Checkout tested merge commit
         if: github.event.workflow_run.conclusion == 'success'
         env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.number }}
+          MERGE_SHA: ${{ needs.resolve-pr.outputs.merge_sha }}
+          BASE_SHA: ${{ needs.resolve-pr.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
         run: |
-          git fetch --no-tags origin "pull/${PR_NUMBER}/head"
-          if ! git cat-file -e "${TESTED_SHA}^{commit}" 2>/dev/null; then
-            git fetch --no-tags origin "${TESTED_SHA}" || true
+          git fetch --no-tags origin "pull/${PR_NUMBER}/merge" || true
+          if ! git cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${MERGE_SHA}" || true
           fi
-          if ! git cat-file -e "${TESTED_SHA}^{commit}" 2>/dev/null; then
-            echo "::error::Tested commit ${TESTED_SHA} is unreachable (PR head moved since the test run); refusing to scan a different tree."
+          if ! git cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Tested merge ${MERGE_SHA} is unreachable; refusing to scan another tree."
             exit 1
           fi
-          git checkout --detach "${TESTED_SHA}"
+
+          PARENT_COUNT="$(git rev-list --parents -n 1 "${MERGE_SHA}" | awk '{print NF - 1}')"
+          ACTUAL_BASE_SHA="$(git rev-parse "${MERGE_SHA}^1")"
+          ACTUAL_HEAD_SHA="$(git rev-parse "${MERGE_SHA}^2")"
+          if [ "${PARENT_COUNT}" -ne 2 ] || [ "${ACTUAL_BASE_SHA}" != "${BASE_SHA}" ] || [ "${ACTUAL_HEAD_SHA}" != "${HEAD_SHA}" ]; then
+            echo "::error::Tested merge ${MERGE_SHA} parents do not match base ${BASE_SHA} and head ${HEAD_SHA}."
+            exit 1
+          fi
+
+          git checkout --detach "${MERGE_SHA}"
 
       - name: Download coverage artifact
         if: github.event.workflow_run.conclusion == 'success'
@@ -153,7 +206,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          args: "-Dsonar.pullrequest.key=${{ steps.pr.outputs.number }} -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head }} -Dsonar.pullrequest.base=${{ steps.pr.outputs.base }}"
+          args: "-Dsonar.pullrequest.key=${{ needs.resolve-pr.outputs.number }} -Dsonar.pullrequest.branch=${{ needs.resolve-pr.outputs.head_ref }} -Dsonar.pullrequest.base=${{ needs.resolve-pr.outputs.base_ref }}"
 
       - name: SonarQube Quality Gate check
         id: qg
@@ -163,45 +216,36 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      # Post the Quality Gate result as a commit status on the *tested* commit
-      # (github.event.workflow_run.head_sha — the SHA the triggering test run
-      # actually ran and Sonar scanned), NOT the live PR head. If a newer commit
-      # was pushed meanwhile this vouches only for the commit that was scanned;
-      # the newer commit gets its own run. Posting to the live head would stamp
-      # commit A's result onto B — a stale green on unscanned code, or a spurious
-      # red — which is exactly what a required check must never do.
+      # Post the Quality Gate result on the exact synthetic merge commit tested
+      # by the source workflow. Coverage, lint reports, checkout, Sonar analysis,
+      # and this status therefore describe one PR/head/base revision.
       #
-      # workflow_run runs in base-repo context where SONAR_TOKEN is available, so
-      # fork PRs are scanned here too — the fork's own token-less test run never
-      # runs this job. Mark it a required check in branch protection under the
-      # context "SonarQube Quality Gate".
+      # PR-number job concurrency prevents unrelated forks with identical branch
+      # names from canceling each other. A self-canceled run remains silent because
+      # its same-PR successor owns the current merge commit.
       #
-      # if: !cancelled() — a self-cancelled sonar run (its own concurrency group)
-      # must never post a transient error. On success/failure it resolves every
-      # path: gate PASSED/WARN -> success, FAILED -> failure, scan errored ->
-      # error, upstream tests failed/skipped -> failure. ('cancelled' upstream is
-      # already excluded at the job level.) One case no workflow_run job can
-      # cover: if "Teranode PR tests" never runs at all (path filter, draft PR)
-      # this never triggers, so require the tests check alongside this one.
+      # if: !cancelled() still resolves every non-canceled path: PASSED/WARN ->
+      # success, FAILED -> failure, scan/checkout failure -> error, and failed
+      # upstream tests -> failure.
       - name: Report Quality Gate as commit status
         if: ${{ !cancelled() }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           QG_STATUS: ${{ steps.qg.outputs.quality-gate-status }}
           TESTS_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          MERGE_SHA: ${{ needs.resolve-pr.outputs.merge_sha }}
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.number }}
         with:
           script: |
             const qg = process.env.QG_STATUS || '';
             const testsConclusion = process.env.TESTS_CONCLUSION || '';
-            const sha = process.env.HEAD_SHA;
+            const sha = process.env.MERGE_SHA;
             const pr = process.env.PR_NUMBER;
             // Keep in sync with sonar.projectKey in sonar-project.properties.
             const projectKey = 'bsv-blockchain_teranode';
 
             if (!sha) {
-              core.setFailed('No tested commit SHA on the workflow_run payload; cannot post commit status.');
+              core.setFailed('No validated tested merge SHA; cannot post commit status.');
               return;
             }
 

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -7,9 +7,31 @@ name: SonarQube Analysis for PRs
 # - workflow_run always runs in the base repository context with access to secrets
 #
 # How it works:
-# 1. teranode_pr_tests.yaml runs on PR (fork or internal) and generates artifacts
+# 1. teranode_pr_tests.yaml runs on the PR (fork or internal), encodes the tested
+#    PR/merge/base identity in its run-name, and uploads an attempt-qualified
+#    Sonar input bundle
 # 2. When that completes, this workflow triggers with access to SONAR_TOKEN
-# 3. Downloads artifacts and runs SonarQube scan with proper PR decoration
+# 3. The identity is validated, the tested synthetic merge tree is scanned, and
+#    the Quality Gate result is posted as a commit status on the PR *head*
+#    commit — the commit branch protection evaluates required checks on — under
+#    the context "SonarQube Quality Gate"
+#
+# Trust model: pull_request runs execute the PR's own copy of the producer
+# workflow, so the run-name (and everything derived from it) is untrusted input.
+# Every parsed field is cross-checked against trusted sources before use:
+# - the live PR via the API (head repo/branch/SHA and base ref must match)
+# - the claimed base must be an ancestor of the PR's current target branch
+# - the claimed merge must be a GitHub-signed synthetic merge whose parents are
+#   exactly (claimed base, workflow_run.head_sha)
+# Scanner settings are read from the trusted base commit and the Sonar host,
+# project key, and organization are pinned as scanner args, so a malicious PR
+# cannot redirect the scanner at another host to exfiltrate SONAR_TOKEN.
+# Validation failures fail the run WITHOUT posting a status, so a hostile or
+# malformed run leaves the required gate pending — the safe default.
+#
+# Base retargets and target-branch advancement do not rerun the analysis; the
+# status on the head commit describes the merge that was tested at run time,
+# the same staleness contract as every other required PR check.
 
 on:
   workflow_run:
@@ -17,8 +39,12 @@ on:
     types:
       - completed
 
-env:
-  GO_VERSION: "1.26.0"
+# One consumer at a time per PR head (repo + branch): a newer producer
+# completion cancels a superseded in-flight analysis, and the cancelled run's
+# status step is guarded by !cancelled() so it never posts a partial result.
+concurrency:
+  group: sonar-pr-${{ github.event.workflow_run.head_repository.full_name || 'unknown' }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 
 jobs:
   resolve-pr:
@@ -26,7 +52,6 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
       pull-requests: read
     outputs:
@@ -45,11 +70,6 @@ jobs:
           script: |
             const run = context.payload.workflow_run;
             const title = run.display_title || '';
-            const runAttempt = run.run_attempt;
-            if (!Number.isSafeInteger(runAttempt) || runAttempt < 1) {
-              core.setFailed(`Invalid triggering source workflow run attempt: ${String(runAttempt)}.`);
-              return;
-            }
             const pattern = /^sonar-pr\/([1-9][0-9]*)\/merge\/([0-9a-f]{40})\/base\/([0-9a-f]{40})\/ref\/(.+)$/;
             const match = pattern.exec(title);
 
@@ -61,216 +81,6 @@ jobs:
             const [, numberText, mergeSha, baseSha, baseRef] = match;
             const prNumber = Number(numberText);
             const runHeadRepo = run.head_repository?.full_name || '';
-
-            const sourceRunParams = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: run.workflow_id,
-              event: 'pull_request',
-              head_sha: run.head_sha,
-              per_page: 100,
-            };
-            const sourceRunIdentity = candidate => `${candidate.id}:${candidate.run_attempt}`;
-            const maxSnapshotAttempts = 2;
-            let sourceRuns;
-            let recheckPage;
-
-            for (let snapshotAttempt = 1; snapshotAttempt <= maxSnapshotAttempts; snapshotAttempt++) {
-              let stableTotal;
-              let paginatedRuns;
-              let snapshotInstability;
-              try {
-                paginatedRuns = await github.paginate(
-                  github.rest.actions.listWorkflowRuns,
-                  sourceRunParams,
-                  response => {
-                    const pageTotal = response.data.total_count;
-                    if (!Number.isSafeInteger(pageTotal)) {
-                      throw new Error(`Invalid source workflow run total_count: ${String(pageTotal)}.`);
-                    }
-                    if (stableTotal === undefined) {
-                      stableTotal = pageTotal;
-                    } else if (pageTotal !== stableTotal && !snapshotInstability) {
-                      snapshotInstability =
-                        `Source workflow run total_count changed during pagination: ` +
-                        `${stableTotal} to ${pageTotal}.`;
-                    }
-                    return response.data;
-                  }
-                );
-              } catch (error) {
-                core.setFailed(`Could not determine latest source workflow run: ${error.message}`);
-                return;
-              }
-
-              if (!snapshotInstability &&
-                  (!Number.isSafeInteger(stableTotal) || paginatedRuns.length !== stableTotal)) {
-                snapshotInstability =
-                  `Incomplete source workflow run result set: fetched ${paginatedRuns.length} of ` +
-                  `${String(stableTotal)} reported runs.`;
-              }
-
-              if (!snapshotInstability) {
-                const sourceRunIds = new Set();
-                for (const candidate of paginatedRuns) {
-                  if (sourceRunIds.has(candidate.id)) {
-                    snapshotInstability =
-                      `Duplicate source workflow run ID ${candidate.id}; refusing unstable recency state.`;
-                    break;
-                  }
-                  sourceRunIds.add(candidate.id);
-                }
-              }
-
-              if (snapshotInstability) {
-                if (snapshotAttempt < maxSnapshotAttempts) {
-                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
-                  continue;
-                }
-                core.setFailed(snapshotInstability);
-                return;
-              }
-
-              let recheckData;
-              try {
-                ({ data: recheckData } = await github.rest.actions.listWorkflowRuns({
-                  ...sourceRunParams,
-                  page: 1,
-                }));
-              } catch (error) {
-                core.setFailed(`Could not recheck latest source workflow runs: ${error.message}`);
-                return;
-              }
-
-              const recheckTotal = recheckData?.total_count;
-              const currentRecheckPage = recheckData?.workflow_runs;
-              if (!Number.isSafeInteger(recheckTotal)) {
-                core.setFailed(`Invalid source workflow run recheck total_count: ${String(recheckTotal)}.`);
-                return;
-              }
-              if (recheckTotal !== stableTotal) {
-                snapshotInstability =
-                  `Source workflow run total_count changed before recheck: ` +
-                  `${String(stableTotal)} to ${String(recheckTotal)}.`;
-              }
-
-              const expectedRecheckLength = Math.min(100, stableTotal);
-              if (!snapshotInstability &&
-                  (!Array.isArray(currentRecheckPage) ||
-                    currentRecheckPage.length !== expectedRecheckLength)) {
-                const fetchedCount = Array.isArray(currentRecheckPage)
-                  ? currentRecheckPage.length
-                  : 'invalid';
-                snapshotInstability =
-                  `Incomplete source workflow run recheck page: fetched ${fetchedCount} of ` +
-                  `${expectedRecheckLength} expected runs.`;
-              }
-
-              if (!snapshotInstability) {
-                const paginatedTopIdentities = paginatedRuns
-                  .slice(0, currentRecheckPage.length)
-                  .map(sourceRunIdentity);
-                const recheckTopIdentities = currentRecheckPage.map(sourceRunIdentity);
-                if (recheckTopIdentities.some(
-                  (identity, index) => identity !== paginatedTopIdentities[index]
-                )) {
-                  snapshotInstability = 'Source workflow run top page changed during recency validation.';
-                }
-              }
-
-              if (snapshotInstability) {
-                if (snapshotAttempt < maxSnapshotAttempts) {
-                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
-                  continue;
-                }
-                core.setFailed(snapshotInstability);
-                return;
-              }
-
-              sourceRuns = paginatedRuns;
-              recheckPage = currentRecheckPage;
-              break;
-            }
-
-            // Refresh the reused run ID after accepting the stable list snapshot.
-            let exactSourceRun;
-            try {
-              ({ data: exactSourceRun } = await github.rest.actions.getWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: run.id,
-              }));
-            } catch (error) {
-              core.setFailed(`Could not recheck exact source workflow run ${run.id}: ${error.message}`);
-              return;
-            }
-
-            if (!exactSourceRun ||
-                exactSourceRun.id !== run.id ||
-                exactSourceRun.workflow_id !== run.workflow_id ||
-                exactSourceRun.head_sha !== run.head_sha ||
-                exactSourceRun.display_title !== title) {
-              core.setFailed(`Exact source workflow run ${run.id} identity did not match the trigger.`);
-              return;
-            }
-
-            const exactRunAttempt = exactSourceRun.run_attempt;
-            if (!Number.isSafeInteger(exactRunAttempt) || exactRunAttempt < 1) {
-              core.setFailed(
-                `Exact source workflow run ${run.id} has invalid attempt ${String(exactRunAttempt)}.`
-              );
-              return;
-            }
-            if (exactRunAttempt > runAttempt) {
-              core.info(
-                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} superseded ` +
-                `trigger attempt ${runAttempt}; skipping Sonar analysis.`
-              );
-              core.setOutput('active', 'false');
-              return;
-            }
-            if (exactRunAttempt < runAttempt) {
-              core.setFailed(
-                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} is older than ` +
-                `trigger attempt ${runAttempt}.`
-              );
-              return;
-            }
-
-            const isNewerSourceRun = candidate =>
-              candidate.display_title === title &&
-              (candidate.id > run.id ||
-                (candidate.id === run.id && candidate.run_attempt > runAttempt));
-            const newerRun =
-              recheckPage.find(isNewerSourceRun) ||
-              sourceRuns.slice(recheckPage.length).find(isNewerSourceRun);
-            if (newerRun) {
-              core.info(
-                `Source workflow run ${newerRun.id} attempt ${newerRun.run_attempt} superseded ` +
-                `trigger ${run.id} attempt ${runAttempt}; skipping Sonar analysis.`
-              );
-              core.setOutput('active', 'false');
-              return;
-            }
-
-            const listedTriggerRun = sourceRuns.find(candidate => candidate.id === run.id);
-            if (!listedTriggerRun) {
-              core.setFailed(`Trigger source workflow run ID ${run.id} is missing from the recency result set.`);
-              return;
-            }
-            if (!Number.isSafeInteger(listedTriggerRun.run_attempt)) {
-              core.setFailed(
-                `Listed trigger run ${run.id} has invalid attempt ${String(listedTriggerRun.run_attempt)}.`
-              );
-              return;
-            }
-            if (listedTriggerRun.run_attempt < runAttempt) {
-              core.setFailed(
-                `Listed trigger run ${run.id} attempt ${listedTriggerRun.run_attempt} is older than ` +
-                `trigger attempt ${runAttempt}.`
-              );
-              return;
-            }
 
             if (!runHeadRepo) {
               core.setFailed('workflow_run has no head repository; refusing unbound PR identity.');
@@ -311,7 +121,7 @@ jobs:
               return;
             }
             if (pr.base.ref !== baseRef) {
-              core.info(`PR ${prNumber} was retargeted; successor edited run owns the current status.`);
+              core.info(`PR ${prNumber} was retargeted; successor run owns the current status.`);
               core.setOutput('active', 'false');
               return;
             }
@@ -321,6 +131,9 @@ jobs:
               return;
             }
 
+            // The claimed base must sit on the current target branch's history,
+            // otherwise the "trusted" sonar-project.properties below could be
+            // read from an attacker-supplied commit.
             let baseComparison;
             try {
               ({ data: baseComparison } = await github.rest.repos.compareCommitsWithBasehead({
@@ -461,13 +274,20 @@ jobs:
           SONAR_HOST_URL: https://sonarcloud.io
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      # Post the Quality Gate result on the exact synthetic merge commit tested
-      # by the source workflow. Coverage, lint reports, checkout, Sonar analysis,
-      # and this status therefore describe one PR/head/base revision.
+      # Post the Quality Gate result as a commit status on the tested PR *head*
+      # commit (workflow_run.head_sha) — the commit branch protection evaluates
+      # required checks on. The scanned tree is the synthetic merge of that head
+      # and the validated base; the merge short-SHA is recorded in the status
+      # description for traceability.
       #
-      # Source-run recency fences keep delayed older attempts silent without
-      # relying on scheduler ordering. Every completed current attempt,
-      # including canceled attempts, owns the terminal status for its merge.
+      # Posting to the tested head is harmless-by-construction when the head has
+      # since moved: the status lands on the old commit, which branch protection
+      # no longer consults, and resolve-pr skips such runs anyway.
+      #
+      # Upstream cancellation needs no job-level exclusion: a run superseded by
+      # a new push fails resolve-pr's head check and goes inactive, while a
+      # manual cancel on the current head posts 'failure' below so a required
+      # gate resolves instead of hanging pending.
       #
       # if: !cancelled() refers to this downstream job, not the source result.
       # PASSED/WARN -> success, FAILED -> failure, scan/checkout failure ->
@@ -478,234 +298,21 @@ jobs:
         env:
           QG_STATUS: ${{ steps.qg.outputs.quality-gate-status }}
           TESTS_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
           MERGE_SHA: ${{ needs.resolve-pr.outputs.merge_sha }}
           PR_NUMBER: ${{ needs.resolve-pr.outputs.number }}
         with:
           script: |
-            const run = context.payload.workflow_run;
-            const title = run.display_title || '';
-            const runAttempt = run.run_attempt;
-            if (!Number.isSafeInteger(runAttempt) || runAttempt < 1) {
-              core.setFailed(`Invalid triggering source workflow run attempt: ${String(runAttempt)}.`);
-              return;
-            }
             const qg = process.env.QG_STATUS || '';
             const testsConclusion = process.env.TESTS_CONCLUSION || '';
-            const sha = process.env.MERGE_SHA;
+            const sha = process.env.HEAD_SHA;
+            const mergeSha = process.env.MERGE_SHA || '';
             const pr = process.env.PR_NUMBER;
             // Keep in sync with sonar.projectKey in sonar-project.properties.
             const projectKey = 'bsv-blockchain_teranode';
 
             if (!sha) {
-              core.setFailed('No validated tested merge SHA; cannot post commit status.');
-              return;
-            }
-
-            const sourceRunParams = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: run.workflow_id,
-              event: 'pull_request',
-              head_sha: run.head_sha,
-              per_page: 100,
-            };
-            const sourceRunIdentity = candidate => `${candidate.id}:${candidate.run_attempt}`;
-            const maxSnapshotAttempts = 2;
-            let sourceRuns;
-            let recheckPage;
-
-            for (let snapshotAttempt = 1; snapshotAttempt <= maxSnapshotAttempts; snapshotAttempt++) {
-              let stableTotal;
-              let paginatedRuns;
-              let snapshotInstability;
-              try {
-                paginatedRuns = await github.paginate(
-                  github.rest.actions.listWorkflowRuns,
-                  sourceRunParams,
-                  response => {
-                    const pageTotal = response.data.total_count;
-                    if (!Number.isSafeInteger(pageTotal)) {
-                      throw new Error(`Invalid source workflow run total_count: ${String(pageTotal)}.`);
-                    }
-                    if (stableTotal === undefined) {
-                      stableTotal = pageTotal;
-                    } else if (pageTotal !== stableTotal && !snapshotInstability) {
-                      snapshotInstability =
-                        `Source workflow run total_count changed during pagination: ` +
-                        `${stableTotal} to ${pageTotal}.`;
-                    }
-                    return response.data;
-                  }
-                );
-              } catch (error) {
-                core.setFailed(`Could not determine latest source workflow run: ${error.message}`);
-                return;
-              }
-
-              if (!snapshotInstability &&
-                  (!Number.isSafeInteger(stableTotal) || paginatedRuns.length !== stableTotal)) {
-                snapshotInstability =
-                  `Incomplete source workflow run result set: fetched ${paginatedRuns.length} of ` +
-                  `${String(stableTotal)} reported runs.`;
-              }
-
-              if (!snapshotInstability) {
-                const sourceRunIds = new Set();
-                for (const candidate of paginatedRuns) {
-                  if (sourceRunIds.has(candidate.id)) {
-                    snapshotInstability =
-                      `Duplicate source workflow run ID ${candidate.id}; refusing unstable recency state.`;
-                    break;
-                  }
-                  sourceRunIds.add(candidate.id);
-                }
-              }
-
-              if (snapshotInstability) {
-                if (snapshotAttempt < maxSnapshotAttempts) {
-                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
-                  continue;
-                }
-                core.setFailed(snapshotInstability);
-                return;
-              }
-
-              let recheckData;
-              try {
-                ({ data: recheckData } = await github.rest.actions.listWorkflowRuns({
-                  ...sourceRunParams,
-                  page: 1,
-                }));
-              } catch (error) {
-                core.setFailed(`Could not recheck latest source workflow runs: ${error.message}`);
-                return;
-              }
-
-              const recheckTotal = recheckData?.total_count;
-              const currentRecheckPage = recheckData?.workflow_runs;
-              if (!Number.isSafeInteger(recheckTotal)) {
-                core.setFailed(`Invalid source workflow run recheck total_count: ${String(recheckTotal)}.`);
-                return;
-              }
-              if (recheckTotal !== stableTotal) {
-                snapshotInstability =
-                  `Source workflow run total_count changed before recheck: ` +
-                  `${String(stableTotal)} to ${String(recheckTotal)}.`;
-              }
-
-              const expectedRecheckLength = Math.min(100, stableTotal);
-              if (!snapshotInstability &&
-                  (!Array.isArray(currentRecheckPage) ||
-                    currentRecheckPage.length !== expectedRecheckLength)) {
-                const fetchedCount = Array.isArray(currentRecheckPage)
-                  ? currentRecheckPage.length
-                  : 'invalid';
-                snapshotInstability =
-                  `Incomplete source workflow run recheck page: fetched ${fetchedCount} of ` +
-                  `${expectedRecheckLength} expected runs.`;
-              }
-
-              if (!snapshotInstability) {
-                const paginatedTopIdentities = paginatedRuns
-                  .slice(0, currentRecheckPage.length)
-                  .map(sourceRunIdentity);
-                const recheckTopIdentities = currentRecheckPage.map(sourceRunIdentity);
-                if (recheckTopIdentities.some(
-                  (identity, index) => identity !== paginatedTopIdentities[index]
-                )) {
-                  snapshotInstability = 'Source workflow run top page changed during recency validation.';
-                }
-              }
-
-              if (snapshotInstability) {
-                if (snapshotAttempt < maxSnapshotAttempts) {
-                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
-                  continue;
-                }
-                core.setFailed(snapshotInstability);
-                return;
-              }
-
-              sourceRuns = paginatedRuns;
-              recheckPage = currentRecheckPage;
-              break;
-            }
-
-            // Refresh the reused run ID after accepting the stable list snapshot.
-            let exactSourceRun;
-            try {
-              ({ data: exactSourceRun } = await github.rest.actions.getWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: run.id,
-              }));
-            } catch (error) {
-              core.setFailed(`Could not recheck exact source workflow run ${run.id}: ${error.message}`);
-              return;
-            }
-
-            if (!exactSourceRun ||
-                exactSourceRun.id !== run.id ||
-                exactSourceRun.workflow_id !== run.workflow_id ||
-                exactSourceRun.head_sha !== run.head_sha ||
-                exactSourceRun.display_title !== title) {
-              core.setFailed(`Exact source workflow run ${run.id} identity did not match the trigger.`);
-              return;
-            }
-
-            const exactRunAttempt = exactSourceRun.run_attempt;
-            if (!Number.isSafeInteger(exactRunAttempt) || exactRunAttempt < 1) {
-              core.setFailed(
-                `Exact source workflow run ${run.id} has invalid attempt ${String(exactRunAttempt)}.`
-              );
-              return;
-            }
-            if (exactRunAttempt > runAttempt) {
-              core.info(
-                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} superseded ` +
-                `trigger attempt ${runAttempt}; not posting commit status.`
-              );
-              return;
-            }
-            if (exactRunAttempt < runAttempt) {
-              core.setFailed(
-                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} is older than ` +
-                `trigger attempt ${runAttempt}.`
-              );
-              return;
-            }
-
-            const isNewerSourceRun = candidate =>
-              candidate.display_title === title &&
-              (candidate.id > run.id ||
-                (candidate.id === run.id && candidate.run_attempt > runAttempt));
-            const newerRun =
-              recheckPage.find(isNewerSourceRun) ||
-              sourceRuns.slice(recheckPage.length).find(isNewerSourceRun);
-            if (newerRun) {
-              core.info(
-                `Source workflow run ${newerRun.id} attempt ${newerRun.run_attempt} superseded ` +
-                `trigger ${run.id} attempt ${runAttempt}; not posting commit status.`
-              );
-              return;
-            }
-
-            const listedTriggerRun = sourceRuns.find(candidate => candidate.id === run.id);
-            if (!listedTriggerRun) {
-              core.setFailed(`Trigger source workflow run ID ${run.id} is missing from the recency result set.`);
-              return;
-            }
-            if (!Number.isSafeInteger(listedTriggerRun.run_attempt)) {
-              core.setFailed(
-                `Listed trigger run ${run.id} has invalid attempt ${String(listedTriggerRun.run_attempt)}.`
-              );
-              return;
-            }
-            if (listedTriggerRun.run_attempt < runAttempt) {
-              core.setFailed(
-                `Listed trigger run ${run.id} attempt ${listedTriggerRun.run_attempt} is older than ` +
-                `trigger attempt ${runAttempt}.`
-              );
+              core.setFailed('No validated tested head SHA; cannot post commit status.');
               return;
             }
 
@@ -729,6 +336,9 @@ jobs:
               state = 'error';
               description = 'Quality Gate did not complete (analysis failed)';
             }
+            if (mergeSha) {
+              description = `${description} — tested merge ${mergeSha.slice(0, 7)}`;
+            }
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -740,4 +350,4 @@ jobs:
               target_url: `https://sonarcloud.io/summary/new_code?id=${projectKey}&pullRequest=${pr}`,
             });
 
-            core.info(`Posted commit status '${state}' (tests=${testsConclusion || 'none'}, qg=${qg || 'none'}) to ${sha}`);
+            core.info(`Posted commit status '${state}' (tests=${testsConclusion || 'none'}, qg=${qg || 'none'}, merge=${mergeSha || 'none'}) to ${sha}`);

--- a/.github/workflows/sonar-pr-analyze.yaml
+++ b/.github/workflows/sonar-pr-analyze.yaml
@@ -17,21 +17,18 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
-  pull-requests: read
-  statuses: write
-
 env:
   GO_VERSION: "1.26.0"
 
 jobs:
   resolve-pr:
     name: Resolve tested PR identity
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled'
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     outputs:
       active: ${{ steps.resolve.outputs.active }}
       number: ${{ steps.resolve.outputs.number }}
@@ -48,6 +45,11 @@ jobs:
           script: |
             const run = context.payload.workflow_run;
             const title = run.display_title || '';
+            const runAttempt = run.run_attempt;
+            if (!Number.isSafeInteger(runAttempt) || runAttempt < 1) {
+              core.setFailed(`Invalid triggering source workflow run attempt: ${String(runAttempt)}.`);
+              return;
+            }
             const pattern = /^sonar-pr\/([1-9][0-9]*)\/merge\/([0-9a-f]{40})\/base\/([0-9a-f]{40})\/ref\/(.+)$/;
             const match = pattern.exec(title);
 
@@ -59,6 +61,216 @@ jobs:
             const [, numberText, mergeSha, baseSha, baseRef] = match;
             const prNumber = Number(numberText);
             const runHeadRepo = run.head_repository?.full_name || '';
+
+            const sourceRunParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: run.workflow_id,
+              event: 'pull_request',
+              head_sha: run.head_sha,
+              per_page: 100,
+            };
+            const sourceRunIdentity = candidate => `${candidate.id}:${candidate.run_attempt}`;
+            const maxSnapshotAttempts = 2;
+            let sourceRuns;
+            let recheckPage;
+
+            for (let snapshotAttempt = 1; snapshotAttempt <= maxSnapshotAttempts; snapshotAttempt++) {
+              let stableTotal;
+              let paginatedRuns;
+              let snapshotInstability;
+              try {
+                paginatedRuns = await github.paginate(
+                  github.rest.actions.listWorkflowRuns,
+                  sourceRunParams,
+                  response => {
+                    const pageTotal = response.data.total_count;
+                    if (!Number.isSafeInteger(pageTotal)) {
+                      throw new Error(`Invalid source workflow run total_count: ${String(pageTotal)}.`);
+                    }
+                    if (stableTotal === undefined) {
+                      stableTotal = pageTotal;
+                    } else if (pageTotal !== stableTotal && !snapshotInstability) {
+                      snapshotInstability =
+                        `Source workflow run total_count changed during pagination: ` +
+                        `${stableTotal} to ${pageTotal}.`;
+                    }
+                    return response.data;
+                  }
+                );
+              } catch (error) {
+                core.setFailed(`Could not determine latest source workflow run: ${error.message}`);
+                return;
+              }
+
+              if (!snapshotInstability &&
+                  (!Number.isSafeInteger(stableTotal) || paginatedRuns.length !== stableTotal)) {
+                snapshotInstability =
+                  `Incomplete source workflow run result set: fetched ${paginatedRuns.length} of ` +
+                  `${String(stableTotal)} reported runs.`;
+              }
+
+              if (!snapshotInstability) {
+                const sourceRunIds = new Set();
+                for (const candidate of paginatedRuns) {
+                  if (sourceRunIds.has(candidate.id)) {
+                    snapshotInstability =
+                      `Duplicate source workflow run ID ${candidate.id}; refusing unstable recency state.`;
+                    break;
+                  }
+                  sourceRunIds.add(candidate.id);
+                }
+              }
+
+              if (snapshotInstability) {
+                if (snapshotAttempt < maxSnapshotAttempts) {
+                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
+                  continue;
+                }
+                core.setFailed(snapshotInstability);
+                return;
+              }
+
+              let recheckData;
+              try {
+                ({ data: recheckData } = await github.rest.actions.listWorkflowRuns({
+                  ...sourceRunParams,
+                  page: 1,
+                }));
+              } catch (error) {
+                core.setFailed(`Could not recheck latest source workflow runs: ${error.message}`);
+                return;
+              }
+
+              const recheckTotal = recheckData?.total_count;
+              const currentRecheckPage = recheckData?.workflow_runs;
+              if (!Number.isSafeInteger(recheckTotal)) {
+                core.setFailed(`Invalid source workflow run recheck total_count: ${String(recheckTotal)}.`);
+                return;
+              }
+              if (recheckTotal !== stableTotal) {
+                snapshotInstability =
+                  `Source workflow run total_count changed before recheck: ` +
+                  `${String(stableTotal)} to ${String(recheckTotal)}.`;
+              }
+
+              const expectedRecheckLength = Math.min(100, stableTotal);
+              if (!snapshotInstability &&
+                  (!Array.isArray(currentRecheckPage) ||
+                    currentRecheckPage.length !== expectedRecheckLength)) {
+                const fetchedCount = Array.isArray(currentRecheckPage)
+                  ? currentRecheckPage.length
+                  : 'invalid';
+                snapshotInstability =
+                  `Incomplete source workflow run recheck page: fetched ${fetchedCount} of ` +
+                  `${expectedRecheckLength} expected runs.`;
+              }
+
+              if (!snapshotInstability) {
+                const paginatedTopIdentities = paginatedRuns
+                  .slice(0, currentRecheckPage.length)
+                  .map(sourceRunIdentity);
+                const recheckTopIdentities = currentRecheckPage.map(sourceRunIdentity);
+                if (recheckTopIdentities.some(
+                  (identity, index) => identity !== paginatedTopIdentities[index]
+                )) {
+                  snapshotInstability = 'Source workflow run top page changed during recency validation.';
+                }
+              }
+
+              if (snapshotInstability) {
+                if (snapshotAttempt < maxSnapshotAttempts) {
+                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
+                  continue;
+                }
+                core.setFailed(snapshotInstability);
+                return;
+              }
+
+              sourceRuns = paginatedRuns;
+              recheckPage = currentRecheckPage;
+              break;
+            }
+
+            // Refresh the reused run ID after accepting the stable list snapshot.
+            let exactSourceRun;
+            try {
+              ({ data: exactSourceRun } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }));
+            } catch (error) {
+              core.setFailed(`Could not recheck exact source workflow run ${run.id}: ${error.message}`);
+              return;
+            }
+
+            if (!exactSourceRun ||
+                exactSourceRun.id !== run.id ||
+                exactSourceRun.workflow_id !== run.workflow_id ||
+                exactSourceRun.head_sha !== run.head_sha ||
+                exactSourceRun.display_title !== title) {
+              core.setFailed(`Exact source workflow run ${run.id} identity did not match the trigger.`);
+              return;
+            }
+
+            const exactRunAttempt = exactSourceRun.run_attempt;
+            if (!Number.isSafeInteger(exactRunAttempt) || exactRunAttempt < 1) {
+              core.setFailed(
+                `Exact source workflow run ${run.id} has invalid attempt ${String(exactRunAttempt)}.`
+              );
+              return;
+            }
+            if (exactRunAttempt > runAttempt) {
+              core.info(
+                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} superseded ` +
+                `trigger attempt ${runAttempt}; skipping Sonar analysis.`
+              );
+              core.setOutput('active', 'false');
+              return;
+            }
+            if (exactRunAttempt < runAttempt) {
+              core.setFailed(
+                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} is older than ` +
+                `trigger attempt ${runAttempt}.`
+              );
+              return;
+            }
+
+            const isNewerSourceRun = candidate =>
+              candidate.display_title === title &&
+              (candidate.id > run.id ||
+                (candidate.id === run.id && candidate.run_attempt > runAttempt));
+            const newerRun =
+              recheckPage.find(isNewerSourceRun) ||
+              sourceRuns.slice(recheckPage.length).find(isNewerSourceRun);
+            if (newerRun) {
+              core.info(
+                `Source workflow run ${newerRun.id} attempt ${newerRun.run_attempt} superseded ` +
+                `trigger ${run.id} attempt ${runAttempt}; skipping Sonar analysis.`
+              );
+              core.setOutput('active', 'false');
+              return;
+            }
+
+            const listedTriggerRun = sourceRuns.find(candidate => candidate.id === run.id);
+            if (!listedTriggerRun) {
+              core.setFailed(`Trigger source workflow run ID ${run.id} is missing from the recency result set.`);
+              return;
+            }
+            if (!Number.isSafeInteger(listedTriggerRun.run_attempt)) {
+              core.setFailed(
+                `Listed trigger run ${run.id} has invalid attempt ${String(listedTriggerRun.run_attempt)}.`
+              );
+              return;
+            }
+            if (listedTriggerRun.run_attempt < runAttempt) {
+              core.setFailed(
+                `Listed trigger run ${run.id} attempt ${listedTriggerRun.run_attempt} is older than ` +
+                `trigger attempt ${runAttempt}.`
+              );
+              return;
+            }
 
             if (!runHeadRepo) {
               core.setFailed('workflow_run has no head repository; refusing unbound PR identity.');
@@ -103,6 +315,30 @@ jobs:
               core.setOutput('active', 'false');
               return;
             }
+            const currentBaseSha = pr.base.sha;
+            if (typeof currentBaseSha !== 'string' || !/^[0-9a-f]{40}$/.test(currentBaseSha)) {
+              core.setFailed(`PR ${prNumber} has invalid current base SHA.`);
+              return;
+            }
+
+            let baseComparison;
+            try {
+              ({ data: baseComparison } = await github.rest.repos.compareCommitsWithBasehead({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                basehead: `${baseSha}...${currentBaseSha}`,
+              }));
+            } catch (error) {
+              core.setFailed(`Could not validate tested base ${baseSha} against current target: ${error.message}`);
+              return;
+            }
+
+            const mergeBaseSha = baseComparison?.merge_base_commit?.sha;
+            if (mergeBaseSha !== baseSha ||
+                (baseComparison?.status !== 'identical' && baseComparison?.status !== 'ahead')) {
+              core.setFailed(`Tested base ${baseSha} is not an ancestor of the current PR target.`);
+              return;
+            }
 
             let mergeCommit;
             try {
@@ -116,7 +352,19 @@ jobs:
               return;
             }
 
-            const parents = mergeCommit.parents || [];
+            const verification = mergeCommit?.commit?.verification;
+            const signedCommitter = mergeCommit?.commit?.committer;
+            if (verification?.verified !== true ||
+                verification.reason !== 'valid' ||
+                mergeCommit?.committer?.login !== 'web-flow' ||
+                signedCommitter?.name !== 'GitHub' ||
+                signedCommitter?.email !== 'noreply@github.com' ||
+                mergeCommit?.commit?.message !== `Merge ${run.head_sha} into ${baseSha}`) {
+              core.setFailed(`Tested merge ${mergeSha} is not a verified GitHub synthetic merge.`);
+              return;
+            }
+
+            const parents = mergeCommit?.parents || [];
             if (parents.length !== 2 || parents[0].sha !== baseSha || parents[1].sha !== run.head_sha) {
               core.setFailed(`Tested merge ${mergeSha} does not match base ${baseSha} and head ${run.head_sha}.`);
               return;
@@ -134,12 +382,13 @@ jobs:
     name: SonarQube Analysis
     needs: resolve-pr
     if: needs.resolve-pr.outputs.active == 'true'
-    concurrency:
-      group: sonar-pr-${{ needs.resolve-pr.outputs.number }}
-      cancel-in-progress: true
-    # arm64-safe: only downloads coverage artifacts + runs the sonar scanner CLI
+    # arm64-safe: only downloads aggregate Sonar inputs + runs the scanner CLI
     # (arm64-available); no Go build, no containers.
     runs-on: teranode-runner-4-core-arm
+    permissions:
+      actions: read
+      contents: read
+      statuses: write
 
     steps:
       - name: Checkout base branch
@@ -175,28 +424,15 @@ jobs:
           fi
 
           git checkout --detach "${MERGE_SHA}"
+          git show "${BASE_SHA}:sonar-project.properties" > "${RUNNER_TEMP}/sonar-project.properties"
 
-      - name: Download coverage artifact
+      # The bundle is additive to fixed producer artifacts. After rollout, only
+      # producer runs already in flight across the merge can lack this bundle.
+      - name: Download Sonar input bundle
         if: github.event.workflow_run.conclusion == 'success'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: coverage-report
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download golangci-lint report
-        if: github.event.workflow_run.conclusion == 'success'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: golangci-lint-report
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download filename check report
-        if: github.event.workflow_run.conclusion == 'success'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: sonar-filename-report
+          name: sonar-inputs-${{ github.event.workflow_run.run_attempt }}
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -204,9 +440,17 @@ jobs:
         if: github.event.workflow_run.conclusion == 'success'
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
+          SONAR_HOST_URL: https://sonarcloud.io
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          args: "-Dsonar.pullrequest.key=${{ needs.resolve-pr.outputs.number }} -Dsonar.pullrequest.branch=${{ needs.resolve-pr.outputs.head_ref }} -Dsonar.pullrequest.base=${{ needs.resolve-pr.outputs.base_ref }}"
+          args: >-
+            -Dproject.settings=${{ runner.temp }}/sonar-project.properties
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.projectKey=bsv-blockchain_teranode
+            -Dsonar.organization=bsv
+            -Dsonar.pullrequest.key=${{ needs.resolve-pr.outputs.number }}
+            -Dsonar.pullrequest.branch=${{ needs.resolve-pr.outputs.head_ref }}
+            -Dsonar.pullrequest.base=${{ needs.resolve-pr.outputs.base_ref }}
 
       - name: SonarQube Quality Gate check
         id: qg
@@ -214,19 +458,20 @@ jobs:
         uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
         timeout-minutes: 10
         env:
+          SONAR_HOST_URL: https://sonarcloud.io
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       # Post the Quality Gate result on the exact synthetic merge commit tested
       # by the source workflow. Coverage, lint reports, checkout, Sonar analysis,
       # and this status therefore describe one PR/head/base revision.
       #
-      # PR-number job concurrency prevents unrelated forks with identical branch
-      # names from canceling each other. A self-canceled run remains silent because
-      # its same-PR successor owns the current merge commit.
+      # Source-run recency fences keep delayed older attempts silent without
+      # relying on scheduler ordering. Every completed current attempt,
+      # including canceled attempts, owns the terminal status for its merge.
       #
-      # if: !cancelled() still resolves every non-canceled path: PASSED/WARN ->
-      # success, FAILED -> failure, scan/checkout failure -> error, and failed
-      # upstream tests -> failure.
+      # if: !cancelled() refers to this downstream job, not the source result.
+      # PASSED/WARN -> success, FAILED -> failure, scan/checkout failure ->
+      # error, and failed or canceled upstream tests -> failure.
       - name: Report Quality Gate as commit status
         if: ${{ !cancelled() }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -237,6 +482,13 @@ jobs:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.number }}
         with:
           script: |
+            const run = context.payload.workflow_run;
+            const title = run.display_title || '';
+            const runAttempt = run.run_attempt;
+            if (!Number.isSafeInteger(runAttempt) || runAttempt < 1) {
+              core.setFailed(`Invalid triggering source workflow run attempt: ${String(runAttempt)}.`);
+              return;
+            }
             const qg = process.env.QG_STATUS || '';
             const testsConclusion = process.env.TESTS_CONCLUSION || '';
             const sha = process.env.MERGE_SHA;
@@ -246,6 +498,214 @@ jobs:
 
             if (!sha) {
               core.setFailed('No validated tested merge SHA; cannot post commit status.');
+              return;
+            }
+
+            const sourceRunParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: run.workflow_id,
+              event: 'pull_request',
+              head_sha: run.head_sha,
+              per_page: 100,
+            };
+            const sourceRunIdentity = candidate => `${candidate.id}:${candidate.run_attempt}`;
+            const maxSnapshotAttempts = 2;
+            let sourceRuns;
+            let recheckPage;
+
+            for (let snapshotAttempt = 1; snapshotAttempt <= maxSnapshotAttempts; snapshotAttempt++) {
+              let stableTotal;
+              let paginatedRuns;
+              let snapshotInstability;
+              try {
+                paginatedRuns = await github.paginate(
+                  github.rest.actions.listWorkflowRuns,
+                  sourceRunParams,
+                  response => {
+                    const pageTotal = response.data.total_count;
+                    if (!Number.isSafeInteger(pageTotal)) {
+                      throw new Error(`Invalid source workflow run total_count: ${String(pageTotal)}.`);
+                    }
+                    if (stableTotal === undefined) {
+                      stableTotal = pageTotal;
+                    } else if (pageTotal !== stableTotal && !snapshotInstability) {
+                      snapshotInstability =
+                        `Source workflow run total_count changed during pagination: ` +
+                        `${stableTotal} to ${pageTotal}.`;
+                    }
+                    return response.data;
+                  }
+                );
+              } catch (error) {
+                core.setFailed(`Could not determine latest source workflow run: ${error.message}`);
+                return;
+              }
+
+              if (!snapshotInstability &&
+                  (!Number.isSafeInteger(stableTotal) || paginatedRuns.length !== stableTotal)) {
+                snapshotInstability =
+                  `Incomplete source workflow run result set: fetched ${paginatedRuns.length} of ` +
+                  `${String(stableTotal)} reported runs.`;
+              }
+
+              if (!snapshotInstability) {
+                const sourceRunIds = new Set();
+                for (const candidate of paginatedRuns) {
+                  if (sourceRunIds.has(candidate.id)) {
+                    snapshotInstability =
+                      `Duplicate source workflow run ID ${candidate.id}; refusing unstable recency state.`;
+                    break;
+                  }
+                  sourceRunIds.add(candidate.id);
+                }
+              }
+
+              if (snapshotInstability) {
+                if (snapshotAttempt < maxSnapshotAttempts) {
+                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
+                  continue;
+                }
+                core.setFailed(snapshotInstability);
+                return;
+              }
+
+              let recheckData;
+              try {
+                ({ data: recheckData } = await github.rest.actions.listWorkflowRuns({
+                  ...sourceRunParams,
+                  page: 1,
+                }));
+              } catch (error) {
+                core.setFailed(`Could not recheck latest source workflow runs: ${error.message}`);
+                return;
+              }
+
+              const recheckTotal = recheckData?.total_count;
+              const currentRecheckPage = recheckData?.workflow_runs;
+              if (!Number.isSafeInteger(recheckTotal)) {
+                core.setFailed(`Invalid source workflow run recheck total_count: ${String(recheckTotal)}.`);
+                return;
+              }
+              if (recheckTotal !== stableTotal) {
+                snapshotInstability =
+                  `Source workflow run total_count changed before recheck: ` +
+                  `${String(stableTotal)} to ${String(recheckTotal)}.`;
+              }
+
+              const expectedRecheckLength = Math.min(100, stableTotal);
+              if (!snapshotInstability &&
+                  (!Array.isArray(currentRecheckPage) ||
+                    currentRecheckPage.length !== expectedRecheckLength)) {
+                const fetchedCount = Array.isArray(currentRecheckPage)
+                  ? currentRecheckPage.length
+                  : 'invalid';
+                snapshotInstability =
+                  `Incomplete source workflow run recheck page: fetched ${fetchedCount} of ` +
+                  `${expectedRecheckLength} expected runs.`;
+              }
+
+              if (!snapshotInstability) {
+                const paginatedTopIdentities = paginatedRuns
+                  .slice(0, currentRecheckPage.length)
+                  .map(sourceRunIdentity);
+                const recheckTopIdentities = currentRecheckPage.map(sourceRunIdentity);
+                if (recheckTopIdentities.some(
+                  (identity, index) => identity !== paginatedTopIdentities[index]
+                )) {
+                  snapshotInstability = 'Source workflow run top page changed during recency validation.';
+                }
+              }
+
+              if (snapshotInstability) {
+                if (snapshotAttempt < maxSnapshotAttempts) {
+                  core.info(`${snapshotInstability} Retrying complete source workflow run snapshot.`);
+                  continue;
+                }
+                core.setFailed(snapshotInstability);
+                return;
+              }
+
+              sourceRuns = paginatedRuns;
+              recheckPage = currentRecheckPage;
+              break;
+            }
+
+            // Refresh the reused run ID after accepting the stable list snapshot.
+            let exactSourceRun;
+            try {
+              ({ data: exactSourceRun } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }));
+            } catch (error) {
+              core.setFailed(`Could not recheck exact source workflow run ${run.id}: ${error.message}`);
+              return;
+            }
+
+            if (!exactSourceRun ||
+                exactSourceRun.id !== run.id ||
+                exactSourceRun.workflow_id !== run.workflow_id ||
+                exactSourceRun.head_sha !== run.head_sha ||
+                exactSourceRun.display_title !== title) {
+              core.setFailed(`Exact source workflow run ${run.id} identity did not match the trigger.`);
+              return;
+            }
+
+            const exactRunAttempt = exactSourceRun.run_attempt;
+            if (!Number.isSafeInteger(exactRunAttempt) || exactRunAttempt < 1) {
+              core.setFailed(
+                `Exact source workflow run ${run.id} has invalid attempt ${String(exactRunAttempt)}.`
+              );
+              return;
+            }
+            if (exactRunAttempt > runAttempt) {
+              core.info(
+                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} superseded ` +
+                `trigger attempt ${runAttempt}; not posting commit status.`
+              );
+              return;
+            }
+            if (exactRunAttempt < runAttempt) {
+              core.setFailed(
+                `Exact source workflow run ${run.id} attempt ${exactRunAttempt} is older than ` +
+                `trigger attempt ${runAttempt}.`
+              );
+              return;
+            }
+
+            const isNewerSourceRun = candidate =>
+              candidate.display_title === title &&
+              (candidate.id > run.id ||
+                (candidate.id === run.id && candidate.run_attempt > runAttempt));
+            const newerRun =
+              recheckPage.find(isNewerSourceRun) ||
+              sourceRuns.slice(recheckPage.length).find(isNewerSourceRun);
+            if (newerRun) {
+              core.info(
+                `Source workflow run ${newerRun.id} attempt ${newerRun.run_attempt} superseded ` +
+                `trigger ${run.id} attempt ${runAttempt}; not posting commit status.`
+              );
+              return;
+            }
+
+            const listedTriggerRun = sourceRuns.find(candidate => candidate.id === run.id);
+            if (!listedTriggerRun) {
+              core.setFailed(`Trigger source workflow run ID ${run.id} is missing from the recency result set.`);
+              return;
+            }
+            if (!Number.isSafeInteger(listedTriggerRun.run_attempt)) {
+              core.setFailed(
+                `Listed trigger run ${run.id} has invalid attempt ${String(listedTriggerRun.run_attempt)}.`
+              );
+              return;
+            }
+            if (listedTriggerRun.run_attempt < runAttempt) {
+              core.setFailed(
+                `Listed trigger run ${run.id} attempt ${listedTriggerRun.run_attempt} is older than ` +
+                `trigger attempt ${runAttempt}.`
+              );
               return;
             }
 

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -1,7 +1,13 @@
 name: Teranode PR tests
+run-name: sonar-pr/${{ github.event.pull_request.number }}/merge/${{ github.sha }}/base/${{ github.event.pull_request.base.sha }}/ref/${{ github.event.pull_request.base.ref }}
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -152,4 +158,3 @@ jobs:
           name: sonar-filename-report
           path: sonar_filename_report.json
           retention-days: 1
-

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -60,6 +60,7 @@ jobs:
         with:
           name: golangci-lint-report
           path: golangci-lint-report.xml
+          if-no-files-found: error
           retention-days: 1
 
   test:
@@ -136,6 +137,7 @@ jobs:
         with:
           name: coverage-report
           path: coverage.out
+          if-no-files-found: error
           retention-days: 1
 
       # - name: Publish Test Summary Results
@@ -157,4 +159,63 @@ jobs:
         with:
           name: sonar-filename-report
           path: sonar_filename_report.json
+          if-no-files-found: error
+          retention-days: 1
+
+  # Fixed producer names keep the legacy downstream compatible during rollout.
+  # Failed-job reruns also rerun dependents, so this job reselects each newest
+  # producer artifact and seals the effective set into the current-attempt bundle.
+  sonar-inputs:
+    name: Aggregate Sonar inputs
+    needs:
+      - golangci-lint
+      - test
+      - filename-check-report
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Download golangci-lint report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: golangci-lint-report
+          run-id: ${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: coverage-report
+          run-id: ${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download filename check report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sonar-filename-report
+          run-id: ${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Presence-only validation: never execute or parse artifact contents.
+      - name: Validate required Sonar inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          for file in coverage.out golangci-lint-report.xml sonar_filename_report.json; do
+            [ -f "$file" ] || {
+              echo "::error::Missing required Sonar input file: $file"
+              exit 1
+            }
+          done
+
+      - name: Upload Sonar input bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sonar-inputs-${{ github.run_attempt }}
+          path: |
+            coverage.out
+            golangci-lint-report.xml
+            sonar_filename_report.json
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -1,13 +1,12 @@
 name: Teranode PR tests
+# The run-name carries the tested PR/merge/base identity to the downstream
+# sonar-pr-analyze.yaml workflow, which validates every field before trusting
+# it. Base retargets do not rerun this workflow (default trigger types), so the
+# Sonar gate keeps the same staleness contract as every other required check.
 run-name: sonar-pr/${{ github.event.pull_request.number }}/merge/${{ github.sha }}/base/${{ github.event.pull_request.base.sha }}/ref/${{ github.event.pull_request.base.ref }}
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - edited
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- post the Quality Gate commit status to the PR head commit — where branch protection evaluates required checks. The tested merge short-SHA is recorded in the status description
- scan the exact GitHub-signed synthetic merge tree the tests ran against. The identity travels in the producer run-name and is validated before use: live-PR match (head repo/branch/SHA, base ref), base-ancestor check against the current target, and merge parents == (claimed base, tested head)
- load scanner settings from the trusted target-base commit and pin SonarCloud host, project, and organization — a malicious PR can no longer redirect the scanner to exfiltrate `SONAR_TOKEN`
- aggregate partial/full rerun artifacts into one attempt-qualified Sonar input bundle
- move Sonar workflow permissions to exact job-level grants
- serialize analysis per PR head via a concurrency group; stale runs skip themselves when the head moved, the PR was retargeted, or the PR closed. Validation failures fail without posting, leaving a required gate pending — the safe default for hostile runs

Base retargets and target-branch advancement do not rerun the analysis: the gate keeps the same staleness contract as every other required check.

## Verification

- filtered `actionlint` passed for both workflows
- both embedded github-script blocks pass `node --check`
- `git diff --check upstream/main...HEAD` passed
- tracked scope is exactly:
  - `.github/workflows/teranode_pr_tests.yaml`
  - `.github/workflows/sonar-pr-analyze.yaml`

## Rollout

Keep `SonarQube Quality Gate` optional until fresh post-merge canaries pass for:

- fork PRs and duplicate fork branch names
- shared head commits targeting different bases (known limitation: one status context per head commit; the merge short-SHA in the description disambiguates)
- base retarget and target-branch advancement
- upstream failure and cancellation
- full and failed-job partial reruns

The fixed producer artifacts remain compatible with the current downstream workflow. Only source runs already in flight across the merge can lack the new aggregate bundle.

After the hardened default-branch workflow is live, rotate `SONAR_TOKEN` because the previous privileged workflow accepted scanner configuration from the tested merge.

Follow-up to #1248.