### PR TITLE
fix(legacy/netsync): CVE-2012-2459 dedup floor on the inline below-checkpoint route

### DIFF
--- a/model/check_duplicate_txs.go
+++ b/model/check_duplicate_txs.go
@@ -6,21 +6,39 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 )
 
-// CheckSubtreeSlicesForDuplicateTxs is the consensus integrity floor for the
-// CVE-2012-2459 duplicate-transaction check on any code path that holds the
-// block's subtree slices in memory but does not go through Block.Valid (which
-// runs the full pooled/disk-backed checkDuplicateTransactions).
+// CheckSubtreeSlicesForDuplicateTxs is a MANDATORY consensus security floor —
+// not an optimization. It enforces the CVE-2012-2459 duplicate-transaction
+// check on any code path that holds the block's subtree slices in memory but
+// does not go through Block.Valid (which runs the full pooled/disk-backed
+// checkDuplicateTransactions). Every such path MUST call it before creating or
+// spending UTXOs.
+//
+// WHY IT IS REQUIRED (do not remove or gate it on "the block is trusted"):
+// the merkle root CANNOT detect a CVE-2012-2459 duplicate. The merkle tree's
+// duplicate-last-node-when-odd rule means a block whose trailing transactions
+// are duplicated in a specific pattern produces the SAME merkle root — and
+// therefore the same block header and the same block hash — as the honest
+// block. So CheckMerkleRoot passing does NOT imply the transaction list is
+// duplicate-free; this scan is the only thing that catches it.
+//
+// WHY IT STILL APPLIES BELOW THE CHECKPOINT: "below checkpoint" trusts the
+// chain of block HASHES (the header chain is checkpoint-anchored), NOT the
+// block BODIES, which are still downloaded from untrusted peers. A CVE-2012-2459
+// mutation produces a body that hashes to the same, trusted block hash while
+// carrying a repeated transaction — so a below-checkpoint block being "safe"
+// (its hash is on the trusted chain) does not make a peer-supplied body safe.
+// Skipping this on a below-checkpoint fast path is a cheap, peer-triggerable
+// sync-DoS / state-corruption vector, because the mutated body reuses the
+// honest block's proof-of-work (no mining required).
 //
 // It scans every node hash across all subtree slices into a plain Go map,
 // skipping the coinbase placeholder at position [0][0], and returns a
