### PR TITLE
fix(legacy): tear down association sub-peer streams on primary disconnect (#1278)

### DIFF
--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -1192,6 +1192,35 @@ func shouldDisconnectOnBlockErr(err error) bool {
 		!errors.Is(err, errors.ErrStorageError)
 }
 
+// tearDownAssociationStreams closes the live connection of every stream
+// sub-peer in assoc except the given peer. It is the primary-disconnect
+// counterpart to disconnectMisbehaving: when an association's PRIMARY goes away
+// (misbehaviour eviction, sync-peer rotation, remote hang-up), handleDonePeerMsg
+// removes only the association BOOKKEEPING, which left the DATA1 sub-peer's TCP
+// connection open reading blocks off the wire for a dead association, and left a
+// budget-parked sub-peer read-loop parked forever — AcquireBlockPrefetch waits
+// on the sub-peer's own serverPeer.quit, which only closes when the sub-peer's
+// own connection drops. Disconnecting the sub-peer closes its peer.Peer.quit,
+// unblocking its peerDoneHandler, which closes its serverPeer.quit and unparks
+// the waiter. StreamPeers() includes the primary (registered as the GENERAL
+// stream at construction), so callers pass it as except — it is already
+// disconnecting. DisconnectWithInfo is idempotent (atomic guard), so overlap
+// with disconnectMisbehaving's explicit stream disconnect, or a sub-peer already
+// mid-teardown, is safe.
+func tearDownAssociationStreams(assoc *peer.Association, except *peer.Peer) {
+	if assoc == nil {
+		return
+	}
+
+	for _, p := range assoc.StreamPeers() {
+		if p == nil || p == except {
+			continue
+		}
+
+		p.DisconnectWithInfo("association primary disconnected")
+	}
+}
+
 // disconnectMisbehaving evicts a peer's whole association for misbehaviour. It
 // disconnects the association PRIMARY — whose disconnect drives
 // handleDonePeerMsg's associationMgr.Remove(...), rotating the sync peer — and
@@ -1203,11 +1232,13 @@ func shouldDisconnectOnBlockErr(err error) bool {
 // handleDonePeerMsg only does assoc.RemoveStream(...), so openRequiredStreams
 // re-opens DATA1 and the node keeps syncing from a peer serving invalid blocks
 // (IBD stalls). Resolving to the primary is what actually rotates the sync peer.
-// Conversely, handleDonePeerMsg tears down the association bookkeeping on primary
-// disconnect but never closes the sub-peers' connections, so the sub-peer must be
-// disconnected here too or its DATA stream keeps reading off the wire.
-// DisconnectWithWarning is idempotent (atomic guard), so the non-stream case
-// (target == sp.Peer) disconnects exactly once.
+// handleDonePeerMsg now also tears down the association's sub-peer connections on
+// primary disconnect (via tearDownAssociationStreams), so eviction of the whole
+// association is covered even when the bad block arrives on the primary; the
+// explicit stream disconnect here is kept as the fast path (it fires immediately,
+// not one peerHandler round-trip later). DisconnectWithWarning is idempotent
+// (atomic guard), so the non-stream case (target == sp.Peer) disconnects exactly
+// once and the overlap with the centralized teardown is harmless.
 func disconnectMisbehaving(sp *serverPeer, reason string) {
 	target := misbehaviorDisconnectTarget(sp.Peer)
 	target.DisconnectWithWarning(reason)
@@ -2306,7 +2337,14 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 			s.logger.Debugf("Removed stream type %d from association %s",
 				sp.Peer.StreamType(), assoc.ID())
 		} else {
-			// Primary peer disconnected - remove the entire association.
+			// Primary peer disconnected - tear down the whole association:
+			// close every sub-peer's live connection, then remove the
+			// bookkeeping. Removing only the bookkeeping left the DATA1 sub-peer
+			// reading off the wire (or parked forever in AcquireBlockPrefetch) on
+			// a connection nothing would ever close. Teardown runs before Remove
+			// so stale sub-peer connections are already dropping by the time the
+			// association ID becomes free for a reconnecting peer to re-register.
+			tearDownAssociationStreams(assoc, sp.Peer)
 			s.associationMgr.Remove(assoc.RawID())
 			s.logger.Debugf("Removed association %s (primary peer disconnected)", assoc.ID())
 		}

--- a/services/legacy/peer_server_test.go
+++ b/services/legacy/peer_server_test.go
@@ -1373,6 +1373,80 @@ func TestDisconnectMisbehaving(t *testing.T) {
 	})
 }
 
