### PR TITLE
fix(pruner): route combined-cleanup parent updates through the native-op builder

### DIFF
--- a/services/blockvalidation/catchup_fork_handling_test.go
+++ b/services/blockvalidation/catchup_fork_handling_test.go
@@ -687,11 +687,16 @@ func TestCatchup_NoMinedSetChurnOnRejectedFork(t *testing.T) {
 		mockBlockchainClient.On("GetBlockExists", mock.Anything, mock.Anything).
 			Return(false, nil).Maybe()
 
-		// Metadata for the common ancestor.
+		// findCommonAncestor now conveys existence through GetBlockHeader: the common
+		// ancestor resolves to its header+meta, while every fork block (and the target)
+		// must report ErrBlockNotFound so the walk stops at the ancestor and the fork
+		// headers are treated as the peer's offered chain. A permissive catch-all that
+		// returned metadata for the fork blocks would make the whole peer chain look
+		// already-present, leaving zero offered headers for the secret-mining check.
 		mockBlockchainClient.On("GetBlockHeader", mock.Anything, ancestorHeader.Hash()).
 			Return(ancestorHeader, &model.BlockHeaderMeta{Height: ancestorHeight, ID: 1, ChainWork: ancestorChainWork.Bytes()}, nil).Maybe()
 		mockBlockchainClient.On("GetBlockHeader", mock.Anything, mock.Anything).
-			Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: ancestorHeight, ChainWork: ancestorChainWork.Bytes()}, nil).Maybe()
+			Return((*model.BlockHeader)(nil), (*model.BlockHeaderMeta)(nil), errors.NewBlockNotFoundError("block not in our chain")).Maybe()
 
 		// Header-fetch plumbing.
 		mockBlockchainClient.On("GetBestBlockHeader", mock.Anything).

