### PR TITLE
MvP-4688 Surface actionable rejection reasons on the public tx error surfaces

### DIFF
--- a/docs/topics/services/validator.md
+++ b/docs/topics/services/validator.md
@@ -246,6 +246,8 @@ The above represents an implementation of the core Teranode validation rules:
 
         - Note: This means that Teranode will deem non-final transactions invalid and REJECT these transactions. It is up to the user to create proper non-final transactions to ensure that Teranode is aware of them. For clarity, if a transaction has a locktime in the future, the Tx Validator will reject it.
 
+        - Design note (mempool-less rejection): Teranode has no mempool — neither a main mempool nor a non-final holding pool — so a non-final transaction is **terminally rejected** rather than retained. This differs from svnode, whose `CTimeLockedMempool` holds a non-final transaction and re-enqueues it once it becomes final. In Teranode this is expected behaviour, not a defect: the client is responsible for resubmitting once the chain tip's median-time-past (BIP113) passes the transaction's locktime. The rejection now carries the actionable reason (`UTXO_NON_FINAL` → `TX_LOCK_TIME`, including the locktime and the compared median block time) through to the public HTTP and gRPC surfaces, so the submitter can see why the transaction was rejected and when it is worth resubmitting.
+
     - No output must be Pay-to-Script-Hash (P2SH)
 
     - A new transaction must not have any output which includes P2SH, as creation of new P2SH transactions is not allowed.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -700,6 +700,14 @@ func WrapGRPC(err error) error {
 // code+message may be surfaced through the public error boundary. Each names a
 // verdict about the submitted transaction, carries no node-internal state, and
 // is actionable by the submitter; everything else collapses to the outermost code.
+//
+// This allowlist is intentionally narrower than the set of codes an HTTP handler
+// may classify as client errors: some codes earn a specific 4xx status yet are
+// deliberately absent here and from ErrorCodeToGRPCCode. An HTTP status only sorts
+// the request into a coarse client-error category and exposes neither the detailed
+// ERR code nor its message; surfacing a message is held to the stricter bar of a
+// client-safe, actionable verdict. Widening this set therefore needs the same
+// safety review — it is not kept in sync with the HTTP classifier by design.
 var publicCauseCodes = map[ERR]struct{}{
 	ERR_UTXO_NON_FINAL:          {},
 	ERR_TX_LOCK_TIME:            {},
@@ -722,6 +730,13 @@ func isPublicCause(code ERR) bool {
 // is present. The walk is bounded like (*Error).Is to stay safe on pathological
 // chains. Only code+message are meaningful on the returned error; callers must
 // never surface its file/line/function, data, or the rest of the chain.
+//
+// This helper backs the shared public error boundary — UserMessage, PublicError,
+// and thus WrapGRPCPublic — consumed by all external surfaces (propagation /tx and
+// /txs, the asset HTTP error boundary, p2p), so preferring the deepest allowlisted
+// cause is a global boundary behaviour, not scoped to a single service. It is safe
+// by construction: only codes on publicCauseCodes are ever surfaced, and any other
+// cause collapses to the outermost code.
 func DeepestPublicCause(err error) *Error {
 	if err == nil {
 		return nil
@@ -952,7 +967,12 @@ func ErrorCodeToGRPCCode(code ERR) codes.Code {
 	case ERR_THRESHOLD_EXCEEDED:
 		return codes.ResourceExhausted
 	// Tx-rejection verdicts: the submitted tx is not acceptable — a client error,
-	// not a server fault. Surfaced only because commit 1 made these eligible public causes.
+	// not a server fault. This is a pure ERR->codes.Code lookup consumed by BOTH
+	// WrapGRPC (outermost code) and WrapGRPCPublic (public cause), so these rows
+	// change the gRPC status for every WrapGRPC caller, not only the public tx
+	// surfaces. That reach is intentional and benign: no caller branches on
+	// codes.Internal, the retry gate keys only on Unavailable/DeadlineExceeded, and
+	// application control-flow keys on the reconstructed ERR code, not the gRPC code.
 	case ERR_TX_INVALID, ERR_TX_LOCK_TIME, ERR_UTXO_NON_FINAL, ERR_TX_POLICY:
 		return codes.InvalidArgument
 	// Conflict/locked family: valid request, chain-state conflict.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -951,6 +951,13 @@ func ErrorCodeToGRPCCode(code ERR) codes.Code {
 		return codes.InvalidArgument
 	case ERR_THRESHOLD_EXCEEDED:
 		return codes.ResourceExhausted
+	// Tx-rejection verdicts: the submitted tx is not acceptable — a client error,
+	// not a server fault. Surfaced only because commit 1 made these eligible public causes.
+	case ERR_TX_INVALID, ERR_TX_LOCK_TIME, ERR_UTXO_NON_FINAL, ERR_TX_POLICY:
+		return codes.InvalidArgument
+	// Conflict/locked family: valid request, chain-state conflict.
+	case ERR_TX_INVALID_DOUBLE_SPEND, ERR_TX_CONFLICTING, ERR_UTXO_SPENT, ERR_TX_LOCKED:
+		return codes.FailedPrecondition
 	default:
 		return codes.Internal
 	}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -696,6 +696,68 @@ func WrapGRPC(err error) error {
 	}
 }
 
+// publicCauseCodes is the allowlist of client-safe verdict codes whose inner
+// code+message may be surfaced through the public error boundary. Each names a
+// verdict about the submitted transaction, carries no node-internal state, and
+// is actionable by the submitter; everything else collapses to the outermost code.
+var publicCauseCodes = map[ERR]struct{}{
+	ERR_UTXO_NON_FINAL:          {},
+	ERR_TX_LOCK_TIME:            {},
+	ERR_TX_POLICY:               {},
+	ERR_TX_INVALID:              {},
+	ERR_TX_INVALID_DOUBLE_SPEND: {},
+	ERR_TX_CONFLICTING:          {},
+	ERR_UTXO_SPENT:              {},
+	ERR_TX_LOCKED:               {},
+}
+
+// isPublicCause reports whether code is on the client-safe allowlist.
+func isPublicCause(code ERR) bool {
+	_, ok := publicCauseCodes[code]
+	return ok
+}
+
+// DeepestPublicCause walks err's wrapped chain and returns the innermost error
+// whose code is on the client-safe allowlist (publicCauseCodes), or nil if none
+// is present. The walk is bounded like (*Error).Is to stay safe on pathological
+// chains. Only code+message are meaningful on the returned error; callers must
+// never surface its file/line/function, data, or the rest of the chain.
+func DeepestPublicCause(err error) *Error {
+	if err == nil {
+		return nil
+	}
+
+	var cur *Error
+	if !errors.As(err, &cur) || cur == nil {
+		return nil
+	}
+
+	var deepest *Error
+
+	for depth := 0; cur != nil && depth < maxIsChainDepth; depth++ {
+		if isPublicCause(cur.code) {
+			deepest = cur
+		}
+
+		if cur.wrappedErr == nil {
+			break
+		}
+
+		next, ok := cur.wrappedErr.(*Error)
+		if !ok {
+			// Non-*Error link: let errors.As dig through foreign wrappers to
+			// the next *Error, mirroring (*Error).Is.
+			if !errors.As(cur.wrappedErr, &next) {
+				break
+			}
+		}
+
+		cur = next
+	}
+
+	return deepest
+}
+
 // UserMessage returns a concise, user-facing error message without wrapped error chains or data.
 // It is intended for external surfaces (HTTP/gRPC) where internal details should not be exposed.
 func UserMessage(err error) string {
@@ -705,6 +767,12 @@ func UserMessage(err error) string {
 
 	if isGRPCWrappedError(err) {
 		err = UnwrapGRPC(err)
+	}
+
+	// Prefer an allowlisted verdict cause so actionable tx-rejection reasons
+	// survive the boundary instead of collapsing to the outermost generic code.
+	if cause := DeepestPublicCause(err); cause != nil {
+		return fmt.Sprintf(errCodeMsgFmt, cause.code.String(), cause.code, cause.message)
 	}
 
 	var tErr *Error
@@ -729,6 +797,14 @@ func PublicError(err error) *Error {
 
 	if isGRPCWrappedError(err) {
 		err = UnwrapGRPC(err)
+	}
+
+	// Prefer an allowlisted verdict cause when present; still emit code+message only.
+	if cause := DeepestPublicCause(err); cause != nil {
+		return &Error{
+			code:    cause.code,
+			message: cause.message,
+		}
 	}
 
 	var tErr *Error

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1426,9 +1426,44 @@ func TestErrorCodeToGRPCCode(t *testing.T) {
 			expected: codes.ResourceExhausted,
 		},
 		{
-			name:     "unmapped code TX_INVALID defaults to codes.Internal",
+			name:     "maps ERR_TX_INVALID to codes.InvalidArgument",
 			errCode:  ERR_TX_INVALID,
-			expected: codes.Internal,
+			expected: codes.InvalidArgument,
+		},
+		{
+			name:     "maps ERR_TX_LOCK_TIME to codes.InvalidArgument",
+			errCode:  ERR_TX_LOCK_TIME,
+			expected: codes.InvalidArgument,
+		},
+		{
+			name:     "maps ERR_UTXO_NON_FINAL to codes.InvalidArgument",
+			errCode:  ERR_UTXO_NON_FINAL,
+			expected: codes.InvalidArgument,
+		},
+		{
+			name:     "maps ERR_TX_POLICY to codes.InvalidArgument",
+			errCode:  ERR_TX_POLICY,
+			expected: codes.InvalidArgument,
+		},
+		{
+			name:     "maps ERR_TX_INVALID_DOUBLE_SPEND to codes.FailedPrecondition",
+			errCode:  ERR_TX_INVALID_DOUBLE_SPEND,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "maps ERR_TX_CONFLICTING to codes.FailedPrecondition",
+			errCode:  ERR_TX_CONFLICTING,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "maps ERR_UTXO_SPENT to codes.FailedPrecondition",
+			errCode:  ERR_UTXO_SPENT,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "maps ERR_TX_LOCKED to codes.FailedPrecondition",
+			errCode:  ERR_TX_LOCKED,
+			expected: codes.FailedPrecondition,
 		},
 		{
 			name:     "unmapped code BLOCK_NOT_FOUND defaults to codes.Internal",

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2261,6 +2261,121 @@ func TestPublicError(t *testing.T) {
 	})
 }
 
+// lockTimeMsg mirrors the actionable non-final message produced by util/lock_time.go.
+const lockTimeMsg = "lock time (1783806110) as timestamp is not less than median block time (1783805456)"
+
+// TestDeepestPublicCause verifies the innermost allowlisted cause is selected and
+// that a non-allowlisted inner code yields no public cause.
+func TestDeepestPublicCause(t *testing.T) {
+	t.Run("innermost allowlisted cause wins", func(t *testing.T) {
+		lockErr := NewTxLockTimeError(lockTimeMsg)
+		nonFinalErr := NewUtxoNonFinalError("transaction is not final", lockErr)
+		procErr := NewProcessingError("[ProcessTransaction][%s] failed to validate transaction", "abc123", nonFinalErr)
+
+		cause := DeepestPublicCause(procErr)
+		require.NotNil(t, cause)
+		require.Equal(t, ERR_TX_LOCK_TIME, cause.Code())
+		require.Equal(t, lockTimeMsg, cause.Message())
+	})
+
+	t.Run("nil for non-allowlisted chain", func(t *testing.T) {
+		innerErr := New(ERR_STORAGE_ERROR, "db lookup failed")
+		procErr := NewProcessingError("failed to validate transaction", innerErr)
+
+		require.Nil(t, DeepestPublicCause(procErr))
+	})
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		require.Nil(t, DeepestPublicCause(nil))
+	})
+}
+
+// TestPublicCauseSurfacing proves the allowlisted verdict code+message survives every
+// public error boundary (UserMessage/PublicError/WrapGRPCPublic/WrapPublic) while a
+// non-allowlisted inner code still collapses to the outermost generic message, and no
+// file/line/data leaks.
+func TestPublicCauseSurfacing(t *testing.T) {
+	lockErr := NewTxLockTimeError(lockTimeMsg)
+	nonFinalErr := NewUtxoNonFinalError("transaction is not final", lockErr)
+	allowlistedChain := NewProcessingError("[ProcessTransaction][%s] failed to validate transaction", "abc123", nonFinalErr)
+
+	storageErr := New(ERR_STORAGE_ERROR, "internal db error at /var/db/internal.db")
+	collapsedChain := NewProcessingError("[ProcessTransaction][%s] failed to validate transaction", "abc123", storageErr)
+
+	tests := []struct {
+		name        string
+		err         *Error
+		wantCode    ERR
+		wantMessage string
+	}{
+		{
+			name:        "allowlisted inner cause is surfaced",
+			err:         allowlistedChain,
+			wantCode:    ERR_TX_LOCK_TIME,
+			wantMessage: lockTimeMsg,
+		},
+		{
+			name:        "non-allowlisted inner code collapses to top-level",
+			err:         collapsedChain,
+			wantCode:    ERR_PROCESSING,
+			wantMessage: "[ProcessTransaction][abc123] failed to validate transaction",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// UserMessage renders the selected code+message.
+			require.Equal(t,
+				fmt.Sprintf(errCodeMsgFmt, tc.wantCode.String(), tc.wantCode, tc.wantMessage),
+				UserMessage(tc.err))
+
+			// PublicError carries the selected code+message and nothing else.
+			pub := PublicError(tc.err)
+			require.NotNil(t, pub)
+			require.Equal(t, tc.wantCode, pub.Code())
+			require.Equal(t, tc.wantMessage, pub.Message())
+			require.Empty(t, pub.file)
+			require.Zero(t, pub.line)
+			require.Empty(t, pub.function)
+			require.Nil(t, pub.WrappedErr())
+			require.Nil(t, pub.Data())
+		})
+	}
+
+	t.Run("WrapGRPCPublic surfaces the allowlisted cause without internal details", func(t *testing.T) {
+		result := WrapGRPCPublic(allowlistedChain)
+		require.NotNil(t, result)
+
+		st, ok := status.FromError(result)
+		require.True(t, ok)
+		// Status message carries the allowlisted cause, not the outer PROCESSING message.
+		require.Equal(t, lockTimeMsg, st.Message())
+
+		// The attached TError detail carries the same allowlisted cause and no internals.
+		unwrapped := UnwrapGRPC(result)
+		require.NotNil(t, unwrapped)
+		require.Equal(t, ERR_TX_LOCK_TIME, unwrapped.code)
+		require.Equal(t, lockTimeMsg, unwrapped.message)
+		require.Empty(t, unwrapped.file)
+		require.Zero(t, unwrapped.line)
+		require.Empty(t, unwrapped.function)
+		require.Nil(t, unwrapped.wrappedErr)
+		require.Nil(t, unwrapped.data)
+	})
+
+	t.Run("WrapPublic surfaces the allowlisted cause without internal details", func(t *testing.T) {
+		detail := WrapPublic(allowlistedChain)
+		require.NotNil(t, detail)
+		require.Equal(t, ERR_TX_LOCK_TIME, detail.Code)
+		require.Equal(t, lockTimeMsg, detail.Message)
+		require.Empty(t, detail.File)
+		require.Zero(t, detail.Line)
+		require.Empty(t, detail.Function)
+		require.Nil(t, detail.Data)
+		require.Nil(t, detail.WrappedError)
+	})
+}
+
 // TestWrapGRPCPublic tests the WrapGRPCPublic function for proper gRPC wrapping without internal details.
 func TestWrapGRPCPublic(t *testing.T) {
 	t.Run("nil error returns nil", func(t *testing.T) {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1485,6 +1485,38 @@ func TestErrorCodeToGRPCCode(t *testing.T) {
 	}
 }
 
+// TestWrapGRPCTxVerdictStatus pins that the tx-verdict gRPC-code mapping reaches
+// the generic WrapGRPC wrapper — the path the single-tx ValidateTransaction RPC
+// uses — and not only WrapGRPCPublic. A verdict code wrapped by WrapGRPC must
+// carry the mapped status (client-error family) rather than the codes.Internal
+// default, so callers see the tx rejection as their fault, not a server fault.
+func TestWrapGRPCTxVerdictStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected codes.Code
+	}{
+		{
+			name:     "invalid-family verdict maps to InvalidArgument",
+			err:      New(ERR_TX_INVALID, "tx failed validation"),
+			expected: codes.InvalidArgument,
+		},
+		{
+			name:     "conflict-family verdict maps to FailedPrecondition",
+			err:      New(ERR_TX_CONFLICTING, "tx conflicts with chain state"),
+			expected: codes.FailedPrecondition,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st, ok := status.FromError(WrapGRPC(tc.err))
+			require.True(t, ok)
+			require.Equal(t, tc.expected, st.Code())
+		})
+	}
+}
+
 // TestJoin tests the Join function to ensure it correctly combines multiple errors into a single error message.
 func TestJoin(t *testing.T) {
 	t.Run("no errors passed returns nil", func(t *testing.T) {

--- a/services/propagation/Server.go
+++ b/services/propagation/Server.go
@@ -903,20 +903,47 @@ func (ps *PropagationServer) handleMultipleTx(_ context.Context) echo.HandlerFun
 
 		var errMsgs []string
 
+		// Derive the aggregate HTTP status from the per-tx errors using the same
+		// classifier as the single-tx path (httpStatusForTxError). A per-tx
+		// outcome that classifies as success (e.g. a duplicate submission ->
+		// StatusOK) is not a failure: skip it from both the body and the status,
+		// mirroring handleSingleTx which returns OK for those. Among the genuine
+		// failures the precedence is: a server fault (5xx, e.g. a storage error)
+		// dominates and forces 500 — the client cannot fix it by resubmitting;
+		// otherwise the first client-error (4xx) status in submission order wins,
+		// so a batch of pure tx rejections is a client error (e.g. 400) rather
+		// than a misleading 500.
+		aggStatus := http.StatusOK
+
 		for _, err := range errSlots[:nextSlot] {
 			if err == nil {
 				continue
 			}
 
+			txStatus := httpStatusForTxError(err)
+			if txStatus < http.StatusBadRequest {
+				// Success-classified outcome (e.g. duplicate submission): not a
+				// failure, so it does not enter the body or raise the status.
+				continue
+			}
+
 			errMsgs = append(errMsgs, errors.UserMessage(err))
+
+			switch {
+			case txStatus >= http.StatusInternalServerError:
+				aggStatus = http.StatusInternalServerError
+			case aggStatus < http.StatusBadRequest:
+				aggStatus = txStatus
+			}
 		}
 
 		if earlyExitMsg != "" {
 			return c.String(http.StatusBadRequest, earlyExitMsg)
 		}
 
+		// errMsgs only holds genuine failures now, so aggStatus is always >= 400 here.
 		if len(errMsgs) > 0 {
-			return c.String(http.StatusInternalServerError, "Failed to process transactions:\n"+strings.Join(errMsgs, "\n")+"\n")
+			return c.String(aggStatus, "Failed to process transactions:\n"+strings.Join(errMsgs, "\n")+"\n")
 		}
 
 		return c.String(http.StatusOK, "OK")

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -820,7 +820,9 @@ func Test_handleMultipleTx_ErrorOrderPreserved(t *testing.T) {
 	c.SetPath("/txs")
 
 	require.NoError(t, handler(c))
-	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	// orderedErrValidator rejects every tx with ERR_TX_INVALID, which the batch
+	// aggregation now classifies (via httpStatusForTxError) as a client error.
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 
 	responseBody, err := io.ReadAll(rec.Body)
 	require.NoError(t, err)
@@ -834,6 +836,215 @@ func Test_handleMultipleTx_ErrorOrderPreserved(t *testing.T) {
 		idx := strings.Index(body[prev:], txid)
 		require.GreaterOrEqualf(t, idx, 0, "txid for submission %d (%s) not found in response after position %d; body=%q", i, txid, prev, body)
 		prev += idx + len(txid)
+	}
+}
+
+// nonFinalMsg mirrors the actionable non-final reason produced by util/lock_time.go.
+const nonFinalMsg = "lock time (1783806110) as timestamp is not less than median block time (1783805456)"
+
+// nonFinalValidator rejects every tx as non-final (UTXO_NON_FINAL -> TX_LOCK_TIME),
+// the exact chain the validator produces for a BIP113 non-final transaction.
+type nonFinalValidator struct {
+	validator.MockValidator
+}
+
+func (m *nonFinalValidator) Validate(_ context.Context, _ *bt.Tx, _ uint32, _ ...validator.Option) (*meta.Data, error) {
+	return nil, errors.NewUtxoNonFinalError("transaction is not final", errors.NewTxLockTimeError(nonFinalMsg))
+}
+
+// verdictValidator returns a caller-supplied error per txid, so a batch can mix a
+// non-final rejection with a genuine storage fault and exercise the aggregate
+// HTTP status rule in handleMultipleTx.
+type verdictValidator struct {
+	validator.MockValidator
+	errByTxID map[string]error
+}
+
+func (m *verdictValidator) Validate(_ context.Context, tx *bt.Tx, _ uint32, _ ...validator.Option) (*meta.Data, error) {
+	if err, ok := m.errByTxID[tx.TxIDChainHash().String()]; ok {
+		return nil, err
+	}
+
+	return nil, errors.NewStorageError("unexpected tx in batch")
+}
+
+// batchSiblings builds n sibling txs each spending a distinct output of a single
+// coinbase (honouring the no-parent-and-child-in-a-batch contract), returning the
+// concatenated extended bytes and the txids in submission order.
+func batchSiblings(t *testing.T, n uint32) ([]byte, []string) {
+	t.Helper()
+
+	_, pubKey := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+	privKey, _ := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+
+	coinbaseTx := transactions.Create(t,
+		transactions.WithCoinbaseData(100, "/Test miner/"),
+		transactions.WithP2PKHOutputs(int(n), 50e6, pubKey),
+	)
+
+	txBytes := make([]byte, 0, 1024)
+	txids := make([]string, 0, n)
+
+	for i := uint32(0); i < n; i++ {
+		tx := transactions.Create(t,
+			transactions.WithPrivateKey(privKey),
+			transactions.WithInput(coinbaseTx, i),
+			transactions.WithP2PKHOutputs(1, 1000),
+		)
+		txids = append(txids, tx.TxIDChainHash().String())
+		txBytes = append(txBytes, tx.ExtendedBytes()...)
+	}
+
+	return txBytes, txids
+}
+
+// Test_handleMultipleTx_NonFinalReturns400 verifies that a batch whose txs are
+// rejected as non-final reports HTTP 400 (a client error) — not the previous
+// hardcoded 500 — with the actionable per-tx reason in the aggregated body.
+func Test_handleMultipleTx_NonFinalReturns400(t *testing.T) {
+	initPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Propagation.GRPCListenAddress = ""
+	tSettings.Propagation.HTTPListenAddress = ""
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	ps := &PropagationServer{
+		logger:    logger,
+		validator: &nonFinalValidator{},
+		txStore:   txStore,
+		settings:  tSettings,
+	}
+
+	handler := ps.handleMultipleTx(t.Context())
+
+	txBytes, _ := batchSiblings(t, 4)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/txs", bytes.NewReader(txBytes))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/txs")
+
+	require.NoError(t, handler(c))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	// The actionable reason surfaces (commit 1) instead of a bare PROCESSING message.
+	require.Contains(t, string(body), "TX_LOCK_TIME")
+	require.Contains(t, string(body), nonFinalMsg)
+}
+
+// Test_handleMultipleTx_StorageErrorReturns500 verifies that when a batch mixes a
+// client-side tx rejection (non-final -> 400) with a genuine storage fault, the
+// server fault dominates and the aggregate status is 500.
+func Test_handleMultipleTx_StorageErrorReturns500(t *testing.T) {
+	initPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Propagation.GRPCListenAddress = ""
+	tSettings.Propagation.HTTPListenAddress = ""
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	txBytes, txids := batchSiblings(t, 2)
+	require.Len(t, txids, 2)
+
+	ps := &PropagationServer{
+		logger: logger,
+		validator: &verdictValidator{
+			errByTxID: map[string]error{
+				txids[0]: errors.NewUtxoNonFinalError("transaction is not final", errors.NewTxLockTimeError(nonFinalMsg)),
+				txids[1]: errors.NewStorageError("simulated store failure"),
+			},
+		},
+		txStore:  txStore,
+		settings: tSettings,
+	}
+
+	handler := ps.handleMultipleTx(t.Context())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/txs", bytes.NewReader(txBytes))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/txs")
+
+	require.NoError(t, handler(c))
+	// A genuine server fault in the batch dominates the client-side rejection.
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "Failed to process transactions")
+	// The client-side rejection reason is still reported alongside.
+	require.Contains(t, string(body), nonFinalMsg)
+}
+
+// Test_handleMultipleTx_FirstClientErrorStatusWins pins the aggregation rule:
+// absent any server fault, the first client-error (4xx) status in submission
+// order determines the batch status, even when the rejection classes differ
+// (e.g. a 409 conflict and a 400 non-final rejection).
+func Test_handleMultipleTx_FirstClientErrorStatusWins(t *testing.T) {
+	initPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Propagation.GRPCListenAddress = ""
+	tSettings.Propagation.HTTPListenAddress = ""
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	conflictErr := func() error { return errors.NewTxLockedError("transaction is locked") }
+	nonFinalErr := func() error {
+		return errors.NewUtxoNonFinalError("transaction is not final", errors.NewTxLockTimeError(nonFinalMsg))
+	}
+
+	tests := []struct {
+		name       string
+		firstErr   error // returned for the first tx in submission order
+		secondErr  error // returned for the second tx in submission order
+		wantStatus int
+	}{
+		{"conflict first yields 409", conflictErr(), nonFinalErr(), http.StatusConflict},
+		{"non-final first yields 400", nonFinalErr(), conflictErr(), http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			txBytes, txids := batchSiblings(t, 2)
+			require.Len(t, txids, 2)
+
+			ps := &PropagationServer{
+				logger: logger,
+				validator: &verdictValidator{
+					errByTxID: map[string]error{
+						txids[0]: tc.firstErr,
+						txids[1]: tc.secondErr,
+					},
+				},
+				txStore:  txStore,
+				settings: tSettings,
+			}
+
+			handler := ps.handleMultipleTx(t.Context())
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/txs", bytes.NewReader(txBytes))
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/txs")
+
+			require.NoError(t, handler(c))
+			require.Equal(t, tc.wantStatus, rec.Code)
+		})
 	}
 }
 

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -42,6 +42,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type panicReadCloser struct{}
@@ -1046,6 +1047,194 @@ func Test_handleMultipleTx_FirstClientErrorStatusWins(t *testing.T) {
 			require.Equal(t, tc.wantStatus, rec.Code)
 		})
 	}