+// TestTearDownAssociationStreams verifies the primary-disconnect teardown that
+// handleDonePeerMsg now performs: when an association's primary goes away, every
+// sub-peer stream connection is closed (fixing the DATA1 stream leak and the
+// budget-parked sub-peer read-loop), while the primary itself — passed as
+// except, since it is already disconnecting — is left untouched.
+// DisconnectWithInfo closes the peer's quit channel, so WaitForDisconnect
+// returning is the observable disconnect signal.
+func TestTearDownAssociationStreams(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	newPeer := func() *peer.Peer {
+		return peer.NewInboundPeer(ulogger.TestLogger{}, tSettings, &peer.Config{})
+	}
+
+	disconnected := func(p *peer.Peer) bool {
+		done := make(chan struct{})
+		go func() {
+			p.WaitForDisconnect()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			return true
+		case <-time.After(100 * time.Millisecond):
+			return false
+		}
+	}
+
+	buildAssoc := func() (*peer.Association, *peer.Peer, *peer.Peer, *peer.Peer) {
+		primary := newPeer()
+		assoc := peer.NewAssociation([]byte{0x01, 0x02, 0x03}, primary)
+		primary.SetAssociation(assoc)
+
+		data1 := newPeer()
+		require.True(t, assoc.AddStream(wire.StreamTypeData1, data1))
+		data1.SetAssociation(assoc)
+		data1.SetStreamType(wire.StreamTypeData1)
+
+		data2 := newPeer()
+		require.True(t, assoc.AddStream(wire.StreamTypeData2, data2))
+		data2.SetAssociation(assoc)
+		data2.SetStreamType(wire.StreamTypeData2)
+
+		return assoc, primary, data1, data2
+	}
+
+	t.Run("closes every sub-peer stream, leaves the primary", func(t *testing.T) {
+		assoc, primary, data1, data2 := buildAssoc()
+
+		tearDownAssociationStreams(assoc, primary)
+
+		require.False(t, disconnected(primary), "the primary is passed as except and must not be disconnected here")
+		require.True(t, disconnected(data1), "the DATA1 sub-peer connection must be closed")
+		require.True(t, disconnected(data2), "the DATA2 sub-peer connection must be closed")
+	})
+
+	t.Run("nil association is a no-op", func(t *testing.T) {
+		require.NotPanics(t, func() { tearDownAssociationStreams(nil, newPeer()) })
+	})
+
+	t.Run("idempotent when a sub-peer is already tearing down", func(t *testing.T) {
+		assoc, primary, data1, data2 := buildAssoc()
+
+		// Pre-disconnect one sub-peer: the helper must not panic (atomic guard)
+		// and must still close the remaining sub-peer.
+		data1.DisconnectWithWarning("already gone")
+
+		require.NotPanics(t, func() { tearDownAssociationStreams(assoc, primary) })
+		require.True(t, disconnected(data1))
+		require.True(t, disconnected(data2))
+		require.False(t, disconnected(primary))
+	})
+}
+
 // TestAwaitBlockResult_ReleasesAndExitsOnTeardown covers the prefetch teardown
 // path: awaitBlockResult must hold the reserved budget until the block actually
 // finishes processing — even after the peer is torn down (sp.quit) — because the


### PR DESCRIPTION
Fixes #1278. Follow-up from #1190; parent #1189.

## Problem
A multistream association's sub-peer teardown was not driven by the primary's disconnect. The server-side `handleDonePeerMsg` removed only association *bookkeeping* (`associationMgr.Remove`) on primary disconnect and never closed the sub-peers' live TCP connections:

1. **DATA1 stream leak on bad-block-at-primary (#&NoBreak;6).** When a bad block arrives on the primary, `disconnectMisbehaving` disconnects only the primary. The DATA1 sub-peer then keeps reading blocks off the wire for an association that no longer exists.
2. **Budget-parked sub-peer never unparked (#&NoBreak;7).** `OnBlock`'s `AcquireBlockPrefetch` waits on the sub-peer's own `serverPeer.quit`, which only closes when the sub-peer's connection drops. Sync-peer rotation closes the *primary's* quit, not the sub-peer's — so a DATA1 read-loop parked on a full budget during a real processing hang stays parked forever.

One root cause: primary disconnect doesn't cascade to sub-peer connection teardown.

## Fix
Centralize sub-peer teardown in `handleDonePeerMsg`'s primary branch via a new `tearDownAssociationStreams(assoc, except)` helper that `DisconnectWithInfo`s every stream peer except the primary (already disconnecting).

The teardown chain closes both gaps at one site:
`subPeer.DisconnectWithInfo` → `close(peer.Peer.quit)` → sub-peer's `peerDoneHandler` `WaitForDisconnect` returns → `close(serverPeer.quit)` → `AcquireBlockPrefetch`'s quit-linked cancel fires → read-loop unparks. The same call closes the TCP connection (the whole of #&NoBreak;6).

- `DisconnectWithInfo` (not Warning): the sub-peer did nothing wrong. Idempotent atomic guard makes the overlap with `disconnectMisbehaving`'s explicit stream disconnect (kept as the immediate fast path) harmless.
- No re-entrant deadlock: the knock-on `donePeers` send runs on the sub-peer's *own* goroutine, and `donePeers` is buffered (`cfg.MaxPeers`). The sub-peer later flows through the STREAM branch (`RemoveStream`) — an idempotent map delete on an already-removed association.

## Tests
- New `TestTearDownAssociationStreams`: builds primary + DATA1 + DATA2, asserts the primary is left connected and both sub-peers are disconnected; plus nil-assoc no-op and idempotency (a pre-disconnected sub-peer) subtests.
- Existing `TestDisconnectMisbehaving` / `TestMisbehaviorDisconnectTarget` unchanged and green.

## Verification
```
go vet ./services/legacy/...
go test -race ./services/legacy/            # ok
go test -race ./services/legacy/netsync/    # ok
```
