### PR TITLE
fix(legacy): rotate sync peer on OnBlock pre-admission timeout (#1277)

### DIFF
--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -943,11 +943,25 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte, payl
 
 	if err == nil {
 		// Ban-check round-trip bounded by preAdmitCtx. ok=false means the query
-		// send or its reply was cancelled/timed out before an answer arrived, so
-		// drop the block rather than park the read-loop on a wedged query goroutine.
+		// send or its reply was cancelled/timed out before an answer arrived.
 		isBanned, ok := sp.checkBannedBounded(preAdmitCtx, host)
 		if !ok {
-			sp.server.logger.Warnf("dropping block %s: ban-check timed out/cancelled for peer %s", msg.BlockHash(), sp)
+			// A pre-admission DEADLINE means the query path is wedged: the block
+			// was solicited (netsync marked it requested and fetchHeaderBlocks
+			// already advanced startHeader past it), so silently dropping it
+			// strands the hash — nothing re-requests it and IBD stalls on this
+			// single block. Rotate the sync peer instead: the primary disconnect
+			// drives handleDonePeerMsg → updateSyncPeer → startSync, which clears
+			// requestedBlocks and re-drives the fetch from a fresh locator
+			// (restoring the pre-prefetch watchdog behaviour). On parent cancel
+			// (daemon shutdown / peer teardown) just drop the block.
+			if preAdmitTimedOut(preAdmitCtx) {
+				disconnectMisbehaving(sp, fmt.Sprintf("pre-admission ban-check timed out for block %s, disconnecting to trigger sync peer rotation", msg.BlockHash()))
+				return
+			}
+
+			sp.server.logger.Warnf("dropping block %s: ban-check cancelled by teardown for peer %s", msg.BlockHash(), sp)
+
 			return
 		}
 
@@ -979,10 +993,23 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte, payl
 	sp.AddKnownInventory(iv)
 
 	// single round-trip: GetBlockHeader tells us both existence and validity.
-	// preAdmitCtx bounds this lookup (see the pre-admission timeout above); a
-	// timed-out lookup returns an error → blockIsKnownValid=false, so the block
-	// proceeds as "not known valid" exactly as an errored lookup does today.
+	// preAdmitCtx bounds this lookup (see the pre-admission timeout above).
 	_, meta, err := sp.server.blockchainClient.GetBlockHeader(preAdmitCtx, blockHash)
+	if err != nil && preAdmitCtx.Err() != nil {
+		// The lookup was cut short by the pre-admission context, so the error
+		// says nothing about whether we already have the block. Proceeding as
+		// "not known valid" would charge a possibly known-valid block against
+		// the prefetch budget and fully re-validate it. On a genuine deadline,
+		// treat the wedged lookup like the wedged ban-check above: rotate the
+		// sync peer so netsync re-drives the fetch. On parent cancel (daemon
+		// shutdown / peer teardown) just drop the block.
+		if preAdmitTimedOut(preAdmitCtx) {
+			disconnectMisbehaving(sp, fmt.Sprintf("pre-admission header lookup timed out for block %s, disconnecting to trigger sync peer rotation", blockHash))
+		}
+
+		return
+	}
+
 	blockIsKnownValid := err == nil && !meta.Invalid
 
 	if !blockIsKnownValid {
@@ -1143,6 +1170,16 @@ func (sp *serverPeer) checkBannedBounded(ctx context.Context, host string) (bann
 	case <-ctx.Done():
 		return false, false
 	}
+}
+
+// preAdmitTimedOut reports whether a failed pre-admission call should rotate
+// the sync peer: true only when the pre-admission context hit its own deadline
+// (a wedged local round-trip that stranded a requested block), not when the
+// parent context was cancelled (daemon shutdown / peer teardown), where the
+// block is simply dropped. Callers must only consult this after the
+// pre-admission call has actually failed.
+func preAdmitTimedOut(preAdmitCtx context.Context) bool {
+	return errors.Is(preAdmitCtx.Err(), context.DeadlineExceeded)
 }
 
 // shouldDisconnectOnBlockErr reports whether a block-processing error should

--- a/services/legacy/peer_server_test.go
+++ b/services/legacy/peer_server_test.go
@@ -1226,6 +1226,50 @@ func TestCheckBannedBounded(t *testing.T) {
 	})
 }
 
