### PR TITLE
fix(model): explicit nil-settings guards in the coinbase candidate builders

### DIFF
--- a/model/mining_candidate.go
+++ b/model/mining_candidate.go
@@ -14,6 +14,18 @@ import (
 // p2pk is an optional parameter to specify if the coinbase output should be a pay to public key
 // instead of a pay to public key hash
 func (mc *MiningCandidate) CreateCoinbaseTxCandidate(tSettings *settings.Settings, p2pk ...bool) (*bt.Tx, error) {
+	// Explicit nil-guard preserving the documented (and tested) panic contract.
+	// Relying on the implicit nil-dereference stopped being safe once the
+	// Settings struct grew toward 4KB: Go only converts a nil dereference into a
+	// recoverable panic while the accessed field's offset stays inside the
+	// runtime's nil guard page (~4KB). Beyond it the access becomes an
+	// UNRECOVERABLE fault ("unexpected fault address") that kills the process
+	// instead of unwinding to the caller's recover — observed live once the
+	// struct crossed the line on a feature branch.
+	if tSettings == nil {
+		panic("CreateCoinbaseTxCandidate: nil settings")
+	}
+
 	// Create a new coinbase transaction
 	arbitraryText := tSettings.Coinbase.ArbitraryText
 
@@ -66,6 +78,18 @@ func (mc *MiningCandidate) CreateCoinbaseTxCandidate(tSettings *settings.Setting
 }
 
 func (mc *MiningCandidate) CreateCoinbaseTxCandidateForAddress(tSettings *settings.Settings, address *string) (*bt.Tx, error) {
+	// Explicit nil-guard preserving the documented (and tested) panic contract.
+	// Relying on the implicit nil-dereference stopped being safe once the
+	// Settings struct grew toward 4KB: Go only converts a nil dereference into a
+	// recoverable panic while the accessed field's offset stays inside the
+	// runtime's nil guard page (~4KB). Beyond it the access becomes an
+	// UNRECOVERABLE fault ("unexpected fault address") that kills the process
+	// instead of unwinding to the caller's recover — observed live once the
+	// struct crossed the line on a feature branch.
+	if tSettings == nil {
+		panic("CreateCoinbaseTxCandidateForAddress: nil settings")
+	}
+
 	arbitraryText := tSettings.Coinbase.ArbitraryText
 
 	if address == nil {


### PR DESCRIPTION
## What happened

The `NilSettings` edge-case test asserts that `CreateCoinbaseTxCandidate` panics when handed nil settings — and until now that contract was met *implicitly*: the first field dereference tripped Go's nil-pointer conversion into a recoverable panic. That conversion only works while the accessed field's offset stays inside the runtime's ~4KB nil guard page. The `Settings` struct has grown to the point where field offsets are crossing that line: on a feature branch where the struct is slightly larger, the very same dereference became an **unrecoverable hardware fault** (`unexpected fault address 0x1020` / `fatal error: fault`) that killed the entire test process instead of unwinding into `assert.Panics`.

## The change

Both coinbase candidate builders (`CreateCoinbaseTxCandidate` and `CreateCoinbaseTxCandidateForAddress`) now check for nil settings explicitly and panic with a named message, so the documented contract holds no matter how large `Settings` grows. There is no caller-visible behaviour change for non-nil settings.

Worth knowing beyond this PR: every new settings field pushes more offsets toward that 4KB cliff, so any other code path that relies on an implicit nil-settings panic has the same latent hazard.

## Testing

- `go test ./model/ -run TestMiningCandidate` — all pass, including the `NilSettings` panic assertions.
- The failure mode itself was reproduced (and is fixed) on the larger-struct feature branch where it was discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)