### PR TITLE
fix(legacy): nil-guard UsePrefetchIngestion + BlockRequested regtest-by-value (#1279)

### DIFF
--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -839,6 +839,25 @@ func (sm *SyncManager) IsHeadersFirstMode() bool {
 	return sm.headersFirstMode.Load()
 }
 
+// isRegtest reports whether the active chain params are regression net by
+// network magic rather than pointer identity with chaincfg.RegressionNetParams,
+// so a copied Params value (as some tests construct) is still recognized, and a
+// nil chainParams is safely not-regtest. It exists to give BlockRequested the
+// SAME value semantics as peerpkg.UseBlockPrefetchIngestion (.Net != RegTestNet)
+// so those two prefetch-path siblings cannot drift on a copied-params manager.
+//
+// It deliberately does NOT replace the pointer-equality regtest checks
+// elsewhere in this file (startSync's headers-first gate, isSyncCandidate,
+// handleBlockMsg's unrequested-block disconnect). Those run on the synchronous
+// (non-prefetch) path that regtest always takes, and the E2E harness builds
+// chainParams as a *copy* of RegressionNetParams — so switching them to value
+// semantics flips real behavior (e.g. isSyncCandidate would apply the regtest
+// localhost restriction, and startSync would drop headers-first) and breaks
+// legacy-sync/smoketest. Pointer equality there is load-bearing; leave it.
+func (sm *SyncManager) isRegtest() bool {
+	return sm.chainParams != nil && sm.chainParams.Net == wire.RegTestNet
+}
+
 // isSyncCandidate returns whether or not the peer is a candidate to consider
 // syncing from.
 func (sm *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
@@ -2448,8 +2467,16 @@ func (sm *SyncManager) QueueBlock(block *bsvutil.Block, peer *peerpkg.Peer, done
 // shares the peerpkg.UseBlockPrefetchIngestion predicate with the read-loop's
 // shouldArmProcessingTimer so both agree on when prefetch is active (a positive
 // budget matches a non-nil budget semaphore, since it is created iff the byte
-// budget is positive).
+// budget is positive). A nil chainParams fails closed to the synchronous path.
 func (sm *SyncManager) UsePrefetchIngestion() bool {
+	if sm.chainParams == nil {
+		// Fail closed to the synchronous path: without params we cannot rule out
+		// regtest, and sync ingestion is the conservative default. Guarding here
+		// matters because sm.chainParams.Net is evaluated as a call argument,
+		// before UseBlockPrefetchIngestion's budget short-circuit could guard it.
+		return false
+	}
+
 	return peerpkg.UseBlockPrefetchIngestion(sm.blockPrefetchBudgetBytes, sm.chainParams.Net)
 }
 
@@ -2464,7 +2491,7 @@ func (sm *SyncManager) UsePrefetchIngestion() bool {
 // per-block disconnect fires. On regtest it always returns true; the regression
 // harness intentionally feeds unrequested/duplicate blocks.
 func (sm *SyncManager) BlockRequested(peer *peerpkg.Peer, blockHash *chainhash.Hash) bool {
-	if sm.chainParams == &chaincfg.RegressionNetParams {
+	if sm.isRegtest() {
 		return true
 	}
 

--- a/services/legacy/netsync/manager_prefetch_test.go
+++ b/services/legacy/netsync/manager_prefetch_test.go
@@ -49,6 +49,15 @@ func TestBlockRequested(t *testing.T) {
 		require.True(t, sm.BlockRequested(&peerpkg.Peer{}, &hash))
 	})
 
+	t.Run("copied regtest params admit any block", func(t *testing.T) {
+		// #1279: detection is by network magic, so a value copy of
+		// RegressionNetParams (distinct pointer) is still recognized as regtest —
+		// matching UsePrefetchIngestion so the two siblings cannot drift.
+		params := chaincfg.RegressionNetParams
+		sm := newSM(&params)
+		require.True(t, sm.BlockRequested(&peerpkg.Peer{}, &hash))
+	})
+
 	t.Run("requested block is admitted", func(t *testing.T) {
 		sm := newSM(&chaincfg.MainNetParams)
 		p := &peerpkg.Peer{}
@@ -151,6 +160,40 @@ func TestUsePrefetchIngestion(t *testing.T) {
 			// The gate tracks the shared predicate for the manager's own budget/net.
 			require.Equal(t, peerpkg.UseBlockPrefetchIngestion(budget, p.Net), sm.UsePrefetchIngestion())
 		}
+	}
+
+	// A nil chainParams fails closed to the synchronous path — no panic, prefetch
+	// off — even with a configured budget. Regression guard for #1279: the deref
+	// used to happen as a call argument, before the budget short-circuit.
+	t.Run("nil chainParams fails closed", func(t *testing.T) {
+		sm := &SyncManager{blockPrefetchBudgetBytes: 100, blockPrefetchBudget: semaphore.NewWeighted(100)}
+		require.NotPanics(t, func() { require.False(t, sm.UsePrefetchIngestion()) })
+	})
+}
+
+// TestIsRegtest pins the value semantics of the sync manager's single regtest
+// predicate: regtest is detected by network magic, not pointer identity with
+// chaincfg.RegressionNetParams, so a copied Params value (as some tests
+// construct) still counts; mainnet does not; and a nil chainParams fails closed.
+func TestIsRegtest(t *testing.T) {
+	regtestCopy := chaincfg.RegressionNetParams // value copy: pointer differs, .Net matches
+
+	tests := []struct {
+		name   string
+		params *chaincfg.Params
+		want   bool
+	}{
+		{name: "nil chain params", params: nil, want: false},
+		{name: "global regtest pointer", params: &chaincfg.RegressionNetParams, want: true},
+		{name: "copied regtest params", params: &regtestCopy, want: true},
+		{name: "mainnet", params: &chaincfg.MainNetParams, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := &SyncManager{chainParams: tt.params}
+			require.Equal(t, tt.want, sm.isRegtest())
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1279. Follow-up from #1190; parent #1189. Latent/production-safe today; cheap hardening.

## 1. nil-guard `UsePrefetchIngestion` (#4)
It passed `sm.chainParams.Net` as a call argument to `peerpkg.UseBlockPrefetchIngestion`, so the pointer was dereferenced *before* that function's `budgetBytes > 0` short-circuit could guard it. `handleBlockMsg` now calls `UsePrefetchIngestion` for every block, so a nil-`chainParams` SyncManager would panic the block-handler goroutine. Latent (`New()` always sets `chainParams`) but guarded now: `chainParams == nil → false` (fail closed to the synchronous path). The shared `peerpkg.UseBlockPrefetchIngestion` predicate is still called, so it stays in lockstep with the read-loop's `shouldArmProcessingTimer`.

## 2. `BlockRequested` regtest-by-value (#5)
`BlockRequested` used pointer equality (`chainParams == &chaincfg.RegressionNetParams`); its prefetch-path sibling `UsePrefetchIngestion` uses value semantics (`.Net != wire.RegTestNet`). They disagree when `chainParams` is a *copy* of `RegressionNetParams`. Added a nil-safe value-based `isRegtest()` helper (`.Net == wire.RegTestNet`) and routed `BlockRequested` through it so the two prefetch-path siblings cannot drift.

## Scope note — why only `BlockRequested`
The issue frames the divergence generally, and an earlier draft converted **all four** regtest checks (adding `startSync`'s headers-first gate, `isSyncCandidate`, `handleBlockMsg`'s unrequested-block disconnect). That broke `legacy-sync`/`smoketest` in CI, and the reason is instructive:

- Those three sites run on the **synchronous (non-prefetch)** path that regtest always takes (`UsePrefetchIngestion` is false on regtest, so `BlockRequested` isn't even called there).
- The **E2E harness builds `chainParams` as a copy** of `RegressionNetParams` (`util/test/helpers.go`), so pointer-equality evaluates to *not-regtest* in E2E.
- Converting them to value semantics flipped real behavior: `isSyncCandidate` began applying the regtest localhost restriction (rejecting the sync peer → "best height 0"), and `startSync` dropped headers-first.

So those three keep pointer equality — it's load-bearing under the copied-params E2E path. Only `BlockRequested` (the actual prefetch-path sibling named in the issue, and inert on the regtest synchronous path) is unified. A comment on `isRegtest()` records this so the trap isn't re-sprung.

## Tests
- New `TestIsRegtest` (nil / global pointer / value copy / mainnet).
- New `TestUsePrefetchIngestion` subtest: nil `chainParams` with a configured budget → no panic, returns false.
- New `TestBlockRequested` subtest: a copied `RegressionNetParams` admits any block (pins the #5 fix).
- Existing `TestUsePrefetchIngestion` / `TestBlockRequested` matrices unchanged and green.

## Verification
```
go vet ./services/legacy/netsync/...
go test -race ./services/legacy/netsync/   # ok
go test -race ./services/legacy/           # ok
```