+// TestPreAdmitTimedOut verifies the deadline-vs-cancel policy OnBlock uses to
+// decide whether a failed pre-admission call (ban-check ok=false, or a
+// GetBlockHeader that erred under preAdmitCtx) should rotate the sync peer.
+// Only a genuine deadline (the wedged-local-round-trip case that strands a
+// requested block) returns true; a parent or direct cancel — daemon shutdown /
+// peer teardown — returns false so the block is dropped without a disconnect
+// storm across every peer that happens to be inside OnBlock.
+func TestPreAdmitTimedOut(t *testing.T) {
+	t.Run("deadline exceeded → rotate", func(t *testing.T) {
+		// Already-past deadline: Err() latches context.DeadlineExceeded.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+		require.True(t, preAdmitTimedOut(ctx))
+	})
+
+	t.Run("parent cancelled → drop, no rotate", func(t *testing.T) {
+		// The daemon-shutdown shape: sp.ctx (parent) is cancelled, so the
+		// derived preAdmitCtx reports Canceled, not DeadlineExceeded.
+		parent, cancelParent := context.WithCancel(context.Background())
+		child, cancelChild := context.WithTimeout(parent, time.Hour)
+		defer cancelChild()
+
+		cancelParent()
+
+		<-child.Done()
+		require.ErrorIs(t, child.Err(), context.Canceled)
+		require.False(t, preAdmitTimedOut(child))
+	})
+
+	t.Run("direct cancel → drop, no rotate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.False(t, preAdmitTimedOut(ctx))
+	})
+
+	t.Run("live context → no rotate (defensive; callers gate on failure)", func(t *testing.T) {
+		require.False(t, preAdmitTimedOut(context.Background()))
+	})
+}
+
 // TestBlockAdmissionWeight verifies the prefetch-budget weight selection used by
 // OnBlock: the wire-measured payload size is preferred, then the raw buffer
 // length, and only as a last resort the O(all-tx) SerializeSize() walk.


### PR DESCRIPTION
Fixes #1277. Follow-up from #1190; parent #1189.

## Problem
PR #1190's pre-admission liveness bound (`preAdmitCtx`) let `OnBlock` treat a context expiry as if it were a real result, regressing two cases versus the pre-prefetch armed-watchdog path:

1. **Ban-check timeout stranded a requested block.** `checkBannedBounded` `ok=false` dropped the block but never cleared its `requestedBlocks` entry. In headers-first mode `fetchHeaderBlocks` has already advanced `startHeader` past the hash, so nothing re-requests it → single-block IBD stall.
2. **Header-lookup timeout reprocessed a known-valid block.** A `GetBlockHeader` that erred under a fired `preAdmitCtx` forced `blockIsKnownValid=false`, admitting a block we may already have against the prefetch budget for a full re-validation.

Both share one root: a `preAdmitCtx` timeout is indistinguishable from a genuine result (not-banned / not-found), and each branch picks the wrong degraded behaviour.

## Fix
On a `preAdmitCtx` **deadline** (`context.DeadlineExceeded`, not a parent cancel) in either pre-admission call, rotate the sync peer via `disconnectMisbehaving`. The primary disconnect drives `handleDonePeerMsg → updateSyncPeer → startSync`, which clears `requestedBlocks` and re-drives the fetch from a fresh locator — restoring the pre-prefetch watchdog behaviour and recovering the stranded block.

A bare `requestedBlocks` delete is **not** sufficient: the headers-first cursor (`startHeader`) has already advanced past the hash, so deleting the entry makes the block eligible but nothing issues the request. Rotation is what actually re-drives.

On **parent cancel** (daemon shutdown / peer teardown) the block is dropped without a disconnect, so shutdown does not storm every peer currently inside `OnBlock`.

Extracts `preAdmitTimedOut` for the deadline-vs-cancel decision (mirroring the `checkBannedBounded` / `shouldDisconnectOnBlockErr` pattern) so the policy is a single, unit-tested point.

## Tests
- New `TestPreAdmitTimedOut` (table-driven): deadline → rotate; parent cancel / direct cancel / live ctx → no rotate. The parent-cancel case is load-bearing — it proves shutdown does not disconnect-storm.
- All existing legacy pre-admission tests unchanged and green.

## Verification
```
go vet ./services/legacy/...
go test -race ./services/legacy/            # ok
go test -race ./services/legacy/netsync/    # ok (rotation path)
```