+}
+
+// siblingTxs builds n sibling txs each spending a distinct output of a single
+// coinbase (honouring the no-parent-and-child-in-a-batch contract), returning the
+// txs themselves so callers can take individual bytes and txids.
+func siblingTxs(t *testing.T, n uint32) []*bt.Tx {
+	t.Helper()
+
+	_, pubKey := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+	privKey, _ := bec.PrivateKeyFromBytes([]byte("THIS_IS_A_DETERMINISTIC_PRIVATE_KEY"))
+
+	coinbaseTx := transactions.Create(t,
+		transactions.WithCoinbaseData(100, "/Test miner/"),
+		transactions.WithP2PKHOutputs(int(n), 50e6, pubKey),
+	)
+
+	txs := make([]*bt.Tx, 0, n)
+
+	for i := uint32(0); i < n; i++ {
+		txs = append(txs, transactions.Create(t,
+			transactions.WithPrivateKey(privKey),
+			transactions.WithInput(coinbaseTx, i),
+			transactions.WithP2PKHOutputs(1, 1000),
+		))
+	}
+
+	return txs
+}
+
+// Test_handleSingleTx_NonFinalReturns400 covers the HTTP /tx surface: a non-final
+// tx returns HTTP 400 with the actionable UTXO_NON_FINAL/TX_LOCK_TIME reason in
+// the body, not just the outer PROCESSING message.
+func Test_handleSingleTx_NonFinalReturns400(t *testing.T) {
+	initPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Propagation.GRPCListenAddress = ""
+	tSettings.Propagation.HTTPListenAddress = ""
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	ps := &PropagationServer{
+		logger:    logger,
+		validator: &nonFinalValidator{},
+		txStore:   txStore,
+		settings:  tSettings,
+	}
+
+	handler := ps.handleSingleTx(t.Context())
+
+	txBytes := siblingTxs(t, 1)[0].ExtendedBytes()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/tx", bytes.NewReader(txBytes))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/tx")
+
+	require.NoError(t, handler(c))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	// The body carries EXACTLY the allowlisted reason: the outer PROCESSING code
+	// and the wrapped chain do not leak into it.
+	expectedReason := fmt.Sprintf("%s (%d): %s", errors.ERR_TX_LOCK_TIME.String(), errors.ERR_TX_LOCK_TIME, nonFinalMsg)
+	require.Equal(t, "Failed to process transaction: "+expectedReason, string(body))
+	require.NotContains(t, string(body), "PROCESSING")
+}
+
+// TestProcessTransaction_NonFinalGRPCStatus covers the gRPC ProcessTransaction
+// surface: a non-final tx yields the client-error status class (InvalidArgument),
+// and both the status message and the attached TError detail carry the allowlisted
+// TX_LOCK_TIME reason.
+func TestProcessTransaction_NonFinalGRPCStatus(t *testing.T) {
+	initPrometheusMetrics()
+	tracing.SetupMockTracer()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	ps := &PropagationServer{
+		logger:    logger,
+		validator: &nonFinalValidator{},
+		txStore:   txStore,
+		settings:  tSettings,
+	}
+
+	txBytes := siblingTxs(t, 1)[0].ExtendedBytes()
+
+	_, err = ps.ProcessTransaction(t.Context(), &propagation_api.ProcessTransactionRequest{Tx: txBytes})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	// The status message is EXACTLY the allowlisted reason — no PROCESSING chain
+	// text, file paths, or other metadata wrapped around it.
+	require.Equal(t, nonFinalMsg, st.Message())
+
+	// The reconstructed public error carries only the allowlisted code+message,
+	// with no wrapped chain and no data.
+	unwrapped := errors.UnwrapGRPC(err)
+	require.NotNil(t, unwrapped)
+	require.Equal(t, errors.ERR_TX_LOCK_TIME, unwrapped.Code())
+	require.Equal(t, nonFinalMsg, unwrapped.Message())
+	require.Nil(t, unwrapped.WrappedErr())
+	require.Nil(t, unwrapped.Data())
+
+	// Inspect the attached wire-level TError detail directly (same access pattern
+	// as errors.UnwrapGRPC): only code+message are present — no file/line/function,
+	// data, or wrapped chain leaks.
+	require.Len(t, st.Details(), 1)
+	anyDetail, ok := st.Details()[0].(*anypb.Any)
+	require.True(t, ok, "status detail should be an *anypb.Any")
+
+	var detail errors.TError
+	require.NoError(t, anyDetail.UnmarshalTo(&detail))
+	require.Equal(t, errors.ERR_TX_LOCK_TIME, detail.Code)
+	require.Equal(t, nonFinalMsg, detail.Message)
+	require.Empty(t, detail.File)
+	require.Zero(t, detail.Line)
+	require.Empty(t, detail.Function)
+	require.Nil(t, detail.Data)
+	require.Nil(t, detail.WrappedError)
+}
+
+// TestProcessTransactionBatch_NonFinalPerTxError covers the gRPC
+// ProcessTransactionBatch surface: the rejected entry's response.Errors[idx]
+// carries the allowlisted TX_LOCK_TIME code+message, while the accepted entry is
+// nil.
+func TestProcessTransactionBatch_NonFinalPerTxError(t *testing.T) {
+	initPrometheusMetrics()
+	tracing.SetupMockTracer()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	txStore, err := null.New(logger)
+	require.NoError(t, err)
+
+	txs := siblingTxs(t, 2)
+	acceptedTxID := txs[0].TxIDChainHash().String()
+	rejectedTxID := txs[1].TxIDChainHash().String()
+
+	ps := &PropagationServer{
+		logger: logger,
+		validator: &verdictValidator{
+			errByTxID: map[string]error{
+				acceptedTxID: nil, // Validate returns (nil, nil) -> accepted
+				rejectedTxID: errors.NewUtxoNonFinalError("transaction is not final", errors.NewTxLockTimeError(nonFinalMsg)),
+			},
+		},
+		txStore:  txStore,
+		settings: tSettings,
+	}
+
+	req := &propagation_api.ProcessTransactionBatchRequest{
+		Items: []*propagation_api.BatchTransactionItem{
+			{Tx: txs[0].ExtendedBytes()},
+			{Tx: txs[1].ExtendedBytes()},
+		},
+	}
+
+	resp, err := ps.ProcessTransactionBatch(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Errors, 2)
+
+	// Accepted entry: nil.
+	require.Nil(t, resp.Errors[0])
+
+	// Rejected entry: EXACTLY the allowlisted code+message, and no leaked
+	// metadata — no wrapped chain, data, or file/line/function.
+	rejected := resp.Errors[1]
+	require.NotNil(t, rejected)
+	require.Equal(t, errors.ERR_TX_LOCK_TIME, rejected.Code)
+	require.Equal(t, nonFinalMsg, rejected.Message)
+	require.Nil(t, rejected.WrappedError)
+	require.Nil(t, rejected.Data)
+	require.Empty(t, rejected.File)
+	require.Zero(t, rejected.Line)
+	require.Empty(t, rejected.Function)
 }
 
 func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {

--- a/services/propagation/http_handlers_test.go
+++ b/services/propagation/http_handlers_test.go
@@ -3,6 +3,7 @@ package propagation
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -417,7 +418,9 @@ func TestHandleMultipleTx(t *testing.T) {
 				buf.Write(tx1.ExtendedBytes())
 				return &buf
 			},
-			expectedStatusCode:  http.StatusInternalServerError,
+			// A tx-level validation rejection (ERR_TX_INVALID) now yields the
+			// derived client-error status, not the old hardcoded 500.
+			expectedStatusCode:  http.StatusBadRequest,
 			expectedResponse:    "Failed to process transaction",
 			mockValidationError: errors.NewTxInvalidError("test validation error"),
 		},
