### PR TITLE
p2p: track catchup-specific counters in the peer registry

### DIFF
--- a/services/asset/httpimpl/get_peers.go
+++ b/services/asset/httpimpl/get_peers.go
@@ -99,10 +99,11 @@ func (h *HTTP) GetPeers(c echo.Context) error {
 			LastBlockTime:   peer.LastBlockTime.Unix(),
 			LastMessageTime: peer.LastMessageTime.Unix(),
 
-			// Interaction/catchup metrics (using the original field names for backward compatibility)
-			CatchupAttempts:        peer.InteractionAttempts,
-			CatchupSuccesses:       peer.InteractionSuccesses,
-			CatchupFailures:        peer.InteractionFailures,
+			// Catchup-specific counters (timestamps below remain the generic
+			// interaction ones; catchup-scoped timestamps are not tracked).
+			CatchupAttempts:        peer.CatchupAttempts,
+			CatchupSuccesses:       peer.CatchupSuccesses,
+			CatchupFailures:        peer.CatchupFailures,
 			CatchupLastAttempt:     peer.LastInteractionAttempt.Unix(),
 			CatchupLastSuccess:     peer.LastInteractionSuccess.Unix(),
 			CatchupLastFailure:     peer.LastInteractionFailure.Unix(),

--- a/services/blockchain/blockchain_api/blockchain_api.pb.go
+++ b/services/blockchain/blockchain_api/blockchain_api.pb.go
@@ -3915,8 +3915,13 @@ type PeerRegistryInfo struct {
 	LastValidatedAt           *timestamppb.Timestamp `protobuf:"bytes,40,opt,name=last_validated_at,json=lastValidatedAt,proto3" json:"last_validated_at,omitempty"`
 	FullStorageContradictions int64                  `protobuf:"varint,41,opt,name=full_storage_contradictions,json=fullStorageContradictions,proto3" json:"full_storage_contradictions,omitempty"` // Count of observed contradictions to full-storage claims
 	FullStoragePenaltyUntil   *timestamppb.Timestamp `protobuf:"bytes,42,opt,name=full_storage_penalty_until,json=fullStoragePenaltyUntil,proto3" json:"full_storage_penalty_until,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// Catchup-specific counters, maintained via RecordCatchupAttempt/Success/Failure.
+	// Distinct from the generic interaction counters, which mix in blocks/subtrees/txs.
+	CatchupAttempts  int64 `protobuf:"varint,43,opt,name=catchup_attempts,json=catchupAttempts,proto3" json:"catchup_attempts,omitempty"`
+	CatchupSuccesses int64 `protobuf:"varint,44,opt,name=catchup_successes,json=catchupSuccesses,proto3" json:"catchup_successes,omitempty"`
+	CatchupFailures  int64 `protobuf:"varint,45,opt,name=catchup_failures,json=catchupFailures,proto3" json:"catchup_failures,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PeerRegistryInfo) Reset() {
@@ -4241,6 +4246,27 @@ func (x *PeerRegistryInfo) GetFullStoragePenaltyUntil() *timestamppb.Timestamp {
 		return x.FullStoragePenaltyUntil
 	}
 	return nil
+}
+
+func (x *PeerRegistryInfo) GetCatchupAttempts() int64 {
+	if x != nil {
+		return x.CatchupAttempts
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetCatchupSuccesses() int64 {
+	if x != nil {
+		return x.CatchupSuccesses
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetCatchupFailures() int64 {
+	if x != nil {
+		return x.CatchupFailures
+	}
+	return 0
 }
 
 // RegisterPeerRequest registers or updates a peer in the centralized registry.
@@ -5327,6 +5353,149 @@ func (x *RecordCatchupErrorRequest) GetErrorMessage() string {
 	return ""
 }
 
+// RecordCatchupAttemptRequest records a catchup attempt against a peer.
+type RecordCatchupAttemptRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PeerId        string                 `protobuf:"bytes,1,opt,name=peer_id,json=peerId,proto3" json:"peer_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RecordCatchupAttemptRequest) Reset() {
+	*x = RecordCatchupAttemptRequest{}
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[92]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordCatchupAttemptRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordCatchupAttemptRequest) ProtoMessage() {}
+
+func (x *RecordCatchupAttemptRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[92]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordCatchupAttemptRequest.ProtoReflect.Descriptor instead.
+func (*RecordCatchupAttemptRequest) Descriptor() ([]byte, []int) {
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{92}
+}
+
+func (x *RecordCatchupAttemptRequest) GetPeerId() string {
+	if x != nil {
+		return x.PeerId
+	}
+	return ""
+}
+
+// RecordCatchupSuccessRequest records a successful catchup from a peer.
+type RecordCatchupSuccessRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	PeerId         string                 `protobuf:"bytes,1,opt,name=peer_id,json=peerId,proto3" json:"peer_id,omitempty"`
+	ResponseTimeMs int64                  `protobuf:"varint,2,opt,name=response_time_ms,json=responseTimeMs,proto3" json:"response_time_ms,omitempty"` // Duration of the catchup operation (0 = not applicable)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RecordCatchupSuccessRequest) Reset() {
+	*x = RecordCatchupSuccessRequest{}
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[93]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordCatchupSuccessRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordCatchupSuccessRequest) ProtoMessage() {}
+
+func (x *RecordCatchupSuccessRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[93]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordCatchupSuccessRequest.ProtoReflect.Descriptor instead.
+func (*RecordCatchupSuccessRequest) Descriptor() ([]byte, []int) {
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{93}
+}
+
+func (x *RecordCatchupSuccessRequest) GetPeerId() string {
+	if x != nil {
+		return x.PeerId
+	}
+	return ""
+}
+
+func (x *RecordCatchupSuccessRequest) GetResponseTimeMs() int64 {
+	if x != nil {
+		return x.ResponseTimeMs
+	}
+	return 0
+}
+
+// RecordCatchupFailureRequest records a failed catchup attempt against a peer.
+type RecordCatchupFailureRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PeerId        string                 `protobuf:"bytes,1,opt,name=peer_id,json=peerId,proto3" json:"peer_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RecordCatchupFailureRequest) Reset() {
+	*x = RecordCatchupFailureRequest{}
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[94]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordCatchupFailureRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordCatchupFailureRequest) ProtoMessage() {}
+
+func (x *RecordCatchupFailureRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[94]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordCatchupFailureRequest.ProtoReflect.Descriptor instead.
+func (*RecordCatchupFailureRequest) Descriptor() ([]byte, []int) {
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{94}
+}
+
+func (x *RecordCatchupFailureRequest) GetPeerId() string {
+	if x != nil {
+		return x.PeerId
+	}
+	return ""
+}
+
 // ResetReputationRequest resets reputation for a single peer or all peers when peer_id is empty.
 type ResetReputationRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -5337,7 +5506,7 @@ type ResetReputationRequest struct {
 
 func (x *ResetReputationRequest) Reset() {
 	*x = ResetReputationRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[92]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5349,7 +5518,7 @@ func (x *ResetReputationRequest) String() string {
 func (*ResetReputationRequest) ProtoMessage() {}
 
 func (x *ResetReputationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[92]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5362,7 +5531,7 @@ func (x *ResetReputationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetReputationRequest.ProtoReflect.Descriptor instead.
 func (*ResetReputationRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{92}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *ResetReputationRequest) GetPeerId() string {
@@ -5382,7 +5551,7 @@ type ResetReputationResponse struct {
 
 func (x *ResetReputationResponse) Reset() {
 	*x = ResetReputationResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[93]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5394,7 +5563,7 @@ func (x *ResetReputationResponse) String() string {
 func (*ResetReputationResponse) ProtoMessage() {}
 
 func (x *ResetReputationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[93]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5407,7 +5576,7 @@ func (x *ResetReputationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetReputationResponse.ProtoReflect.Descriptor instead.
 func (*ResetReputationResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{93}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ResetReputationResponse) GetReset_() int32 {
@@ -5427,7 +5596,7 @@ type ReconsiderBadPeersRequest struct {
 
 func (x *ReconsiderBadPeersRequest) Reset() {
 	*x = ReconsiderBadPeersRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[94]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5439,7 +5608,7 @@ func (x *ReconsiderBadPeersRequest) String() string {
 func (*ReconsiderBadPeersRequest) ProtoMessage() {}
 
 func (x *ReconsiderBadPeersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[94]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5452,7 +5621,7 @@ func (x *ReconsiderBadPeersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReconsiderBadPeersRequest.ProtoReflect.Descriptor instead.
 func (*ReconsiderBadPeersRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{94}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ReconsiderBadPeersRequest) GetCooldownSeconds() int64 {
@@ -5472,7 +5641,7 @@ type ReconsiderBadPeersResponse struct {
 
 func (x *ReconsiderBadPeersResponse) Reset() {
 	*x = ReconsiderBadPeersResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[95]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5484,7 +5653,7 @@ func (x *ReconsiderBadPeersResponse) String() string {
 func (*ReconsiderBadPeersResponse) ProtoMessage() {}
 
 func (x *ReconsiderBadPeersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[95]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5497,7 +5666,7 @@ func (x *ReconsiderBadPeersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReconsiderBadPeersResponse.ProtoReflect.Descriptor instead.
 func (*ReconsiderBadPeersResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{95}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ReconsiderBadPeersResponse) GetReconsidered() int32 {
@@ -5518,7 +5687,7 @@ type GetBlockLocatorRequest struct {
 
 func (x *GetBlockLocatorRequest) Reset() {
 	*x = GetBlockLocatorRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[96]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5530,7 +5699,7 @@ func (x *GetBlockLocatorRequest) String() string {
 func (*GetBlockLocatorRequest) ProtoMessage() {}
 
 func (x *GetBlockLocatorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[96]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5543,7 +5712,7 @@ func (x *GetBlockLocatorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlockLocatorRequest.ProtoReflect.Descriptor instead.
 func (*GetBlockLocatorRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{96}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *GetBlockLocatorRequest) GetHash() []byte {
@@ -5570,7 +5739,7 @@ type GetBlockLocatorResponse struct {
 
 func (x *GetBlockLocatorResponse) Reset() {
 	*x = GetBlockLocatorResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[97]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5582,7 +5751,7 @@ func (x *GetBlockLocatorResponse) String() string {
 func (*GetBlockLocatorResponse) ProtoMessage() {}
 
 func (x *GetBlockLocatorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[97]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5595,7 +5764,7 @@ func (x *GetBlockLocatorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlockLocatorResponse.ProtoReflect.Descriptor instead.
 func (*GetBlockLocatorResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{97}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *GetBlockLocatorResponse) GetLocator() [][]byte {
@@ -5617,7 +5786,7 @@ type LocateBlockHeadersRequest struct {
 
 func (x *LocateBlockHeadersRequest) Reset() {
 	*x = LocateBlockHeadersRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[98]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5629,7 +5798,7 @@ func (x *LocateBlockHeadersRequest) String() string {
 func (*LocateBlockHeadersRequest) ProtoMessage() {}
 
 func (x *LocateBlockHeadersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[98]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5642,7 +5811,7 @@ func (x *LocateBlockHeadersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocateBlockHeadersRequest.ProtoReflect.Descriptor instead.
 func (*LocateBlockHeadersRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{98}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *LocateBlockHeadersRequest) GetLocator() [][]byte {
@@ -5676,7 +5845,7 @@ type LocateBlockHeadersResponse struct {
 
 func (x *LocateBlockHeadersResponse) Reset() {
 	*x = LocateBlockHeadersResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[99]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5688,7 +5857,7 @@ func (x *LocateBlockHeadersResponse) String() string {
 func (*LocateBlockHeadersResponse) ProtoMessage() {}
 
 func (x *LocateBlockHeadersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[99]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5701,7 +5870,7 @@ func (x *LocateBlockHeadersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocateBlockHeadersResponse.ProtoReflect.Descriptor instead.
 func (*LocateBlockHeadersResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{99}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *LocateBlockHeadersResponse) GetBlockHeaders() [][]byte {
@@ -5722,7 +5891,7 @@ type GetBestHeightAndTimeResponse struct {
 
 func (x *GetBestHeightAndTimeResponse) Reset() {
 	*x = GetBestHeightAndTimeResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[100]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5734,7 +5903,7 @@ func (x *GetBestHeightAndTimeResponse) String() string {
 func (*GetBestHeightAndTimeResponse) ProtoMessage() {}
 
 func (x *GetBestHeightAndTimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[100]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5747,7 +5916,7 @@ func (x *GetBestHeightAndTimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBestHeightAndTimeResponse.ProtoReflect.Descriptor instead.
 func (*GetBestHeightAndTimeResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{100}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *GetBestHeightAndTimeResponse) GetHeight() uint32 {
@@ -5774,7 +5943,7 @@ type GetChainTipsResponse struct {
 
 func (x *GetChainTipsResponse) Reset() {
 	*x = GetChainTipsResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[101]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5786,7 +5955,7 @@ func (x *GetChainTipsResponse) String() string {
 func (*GetChainTipsResponse) ProtoMessage() {}
 
 func (x *GetChainTipsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[101]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5799,7 +5968,7 @@ func (x *GetChainTipsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChainTipsResponse.ProtoReflect.Descriptor instead.
 func (*GetChainTipsResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{101}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetChainTipsResponse) GetTips() []*model.ChainTip {
@@ -5822,7 +5991,7 @@ type ReportPeerFailureRequest struct {
 
 func (x *ReportPeerFailureRequest) Reset() {
 	*x = ReportPeerFailureRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[102]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5834,7 +6003,7 @@ func (x *ReportPeerFailureRequest) String() string {
 func (*ReportPeerFailureRequest) ProtoMessage() {}
 
 func (x *ReportPeerFailureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[102]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5847,7 +6016,7 @@ func (x *ReportPeerFailureRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportPeerFailureRequest.ProtoReflect.Descriptor instead.
 func (*ReportPeerFailureRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{102}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ReportPeerFailureRequest) GetHash() []byte {
@@ -5888,7 +6057,7 @@ type SetBlockPersistedAtRequest struct {
 
 func (x *SetBlockPersistedAtRequest) Reset() {
 	*x = SetBlockPersistedAtRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[103]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5900,7 +6069,7 @@ func (x *SetBlockPersistedAtRequest) String() string {
 func (*SetBlockPersistedAtRequest) ProtoMessage() {}
 
 func (x *SetBlockPersistedAtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[103]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5913,7 +6082,7 @@ func (x *SetBlockPersistedAtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetBlockPersistedAtRequest.ProtoReflect.Descriptor instead.
 func (*SetBlockPersistedAtRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{103}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *SetBlockPersistedAtRequest) GetBlockHash() []byte {
@@ -5933,7 +6102,7 @@ type GetBlocksNotPersistedRequest struct {
 
 func (x *GetBlocksNotPersistedRequest) Reset() {
 	*x = GetBlocksNotPersistedRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[104]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5945,7 +6114,7 @@ func (x *GetBlocksNotPersistedRequest) String() string {
 func (*GetBlocksNotPersistedRequest) ProtoMessage() {}
 
 func (x *GetBlocksNotPersistedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[104]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5958,7 +6127,7 @@ func (x *GetBlocksNotPersistedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlocksNotPersistedRequest.ProtoReflect.Descriptor instead.
 func (*GetBlocksNotPersistedRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{104}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *GetBlocksNotPersistedRequest) GetLimit() int32 {
@@ -5978,7 +6147,7 @@ type GetBlocksNotPersistedResponse struct {
 
 func (x *GetBlocksNotPersistedResponse) Reset() {
 	*x = GetBlocksNotPersistedResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[105]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5990,7 +6159,7 @@ func (x *GetBlocksNotPersistedResponse) String() string {
 func (*GetBlocksNotPersistedResponse) ProtoMessage() {}
 
 func (x *GetBlocksNotPersistedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[105]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6003,7 +6172,7 @@ func (x *GetBlocksNotPersistedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBlocksNotPersistedResponse.ProtoReflect.Descriptor instead.
 func (*GetBlocksNotPersistedResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{105}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *GetBlocksNotPersistedResponse) GetBlockBytes() [][]byte {
@@ -6025,7 +6194,7 @@ type ScheduleBlobDeletionRequest struct {
 
 func (x *ScheduleBlobDeletionRequest) Reset() {
 	*x = ScheduleBlobDeletionRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[106]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6037,7 +6206,7 @@ func (x *ScheduleBlobDeletionRequest) String() string {
 func (*ScheduleBlobDeletionRequest) ProtoMessage() {}
 
 func (x *ScheduleBlobDeletionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[106]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6050,7 +6219,7 @@ func (x *ScheduleBlobDeletionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleBlobDeletionRequest.ProtoReflect.Descriptor instead.
 func (*ScheduleBlobDeletionRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{106}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ScheduleBlobDeletionRequest) GetBlobKey() []byte {
@@ -6092,7 +6261,7 @@ type ScheduleBlobDeletionResponse struct {
 
 func (x *ScheduleBlobDeletionResponse) Reset() {
 	*x = ScheduleBlobDeletionResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[107]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6104,7 +6273,7 @@ func (x *ScheduleBlobDeletionResponse) String() string {
 func (*ScheduleBlobDeletionResponse) ProtoMessage() {}
 
 func (x *ScheduleBlobDeletionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[107]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6117,7 +6286,7 @@ func (x *ScheduleBlobDeletionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleBlobDeletionResponse.ProtoReflect.Descriptor instead.
 func (*ScheduleBlobDeletionResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{107}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ScheduleBlobDeletionResponse) GetDeletionId() int64 {
@@ -6153,7 +6322,7 @@ type CancelBlobDeletionRequest struct {
 
 func (x *CancelBlobDeletionRequest) Reset() {
 	*x = CancelBlobDeletionRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[108]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6165,7 +6334,7 @@ func (x *CancelBlobDeletionRequest) String() string {
 func (*CancelBlobDeletionRequest) ProtoMessage() {}
 
 func (x *CancelBlobDeletionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[108]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6178,7 +6347,7 @@ func (x *CancelBlobDeletionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelBlobDeletionRequest.ProtoReflect.Descriptor instead.
 func (*CancelBlobDeletionRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{108}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *CancelBlobDeletionRequest) GetBlobKey() []byte {
@@ -6219,7 +6388,7 @@ type CancelBlobDeletionResponse struct {
 
 func (x *CancelBlobDeletionResponse) Reset() {
 	*x = CancelBlobDeletionResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[109]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6231,7 +6400,7 @@ func (x *CancelBlobDeletionResponse) String() string {
 func (*CancelBlobDeletionResponse) ProtoMessage() {}
 
 func (x *CancelBlobDeletionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[109]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6244,7 +6413,7 @@ func (x *CancelBlobDeletionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelBlobDeletionResponse.ProtoReflect.Descriptor instead.
 func (*CancelBlobDeletionResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{109}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *CancelBlobDeletionResponse) GetCancelled() bool {
@@ -6275,7 +6444,7 @@ type ListScheduledDeletionsRequest struct {
 
 func (x *ListScheduledDeletionsRequest) Reset() {
 	*x = ListScheduledDeletionsRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[110]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6287,7 +6456,7 @@ func (x *ListScheduledDeletionsRequest) String() string {
 func (*ListScheduledDeletionsRequest) ProtoMessage() {}
 
 func (x *ListScheduledDeletionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[110]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6300,7 +6469,7 @@ func (x *ListScheduledDeletionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListScheduledDeletionsRequest.ProtoReflect.Descriptor instead.
 func (*ListScheduledDeletionsRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{110}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ListScheduledDeletionsRequest) GetMinHeight() uint32 {
@@ -6359,7 +6528,7 @@ type ScheduledDeletion struct {
 
 func (x *ScheduledDeletion) Reset() {
 	*x = ScheduledDeletion{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[111]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6371,7 +6540,7 @@ func (x *ScheduledDeletion) String() string {
 func (*ScheduledDeletion) ProtoMessage() {}
 
 func (x *ScheduledDeletion) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[111]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6384,7 +6553,7 @@ func (x *ScheduledDeletion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduledDeletion.ProtoReflect.Descriptor instead.
 func (*ScheduledDeletion) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{111}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ScheduledDeletion) GetId() int64 {
@@ -6439,7 +6608,7 @@ type ListScheduledDeletionsResponse struct {
 
 func (x *ListScheduledDeletionsResponse) Reset() {
 	*x = ListScheduledDeletionsResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[112]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6451,7 +6620,7 @@ func (x *ListScheduledDeletionsResponse) String() string {
 func (*ListScheduledDeletionsResponse) ProtoMessage() {}
 
 func (x *ListScheduledDeletionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[112]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6464,7 +6633,7 @@ func (x *ListScheduledDeletionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListScheduledDeletionsResponse.ProtoReflect.Descriptor instead.
 func (*ListScheduledDeletionsResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{112}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ListScheduledDeletionsResponse) GetDeletions() []*ScheduledDeletion {
@@ -6491,7 +6660,7 @@ type GetPendingBlobDeletionsRequest struct {
 
 func (x *GetPendingBlobDeletionsRequest) Reset() {
 	*x = GetPendingBlobDeletionsRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[113]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6503,7 +6672,7 @@ func (x *GetPendingBlobDeletionsRequest) String() string {
 func (*GetPendingBlobDeletionsRequest) ProtoMessage() {}
 
 func (x *GetPendingBlobDeletionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[113]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6516,7 +6685,7 @@ func (x *GetPendingBlobDeletionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPendingBlobDeletionsRequest.ProtoReflect.Descriptor instead.
 func (*GetPendingBlobDeletionsRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{113}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *GetPendingBlobDeletionsRequest) GetHeight() uint32 {
@@ -6542,7 +6711,7 @@ type GetPendingBlobDeletionsResponse struct {
 
 func (x *GetPendingBlobDeletionsResponse) Reset() {
 	*x = GetPendingBlobDeletionsResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[114]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6554,7 +6723,7 @@ func (x *GetPendingBlobDeletionsResponse) String() string {
 func (*GetPendingBlobDeletionsResponse) ProtoMessage() {}
 
 func (x *GetPendingBlobDeletionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[114]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6567,7 +6736,7 @@ func (x *GetPendingBlobDeletionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPendingBlobDeletionsResponse.ProtoReflect.Descriptor instead.
 func (*GetPendingBlobDeletionsResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{114}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *GetPendingBlobDeletionsResponse) GetDeletions() []*ScheduledDeletion {
@@ -6586,7 +6755,7 @@ type RemoveBlobDeletionRequest struct {
 
 func (x *RemoveBlobDeletionRequest) Reset() {
 	*x = RemoveBlobDeletionRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[115]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6598,7 +6767,7 @@ func (x *RemoveBlobDeletionRequest) String() string {
 func (*RemoveBlobDeletionRequest) ProtoMessage() {}
 
 func (x *RemoveBlobDeletionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[115]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6611,7 +6780,7 @@ func (x *RemoveBlobDeletionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveBlobDeletionRequest.ProtoReflect.Descriptor instead.
 func (*RemoveBlobDeletionRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{115}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *RemoveBlobDeletionRequest) GetDeletionId() int64 {
@@ -6631,7 +6800,7 @@ type IncrementBlobDeletionRetryRequest struct {
 
 func (x *IncrementBlobDeletionRetryRequest) Reset() {
 	*x = IncrementBlobDeletionRetryRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[116]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6643,7 +6812,7 @@ func (x *IncrementBlobDeletionRetryRequest) String() string {
 func (*IncrementBlobDeletionRetryRequest) ProtoMessage() {}
 
 func (x *IncrementBlobDeletionRetryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[116]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6656,7 +6825,7 @@ func (x *IncrementBlobDeletionRetryRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use IncrementBlobDeletionRetryRequest.ProtoReflect.Descriptor instead.
 func (*IncrementBlobDeletionRetryRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{116}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *IncrementBlobDeletionRetryRequest) GetDeletionId() int64 {
@@ -6683,7 +6852,7 @@ type IncrementBlobDeletionRetryResponse struct {
 
 func (x *IncrementBlobDeletionRetryResponse) Reset() {
 	*x = IncrementBlobDeletionRetryResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[117]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6695,7 +6864,7 @@ func (x *IncrementBlobDeletionRetryResponse) String() string {
 func (*IncrementBlobDeletionRetryResponse) ProtoMessage() {}
 
 func (x *IncrementBlobDeletionRetryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[117]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6708,7 +6877,7 @@ func (x *IncrementBlobDeletionRetryResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use IncrementBlobDeletionRetryResponse.ProtoReflect.Descriptor instead.
 func (*IncrementBlobDeletionRetryResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{117}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *IncrementBlobDeletionRetryResponse) GetShouldRemove() bool {
@@ -6736,7 +6905,7 @@ type CompleteBlobDeletionsRequest struct {
 
 func (x *CompleteBlobDeletionsRequest) Reset() {
 	*x = CompleteBlobDeletionsRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[118]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6748,7 +6917,7 @@ func (x *CompleteBlobDeletionsRequest) String() string {
 func (*CompleteBlobDeletionsRequest) ProtoMessage() {}
 
 func (x *CompleteBlobDeletionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[118]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6761,7 +6930,7 @@ func (x *CompleteBlobDeletionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompleteBlobDeletionsRequest.ProtoReflect.Descriptor instead.
 func (*CompleteBlobDeletionsRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{118}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *CompleteBlobDeletionsRequest) GetCompletedIds() []int64 {
@@ -6795,7 +6964,7 @@ type CompleteBlobDeletionsResponse struct {
 
 func (x *CompleteBlobDeletionsResponse) Reset() {
 	*x = CompleteBlobDeletionsResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[119]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6807,7 +6976,7 @@ func (x *CompleteBlobDeletionsResponse) String() string {
 func (*CompleteBlobDeletionsResponse) ProtoMessage() {}
 
 func (x *CompleteBlobDeletionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[119]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6820,7 +6989,7 @@ func (x *CompleteBlobDeletionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompleteBlobDeletionsResponse.ProtoReflect.Descriptor instead.
 func (*CompleteBlobDeletionsResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{119}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *CompleteBlobDeletionsResponse) GetRemovedCount() int32 {
@@ -6848,7 +7017,7 @@ type AcquireBlobDeletionBatchRequest struct {
 
 func (x *AcquireBlobDeletionBatchRequest) Reset() {
 	*x = AcquireBlobDeletionBatchRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[120]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6860,7 +7029,7 @@ func (x *AcquireBlobDeletionBatchRequest) String() string {
 func (*AcquireBlobDeletionBatchRequest) ProtoMessage() {}
 
 func (x *AcquireBlobDeletionBatchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[120]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6873,7 +7042,7 @@ func (x *AcquireBlobDeletionBatchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcquireBlobDeletionBatchRequest.ProtoReflect.Descriptor instead.
 func (*AcquireBlobDeletionBatchRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{120}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AcquireBlobDeletionBatchRequest) GetHeight() uint32 {
@@ -6907,7 +7076,7 @@ type AcquireBlobDeletionBatchResponse struct {
 
 func (x *AcquireBlobDeletionBatchResponse) Reset() {
 	*x = AcquireBlobDeletionBatchResponse{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[121]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6919,7 +7088,7 @@ func (x *AcquireBlobDeletionBatchResponse) String() string {
 func (*AcquireBlobDeletionBatchResponse) ProtoMessage() {}
 
 func (x *AcquireBlobDeletionBatchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[121]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6932,7 +7101,7 @@ func (x *AcquireBlobDeletionBatchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcquireBlobDeletionBatchResponse.ProtoReflect.Descriptor instead.
 func (*AcquireBlobDeletionBatchResponse) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{121}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *AcquireBlobDeletionBatchResponse) GetBatchToken() string {
@@ -6961,7 +7130,7 @@ type CompleteBlobDeletionBatchRequest struct {
 
 func (x *CompleteBlobDeletionBatchRequest) Reset() {
 	*x = CompleteBlobDeletionBatchRequest{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[122]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6973,7 +7142,7 @@ func (x *CompleteBlobDeletionBatchRequest) String() string {
 func (*CompleteBlobDeletionBatchRequest) ProtoMessage() {}
 
 func (x *CompleteBlobDeletionBatchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[122]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6986,7 +7155,7 @@ func (x *CompleteBlobDeletionBatchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompleteBlobDeletionBatchRequest.ProtoReflect.Descriptor instead.
 func (*CompleteBlobDeletionBatchRequest) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{122}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *CompleteBlobDeletionBatchRequest) GetBatchToken() string {
@@ -7029,7 +7198,7 @@ type BatchTokenInfo struct {
 
 func (x *BatchTokenInfo) Reset() {
 	*x = BatchTokenInfo{}
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[123]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7041,7 +7210,7 @@ func (x *BatchTokenInfo) String() string {
 func (*BatchTokenInfo) ProtoMessage() {}
 
 func (x *BatchTokenInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[123]
+	mi := &file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7054,7 +7223,7 @@ func (x *BatchTokenInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchTokenInfo.ProtoReflect.Descriptor instead.
 func (*BatchTokenInfo) Descriptor() ([]byte, []int) {
-	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{123}
+	return file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *BatchTokenInfo) GetToken() string {
@@ -7324,7 +7493,7 @@ const file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc = "" 
 	"\x13GetFSMStateResponse\x122\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x1c.blockchain_api.FSMStateTypeR\x05state\"I\n" +
 	"\x13SendFSMEventRequest\x122\n" +
-	"\x05event\x18\x01 \x01(\x0e2\x1c.blockchain_api.FSMEventTypeR\x05event\"\x96\x11\n" +
+	"\x05event\x18\x01 \x01(\x0e2\x1c.blockchain_api.FSMEventTypeR\x05event\"\x99\x12\n" +
 	"\x10PeerRegistryInfo\x12\x17\n" +
 	"\apeer_id\x18\x01 \x01(\tR\x06peerId\x12D\n" +
 	"\x0etransport_type\x18\x02 \x01(\x0e2\x1d.blockchain_api.TransportTypeR\rtransportType\x12\x1f\n" +
@@ -7372,7 +7541,10 @@ const file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc = "" 
 	"\x14validated_chain_work\x18' \x01(\fR\x12validatedChainWork\x12F\n" +
 	"\x11last_validated_at\x18( \x01(\v2\x1a.google.protobuf.TimestampR\x0flastValidatedAt\x12>\n" +
 	"\x1bfull_storage_contradictions\x18) \x01(\x03R\x19fullStorageContradictions\x12W\n" +
-	"\x1afull_storage_penalty_until\x18* \x01(\v2\x1a.google.protobuf.TimestampR\x17fullStoragePenaltyUntil\"K\n" +
+	"\x1afull_storage_penalty_until\x18* \x01(\v2\x1a.google.protobuf.TimestampR\x17fullStoragePenaltyUntil\x12)\n" +
+	"\x10catchup_attempts\x18+ \x01(\x03R\x0fcatchupAttempts\x12+\n" +
+	"\x11catchup_successes\x18, \x01(\x03R\x10catchupSuccesses\x12)\n" +
+	"\x10catchup_failures\x18- \x01(\x03R\x0fcatchupFailures\"K\n" +
 	"\x13RegisterPeerRequest\x124\n" +
 	"\x04peer\x18\x01 \x01(\v2 .blockchain_api.PeerRegistryInfoR\x04peer\"\x93\x01\n" +
 	"\"RecordValidatedPeerProgressRequest\x12\x17\n" +
@@ -7438,7 +7610,14 @@ const file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc = "" 
 	"\x10response_time_ms\x18\x02 \x01(\x03R\x0eresponseTimeMs\"Y\n" +
 	"\x19RecordCatchupErrorRequest\x12\x17\n" +
 	"\apeer_id\x18\x01 \x01(\tR\x06peerId\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"1\n" +
+	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"6\n" +
+	"\x1bRecordCatchupAttemptRequest\x12\x17\n" +
+	"\apeer_id\x18\x01 \x01(\tR\x06peerId\"`\n" +
+	"\x1bRecordCatchupSuccessRequest\x12\x17\n" +
+	"\apeer_id\x18\x01 \x01(\tR\x06peerId\x12(\n" +
+	"\x10response_time_ms\x18\x02 \x01(\x03R\x0eresponseTimeMs\"6\n" +
+	"\x1bRecordCatchupFailureRequest\x12\x17\n" +
+	"\apeer_id\x18\x01 \x01(\tR\x06peerId\"1\n" +
 	"\x16ResetReputationRequest\x12\x17\n" +
 	"\apeer_id\x18\x01 \x01(\tR\x06peerId\"/\n" +
 	"\x17ResetReputationResponse\x12\x14\n" +
@@ -7648,7 +7827,7 @@ const file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc = "" 
 	"\x1aIncrementBlobDeletionRetry\x121.blockchain_api.IncrementBlobDeletionRetryRequest\x1a2.blockchain_api.IncrementBlobDeletionRetryResponse\"\x00\x12v\n" +
 	"\x15CompleteBlobDeletions\x12,.blockchain_api.CompleteBlobDeletionsRequest\x1a-.blockchain_api.CompleteBlobDeletionsResponse\"\x00\x12\x7f\n" +
 	"\x18AcquireBlobDeletionBatch\x12/.blockchain_api.AcquireBlobDeletionBatchRequest\x1a0.blockchain_api.AcquireBlobDeletionBatchResponse\"\x00\x12g\n" +
-	"\x19CompleteBlobDeletionBatch\x120.blockchain_api.CompleteBlobDeletionBatchRequest\x1a\x16.google.protobuf.Empty\"\x002\xf6\x0e\n" +
+	"\x19CompleteBlobDeletionBatch\x120.blockchain_api.CompleteBlobDeletionBatchRequest\x1a\x16.google.protobuf.Empty\"\x002\x93\x11\n" +
 	"\x13PeerRegistryService\x12M\n" +
 	"\fRegisterPeer\x12#.blockchain_api.RegisterPeerRequest\x1a\x16.google.protobuf.Empty\"\x00\x12W\n" +
 	"\x11UpdatePeerMetrics\x12(.blockchain_api.UpdatePeerMetricsRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n" +
@@ -7668,7 +7847,10 @@ const file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc = "" 
 	"\x13RecordBlockReceived\x12%.blockchain_api.RecordReceivedRequest\x1a\x16.google.protobuf.Empty\"\x00\x12X\n" +
 	"\x15RecordSubtreeReceived\x12%.blockchain_api.RecordReceivedRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\\\n" +
 	"\x19RecordTransactionReceived\x12%.blockchain_api.RecordReceivedRequest\x1a\x16.google.protobuf.Empty\"\x00\x12Y\n" +
-	"\x12RecordCatchupError\x12).blockchain_api.RecordCatchupErrorRequest\x1a\x16.google.protobuf.Empty\"\x00\x12d\n" +
+	"\x12RecordCatchupError\x12).blockchain_api.RecordCatchupErrorRequest\x1a\x16.google.protobuf.Empty\"\x00\x12]\n" +
+	"\x14RecordCatchupAttempt\x12+.blockchain_api.RecordCatchupAttemptRequest\x1a\x16.google.protobuf.Empty\"\x00\x12]\n" +
+	"\x14RecordCatchupSuccess\x12+.blockchain_api.RecordCatchupSuccessRequest\x1a\x16.google.protobuf.Empty\"\x00\x12]\n" +
+	"\x14RecordCatchupFailure\x12+.blockchain_api.RecordCatchupFailureRequest\x1a\x16.google.protobuf.Empty\"\x00\x12d\n" +
 	"\x0fResetReputation\x12&.blockchain_api.ResetReputationRequest\x1a'.blockchain_api.ResetReputationResponse\"\x00\x12m\n" +
 	"\x12ReconsiderBadPeers\x12).blockchain_api.ReconsiderBadPeersRequest\x1a*.blockchain_api.ReconsiderBadPeersResponse\"\x00\x12k\n" +
 	"\x1bRecordValidatedPeerProgress\x122.blockchain_api.RecordValidatedPeerProgressRequest\x1a\x16.google.protobuf.Empty\"\x00B\x13Z\x11./;blockchain_apib\x06proto3"
@@ -7686,7 +7868,7 @@ func file_services_blockchain_blockchain_api_blockchain_api_proto_rawDescGZIP() 
 }
 
 var file_services_blockchain_blockchain_api_blockchain_api_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes = make([]protoimpl.MessageInfo, 125)
+var file_services_blockchain_blockchain_api_blockchain_api_proto_msgTypes = make([]protoimpl.MessageInfo, 128)
 var file_services_blockchain_blockchain_api_blockchain_api_proto_goTypes = []any{
 	(FSMEventType)(0),                                   // 0: blockchain_api.FSMEventType
 	(TransportType)(0),                                  // 1: blockchain_api.TransportType
@@ -7783,89 +7965,92 @@ var file_services_blockchain_blockchain_api_blockchain_api_proto_goTypes = []any
 	(*ClearAllSyncAttemptsResponse)(nil),                // 92: blockchain_api.ClearAllSyncAttemptsResponse
 	(*RecordReceivedRequest)(nil),                       // 93: blockchain_api.RecordReceivedRequest
 	(*RecordCatchupErrorRequest)(nil),                   // 94: blockchain_api.RecordCatchupErrorRequest
-	(*ResetReputationRequest)(nil),                      // 95: blockchain_api.ResetReputationRequest
-	(*ResetReputationResponse)(nil),                     // 96: blockchain_api.ResetReputationResponse
-	(*ReconsiderBadPeersRequest)(nil),                   // 97: blockchain_api.ReconsiderBadPeersRequest
-	(*ReconsiderBadPeersResponse)(nil),                  // 98: blockchain_api.ReconsiderBadPeersResponse
-	(*GetBlockLocatorRequest)(nil),                      // 99: blockchain_api.GetBlockLocatorRequest
-	(*GetBlockLocatorResponse)(nil),                     // 100: blockchain_api.GetBlockLocatorResponse
-	(*LocateBlockHeadersRequest)(nil),                   // 101: blockchain_api.LocateBlockHeadersRequest
-	(*LocateBlockHeadersResponse)(nil),                  // 102: blockchain_api.LocateBlockHeadersResponse
-	(*GetBestHeightAndTimeResponse)(nil),                // 103: blockchain_api.GetBestHeightAndTimeResponse
-	(*GetChainTipsResponse)(nil),                        // 104: blockchain_api.GetChainTipsResponse
-	(*ReportPeerFailureRequest)(nil),                    // 105: blockchain_api.ReportPeerFailureRequest
-	(*SetBlockPersistedAtRequest)(nil),                  // 106: blockchain_api.SetBlockPersistedAtRequest
-	(*GetBlocksNotPersistedRequest)(nil),                // 107: blockchain_api.GetBlocksNotPersistedRequest
-	(*GetBlocksNotPersistedResponse)(nil),               // 108: blockchain_api.GetBlocksNotPersistedResponse
-	(*ScheduleBlobDeletionRequest)(nil),                 // 109: blockchain_api.ScheduleBlobDeletionRequest
-	(*ScheduleBlobDeletionResponse)(nil),                // 110: blockchain_api.ScheduleBlobDeletionResponse
-	(*CancelBlobDeletionRequest)(nil),                   // 111: blockchain_api.CancelBlobDeletionRequest
-	(*CancelBlobDeletionResponse)(nil),                  // 112: blockchain_api.CancelBlobDeletionResponse
-	(*ListScheduledDeletionsRequest)(nil),               // 113: blockchain_api.ListScheduledDeletionsRequest
-	(*ScheduledDeletion)(nil),                           // 114: blockchain_api.ScheduledDeletion
-	(*ListScheduledDeletionsResponse)(nil),              // 115: blockchain_api.ListScheduledDeletionsResponse
-	(*GetPendingBlobDeletionsRequest)(nil),              // 116: blockchain_api.GetPendingBlobDeletionsRequest
-	(*GetPendingBlobDeletionsResponse)(nil),             // 117: blockchain_api.GetPendingBlobDeletionsResponse
-	(*RemoveBlobDeletionRequest)(nil),                   // 118: blockchain_api.RemoveBlobDeletionRequest
-	(*IncrementBlobDeletionRetryRequest)(nil),           // 119: blockchain_api.IncrementBlobDeletionRetryRequest
-	(*IncrementBlobDeletionRetryResponse)(nil),          // 120: blockchain_api.IncrementBlobDeletionRetryResponse
-	(*CompleteBlobDeletionsRequest)(nil),                // 121: blockchain_api.CompleteBlobDeletionsRequest
-	(*CompleteBlobDeletionsResponse)(nil),               // 122: blockchain_api.CompleteBlobDeletionsResponse
-	(*AcquireBlobDeletionBatchRequest)(nil),             // 123: blockchain_api.AcquireBlobDeletionBatchRequest
-	(*AcquireBlobDeletionBatchResponse)(nil),            // 124: blockchain_api.AcquireBlobDeletionBatchResponse
-	(*CompleteBlobDeletionBatchRequest)(nil),            // 125: blockchain_api.CompleteBlobDeletionBatchRequest
-	(*BatchTokenInfo)(nil),                              // 126: blockchain_api.BatchTokenInfo
-	nil,                                                 // 127: blockchain_api.NotificationMetadata.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                       // 128: google.protobuf.Timestamp
-	(model.NotificationType)(0),                         // 129: model.NotificationType
-	(*model.BlockInfo)(nil),                             // 130: model.BlockInfo
-	(*model.SuitableBlock)(nil),                         // 131: model.SuitableBlock
-	(*model.ChainTip)(nil),                              // 132: model.ChainTip
-	(*emptypb.Empty)(nil),                               // 133: google.protobuf.Empty
-	(*model.BlockStats)(nil),                            // 134: model.BlockStats
-	(*model.BlockDataPoints)(nil),                       // 135: model.BlockDataPoints
+	(*RecordCatchupAttemptRequest)(nil),                 // 95: blockchain_api.RecordCatchupAttemptRequest
+	(*RecordCatchupSuccessRequest)(nil),                 // 96: blockchain_api.RecordCatchupSuccessRequest
+	(*RecordCatchupFailureRequest)(nil),                 // 97: blockchain_api.RecordCatchupFailureRequest
+	(*ResetReputationRequest)(nil),                      // 98: blockchain_api.ResetReputationRequest
+	(*ResetReputationResponse)(nil),                     // 99: blockchain_api.ResetReputationResponse
+	(*ReconsiderBadPeersRequest)(nil),                   // 100: blockchain_api.ReconsiderBadPeersRequest
+	(*ReconsiderBadPeersResponse)(nil),                  // 101: blockchain_api.ReconsiderBadPeersResponse
+	(*GetBlockLocatorRequest)(nil),                      // 102: blockchain_api.GetBlockLocatorRequest
+	(*GetBlockLocatorResponse)(nil),                     // 103: blockchain_api.GetBlockLocatorResponse
+	(*LocateBlockHeadersRequest)(nil),                   // 104: blockchain_api.LocateBlockHeadersRequest
+	(*LocateBlockHeadersResponse)(nil),                  // 105: blockchain_api.LocateBlockHeadersResponse
+	(*GetBestHeightAndTimeResponse)(nil),                // 106: blockchain_api.GetBestHeightAndTimeResponse
+	(*GetChainTipsResponse)(nil),                        // 107: blockchain_api.GetChainTipsResponse
+	(*ReportPeerFailureRequest)(nil),                    // 108: blockchain_api.ReportPeerFailureRequest
+	(*SetBlockPersistedAtRequest)(nil),                  // 109: blockchain_api.SetBlockPersistedAtRequest
+	(*GetBlocksNotPersistedRequest)(nil),                // 110: blockchain_api.GetBlocksNotPersistedRequest
+	(*GetBlocksNotPersistedResponse)(nil),               // 111: blockchain_api.GetBlocksNotPersistedResponse
+	(*ScheduleBlobDeletionRequest)(nil),                 // 112: blockchain_api.ScheduleBlobDeletionRequest
+	(*ScheduleBlobDeletionResponse)(nil),                // 113: blockchain_api.ScheduleBlobDeletionResponse
+	(*CancelBlobDeletionRequest)(nil),                   // 114: blockchain_api.CancelBlobDeletionRequest
+	(*CancelBlobDeletionResponse)(nil),                  // 115: blockchain_api.CancelBlobDeletionResponse
+	(*ListScheduledDeletionsRequest)(nil),               // 116: blockchain_api.ListScheduledDeletionsRequest
+	(*ScheduledDeletion)(nil),                           // 117: blockchain_api.ScheduledDeletion
+	(*ListScheduledDeletionsResponse)(nil),              // 118: blockchain_api.ListScheduledDeletionsResponse
+	(*GetPendingBlobDeletionsRequest)(nil),              // 119: blockchain_api.GetPendingBlobDeletionsRequest
+	(*GetPendingBlobDeletionsResponse)(nil),             // 120: blockchain_api.GetPendingBlobDeletionsResponse
+	(*RemoveBlobDeletionRequest)(nil),                   // 121: blockchain_api.RemoveBlobDeletionRequest
+	(*IncrementBlobDeletionRetryRequest)(nil),           // 122: blockchain_api.IncrementBlobDeletionRetryRequest
+	(*IncrementBlobDeletionRetryResponse)(nil),          // 123: blockchain_api.IncrementBlobDeletionRetryResponse
+	(*CompleteBlobDeletionsRequest)(nil),                // 124: blockchain_api.CompleteBlobDeletionsRequest
+	(*CompleteBlobDeletionsResponse)(nil),               // 125: blockchain_api.CompleteBlobDeletionsResponse
+	(*AcquireBlobDeletionBatchRequest)(nil),             // 126: blockchain_api.AcquireBlobDeletionBatchRequest
+	(*AcquireBlobDeletionBatchResponse)(nil),            // 127: blockchain_api.AcquireBlobDeletionBatchResponse
+	(*CompleteBlobDeletionBatchRequest)(nil),            // 128: blockchain_api.CompleteBlobDeletionBatchRequest
+	(*BatchTokenInfo)(nil),                              // 129: blockchain_api.BatchTokenInfo
+	nil,                                                 // 130: blockchain_api.NotificationMetadata.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                       // 131: google.protobuf.Timestamp
+	(model.NotificationType)(0),                         // 132: model.NotificationType
+	(*model.BlockInfo)(nil),                             // 133: model.BlockInfo
+	(*model.SuitableBlock)(nil),                         // 134: model.SuitableBlock
+	(*model.ChainTip)(nil),                              // 135: model.ChainTip
+	(*emptypb.Empty)(nil),                               // 136: google.protobuf.Empty
+	(*model.BlockStats)(nil),                            // 137: model.BlockStats
+	(*model.BlockDataPoints)(nil),                       // 138: model.BlockDataPoints
 }
 var file_services_blockchain_blockchain_api_blockchain_api_proto_depIdxs = []int32{
-	128, // 0: blockchain_api.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
-	128, // 1: blockchain_api.GetBlockHeaderResponse.processed_at:type_name -> google.protobuf.Timestamp
-	129, // 2: blockchain_api.Notification.type:type_name -> model.NotificationType
+	131, // 0: blockchain_api.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
+	131, // 1: blockchain_api.GetBlockHeaderResponse.processed_at:type_name -> google.protobuf.Timestamp
+	132, // 2: blockchain_api.Notification.type:type_name -> model.NotificationType
 	47,  // 3: blockchain_api.Notification.metadata:type_name -> blockchain_api.NotificationMetadata
-	127, // 4: blockchain_api.NotificationMetadata.metadata:type_name -> blockchain_api.NotificationMetadata.MetadataEntry
-	130, // 5: blockchain_api.GetLastNBlocksResponse.blocks:type_name -> model.BlockInfo
-	130, // 6: blockchain_api.GetLastNInvalidBlocksResponse.blocks:type_name -> model.BlockInfo
-	131, // 7: blockchain_api.GetSuitableBlockResponse.block:type_name -> model.SuitableBlock
+	130, // 4: blockchain_api.NotificationMetadata.metadata:type_name -> blockchain_api.NotificationMetadata.MetadataEntry
+	133, // 5: blockchain_api.GetLastNBlocksResponse.blocks:type_name -> model.BlockInfo
+	133, // 6: blockchain_api.GetLastNInvalidBlocksResponse.blocks:type_name -> model.BlockInfo
+	134, // 7: blockchain_api.GetSuitableBlockResponse.block:type_name -> model.SuitableBlock
 	2,   // 8: blockchain_api.GetFSMStateResponse.state:type_name -> blockchain_api.FSMStateType
 	0,   // 9: blockchain_api.SendFSMEventRequest.event:type_name -> blockchain_api.FSMEventType
 	1,   // 10: blockchain_api.PeerRegistryInfo.transport_type:type_name -> blockchain_api.TransportType
-	128, // 11: blockchain_api.PeerRegistryInfo.connected_at:type_name -> google.protobuf.Timestamp
-	128, // 12: blockchain_api.PeerRegistryInfo.last_message_time:type_name -> google.protobuf.Timestamp
-	128, // 13: blockchain_api.PeerRegistryInfo.last_interaction_attempt:type_name -> google.protobuf.Timestamp
-	128, // 14: blockchain_api.PeerRegistryInfo.last_interaction_success:type_name -> google.protobuf.Timestamp
-	128, // 15: blockchain_api.PeerRegistryInfo.last_interaction_failure:type_name -> google.protobuf.Timestamp
-	128, // 16: blockchain_api.PeerRegistryInfo.last_seen:type_name -> google.protobuf.Timestamp
-	128, // 17: blockchain_api.PeerRegistryInfo.last_block_time:type_name -> google.protobuf.Timestamp
-	128, // 18: blockchain_api.PeerRegistryInfo.last_sync_attempt:type_name -> google.protobuf.Timestamp
-	128, // 19: blockchain_api.PeerRegistryInfo.last_reputation_reset:type_name -> google.protobuf.Timestamp
-	128, // 20: blockchain_api.PeerRegistryInfo.last_catchup_error_time:type_name -> google.protobuf.Timestamp
-	128, // 21: blockchain_api.PeerRegistryInfo.last_validated_at:type_name -> google.protobuf.Timestamp
-	128, // 22: blockchain_api.PeerRegistryInfo.full_storage_penalty_until:type_name -> google.protobuf.Timestamp
+	131, // 11: blockchain_api.PeerRegistryInfo.connected_at:type_name -> google.protobuf.Timestamp
+	131, // 12: blockchain_api.PeerRegistryInfo.last_message_time:type_name -> google.protobuf.Timestamp
+	131, // 13: blockchain_api.PeerRegistryInfo.last_interaction_attempt:type_name -> google.protobuf.Timestamp
+	131, // 14: blockchain_api.PeerRegistryInfo.last_interaction_success:type_name -> google.protobuf.Timestamp
+	131, // 15: blockchain_api.PeerRegistryInfo.last_interaction_failure:type_name -> google.protobuf.Timestamp
+	131, // 16: blockchain_api.PeerRegistryInfo.last_seen:type_name -> google.protobuf.Timestamp
+	131, // 17: blockchain_api.PeerRegistryInfo.last_block_time:type_name -> google.protobuf.Timestamp
+	131, // 18: blockchain_api.PeerRegistryInfo.last_sync_attempt:type_name -> google.protobuf.Timestamp
+	131, // 19: blockchain_api.PeerRegistryInfo.last_reputation_reset:type_name -> google.protobuf.Timestamp
+	131, // 20: blockchain_api.PeerRegistryInfo.last_catchup_error_time:type_name -> google.protobuf.Timestamp
+	131, // 21: blockchain_api.PeerRegistryInfo.last_validated_at:type_name -> google.protobuf.Timestamp
+	131, // 22: blockchain_api.PeerRegistryInfo.full_storage_penalty_until:type_name -> google.protobuf.Timestamp
 	74,  // 23: blockchain_api.RegisterPeerRequest.peer:type_name -> blockchain_api.PeerRegistryInfo
 	1,   // 24: blockchain_api.ListPeersRequest.transport_filter:type_name -> blockchain_api.TransportType
 	74,  // 25: blockchain_api.ListPeersResponse.peers:type_name -> blockchain_api.PeerRegistryInfo
 	74,  // 26: blockchain_api.GetPeerResponse.peer:type_name -> blockchain_api.PeerRegistryInfo
-	132, // 27: blockchain_api.GetChainTipsResponse.tips:type_name -> model.ChainTip
-	114, // 28: blockchain_api.ListScheduledDeletionsResponse.deletions:type_name -> blockchain_api.ScheduledDeletion
-	114, // 29: blockchain_api.GetPendingBlobDeletionsResponse.deletions:type_name -> blockchain_api.ScheduledDeletion
-	114, // 30: blockchain_api.AcquireBlobDeletionBatchResponse.deletions:type_name -> blockchain_api.ScheduledDeletion
-	133, // 31: blockchain_api.BlockchainAPI.HealthGRPC:input_type -> google.protobuf.Empty
+	135, // 27: blockchain_api.GetChainTipsResponse.tips:type_name -> model.ChainTip
+	117, // 28: blockchain_api.ListScheduledDeletionsResponse.deletions:type_name -> blockchain_api.ScheduledDeletion
+	117, // 29: blockchain_api.GetPendingBlobDeletionsResponse.deletions:type_name -> blockchain_api.ScheduledDeletion
+	117, // 30: blockchain_api.AcquireBlobDeletionBatchResponse.deletions:type_name -> blockchain_api.ScheduledDeletion
+	136, // 31: blockchain_api.BlockchainAPI.HealthGRPC:input_type -> google.protobuf.Empty
 	4,   // 32: blockchain_api.BlockchainAPI.AddBlock:input_type -> blockchain_api.AddBlockRequest
 	5,   // 33: blockchain_api.BlockchainAPI.GetBlock:input_type -> blockchain_api.GetBlockRequest
 	6,   // 34: blockchain_api.BlockchainAPI.GetBlocks:input_type -> blockchain_api.GetBlocksRequest
 	8,   // 35: blockchain_api.BlockchainAPI.GetBlockByHeight:input_type -> blockchain_api.GetBlockByHeightRequest
 	9,   // 36: blockchain_api.BlockchainAPI.GetBlockByID:input_type -> blockchain_api.GetBlockByIDRequest
-	133, // 37: blockchain_api.BlockchainAPI.GetNextBlockID:input_type -> google.protobuf.Empty
+	136, // 37: blockchain_api.BlockchainAPI.GetNextBlockID:input_type -> google.protobuf.Empty
 	11,  // 38: blockchain_api.BlockchainAPI.AssignBlockID:input_type -> blockchain_api.AssignBlockIDRequest
-	133, // 39: blockchain_api.BlockchainAPI.GetBlockStats:input_type -> google.protobuf.Empty
+	136, // 39: blockchain_api.BlockchainAPI.GetBlockStats:input_type -> google.protobuf.Empty
 	16,  // 40: blockchain_api.BlockchainAPI.GetBlockGraphData:input_type -> blockchain_api.GetBlockGraphDataRequest
 	54,  // 41: blockchain_api.BlockchainAPI.GetLastNBlocks:input_type -> blockchain_api.GetLastNBlocksRequest
 	56,  // 42: blockchain_api.BlockchainAPI.GetLastNInvalidBlocks:input_type -> blockchain_api.GetLastNInvalidBlocksRequest
@@ -7885,46 +8070,46 @@ var file_services_blockchain_blockchain_api_blockchain_api_proto_depIdxs = []int
 	30,  // 56: blockchain_api.BlockchainAPI.GetBlocksByHeight:input_type -> blockchain_api.GetBlocksByHeightRequest
 	32,  // 57: blockchain_api.BlockchainAPI.FindBlocksContainingSubtree:input_type -> blockchain_api.FindBlocksContainingSubtreeRequest
 	19,  // 58: blockchain_api.BlockchainAPI.GetBlockHeaderIDs:input_type -> blockchain_api.GetBlockHeadersRequest
-	133, // 59: blockchain_api.BlockchainAPI.GetBestBlockHeader:input_type -> google.protobuf.Empty
+	136, // 59: blockchain_api.BlockchainAPI.GetBestBlockHeader:input_type -> google.protobuf.Empty
 	37,  // 60: blockchain_api.BlockchainAPI.CheckBlockIsInCurrentChain:input_type -> blockchain_api.CheckBlockIsCurrentChainRequest
 	43,  // 61: blockchain_api.BlockchainAPI.CheckBlockIsAncestorOfBlock:input_type -> blockchain_api.CheckBlockIsAncestorOfBlockRequest
-	133, // 62: blockchain_api.BlockchainAPI.GetChainTips:input_type -> google.protobuf.Empty
+	136, // 62: blockchain_api.BlockchainAPI.GetChainTips:input_type -> google.protobuf.Empty
 	36,  // 63: blockchain_api.BlockchainAPI.GetBlockHeader:input_type -> blockchain_api.GetBlockHeaderRequest
 	38,  // 64: blockchain_api.BlockchainAPI.InvalidateBlock:input_type -> blockchain_api.InvalidateBlockRequest
 	40,  // 65: blockchain_api.BlockchainAPI.RevalidateBlock:input_type -> blockchain_api.RevalidateBlockRequest
 	45,  // 66: blockchain_api.BlockchainAPI.Subscribe:input_type -> blockchain_api.SubscribeRequest
 	46,  // 67: blockchain_api.BlockchainAPI.SendNotification:input_type -> blockchain_api.Notification
-	133, // 68: blockchain_api.BlockchainAPI.GetSubscribers:input_type -> google.protobuf.Empty
+	136, // 68: blockchain_api.BlockchainAPI.GetSubscribers:input_type -> google.protobuf.Empty
 	49,  // 69: blockchain_api.BlockchainAPI.GetState:input_type -> blockchain_api.GetStateRequest
 	51,  // 70: blockchain_api.BlockchainAPI.SetState:input_type -> blockchain_api.SetStateRequest
 	52,  // 71: blockchain_api.BlockchainAPI.GetBlockIsMined:input_type -> blockchain_api.GetBlockIsMinedRequest
 	66,  // 72: blockchain_api.BlockchainAPI.SetBlockMinedSet:input_type -> blockchain_api.SetBlockMinedSetRequest
 	67,  // 73: blockchain_api.BlockchainAPI.ClearBlockMinedSet:input_type -> blockchain_api.ClearBlockMinedSetRequest
-	133, // 74: blockchain_api.BlockchainAPI.GetBlocksMinedNotSet:input_type -> google.protobuf.Empty
+	136, // 74: blockchain_api.BlockchainAPI.GetBlocksMinedNotSet:input_type -> google.protobuf.Empty
 	69,  // 75: blockchain_api.BlockchainAPI.SetBlockSubtreesSet:input_type -> blockchain_api.SetBlockSubtreesSetRequest
-	133, // 76: blockchain_api.BlockchainAPI.GetBlocksSubtreesNotSet:input_type -> google.protobuf.Empty
+	136, // 76: blockchain_api.BlockchainAPI.GetBlocksSubtreesNotSet:input_type -> google.protobuf.Empty
 	71,  // 77: blockchain_api.BlockchainAPI.SetBlockProcessedAt:input_type -> blockchain_api.SetBlockProcessedAtRequest
-	106, // 78: blockchain_api.BlockchainAPI.SetBlockPersistedAt:input_type -> blockchain_api.SetBlockPersistedAtRequest
-	107, // 79: blockchain_api.BlockchainAPI.GetBlocksNotPersisted:input_type -> blockchain_api.GetBlocksNotPersistedRequest
+	109, // 78: blockchain_api.BlockchainAPI.SetBlockPersistedAt:input_type -> blockchain_api.SetBlockPersistedAtRequest
+	110, // 79: blockchain_api.BlockchainAPI.GetBlocksNotPersisted:input_type -> blockchain_api.GetBlocksNotPersistedRequest
 	73,  // 80: blockchain_api.BlockchainAPI.SendFSMEvent:input_type -> blockchain_api.SendFSMEventRequest
-	133, // 81: blockchain_api.BlockchainAPI.GetFSMCurrentState:input_type -> google.protobuf.Empty
-	133, // 82: blockchain_api.BlockchainAPI.WaitUntilFSMTransitionFromIdleState:input_type -> google.protobuf.Empty
-	133, // 83: blockchain_api.BlockchainAPI.Run:input_type -> google.protobuf.Empty
-	133, // 84: blockchain_api.BlockchainAPI.CatchUpBlocks:input_type -> google.protobuf.Empty
-	133, // 85: blockchain_api.BlockchainAPI.Idle:input_type -> google.protobuf.Empty
-	105, // 86: blockchain_api.BlockchainAPI.ReportPeerFailure:input_type -> blockchain_api.ReportPeerFailureRequest
-	99,  // 87: blockchain_api.BlockchainAPI.GetBlockLocator:input_type -> blockchain_api.GetBlockLocatorRequest
-	101, // 88: blockchain_api.BlockchainAPI.LocateBlockHeaders:input_type -> blockchain_api.LocateBlockHeadersRequest
-	133, // 89: blockchain_api.BlockchainAPI.GetBestHeightAndTime:input_type -> google.protobuf.Empty
-	109, // 90: blockchain_api.BlockchainAPI.ScheduleBlobDeletion:input_type -> blockchain_api.ScheduleBlobDeletionRequest
-	111, // 91: blockchain_api.BlockchainAPI.CancelBlobDeletion:input_type -> blockchain_api.CancelBlobDeletionRequest
-	113, // 92: blockchain_api.BlockchainAPI.ListScheduledDeletions:input_type -> blockchain_api.ListScheduledDeletionsRequest
-	116, // 93: blockchain_api.BlockchainAPI.GetPendingBlobDeletions:input_type -> blockchain_api.GetPendingBlobDeletionsRequest
-	118, // 94: blockchain_api.BlockchainAPI.RemoveBlobDeletion:input_type -> blockchain_api.RemoveBlobDeletionRequest
-	119, // 95: blockchain_api.BlockchainAPI.IncrementBlobDeletionRetry:input_type -> blockchain_api.IncrementBlobDeletionRetryRequest
-	121, // 96: blockchain_api.BlockchainAPI.CompleteBlobDeletions:input_type -> blockchain_api.CompleteBlobDeletionsRequest
-	123, // 97: blockchain_api.BlockchainAPI.AcquireBlobDeletionBatch:input_type -> blockchain_api.AcquireBlobDeletionBatchRequest
-	125, // 98: blockchain_api.BlockchainAPI.CompleteBlobDeletionBatch:input_type -> blockchain_api.CompleteBlobDeletionBatchRequest
+	136, // 81: blockchain_api.BlockchainAPI.GetFSMCurrentState:input_type -> google.protobuf.Empty
+	136, // 82: blockchain_api.BlockchainAPI.WaitUntilFSMTransitionFromIdleState:input_type -> google.protobuf.Empty
+	136, // 83: blockchain_api.BlockchainAPI.Run:input_type -> google.protobuf.Empty
+	136, // 84: blockchain_api.BlockchainAPI.CatchUpBlocks:input_type -> google.protobuf.Empty
+	136, // 85: blockchain_api.BlockchainAPI.Idle:input_type -> google.protobuf.Empty
+	108, // 86: blockchain_api.BlockchainAPI.ReportPeerFailure:input_type -> blockchain_api.ReportPeerFailureRequest
+	102, // 87: blockchain_api.BlockchainAPI.GetBlockLocator:input_type -> blockchain_api.GetBlockLocatorRequest
+	104, // 88: blockchain_api.BlockchainAPI.LocateBlockHeaders:input_type -> blockchain_api.LocateBlockHeadersRequest
+	136, // 89: blockchain_api.BlockchainAPI.GetBestHeightAndTime:input_type -> google.protobuf.Empty
+	112, // 90: blockchain_api.BlockchainAPI.ScheduleBlobDeletion:input_type -> blockchain_api.ScheduleBlobDeletionRequest
+	114, // 91: blockchain_api.BlockchainAPI.CancelBlobDeletion:input_type -> blockchain_api.CancelBlobDeletionRequest
+	116, // 92: blockchain_api.BlockchainAPI.ListScheduledDeletions:input_type -> blockchain_api.ListScheduledDeletionsRequest
+	119, // 93: blockchain_api.BlockchainAPI.GetPendingBlobDeletions:input_type -> blockchain_api.GetPendingBlobDeletionsRequest
+	121, // 94: blockchain_api.BlockchainAPI.RemoveBlobDeletion:input_type -> blockchain_api.RemoveBlobDeletionRequest
+	122, // 95: blockchain_api.BlockchainAPI.IncrementBlobDeletionRetry:input_type -> blockchain_api.IncrementBlobDeletionRetryRequest
+	124, // 96: blockchain_api.BlockchainAPI.CompleteBlobDeletions:input_type -> blockchain_api.CompleteBlobDeletionsRequest
+	126, // 97: blockchain_api.BlockchainAPI.AcquireBlobDeletionBatch:input_type -> blockchain_api.AcquireBlobDeletionBatchRequest
+	128, // 98: blockchain_api.BlockchainAPI.CompleteBlobDeletionBatch:input_type -> blockchain_api.CompleteBlobDeletionBatchRequest
 	75,  // 99: blockchain_api.PeerRegistryService.RegisterPeer:input_type -> blockchain_api.RegisterPeerRequest
 	77,  // 100: blockchain_api.PeerRegistryService.UpdatePeerMetrics:input_type -> blockchain_api.UpdatePeerMetricsRequest
 	78,  // 101: blockchain_api.PeerRegistryService.RemovePeer:input_type -> blockchain_api.RemovePeerRequest
@@ -7932,111 +8117,117 @@ var file_services_blockchain_blockchain_api_blockchain_api_proto_depIdxs = []int
 	81,  // 103: blockchain_api.PeerRegistryService.GetPeer:input_type -> blockchain_api.GetPeerRequest
 	83,  // 104: blockchain_api.PeerRegistryService.AddBanScore:input_type -> blockchain_api.AddBanScoreRequest
 	85,  // 105: blockchain_api.PeerRegistryService.IsPeerBanned:input_type -> blockchain_api.IsPeerBannedRequest
-	133, // 106: blockchain_api.PeerRegistryService.ListBannedPeers:input_type -> google.protobuf.Empty
-	133, // 107: blockchain_api.PeerRegistryService.ClearBannedPeers:input_type -> google.protobuf.Empty
+	136, // 106: blockchain_api.PeerRegistryService.ListBannedPeers:input_type -> google.protobuf.Empty
+	136, // 107: blockchain_api.PeerRegistryService.ClearBannedPeers:input_type -> google.protobuf.Empty
 	88,  // 108: blockchain_api.PeerRegistryService.UpdateConnectionState:input_type -> blockchain_api.UpdateConnectionStateRequest
 	89,  // 109: blockchain_api.PeerRegistryService.UpdateLastMessageTime:input_type -> blockchain_api.UpdateLastMessageTimeRequest
 	90,  // 110: blockchain_api.PeerRegistryService.UpdateStorage:input_type -> blockchain_api.UpdateStorageRequest
 	91,  // 111: blockchain_api.PeerRegistryService.RecordSyncAttempt:input_type -> blockchain_api.RecordSyncAttemptRequest
-	133, // 112: blockchain_api.PeerRegistryService.ClearAllSyncAttempts:input_type -> google.protobuf.Empty
+	136, // 112: blockchain_api.PeerRegistryService.ClearAllSyncAttempts:input_type -> google.protobuf.Empty
 	93,  // 113: blockchain_api.PeerRegistryService.RecordBlockReceived:input_type -> blockchain_api.RecordReceivedRequest
 	93,  // 114: blockchain_api.PeerRegistryService.RecordSubtreeReceived:input_type -> blockchain_api.RecordReceivedRequest
 	93,  // 115: blockchain_api.PeerRegistryService.RecordTransactionReceived:input_type -> blockchain_api.RecordReceivedRequest
 	94,  // 116: blockchain_api.PeerRegistryService.RecordCatchupError:input_type -> blockchain_api.RecordCatchupErrorRequest
-	95,  // 117: blockchain_api.PeerRegistryService.ResetReputation:input_type -> blockchain_api.ResetReputationRequest
-	97,  // 118: blockchain_api.PeerRegistryService.ReconsiderBadPeers:input_type -> blockchain_api.ReconsiderBadPeersRequest
-	76,  // 119: blockchain_api.PeerRegistryService.RecordValidatedPeerProgress:input_type -> blockchain_api.RecordValidatedPeerProgressRequest
-	3,   // 120: blockchain_api.BlockchainAPI.HealthGRPC:output_type -> blockchain_api.HealthResponse
-	133, // 121: blockchain_api.BlockchainAPI.AddBlock:output_type -> google.protobuf.Empty
-	14,  // 122: blockchain_api.BlockchainAPI.GetBlock:output_type -> blockchain_api.GetBlockResponse
-	7,   // 123: blockchain_api.BlockchainAPI.GetBlocks:output_type -> blockchain_api.GetBlocksResponse
-	14,  // 124: blockchain_api.BlockchainAPI.GetBlockByHeight:output_type -> blockchain_api.GetBlockResponse
-	14,  // 125: blockchain_api.BlockchainAPI.GetBlockByID:output_type -> blockchain_api.GetBlockResponse
-	10,  // 126: blockchain_api.BlockchainAPI.GetNextBlockID:output_type -> blockchain_api.GetNextBlockIDResponse
-	12,  // 127: blockchain_api.BlockchainAPI.AssignBlockID:output_type -> blockchain_api.AssignBlockIDResponse
-	134, // 128: blockchain_api.BlockchainAPI.GetBlockStats:output_type -> model.BlockStats
-	135, // 129: blockchain_api.BlockchainAPI.GetBlockGraphData:output_type -> model.BlockDataPoints
-	55,  // 130: blockchain_api.BlockchainAPI.GetLastNBlocks:output_type -> blockchain_api.GetLastNBlocksResponse
-	57,  // 131: blockchain_api.BlockchainAPI.GetLastNInvalidBlocks:output_type -> blockchain_api.GetLastNInvalidBlocksResponse
-	59,  // 132: blockchain_api.BlockchainAPI.GetSuitableBlock:output_type -> blockchain_api.GetSuitableBlockResponse
-	63,  // 133: blockchain_api.BlockchainAPI.GetHashOfAncestorBlock:output_type -> blockchain_api.GetHashOfAncestorBlockResponse
-	41,  // 134: blockchain_api.BlockchainAPI.GetLatestBlockHeaderFromBlockLocator:output_type -> blockchain_api.GetBlockHeaderResponse
-	22,  // 135: blockchain_api.BlockchainAPI.GetBlockHeadersFromOldest:output_type -> blockchain_api.GetBlockHeadersResponse
-	65,  // 136: blockchain_api.BlockchainAPI.GetNextWorkRequired:output_type -> blockchain_api.GetNextWorkRequiredResponse
-	17,  // 137: blockchain_api.BlockchainAPI.GetBlockExists:output_type -> blockchain_api.GetBlockExistsResponse
-	22,  // 138: blockchain_api.BlockchainAPI.GetBlockHeaders:output_type -> blockchain_api.GetBlockHeadersResponse
-	22,  // 139: blockchain_api.BlockchainAPI.GetBlockHeadersToCommonAncestor:output_type -> blockchain_api.GetBlockHeadersResponse
-	22,  // 140: blockchain_api.BlockchainAPI.GetBlockHeadersFromCommonAncestor:output_type -> blockchain_api.GetBlockHeadersResponse
-	22,  // 141: blockchain_api.BlockchainAPI.GetBlockHeadersFromTill:output_type -> blockchain_api.GetBlockHeadersResponse
-	25,  // 142: blockchain_api.BlockchainAPI.GetBlockHeadersFromHeight:output_type -> blockchain_api.GetBlockHeadersFromHeightResponse
-	27,  // 143: blockchain_api.BlockchainAPI.GetBlockHeadersByHeight:output_type -> blockchain_api.GetBlockHeadersByHeightResponse
-	29,  // 144: blockchain_api.BlockchainAPI.GetMedianTimePastByHeights:output_type -> blockchain_api.GetMedianTimePastByHeightsResponse
-	31,  // 145: blockchain_api.BlockchainAPI.GetBlocksByHeight:output_type -> blockchain_api.GetBlocksByHeightResponse
-	33,  // 146: blockchain_api.BlockchainAPI.FindBlocksContainingSubtree:output_type -> blockchain_api.FindBlocksContainingSubtreeResponse
-	34,  // 147: blockchain_api.BlockchainAPI.GetBlockHeaderIDs:output_type -> blockchain_api.GetBlockHeaderIDsResponse
-	41,  // 148: blockchain_api.BlockchainAPI.GetBestBlockHeader:output_type -> blockchain_api.GetBlockHeaderResponse
-	42,  // 149: blockchain_api.BlockchainAPI.CheckBlockIsInCurrentChain:output_type -> blockchain_api.CheckBlockIsCurrentChainResponse
-	44,  // 150: blockchain_api.BlockchainAPI.CheckBlockIsAncestorOfBlock:output_type -> blockchain_api.CheckBlockIsAncestorOfBlockResponse
-	104, // 151: blockchain_api.BlockchainAPI.GetChainTips:output_type -> blockchain_api.GetChainTipsResponse
-	41,  // 152: blockchain_api.BlockchainAPI.GetBlockHeader:output_type -> blockchain_api.GetBlockHeaderResponse
-	39,  // 153: blockchain_api.BlockchainAPI.InvalidateBlock:output_type -> blockchain_api.InvalidateBlockResponse
-	133, // 154: blockchain_api.BlockchainAPI.RevalidateBlock:output_type -> google.protobuf.Empty
-	46,  // 155: blockchain_api.BlockchainAPI.Subscribe:output_type -> blockchain_api.Notification
-	133, // 156: blockchain_api.BlockchainAPI.SendNotification:output_type -> google.protobuf.Empty
-	48,  // 157: blockchain_api.BlockchainAPI.GetSubscribers:output_type -> blockchain_api.GetSubscribersResponse
-	50,  // 158: blockchain_api.BlockchainAPI.GetState:output_type -> blockchain_api.StateResponse
-	133, // 159: blockchain_api.BlockchainAPI.SetState:output_type -> google.protobuf.Empty
-	53,  // 160: blockchain_api.BlockchainAPI.GetBlockIsMined:output_type -> blockchain_api.GetBlockIsMinedResponse
-	133, // 161: blockchain_api.BlockchainAPI.SetBlockMinedSet:output_type -> google.protobuf.Empty
-	133, // 162: blockchain_api.BlockchainAPI.ClearBlockMinedSet:output_type -> google.protobuf.Empty
-	68,  // 163: blockchain_api.BlockchainAPI.GetBlocksMinedNotSet:output_type -> blockchain_api.GetBlocksMinedNotSetResponse
-	133, // 164: blockchain_api.BlockchainAPI.SetBlockSubtreesSet:output_type -> google.protobuf.Empty
-	70,  // 165: blockchain_api.BlockchainAPI.GetBlocksSubtreesNotSet:output_type -> blockchain_api.GetBlocksSubtreesNotSetResponse
-	133, // 166: blockchain_api.BlockchainAPI.SetBlockProcessedAt:output_type -> google.protobuf.Empty
-	133, // 167: blockchain_api.BlockchainAPI.SetBlockPersistedAt:output_type -> google.protobuf.Empty
-	108, // 168: blockchain_api.BlockchainAPI.GetBlocksNotPersisted:output_type -> blockchain_api.GetBlocksNotPersistedResponse
-	72,  // 169: blockchain_api.BlockchainAPI.SendFSMEvent:output_type -> blockchain_api.GetFSMStateResponse
-	72,  // 170: blockchain_api.BlockchainAPI.GetFSMCurrentState:output_type -> blockchain_api.GetFSMStateResponse
-	133, // 171: blockchain_api.BlockchainAPI.WaitUntilFSMTransitionFromIdleState:output_type -> google.protobuf.Empty
-	133, // 172: blockchain_api.BlockchainAPI.Run:output_type -> google.protobuf.Empty
-	133, // 173: blockchain_api.BlockchainAPI.CatchUpBlocks:output_type -> google.protobuf.Empty
-	133, // 174: blockchain_api.BlockchainAPI.Idle:output_type -> google.protobuf.Empty
-	133, // 175: blockchain_api.BlockchainAPI.ReportPeerFailure:output_type -> google.protobuf.Empty
-	100, // 176: blockchain_api.BlockchainAPI.GetBlockLocator:output_type -> blockchain_api.GetBlockLocatorResponse
-	102, // 177: blockchain_api.BlockchainAPI.LocateBlockHeaders:output_type -> blockchain_api.LocateBlockHeadersResponse
-	103, // 178: blockchain_api.BlockchainAPI.GetBestHeightAndTime:output_type -> blockchain_api.GetBestHeightAndTimeResponse
-	110, // 179: blockchain_api.BlockchainAPI.ScheduleBlobDeletion:output_type -> blockchain_api.ScheduleBlobDeletionResponse
-	112, // 180: blockchain_api.BlockchainAPI.CancelBlobDeletion:output_type -> blockchain_api.CancelBlobDeletionResponse
-	115, // 181: blockchain_api.BlockchainAPI.ListScheduledDeletions:output_type -> blockchain_api.ListScheduledDeletionsResponse
-	117, // 182: blockchain_api.BlockchainAPI.GetPendingBlobDeletions:output_type -> blockchain_api.GetPendingBlobDeletionsResponse
-	133, // 183: blockchain_api.BlockchainAPI.RemoveBlobDeletion:output_type -> google.protobuf.Empty
-	120, // 184: blockchain_api.BlockchainAPI.IncrementBlobDeletionRetry:output_type -> blockchain_api.IncrementBlobDeletionRetryResponse
-	122, // 185: blockchain_api.BlockchainAPI.CompleteBlobDeletions:output_type -> blockchain_api.CompleteBlobDeletionsResponse
-	124, // 186: blockchain_api.BlockchainAPI.AcquireBlobDeletionBatch:output_type -> blockchain_api.AcquireBlobDeletionBatchResponse
-	133, // 187: blockchain_api.BlockchainAPI.CompleteBlobDeletionBatch:output_type -> google.protobuf.Empty
-	133, // 188: blockchain_api.PeerRegistryService.RegisterPeer:output_type -> google.protobuf.Empty
-	133, // 189: blockchain_api.PeerRegistryService.UpdatePeerMetrics:output_type -> google.protobuf.Empty
-	133, // 190: blockchain_api.PeerRegistryService.RemovePeer:output_type -> google.protobuf.Empty
-	80,  // 191: blockchain_api.PeerRegistryService.ListPeers:output_type -> blockchain_api.ListPeersResponse
-	82,  // 192: blockchain_api.PeerRegistryService.GetPeer:output_type -> blockchain_api.GetPeerResponse
-	84,  // 193: blockchain_api.PeerRegistryService.AddBanScore:output_type -> blockchain_api.AddBanScoreResponse
-	86,  // 194: blockchain_api.PeerRegistryService.IsPeerBanned:output_type -> blockchain_api.IsPeerBannedResponse
-	87,  // 195: blockchain_api.PeerRegistryService.ListBannedPeers:output_type -> blockchain_api.ListBannedPeersResponse
-	133, // 196: blockchain_api.PeerRegistryService.ClearBannedPeers:output_type -> google.protobuf.Empty
-	133, // 197: blockchain_api.PeerRegistryService.UpdateConnectionState:output_type -> google.protobuf.Empty
-	133, // 198: blockchain_api.PeerRegistryService.UpdateLastMessageTime:output_type -> google.protobuf.Empty
-	133, // 199: blockchain_api.PeerRegistryService.UpdateStorage:output_type -> google.protobuf.Empty
-	133, // 200: blockchain_api.PeerRegistryService.RecordSyncAttempt:output_type -> google.protobuf.Empty
-	92,  // 201: blockchain_api.PeerRegistryService.ClearAllSyncAttempts:output_type -> blockchain_api.ClearAllSyncAttemptsResponse
-	133, // 202: blockchain_api.PeerRegistryService.RecordBlockReceived:output_type -> google.protobuf.Empty
-	133, // 203: blockchain_api.PeerRegistryService.RecordSubtreeReceived:output_type -> google.protobuf.Empty
-	133, // 204: blockchain_api.PeerRegistryService.RecordTransactionReceived:output_type -> google.protobuf.Empty
-	133, // 205: blockchain_api.PeerRegistryService.RecordCatchupError:output_type -> google.protobuf.Empty
-	96,  // 206: blockchain_api.PeerRegistryService.ResetReputation:output_type -> blockchain_api.ResetReputationResponse
-	98,  // 207: blockchain_api.PeerRegistryService.ReconsiderBadPeers:output_type -> blockchain_api.ReconsiderBadPeersResponse
-	133, // 208: blockchain_api.PeerRegistryService.RecordValidatedPeerProgress:output_type -> google.protobuf.Empty
-	120, // [120:209] is the sub-list for method output_type
-	31,  // [31:120] is the sub-list for method input_type
+	95,  // 117: blockchain_api.PeerRegistryService.RecordCatchupAttempt:input_type -> blockchain_api.RecordCatchupAttemptRequest
+	96,  // 118: blockchain_api.PeerRegistryService.RecordCatchupSuccess:input_type -> blockchain_api.RecordCatchupSuccessRequest
+	97,  // 119: blockchain_api.PeerRegistryService.RecordCatchupFailure:input_type -> blockchain_api.RecordCatchupFailureRequest
+	98,  // 120: blockchain_api.PeerRegistryService.ResetReputation:input_type -> blockchain_api.ResetReputationRequest
+	100, // 121: blockchain_api.PeerRegistryService.ReconsiderBadPeers:input_type -> blockchain_api.ReconsiderBadPeersRequest
+	76,  // 122: blockchain_api.PeerRegistryService.RecordValidatedPeerProgress:input_type -> blockchain_api.RecordValidatedPeerProgressRequest
+	3,   // 123: blockchain_api.BlockchainAPI.HealthGRPC:output_type -> blockchain_api.HealthResponse
+	136, // 124: blockchain_api.BlockchainAPI.AddBlock:output_type -> google.protobuf.Empty
+	14,  // 125: blockchain_api.BlockchainAPI.GetBlock:output_type -> blockchain_api.GetBlockResponse
+	7,   // 126: blockchain_api.BlockchainAPI.GetBlocks:output_type -> blockchain_api.GetBlocksResponse
+	14,  // 127: blockchain_api.BlockchainAPI.GetBlockByHeight:output_type -> blockchain_api.GetBlockResponse
+	14,  // 128: blockchain_api.BlockchainAPI.GetBlockByID:output_type -> blockchain_api.GetBlockResponse
+	10,  // 129: blockchain_api.BlockchainAPI.GetNextBlockID:output_type -> blockchain_api.GetNextBlockIDResponse
+	12,  // 130: blockchain_api.BlockchainAPI.AssignBlockID:output_type -> blockchain_api.AssignBlockIDResponse
+	137, // 131: blockchain_api.BlockchainAPI.GetBlockStats:output_type -> model.BlockStats
+	138, // 132: blockchain_api.BlockchainAPI.GetBlockGraphData:output_type -> model.BlockDataPoints
+	55,  // 133: blockchain_api.BlockchainAPI.GetLastNBlocks:output_type -> blockchain_api.GetLastNBlocksResponse
+	57,  // 134: blockchain_api.BlockchainAPI.GetLastNInvalidBlocks:output_type -> blockchain_api.GetLastNInvalidBlocksResponse
+	59,  // 135: blockchain_api.BlockchainAPI.GetSuitableBlock:output_type -> blockchain_api.GetSuitableBlockResponse
+	63,  // 136: blockchain_api.BlockchainAPI.GetHashOfAncestorBlock:output_type -> blockchain_api.GetHashOfAncestorBlockResponse
+	41,  // 137: blockchain_api.BlockchainAPI.GetLatestBlockHeaderFromBlockLocator:output_type -> blockchain_api.GetBlockHeaderResponse
+	22,  // 138: blockchain_api.BlockchainAPI.GetBlockHeadersFromOldest:output_type -> blockchain_api.GetBlockHeadersResponse
+	65,  // 139: blockchain_api.BlockchainAPI.GetNextWorkRequired:output_type -> blockchain_api.GetNextWorkRequiredResponse
+	17,  // 140: blockchain_api.BlockchainAPI.GetBlockExists:output_type -> blockchain_api.GetBlockExistsResponse
+	22,  // 141: blockchain_api.BlockchainAPI.GetBlockHeaders:output_type -> blockchain_api.GetBlockHeadersResponse
+	22,  // 142: blockchain_api.BlockchainAPI.GetBlockHeadersToCommonAncestor:output_type -> blockchain_api.GetBlockHeadersResponse
+	22,  // 143: blockchain_api.BlockchainAPI.GetBlockHeadersFromCommonAncestor:output_type -> blockchain_api.GetBlockHeadersResponse
+	22,  // 144: blockchain_api.BlockchainAPI.GetBlockHeadersFromTill:output_type -> blockchain_api.GetBlockHeadersResponse
+	25,  // 145: blockchain_api.BlockchainAPI.GetBlockHeadersFromHeight:output_type -> blockchain_api.GetBlockHeadersFromHeightResponse
+	27,  // 146: blockchain_api.BlockchainAPI.GetBlockHeadersByHeight:output_type -> blockchain_api.GetBlockHeadersByHeightResponse
+	29,  // 147: blockchain_api.BlockchainAPI.GetMedianTimePastByHeights:output_type -> blockchain_api.GetMedianTimePastByHeightsResponse
+	31,  // 148: blockchain_api.BlockchainAPI.GetBlocksByHeight:output_type -> blockchain_api.GetBlocksByHeightResponse
+	33,  // 149: blockchain_api.BlockchainAPI.FindBlocksContainingSubtree:output_type -> blockchain_api.FindBlocksContainingSubtreeResponse
+	34,  // 150: blockchain_api.BlockchainAPI.GetBlockHeaderIDs:output_type -> blockchain_api.GetBlockHeaderIDsResponse
+	41,  // 151: blockchain_api.BlockchainAPI.GetBestBlockHeader:output_type -> blockchain_api.GetBlockHeaderResponse
+	42,  // 152: blockchain_api.BlockchainAPI.CheckBlockIsInCurrentChain:output_type -> blockchain_api.CheckBlockIsCurrentChainResponse
+	44,  // 153: blockchain_api.BlockchainAPI.CheckBlockIsAncestorOfBlock:output_type -> blockchain_api.CheckBlockIsAncestorOfBlockResponse
+	107, // 154: blockchain_api.BlockchainAPI.GetChainTips:output_type -> blockchain_api.GetChainTipsResponse
+	41,  // 155: blockchain_api.BlockchainAPI.GetBlockHeader:output_type -> blockchain_api.GetBlockHeaderResponse
+	39,  // 156: blockchain_api.BlockchainAPI.InvalidateBlock:output_type -> blockchain_api.InvalidateBlockResponse
+	136, // 157: blockchain_api.BlockchainAPI.RevalidateBlock:output_type -> google.protobuf.Empty
+	46,  // 158: blockchain_api.BlockchainAPI.Subscribe:output_type -> blockchain_api.Notification
+	136, // 159: blockchain_api.BlockchainAPI.SendNotification:output_type -> google.protobuf.Empty
+	48,  // 160: blockchain_api.BlockchainAPI.GetSubscribers:output_type -> blockchain_api.GetSubscribersResponse
+	50,  // 161: blockchain_api.BlockchainAPI.GetState:output_type -> blockchain_api.StateResponse
+	136, // 162: blockchain_api.BlockchainAPI.SetState:output_type -> google.protobuf.Empty
+	53,  // 163: blockchain_api.BlockchainAPI.GetBlockIsMined:output_type -> blockchain_api.GetBlockIsMinedResponse
+	136, // 164: blockchain_api.BlockchainAPI.SetBlockMinedSet:output_type -> google.protobuf.Empty
+	136, // 165: blockchain_api.BlockchainAPI.ClearBlockMinedSet:output_type -> google.protobuf.Empty
+	68,  // 166: blockchain_api.BlockchainAPI.GetBlocksMinedNotSet:output_type -> blockchain_api.GetBlocksMinedNotSetResponse
+	136, // 167: blockchain_api.BlockchainAPI.SetBlockSubtreesSet:output_type -> google.protobuf.Empty
+	70,  // 168: blockchain_api.BlockchainAPI.GetBlocksSubtreesNotSet:output_type -> blockchain_api.GetBlocksSubtreesNotSetResponse
+	136, // 169: blockchain_api.BlockchainAPI.SetBlockProcessedAt:output_type -> google.protobuf.Empty
+	136, // 170: blockchain_api.BlockchainAPI.SetBlockPersistedAt:output_type -> google.protobuf.Empty
+	111, // 171: blockchain_api.BlockchainAPI.GetBlocksNotPersisted:output_type -> blockchain_api.GetBlocksNotPersistedResponse
+	72,  // 172: blockchain_api.BlockchainAPI.SendFSMEvent:output_type -> blockchain_api.GetFSMStateResponse
+	72,  // 173: blockchain_api.BlockchainAPI.GetFSMCurrentState:output_type -> blockchain_api.GetFSMStateResponse
+	136, // 174: blockchain_api.BlockchainAPI.WaitUntilFSMTransitionFromIdleState:output_type -> google.protobuf.Empty
+	136, // 175: blockchain_api.BlockchainAPI.Run:output_type -> google.protobuf.Empty
+	136, // 176: blockchain_api.BlockchainAPI.CatchUpBlocks:output_type -> google.protobuf.Empty
+	136, // 177: blockchain_api.BlockchainAPI.Idle:output_type -> google.protobuf.Empty
+	136, // 178: blockchain_api.BlockchainAPI.ReportPeerFailure:output_type -> google.protobuf.Empty
+	103, // 179: blockchain_api.BlockchainAPI.GetBlockLocator:output_type -> blockchain_api.GetBlockLocatorResponse
+	105, // 180: blockchain_api.BlockchainAPI.LocateBlockHeaders:output_type -> blockchain_api.LocateBlockHeadersResponse
+	106, // 181: blockchain_api.BlockchainAPI.GetBestHeightAndTime:output_type -> blockchain_api.GetBestHeightAndTimeResponse
+	113, // 182: blockchain_api.BlockchainAPI.ScheduleBlobDeletion:output_type -> blockchain_api.ScheduleBlobDeletionResponse
+	115, // 183: blockchain_api.BlockchainAPI.CancelBlobDeletion:output_type -> blockchain_api.CancelBlobDeletionResponse
+	118, // 184: blockchain_api.BlockchainAPI.ListScheduledDeletions:output_type -> blockchain_api.ListScheduledDeletionsResponse
+	120, // 185: blockchain_api.BlockchainAPI.GetPendingBlobDeletions:output_type -> blockchain_api.GetPendingBlobDeletionsResponse
+	136, // 186: blockchain_api.BlockchainAPI.RemoveBlobDeletion:output_type -> google.protobuf.Empty
+	123, // 187: blockchain_api.BlockchainAPI.IncrementBlobDeletionRetry:output_type -> blockchain_api.IncrementBlobDeletionRetryResponse
+	125, // 188: blockchain_api.BlockchainAPI.CompleteBlobDeletions:output_type -> blockchain_api.CompleteBlobDeletionsResponse
+	127, // 189: blockchain_api.BlockchainAPI.AcquireBlobDeletionBatch:output_type -> blockchain_api.AcquireBlobDeletionBatchResponse
+	136, // 190: blockchain_api.BlockchainAPI.CompleteBlobDeletionBatch:output_type -> google.protobuf.Empty
+	136, // 191: blockchain_api.PeerRegistryService.RegisterPeer:output_type -> google.protobuf.Empty
+	136, // 192: blockchain_api.PeerRegistryService.UpdatePeerMetrics:output_type -> google.protobuf.Empty
+	136, // 193: blockchain_api.PeerRegistryService.RemovePeer:output_type -> google.protobuf.Empty
+	80,  // 194: blockchain_api.PeerRegistryService.ListPeers:output_type -> blockchain_api.ListPeersResponse
+	82,  // 195: blockchain_api.PeerRegistryService.GetPeer:output_type -> blockchain_api.GetPeerResponse
+	84,  // 196: blockchain_api.PeerRegistryService.AddBanScore:output_type -> blockchain_api.AddBanScoreResponse
+	86,  // 197: blockchain_api.PeerRegistryService.IsPeerBanned:output_type -> blockchain_api.IsPeerBannedResponse
+	87,  // 198: blockchain_api.PeerRegistryService.ListBannedPeers:output_type -> blockchain_api.ListBannedPeersResponse
+	136, // 199: blockchain_api.PeerRegistryService.ClearBannedPeers:output_type -> google.protobuf.Empty
+	136, // 200: blockchain_api.PeerRegistryService.UpdateConnectionState:output_type -> google.protobuf.Empty
+	136, // 201: blockchain_api.PeerRegistryService.UpdateLastMessageTime:output_type -> google.protobuf.Empty
+	136, // 202: blockchain_api.PeerRegistryService.UpdateStorage:output_type -> google.protobuf.Empty
+	136, // 203: blockchain_api.PeerRegistryService.RecordSyncAttempt:output_type -> google.protobuf.Empty
+	92,  // 204: blockchain_api.PeerRegistryService.ClearAllSyncAttempts:output_type -> blockchain_api.ClearAllSyncAttemptsResponse
+	136, // 205: blockchain_api.PeerRegistryService.RecordBlockReceived:output_type -> google.protobuf.Empty
+	136, // 206: blockchain_api.PeerRegistryService.RecordSubtreeReceived:output_type -> google.protobuf.Empty
+	136, // 207: blockchain_api.PeerRegistryService.RecordTransactionReceived:output_type -> google.protobuf.Empty
+	136, // 208: blockchain_api.PeerRegistryService.RecordCatchupError:output_type -> google.protobuf.Empty
+	136, // 209: blockchain_api.PeerRegistryService.RecordCatchupAttempt:output_type -> google.protobuf.Empty
+	136, // 210: blockchain_api.PeerRegistryService.RecordCatchupSuccess:output_type -> google.protobuf.Empty
+	136, // 211: blockchain_api.PeerRegistryService.RecordCatchupFailure:output_type -> google.protobuf.Empty
+	99,  // 212: blockchain_api.PeerRegistryService.ResetReputation:output_type -> blockchain_api.ResetReputationResponse
+	101, // 213: blockchain_api.PeerRegistryService.ReconsiderBadPeers:output_type -> blockchain_api.ReconsiderBadPeersResponse
+	136, // 214: blockchain_api.PeerRegistryService.RecordValidatedPeerProgress:output_type -> google.protobuf.Empty
+	123, // [123:215] is the sub-list for method output_type
+	31,  // [31:123] is the sub-list for method input_type
 	31,  // [31:31] is the sub-list for extension type_name
 	31,  // [31:31] is the sub-list for extension extendee
 	0,   // [0:31] is the sub-list for field type_name
@@ -8053,7 +8244,7 @@ func file_services_blockchain_blockchain_api_blockchain_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc), len(file_services_blockchain_blockchain_api_blockchain_api_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   125,
+			NumMessages:   128,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/services/blockchain/blockchain_api/blockchain_api.proto
+++ b/services/blockchain/blockchain_api/blockchain_api.proto
@@ -726,6 +726,17 @@ service PeerRegistryService {
   // RecordCatchupError stores the peer's most recent catchup error for diagnostics.
   rpc RecordCatchupError(RecordCatchupErrorRequest) returns (google.protobuf.Empty) {}
 
+  // RecordCatchupAttempt increments the peer's catchup-attempt counter and updates
+  // sync backoff tracking (LastSyncAttempt / SyncAttemptCount).
+  rpc RecordCatchupAttempt(RecordCatchupAttemptRequest) returns (google.protobuf.Empty) {}
+
+  // RecordCatchupSuccess increments the peer's catchup-success counter and records
+  // a successful interaction with the given response time.
+  rpc RecordCatchupSuccess(RecordCatchupSuccessRequest) returns (google.protobuf.Empty) {}
+
+  // RecordCatchupFailure increments the peer's catchup-failure counter and records a failed interaction.
+  rpc RecordCatchupFailure(RecordCatchupFailureRequest) returns (google.protobuf.Empty) {}
+
   // ResetReputation resets reputation for the given peer (or all peers when peer_id is empty)
   // to the recovery baseline and returns the count of peers reset.
   rpc ResetReputation(ResetReputationRequest) returns (ResetReputationResponse) {}
@@ -790,6 +801,12 @@ message PeerRegistryInfo {
   google.protobuf.Timestamp last_validated_at = 40;
   int64 full_storage_contradictions = 41;     // Count of observed contradictions to full-storage claims
   google.protobuf.Timestamp full_storage_penalty_until = 42;
+
+  // Catchup-specific counters, maintained via RecordCatchupAttempt/Success/Failure.
+  // Distinct from the generic interaction counters, which mix in blocks/subtrees/txs.
+  int64 catchup_attempts = 43;
+  int64 catchup_successes = 44;
+  int64 catchup_failures = 45;
 }
 
 // RegisterPeerRequest registers or updates a peer in the centralized registry.
@@ -913,6 +930,22 @@ message RecordReceivedRequest {
 message RecordCatchupErrorRequest {
   string peer_id = 1;
   string error_message = 2;
+}
+
+// RecordCatchupAttemptRequest records a catchup attempt against a peer.
+message RecordCatchupAttemptRequest {
+  string peer_id = 1;
+}
+
+// RecordCatchupSuccessRequest records a successful catchup from a peer.
+message RecordCatchupSuccessRequest {
+  string peer_id = 1;
+  int64 response_time_ms = 2;                 // Duration of the catchup operation (0 = not applicable)
+}
+
+// RecordCatchupFailureRequest records a failed catchup attempt against a peer.
+message RecordCatchupFailureRequest {
+  string peer_id = 1;
 }
 
 // ResetReputationRequest resets reputation for a single peer or all peers when peer_id is empty.

--- a/services/blockchain/blockchain_api/blockchain_api_grpc.pb.go
+++ b/services/blockchain/blockchain_api/blockchain_api_grpc.pb.go
@@ -2849,6 +2849,9 @@ const (
 	PeerRegistryService_RecordSubtreeReceived_FullMethodName       = "/blockchain_api.PeerRegistryService/RecordSubtreeReceived"
 	PeerRegistryService_RecordTransactionReceived_FullMethodName   = "/blockchain_api.PeerRegistryService/RecordTransactionReceived"
 	PeerRegistryService_RecordCatchupError_FullMethodName          = "/blockchain_api.PeerRegistryService/RecordCatchupError"
+	PeerRegistryService_RecordCatchupAttempt_FullMethodName        = "/blockchain_api.PeerRegistryService/RecordCatchupAttempt"
+	PeerRegistryService_RecordCatchupSuccess_FullMethodName        = "/blockchain_api.PeerRegistryService/RecordCatchupSuccess"
+	PeerRegistryService_RecordCatchupFailure_FullMethodName        = "/blockchain_api.PeerRegistryService/RecordCatchupFailure"
 	PeerRegistryService_ResetReputation_FullMethodName             = "/blockchain_api.PeerRegistryService/ResetReputation"
 	PeerRegistryService_ReconsiderBadPeers_FullMethodName          = "/blockchain_api.PeerRegistryService/ReconsiderBadPeers"
 	PeerRegistryService_RecordValidatedPeerProgress_FullMethodName = "/blockchain_api.PeerRegistryService/RecordValidatedPeerProgress"
@@ -2899,6 +2902,14 @@ type PeerRegistryServiceClient interface {
 	RecordTransactionReceived(ctx context.Context, in *RecordReceivedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// RecordCatchupError stores the peer's most recent catchup error for diagnostics.
 	RecordCatchupError(ctx context.Context, in *RecordCatchupErrorRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// RecordCatchupAttempt increments the peer's catchup-attempt counter and updates
+	// sync backoff tracking (LastSyncAttempt / SyncAttemptCount).
+	RecordCatchupAttempt(ctx context.Context, in *RecordCatchupAttemptRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// RecordCatchupSuccess increments the peer's catchup-success counter and records
+	// a successful interaction with the given response time.
+	RecordCatchupSuccess(ctx context.Context, in *RecordCatchupSuccessRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// RecordCatchupFailure increments the peer's catchup-failure counter and records a failed interaction.
+	RecordCatchupFailure(ctx context.Context, in *RecordCatchupFailureRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// ResetReputation resets reputation for the given peer (or all peers when peer_id is empty)
 	// to the recovery baseline and returns the count of peers reset.
 	ResetReputation(ctx context.Context, in *ResetReputationRequest, opts ...grpc.CallOption) (*ResetReputationResponse, error)
@@ -3097,6 +3108,36 @@ func (c *peerRegistryServiceClient) RecordCatchupError(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *peerRegistryServiceClient) RecordCatchupAttempt(ctx context.Context, in *RecordCatchupAttemptRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, PeerRegistryService_RecordCatchupAttempt_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *peerRegistryServiceClient) RecordCatchupSuccess(ctx context.Context, in *RecordCatchupSuccessRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, PeerRegistryService_RecordCatchupSuccess_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *peerRegistryServiceClient) RecordCatchupFailure(ctx context.Context, in *RecordCatchupFailureRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, PeerRegistryService_RecordCatchupFailure_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *peerRegistryServiceClient) ResetReputation(ctx context.Context, in *ResetReputationRequest, opts ...grpc.CallOption) (*ResetReputationResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ResetReputationResponse)
@@ -3172,6 +3213,14 @@ type PeerRegistryServiceServer interface {
 	RecordTransactionReceived(context.Context, *RecordReceivedRequest) (*emptypb.Empty, error)
 	// RecordCatchupError stores the peer's most recent catchup error for diagnostics.
 	RecordCatchupError(context.Context, *RecordCatchupErrorRequest) (*emptypb.Empty, error)
+	// RecordCatchupAttempt increments the peer's catchup-attempt counter and updates
+	// sync backoff tracking (LastSyncAttempt / SyncAttemptCount).
+	RecordCatchupAttempt(context.Context, *RecordCatchupAttemptRequest) (*emptypb.Empty, error)
+	// RecordCatchupSuccess increments the peer's catchup-success counter and records
+	// a successful interaction with the given response time.
+	RecordCatchupSuccess(context.Context, *RecordCatchupSuccessRequest) (*emptypb.Empty, error)
+	// RecordCatchupFailure increments the peer's catchup-failure counter and records a failed interaction.
+	RecordCatchupFailure(context.Context, *RecordCatchupFailureRequest) (*emptypb.Empty, error)
 	// ResetReputation resets reputation for the given peer (or all peers when peer_id is empty)
 	// to the recovery baseline and returns the count of peers reset.
 	ResetReputation(context.Context, *ResetReputationRequest) (*ResetReputationResponse, error)
@@ -3243,6 +3292,15 @@ func (UnimplementedPeerRegistryServiceServer) RecordTransactionReceived(context.
 }
 func (UnimplementedPeerRegistryServiceServer) RecordCatchupError(context.Context, *RecordCatchupErrorRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method RecordCatchupError not implemented")
+}
+func (UnimplementedPeerRegistryServiceServer) RecordCatchupAttempt(context.Context, *RecordCatchupAttemptRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method RecordCatchupAttempt not implemented")
+}
+func (UnimplementedPeerRegistryServiceServer) RecordCatchupSuccess(context.Context, *RecordCatchupSuccessRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method RecordCatchupSuccess not implemented")
+}
+func (UnimplementedPeerRegistryServiceServer) RecordCatchupFailure(context.Context, *RecordCatchupFailureRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method RecordCatchupFailure not implemented")
 }
 func (UnimplementedPeerRegistryServiceServer) ResetReputation(context.Context, *ResetReputationRequest) (*ResetReputationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResetReputation not implemented")
@@ -3598,6 +3656,60 @@ func _PeerRegistryService_RecordCatchupError_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PeerRegistryService_RecordCatchupAttempt_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RecordCatchupAttemptRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PeerRegistryServiceServer).RecordCatchupAttempt(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PeerRegistryService_RecordCatchupAttempt_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PeerRegistryServiceServer).RecordCatchupAttempt(ctx, req.(*RecordCatchupAttemptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PeerRegistryService_RecordCatchupSuccess_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RecordCatchupSuccessRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PeerRegistryServiceServer).RecordCatchupSuccess(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PeerRegistryService_RecordCatchupSuccess_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PeerRegistryServiceServer).RecordCatchupSuccess(ctx, req.(*RecordCatchupSuccessRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PeerRegistryService_RecordCatchupFailure_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RecordCatchupFailureRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PeerRegistryServiceServer).RecordCatchupFailure(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PeerRegistryService_RecordCatchupFailure_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PeerRegistryServiceServer).RecordCatchupFailure(ctx, req.(*RecordCatchupFailureRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _PeerRegistryService_ResetReputation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ResetReputationRequest)
 	if err := dec(in); err != nil {
@@ -3730,6 +3842,18 @@ var PeerRegistryService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RecordCatchupError",
 			Handler:    _PeerRegistryService_RecordCatchupError_Handler,
+		},
+		{
+			MethodName: "RecordCatchupAttempt",
+			Handler:    _PeerRegistryService_RecordCatchupAttempt_Handler,
+		},
+		{
+			MethodName: "RecordCatchupSuccess",
+			Handler:    _PeerRegistryService_RecordCatchupSuccess_Handler,
+		},
+		{
+			MethodName: "RecordCatchupFailure",
+			Handler:    _PeerRegistryService_RecordCatchupFailure_Handler,
 		},
 		{
 			MethodName: "ResetReputation",

--- a/services/blockchain/peer_registry.go
+++ b/services/blockchain/peer_registry.go
@@ -100,6 +100,9 @@ type PeerInfo struct {
 	SubtreesReceived     int64
 	TransactionsReceived int64
 	CatchupBlocks        int64
+	CatchupAttempts      int64
+	CatchupSuccesses     int64
+	CatchupFailures      int64
 	LastSyncAttempt      time.Time
 	SyncAttemptCount     int32
 	LastReputationReset  time.Time
@@ -1054,6 +1057,10 @@ func (r *CentralizedPeerRegistry) ResetReputation(peerID string) int {
 
 		info.LastSyncAttempt = time.Time{}
 		info.SyncAttemptCount = 0
+
+		info.CatchupAttempts = 0
+		info.CatchupSuccesses = 0
+		info.CatchupFailures = 0
 	}
 
 	if peerID == "" {
@@ -1186,9 +1193,9 @@ func (r *CentralizedPeerRegistry) ClearAllSyncAttempts() int {
 }
 
 // recordReceivedSuccessLocked is the shared body of RecordBlockReceived /
-// RecordSubtreeReceived: increment the supplied counter, mark a successful
-// interaction, blend the response time into the rolling average, recompute
-// reputation. Caller must hold the write lock.
+// RecordSubtreeReceived / RecordCatchupSuccess: increment the supplied counter,
+// mark a successful interaction, blend the response time into the rolling
+// average, recompute reputation. Caller must hold the write lock.
 func (r *CentralizedPeerRegistry) recordReceivedSuccessLocked(info *PeerInfo, counter *int64, responseTimeMs int64) {
 	*counter++
 	info.InteractionAttempts++
@@ -1241,6 +1248,50 @@ func (r *CentralizedPeerRegistry) RecordTransactionReceived(peerID string) {
 		info.InteractionSuccesses++
 		info.LastInteractionSuccess = time.Now()
 		info.LastSeen = info.LastInteractionSuccess
+		r.calculateAndUpdateReputation(info)
+	}
+}
+
+// RecordCatchupAttempt notes that a catchup attempt was made to the peer:
+// increments the catchup-attempt counter and updates the sync backoff tracking
+// fields (LastSyncAttempt / SyncAttemptCount). The attempt is counted even when
+// it later produces neither a success nor a failure.
+func (r *CentralizedPeerRegistry) RecordCatchupAttempt(peerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info, ok := r.peers[peerID]; ok {
+		info.CatchupAttempts++
+		info.LastSyncAttempt = time.Now()
+		info.SyncAttemptCount++
+	}
+}
+
+// RecordCatchupSuccess increments the catchup-success counter and records a
+// successful interaction with the given response time.
+func (r *CentralizedPeerRegistry) RecordCatchupSuccess(peerID string, responseTimeMs int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info, ok := r.peers[peerID]; ok {
+		r.recordReceivedSuccessLocked(info, &info.CatchupSuccesses, responseTimeMs)
+	}
+}
+
+// RecordCatchupFailure increments the catchup-failure counter and records a
+// failed interaction.
+func (r *CentralizedPeerRegistry) RecordCatchupFailure(peerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info, ok := r.peers[peerID]; ok {
+		now := time.Now()
+		info.CatchupFailures++
+		info.InteractionAttempts++
+		info.InteractionFailures++
+		info.LastInteractionAttempt = now
+		info.LastInteractionFailure = now
+		info.LastSeen = now
 		r.calculateAndUpdateReputation(info)
 	}
 }

--- a/services/blockchain/peer_registry_client.go
+++ b/services/blockchain/peer_registry_client.go
@@ -75,6 +75,18 @@ type PeerRegistryClientI interface {
 	// RecordCatchupError stores the peer's most recent catchup error.
 	RecordCatchupError(ctx context.Context, peerID, errMsg string) error
 
+	// RecordCatchupAttempt increments the peer's catchup-attempt counter and
+	// updates sync backoff tracking.
+	RecordCatchupAttempt(ctx context.Context, peerID string) error
+
+	// RecordCatchupSuccess increments the peer's catchup-success counter and
+	// records a successful interaction with the given response time.
+	RecordCatchupSuccess(ctx context.Context, peerID string, responseTimeMs int64) error
+
+	// RecordCatchupFailure increments the peer's catchup-failure counter and
+	// records a failed interaction.
+	RecordCatchupFailure(ctx context.Context, peerID string) error
+
 	// ResetReputation resets reputation for a peer (or all peers when peerID is empty).
 	// Returns the count of peers reset.
 	ResetReputation(ctx context.Context, peerID string) (int32, error)
@@ -312,6 +324,27 @@ func (c *PeerRegistryClient) RecordCatchupError(ctx context.Context, peerID, err
 	return err
 }
 
+// RecordCatchupAttempt implements PeerRegistryClientI.
+func (c *PeerRegistryClient) RecordCatchupAttempt(ctx context.Context, peerID string) error {
+	_, err := c.client.RecordCatchupAttempt(ctx, &blockchain_api.RecordCatchupAttemptRequest{PeerId: peerID})
+	return err
+}
+
+// RecordCatchupSuccess implements PeerRegistryClientI.
+func (c *PeerRegistryClient) RecordCatchupSuccess(ctx context.Context, peerID string, responseTimeMs int64) error {
+	_, err := c.client.RecordCatchupSuccess(ctx, &blockchain_api.RecordCatchupSuccessRequest{
+		PeerId:         peerID,
+		ResponseTimeMs: responseTimeMs,
+	})
+	return err
+}
+
+// RecordCatchupFailure implements PeerRegistryClientI.
+func (c *PeerRegistryClient) RecordCatchupFailure(ctx context.Context, peerID string) error {
+	_, err := c.client.RecordCatchupFailure(ctx, &blockchain_api.RecordCatchupFailureRequest{PeerId: peerID})
+	return err
+}
+
 // ResetReputation implements PeerRegistryClientI.
 func (c *PeerRegistryClient) ResetReputation(ctx context.Context, peerID string) (int32, error) {
 	resp, err := c.client.ResetReputation(ctx, &blockchain_api.ResetReputationRequest{PeerId: peerID})
@@ -458,6 +491,21 @@ func (l *localPeerRegistryClient) RecordTransactionReceived(_ context.Context, p
 
 func (l *localPeerRegistryClient) RecordCatchupError(_ context.Context, peerID, errMsg string) error {
 	l.reg.RecordCatchupError(peerID, errMsg)
+	return nil
+}
+
+func (l *localPeerRegistryClient) RecordCatchupAttempt(_ context.Context, peerID string) error {
+	l.reg.RecordCatchupAttempt(peerID)
+	return nil
+}
+
+func (l *localPeerRegistryClient) RecordCatchupSuccess(_ context.Context, peerID string, responseTimeMs int64) error {
+	l.reg.RecordCatchupSuccess(peerID, responseTimeMs)
+	return nil
+}
+
+func (l *localPeerRegistryClient) RecordCatchupFailure(_ context.Context, peerID string) error {
+	l.reg.RecordCatchupFailure(peerID)
 	return nil
 }
 

--- a/services/blockchain/peer_registry_client.go
+++ b/services/blockchain/peer_registry_client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -324,24 +326,40 @@ func (c *PeerRegistryClient) RecordCatchupError(ctx context.Context, peerID, err
 	return err
 }
 
-// RecordCatchupAttempt implements PeerRegistryClientI.
+// RecordCatchupAttempt implements PeerRegistryClientI. During a rolling upgrade
+// the blockchain service may predate this RPC; fall back to the legacy
+// RecordSyncAttempt call so sync backoff tracking keeps working (only the new
+// catchup-attempt counter is lost until the server is upgraded).
 func (c *PeerRegistryClient) RecordCatchupAttempt(ctx context.Context, peerID string) error {
 	_, err := c.client.RecordCatchupAttempt(ctx, &blockchain_api.RecordCatchupAttemptRequest{PeerId: peerID})
+	if status.Code(err) == codes.Unimplemented {
+		_, err = c.client.RecordSyncAttempt(ctx, &blockchain_api.RecordSyncAttemptRequest{PeerId: peerID})
+	}
 	return err
 }
 
-// RecordCatchupSuccess implements PeerRegistryClientI.
+// RecordCatchupSuccess implements PeerRegistryClientI. Falls back to the legacy
+// UpdatePeerMetrics(success) call when the blockchain service predates this RPC,
+// so reputation credit keeps flowing during a rolling upgrade.
 func (c *PeerRegistryClient) RecordCatchupSuccess(ctx context.Context, peerID string, responseTimeMs int64) error {
 	_, err := c.client.RecordCatchupSuccess(ctx, &blockchain_api.RecordCatchupSuccessRequest{
 		PeerId:         peerID,
 		ResponseTimeMs: responseTimeMs,
 	})
+	if status.Code(err) == codes.Unimplemented {
+		return c.UpdatePeerMetrics(ctx, peerID, 0, 0, 0, true, false, false, responseTimeMs)
+	}
 	return err
 }
 
-// RecordCatchupFailure implements PeerRegistryClientI.
+// RecordCatchupFailure implements PeerRegistryClientI. Falls back to the legacy
+// UpdatePeerMetrics(failure) call when the blockchain service predates this RPC,
+// so reputation penalties keep applying during a rolling upgrade.
 func (c *PeerRegistryClient) RecordCatchupFailure(ctx context.Context, peerID string) error {
 	_, err := c.client.RecordCatchupFailure(ctx, &blockchain_api.RecordCatchupFailureRequest{PeerId: peerID})
+	if status.Code(err) == codes.Unimplemented {
+		return c.UpdatePeerMetrics(ctx, peerID, 0, 0, 0, false, true, false, 0)
+	}
 	return err
 }
 

--- a/services/blockchain/peer_registry_client_test.go
+++ b/services/blockchain/peer_registry_client_test.go
@@ -1,7 +1,9 @@
 package blockchain
 
 import (
+	"context"
 	"net"
+	"sync"
 	"testing"
 
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
@@ -10,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // startFakePeerRegistryServer starts a gRPC server with the unimplemented
@@ -202,4 +205,69 @@ func TestPeerRegistryClient_SetLoggerNilIsNoop(t *testing.T) {
 	first := client.log()
 	client.SetLogger(nil)
 	require.Equal(t, first, client.log())
+}
+
+// ---------------------------------------------------------------------------
+// Rolling-upgrade fallback: catchup RPCs against an old blockchain service
+// ---------------------------------------------------------------------------
+
+// legacyPeerRegistryServer simulates a blockchain service that predates the
+// catchup-specific RPCs: RecordCatchupAttempt/Success/Failure return
+// codes.Unimplemented (via the embedded unimplemented server), while the
+// legacy RecordSyncAttempt and UpdatePeerMetrics RPCs work and record calls.
+type legacyPeerRegistryServer struct {
+	blockchain_api.UnimplementedPeerRegistryServiceServer
+
+	mu            sync.Mutex
+	syncAttempts  []string
+	metricUpdates []*blockchain_api.UpdatePeerMetricsRequest
+}
+
+func (s *legacyPeerRegistryServer) RecordSyncAttempt(_ context.Context, req *blockchain_api.RecordSyncAttemptRequest) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.syncAttempts = append(s.syncAttempts, req.PeerId)
+	return &emptypb.Empty{}, nil
+}
+
+func (s *legacyPeerRegistryServer) UpdatePeerMetrics(_ context.Context, req *blockchain_api.UpdatePeerMetricsRequest) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metricUpdates = append(s.metricUpdates, req)
+	return &emptypb.Empty{}, nil
+}
+
+func TestPeerRegistryClient_CatchupRPCs_FallBackOnUnimplemented(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	legacy := &legacyPeerRegistryServer{}
+	s := grpc.NewServer()
+	blockchain_api.RegisterPeerRegistryServiceServer(s, legacy)
+	go func() { _ = s.Serve(lis) }()
+	defer s.Stop()
+
+	conn := dialConn(t, lis.Addr().String())
+	defer conn.Close()
+	client := NewPeerRegistryClientFromConn(conn)
+
+	ctx := context.Background()
+
+	require.NoError(t, client.RecordCatchupAttempt(ctx, "peer-1"))
+	require.NoError(t, client.RecordCatchupSuccess(ctx, "peer-1", 150))
+	require.NoError(t, client.RecordCatchupFailure(ctx, "peer-1"))
+
+	legacy.mu.Lock()
+	defer legacy.mu.Unlock()
+
+	require.Equal(t, []string{"peer-1"}, legacy.syncAttempts, "attempt must fall back to RecordSyncAttempt")
+
+	require.Len(t, legacy.metricUpdates, 2)
+	success := legacy.metricUpdates[0]
+	require.True(t, success.RecordSuccess, "success must fall back to UpdatePeerMetrics(success)")
+	require.False(t, success.RecordFailure)
+	require.Equal(t, int64(150), success.ResponseTimeMs)
+	failure := legacy.metricUpdates[1]
+	require.True(t, failure.RecordFailure, "failure must fall back to UpdatePeerMetrics(failure)")
+	require.False(t, failure.RecordSuccess)
 }

--- a/services/blockchain/peer_registry_grpc.go
+++ b/services/blockchain/peer_registry_grpc.go
@@ -151,6 +151,24 @@ func (b *Blockchain) RecordCatchupError(_ context.Context, req *blockchain_api.R
 	return &emptypb.Empty{}, nil
 }
 
+// RecordCatchupAttempt increments the peer's catchup-attempt counter and updates sync backoff tracking.
+func (b *Blockchain) RecordCatchupAttempt(_ context.Context, req *blockchain_api.RecordCatchupAttemptRequest) (*emptypb.Empty, error) {
+	b.peerRegistry.RecordCatchupAttempt(req.PeerId)
+	return &emptypb.Empty{}, nil
+}
+
+// RecordCatchupSuccess increments the peer's catchup-success counter and records a successful interaction.
+func (b *Blockchain) RecordCatchupSuccess(_ context.Context, req *blockchain_api.RecordCatchupSuccessRequest) (*emptypb.Empty, error) {
+	b.peerRegistry.RecordCatchupSuccess(req.PeerId, req.ResponseTimeMs)
+	return &emptypb.Empty{}, nil
+}
+
+// RecordCatchupFailure increments the peer's catchup-failure counter and records a failed interaction.
+func (b *Blockchain) RecordCatchupFailure(_ context.Context, req *blockchain_api.RecordCatchupFailureRequest) (*emptypb.Empty, error) {
+	b.peerRegistry.RecordCatchupFailure(req.PeerId)
+	return &emptypb.Empty{}, nil
+}
+
 // ResetReputation resets reputation for a peer (or all peers when peer_id is empty).
 func (b *Blockchain) ResetReputation(_ context.Context, req *blockchain_api.ResetReputationRequest) (*blockchain_api.ResetReputationResponse, error) {
 	reset := b.peerRegistry.ResetReputation(req.PeerId)
@@ -221,6 +239,9 @@ func peerInfoToProto(info *PeerInfo) *blockchain_api.PeerRegistryInfo {
 		LastValidatedAt:           timestamppb.New(info.LastValidatedAt),
 		FullStorageContradictions: info.FullStorageContradictions,
 		FullStoragePenaltyUntil:   timestamppb.New(info.FullStoragePenaltyUntil),
+		CatchupAttempts:           info.CatchupAttempts,
+		CatchupSuccesses:          info.CatchupSuccesses,
+		CatchupFailures:           info.CatchupFailures,
 	}
 }
 
@@ -288,6 +309,9 @@ func protoToPeerInfo(logger ulogger.Logger, p *blockchain_api.PeerRegistryInfo) 
 		LastValidatedAt:           protoTimeToTime(p.LastValidatedAt),
 		FullStorageContradictions: p.FullStorageContradictions,
 		FullStoragePenaltyUntil:   protoTimeToTime(p.FullStoragePenaltyUntil),
+		CatchupAttempts:           p.CatchupAttempts,
+		CatchupSuccesses:          p.CatchupSuccesses,
+		CatchupFailures:           p.CatchupFailures,
 	}
 }
 

--- a/services/blockchain/peer_registry_grpc_test.go
+++ b/services/blockchain/peer_registry_grpc_test.go
@@ -120,6 +120,36 @@ func TestGRPC_RecordValidatedPeerProgress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// RecordCatchupAttempt / RecordCatchupSuccess / RecordCatchupFailure
+// ---------------------------------------------------------------------------
+
+func TestGRPC_RecordCatchupCounters(t *testing.T) {
+	b := newTestBlockchain()
+	ctx := context.Background()
+
+	_, err := b.RegisterPeer(ctx, &blockchain_api.RegisterPeerRequest{
+		Peer: &blockchain_api.PeerRegistryInfo{PeerId: "peer-1"},
+	})
+	require.NoError(t, err)
+
+	_, err = b.RecordCatchupAttempt(ctx, &blockchain_api.RecordCatchupAttemptRequest{PeerId: "peer-1"})
+	require.NoError(t, err)
+	_, err = b.RecordCatchupAttempt(ctx, &blockchain_api.RecordCatchupAttemptRequest{PeerId: "peer-1"})
+	require.NoError(t, err)
+	_, err = b.RecordCatchupSuccess(ctx, &blockchain_api.RecordCatchupSuccessRequest{PeerId: "peer-1", ResponseTimeMs: 150})
+	require.NoError(t, err)
+	_, err = b.RecordCatchupFailure(ctx, &blockchain_api.RecordCatchupFailureRequest{PeerId: "peer-1"})
+	require.NoError(t, err)
+
+	got, ok := b.peerRegistry.Get("peer-1")
+	require.True(t, ok)
+	require.Equal(t, int64(2), got.CatchupAttempts)
+	require.Equal(t, int64(1), got.CatchupSuccesses)
+	require.Equal(t, int64(1), got.CatchupFailures)
+	require.Equal(t, int64(150), got.AvgResponseTimeMs)
+}
+
+// ---------------------------------------------------------------------------
 // RemovePeer
 // ---------------------------------------------------------------------------
 
@@ -444,6 +474,9 @@ func TestGRPC_PeerInfoProtoRoundTrip(t *testing.T) {
 		LastValidatedAt:           now.Add(-2 * time.Minute),
 		FullStorageContradictions: 3,
 		FullStoragePenaltyUntil:   now.Add(30 * time.Minute),
+		CatchupAttempts:           12,
+		CatchupSuccesses:          9,
+		CatchupFailures:           2,
 	}
 
 	proto := peerInfoToProto(original)
@@ -466,6 +499,9 @@ func TestGRPC_PeerInfoProtoRoundTrip(t *testing.T) {
 	require.Equal(t, original.MaliciousCount, roundTripped.MaliciousCount)
 	require.Equal(t, original.ReputationScore, roundTripped.ReputationScore)
 	require.Equal(t, original.AvgResponseTimeMs, roundTripped.AvgResponseTimeMs)
+	require.Equal(t, original.CatchupAttempts, roundTripped.CatchupAttempts)
+	require.Equal(t, original.CatchupSuccesses, roundTripped.CatchupSuccesses)
+	require.Equal(t, original.CatchupFailures, roundTripped.CatchupFailures)
 
 	// Timestamps: protobuf round-trips lose sub-microsecond precision, but we
 	// truncated above so direct comparison is safe within a second.

--- a/services/blockchain/peer_registry_persistence.go
+++ b/services/blockchain/peer_registry_persistence.go
@@ -39,7 +39,12 @@ type persistedBanEntry struct {
 	Reasons   []string  `json:"reasons,omitempty"`
 }
 
-const persistedRegistryVersion = 1
+// Version history:
+//   - 1: initial format
+//   - 2: added catchup-specific counters (CatchupAttempts/CatchupSuccesses/
+//     CatchupFailures) to PeerInfo. Bumped so a downgraded binary refuses to
+//     re-save (and thereby silently zero) counters it does not understand.
+const persistedRegistryVersion = 2
 
 // errFutureRegistryVersion is returned by loadPeerRegistry when the blob's
 // envelope.Version is newer than this binary supports. Callers (currently

--- a/services/blockchain/peer_registry_test.go
+++ b/services/blockchain/peer_registry_test.go
@@ -369,6 +369,43 @@ func TestCentralizedPeerRegistry_RecordBlockSubtreeTransaction(t *testing.T) {
 	require.False(t, got.LastBlockTime.IsZero())
 }
 
+func TestCentralizedPeerRegistry_RecordCatchupCounters(t *testing.T) {
+	r := NewCentralizedPeerRegistry(DefaultBanConfig())
+
+	r.Register(&PeerInfo{ID: "p"})
+
+	r.RecordCatchupAttempt("p")
+	r.RecordCatchupAttempt("p")
+	r.RecordCatchupAttempt("p")
+	r.RecordCatchupSuccess("p", 150)
+	r.RecordCatchupFailure("p")
+
+	// Non-catchup activity must not move the catchup counters.
+	r.RecordBlockReceived("p", 100)
+	r.RecordSubtreeReceived("p", 0)
+
+	got, _ := r.Get("p")
+	require.Equal(t, int64(3), got.CatchupAttempts)
+	require.Equal(t, int64(1), got.CatchupSuccesses)
+	require.Equal(t, int64(1), got.CatchupFailures)
+
+	// Attempts also feed the sync backoff tracking.
+	require.Equal(t, int32(3), got.SyncAttemptCount)
+	require.False(t, got.LastSyncAttempt.IsZero())
+
+	// Success/failure still feed the generic interaction metrics.
+	require.Equal(t, int64(3), got.InteractionSuccesses, "catchup success + block + subtree")
+	require.Equal(t, int64(1), got.InteractionFailures)
+	require.False(t, got.LastInteractionFailure.IsZero())
+
+	// Unknown peers are a no-op.
+	r.RecordCatchupAttempt("ghost")
+	r.RecordCatchupSuccess("ghost", 0)
+	r.RecordCatchupFailure("ghost")
+	_, ok := r.Get("ghost")
+	require.False(t, ok)
+}
+
 func TestCentralizedPeerRegistry_RecordCatchupError(t *testing.T) {
 	r := NewCentralizedPeerRegistry(DefaultBanConfig())
 
@@ -732,12 +769,18 @@ func TestCentralizedPeerRegistry_ResetReputation(t *testing.T) {
 	r.Register(&PeerInfo{ID: "a"})
 	r.UpdateMetrics("a", 0, 0, 0, false, false, true, 0)
 	r.RecordSyncAttempt("a")
+	r.RecordCatchupAttempt("a")
+	r.RecordCatchupSuccess("a", 100)
+	r.RecordCatchupFailure("a")
 
 	require.Equal(t, 1, r.ResetReputation("a"))
 	got, _ := r.Get("a")
 	require.Equal(t, 50.0, got.ReputationScore)
 	require.Equal(t, int64(0), got.MaliciousCount)
 	require.Equal(t, int32(0), got.SyncAttemptCount)
+	require.Equal(t, int64(0), got.CatchupAttempts)
+	require.Equal(t, int64(0), got.CatchupSuccesses)
+	require.Equal(t, int64(0), got.CatchupFailures)
 
 	// Reset all.
 	r.Register(&PeerInfo{ID: "b"})

--- a/services/blockvalidation/catchup_get_block_headers.go
+++ b/services/blockvalidation/catchup_get_block_headers.go
@@ -448,11 +448,13 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 		u.logger.Warnf("[catchup][%s] stopped after %d iterations without reaching target", chainTipHash.String(), iteration)
 	}
 
-	// Do NOT report catchup success here: fetching headers is only one stage of a
-	// catchup, and the whole operation records exactly one attempt (doCatchup).
-	// Reporting a second success would let CatchupSuccesses exceed CatchupAttempts;
-	// the single success is reported by doCatchup once blocks are fetched and
-	// validated. Header-fetch failures above still count as catchup failures.
+	// Credit the peer for serving headers. This is a generic interaction success
+	// (reputation), deliberately NOT a catchup success: the whole catchup records
+	// exactly one attempt (doCatchup) and one outcome, so counting this stage as a
+	// catchup success would let CatchupSuccesses exceed CatchupAttempts.
+	if totalHeadersFetched > 0 {
+		u.reportValidBlockHeaders(ctx, identifier, time.Since(startTime))
+	}
 
 	// Set default stop reason if none was set
 	if stopReason == "" {

--- a/services/blockvalidation/catchup_get_block_headers.go
+++ b/services/blockvalidation/catchup_get_block_headers.go
@@ -262,11 +262,13 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 				}
 				failedIterations = append(failedIterations, iterErr)
 
-				// Return a timeout error - this is just a slow peer, not necessarily malicious
+				// Return a timeout error - this is just a slow peer, not necessarily malicious.
+				// Marked as already-reported so the top-level catchup handler does not
+				// record a second failure for the same attempt.
 				return catchup.CreateCatchupResult(
 					allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
 					iteration, failedIterations, false, "Peer response timeout",
-				), nil, errors.NewNetworkTimeoutError("peer %s timed out after %v during iteration %d", baseURL, elapsed, iteration)
+				), nil, markCatchupFailureReported(errors.NewNetworkTimeoutError("peer %s timed out after %v during iteration %d", baseURL, elapsed, iteration))
 			}
 
 			// Handle other non-timeout errors
@@ -287,18 +289,21 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 			// Report failed request to P2P service
 			u.reportCatchupFailure(ctx, identifier)
 
-			// Check if this is a malicious response
+			// Check if this is a malicious response. Both returns below are marked
+			// as already-reported (the failure was recorded just above) so the
+			// top-level catchup handler does not record a second failure for the
+			// same attempt; the malicious classification itself is unaffected.
 			if errors.IsMaliciousResponseError(err) {
 				return catchup.CreateCatchupResult(
 					allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
 					iteration, failedIterations, false, "Malicious peer detected",
-				), nil, errors.NewNetworkPeerMaliciousError("peer returned malicious response: %w", err)
+				), nil, markCatchupFailureReported(errors.NewNetworkPeerMaliciousError("peer returned malicious response: %w", err))
 			}
 
 			return catchup.CreateCatchupResult(
 				allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
 				iteration, failedIterations, false, "Failed to fetch headers",
-			), nil, err
+			), nil, markCatchupFailureReported(err)
 		}
 
 		// Validate header bytes

--- a/services/blockvalidation/catchup_get_block_headers.go
+++ b/services/blockvalidation/catchup_get_block_headers.go
@@ -448,11 +448,11 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 		u.logger.Warnf("[catchup][%s] stopped after %d iterations without reaching target", chainTipHash.String(), iteration)
 	}
 
-	// Report successful catchup to P2P service (if we got any headers)
-	if totalHeadersFetched > 0 {
-		responseTime := time.Since(startTime)
-		u.reportCatchupSuccess(ctx, identifier, responseTime)
-	}
+	// Do NOT report catchup success here: fetching headers is only one stage of a
+	// catchup, and the whole operation records exactly one attempt (doCatchup).
+	// Reporting a second success would let CatchupSuccesses exceed CatchupAttempts;
+	// the single success is reported by doCatchup once blocks are fetched and
+	// validated. Header-fetch failures above still count as catchup failures.
 
 	// Set default stop reason if none was set
 	if stopReason == "" {

--- a/services/blockvalidation/catchup_malicious_abort_test.go
+++ b/services/blockvalidation/catchup_malicious_abort_test.go
@@ -68,6 +68,10 @@ func (m *maliciousAbortP2PClient) GetPeersForCatchup(_ context.Context) ([]*p2p.
 func (m *maliciousAbortP2PClient) GetPeer(_ context.Context, _ string) (*p2p.PeerInfo, error) {
 	return nil, nil
 }
+func (m *maliciousAbortP2PClient) ReportValidBlockHeaders(_ context.Context, _ string, _ int64) error {
+	return nil
+}
+
 func (m *maliciousAbortP2PClient) ReportValidBlock(_ context.Context, _ string, _ string) error {
 	return nil
 }

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -4205,6 +4205,10 @@ func (r *recordingValidatedProgressP2PClient) IsPeerMalicious(_ context.Context,
 	return false, "", nil
 }
 
+func (r *recordingValidatedProgressP2PClient) ReportValidBlockHeaders(_ context.Context, _ string, _ int64) error {
+	return nil
+}
+
 func (r *recordingValidatedProgressP2PClient) ReportValidBlock(_ context.Context, peerID string, blockHash string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/services/blockvalidation/p2p_client_interface.go
+++ b/services/blockvalidation/p2p_client_interface.go
@@ -44,6 +44,11 @@ type P2PClientI interface {
 	// ReportValidBlock reports that a block was successfully received and validated from a peer.
 	ReportValidBlock(ctx context.Context, peerID string, blockHash string) error
 
+	// ReportValidBlockHeaders reports that a peer successfully served a batch of block
+	// headers during catchup. Credits a generic interaction success (reputation) without
+	// touching the catchup-operation counters.
+	ReportValidBlockHeaders(ctx context.Context, peerID string, durationMs int64) error
+
 	// ReportValidSubtree reports that a subtree was successfully received and validated from a peer.
 	ReportValidSubtree(ctx context.Context, peerID string, subtreeHash string) error
 

--- a/services/blockvalidation/peer_metrics_helpers.go
+++ b/services/blockvalidation/peer_metrics_helpers.go
@@ -2,7 +2,6 @@ package blockvalidation
 
 import (
 	"context"
-	stderrors "errors"
 	"time"
 
 	"github.com/bsv-blockchain/teranode/errors"
@@ -107,32 +106,54 @@ func (u *Server) reportCatchupFailureForError(ctx context.Context, peerID string
 	u.reportCatchupFailure(ctx, peerID)
 }
 
-// catchupFailureReportedError marks an error chain whose catchup failure has
-// already been recorded against the peer by the layer where it occurred, so
-// upper layers that report failures for propagated errors can skip
-// re-reporting. It is transparent to error-code matching: teranode errors.Is
-// digs through foreign links via Unwrap.
-type catchupFailureReportedError struct{ err error }
-
-func (e *catchupFailureReportedError) Error() string { return e.err.Error() }
-func (e *catchupFailureReportedError) Unwrap() error { return e.err }
+// catchupFailureReportedKey is the error-data key that marks an error chain
+// whose catchup failure has already been recorded against the peer by the
+// layer where it occurred, so upper layers that report failures for propagated
+// errors can skip re-reporting.
+const catchupFailureReportedKey = "catchup_failure_reported"
 
 // markCatchupFailureReported wraps err to signal that its catchup failure has
-// already been reported to the P2P service. Nil-safe.
+// already been reported to the P2P service. The wrapper is a native *Error
+// carrying a data-key marker: the errors package flattens foreign wrapper
+// types into message-only links (breaking code matching downstream), so the
+// marker must live in error data on a native link, which keeps the wrapped
+// chain fully intact for errors.Is dispatch. Nil-safe.
 func markCatchupFailureReported(err error) error {
 	if err == nil {
 		return nil
 	}
-	return &catchupFailureReportedError{err: err}
+	wrapped := errors.NewProcessingError("catchup failure reported at source: %w", err)
+	wrapped.SetData(catchupFailureReportedKey, true)
+	return wrapped
 }
 
 // catchupFailureAlreadyReported reports whether err carries the
-// markCatchupFailureReported marker anywhere in its chain. Uses the stdlib
-// errors.As because it walks every Unwrap link uniformly, regardless of where
-// foreign wrappers sit relative to teranode *Error links.
+// markCatchupFailureReported marker anywhere in its wrapped chain. The walk is
+// depth-bounded defensively, mirroring the errors package's own chain walks.
 func catchupFailureAlreadyReported(err error) bool {
-	var marker *catchupFailureReportedError
-	return stderrors.As(err, &marker)
+	var e *errors.Error
+	if !errors.As(err, &e) {
+		return false
+	}
+
+	for depth := 0; e != nil && depth < 32; depth++ {
+		if v, ok := e.GetData(catchupFailureReportedKey).(bool); ok && v {
+			return true
+		}
+
+		next := e.WrappedErr()
+		if next == nil {
+			return false
+		}
+
+		var nextErr *errors.Error
+		if !errors.As(next, &nextErr) {
+			return false
+		}
+		e = nextErr
+	}
+
+	return false
 }
 
 func (u *Server) reportCatchupFailureWithKind(ctx context.Context, peerID, failureKind, blockHash string) {

--- a/services/blockvalidation/peer_metrics_helpers.go
+++ b/services/blockvalidation/peer_metrics_helpers.go
@@ -2,6 +2,7 @@ package blockvalidation
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
 	"github.com/bsv-blockchain/teranode/errors"
@@ -97,7 +98,41 @@ func (u *Server) reportCatchupFailureForError(ctx context.Context, peerID string
 	if errors.Is(err, errors.ErrBlockIncomplete) {
 		return
 	}
+	if catchupFailureAlreadyReported(err) {
+		// The layer where the failure occurred (e.g. the header-fetch stage)
+		// already recorded it; reporting again would let CatchupFailures exceed
+		// CatchupAttempts and double the reputation penalty for one attempt.
+		return
+	}
 	u.reportCatchupFailure(ctx, peerID)
+}
+
+// catchupFailureReportedError marks an error chain whose catchup failure has
+// already been recorded against the peer by the layer where it occurred, so
+// upper layers that report failures for propagated errors can skip
+// re-reporting. It is transparent to error-code matching: teranode errors.Is
+// digs through foreign links via Unwrap.
+type catchupFailureReportedError struct{ err error }
+
+func (e *catchupFailureReportedError) Error() string { return e.err.Error() }
+func (e *catchupFailureReportedError) Unwrap() error { return e.err }
+
+// markCatchupFailureReported wraps err to signal that its catchup failure has
+// already been reported to the P2P service. Nil-safe.
+func markCatchupFailureReported(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &catchupFailureReportedError{err: err}
+}
+
+// catchupFailureAlreadyReported reports whether err carries the
+// markCatchupFailureReported marker anywhere in its chain. Uses the stdlib
+// errors.As because it walks every Unwrap link uniformly, regardless of where
+// foreign wrappers sit relative to teranode *Error links.
+func catchupFailureAlreadyReported(err error) bool {
+	var marker *catchupFailureReportedError
+	return stderrors.As(err, &marker)
 }
 
 func (u *Server) reportCatchupFailureWithKind(ctx context.Context, peerID, failureKind, blockHash string) {

--- a/services/blockvalidation/peer_metrics_helpers.go
+++ b/services/blockvalidation/peer_metrics_helpers.go
@@ -64,6 +64,25 @@ func (u *Server) reportCatchupSuccess(ctx context.Context, peerID string, durati
 	// Fallback: No local metrics needed since we're using P2P service for all peer tracking
 }
 
+// reportValidBlockHeaders credits a peer for successfully serving a batch of
+// block headers during catchup. This is a generic interaction success
+// (reputation and response time) and does NOT count as a completed catchup —
+// the catchup-operation outcome is reported separately by doCatchup. Keeping
+// this credit prevents a peer that serves headers fine but keeps failing at the
+// block-fetch stage from having its reputation collapse to the point where the
+// only viable catchup peer is excluded as unhealthy.
+func (u *Server) reportValidBlockHeaders(ctx context.Context, peerID string, duration time.Duration) {
+	if peerID == "" {
+		return
+	}
+
+	if u.p2pClient != nil {
+		if err := u.p2pClient.ReportValidBlockHeaders(ctx, peerID, duration.Milliseconds()); err != nil {
+			u.logger.Warnf("[peer_metrics] Failed to report valid block headers to P2P service for peer %s: %v", peerID, err)
+		}
+	}
+}
+
 // reportCatchupFailure reports a failed catchup to the P2P service.
 // Falls back to local metrics if P2P client is unavailable.
 //

--- a/services/blockvalidation/peer_metrics_helpers_test.go
+++ b/services/blockvalidation/peer_metrics_helpers_test.go
@@ -1,0 +1,84 @@
+package blockvalidation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// failureCountingP2PClient counts RecordCatchupFailure calls; every other
+// P2PClientI method is inherited as a no-op from maliciousAbortP2PClient.
+type failureCountingP2PClient struct {
+	maliciousAbortP2PClient
+	failures int
+}
+
+func (f *failureCountingP2PClient) RecordCatchupFailure(_ context.Context, _ string) error {
+	f.failures++
+	return nil
+}
+
+// TestReportCatchupFailureForError_SkipsAlreadyReported guards the
+// one-failure-per-attempt invariant: when a lower layer (the header-fetch
+// stage) has already recorded the failure, the top-level handler must not
+// record a second one for the same propagated error.
+func TestReportCatchupFailureForError_SkipsAlreadyReported(t *testing.T) {
+	newServer := func() (*Server, *failureCountingP2PClient) {
+		client := &failureCountingP2PClient{}
+		return &Server{p2pClient: client, logger: ulogger.TestLogger{}}, client
+	}
+
+	t.Run("unmarked error is reported", func(t *testing.T) {
+		u, client := newServer()
+		u.reportCatchupFailureForError(context.Background(), "peer-1", errors.NewNetworkTimeoutError("peer timed out"))
+		require.Equal(t, 1, client.failures)
+	})
+
+	t.Run("marked error is skipped", func(t *testing.T) {
+		u, client := newServer()
+		err := markCatchupFailureReported(errors.NewNetworkTimeoutError("peer timed out"))
+		u.reportCatchupFailureForError(context.Background(), "peer-1", err)
+		require.Equal(t, 0, client.failures)
+	})
+
+	t.Run("marker survives teranode error wrapping", func(t *testing.T) {
+		u, client := newServer()
+		// Same shape fetchHeaders produces: ProcessingError wrapping the marked error.
+		err := errors.NewProcessingError("failed to get block headers: %w",
+			markCatchupFailureReported(errors.NewServiceError("http request returned status code [429]")))
+		u.reportCatchupFailureForError(context.Background(), "peer-1", err)
+		require.Equal(t, 0, client.failures)
+	})
+
+	t.Run("block incomplete is still skipped", func(t *testing.T) {
+		u, client := newServer()
+		u.reportCatchupFailureForError(context.Background(), "peer-1", errors.ErrBlockIncomplete)
+		require.Equal(t, 0, client.failures)
+	})
+}
+
+// TestMarkCatchupFailureReported_TransparentToErrorCodes proves the marker does
+// not break teranode error-code matching, which the top-level catchup dispatch
+// in Server.go relies on (ErrServiceError, malicious classification, etc.).
+func TestMarkCatchupFailureReported_TransparentToErrorCodes(t *testing.T) {
+	require.Nil(t, markCatchupFailureReported(nil))
+
+	// ProcessingError → marker → ServiceError: the ServiceError code must still
+	// match through the foreign marker link (the top-level ErrServiceError
+	// branch routes on this).
+	err := errors.NewProcessingError("wrap: %w",
+		markCatchupFailureReported(errors.NewServiceError("http 429")))
+	require.True(t, errors.Is(err, errors.ErrServiceError))
+	require.True(t, catchupFailureAlreadyReported(err))
+
+	// Malicious classification survives the marker too.
+	malicious := errors.NewProcessingError("wrap: %w",
+		markCatchupFailureReported(errors.NewNetworkPeerMaliciousError("bad headers")))
+	require.True(t, errors.Is(malicious, errors.ErrNetworkPeerMalicious))
+
+	// An unmarked error must not read as already-reported.
+	require.False(t, catchupFailureAlreadyReported(errors.NewServiceError("http 429")))
+}

--- a/services/blockvalidation/peer_metrics_helpers_test.go
+++ b/services/blockvalidation/peer_metrics_helpers_test.go
@@ -9,14 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// failureCountingP2PClient counts RecordCatchupFailure calls; every other
+// failureCountingP2PClient counts recorded catchup failures; every other
 // P2PClientI method is inherited as a no-op from maliciousAbortP2PClient.
+// reportCatchupFailure routes through RecordCatchupFailureWithKind, so both
+// entry points are counted.
 type failureCountingP2PClient struct {
 	maliciousAbortP2PClient
 	failures int
 }
 
 func (f *failureCountingP2PClient) RecordCatchupFailure(_ context.Context, _ string) error {
+	f.failures++
+	return nil
+}
+
+func (f *failureCountingP2PClient) RecordCatchupFailureWithKind(_ context.Context, _, _, _ string) error {
 	f.failures++
 	return nil
 }

--- a/services/blockvalidation/peer_selection.go
+++ b/services/blockvalidation/peer_selection.go
@@ -72,21 +72,24 @@ func (u *Server) selectBestPeersForCatchup(ctx context.Context, targetHeight uin
 			Height:                 p.Height,
 			BlockHash:              p.BlockHash,
 			CatchupReputationScore: p.ReputationScore,
-			CatchupAttempts:        p.InteractionAttempts,
-			CatchupSuccesses:       p.InteractionSuccesses,
-			CatchupFailures:        p.InteractionFailures,
+			CatchupAttempts:        p.CatchupAttempts,
+			CatchupSuccesses:       p.CatchupSuccesses,
+			CatchupFailures:        p.CatchupFailures,
 		})
 	}
 
 	u.logger.Infof("[peer_selection] Selected %d peers for catchup (from %d total)", len(peers), len(peerInfos))
 	for i, p := range peers {
+		// Success rate over resolved outcomes only: attempts include catchups
+		// still in flight or abandoned without a verdict, so successes/attempts
+		// would understate a usable peer.
 		successRate := float64(0)
 
-		if p.CatchupAttempts > 0 {
-			successRate = float64(p.CatchupSuccesses) / float64(p.CatchupAttempts) * 100
+		if resolved := p.CatchupSuccesses + p.CatchupFailures; resolved > 0 {
+			successRate = float64(p.CatchupSuccesses) / float64(resolved) * 100
 		}
 
-		u.logger.Debugf("[peer_selection] Peer %d: %s (score: %.2f, success: %d/%d = %.1f%%, height: %d)", i+1, p.ID, p.CatchupReputationScore, p.CatchupSuccesses, p.CatchupAttempts, successRate, p.Height)
+		u.logger.Debugf("[peer_selection] Peer %d: %s (score: %.2f, success: %d ok / %d failed of %d attempts = %.1f%%, height: %d)", i+1, p.ID, p.CatchupReputationScore, p.CatchupSuccesses, p.CatchupFailures, p.CatchupAttempts, successRate, p.Height)
 	}
 
 	return peers, nil

--- a/services/p2p/Client.go
+++ b/services/p2p/Client.go
@@ -732,14 +732,14 @@ func convertFromAPIPeerInfo(apiPeer interface{}) *PeerInfo {
 		}
 
 		return &PeerInfo{
-			ID:                   peerID,
-			Height:               p.Height,
-			BlockHash:            blockHash,
-			DataHubURL:           p.DataHubUrl,
-			ReputationScore:      p.CatchupReputationScore,
-			InteractionAttempts:  p.CatchupAttempts,
-			InteractionSuccesses: p.CatchupSuccesses,
-			InteractionFailures:  p.CatchupFailures,
+			ID:               peerID,
+			Height:           p.Height,
+			BlockHash:        blockHash,
+			DataHubURL:       p.DataHubUrl,
+			ReputationScore:  p.CatchupReputationScore,
+			CatchupAttempts:  p.CatchupAttempts,
+			CatchupSuccesses: p.CatchupSuccesses,
+			CatchupFailures:  p.CatchupFailures,
 		}
 
 	case *p2p_api.PeerRegistryInfo:
@@ -775,6 +775,9 @@ func convertFromAPIPeerInfo(apiPeer interface{}) *PeerInfo {
 			AvgResponseTime:        time.Duration(p.AvgResponseTimeMs) * time.Millisecond,
 			LastCatchupError:       p.LastCatchupError,
 			LastCatchupErrorTime:   time.Unix(p.LastCatchupErrorTime, 0),
+			CatchupAttempts:        p.CatchupAttempts,
+			CatchupSuccesses:       p.CatchupSuccesses,
+			CatchupFailures:        p.CatchupFailures,
 		}
 
 	default:

--- a/services/p2p/Client.go
+++ b/services/p2p/Client.go
@@ -580,6 +580,35 @@ func (c *Client) ReportValidBlock(ctx context.Context, peerID string, blockHash 
 	return nil
 }
 
+// ReportValidBlockHeaders reports that a peer successfully served a batch of block
+// headers during catchup. Credits a generic interaction success (reputation and
+// response time) without touching the catchup-operation counters.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - peerID: Peer ID that served the headers
+//   - durationMs: Time taken to serve the headers (0 = not applicable)
+//
+// Returns:
+//   - error: Any error encountered during the operation
+func (c *Client) ReportValidBlockHeaders(ctx context.Context, peerID string, durationMs int64) error {
+	req := &p2p_api.ReportValidBlockHeadersRequest{
+		PeerId:     peerID,
+		DurationMs: durationMs,
+	}
+
+	resp, err := c.client.ReportValidBlockHeaders(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil && !resp.Success {
+		return errors.NewServiceError("failed to report valid block headers: %s", resp.Message)
+	}
+
+	return nil
+}
+
 // ReportValidatedChainProgress reports locally validated header-chain progress for a peer.
 //
 // Parameters:

--- a/services/p2p/Client.go
+++ b/services/p2p/Client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -598,6 +600,24 @@ func (c *Client) ReportValidBlockHeaders(ctx context.Context, peerID string, dur
 	}
 
 	resp, err := c.client.ReportValidBlockHeaders(ctx, req)
+	if status.Code(err) == codes.Unimplemented {
+		// Rolling upgrade: the p2p service predates this RPC. Fall back to
+		// RecordCatchupSuccess, which on such a server is implemented as a
+		// generic interaction success — exactly the credit this call carries.
+		// (New servers never hit this: there RecordCatchupSuccess would also
+		// bump the catchup counters, which a headers batch must not do.)
+		legacyResp, legacyErr := c.client.RecordCatchupSuccess(ctx, &p2p_api.RecordCatchupSuccessRequest{
+			PeerId:     peerID,
+			DurationMs: durationMs,
+		})
+		if legacyErr != nil {
+			return legacyErr
+		}
+		if legacyResp != nil && !legacyResp.Ok {
+			return errors.NewServiceError("failed to report valid block headers via legacy fallback")
+		}
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/services/p2p/Client_test.go
+++ b/services/p2p/Client_test.go
@@ -39,6 +39,7 @@ type MockPeerServiceClient struct {
 	GetPeersForCatchupFunc           func(ctx context.Context, in *p2p_api.GetPeersForCatchupRequest, opts ...grpc.CallOption) (*p2p_api.GetPeersForCatchupResponse, error)
 	ReportValidSubtreeFunc           func(ctx context.Context, in *p2p_api.ReportValidSubtreeRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidSubtreeResponse, error)
 	ReportValidBlockFunc             func(ctx context.Context, in *p2p_api.ReportValidBlockRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidBlockResponse, error)
+	ReportValidBlockHeadersFunc      func(ctx context.Context, in *p2p_api.ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidBlockHeadersResponse, error)
 	ReportValidatedChainProgressFunc func(ctx context.Context, in *p2p_api.ReportValidatedChainProgressRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidatedChainProgressResponse, error)
 	IsPeerMaliciousFunc              func(ctx context.Context, in *p2p_api.IsPeerMaliciousRequest, opts ...grpc.CallOption) (*p2p_api.IsPeerMaliciousResponse, error)
 	IsPeerUnhealthyFunc              func(ctx context.Context, in *p2p_api.IsPeerUnhealthyRequest, opts ...grpc.CallOption) (*p2p_api.IsPeerUnhealthyResponse, error)
@@ -178,6 +179,13 @@ func (m *MockPeerServiceClient) ReportValidBlock(ctx context.Context, in *p2p_ap
 		return m.ReportValidBlockFunc(ctx, in, opts...)
 	}
 	return &p2p_api.ReportValidBlockResponse{Success: true}, nil
+}
+
+func (m *MockPeerServiceClient) ReportValidBlockHeaders(ctx context.Context, in *p2p_api.ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidBlockHeadersResponse, error) {
+	if m.ReportValidBlockHeadersFunc != nil {
+		return m.ReportValidBlockHeadersFunc(ctx, in, opts...)
+	}
+	return &p2p_api.ReportValidBlockHeadersResponse{Success: true}, nil
 }
 
 func (m *MockPeerServiceClient) ReportValidatedChainProgress(ctx context.Context, in *p2p_api.ReportValidatedChainProgressRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidatedChainProgressResponse, error) {

--- a/services/p2p/Client_test.go
+++ b/services/p2p/Client_test.go
@@ -708,7 +708,9 @@ func TestSimpleClientGetPeersForCatchup(t *testing.T) {
 		require.Len(t, peers, 1)
 		require.Equal(t, uint32(42), peers[0].Height)
 		require.InDelta(t, 88.5, peers[0].ReputationScore, 0.001)
-		require.Equal(t, int64(3), peers[0].InteractionAttempts)
+		require.Equal(t, int64(3), peers[0].CatchupAttempts)
+		require.Equal(t, int64(2), peers[0].CatchupSuccesses)
+		require.Equal(t, int64(1), peers[0].CatchupFailures)
 	})
 	t.Run("grpc_error", func(t *testing.T) {
 		client := newClientWithMock(&MockPeerServiceClient{

--- a/services/p2p/Client_test.go
+++ b/services/p2p/Client_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -728,6 +730,45 @@ func TestSimpleClientGetPeersForCatchup(t *testing.T) {
 		})
 		_, err := client.GetPeersForCatchup(context.Background())
 		require.Error(t, err)
+	})
+}
+
+func TestSimpleClientReportValidBlockHeaders(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var gotReq *p2p_api.ReportValidBlockHeadersRequest
+		client := newClientWithMock(&MockPeerServiceClient{
+			ReportValidBlockHeadersFunc: func(ctx context.Context, in *p2p_api.ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidBlockHeadersResponse, error) {
+				gotReq = in
+				return &p2p_api.ReportValidBlockHeadersResponse{Success: true}, nil
+			},
+		})
+		require.NoError(t, client.ReportValidBlockHeaders(context.Background(), "peer1", 150))
+		require.Equal(t, "peer1", gotReq.PeerId)
+		require.Equal(t, int64(150), gotReq.DurationMs)
+	})
+	t.Run("falls back to RecordCatchupSuccess on Unimplemented", func(t *testing.T) {
+		var legacyReq *p2p_api.RecordCatchupSuccessRequest
+		client := newClientWithMock(&MockPeerServiceClient{
+			ReportValidBlockHeadersFunc: func(ctx context.Context, in *p2p_api.ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidBlockHeadersResponse, error) {
+				return nil, status.Error(codes.Unimplemented, "unknown method")
+			},
+			RecordCatchupSuccessFunc: func(ctx context.Context, in *p2p_api.RecordCatchupSuccessRequest, opts ...grpc.CallOption) (*p2p_api.RecordCatchupSuccessResponse, error) {
+				legacyReq = in
+				return &p2p_api.RecordCatchupSuccessResponse{Ok: true}, nil
+			},
+		})
+		require.NoError(t, client.ReportValidBlockHeaders(context.Background(), "peer1", 200))
+		require.NotNil(t, legacyReq, "old p2p server must receive the legacy success report")
+		require.Equal(t, "peer1", legacyReq.PeerId)
+		require.Equal(t, int64(200), legacyReq.DurationMs)
+	})
+	t.Run("grpc_error", func(t *testing.T) {
+		client := newClientWithMock(&MockPeerServiceClient{
+			ReportValidBlockHeadersFunc: func(ctx context.Context, in *p2p_api.ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*p2p_api.ReportValidBlockHeadersResponse, error) {
+				return nil, assert.AnError
+			},
+		})
+		require.Error(t, client.ReportValidBlockHeaders(context.Background(), "peer1", 0))
 	})
 }
 

--- a/services/p2p/Interface.go
+++ b/services/p2p/Interface.go
@@ -195,6 +195,11 @@ type ClientI interface {
 	// This increases the peer's reputation score for providing valid data.
 	ReportValidSubtree(ctx context.Context, peerID string, subtreeHash string) error
 
+	// ReportValidBlockHeaders reports that a peer successfully served a batch of block
+	// headers during catchup. Credits a generic interaction success (reputation and
+	// response time) without touching the catchup-operation counters.
+	ReportValidBlockHeaders(ctx context.Context, peerID string, durationMs int64) error
+
 	// ReportValidBlock reports that a block was successfully received and validated from a peer.
 	// This increases the peer's reputation score for providing valid blocks.
 	ReportValidBlock(ctx context.Context, peerID string, blockHash string) error

--- a/services/p2p/Interface.go
+++ b/services/p2p/Interface.go
@@ -45,6 +45,12 @@ type PeerInfo struct {
 	TransactionsReceived int64 // Number of transactions received from this peer
 	CatchupBlocks        int64 // Number of blocks received during catchup
 
+	// Catchup-specific counters (recorded via RecordCatchupAttempt/Success/Failure),
+	// distinct from the generic interaction counters above.
+	CatchupAttempts  int64 // Catchup attempts made to this peer (including unresolved ones)
+	CatchupSuccesses int64 // Catchup operations that completed successfully
+	CatchupFailures  int64 // Catchup operations that failed
+
 	// Sync attempt tracking for backoff and recovery
 	LastSyncAttempt      time.Time // When we last attempted to sync with this peer
 	SyncAttemptCount     int       // Number of sync attempts with this peer

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -2175,6 +2175,9 @@ func peerInfoToP2PProto(p *blockchain.PeerInfo) *p2p_api.PeerRegistryInfo {
 		ClientName:             p.ClientName,
 		LastCatchupError:       p.LastCatchupError,
 		LastCatchupErrorTime:   timeToUnix(p.LastCatchupErrorTime),
+		CatchupAttempts:        p.CatchupAttempts,
+		CatchupSuccesses:       p.CatchupSuccesses,
+		CatchupFailures:        p.CatchupFailures,
 	}
 }
 

--- a/services/p2p/handle_catchup_metrics.go
+++ b/services/p2p/handle_catchup_metrics.go
@@ -25,7 +25,8 @@ const (
 )
 
 // RecordCatchupAttempt records that a catchup attempt was made to a peer.
-// Backed by the centralized peer registry's interaction-attempt counter.
+// Backed by the centralized peer registry's catchup-attempt counter, which
+// also updates the sync backoff tracking fields.
 func (s *Server) RecordCatchupAttempt(ctx context.Context, req *p2p_api.RecordCatchupAttemptRequest) (*p2p_api.RecordCatchupAttemptResponse, error) {
 	if s.peerRegistry == nil {
 		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
@@ -35,10 +36,8 @@ func (s *Server) RecordCatchupAttempt(ctx context.Context, req *p2p_api.RecordCa
 		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
 	}
 
-	// UpdatePeerMetrics with no flags increments LastSeen and BytesReceived; bump
-	// the attempt counter via RecordSyncAttempt which sets LastSyncAttempt.
-	if err := s.peerRegistry.RecordSyncAttempt(ctx, req.PeerId); err != nil {
-		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("record sync attempt", err))
+	if err := s.peerRegistry.RecordCatchupAttempt(ctx, req.PeerId); err != nil {
+		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("record catchup attempt", err))
 	}
 
 	return &p2p_api.RecordCatchupAttemptResponse{Ok: true}, nil
@@ -54,8 +53,8 @@ func (s *Server) RecordCatchupSuccess(ctx context.Context, req *p2p_api.RecordCa
 		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
 	}
 
-	if err := s.peerRegistry.UpdatePeerMetrics(ctx, req.PeerId, 0, 0, 0, true, false, false, req.DurationMs); err != nil {
-		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("update peer metrics", err))
+	if err := s.peerRegistry.RecordCatchupSuccess(ctx, req.PeerId, req.DurationMs); err != nil {
+		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("record catchup success", err))
 	}
 
 	return &p2p_api.RecordCatchupSuccessResponse{Ok: true}, nil
@@ -71,8 +70,8 @@ func (s *Server) RecordCatchupFailure(ctx context.Context, req *p2p_api.RecordCa
 		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
 	}
 
-	if err := s.peerRegistry.UpdatePeerMetrics(ctx, req.PeerId, 0, 0, 0, false, true, false, 0); err != nil {
-		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("update peer metrics", err))
+	if err := s.peerRegistry.RecordCatchupFailure(ctx, req.PeerId); err != nil {
+		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("record catchup failure", err))
 	}
 
 	if normalizeCatchupFailureKind(req.FailureKind) == catchupFailureKindBlockIncomplete {
@@ -215,8 +214,6 @@ func (s *Server) GetPeersForCatchup(ctx context.Context, _ *p2p_api.GetPeersForC
 			continue
 		}
 
-		totalAttempts := p.InteractionSuccesses + p.InteractionFailures
-
 		blockHashStr := ""
 		if p.BlockHash != nil {
 			blockHashStr = p.BlockHash.String()
@@ -228,9 +225,9 @@ func (s *Server) GetPeersForCatchup(ctx context.Context, _ *p2p_api.GetPeersForC
 			BlockHash:              blockHashStr,
 			DataHubUrl:             p.DataHubURL,
 			CatchupReputationScore: p.ReputationScore,
-			CatchupAttempts:        totalAttempts,
-			CatchupSuccesses:       p.InteractionSuccesses,
-			CatchupFailures:        p.InteractionFailures,
+			CatchupAttempts:        p.CatchupAttempts,
+			CatchupSuccesses:       p.CatchupSuccesses,
+			CatchupFailures:        p.CatchupFailures,
 		})
 	}
 

--- a/services/p2p/handle_catchup_metrics.go
+++ b/services/p2p/handle_catchup_metrics.go
@@ -399,6 +399,49 @@ func (s *Server) ReportValidatedChainProgress(ctx context.Context, req *p2p_api.
 	}, nil
 }
 
+// ReportValidBlockHeaders records that a peer successfully served a batch of
+// block headers during catchup. This credits the peer with a generic
+// interaction success (reputation and response time) WITHOUT incrementing the
+// catchup-operation counters: a headers batch is one stage of a catchup, not a
+// completed catchup. Keeping this credit matters — during a catchup that keeps
+// failing at the block-fetch stage (e.g. the serving peer rate-limits subtree
+// requests), it offsets the recorded failures so the peer's reputation does not
+// collapse below the unhealthy threshold and get the only viable peer excluded.
+func (s *Server) ReportValidBlockHeaders(ctx context.Context, req *p2p_api.ReportValidBlockHeadersRequest) (*p2p_api.ReportValidBlockHeadersResponse, error) {
+	if s.peerRegistry == nil {
+		return &p2p_api.ReportValidBlockHeadersResponse{
+			Success: false,
+			Message: "peer registry not initialized",
+		}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+	}
+
+	if req.PeerId == "" {
+		return &p2p_api.ReportValidBlockHeadersResponse{
+			Success: false,
+			Message: "peer ID is required",
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError("peer ID is required"))
+	}
+
+	if _, err := peer.Decode(req.PeerId); err != nil {
+		return &p2p_api.ReportValidBlockHeadersResponse{
+			Success: false,
+			Message: "invalid peer ID",
+		}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+	}
+
+	if err := s.peerRegistry.UpdatePeerMetrics(ctx, req.PeerId, 0, 0, 0, true, false, false, req.DurationMs); err != nil {
+		return &p2p_api.ReportValidBlockHeadersResponse{
+			Success: false,
+			Message: "failed to record headers success",
+		}, errors.WrapGRPC(errors.NewServiceError("update peer metrics", err))
+	}
+
+	return &p2p_api.ReportValidBlockHeadersResponse{
+		Success: true,
+		Message: "headers success recorded",
+	}, nil
+}
+
 // IsPeerMalicious returns whether a peer is currently considered malicious
 // (banned in the centralized registry).
 func (s *Server) IsPeerMalicious(ctx context.Context, req *p2p_api.IsPeerMaliciousRequest) (*p2p_api.IsPeerMaliciousResponse, error) {

--- a/services/p2p/handle_catchup_metrics_test.go
+++ b/services/p2p/handle_catchup_metrics_test.go
@@ -58,6 +58,7 @@ func TestRecordCatchupAttempt_RegistersSyncAttempt(t *testing.T) {
 	got, _ := reg.Get(pid.String())
 	require.Equal(t, int32(1), got.SyncAttemptCount)
 	require.False(t, got.LastSyncAttempt.IsZero())
+	require.Equal(t, int64(1), got.CatchupAttempts)
 }
 
 func TestRecordCatchupAttempt_InvalidPeerID(t *testing.T) {
@@ -81,6 +82,7 @@ func TestRecordCatchupSuccess_UpdatesInteractionMetrics(t *testing.T) {
 	got, _ := reg.Get(pid.String())
 	require.Equal(t, int64(1), got.InteractionSuccesses)
 	require.Equal(t, int64(250), got.AvgResponseTimeMs)
+	require.Equal(t, int64(1), got.CatchupSuccesses)
 }
 
 func TestRecordCatchupFailure_UpdatesInteractionMetrics(t *testing.T) {
@@ -93,6 +95,7 @@ func TestRecordCatchupFailure_UpdatesInteractionMetrics(t *testing.T) {
 
 	got, _ := reg.Get(pid.String())
 	require.Equal(t, int64(1), got.InteractionFailures)
+	require.Equal(t, int64(1), got.CatchupFailures)
 }
 
 func TestRecordCatchupFailure_BlockIncomplete_DowngradesFullPeer(t *testing.T) {
@@ -295,6 +298,38 @@ func TestGetPeersForCatchup_FiltersAndSorts(t *testing.T) {
 	ids := []string{resp.Peers[0].Id, resp.Peers[1].Id}
 	require.ElementsMatch(t, []string{"full", "pruned"}, ids)
 	require.Equal(t, "full", resp.Peers[0].Id, "full must sort ahead of pruned")
+}
+
+func TestGetPeersForCatchup_UsesCatchupSpecificCounters(t *testing.T) {
+	s, reg, pid := freshTestServer(t)
+	reg.Register(&blockchain.PeerInfo{ID: pid.String(), DataHubURL: "http://peer", Height: 100})
+
+	ctx := context.Background()
+
+	// Three catchup attempts: one succeeds, one fails, one produces no outcome.
+	for i := 0; i < 3; i++ {
+		_, err := s.RecordCatchupAttempt(ctx, &p2p_api.RecordCatchupAttemptRequest{PeerId: pid.String()})
+		require.NoError(t, err)
+	}
+	_, err := s.RecordCatchupSuccess(ctx, &p2p_api.RecordCatchupSuccessRequest{PeerId: pid.String(), DurationMs: 100})
+	require.NoError(t, err)
+	_, err = s.RecordCatchupFailure(ctx, &p2p_api.RecordCatchupFailureRequest{PeerId: pid.String()})
+	require.NoError(t, err)
+
+	// Non-catchup interactions must not bleed into the catchup counters.
+	_, err = s.ReportValidBlock(ctx, &p2p_api.ReportValidBlockRequest{PeerId: pid.String(), BlockHash: "abc"})
+	require.NoError(t, err)
+	_, err = s.ReportValidSubtree(ctx, &p2p_api.ReportValidSubtreeRequest{PeerId: pid.String(), SubtreeHash: "def"})
+	require.NoError(t, err)
+
+	resp, err := s.GetPeersForCatchup(ctx, &p2p_api.GetPeersForCatchupRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Peers, 1)
+
+	p := resp.Peers[0]
+	require.Equal(t, int64(3), p.CatchupAttempts, "attempts without an outcome must still be counted")
+	require.Equal(t, int64(1), p.CatchupSuccesses)
+	require.Equal(t, int64(1), p.CatchupFailures)
 }
 
 func TestReportValidSubtree_HappyPath(t *testing.T) {

--- a/services/p2p/handle_catchup_metrics_test.go
+++ b/services/p2p/handle_catchup_metrics_test.go
@@ -332,6 +332,59 @@ func TestGetPeersForCatchup_UsesCatchupSpecificCounters(t *testing.T) {
 	require.Equal(t, int64(1), p.CatchupFailures)
 }
 
+func TestReportValidBlockHeaders_CreditsReputationNotCatchupCounters(t *testing.T) {
+	s, reg, pid := freshTestServer(t)
+	reg.Register(&blockchain.PeerInfo{ID: pid.String()})
+
+	resp, err := s.ReportValidBlockHeaders(context.Background(), &p2p_api.ReportValidBlockHeadersRequest{
+		PeerId:     pid.String(),
+		DurationMs: 120,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	got, _ := reg.Get(pid.String())
+	require.Equal(t, int64(1), got.InteractionSuccesses)
+	require.Equal(t, int64(120), got.AvgResponseTimeMs)
+	require.Equal(t, int64(0), got.CatchupSuccesses, "headers batch must not count as a completed catchup")
+	require.Equal(t, int64(0), got.CatchupAttempts)
+}
+
+// TestReportValidBlockHeaders_KeepsFailingPeerHealthy guards the catchup
+// recovery dynamics: a peer that serves headers fine but keeps failing at the
+// block-fetch stage (e.g. it rate-limits subtree requests) must not collapse to
+// an unhealthy reputation, or catchup would exclude the only peer that has the
+// blocks and never recover.
+func TestReportValidBlockHeaders_KeepsFailingPeerHealthy(t *testing.T) {
+	s, reg, pid := freshTestServer(t)
+	reg.Register(&blockchain.PeerInfo{ID: pid.String()})
+
+	ctx := context.Background()
+
+	// Three catchup cycles: headers served ok, then the catchup fails.
+	for i := 0; i < 3; i++ {
+		_, err := s.RecordCatchupAttempt(ctx, &p2p_api.RecordCatchupAttemptRequest{PeerId: pid.String()})
+		require.NoError(t, err)
+		_, err = s.ReportValidBlockHeaders(ctx, &p2p_api.ReportValidBlockHeadersRequest{PeerId: pid.String(), DurationMs: 100})
+		require.NoError(t, err)
+		_, err = s.RecordCatchupFailure(ctx, &p2p_api.RecordCatchupFailureRequest{PeerId: pid.String()})
+		require.NoError(t, err)
+	}
+
+	unhealthy, err := s.IsPeerUnhealthy(ctx, &p2p_api.IsPeerUnhealthyRequest{PeerId: pid.String()})
+	require.NoError(t, err)
+	require.False(t, unhealthy.IsUnhealthy, "peer serving headers must stay healthy despite catchup failures (reputation: %.2f, reason: %s)", unhealthy.ReputationScore, unhealthy.Reason)
+}
+
+func TestReportValidBlockHeaders_InvalidPeerID(t *testing.T) {
+	s, _, _ := freshTestServer(t)
+	_, err := s.ReportValidBlockHeaders(context.Background(), &p2p_api.ReportValidBlockHeadersRequest{PeerId: "not-a-peer"})
+	require.Error(t, err)
+
+	_, err = s.ReportValidBlockHeaders(context.Background(), &p2p_api.ReportValidBlockHeadersRequest{})
+	require.Error(t, err)
+}
+
 func TestReportValidSubtree_HappyPath(t *testing.T) {
 	s, reg, pid := freshTestServer(t)
 	reg.Register(&blockchain.PeerInfo{ID: pid.String()})

--- a/services/p2p/p2p_api/p2p_api.pb.go
+++ b/services/p2p/p2p_api/p2p_api.pb.go
@@ -2021,6 +2021,113 @@ func (x *ReportValidBlockResponse) GetMessage() string {
 	return ""
 }
 
+// Report a successfully served batch of block headers during catchup.
+// Credits the peer with a generic interaction success (reputation and
+// response time) without touching the catchup-operation counters.
+type ReportValidBlockHeadersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PeerId        string                 `protobuf:"bytes,1,opt,name=peer_id,json=peerId,proto3" json:"peer_id,omitempty"`              // Peer ID that served the headers
+	DurationMs    int64                  `protobuf:"varint,2,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"` // Time taken to serve the headers (0 = not applicable)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportValidBlockHeadersRequest) Reset() {
+	*x = ReportValidBlockHeadersRequest{}
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportValidBlockHeadersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportValidBlockHeadersRequest) ProtoMessage() {}
+
+func (x *ReportValidBlockHeadersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportValidBlockHeadersRequest.ProtoReflect.Descriptor instead.
+func (*ReportValidBlockHeadersRequest) Descriptor() ([]byte, []int) {
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *ReportValidBlockHeadersRequest) GetPeerId() string {
+	if x != nil {
+		return x.PeerId
+	}
+	return ""
+}
+
+func (x *ReportValidBlockHeadersRequest) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+type ReportValidBlockHeadersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportValidBlockHeadersResponse) Reset() {
+	*x = ReportValidBlockHeadersResponse{}
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportValidBlockHeadersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportValidBlockHeadersResponse) ProtoMessage() {}
+
+func (x *ReportValidBlockHeadersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportValidBlockHeadersResponse.ProtoReflect.Descriptor instead.
+func (*ReportValidBlockHeadersResponse) Descriptor() ([]byte, []int) {
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ReportValidBlockHeadersResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *ReportValidBlockHeadersResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 // Report locally validated peer chain progress
 type ReportValidatedChainProgressRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2034,7 +2141,7 @@ type ReportValidatedChainProgressRequest struct {
 
 func (x *ReportValidatedChainProgressRequest) Reset() {
 	*x = ReportValidatedChainProgressRequest{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[37]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2046,7 +2153,7 @@ func (x *ReportValidatedChainProgressRequest) String() string {
 func (*ReportValidatedChainProgressRequest) ProtoMessage() {}
 
 func (x *ReportValidatedChainProgressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[37]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2059,7 +2166,7 @@ func (x *ReportValidatedChainProgressRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ReportValidatedChainProgressRequest.ProtoReflect.Descriptor instead.
 func (*ReportValidatedChainProgressRequest) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{37}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ReportValidatedChainProgressRequest) GetPeerId() string {
@@ -2100,7 +2207,7 @@ type ReportValidatedChainProgressResponse struct {
 
 func (x *ReportValidatedChainProgressResponse) Reset() {
 	*x = ReportValidatedChainProgressResponse{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[38]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2112,7 +2219,7 @@ func (x *ReportValidatedChainProgressResponse) String() string {
 func (*ReportValidatedChainProgressResponse) ProtoMessage() {}
 
 func (x *ReportValidatedChainProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[38]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2125,7 +2232,7 @@ func (x *ReportValidatedChainProgressResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use ReportValidatedChainProgressResponse.ProtoReflect.Descriptor instead.
 func (*ReportValidatedChainProgressResponse) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{38}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ReportValidatedChainProgressResponse) GetSuccess() bool {
@@ -2152,7 +2259,7 @@ type IsPeerMaliciousRequest struct {
 
 func (x *IsPeerMaliciousRequest) Reset() {
 	*x = IsPeerMaliciousRequest{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[39]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2271,7 @@ func (x *IsPeerMaliciousRequest) String() string {
 func (*IsPeerMaliciousRequest) ProtoMessage() {}
 
 func (x *IsPeerMaliciousRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[39]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2284,7 @@ func (x *IsPeerMaliciousRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsPeerMaliciousRequest.ProtoReflect.Descriptor instead.
 func (*IsPeerMaliciousRequest) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{39}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *IsPeerMaliciousRequest) GetPeerId() string {
@@ -2197,7 +2304,7 @@ type IsPeerMaliciousResponse struct {
 
 func (x *IsPeerMaliciousResponse) Reset() {
 	*x = IsPeerMaliciousResponse{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[40]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2209,7 +2316,7 @@ func (x *IsPeerMaliciousResponse) String() string {
 func (*IsPeerMaliciousResponse) ProtoMessage() {}
 
 func (x *IsPeerMaliciousResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[40]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,7 +2329,7 @@ func (x *IsPeerMaliciousResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsPeerMaliciousResponse.ProtoReflect.Descriptor instead.
 func (*IsPeerMaliciousResponse) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{40}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *IsPeerMaliciousResponse) GetIsMalicious() bool {
@@ -2248,7 +2355,7 @@ type IsPeerUnhealthyRequest struct {
 
 func (x *IsPeerUnhealthyRequest) Reset() {
 	*x = IsPeerUnhealthyRequest{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[41]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2260,7 +2367,7 @@ func (x *IsPeerUnhealthyRequest) String() string {
 func (*IsPeerUnhealthyRequest) ProtoMessage() {}
 
 func (x *IsPeerUnhealthyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[41]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2273,7 +2380,7 @@ func (x *IsPeerUnhealthyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsPeerUnhealthyRequest.ProtoReflect.Descriptor instead.
 func (*IsPeerUnhealthyRequest) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{41}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *IsPeerUnhealthyRequest) GetPeerId() string {
@@ -2294,7 +2401,7 @@ type IsPeerUnhealthyResponse struct {
 
 func (x *IsPeerUnhealthyResponse) Reset() {
 	*x = IsPeerUnhealthyResponse{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[42]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2306,7 +2413,7 @@ func (x *IsPeerUnhealthyResponse) String() string {
 func (*IsPeerUnhealthyResponse) ProtoMessage() {}
 
 func (x *IsPeerUnhealthyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[42]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2319,7 +2426,7 @@ func (x *IsPeerUnhealthyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsPeerUnhealthyResponse.ProtoReflect.Descriptor instead.
 func (*IsPeerUnhealthyResponse) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{42}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *IsPeerUnhealthyResponse) GetIsUnhealthy() bool {
@@ -2382,7 +2489,7 @@ type PeerRegistryInfo struct {
 
 func (x *PeerRegistryInfo) Reset() {
 	*x = PeerRegistryInfo{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[43]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2394,7 +2501,7 @@ func (x *PeerRegistryInfo) String() string {
 func (*PeerRegistryInfo) ProtoMessage() {}
 
 func (x *PeerRegistryInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[43]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2407,7 +2514,7 @@ func (x *PeerRegistryInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeerRegistryInfo.ProtoReflect.Descriptor instead.
 func (*PeerRegistryInfo) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{43}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *PeerRegistryInfo) GetId() string {
@@ -2608,7 +2715,7 @@ type GetPeerRegistryResponse struct {
 
 func (x *GetPeerRegistryResponse) Reset() {
 	*x = GetPeerRegistryResponse{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[44]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2620,7 +2727,7 @@ func (x *GetPeerRegistryResponse) String() string {
 func (*GetPeerRegistryResponse) ProtoMessage() {}
 
 func (x *GetPeerRegistryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[44]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2633,7 +2740,7 @@ func (x *GetPeerRegistryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPeerRegistryResponse.ProtoReflect.Descriptor instead.
 func (*GetPeerRegistryResponse) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{44}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetPeerRegistryResponse) GetPeers() []*PeerRegistryInfo {
@@ -2654,7 +2761,7 @@ type RecordBytesDownloadedRequest struct {
 
 func (x *RecordBytesDownloadedRequest) Reset() {
 	*x = RecordBytesDownloadedRequest{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[45]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2666,7 +2773,7 @@ func (x *RecordBytesDownloadedRequest) String() string {
 func (*RecordBytesDownloadedRequest) ProtoMessage() {}
 
 func (x *RecordBytesDownloadedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[45]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2679,7 +2786,7 @@ func (x *RecordBytesDownloadedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordBytesDownloadedRequest.ProtoReflect.Descriptor instead.
 func (*RecordBytesDownloadedRequest) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{45}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *RecordBytesDownloadedRequest) GetPeerId() string {
@@ -2705,7 +2812,7 @@ type RecordBytesDownloadedResponse struct {
 
 func (x *RecordBytesDownloadedResponse) Reset() {
 	*x = RecordBytesDownloadedResponse{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[46]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2717,7 +2824,7 @@ func (x *RecordBytesDownloadedResponse) String() string {
 func (*RecordBytesDownloadedResponse) ProtoMessage() {}
 
 func (x *RecordBytesDownloadedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[46]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2730,7 +2837,7 @@ func (x *RecordBytesDownloadedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordBytesDownloadedResponse.ProtoReflect.Descriptor instead.
 func (*RecordBytesDownloadedResponse) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{46}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *RecordBytesDownloadedResponse) GetOk() bool {
@@ -2749,7 +2856,7 @@ type GetPeerRequest struct {
 
 func (x *GetPeerRequest) Reset() {
 	*x = GetPeerRequest{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[47]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2761,7 +2868,7 @@ func (x *GetPeerRequest) String() string {
 func (*GetPeerRequest) ProtoMessage() {}
 
 func (x *GetPeerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[47]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2774,7 +2881,7 @@ func (x *GetPeerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPeerRequest.ProtoReflect.Descriptor instead.
 func (*GetPeerRequest) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{47}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetPeerRequest) GetPeerId() string {
@@ -2794,7 +2901,7 @@ type GetPeerResponse struct {
 
 func (x *GetPeerResponse) Reset() {
 	*x = GetPeerResponse{}
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[48]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2806,7 +2913,7 @@ func (x *GetPeerResponse) String() string {
 func (*GetPeerResponse) ProtoMessage() {}
 
 func (x *GetPeerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[48]
+	mi := &file_services_p2p_p2p_api_p2p_api_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2819,7 +2926,7 @@ func (x *GetPeerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPeerResponse.ProtoReflect.Descriptor instead.
 func (*GetPeerResponse) Descriptor() ([]byte, []int) {
-	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{48}
+	return file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetPeerResponse) GetPeer() *PeerRegistryInfo {
@@ -2973,6 +3080,13 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"block_hash\x18\x02 \x01(\tR\tblockHash\"N\n" +
 	"\x18ReportValidBlockResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"Z\n" +
+	"\x1eReportValidBlockHeadersRequest\x12\x17\n" +
+	"\apeer_id\x18\x01 \x01(\tR\x06peerId\x12\x1f\n" +
+	"\vduration_ms\x18\x02 \x01(\x03R\n" +
+	"durationMs\"U\n" +
+	"\x1fReportValidBlockHeadersResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\x94\x01\n" +
 	"#ReportValidatedChainProgressRequest\x12\x17\n" +
 	"\apeer_id\x18\x01 \x01(\tR\x06peerId\x12\x16\n" +
@@ -3038,7 +3152,7 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"\apeer_id\x18\x01 \x01(\tR\x06peerId\"V\n" +
 	"\x0fGetPeerResponse\x12-\n" +
 	"\x04peer\x18\x01 \x01(\v2\x19.p2p_api.PeerRegistryInfoR\x04peer\x12\x14\n" +
-	"\x05found\x18\x02 \x01(\bR\x05found2\xa0\x11\n" +
+	"\x05found\x18\x02 \x01(\bR\x05found2\x90\x12\n" +
 	"\vPeerService\x12?\n" +
 	"\bGetPeers\x12\x16.google.protobuf.Empty\x1a\x19.p2p_api.GetPeersResponse\"\x00\x12>\n" +
 	"\aBanPeer\x12\x17.p2p_api.BanPeerRequest\x1a\x18.p2p_api.BanPeerResponse\"\x00\x12D\n" +
@@ -3059,7 +3173,8 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"\x0fResetReputation\x12\x1f.p2p_api.ResetReputationRequest\x1a .p2p_api.ResetReputationResponse\"\x00\x12_\n" +
 	"\x12GetPeersForCatchup\x12\".p2p_api.GetPeersForCatchupRequest\x1a#.p2p_api.GetPeersForCatchupResponse\"\x00\x12_\n" +
 	"\x12ReportValidSubtree\x12\".p2p_api.ReportValidSubtreeRequest\x1a#.p2p_api.ReportValidSubtreeResponse\"\x00\x12Y\n" +
-	"\x10ReportValidBlock\x12 .p2p_api.ReportValidBlockRequest\x1a!.p2p_api.ReportValidBlockResponse\"\x00\x12}\n" +
+	"\x10ReportValidBlock\x12 .p2p_api.ReportValidBlockRequest\x1a!.p2p_api.ReportValidBlockResponse\"\x00\x12n\n" +
+	"\x17ReportValidBlockHeaders\x12'.p2p_api.ReportValidBlockHeadersRequest\x1a(.p2p_api.ReportValidBlockHeadersResponse\"\x00\x12}\n" +
 	"\x1cReportValidatedChainProgress\x12,.p2p_api.ReportValidatedChainProgressRequest\x1a-.p2p_api.ReportValidatedChainProgressResponse\"\x00\x12V\n" +
 	"\x0fIsPeerMalicious\x12\x1f.p2p_api.IsPeerMaliciousRequest\x1a .p2p_api.IsPeerMaliciousResponse\"\x00\x12V\n" +
 	"\x0fIsPeerUnhealthy\x12\x1f.p2p_api.IsPeerUnhealthyRequest\x1a .p2p_api.IsPeerUnhealthyResponse\"\x00\x12M\n" +
@@ -3080,7 +3195,7 @@ func file_services_p2p_p2p_api_p2p_api_proto_rawDescGZIP() []byte {
 	return file_services_p2p_p2p_api_p2p_api_proto_rawDescData
 }
 
-var file_services_p2p_p2p_api_p2p_api_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_services_p2p_p2p_api_p2p_api_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
 var file_services_p2p_p2p_api_p2p_api_proto_goTypes = []any{
 	(*Peer)(nil),                                 // 0: p2p_api.Peer
 	(*GetPeersResponse)(nil),                     // 1: p2p_api.GetPeersResponse
@@ -3119,31 +3234,33 @@ var file_services_p2p_p2p_api_p2p_api_proto_goTypes = []any{
 	(*ReportValidSubtreeResponse)(nil),           // 34: p2p_api.ReportValidSubtreeResponse
 	(*ReportValidBlockRequest)(nil),              // 35: p2p_api.ReportValidBlockRequest
 	(*ReportValidBlockResponse)(nil),             // 36: p2p_api.ReportValidBlockResponse
-	(*ReportValidatedChainProgressRequest)(nil),  // 37: p2p_api.ReportValidatedChainProgressRequest
-	(*ReportValidatedChainProgressResponse)(nil), // 38: p2p_api.ReportValidatedChainProgressResponse
-	(*IsPeerMaliciousRequest)(nil),               // 39: p2p_api.IsPeerMaliciousRequest
-	(*IsPeerMaliciousResponse)(nil),              // 40: p2p_api.IsPeerMaliciousResponse
-	(*IsPeerUnhealthyRequest)(nil),               // 41: p2p_api.IsPeerUnhealthyRequest
-	(*IsPeerUnhealthyResponse)(nil),              // 42: p2p_api.IsPeerUnhealthyResponse
-	(*PeerRegistryInfo)(nil),                     // 43: p2p_api.PeerRegistryInfo
-	(*GetPeerRegistryResponse)(nil),              // 44: p2p_api.GetPeerRegistryResponse
-	(*RecordBytesDownloadedRequest)(nil),         // 45: p2p_api.RecordBytesDownloadedRequest
-	(*RecordBytesDownloadedResponse)(nil),        // 46: p2p_api.RecordBytesDownloadedResponse
-	(*GetPeerRequest)(nil),                       // 47: p2p_api.GetPeerRequest
-	(*GetPeerResponse)(nil),                      // 48: p2p_api.GetPeerResponse
-	(*emptypb.Empty)(nil),                        // 49: google.protobuf.Empty
+	(*ReportValidBlockHeadersRequest)(nil),       // 37: p2p_api.ReportValidBlockHeadersRequest
+	(*ReportValidBlockHeadersResponse)(nil),      // 38: p2p_api.ReportValidBlockHeadersResponse
+	(*ReportValidatedChainProgressRequest)(nil),  // 39: p2p_api.ReportValidatedChainProgressRequest
+	(*ReportValidatedChainProgressResponse)(nil), // 40: p2p_api.ReportValidatedChainProgressResponse
+	(*IsPeerMaliciousRequest)(nil),               // 41: p2p_api.IsPeerMaliciousRequest
+	(*IsPeerMaliciousResponse)(nil),              // 42: p2p_api.IsPeerMaliciousResponse
+	(*IsPeerUnhealthyRequest)(nil),               // 43: p2p_api.IsPeerUnhealthyRequest
+	(*IsPeerUnhealthyResponse)(nil),              // 44: p2p_api.IsPeerUnhealthyResponse
+	(*PeerRegistryInfo)(nil),                     // 45: p2p_api.PeerRegistryInfo
+	(*GetPeerRegistryResponse)(nil),              // 46: p2p_api.GetPeerRegistryResponse
+	(*RecordBytesDownloadedRequest)(nil),         // 47: p2p_api.RecordBytesDownloadedRequest
+	(*RecordBytesDownloadedResponse)(nil),        // 48: p2p_api.RecordBytesDownloadedResponse
+	(*GetPeerRequest)(nil),                       // 49: p2p_api.GetPeerRequest
+	(*GetPeerResponse)(nil),                      // 50: p2p_api.GetPeerResponse
+	(*emptypb.Empty)(nil),                        // 51: google.protobuf.Empty
 }
 var file_services_p2p_p2p_api_p2p_api_proto_depIdxs = []int32{
 	0,  // 0: p2p_api.GetPeersResponse.peers:type_name -> p2p_api.Peer
 	31, // 1: p2p_api.GetPeersForCatchupResponse.peers:type_name -> p2p_api.PeerInfoForCatchup
-	43, // 2: p2p_api.GetPeerRegistryResponse.peers:type_name -> p2p_api.PeerRegistryInfo
-	43, // 3: p2p_api.GetPeerResponse.peer:type_name -> p2p_api.PeerRegistryInfo
-	49, // 4: p2p_api.PeerService.GetPeers:input_type -> google.protobuf.Empty
+	45, // 2: p2p_api.GetPeerRegistryResponse.peers:type_name -> p2p_api.PeerRegistryInfo
+	45, // 3: p2p_api.GetPeerResponse.peer:type_name -> p2p_api.PeerRegistryInfo
+	51, // 4: p2p_api.PeerService.GetPeers:input_type -> google.protobuf.Empty
 	2,  // 5: p2p_api.PeerService.BanPeer:input_type -> p2p_api.BanPeerRequest
 	4,  // 6: p2p_api.PeerService.UnbanPeer:input_type -> p2p_api.UnbanPeerRequest
 	6,  // 7: p2p_api.PeerService.IsBanned:input_type -> p2p_api.IsBannedRequest
-	49, // 8: p2p_api.PeerService.ListBanned:input_type -> google.protobuf.Empty
-	49, // 9: p2p_api.PeerService.ClearBanned:input_type -> google.protobuf.Empty
+	51, // 8: p2p_api.PeerService.ListBanned:input_type -> google.protobuf.Empty
+	51, // 9: p2p_api.PeerService.ClearBanned:input_type -> google.protobuf.Empty
 	10, // 10: p2p_api.PeerService.AddBanScore:input_type -> p2p_api.AddBanScoreRequest
 	12, // 11: p2p_api.PeerService.ConnectPeer:input_type -> p2p_api.ConnectPeerRequest
 	14, // 12: p2p_api.PeerService.DisconnectPeer:input_type -> p2p_api.DisconnectPeerRequest
@@ -3157,39 +3274,41 @@ var file_services_p2p_p2p_api_p2p_api_proto_depIdxs = []int32{
 	30, // 20: p2p_api.PeerService.GetPeersForCatchup:input_type -> p2p_api.GetPeersForCatchupRequest
 	33, // 21: p2p_api.PeerService.ReportValidSubtree:input_type -> p2p_api.ReportValidSubtreeRequest
 	35, // 22: p2p_api.PeerService.ReportValidBlock:input_type -> p2p_api.ReportValidBlockRequest
-	37, // 23: p2p_api.PeerService.ReportValidatedChainProgress:input_type -> p2p_api.ReportValidatedChainProgressRequest
-	39, // 24: p2p_api.PeerService.IsPeerMalicious:input_type -> p2p_api.IsPeerMaliciousRequest
-	41, // 25: p2p_api.PeerService.IsPeerUnhealthy:input_type -> p2p_api.IsPeerUnhealthyRequest
-	49, // 26: p2p_api.PeerService.GetPeerRegistry:input_type -> google.protobuf.Empty
-	45, // 27: p2p_api.PeerService.RecordBytesDownloaded:input_type -> p2p_api.RecordBytesDownloadedRequest
-	47, // 28: p2p_api.PeerService.GetPeer:input_type -> p2p_api.GetPeerRequest
-	1,  // 29: p2p_api.PeerService.GetPeers:output_type -> p2p_api.GetPeersResponse
-	3,  // 30: p2p_api.PeerService.BanPeer:output_type -> p2p_api.BanPeerResponse
-	5,  // 31: p2p_api.PeerService.UnbanPeer:output_type -> p2p_api.UnbanPeerResponse
-	7,  // 32: p2p_api.PeerService.IsBanned:output_type -> p2p_api.IsBannedResponse
-	8,  // 33: p2p_api.PeerService.ListBanned:output_type -> p2p_api.ListBannedResponse
-	9,  // 34: p2p_api.PeerService.ClearBanned:output_type -> p2p_api.ClearBannedResponse
-	11, // 35: p2p_api.PeerService.AddBanScore:output_type -> p2p_api.AddBanScoreResponse
-	13, // 36: p2p_api.PeerService.ConnectPeer:output_type -> p2p_api.ConnectPeerResponse
-	15, // 37: p2p_api.PeerService.DisconnectPeer:output_type -> p2p_api.DisconnectPeerResponse
-	17, // 38: p2p_api.PeerService.RecordCatchupAttempt:output_type -> p2p_api.RecordCatchupAttemptResponse
-	19, // 39: p2p_api.PeerService.RecordCatchupSuccess:output_type -> p2p_api.RecordCatchupSuccessResponse
-	21, // 40: p2p_api.PeerService.RecordCatchupFailure:output_type -> p2p_api.RecordCatchupFailureResponse
-	23, // 41: p2p_api.PeerService.RecordCatchupMalicious:output_type -> p2p_api.RecordCatchupMaliciousResponse
-	25, // 42: p2p_api.PeerService.UpdateCatchupReputation:output_type -> p2p_api.UpdateCatchupReputationResponse
-	27, // 43: p2p_api.PeerService.UpdateCatchupError:output_type -> p2p_api.UpdateCatchupErrorResponse
-	29, // 44: p2p_api.PeerService.ResetReputation:output_type -> p2p_api.ResetReputationResponse
-	32, // 45: p2p_api.PeerService.GetPeersForCatchup:output_type -> p2p_api.GetPeersForCatchupResponse
-	34, // 46: p2p_api.PeerService.ReportValidSubtree:output_type -> p2p_api.ReportValidSubtreeResponse
-	36, // 47: p2p_api.PeerService.ReportValidBlock:output_type -> p2p_api.ReportValidBlockResponse
-	38, // 48: p2p_api.PeerService.ReportValidatedChainProgress:output_type -> p2p_api.ReportValidatedChainProgressResponse
-	40, // 49: p2p_api.PeerService.IsPeerMalicious:output_type -> p2p_api.IsPeerMaliciousResponse
-	42, // 50: p2p_api.PeerService.IsPeerUnhealthy:output_type -> p2p_api.IsPeerUnhealthyResponse
-	44, // 51: p2p_api.PeerService.GetPeerRegistry:output_type -> p2p_api.GetPeerRegistryResponse
-	46, // 52: p2p_api.PeerService.RecordBytesDownloaded:output_type -> p2p_api.RecordBytesDownloadedResponse
-	48, // 53: p2p_api.PeerService.GetPeer:output_type -> p2p_api.GetPeerResponse
-	29, // [29:54] is the sub-list for method output_type
-	4,  // [4:29] is the sub-list for method input_type
+	37, // 23: p2p_api.PeerService.ReportValidBlockHeaders:input_type -> p2p_api.ReportValidBlockHeadersRequest
+	39, // 24: p2p_api.PeerService.ReportValidatedChainProgress:input_type -> p2p_api.ReportValidatedChainProgressRequest
+	41, // 25: p2p_api.PeerService.IsPeerMalicious:input_type -> p2p_api.IsPeerMaliciousRequest
+	43, // 26: p2p_api.PeerService.IsPeerUnhealthy:input_type -> p2p_api.IsPeerUnhealthyRequest
+	51, // 27: p2p_api.PeerService.GetPeerRegistry:input_type -> google.protobuf.Empty
+	47, // 28: p2p_api.PeerService.RecordBytesDownloaded:input_type -> p2p_api.RecordBytesDownloadedRequest
+	49, // 29: p2p_api.PeerService.GetPeer:input_type -> p2p_api.GetPeerRequest
+	1,  // 30: p2p_api.PeerService.GetPeers:output_type -> p2p_api.GetPeersResponse
+	3,  // 31: p2p_api.PeerService.BanPeer:output_type -> p2p_api.BanPeerResponse
+	5,  // 32: p2p_api.PeerService.UnbanPeer:output_type -> p2p_api.UnbanPeerResponse
+	7,  // 33: p2p_api.PeerService.IsBanned:output_type -> p2p_api.IsBannedResponse
+	8,  // 34: p2p_api.PeerService.ListBanned:output_type -> p2p_api.ListBannedResponse
+	9,  // 35: p2p_api.PeerService.ClearBanned:output_type -> p2p_api.ClearBannedResponse
+	11, // 36: p2p_api.PeerService.AddBanScore:output_type -> p2p_api.AddBanScoreResponse
+	13, // 37: p2p_api.PeerService.ConnectPeer:output_type -> p2p_api.ConnectPeerResponse
+	15, // 38: p2p_api.PeerService.DisconnectPeer:output_type -> p2p_api.DisconnectPeerResponse
+	17, // 39: p2p_api.PeerService.RecordCatchupAttempt:output_type -> p2p_api.RecordCatchupAttemptResponse
+	19, // 40: p2p_api.PeerService.RecordCatchupSuccess:output_type -> p2p_api.RecordCatchupSuccessResponse
+	21, // 41: p2p_api.PeerService.RecordCatchupFailure:output_type -> p2p_api.RecordCatchupFailureResponse
+	23, // 42: p2p_api.PeerService.RecordCatchupMalicious:output_type -> p2p_api.RecordCatchupMaliciousResponse
+	25, // 43: p2p_api.PeerService.UpdateCatchupReputation:output_type -> p2p_api.UpdateCatchupReputationResponse
+	27, // 44: p2p_api.PeerService.UpdateCatchupError:output_type -> p2p_api.UpdateCatchupErrorResponse
+	29, // 45: p2p_api.PeerService.ResetReputation:output_type -> p2p_api.ResetReputationResponse
+	32, // 46: p2p_api.PeerService.GetPeersForCatchup:output_type -> p2p_api.GetPeersForCatchupResponse
+	34, // 47: p2p_api.PeerService.ReportValidSubtree:output_type -> p2p_api.ReportValidSubtreeResponse
+	36, // 48: p2p_api.PeerService.ReportValidBlock:output_type -> p2p_api.ReportValidBlockResponse
+	38, // 49: p2p_api.PeerService.ReportValidBlockHeaders:output_type -> p2p_api.ReportValidBlockHeadersResponse
+	40, // 50: p2p_api.PeerService.ReportValidatedChainProgress:output_type -> p2p_api.ReportValidatedChainProgressResponse
+	42, // 51: p2p_api.PeerService.IsPeerMalicious:output_type -> p2p_api.IsPeerMaliciousResponse
+	44, // 52: p2p_api.PeerService.IsPeerUnhealthy:output_type -> p2p_api.IsPeerUnhealthyResponse
+	46, // 53: p2p_api.PeerService.GetPeerRegistry:output_type -> p2p_api.GetPeerRegistryResponse
+	48, // 54: p2p_api.PeerService.RecordBytesDownloaded:output_type -> p2p_api.RecordBytesDownloadedResponse
+	50, // 55: p2p_api.PeerService.GetPeer:output_type -> p2p_api.GetPeerResponse
+	30, // [30:56] is the sub-list for method output_type
+	4,  // [4:30] is the sub-list for method input_type
 	4,  // [4:4] is the sub-list for extension type_name
 	4,  // [4:4] is the sub-list for extension extendee
 	0,  // [0:4] is the sub-list for field type_name
@@ -3206,7 +3325,7 @@ func file_services_p2p_p2p_api_p2p_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_services_p2p_p2p_api_p2p_api_proto_rawDesc), len(file_services_p2p_p2p_api_p2p_api_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   49,
+			NumMessages:   51,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/services/p2p/p2p_api/p2p_api.pb.go
+++ b/services/p2p/p2p_api/p2p_api.pb.go
@@ -2371,8 +2371,13 @@ type PeerRegistryInfo struct {
 	ClientName             string  `protobuf:"bytes,24,opt,name=client_name,json=clientName,proto3" json:"client_name,omitempty"`                                    // Human-readable name of the client
 	LastCatchupError       string  `protobuf:"bytes,25,opt,name=last_catchup_error,json=lastCatchupError,proto3" json:"last_catchup_error,omitempty"`                // Last error message from catchup attempt
 	LastCatchupErrorTime   int64   `protobuf:"varint,26,opt,name=last_catchup_error_time,json=lastCatchupErrorTime,proto3" json:"last_catchup_error_time,omitempty"` // Unix timestamp of last catchup error
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// Catchup-specific counters (recorded via RecordCatchupAttempt/Success/Failure),
+	// distinct from the generic interaction counters above.
+	CatchupAttempts  int64 `protobuf:"varint,27,opt,name=catchup_attempts,json=catchupAttempts,proto3" json:"catchup_attempts,omitempty"`
+	CatchupSuccesses int64 `protobuf:"varint,28,opt,name=catchup_successes,json=catchupSuccesses,proto3" json:"catchup_successes,omitempty"`
+	CatchupFailures  int64 `protobuf:"varint,29,opt,name=catchup_failures,json=catchupFailures,proto3" json:"catchup_failures,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PeerRegistryInfo) Reset() {
@@ -2569,6 +2574,27 @@ func (x *PeerRegistryInfo) GetLastCatchupError() string {
 func (x *PeerRegistryInfo) GetLastCatchupErrorTime() int64 {
 	if x != nil {
 		return x.LastCatchupErrorTime
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetCatchupAttempts() int64 {
+	if x != nil {
+		return x.CatchupAttempts
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetCatchupSuccesses() int64 {
+	if x != nil {
+		return x.CatchupSuccesses
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetCatchupFailures() int64 {
+	if x != nil {
+		return x.CatchupFailures
 	}
 	return 0
 }
@@ -2968,7 +2994,7 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"\x17IsPeerUnhealthyResponse\x12!\n" +
 	"\fis_unhealthy\x18\x01 \x01(\bR\visUnhealthy\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12)\n" +
-	"\x10reputation_score\x18\x03 \x01(\x02R\x0freputationScore\"\xe4\a\n" +
+	"\x10reputation_score\x18\x03 \x01(\x02R\x0freputationScore\"\xe7\b\n" +
 	"\x10PeerRegistryInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\rR\x06height\x12\x1d\n" +
@@ -2997,7 +3023,10 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"\vclient_name\x18\x18 \x01(\tR\n" +
 	"clientName\x12,\n" +
 	"\x12last_catchup_error\x18\x19 \x01(\tR\x10lastCatchupError\x125\n" +
-	"\x17last_catchup_error_time\x18\x1a \x01(\x03R\x14lastCatchupErrorTime\"J\n" +
+	"\x17last_catchup_error_time\x18\x1a \x01(\x03R\x14lastCatchupErrorTime\x12)\n" +
+	"\x10catchup_attempts\x18\x1b \x01(\x03R\x0fcatchupAttempts\x12+\n" +
+	"\x11catchup_successes\x18\x1c \x01(\x03R\x10catchupSuccesses\x12)\n" +
+	"\x10catchup_failures\x18\x1d \x01(\x03R\x0fcatchupFailures\"J\n" +
 	"\x17GetPeerRegistryResponse\x12/\n" +
 	"\x05peers\x18\x01 \x03(\v2\x19.p2p_api.PeerRegistryInfoR\x05peers\"b\n" +
 	"\x1cRecordBytesDownloadedRequest\x12\x17\n" +

--- a/services/p2p/p2p_api/p2p_api.proto
+++ b/services/p2p/p2p_api/p2p_api.proto
@@ -266,6 +266,12 @@ message AddBanScoreRequest {
     string client_name = 24;  // Human-readable name of the client
     string last_catchup_error = 25;  // Last error message from catchup attempt
     int64 last_catchup_error_time = 26;  // Unix timestamp of last catchup error
+
+    // Catchup-specific counters (recorded via RecordCatchupAttempt/Success/Failure),
+    // distinct from the generic interaction counters above.
+    int64 catchup_attempts = 27;
+    int64 catchup_successes = 28;
+    int64 catchup_failures = 29;
   }
 
   message GetPeerRegistryResponse {

--- a/services/p2p/p2p_api/p2p_api.proto
+++ b/services/p2p/p2p_api/p2p_api.proto
@@ -205,6 +205,19 @@ message AddBanScoreRequest {
     string message = 2;
   }
 
+  // Report a successfully served batch of block headers during catchup.
+  // Credits the peer with a generic interaction success (reputation and
+  // response time) without touching the catchup-operation counters.
+  message ReportValidBlockHeadersRequest {
+    string peer_id = 1;      // Peer ID that served the headers
+    int64 duration_ms = 2;   // Time taken to serve the headers (0 = not applicable)
+  }
+
+  message ReportValidBlockHeadersResponse {
+    bool success = 1;
+    string message = 2;
+  }
+
   // Report locally validated peer chain progress
   message ReportValidatedChainProgressRequest {
     string peer_id = 1;
@@ -322,6 +335,7 @@ message AddBanScoreRequest {
     // Subtree and block validation reporting
     rpc ReportValidSubtree(ReportValidSubtreeRequest) returns (ReportValidSubtreeResponse) {}
     rpc ReportValidBlock(ReportValidBlockRequest) returns (ReportValidBlockResponse) {}
+    rpc ReportValidBlockHeaders(ReportValidBlockHeadersRequest) returns (ReportValidBlockHeadersResponse) {}
     rpc ReportValidatedChainProgress(ReportValidatedChainProgressRequest) returns (ReportValidatedChainProgressResponse) {}
 
     // Peer status checking

--- a/services/p2p/p2p_api/p2p_api_grpc.pb.go
+++ b/services/p2p/p2p_api/p2p_api_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	PeerService_GetPeersForCatchup_FullMethodName           = "/p2p_api.PeerService/GetPeersForCatchup"
 	PeerService_ReportValidSubtree_FullMethodName           = "/p2p_api.PeerService/ReportValidSubtree"
 	PeerService_ReportValidBlock_FullMethodName             = "/p2p_api.PeerService/ReportValidBlock"
+	PeerService_ReportValidBlockHeaders_FullMethodName      = "/p2p_api.PeerService/ReportValidBlockHeaders"
 	PeerService_ReportValidatedChainProgress_FullMethodName = "/p2p_api.PeerService/ReportValidatedChainProgress"
 	PeerService_IsPeerMalicious_FullMethodName              = "/p2p_api.PeerService/IsPeerMalicious"
 	PeerService_IsPeerUnhealthy_FullMethodName              = "/p2p_api.PeerService/IsPeerUnhealthy"
@@ -74,6 +75,7 @@ type PeerServiceClient interface {
 	// Subtree and block validation reporting
 	ReportValidSubtree(ctx context.Context, in *ReportValidSubtreeRequest, opts ...grpc.CallOption) (*ReportValidSubtreeResponse, error)
 	ReportValidBlock(ctx context.Context, in *ReportValidBlockRequest, opts ...grpc.CallOption) (*ReportValidBlockResponse, error)
+	ReportValidBlockHeaders(ctx context.Context, in *ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*ReportValidBlockHeadersResponse, error)
 	ReportValidatedChainProgress(ctx context.Context, in *ReportValidatedChainProgressRequest, opts ...grpc.CallOption) (*ReportValidatedChainProgressResponse, error)
 	// Peer status checking
 	IsPeerMalicious(ctx context.Context, in *IsPeerMaliciousRequest, opts ...grpc.CallOption) (*IsPeerMaliciousResponse, error)
@@ -284,6 +286,16 @@ func (c *peerServiceClient) ReportValidBlock(ctx context.Context, in *ReportVali
 	return out, nil
 }
 
+func (c *peerServiceClient) ReportValidBlockHeaders(ctx context.Context, in *ReportValidBlockHeadersRequest, opts ...grpc.CallOption) (*ReportValidBlockHeadersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReportValidBlockHeadersResponse)
+	err := c.cc.Invoke(ctx, PeerService_ReportValidBlockHeaders_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *peerServiceClient) ReportValidatedChainProgress(ctx context.Context, in *ReportValidatedChainProgressRequest, opts ...grpc.CallOption) (*ReportValidatedChainProgressResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ReportValidatedChainProgressResponse)
@@ -371,6 +383,7 @@ type PeerServiceServer interface {
 	// Subtree and block validation reporting
 	ReportValidSubtree(context.Context, *ReportValidSubtreeRequest) (*ReportValidSubtreeResponse, error)
 	ReportValidBlock(context.Context, *ReportValidBlockRequest) (*ReportValidBlockResponse, error)
+	ReportValidBlockHeaders(context.Context, *ReportValidBlockHeadersRequest) (*ReportValidBlockHeadersResponse, error)
 	ReportValidatedChainProgress(context.Context, *ReportValidatedChainProgressRequest) (*ReportValidatedChainProgressResponse, error)
 	// Peer status checking
 	IsPeerMalicious(context.Context, *IsPeerMaliciousRequest) (*IsPeerMaliciousResponse, error)
@@ -447,6 +460,9 @@ func (UnimplementedPeerServiceServer) ReportValidSubtree(context.Context, *Repor
 }
 func (UnimplementedPeerServiceServer) ReportValidBlock(context.Context, *ReportValidBlockRequest) (*ReportValidBlockResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReportValidBlock not implemented")
+}
+func (UnimplementedPeerServiceServer) ReportValidBlockHeaders(context.Context, *ReportValidBlockHeadersRequest) (*ReportValidBlockHeadersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReportValidBlockHeaders not implemented")
 }
 func (UnimplementedPeerServiceServer) ReportValidatedChainProgress(context.Context, *ReportValidatedChainProgressRequest) (*ReportValidatedChainProgressResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReportValidatedChainProgress not implemented")
@@ -829,6 +845,24 @@ func _PeerService_ReportValidBlock_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PeerService_ReportValidBlockHeaders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReportValidBlockHeadersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PeerServiceServer).ReportValidBlockHeaders(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PeerService_ReportValidBlockHeaders_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PeerServiceServer).ReportValidBlockHeaders(ctx, req.(*ReportValidBlockHeadersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _PeerService_ReportValidatedChainProgress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ReportValidatedChainProgressRequest)
 	if err := dec(in); err != nil {
@@ -1019,6 +1053,10 @@ var PeerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReportValidBlock",
 			Handler:    _PeerService_ReportValidBlock_Handler,
+		},
+		{
+			MethodName: "ReportValidBlockHeaders",
+			Handler:    _PeerService_ReportValidBlockHeaders_Handler,
 		},
 		{
 			MethodName: "ReportValidatedChainProgress",

--- a/services/p2p/server_auth_test.go
+++ b/services/p2p/server_auth_test.go
@@ -37,6 +37,7 @@ var publicPeerServiceMethods = map[string]bool{
 	"/p2p_api.PeerService/UpdateCatchupError":           true,
 	"/p2p_api.PeerService/ReportValidSubtree":           true,
 	"/p2p_api.PeerService/ReportValidBlock":             true,
+	"/p2p_api.PeerService/ReportValidBlockHeaders":      true,
 	"/p2p_api.PeerService/ReportValidatedChainProgress": true,
 	"/p2p_api.PeerService/RecordBytesDownloaded":        true,
 }

--- a/services/p2p/server_handler_test.go
+++ b/services/p2p/server_handler_test.go
@@ -43,6 +43,9 @@ func TestServer_PeerInfoToP2PProto_RoundTripFields(t *testing.T) {
 		ClientName:             "test/1.0",
 		LastCatchupError:       "boom",
 		LastCatchupErrorTime:   now,
+		CatchupAttempts:        7,
+		CatchupSuccesses:       5,
+		CatchupFailures:        2,
 	}
 
 	out := peerInfoToP2PProto(bp)
@@ -58,6 +61,9 @@ func TestServer_PeerInfoToP2PProto_RoundTripFields(t *testing.T) {
 	require.Equal(t, bp.ClientName, out.ClientName)
 	require.Equal(t, bp.LastCatchupError, out.LastCatchupError)
 	require.Equal(t, now.Unix(), out.ConnectedAt)
+	require.Equal(t, bp.CatchupAttempts, out.CatchupAttempts)
+	require.Equal(t, bp.CatchupSuccesses, out.CatchupSuccesses)
+	require.Equal(t, bp.CatchupFailures, out.CatchupFailures)
 }
 
 func TestServer_PeerInfoToP2PProto_NilHashAndZeroTimes(t *testing.T) {

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -5490,6 +5490,10 @@ func (m *mockP2PClient) ReportValidSubtree(ctx context.Context, peerID string, s
 	return nil
 }
 
+func (m *mockP2PClient) ReportValidBlockHeaders(ctx context.Context, peerID string, durationMs int64) error {
+	return nil
+}
+
 func (m *mockP2PClient) ReportValidBlock(ctx context.Context, peerID string, blockHash string) error {
 	return nil
 }


### PR DESCRIPTION


### Problem
`GetPeersForCatchup` populated `CatchupAttempts`/`CatchupSuccesses`/`CatchupFailures` from the peer's generic interaction counters (`InteractionSuccesses`/`InteractionFailures`), which mix in blocks, subtrees, and transactions. `RecordCatchupAttempt` only recorded sync backoff state (`RecordSyncAttempt`), so catchup attempts that produced neither success nor failure were invisible, and the reported "catchup" metrics were really "all interactions". This degraded catchup peer ranking and diagnostics.

### Fix
Added dedicated catchup counters to the centralized registry, following the existing dedicated-RPC pattern (`RecordSyncAttempt`, `RecordCatchupError`):

- `PeerInfo` gains `CatchupAttempts`, `CatchupSuccesses`, `CatchupFailures`.
- New registry methods: `RecordCatchupAttempt` (increments the attempt counter and keeps the existing `LastSyncAttempt`/`SyncAttemptCount` backoff tracking, so prior behavior is preserved), `RecordCatchupSuccess` (increments the counter and records a generic successful interaction with response time, reusing `recordReceivedSuccessLocked`), `RecordCatchupFailure` (increments the counter and records a generic failed interaction). Reputation computation is unchanged.
- Wired through the proto (`RecordCatchupAttempt`/`RecordCatchupSuccess`/`RecordCatchupFailure` RPCs, `PeerRegistryInfo` fields 37-39), the `Blockchain` gRPC handlers, `PeerRegistryClientI` and both implementations.
- The p2p `RecordCatchupAttempt`/`RecordCatchupSuccess`/`RecordCatchupFailure` handlers now call the catchup-specific methods, and `GetPeersForCatchup` reports the catchup-specific counters.
- `ResetReputation` also clears the new counters; JSON persistence picks them up automatically.

Note: pb files regenerated with the repo's canonical toolchain (protoc v33.2, `protoc-gen-go` 1.36.11, `protoc-gen-go-grpc` 1.6.1), so the generated diff contains only the new fields/RPCs - no version-stamp churn.

### Review-round fixes
- **Rolling upgrade**: the registry client's `RecordCatchupAttempt/Success/Failure` fall back to the legacy `RecordSyncAttempt`/`UpdatePeerMetrics` RPCs on `codes.Unimplemented`, so backoff and reputation keep working against an old blockchain service.
- **One success per attempt**: the header-fetch stage no longer reports a catchup success; `doCatchup` reports the single outcome per attempt.
- **Headers-stage reputation credit (`ReportValidBlockHeaders`)**: removing the header-stage catchup-success report initially also removed its generic interaction credit, which broke catchup recovery — with only failures recorded, a fresh peer's reputation dropped to ~5 after one failed attempt (`0*0.6 + 50*0.4 - 15`), `isPeerBad` then excluded the only peer with the data, and the `chainintegrity`/`TestCatchup` e2e tests timed out (the 429 rate-limit storms in those tests fail the block-fetch stage repeatedly, and previously each header-stage success kept the ratio at ~50%). The new `ReportValidBlockHeaders` p2p RPC (mirroring `ReportValidBlock`/`ReportValidSubtree`) restores exactly that credit: generic interaction success + response time, no catchup counter — so `CatchupSuccesses ≤ CatchupAttempts` still holds while a headers-serving peer stays healthy through failed catchup cycles. Rolling upgrade is covered here too: on `codes.Unimplemented` from an old p2p service the client falls back to the legacy `RecordCatchupSuccess` RPC, which on such servers is implemented as exactly this generic credit.
- **Success-rate diagnostics** compute over resolved outcomes (`successes/(successes+failures)`), not raw attempts, since attempts now include in-flight/unresolved catchups.
- **Dashboard**: `p2p_api.PeerRegistryInfo` carries the catchup counters (fields 27-29) and `get_peers.go` serves them under the `catchup_*` JSON names instead of the generic interaction counters. Catchup-scoped timestamps are not tracked; the `catchup_last_*` timestamps remain generic-interaction ones (commented at the mapping site).
- **One failure per attempt**: header-stage failures were reported twice — once inside `catchupGetBlockHeaders` (closest to the failure, and the only report for HTTP-status errors, whose `ServiceError` classification the top-level dispatch deliberately does not report) and again by the top-level catchup handler when the error propagated up. The header stage now wraps its returned errors with an already-reported marker (`markCatchupFailureReported`: a native `ProcessingError` wrap carrying an error-data key, since the errors package flattens foreign wrapper types and would break code matching), and `reportCatchupFailureForError` skips marked errors — so one failed attempt records exactly one `CatchupFailure` and one reputation penalty. The pre-existing double reputation penalty this fixes was surfaced by the new dedicated counter.
- **Persistence**: `persistedRegistryVersion` bumped to 2 so a downgraded binary refuses to re-save (and silently zero) counters it does not understand.

### Tests
- `TestCentralizedPeerRegistry_RecordCatchupCounters`: counters increment correctly, block/subtree activity does not bleed into them, attempts feed sync backoff, success/failure still feed generic interaction metrics, unknown peers are a no-op.
- `TestCentralizedPeerRegistry_ResetReputation`: extended to verify the new counters are cleared.
- `TestGRPC_RecordCatchupCounters`: the three new gRPC handlers against a real registry.
- `TestGRPC_PeerInfoProtoRoundTrip`: extended with the new fields.
- `TestGetPeersForCatchup_UsesCatchupSpecificCounters` (regression for this issue): attempts without an outcome are counted, and non-catchup interactions no longer inflate the reported catchup metrics.
- Existing `TestRecordCatchup*` p2p handler tests extended to assert the new counters.
- `TestPeerRegistryClient_CatchupRPCs_FallBackOnUnimplemented`: rolling-upgrade fallback against a real gRPC server implementing only the legacy RPCs.
- `TestReportValidBlockHeaders_CreditsReputationNotCatchupCounters` and `TestReportValidBlockHeaders_KeepsFailingPeerHealthy`: the headers-stage credit does not touch catchup counters, and a peer serving headers through repeated catchup failures stays healthy (the e2e regression mechanism).
- `TestReportCatchupFailureForError_SkipsAlreadyReported` and `TestMarkCatchupFailureReported_TransparentToErrorCodes`: the already-reported marker suppresses the top-level duplicate, survives teranode error wrapping, and does not break `ErrServiceError`/malicious error-code dispatch.
- `TestSimpleClientReportValidBlockHeaders`: p2p client happy path plus the `Unimplemented` → `RecordCatchupSuccess` rolling-upgrade fallback.

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/blockchain/...   # ok
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...          # ok
```