--- a/stores/utxo/aerospike/native_op_add_deleted_children_integration_test.go
+++ b/stores/utxo/aerospike/native_op_add_deleted_children_integration_test.go
@@ -1,0 +1,143 @@
+//go:build aerospike
+
+package aerospike
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// sumNamespaceStat reads a numeric Aerospike namespace statistic, summed across
+// every node in the cluster.
+func sumNamespaceStat(t *testing.T, db *Store, stat string) int64 {
+	t.Helper()
+
+	cmd := "namespace/" + db.namespace
+
+	var total int64
+
+	nodes := db.client.Cluster().GetNodes()
+	require.NotEmpty(t, nodes, "cluster must expose at least one node")
+
+	infoPolicy := aerospike.NewInfoPolicy()
+
+	for _, nd := range nodes {
+		info, err := nd.RequestInfo(infoPolicy, cmd)
+		require.NoError(t, err)
+
+		for _, kv := range strings.Split(info[cmd], ";") {
+			name, value, found := strings.Cut(kv, "=")
+			if !found || name != stat {
+				continue
+			}
+
+			v, perr := strconv.ParseInt(value, 10, 64)
+			require.NoError(t, perr)
+
+			total += v
+		}
+	}
+
+	return total
+}
+
+// TestNativeOp_AddDeletedChildren_Integration verifies against a real Teraspike
+// server (the BSV fork of aerospike-server with native operate-path support,
+// wire op 200) that the pruner's addDeletedChildren parent-update — the op that
+// PR #1269 re-routed onto the native builder in the combined cleanup path — runs
+// as a NATIVE batch write (zero batch_sub_udf) and correctly mutates the parent's
+// deletedChildren map.
+//
+// It builds the record via exactly the call GetPrunerService's
+// BuildAddDeletedChildrenRecord uses, so it exercises the shared native path the
+// pruner relies on. Skips cleanly on a stock Aerospike image (native-op probe
+// fails); point at a Teraspike build with AEROSPIKE_CONTAINER_IMAGE to run it.
+func TestNativeOp_AddDeletedChildren_Integration(t *testing.T) {
+	InitPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	ctx := context.Background()
+
+	container, err := runAerospikeTestContainer(ctx)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
+
+	t.Cleanup(func() { require.NoError(t, container.Terminate(ctx)) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	port, err := container.ServicePort(ctx)
+	require.NoError(t, err)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Aerospike.UseNativeTeranodeOps = true
+
+	aeroURL, err := url.Parse(fmt.Sprintf("aerospike://%s:%d/test?set=test&externalStore=file://./data/externalStore", host, port))
+	require.NoError(t, err)
+
+	db, err := New(ctx, logger, tSettings, aeroURL)
+	require.NoError(t, err)
+
+	db.SetExternalStore(memory.New())
+
+	if !db.useNativeTeranodeOps {
+		t.Skipf("native ops not enabled (image %q is not a Teraspike build); set AEROSPIKE_CONTAINER_IMAGE to a native-op server", os.Getenv("AEROSPIKE_CONTAINER_IMAGE"))
+	}
+
+	// Seed a parent record so addDeletedChildren has a record to update
+	// (the op returns TX_NOT_FOUND for a missing record and mutates nothing).
+	var parentHash chainhash.Hash
+	parentHash[0] = 0xAB
+
+	key, err := aerospike.NewKey(db.namespace, db.setName, parentHash[:])
+	require.NoError(t, err)
+	require.NoError(t, db.client.PutBins(nil, key, aerospike.NewBin("seed", 1)))
+
+	var childHash chainhash.Hash
+	childHash[0] = 0xCD
+
+	childList := []interface{}{childHash.String()}
+
+	udfBefore := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+
+	// Build the record exactly as GetPrunerService.BuildAddDeletedChildrenRecord does.
+	rec := db.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key, subOpAddDeletedChildren, "addDeletedChildren", childList)
+
+	_, builtAsUDF := rec.(*aerospike.BatchUDF)
+	require.False(t, builtAsUDF, "a native-op store must build addDeletedChildren as a BatchWrite, not a NewBatchUDF")
+
+	require.NoError(t, db.client.BatchOperate(nil, []aerospike.BatchRecordIfc{rec}))
+	require.NoError(t, rec.BatchRec().Err, "native addDeletedChildren batch operation must succeed")
+
+	// The parent's deletedChildren map must now contain the child hash — proof
+	// the native subOpAddDeletedChildren dispatcher executed server-side.
+	parent, err := db.client.Get(nil, key, fields.DeletedChildren.String())
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+
+	deletedChildren, ok := parent.Bins[fields.DeletedChildren.String()].(map[interface{}]interface{})
+	require.Truef(t, ok, "deletedChildren must be a map, got %T", parent.Bins[fields.DeletedChildren.String()])
+	require.Equal(t, true, deletedChildren[childHash.String()], "child hash must be recorded in the parent's deletedChildren map")
+
+	udfAfter := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+
+	// The decisive check: the parent was mutated (native dispatcher ran) yet the
+	// server's Lua-UDF sub-transaction counter did not move at all. The native
+	// wire-op-200 path is deliberately not counted under batch_sub_udf.
+	require.Equalf(t, udfBefore, udfAfter, "addDeletedChildren must NOT invoke a Lua UDF on a native-op store (batch_sub_udf_complete went %d -> %d)", udfBefore, udfAfter)
+}

--- a/stores/utxo/aerospike/pruner/combined_cleanup_native_op_test.go
+++ b/stores/utxo/aerospike/pruner/combined_cleanup_native_op_test.go
@@ -1,0 +1,99 @@
+package pruner
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// makeParentUpdates builds n distinct parentUpdateInfo entries with valid keys.
+func makeParentUpdates(t *testing.T, n int) map[string]*parentUpdateInfo {
+	t.Helper()
+
+	updates := make(map[string]*parentUpdateInfo, n)
+
+	for i := 0; i < n; i++ {
+		var h chainhash.Hash
+		h[0] = byte(i + 1)
+
+		key, err := aerospike.NewKey("test", "utxo", h[:])
+		require.NoError(t, err)
+
+		updates[h.String()] = &parentUpdateInfo{key: key, childHashes: []*chainhash.Hash{&h}}
+	}
+
+	return updates
+}
+
+// isUDF reports whether a batch record is a Lua NewBatchUDF invocation (as
+// opposed to the native/BatchWrite operate-path).
+func isUDF(rec aerospike.BatchRecordIfc) bool {
+	_, ok := rec.(*aerospike.BatchUDF)
+	return ok
+}
+
+// The combined cleanup path (defensive mode off) must route parent updates
+// through the injected native-op builder when it is present, NOT through a raw
+// Lua NewBatchUDF — even though luaPackage is also set as the fallback. This is
+// the regression that left the pruner emitting a per-block batch_sub_udf burst
+// on native-op-enabled deployments running with defensive mode off.
+func TestBuildCombinedCleanupRecords_PrefersNativeBuilderOverUDF(t *testing.T) {
+	nativeCalls := 0
+
+	s := &Service{
+		luaPackage: "teranode", // provider always sets this as the UDF fallback
+		buildAddDeletedChildrenRecord: func(p *aerospike.BatchUDFPolicy, key *aerospike.Key, childHashes []interface{}) aerospike.BatchRecordIfc {
+			nativeCalls++
+			return aerospike.NewBatchWrite(aerospike.NewBatchWritePolicy(), key, aerospike.TouchOp())
+		},
+	}
+
+	updates := makeParentUpdates(t, 2)
+
+	records, parentEnd, usesModTeranode := s.buildCombinedCleanupRecords(updates, nil)
+
+	require.Equal(t, len(updates), nativeCalls, "native builder must be invoked once per parent update")
+	require.Equal(t, len(updates), parentEnd, "parentEnd must cover exactly the parent-update records")
+	require.True(t, usesModTeranode, "native-op path must be flagged as mod-teranode for SUCCESS-map result parsing")
+
+	for i := 0; i < parentEnd; i++ {
+		require.Falsef(t, isUDF(records[i]), "parent update %d must not be a NewBatchUDF when the native builder is present", i)
+	}
+}
+
+// With no native builder but a lua package configured, the combined path still
+// falls back to the Lua UDF call and flags the mod-teranode SUCCESS-map shape.
+func TestBuildCombinedCleanupRecords_FallsBackToUDFWhenNoNativeBuilder(t *testing.T) {
+	s := &Service{luaPackage: "teranode"}
+
+	updates := makeParentUpdates(t, 2)
+
+	records, parentEnd, usesModTeranode := s.buildCombinedCleanupRecords(updates, nil)
+
+	require.Equal(t, len(updates), parentEnd)
+	require.True(t, usesModTeranode, "UDF path is also a mod-teranode SUCCESS-map path")
+
+	for i := 0; i < parentEnd; i++ {
+		require.Truef(t, isUDF(records[i]), "parent update %d must be a NewBatchUDF when only luaPackage is set", i)
+	}
+}
+
+// With neither a native builder nor a lua package, the combined path uses the
+// plain MapPutItems BatchWrite and reports it is NOT a mod-teranode path (so
+// results are parsed via KEY_NOT_FOUND, not a SUCCESS map).
+func TestBuildCombinedCleanupRecords_PlainMapWriteWhenNoLuaNoNative(t *testing.T) {
+	s := &Service{fieldDeletedChildren: "deletedChildren"}
+
+	updates := makeParentUpdates(t, 2)
+
+	records, parentEnd, usesModTeranode := s.buildCombinedCleanupRecords(updates, nil)
+
+	require.Equal(t, len(updates), parentEnd)
+	require.False(t, usesModTeranode, "plain MapPutItems path must not be flagged as mod-teranode")
+
+	for i := 0; i < parentEnd; i++ {
+		require.Falsef(t, isUDF(records[i]), "parent update %d must be a BatchWrite, not a UDF", i)
+	}
+}

--- a/stores/utxo/aerospike/pruner/parent_update_response_test.go
+++ b/stores/utxo/aerospike/pruner/parent_update_response_test.go
@@ -6,44 +6,83 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNormaliseAddDeletedChildrenResponse covers both response shapes that the
-// addDeletedChildren mod-teranode op may return: the UDF path's
-// map[interface{}]interface{} and the native-op path's map[string]interface{}.
-// The pruner's per-record handler dereferences `respMap["status"]` so both
-// shapes must round-trip into a single interface-keyed map.
-func TestNormaliseAddDeletedChildrenResponse(t *testing.T) {
-	t.Run("interface-keyed map passes through unchanged", func(t *testing.T) {
-		in := map[interface{}]interface{}{
+// TestAddDeletedChildrenStatus covers both response shapes that the
+// addDeletedChildren mod-teranode op may return — the UDF path's
+// map[interface{}]interface{} and the native-op path's map[string]interface{} —
+// and the classification the pruner's per-record handler keys on. In particular
+// the ERROR/TX_NOT_FOUND case is the branch that decides whether a missing parent
+// is treated as a benign skip or a hard cleanup failure, so it is asserted for
+// both shapes (the native path's TX_NOT_FOUND handling had no direct coverage).
+func TestAddDeletedChildrenStatus(t *testing.T) {
+	t.Run("interface-keyed OK", func(t *testing.T) {
+		status, errCode, errMsg, ok := addDeletedChildrenStatus(map[interface{}]interface{}{
 			"status":    "OK",
 			"errorCode": "",
-		}
-
-		out, ok := normaliseAddDeletedChildrenResponse(in)
+		})
 		require.True(t, ok)
-		require.Equal(t, "OK", out["status"])
-		require.Equal(t, "", out["errorCode"])
+		require.Equal(t, "OK", status)
+		require.Empty(t, errCode)
+		require.Empty(t, errMsg)
 	})
 
-	t.Run("string-keyed map is rekeyed to interface-keyed", func(t *testing.T) {
-		in := map[string]interface{}{
+	t.Run("string-keyed OK (native-op shape)", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status":    "OK",
+			"errorCode": "",
+		})
+		require.True(t, ok)
+		require.Equal(t, "OK", status)
+		require.Empty(t, errCode)
+	})
+
+	t.Run("interface-keyed ERROR TX_NOT_FOUND", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus(map[interface{}]interface{}{
 			"status":    "ERROR",
 			"errorCode": "TX_NOT_FOUND",
-		}
-
-		out, ok := normaliseAddDeletedChildrenResponse(in)
+		})
 		require.True(t, ok)
-		require.Equal(t, "ERROR", out["status"])
-		require.Equal(t, "TX_NOT_FOUND", out["errorCode"])
+		require.Equal(t, "ERROR", status)
+		require.Equal(t, "TX_NOT_FOUND", errCode)
+	})
+
+	t.Run("string-keyed ERROR TX_NOT_FOUND (native-op shape)", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status":    "ERROR",
+			"errorCode": "TX_NOT_FOUND",
+		})
+		require.True(t, ok)
+		require.Equal(t, "ERROR", status)
+		require.Equal(t, "TX_NOT_FOUND", errCode)
+	})
+
+	t.Run("string-keyed ERROR with message", func(t *testing.T) {
+		status, errCode, errMsg, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status":       "ERROR",
+			"errorCode":    "SOME_FAILURE",
+			"errorMessage": "boom",
+		})
+		require.True(t, ok)
+		require.Equal(t, "ERROR", status)
+		require.Equal(t, "SOME_FAILURE", errCode)
+		require.Equal(t, "boom", errMsg)
+	})
+
+	t.Run("map without a string status reports not-ok (caller falls through to success)", func(t *testing.T) {
+		_, _, _, ok := addDeletedChildrenStatus(map[interface{}]interface{}{"errorCode": "X"})
+		require.False(t, ok)
+
+		_, _, _, ok = addDeletedChildrenStatus(map[string]interface{}{"status": 42})
+		require.False(t, ok)
 	})
 
 	t.Run("unrecognised shape returns false", func(t *testing.T) {
-		_, ok := normaliseAddDeletedChildrenResponse("not-a-map")
+		_, _, _, ok := addDeletedChildrenStatus("not-a-map")
 		require.False(t, ok)
 
-		_, ok = normaliseAddDeletedChildrenResponse(nil)
+		_, _, _, ok = addDeletedChildrenStatus(nil)
 		require.False(t, ok)
 
-		_, ok = normaliseAddDeletedChildrenResponse(42)
+		_, _, _, ok = addDeletedChildrenStatus(42)
 		require.False(t, ok)
 	})
 }

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -1572,38 +1572,46 @@ func (s *Service) flushCleanupBatches(ctx context.Context, parentUpdates map[str
 	return nil
 }
 
-// executeBatchCleanupCombined sends parent UDF updates and child record
-// deletions in a SINGLE Aerospike BatchOperate call. Halves the round-trip
-// count vs the two-call path. Only safe when defensive mode is off (because
-// the defensive safety check has an implicit ordering dependency between
-// parent.deletedChildren writes and child record deletions).
-func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[string]*parentUpdateInfo, keys []*aerospike.Key) error {
-	if len(updates) == 0 && len(keys) == 0 {
-		return nil
-	}
+// buildCombinedCleanupRecords builds the batch records for the single-round-trip
+// combined cleanup: parent updates in [0, parentEnd) followed by child deletions
+// in [parentEnd, len).
+//
+// Parent updates prefer the injected native-op builder
+// (buildAddDeletedChildrenRecord → native subOpAddDeletedChildren), fall back to
+// a direct Lua NewBatchUDF, and finally to a plain MapPutItems BatchWrite when
+// neither mod-teranode path is configured. This mirrors executeBatchParentUpdates:
+// keying the choice purely on luaPackage (the old behaviour) ignored the native
+// builder and left the pruner emitting batch_sub_udf on native-op deployments
+// with defensive mode off.
+//
+// parentUsesModTeranode reports whether the parent-update records carry a
+// mod-teranode SUCCESS-map response (native or UDF, both silent on missing
+// parents) rather than the plain BatchWrite path (missing parent → KEY_NOT_FOUND).
+// The caller uses it to parse the batch results.
+func (s *Service) buildCombinedCleanupRecords(updates map[string]*parentUpdateInfo, keys []*aerospike.Key) (batchRecords []aerospike.BatchRecordIfc, parentEnd int, parentUsesModTeranode bool) {
+	batchRecords = make([]aerospike.BatchRecordIfc, 0, len(updates)+len(keys))
 
-	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(updates)+len(keys))
+	parentUsesModTeranode = s.buildAddDeletedChildrenRecord != nil || s.luaPackage != ""
 
-	// Parent updates: prefer Lua UDF (silent on missing parents — no
-	// KEY_NOT_FOUND noise in client metrics) and fall back to a plain
-	// BatchWrite+MapPutItems if no Lua package is configured.
-	parentEnd := 0
-	useUDF := s.luaPackage != ""
 	if len(updates) > 0 {
-		if useUDF {
+		if parentUsesModTeranode {
 			batchUDFPolicy := aerospike.NewBatchUDFPolicy()
 			for _, info := range updates {
 				childHashList := make([]interface{}, 0, len(info.childHashes))
 				for _, childHash := range info.childHashes {
 					childHashList = append(childHashList, childHash.String())
 				}
-				batchRecords = append(batchRecords, aerospike.NewBatchUDF(
-					batchUDFPolicy,
-					info.key,
-					s.luaPackage,
-					"addDeletedChildren",
-					aerospike.NewValue(childHashList),
-				))
+				if s.buildAddDeletedChildrenRecord != nil {
+					batchRecords = append(batchRecords, s.buildAddDeletedChildrenRecord(batchUDFPolicy, info.key, childHashList))
+				} else {
+					batchRecords = append(batchRecords, aerospike.NewBatchUDF(
+						batchUDFPolicy,
+						info.key,
+						s.luaPackage,
+						"addDeletedChildren",
+						aerospike.NewValue(childHashList),
+					))
+				}
 			}
 		} else {
 			batchWritePolicy := aerospike.NewBatchWritePolicy()
@@ -1619,6 +1627,7 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 			}
 		}
 	}
+
 	parentEnd = len(batchRecords)
 
 	// Child deletions — TTL touch (utxoSetTTL=true) or hard delete.
@@ -1637,6 +1646,21 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 			}
 		}
 	}
