### PR TITLE
fix(validator): bound parent vout before extend deref (backport #1243 to release/v0.15)

### DIFF
--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -1025,14 +1025,22 @@ func (v *Validator) getUtxoBlockHeightAndExtendForParentTx(gCtx context.Context,
 					tx.TxIDChainHash().String(), idx, len(tx.Inputs))
 			}
 
-			if txMeta.Tx == nil || txMeta.Tx.Outputs == nil || txMeta.Tx.Outputs[tx.Inputs[idx].PreviousTxOutIndex] == nil {
-				return errors.NewProcessingError("[Validate][%s] parent transaction %s does not have outputs for input index %d",
-					tx.TxIDChainHash().String(), parentTxHash.String(), idx)
+			// PreviousTxOutIndex comes from the (untrusted) child transaction, so
+			// bound it against the parent's output count BEFORE indexing. Otherwise a
+			// tx referencing a real parent but a non-existent vout (e.g. vout 2 on a
+			// 2-output parent) panics here with index out of range and crashes the
+			// validator. This is the reachable half of #1243 that the v0.15.4 backport
+			// (ea6d8ce76) omitted.
+			vout := tx.Inputs[idx].PreviousTxOutIndex
+			if txMeta.Tx == nil || txMeta.Tx.Outputs == nil ||
+				int(vout) >= len(txMeta.Tx.Outputs) || txMeta.Tx.Outputs[vout] == nil {
+				return errors.NewProcessingError("[Validate][%s] parent transaction %s has no output for index %d",
+					tx.TxIDChainHash().String(), parentTxHash.String(), vout)
 			}
 
 			// extend the input with the parent tx outputs
-			tx.Inputs[idx].PreviousTxSatoshis = txMeta.Tx.Outputs[tx.Inputs[idx].PreviousTxOutIndex].Satoshis
-			tx.Inputs[idx].PreviousTxScript = txMeta.Tx.Outputs[tx.Inputs[idx].PreviousTxOutIndex].LockingScript
+			tx.Inputs[idx].PreviousTxSatoshis = txMeta.Tx.Outputs[vout].Satoshis
+			tx.Inputs[idx].PreviousTxScript = txMeta.Tx.Outputs[vout].LockingScript
 		}
 	}
 

--- a/services/validator/validator_vout_bounds_test.go
+++ b/services/validator/validator_vout_bounds_test.go
@@ -1,0 +1,52 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_getUtxoBlockHeightAndExtendForParentTx_VoutOutOfRange is a regression test
+// for the validator crash reported on v0.15.2/v0.15.4: a child tx whose input
+// references a non-existent output index (vout) of a real parent panicked at
+// txMeta.Tx.Outputs[PreviousTxOutIndex] with "index out of range" and killed the
+// validator process. The extend path must reject an out-of-range vout with a
+// clean processing error, not panic.
+//
+// The v0.15.4 backport (ea6d8ce76) ported only the unreachable idx>=len half of
+// #1243 and omitted this reachable bound, so the deref stayed unguarded.
+func Test_getUtxoBlockHeightAndExtendForParentTx_VoutOutOfRange(t *testing.T) {
+	ctx := context.Background()
+
+	// Child tx: single validly-indexed input (idx 0) whose PreviousTxOutIndex
+	// points past the parent's outputs.
+	childTx := &bt.Tx{Inputs: []*bt.Input{{PreviousTxOutIndex: 99}}}
+	utxoHeights := make([]uint32, len(childTx.Inputs))
+
+	parentHash := chainhash.Hash{}
+
+	// Parent exists and is confirmed, but has only 2 outputs (vouts 0 and 1).
+	parentMeta := &meta.Data{
+		BlockHeights: []uint32{100},
+		Tx:           &bt.Tx{Outputs: []*bt.Output{{}, {}}},
+	}
+
+	mockStore := &utxostore.MockUtxostore{}
+	mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(parentMeta, nil)
+
+	v := &Validator{settings: settings.NewSettings(), utxoStore: mockStore}
+
+	// extend=true forces the parent-output dereference path. nil validationOptions
+	// is handled (the ParentMetadata shortcut is nil-guarded), so the store Get
+	// path is taken.
+	err := v.getUtxoBlockHeightAndExtendForParentTx(ctx, parentHash, []int{0}, utxoHeights, childTx, true, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "has no output for index")
+}


### PR DESCRIPTION
v0.15.4 (`ea6d8ce76`) backported only the unreachable `idx >= len` half of #1243 and dropped the half that stops the crash: bounding the untrusted `PreviousTxOutIndex` before indexing `txMeta.Tx.Outputs` in the validator's transaction-validation path. A child spending a non-existent vout of a real parent (e.g. vout 2 on a 2-output parent) still panics the validator with `index out of range` on v0.15.4 — an operator hit exactly this in prod (`getUtxoBlockHeightAndExtendForParentTx`). It is reachable via tx/subtree validation of peer-supplied transactions, so it's a remotely-triggerable crash/DoS.

## Scope
This fixes the validator-helper path only — the exact path the reported crash occurred on. It is a faithful, complete backport of #1243 (which likewise only touched this helper).

It does **not** cover the block-validation quick-validate path (`services/blockvalidation/quick_validate.go`), which dereferences the same untrusted vout unguarded and is a separate, pre-existing gap present on `main` too. Raised by @ctnguyen in review (ChiR1) and tracked as a main-first follow-up — see #1283.

## Fix
Adds the vout bound to the extend path in `getUtxoBlockHeightAndExtendForParentTx`. Because Go `||` short-circuits, `int(vout) >= len(txMeta.Tx.Outputs)` runs before the deref, so an out-of-range vout returns a clean processing error instead of panicking. The guard is identical to the one already on `main` from #1243.

## Test
Standalone store-based regression test. The upstream PR's test (`validator_prefetched_parents_test.go`) depends on prefetched-parents (#1118), which is not on this release train, so the test is rewritten against the UTXO-store path. It reproduces the panic on current `release/v0.15` and passes with the guard.

## Verification
- Test fails (panics `index out of range [99] with length 2`) on unpatched `release/v0.15`, passes after the guard.
- Full validator package green under `-race`; `go vet`, `gofmt`, `golangci-lint` clean.

## Ship path
Cut `v0.15.5-beta-1` from this, have the affected operator confirm no panic, then promote to `v0.15.5`. Block-validation path (#1283) handled separately, main-first.

Refs #1243