@@ -459,6 +462,14 @@ func TestHandleMultipleTx(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedStatusCode, rec.Code)
 			assert.Contains(t, rec.Body.String(), tc.expectedResponse)
+
+			// The batch must surface the per-tx public reason, not collapse to a
+			// generic PROCESSING message: assert the derived UserMessage for the
+			// tx-rejection case is present in the aggregated body.
+			if tc.name == "Transaction validation error" {
+				require.Contains(t, rec.Body.String(),
+					fmt.Sprintf("%s (%d): %s", errors.ERR_TX_INVALID.String(), errors.ERR_TX_INVALID, "test validation error"))
+			}
 
 			// Verify validation and storage behaviors for non-error cases
 			if tc.name == "Multiple valid transactions" {


### PR DESCRIPTION
Resolves https://github.com/bitcoin-sv/teranode/issues/4688
(public report: https://github.com/bsv-blockchain/teranode/issues/1272)

## Problem

When a submitted transaction is rejected, all four public surfaces (HTTP `/tx`, HTTP
`/txs`, gRPC single, gRPC batch) return only the generic outermost error —
`PROCESSING (4): ... failed to validate transaction` — while the actionable verdict
Teranode already computed (e.g. `UTXO_NON_FINAL (71) -> TX_LOCK_TIME (35): lock time ...
median block time ...`) is stripped by the public error boundary. Clients cannot tell a
transient rejection (not final yet) from a permanent one (invalid script, bad fee). Two
status-class bugs compound it: `/txs` always returns HTTP 500, and gRPC maps every tx
rejection to `codes.Internal` — both mis-signal "server fault" for client-side rejections.

## Fix

- `errors`: an allowlist of client-safe verdict codes (non-final/lock-time/policy/invalid
  plus the conflict family) and a `DeepestPublicCause` helper; `UserMessage` and
  `PublicError` now surface the innermost allowlisted cause's `code`+`message`. Everything
  off the allowlist keeps the current generic collapse; file/line, `data`, and the wrapped
  chain are never emitted.
- `errors`: `ErrorCodeToGRPCCode` maps tx-content rejections to `codes.InvalidArgument`
  and chain-state conflicts (double-spend/conflicting/spent/locked) to
  `codes.FailedPrecondition`; everything else still `codes.Internal`.
- `propagation`: `/txs` derives its aggregate status from the per-tx errors (first
  client-error status wins; genuine system/storage errors still dominate to 500; OK-class
  outcomes such as already-known txs no longer force 500).
- Tests: end-to-end coverage of all four public surfaces, asserting the allowlisted reason
  is carried verbatim and no internal metadata leaks; unit coverage for the allowlist
  walk, the collapse of non-allowlisted chains, and the gRPC code mapping.
- Docs: a short validator note recording that Teranode is mempool-less and terminally
  rejects non-final transactions by design (unlike svnode's `CTimeLockedMempool`
  retention); clients resubmit once the tip's median-time-past passes the locktime.

## Non-goals

No consensus/validation change (the finality rule is at parity with svnode), no non-final
retention/mempool, no bdk changes. Structured per-tx response fields and bdk policy-code
names in messages are follow-ups.