+
+	return batchRecords, parentEnd, parentUsesModTeranode
+}
+
+// executeBatchCleanupCombined sends parent updates and child record deletions in
+// a SINGLE Aerospike BatchOperate call. Halves the round-trip count vs the
+// two-call path. Only safe when defensive mode is off (because the defensive
+// safety check has an implicit ordering dependency between parent.deletedChildren
+// writes and child record deletions).
+func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[string]*parentUpdateInfo, keys []*aerospike.Key) error {
+	if len(updates) == 0 && len(keys) == 0 {
+		return nil
+	}
+
+	batchRecords, parentEnd, parentUsesModTeranode := s.buildCombinedCleanupRecords(updates, keys)
 
 	if len(batchRecords) == 0 {
 		return nil
@@ -1671,8 +1695,10 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 		if i < parentEnd {
 			// Parent update result
 			if batchRec.Err != nil {
-				// BatchWrite path surfaces missing parents as KEY_NOT_FOUND
-				if !useUDF && batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
+				// Plain MapPutItems BatchWrite path surfaces missing parents as
+				// KEY_NOT_FOUND; the mod-teranode paths (native + UDF) handle
+				// missing parents server-side and never surface it here.
+				if !parentUsesModTeranode && batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
 					parentNotFound++
 					continue
 				}
@@ -1682,10 +1708,12 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 				parentErrors++
 				continue
 			}
-			// UDF path returns a SUCCESS/ERROR map in the record bins
-			if useUDF && batchRec.Record != nil && batchRec.Record.Bins != nil {
+			// mod-teranode paths (native + UDF) return a SUCCESS/ERROR map in the
+			// record bins; the UDF path yields map[interface{}]interface{} and the
+			// native-op dispatcher yields map[string]interface{}.
+			if parentUsesModTeranode && batchRec.Record != nil && batchRec.Record.Bins != nil {
 				if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
-					if respMap, ok := resp.(map[interface{}]interface{}); ok {
+					if respMap, ok := normaliseAddDeletedChildrenResponse(resp); ok {
 						if status, ok := respMap["status"].(string); ok {
 							switch status {
 							case "OK":

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -1572,6 +1572,38 @@ func (s *Service) flushCleanupBatches(ctx context.Context, parentUpdates map[str
 	return nil
 }
 
+// buildParentUpdateRecords builds the addDeletedChildren parent-update batch
+// records on the mod-teranode path: it prefers the injected native-op builder
+// (buildAddDeletedChildrenRecord → native subOpAddDeletedChildren) and falls back
+// to a direct Lua NewBatchUDF. Callers must only invoke it when the mod-teranode
+// path is active (buildAddDeletedChildrenRecord != nil || luaPackage != ""); it
+// is shared by the combined and two-call cleanup paths so the two never diverge.
+func (s *Service) buildParentUpdateRecords(updates map[string]*parentUpdateInfo) []aerospike.BatchRecordIfc {
+	batchUDFPolicy := aerospike.NewBatchUDFPolicy()
+	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(updates))
+
+	for _, info := range updates {
+		childHashList := make([]interface{}, 0, len(info.childHashes))
+		for _, childHash := range info.childHashes {
+			childHashList = append(childHashList, childHash.String())
+		}
+
+		if s.buildAddDeletedChildrenRecord != nil {
+			batchRecords = append(batchRecords, s.buildAddDeletedChildrenRecord(batchUDFPolicy, info.key, childHashList))
+		} else {
+			batchRecords = append(batchRecords, aerospike.NewBatchUDF(
+				batchUDFPolicy,
+				info.key,
+				s.luaPackage,
+				"addDeletedChildren",
+				aerospike.NewValue(childHashList),
+			))
+		}
+	}
+
+	return batchRecords
+}
+
 // buildCombinedCleanupRecords builds the batch records for the single-round-trip
 // combined cleanup: parent updates in [0, parentEnd) followed by child deletions
 // in [parentEnd, len).
@@ -1595,24 +1627,7 @@ func (s *Service) buildCombinedCleanupRecords(updates map[string]*parentUpdateIn
 
 	if len(updates) > 0 {
 		if parentUsesModTeranode {
-			batchUDFPolicy := aerospike.NewBatchUDFPolicy()
-			for _, info := range updates {
-				childHashList := make([]interface{}, 0, len(info.childHashes))
-				for _, childHash := range info.childHashes {
-					childHashList = append(childHashList, childHash.String())
-				}
-				if s.buildAddDeletedChildrenRecord != nil {
-					batchRecords = append(batchRecords, s.buildAddDeletedChildrenRecord(batchUDFPolicy, info.key, childHashList))
-				} else {
-					batchRecords = append(batchRecords, aerospike.NewBatchUDF(
-						batchUDFPolicy,
-						info.key,
-						s.luaPackage,
-						"addDeletedChildren",
-						aerospike.NewValue(childHashList),
-					))
-				}
-			}
+			batchRecords = append(batchRecords, s.buildParentUpdateRecords(updates)...)
 		} else {
 			batchWritePolicy := aerospike.NewBatchWritePolicy()
 			batchWritePolicy.RecordExistsAction = aerospike.UPDATE_ONLY
@@ -1713,29 +1728,25 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 			// native-op dispatcher yields map[string]interface{}.
 			if parentUsesModTeranode && batchRec.Record != nil && batchRec.Record.Bins != nil {
 				if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
-					if respMap, ok := normaliseAddDeletedChildrenResponse(resp); ok {
-						if status, ok := respMap["status"].(string); ok {
-							switch status {
-							case "OK":
-								parentSuccess++
-							case "ERROR":
-								if errCode, ok := respMap["errorCode"].(string); ok && errCode == "TX_NOT_FOUND" {
-									parentNotFound++
-								} else {
-									parentErrors++
-									// UDF-path errors don't carry an
-									// aerospike.Error; synthesise one
-									// describing the UDF response so the
-									// returned error chain isn't empty.
-									if firstParentErr == nil {
-										errCode, _ := respMap["errorCode"].(string)
-										errMsg, _ := respMap["errorMessage"].(string)
-										firstParentErr = errors.NewProcessingError("UDF parent update returned ERROR (code=%q, message=%q)", errCode, errMsg)
-									}
+					if status, errCode, errMsg, ok := addDeletedChildrenStatus(resp); ok {
+						switch status {
+						case "OK":
+							parentSuccess++
+						case "ERROR":
+							if errCode == "TX_NOT_FOUND" {
+								parentNotFound++
+							} else {
+								parentErrors++
+								// UDF-path errors don't carry an
+								// aerospike.Error; synthesise one
+								// describing the UDF response so the
+								// returned error chain isn't empty.
+								if firstParentErr == nil {
+									firstParentErr = errors.NewProcessingError("UDF parent update returned ERROR (code=%q, message=%q)", errCode, errMsg)
 								}
 							}
-							continue
 						}
+						continue
 					}
 				}
 			}
@@ -1824,30 +1835,7 @@ func (s *Service) executeBatchParentUpdates(ctx context.Context, updates map[str
 // records are handled server-side, avoiding KEY_NOT_FOUND noise in Aerospike
 // client metrics.
 func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[string]*parentUpdateInfo) error {
-	batchUDFPolicy := aerospike.NewBatchUDFPolicy()
-	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(updates))
-
-	for _, info := range updates {
-		childHashList := make([]interface{}, 0, len(info.childHashes))
-		for _, childHash := range info.childHashes {
-			childHashList = append(childHashList, childHash.String())
-		}
-
-		var record aerospike.BatchRecordIfc
-		if s.buildAddDeletedChildrenRecord != nil {
-			record = s.buildAddDeletedChildrenRecord(batchUDFPolicy, info.key, childHashList)
-		} else {
-			record = aerospike.NewBatchUDF(
-				batchUDFPolicy,
-				info.key,
-				s.luaPackage,
-				"addDeletedChildren",
-				aerospike.NewValue(childHashList),
-			)
-		}
-
-		batchRecords = append(batchRecords, record)
-	}
+	batchRecords := s.buildParentUpdateRecords(updates)
 
 	select {
 	case <-ctx.Done():
@@ -1877,24 +1865,21 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 			if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
 				// The UDF path returns map[interface{}]interface{}; the native-op
 				// dispatcher decodes the same Lua-style response as
-				// map[string]interface{}. Normalise to the former so the rest of
-				// the handler reads as before.
-				respMap, ok := normaliseAddDeletedChildrenResponse(resp)
-				if ok {
-					if status, ok := respMap["status"].(string); ok {
-						switch status {
-						case "OK":
-							successCount++
-						case "ERROR":
-							if errCode, ok := respMap["errorCode"].(string); ok && errCode == "TX_NOT_FOUND" {
-								notFoundCount++
-							} else {
-								s.logger.Errorf("Parent update Lua error for key %v: %v", batchRec.Key, respMap)
-								errorCount++
-							}
+				// map[string]interface{}. addDeletedChildrenStatus reads both
+				// shapes without copying the map.
+				if status, errCode, _, ok := addDeletedChildrenStatus(resp); ok {
+					switch status {
+					case "OK":
+						successCount++
+					case "ERROR":
+						if errCode == "TX_NOT_FOUND" {
+							notFoundCount++
+						} else {
+							s.logger.Errorf("Parent update Lua error for key %v: code=%q", batchRec.Key, errCode)
+							errorCount++
 						}
-						continue
 					}
+					continue
 				}
 			}
 		}
@@ -1917,22 +1902,32 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 	return nil
 }
 
-// normaliseAddDeletedChildrenResponse converts both response shapes the
-// addDeletedChildren mod-teranode op may return (legacy UDF path:
-// map[interface{}]interface{}; native-op path: map[string]interface{}) into
-// a single interface-keyed map. Returns false if the value isn't either.
-func normaliseAddDeletedChildrenResponse(v interface{}) (map[interface{}]interface{}, bool) {
-	switch m := v.(type) {
+// addDeletedChildrenStatus reads the status / errorCode / errorMessage fields
+// from the SUCCESS map returned by the addDeletedChildren mod-teranode op,
+// without allocating a copy of the map (this runs once per parent update on the
+// per-block cleanup hot path). Both response shapes are handled: the legacy UDF
+// path yields map[interface{}]interface{}; the native-op dispatcher yields
+// map[string]interface{}.
+//
+// ok reports that resp is one of those two map shapes AND carries a string
+// "status" field — matching the old two-step (normalise + status type-assert)
+// guard, so callers fall through to their default success handling unchanged
+// when the response has no parseable status.
+func addDeletedChildrenStatus(resp interface{}) (status, errorCode, errorMessage string, ok bool) {
+	switch m := resp.(type) {
 	case map[interface{}]interface{}:
-		return m, true
+		status, ok = m["status"].(string)
+		errorCode, _ = m["errorCode"].(string)
+		errorMessage, _ = m["errorMessage"].(string)
 	case map[string]interface{}:
-		out := make(map[interface{}]interface{}, len(m))
-		for k, val := range m {
-			out[k] = val
-		}
-		return out, true
+		status, ok = m["status"].(string)
+		errorCode, _ = m["errorCode"].(string)
+		errorMessage, _ = m["errorMessage"].(string)
+	default:
+		return "", "", "", false
 	}
-	return nil, false
+
+	return status, errorCode, errorMessage, ok
 }
 
 // executeBatchParentUpdatesBatchWrite is the fallback when Lua UDF is not configured.


### PR DESCRIPTION
Follow-up to #828. The native-ops migration left the pruner still emitting a per-block Lua UDF burst on native-op-enabled deployments.

## Problem

Observed on the scaling clusters: with native ops fully enabled (probe passing on all services), the spend/setMined hot path is native (`batch_sub_write`), but `batch_sub_udf_complete` still climbs in a **per-block burst up to ~3.5M/s**. Traced to the pruner's `addDeletedChildren` parent-update.

The pruner has two cleanup paths:

- `executeBatchParentUpdates` (defensive mode on, two-call) — correctly prefers the injected `buildAddDeletedChildrenRecord` native-op builder.
- `executeBatchCleanupCombined` (defensive mode off, single round-trip) — chose UDF-vs-native purely on `luaPackage != ""`, **ignoring the native builder entirely**.

`pruner_provider.go` always injects the native builder *and* sets `LuaPackage` as the fallback, so the combined path always emitted a raw `NewBatchUDF`. Deployments run `pruner_utxoDefensiveEnabled=false` (the default) → combined path → the exact `batch_sub_udf` stream #828 set out to eliminate.

## Fix

- Extract record-building into `buildCombinedCleanupRecords`, which prefers the native builder, falls back to `NewBatchUDF`, then to the plain MapPutItems `BatchWrite` — mirroring `executeBatchParentUpdates`.
- Result parsing keys on `parentUsesModTeranode` (native + UDF both return a SUCCESS map and handle missing parents server-side) instead of `useUDF`, and normalises the native dispatcher's `map[string]interface{}` response via the existing `normaliseAddDeletedChildrenResponse`.

## Tests

- **Unit** (`combined_cleanup_native_op_test.go`): record routing for all three paths — native builder present, UDF fallback, plain MapPutItems.
- **Integration** (`native_op_add_deleted_children_integration_test.go`, build tag `aerospike`): against a real **Teraspike** server (BSV fork, wire op 200), asserts the store's native probe enables native ops, the record is a `BatchWrite` (not `NewBatchUDF`), the parent's `deletedChildren` map is mutated server-side, and the server's `batch_sub_udf_complete` counter does **not** move. Guarded by the build tag so it stays out of the default `go test`; skips cleanly on a stock Aerospike image. Verified locally against `aerospike-server:8.1.2.0-rc-9`.
- `go vet` (tagged + untagged) / `golangci-lint` clean on the changed files.