-// BlockInvalidError on the first duplicate. The function is intentionally
-// lightweight — O(N) in the total transaction count with one map allocation —
-// and is suitable for the below-checkpoint unified route where blocks are
-// small enough that the slice-based in-memory scan is the right trade-off.
-//
-// Callers on the full validation path (Block.Valid) continue to use the
-// existing pooled/disk-backed checkDuplicateTransactions; this helper is an
-// independent, non-invasive floor for slice-only paths.
+// BlockInvalidError on the first duplicate. It is intentionally lightweight —
+// O(N) in the total transaction count with one map allocation — so it is cheap
+// enough to run unconditionally on every slice-only path. Callers on the full
+// validation path (Block.Valid) instead use the pooled/disk-backed
+// checkDuplicateTransactions; this helper is the independent floor for the
+// paths that skip it.
 func CheckSubtreeSlicesForDuplicateTxs(slices []*subtreepkg.Subtree) error {
 	// Estimate total node count for the initial map capacity to avoid rehashing.
 	totalNodes := 0

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -221,9 +221,11 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	// CheckMerkleRoot alone is NOT sufficient: a CVE-2012-2459 duplicate-tx
 	// mutation preserves the merkle root via the duplicate-last-when-odd rule,
 	// so it passes the merkle check while still containing a repeated hash.
-	// CheckSubtreeSlicesForDuplicateTxs is the explicit dedup floor that closes
-	// this gap; it must run while SubtreeSlices is still populated, before the
-	// nil-out below.
+	// The CVE-2012-2459 dedup floor now runs unconditionally inside prepareSubtrees
+	// (on the locally-built slices, for every route), so it is already enforced
+	// before we get here — the second call below is a defensive belt-and-braces on
+	// the unified route's returned slices and is kept in sync with unified_dedup_test.go.
+	// It must run while SubtreeSlices is still populated, before the nil-out below.
 	if preparedSubtreeSlices != nil {
 		teranodeBlock.SubtreeSlices = preparedSubtreeSlices
 		if err = teranodeBlock.CheckMerkleRoot(ctx); err != nil {
@@ -448,6 +450,22 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 
 	if err = sm.createSubtrees(ctx, bi, txOrder, txMap, slices, subtreeDatas, subtreeMetas, outpointOnly); err != nil {
 		return nil, nil, 0, err
+	}
+
+	// CVE-2012-2459 dedup floor for EVERY route (inline, unified, non-quick).
+	// createTxMap uses txMap.Set, which silently overwrites a duplicated txid, so
+	// the map cannot catch it; but createSubtrees replays the block-order txOrder
+	// (which retains both copies) and AddNodes the duplicate into `slices` twice.
+	// Run the explicit dedup scan here, on the locally-built slices, before any
+	// UTXO create/spend or subtree write — regardless of which slices are later
+	// returned to the caller. The gated call in HandleBlockDirect fires only when
+	// preparedSubtreeSlices != nil (the unified route), so the inline route never
+	// ran the check; this single call closes that gap for all paths. A
+	// CVE-2012-2459 duplicate-tx mutation preserves the merkle root via the
+	// duplicate-last-when-odd rule, so CheckMerkleRoot alone would pass — this is
+	// the only thing that catches it.
+	if err = model.CheckSubtreeSlicesForDuplicateTxs(slices); err != nil {
+		return nil, nil, 0, errors.NewBlockInvalidError("[prepareSubtrees][%s %d] duplicate transaction in block (CVE-2012-2459)", bi.hash.String(), bi.height, err)
 	}
 
 	// Quick validation is safe whenever the block sits at/below the highest hard-coded

--- a/services/legacy/netsync/inline_dedup_test.go
+++ b/services/legacy/netsync/inline_dedup_test.go
@@ -1,0 +1,129 @@
+package netsync
+
+// CVE-2012-2459 duplicate-transaction dedup floor on the INLINE (non-unified)
+// below-checkpoint path.
+//
+// Background: CheckSubtreeSlicesForDuplicateTxs is the explicit dedup guard for
+// any path that holds the block's subtree slices in memory without running the
+// full Block.Valid duplicate-tx scan. Before this task it ran only inside the
+// `if preparedSubtreeSlices != nil` block in HandleBlockDirect  — and prepareSubtrees only returns non-nil
+// preparedSubtreeSlices on the UNIFIED route (see the `if sm.legacyUnified(...)`
+// guard at the bottom of prepareSubtrees). On the inline route the returned
+// slices are nil, so HandleBlockDirect's guard is skipped and the CVE check
+// never ran on that path.
+//
+// createTxMap uses txMap.Set, which SILENTLY OVERWRITES a duplicate txid, so the
+// map itself cannot catch the duplicate. But createSubtrees iterates the
+// block-order txOrder (which retains both copies of the duplicated hash) and
+// AddNodes the duplicate twice into the locally-built slices. The fix runs
+// CheckSubtreeSlicesForDuplicateTxs on those locally-built slices inside
+// prepareSubtrees, unconditionally, right after createSubtrees — so every path
+// (inline, unified, non-quick) gets the floor from one place.
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/legacy/bsvutil"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	utxosql "github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// makeDuplicateTxidBlock builds a below-checkpoint wire block whose transaction
+// list contains a duplicated non-coinbase txid: [coinbase, txX, txX]. This is
+// the CVE-2012-2459 mutation shape at the tx-list level — the merkle root of
+// such a block is preserved by the duplicate-last-when-odd rule, so the merkle
+// check alone would pass, but the block still contains a repeated hash.
+func makeDuplicateTxidBlock(height int32) *bsvutil.Block {
+	makeCoinbase := func(h int32) *wire.MsgTx {
+		cb := wire.NewMsgTx(1)
+		cb.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+			SignatureScript:  []byte{byte(h & 0xff), 0x01}, //nolint:gosec // test coinbase script
+			Sequence:         0xffffffff,
+		})
+		cb.AddTxOut(&wire.TxOut{Value: 5000, PkScript: []byte{0x76, 0xa9, 0x14}})
+		return cb
+	}
+
+	// A single regular tx, added to the block twice → identical txid twice.
+	external := chainhash.Hash{0xde, 0xad, 0x42}
+	tx := wire.NewMsgTx(1)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: external, Index: 0},
+		SignatureScript:  []byte{0x00, 0x42},
+		Sequence:         0xffffffff,
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x76, 0xa9, 0x14, 0x42}})
+
+	msgBlock := &wire.MsgBlock{
+		Header:       wire.BlockHeader{Version: 1, Timestamp: time.Now(), Bits: 0x1d00ffff},
+		Transactions: []*wire.MsgTx{makeCoinbase(height), tx, tx}, // tx duplicated
+	}
+
+	block := bsvutil.NewBlock(msgBlock)
+	block.SetHeight(height)
+
+	return block
+}
+
+// TestLegacyInline_DuplicateTxid_Rejected proves that a below-checkpoint block
+// routed through the INLINE path (prepareSubtrees,
+// LegacyUnifiedBelowCheckpoint=false) carrying a duplicated txid is rejected
+// with a BlockInvalidError before any UTXO commit. Previously this block would
+// slip past the dedup guard (which only fired on the unified route) and reach
+// ValidateTransactionsLegacyMode.
+func TestLegacyInline_DuplicateTxid_Rejected(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const checkpointHeight = int32(1000)
+	const height = int32(500)
+
+	tSettings, params := newOutpointOnlySettings(t, true, true, checkpointHeight)
+	tSettings.BlockValidation.LegacyUnifiedBelowCheckpoint = false
+
+	logger := ulogger.TestLogger{}
+
+	storeURL, err := url.Parse("sqlitememory:///inline_dedup")
+	require.NoError(t, err)
+	store, err := utxosql.New(ctx, logger, tSettings, storeURL)
+	require.NoError(t, err)
+	defer func() { _ = store.Close(ctx) }()
+
+	mockBC := &blockchain.Mock{}
+	mockBC.On("AssignBlockID", mock.Anything, mock.Anything).Return(uint64(101), nil).Maybe()
+
+	sm := &SyncManager{
+		settings:         tSettings,
+		chainParams:      params,
+		logger:           logger,
+		utxoStore:        store,
+		blockchainClient: mockBC,
+		validationClient: makeSpendValidator(store),
+		subtreeStore:     memory.New(),
+		ctx:              ctx,
+	}
+
+	// Sanity: the below-checkpoint inline gate engages for this block.
+	require.True(t, sm.legacyOutpointOnly(uint32(height)), "below-checkpoint outpoint-only gate must engage for the test block")
+	require.False(t, sm.legacyUnified(uint32(height)), "test must exercise the inline (non-unified) route")
+
+	block := makeDuplicateTxidBlock(height)
+
+	_, _, _, prepErr := sm.prepareSubtrees(ctx, block)
+	require.Error(t, prepErr, "a duplicated txid must be rejected on the inline path")
+	require.True(t, errors.Is(prepErr, errors.ErrBlockInvalid),
+		"duplicate-txid rejection must be a BlockInvalidError (CVE-2012-2459), got: %v", prepErr)
+}


