### PR TITLE
fix(p2p): count only connected peers in node_status

### DIFF
--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -1294,14 +1294,19 @@ func (s *Server) getNodeStatusMessage(ctx context.Context) *notificationMsg {
 		s.logger.Debugf("[getNodeStatusMessage] Policy settings not available, using default MinMiningTxFee: %f", defaultFee)
 	}
 
-	// Get connected peers count from the registry
+	// Get connected peers count from the registry. The registry also holds
+	// gossiped/disconnected peers, so count only directly connected ones.
 	connectedPeersCount := 0
 	if s.peerRegistry != nil {
 		allPeers, err := s.peerRegistry.ListPeers(ctx, nil, 0, 0, false, false)
 		if err != nil {
 			s.logger.Warnf("[getNodeStatusMessage] ListPeers failed: %v", err)
 		} else {
-			connectedPeersCount = len(allPeers)
+			for _, p := range allPeers {
+				if p.IsConnected {
+					connectedPeersCount++
+				}
+			}
 		}
 	}
 

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -117,6 +117,22 @@ func TestServerHelpers_InjectPeerForTesting_MarksFull(t *testing.T) {
 	require.Equal(t, uint32(99), got.Height)
 }
 
+// TestGetNodeStatusMessage_CountsOnlyConnectedPeers is a regression test:
+// ConnectedPeersCount in the node_status message must count only directly
+// connected peers, not every peer known to the registry (gossiped peers stay
+// registered with IsConnected=false).
+func TestGetNodeStatusMessage_CountsOnlyConnectedPeers(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+
+	s.addConnectedPeer(mustNewPeerID(t), "client/1.0", 10, nil, "")
+	s.addConnectedPeer(mustNewPeerID(t), "client/1.0", 20, nil, "")
+	s.addPeer(mustNewPeerID(t), "client/1.0", 30, nil, "") // gossiped, not connected
+
+	msg := s.getNodeStatusMessage(context.Background())
+	require.NotNil(t, msg)
+	require.Equal(t, 2, msg.ConnectedPeersCount, "gossiped/disconnected registry peers must not be counted")
+}
+
 func TestServerHelpers_GetSyncPeer_NoCoordinator(t *testing.T) {
 	s, _ := newServerWithLocalRegistry(t)
 	require.Empty(t, s.getSyncPeer())


### PR DESCRIPTION


### Problem
`ConnectedPeersCount` in the node_status message was set to `len(allPeers)` from `peerRegistry.ListPeers(...)`, which returns every peer in the registry - including gossiped and long-disconnected peers. The dashboard and any consumer of `connected_peers_count` saw an inflated value that misrepresented node connectivity.

### Fix
`getNodeStatusMessage` now counts only peers with `IsConnected == true`, the same filter `GetPeers` already applies to the same `ListPeers` result. The list is filtered client-side because `PeerRegistryClientI.ListPeers` has no connected-only parameter; adding one would touch the blockchain gRPC API for no benefit.

### Tests
Added `TestGetNodeStatusMessage_CountsOnlyConnectedPeers` in `services/p2p/server_helpers_test.go`: two peers registered via `addConnectedPeer` plus one gossiped-only peer via `addPeer`, asserting the message reports 2, not 3. Uses the existing `CentralizedPeerRegistry`-backed local client (no mocks).

Ran (affected package only):
```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```
Result: `ok github.com/bsv-blockchain/teranode/services/p2p 13.300s`