### PR DESCRIPTION
## What happened

The explicit duplicate-transaction scan (`CheckSubtreeSlicesForDuplicateTxs`) only ran inside `HandleBlockDirect`'s `preparedSubtreeSlices != nil` block — and `prepareSubtrees` returns non-nil slices **only on the unified route**. On the default inline route the returned slices are nil, so the CVE check never ran on that path at all.

## Why it matters

A CVE-2012-2459 mutation duplicates trailing transactions in a pattern that **preserves the merkle root** (the duplicate-last-node-when-odd rule), so the mutated body hashes to the same trusted block hash and reuses the honest block's proof-of-work — no mining required to trigger it. Below the checkpoint only the header *chain* is trusted; block *bodies* still come from untrusted peers, so an unchecked inline route is a peer-triggerable state-corruption / sync-DoS vector.

`createTxMap` can't catch it either: `txMap.Set` silently overwrites the duplicated txid, while `createSubtrees` replays the block-order `txOrder` (which keeps both copies) and adds the duplicate into the slices twice.

## The change

One unconditional call in `prepareSubtrees`, right after `createSubtrees` and before any UTXO create/spend or subtree write, so **every** route (inline, unified, non-quick) gets the floor from a single place. The existing gated call in `HandleBlockDirect` stays as defensive belt-and-braces on the unified route's returned slices, and its comment now says so. The `CheckSubtreeSlicesForDuplicateTxs` doc comment is enriched to state plainly why it's a mandatory consensus floor rather than an optimization.

## Testing

- New `TestLegacyInline_DuplicateTxid_Rejected`: a `[coinbase, txX, txX]` block on the inline route (unified flag off) is rejected with `BlockInvalidError` before any UTXO commit; without the fix it slips past the guard and reaches `ValidateTransactionsLegacyMode`.
- Existing `unified_dedup` tests stay green (the unified route's guard is unchanged).
- Full `netsync` and `model` suites pass.

## Notes

Independent of the window/flow-control work — this is the security floor on its own, deliberately sliced out first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)