### PR TITLE
p2p: enforce DataHub URL blacklist on block and node_status announcements

### DIFF
--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -990,13 +990,11 @@ func (s *Server) handleNodeStatusTopic(_ context.Context, m []byte, peerID strin
 		return
 	}
 
-	// Validate BaseURL to prevent SSRF attacks
-	if nodeStatusMessage.BaseURL != "" {
-		if err := s.validateDataHubURL(nodeStatusMessage.BaseURL); err != nil {
-			s.logger.Errorf("[handleNodeStatusTopic] invalid BaseURL from peer %s: %v", peerID, err)
-			s.applyBanScore(peerID, ReasonProtocolViolation)
-			return
-		}
+	// Validate BaseURL (SSRF + operator blacklist) — it is stored in the peer
+	// registry as the peer's DataHub URL, so it must pass the same trust checks
+	// as block/subtree announcements.
+	if nodeStatusMessage.BaseURL != "" && !s.checkDataHubURL(nodeStatusMessage.BaseURL, peerID, "handleNodeStatusTopic") {
+		return
 	}
 
 	if !isSelf && nodeStatusMessage.BestHeight > 0 && nodeStatusMessage.PeerID != "" {

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -998,9 +998,12 @@ func (s *Server) handleNodeStatusTopic(_ context.Context, m []byte, peerID strin
 			return
 		}
 
-		// A blacklisted BaseURL must never reach the peer registry (catchup
-		// would fetch from it), but node_status is telemetry: keep the message
-		// with the URL removed instead of hiding the peer from monitoring.
+		// A blacklisted BaseURL must not reach the peer registry, but
+		// node_status is telemetry: keep the message with the URL removed
+		// instead of hiding the peer from monitoring. This only stops fresh
+		// registrations; a URL stored before its host was blacklisted stays in
+		// the registry and is filtered at the point of use instead
+		// (GetPeersForCatchup and PeerSelector.isEligible).
 		if s.isBlacklistedBaseURL(nodeStatusMessage.BaseURL) {
 			s.logger.Warnf("[handleNodeStatusTopic] removed blacklisted BaseURL %s from node_status of peer %s", nodeStatusMessage.BaseURL, peerID)
 			nodeStatusMessage.BaseURL = ""

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -990,11 +990,21 @@ func (s *Server) handleNodeStatusTopic(_ context.Context, m []byte, peerID strin
 		return
 	}
 
-	// Validate BaseURL (SSRF + operator blacklist) — it is stored in the peer
-	// registry as the peer's DataHub URL, so it must pass the same trust checks
-	// as block/subtree announcements.
-	if nodeStatusMessage.BaseURL != "" && !s.checkDataHubURL(nodeStatusMessage.BaseURL, peerID, "handleNodeStatusTopic") {
-		return
+	if nodeStatusMessage.BaseURL != "" {
+		// Validate BaseURL to prevent SSRF attacks
+		if err := s.validateDataHubURL(nodeStatusMessage.BaseURL); err != nil {
+			s.logger.Errorf("[handleNodeStatusTopic] invalid BaseURL from peer %s: %v", peerID, err)
+			s.applyBanScore(peerID, ReasonProtocolViolation)
+			return
+		}
+
+		// A blacklisted BaseURL must never reach the peer registry (catchup
+		// would fetch from it), but node_status is telemetry: keep the message
+		// with the URL removed instead of hiding the peer from monitoring.
+		if s.isBlacklistedBaseURL(nodeStatusMessage.BaseURL) {
+			s.logger.Warnf("[handleNodeStatusTopic] removed blacklisted BaseURL %s from node_status of peer %s", nodeStatusMessage.BaseURL, peerID)
+			nodeStatusMessage.BaseURL = ""
+		}
 	}
 
 	if !isSelf && nodeStatusMessage.BestHeight > 0 && nodeStatusMessage.PeerID != "" {

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -240,6 +240,15 @@ func NewServer(
 		return nil, errors.NewConfigurationError("listen_mode must be one of '%s', '%s', or '%s' (got '%s')", settings.ListenModeFull, settings.ListenModeListenOnly, settings.ListenModeSilent, listenMode)
 	}
 
+	// Surface blacklist entries with no parseable host: they can only ever
+	// match an announcement byte-for-byte, so the operator almost certainly
+	// misconfigured them. Warn loudly instead of leaving the entry silently inert.
+	for blocked := range tSettings.SubtreeValidation.BlacklistedBaseURLs {
+		if blacklistEntryHost(blocked) == "" {
+			logger.Warnf("[P2P] blacklisted base URL %q has no parseable host and will only match announcements exactly equal to it", blocked)
+		}
+	}
+
 	banlist, banChan, err := GetBanList(ctx, logger, tSettings)
 	if err != nil {
 		return nil, errors.NewServiceError("error getting banlist", err)

--- a/services/p2p/handle_catchup_metrics.go
+++ b/services/p2p/handle_catchup_metrics.go
@@ -215,6 +215,14 @@ func (s *Server) GetPeersForCatchup(ctx context.Context, _ *p2p_api.GetPeersForC
 			continue
 		}
 
+		// Enforce the operator blacklist at the point of use: a URL stored in
+		// the registry before its host was blacklisted must not be handed to
+		// catchup (gossip-time checks cannot evict already-stored URLs).
+		if s.isBlacklistedBaseURL(p.DataHubURL) {
+			s.logger.Debugf("[GetPeersForCatchup] skipping peer %s with blacklisted DataHubURL %s", p.ID, p.DataHubURL)
+			continue
+		}
+
 		totalAttempts := p.InteractionSuccesses + p.InteractionFailures
 
 		blockHashStr := ""

--- a/services/p2p/peer_selector.go
+++ b/services/p2p/peer_selector.go
@@ -196,6 +196,14 @@ func (ps *PeerSelector) isEligible(p *blockchain.PeerInfo, criteria SelectionCri
 		return false
 	}
 
+	// Enforce the operator blacklist at the point of use: a URL stored in the
+	// registry before its host was blacklisted must never be selected for
+	// sync/catchup (gossip-time checks cannot evict already-stored URLs).
+	if ps.settings != nil && isBaseURLBlacklisted(p.DataHubURL, ps.settings.SubtreeValidation.BlacklistedBaseURLs) {
+		ps.logger.Debugf("[PeerSelector] Peer %s has blacklisted DataHub URL %s", p.ID, p.DataHubURL)
+		return false
+	}
+
 	// Check reputation threshold - peers with very low reputation should not be selected
 	if p.ReputationScore < 20.0 {
 		ps.logger.Debugf("[PeerSelector] Peer %s has very low reputation %.2f (below threshold 20.0)", p.ID, p.ReputationScore)

--- a/services/p2p/peer_selector.go
+++ b/services/p2p/peer_selector.go
@@ -46,7 +46,11 @@ func NewPeerSelector(logger ulogger.Logger, settings *settings.Settings) *PeerSe
 // This is a pure function - no side effects, no network calls.
 // Peer IDs are canonical libp2p ID strings.
 func (ps *PeerSelector) SelectSyncPeer(peers []*blockchain.PeerInfo, criteria SelectionCriteria) string {
-	// Handle forced peer - always select it if it exists, regardless of eligibility
+	// Handle forced peer - always select it if it exists, regardless of
+	// eligibility. This deliberately skips the blacklist check in isEligible
+	// too, but a blacklisted DataHub URL is still refused downstream:
+	// sendSyncTriggerToKafka drops the trigger rather than handing the URL to
+	// block validation, so forcing a peer cannot override the blacklist.
 	if criteria.ForcedPeerID != "" {
 		for _, p := range peers {
 			if p.ID == criteria.ForcedPeerID {

--- a/services/p2p/peer_selector_test.go
+++ b/services/p2p/peer_selector_test.go
@@ -280,3 +280,28 @@ func TestPeerSelector_SelectSyncPeer_UnprovenProbeBudgetBoundsHeaderOnlyPeers(t 
 	boundedBudget.UnprovenProbeBudgetRemaining = 3
 	require.NotEmpty(t, ps.SelectSyncPeer(peers, boundedBudget))
 }
+
+// TestPeerSelector_SelectSyncPeer_SkipsBlacklistedDataHubURL: the operator
+// blacklist is enforced at sync-peer selection so a DataHub URL stored in the
+// registry before its host was blacklisted can never be chosen for catchup.
+func TestPeerSelector_SelectSyncPeer_SkipsBlacklistedDataHubURL(t *testing.T) {
+	ps := NewPeerSelector(ulogger.TestLogger{}, &settings.Settings{
+		P2P: settings.P2PSettings{
+			AllowPrunedNodeFallback:     true,
+			FullDeliveryFreshnessWindow: 24 * time.Hour,
+		},
+		SubtreeValidation: settings.SubtreeValidationSettings{
+			BlacklistedBaseURLs: map[string]struct{}{"http://evil.example": {}},
+		},
+	})
+
+	good := newPeer("good", 100, "full", 60, 0)
+	bad := newPeer("bad", 200, "full", 90, 0)
+	bad.DataHubURL = "http://evil.example:8080/api" // same host as blacklist entry
+
+	got := ps.SelectSyncPeer([]*blockchain.PeerInfo{bad, good}, advertisedProbeCriteria(50))
+	require.Equal(t, "good", got, "peer with blacklisted DataHub URL must not win selection")
+
+	got = ps.SelectSyncPeer([]*blockchain.PeerInfo{bad}, advertisedProbeCriteria(50))
+	require.Empty(t, got, "a blacklisted peer must not be selected even as the only candidate")
+}

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -361,9 +361,10 @@ func (s *Server) validateDataHubURL(urlStr string) error {
 		return errors.NewInvalidArgumentError("DataHubURL has invalid scheme: %s (only http/https allowed)", parsed.Scheme)
 	}
 
-	// Strip the trailing dot of a rooted FQDN so "localhost." or "127.0.0.1."
-	// cannot slip past the checks below.
-	hostname := strings.TrimSuffix(parsed.Hostname(), ".")
+	// Canonicalize before checking: strip the trailing dot of a rooted FQDN and
+	// lowercase, so "localhost.", "LOCALHOST" or "127.0.0.1." cannot slip past
+	// the checks below (DNS resolution is case-insensitive).
+	hostname := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
 	if hostname == "" {
 		return errors.NewInvalidArgumentError("DataHubURL has no hostname")
 	}

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -309,7 +309,9 @@ func (s *Server) extractHost(urlStr string) string {
 		return ""
 	}
 
-	host := parsedURL.Hostname()
+	// Strip the trailing dot of a rooted FQDN so "evil.example." matches a
+	// blacklist entry for "evil.example".
+	host := strings.TrimSuffix(parsedURL.Hostname(), ".")
 	if host == "" {
 		return ""
 	}
@@ -359,7 +361,9 @@ func (s *Server) validateDataHubURL(urlStr string) error {
 		return errors.NewInvalidArgumentError("DataHubURL has invalid scheme: %s (only http/https allowed)", parsed.Scheme)
 	}
 
-	hostname := parsed.Hostname()
+	// Strip the trailing dot of a rooted FQDN so "localhost." or "127.0.0.1."
+	// cannot slip past the checks below.
+	hostname := strings.TrimSuffix(parsed.Hostname(), ".")
 	if hostname == "" {
 		return errors.NewInvalidArgumentError("DataHubURL has no hostname")
 	}
@@ -380,10 +384,12 @@ func (s *Server) validateDataHubURL(urlStr string) error {
 	return nil
 }
 
-// checkDataHubURL runs the trust checks shared by every gossip handler that
-// receives a DataHub URL: SSRF validation (a failure counts as a protocol
+// checkDataHubURL runs the trust checks shared by the block and subtree
+// announcement handlers: SSRF validation (a failure counts as a protocol
 // violation) and the operator-configured blacklist (a match drops the message
 // without penalising the peer). Returns false when the message must be dropped.
+// handleNodeStatusTopic runs the same two checks inline because a blacklist
+// match there only strips the BaseURL instead of dropping the telemetry.
 func (s *Server) checkDataHubURL(dataHubURL, fromID, handlerName string) bool {
 	if err := s.validateDataHubURL(dataHubURL); err != nil {
 		s.logger.Errorf("[%s] invalid DataHubURL from peer %s: %v", handlerName, fromID, err)

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -268,12 +268,24 @@ func (s *Server) addProtocolViolation(peerID string) {
 	s.applyBanScore(peerID, ReasonProtocolViolation)
 }
 
-// isBlacklistedBaseURL checks if the given baseURL matches any entry in the blacklist.
+// isBlacklistedBaseURL checks the given baseURL against the operator-configured
+// blacklist (settings.SubtreeValidation.BlacklistedBaseURLs).
 func (s *Server) isBlacklistedBaseURL(baseURL string) bool {
-	inputHost := s.extractHost(baseURL)
+	if s.settings == nil {
+		return false
+	}
+
+	return isBaseURLBlacklisted(baseURL, s.settings.SubtreeValidation.BlacklistedBaseURLs)
+}
+
+// isBaseURLBlacklisted checks if the given baseURL matches any entry in the
+// blacklist. Package-level so both the gossip handlers (via the Server wrapper
+// above) and the sync PeerSelector can enforce the same blacklist.
+func isBaseURLBlacklisted(baseURL string, blacklist map[string]struct{}) bool {
+	inputHost := extractHost(baseURL)
 	if inputHost == "" {
 		// Fall back to exact string matching for invalid URLs
-		for blocked := range s.settings.SubtreeValidation.BlacklistedBaseURLs {
+		for blocked := range blacklist {
 			if baseURL == blocked {
 				return true
 			}
@@ -283,8 +295,8 @@ func (s *Server) isBlacklistedBaseURL(baseURL string) bool {
 	}
 
 	// Check each blacklisted URL
-	for blocked := range s.settings.SubtreeValidation.BlacklistedBaseURLs {
-		blockedHost := s.extractHost(blocked)
+	for blocked := range blacklist {
+		blockedHost := extractHost(blocked)
 		if blockedHost == "" {
 			// Fall back to exact string matching for invalid blacklisted URLs
 			if baseURL == blocked {
@@ -303,7 +315,7 @@ func (s *Server) isBlacklistedBaseURL(baseURL string) bool {
 }
 
 // extractHost extracts and normalizes the host component from a URL
-func (s *Server) extractHost(urlStr string) string {
+func extractHost(urlStr string) string {
 	parsedURL, err := url.Parse(urlStr)
 	if err != nil {
 		return ""

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -424,7 +424,7 @@ func (s *Server) checkDataHubURL(dataHubURL, fromID, handlerName string) bool {
 	}
 
 	if s.isBlacklistedBaseURL(dataHubURL) {
-		s.logger.Errorf("[%s] blocked notification from blacklisted DataHubURL %s (peer %s)", handlerName, dataHubURL, fromID)
+		s.logger.Warnf("[%s] blocked notification from blacklisted DataHubURL %s (peer %s)", handlerName, dataHubURL, fromID)
 		return false
 	}
 

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -296,9 +296,9 @@ func isBaseURLBlacklisted(baseURL string, blacklist map[string]struct{}) bool {
 
 	// Check each blacklisted URL
 	for blocked := range blacklist {
-		blockedHost := extractHost(blocked)
+		blockedHost := blacklistEntryHost(blocked)
 		if blockedHost == "" {
-			// Fall back to exact string matching for invalid blacklisted URLs
+			// Fall back to exact string matching for unparseable blacklisted entries
 			if baseURL == blocked {
 				return true
 			}
@@ -314,6 +314,18 @@ func isBaseURLBlacklisted(baseURL string, blacklist map[string]struct{}) bool {
 	return false
 }
 
+// blacklistEntryHost extracts the normalized host of a blacklist entry.
+// Operators commonly configure bare hosts ("evil.example"), which url.Parse
+// reads as a path (empty host), so scheme-less entries are retried in
+// protocol-relative form. Returns "" only for entries with no parseable host.
+func blacklistEntryHost(blocked string) string {
+	if host := extractHost(blocked); host != "" {
+		return host
+	}
+
+	return extractHost("//" + blocked)
+}
+
 // extractHost extracts and normalizes the host component from a URL
 func extractHost(urlStr string) string {
 	parsedURL, err := url.Parse(urlStr)
@@ -321,9 +333,10 @@ func extractHost(urlStr string) string {
 		return ""
 	}
 
-	// Strip the trailing dot of a rooted FQDN so "evil.example." matches a
-	// blacklist entry for "evil.example".
-	host := strings.TrimSuffix(parsedURL.Hostname(), ".")
+	// Strip trailing dots of a rooted FQDN so "evil.example." (or the
+	// non-resolvable "evil.example..") matches a blacklist entry for
+	// "evil.example".
+	host := strings.TrimRight(parsedURL.Hostname(), ".")
 	if host == "" {
 		return ""
 	}
@@ -373,10 +386,10 @@ func (s *Server) validateDataHubURL(urlStr string) error {
 		return errors.NewInvalidArgumentError("DataHubURL has invalid scheme: %s (only http/https allowed)", parsed.Scheme)
 	}
 
-	// Canonicalize before checking: strip the trailing dot of a rooted FQDN and
+	// Canonicalize before checking: strip trailing dots of a rooted FQDN and
 	// lowercase, so "localhost.", "LOCALHOST" or "127.0.0.1." cannot slip past
 	// the checks below (DNS resolution is case-insensitive).
-	hostname := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	hostname := strings.ToLower(strings.TrimRight(parsed.Hostname(), "."))
 	if hostname == "" {
 		return errors.NewInvalidArgumentError("DataHubURL has no hostname")
 	}

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -66,10 +66,8 @@ func (s *Server) handleBlockTopic(_ context.Context, m []byte, fromID string) {
 		return
 	}
 
-	// Validate DataHubURL to prevent SSRF attacks
-	if err = s.validateDataHubURL(blockMessage.DataHubURL); err != nil {
-		s.logger.Errorf("[handleBlockTopic] invalid DataHubURL from peer %s: %v", fromID, err)
-		s.addProtocolViolation(fromID)
+	// Validate DataHubURL (SSRF + operator blacklist)
+	if !s.checkDataHubURL(blockMessage.DataHubURL, fromID, "handleBlockTopic") {
 		return
 	}
 
@@ -196,19 +194,12 @@ func (s *Server) handleSubtreeTopic(_ context.Context, m []byte, fromID string) 
 		return
 	}
 
-	// Validate DataHubURL to prevent SSRF attacks
-	if err = s.validateDataHubURL(subtreeMessage.DataHubURL); err != nil {
-		s.logger.Errorf("[handleSubtreeTopic] invalid DataHubURL from peer %s: %v", fromID, err)
-		s.addProtocolViolation(fromID)
+	// Validate DataHubURL (SSRF + operator blacklist)
+	if !s.checkDataHubURL(subtreeMessage.DataHubURL, fromID, "handleSubtreeTopic") {
 		return
 	}
 
 	s.logger.Debugf("[handleSubtreeTopic] received subtree %s from %s", subtreeMessage.Hash, subtreeMessage.PeerID)
-
-	if s.isBlacklistedBaseURL(subtreeMessage.DataHubURL) {
-		s.logger.Errorf("[handleSubtreeTopic] Blocked subtree notification from blacklisted baseURL: %s", subtreeMessage.DataHubURL)
-		return
-	}
 
 	now := time.Now().UTC()
 
@@ -387,6 +378,25 @@ func (s *Server) validateDataHubURL(urlStr string) error {
 	}
 
 	return nil
+}
+
+// checkDataHubURL runs the trust checks shared by every gossip handler that
+// receives a DataHub URL: SSRF validation (a failure counts as a protocol
+// violation) and the operator-configured blacklist (a match drops the message
+// without penalising the peer). Returns false when the message must be dropped.
+func (s *Server) checkDataHubURL(dataHubURL, fromID, handlerName string) bool {
+	if err := s.validateDataHubURL(dataHubURL); err != nil {
+		s.logger.Errorf("[%s] invalid DataHubURL from peer %s: %v", handlerName, fromID, err)
+		s.addProtocolViolation(fromID)
+		return false
+	}
+
+	if s.isBlacklistedBaseURL(dataHubURL) {
+		s.logger.Errorf("[%s] blocked notification from blacklisted DataHubURL %s (peer %s)", handlerName, dataHubURL, fromID)
+		return false
+	}
+
+	return true
 }
 
 func (s *Server) handleRejectedTxTopic(_ context.Context, m []byte, fromID string) {

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -601,9 +601,11 @@ func TestValidateDataHubURL(t *testing.T) {
 		{"localhost_port", "http://localhost:8080/api", true, "localhost"},
 		{"sub_localhost", "http://sub.localhost/api", true, "localhost"},
 
-		// Rooted FQDN (trailing dot) must not bypass the checks
+		// Rooted FQDN (trailing dots, even multiple) must not bypass the checks
 		{"localhost_trailing_dot", "http://localhost./api", true, "localhost"},
 		{"loopback_trailing_dot", "http://127.0.0.1./api", true, "loopback"},
+		{"localhost_double_trailing_dot", "http://localhost../api", true, "localhost"},
+		{"loopback_double_trailing_dot", "http://127.0.0.1../api", true, "loopback"},
 
 		// Hostname case must not bypass the checks (DNS is case-insensitive)
 		{"localhost_uppercase", "http://LOCALHOST/api", true, "localhost"},

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -683,3 +683,131 @@ func TestServerHelpers_SanitizeAdvertisedTip_ClampsAndOverflow(t *testing.T) {
 		require.Equal(t, uint32(0), height)
 	})
 }
+
+// TestHandleBlockTopic_RejectsBlacklistedDataHubURL guards the fix for block
+// announcements bypassing the DataHub URL blacklist that subtree announcements
+// enforce: a blacklisted host must be dropped before any WebSocket forwarding,
+// peer registration, or Kafka publish (which would otherwise trigger catchup
+// from the blacklisted host).
+func TestHandleBlockTopic_RejectsBlacklistedDataHubURL(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+	s.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	producer := kafka.NewKafkaAsyncProducerMock()
+	s.blocksKafkaProducerClient = producer
+
+	remote := mustNewPeerID(t)
+	blockHash := chainhash.HashH([]byte("blacklisted block")).String()
+	msgBytes, err := json.Marshal(BlockMessage{
+		PeerID:     remote.String(),
+		ClientName: "client/1.0",
+		DataHubURL: "http://evil.example:8080/path", // same host as blacklist entry
+		Hash:       blockHash,
+		Height:     1,
+	})
+	require.NoError(t, err)
+
+	s.handleBlockTopic(context.Background(), msgBytes, remote.String())
+
+	select {
+	case notification := <-s.notificationCh:
+		t.Fatalf("unexpected block notification for blacklisted DataHubURL: %+v", notification)
+	default:
+	}
+
+	_, ok := reg.Get(remote.String())
+	require.False(t, ok, "peer with blacklisted DataHubURL must not be registered")
+
+	select {
+	case published := <-producer.PublishChannel():
+		t.Fatalf("unexpected Kafka publish for blacklisted DataHubURL: %+v", published)
+	default:
+	}
+
+	require.False(t, s.shouldSkipBannedPeer(remote.String(), "test"),
+		"blacklist match is an operator choice, not a peer protocol violation")
+}
+
+// TestHandleSubtreeTopic_RejectsBlacklistedDataHubURL is a regression test:
+// the subtree handler enforced the blacklist before the checks were factored
+// into checkDataHubURL and must keep doing so.
+func TestHandleSubtreeTopic_RejectsBlacklistedDataHubURL(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+	s.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	producer := kafka.NewKafkaAsyncProducerMock()
+	s.subtreeKafkaProducerClient = producer
+
+	remote := mustNewPeerID(t)
+	subtreeHash := chainhash.HashH([]byte("blacklisted subtree")).String()
+	msgBytes, err := json.Marshal(SubtreeMessage{
+		PeerID:     remote.String(),
+		ClientName: "client/1.0",
+		DataHubURL: "http://evil.example",
+		Hash:       subtreeHash,
+	})
+	require.NoError(t, err)
+
+	s.handleSubtreeTopic(context.Background(), msgBytes, remote.String())
+
+	select {
+	case notification := <-s.notificationCh:
+		t.Fatalf("unexpected subtree notification for blacklisted DataHubURL: %+v", notification)
+	default:
+	}
+
+	select {
+	case published := <-producer.PublishChannel():
+		t.Fatalf("unexpected Kafka publish for blacklisted DataHubURL: %+v", published)
+	default:
+	}
+}
+
+// TestHandleNodeStatusTopic_RejectsBlacklistedBaseURL: node_status stores the
+// announced BaseURL in the peer registry as the peer's DataHub URL (used by
+// catchup), so it must enforce the same blacklist as block/subtree handlers.
+func TestHandleNodeStatusTopic_RejectsBlacklistedBaseURL(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+	s.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
+	setServerLocalHeight(t, s, 100)
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	remote := mustNewPeerID(t)
+	blockHash := chainhash.HashH([]byte("blacklisted node status")).String()
+	msgBytes, err := json.Marshal(NodeStatusMessage{
+		PeerID:        remote.String(),
+		ClientName:    "client/1.0",
+		BaseURL:       "http://evil.example",
+		BestHeight:    101,
+		BestBlockHash: blockHash,
+	})
+	require.NoError(t, err)
+
+	s.handleNodeStatusTopic(context.Background(), msgBytes, remote.String())
+
+	select {
+	case notification := <-s.notificationCh:
+		t.Fatalf("unexpected node_status notification for blacklisted BaseURL: %+v", notification)
+	default:
+	}
+
+	_, ok := reg.Get(remote.String())
+	require.False(t, ok, "peer with blacklisted BaseURL must not be registered")
+}

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -599,6 +599,10 @@ func TestValidateDataHubURL(t *testing.T) {
 		{"localhost", "http://localhost/api", true, "localhost"},
 		{"localhost_port", "http://localhost:8080/api", true, "localhost"},
 		{"sub_localhost", "http://sub.localhost/api", true, "localhost"},
+
+		// Rooted FQDN (trailing dot) must not bypass the checks
+		{"localhost_trailing_dot", "http://localhost./api", true, "localhost"},
+		{"loopback_trailing_dot", "http://127.0.0.1./api", true, "loopback"},
 	}
 
 	for _, tt := range tests {
@@ -702,36 +706,41 @@ func TestHandleBlockTopic_RejectsBlacklistedDataHubURL(t *testing.T) {
 	producer := kafka.NewKafkaAsyncProducerMock()
 	s.blocksKafkaProducerClient = producer
 
-	remote := mustNewPeerID(t)
-	blockHash := chainhash.HashH([]byte("blacklisted block")).String()
-	msgBytes, err := json.Marshal(BlockMessage{
-		PeerID:     remote.String(),
-		ClientName: "client/1.0",
-		DataHubURL: "http://evil.example:8080/path", // same host as blacklist entry
-		Hash:       blockHash,
-		Height:     1,
-	})
-	require.NoError(t, err)
+	for _, dataHubURL := range []string{
+		"http://evil.example:8080/path", // same host as blacklist entry, different port/path
+		"http://evil.example./path",     // rooted FQDN (trailing dot) must not bypass the blacklist
+	} {
+		remote := mustNewPeerID(t)
+		blockHash := chainhash.HashH([]byte("blacklisted block " + dataHubURL)).String()
+		msgBytes, err := json.Marshal(BlockMessage{
+			PeerID:     remote.String(),
+			ClientName: "client/1.0",
+			DataHubURL: dataHubURL,
+			Hash:       blockHash,
+			Height:     1,
+		})
+		require.NoError(t, err)
 
-	s.handleBlockTopic(context.Background(), msgBytes, remote.String())
+		s.handleBlockTopic(context.Background(), msgBytes, remote.String())
 
-	select {
-	case notification := <-s.notificationCh:
-		t.Fatalf("unexpected block notification for blacklisted DataHubURL: %+v", notification)
-	default:
+		select {
+		case notification := <-s.notificationCh:
+			t.Fatalf("unexpected block notification for blacklisted DataHubURL %s: %+v", dataHubURL, notification)
+		default:
+		}
+
+		_, ok := reg.Get(remote.String())
+		require.False(t, ok, "peer with blacklisted DataHubURL %s must not be registered", dataHubURL)
+
+		select {
+		case published := <-producer.PublishChannel():
+			t.Fatalf("unexpected Kafka publish for blacklisted DataHubURL %s: %+v", dataHubURL, published)
+		default:
+		}
+
+		require.False(t, s.shouldSkipBannedPeer(remote.String(), "test"),
+			"blacklist match is an operator choice, not a peer protocol violation")
 	}
-
-	_, ok := reg.Get(remote.String())
-	require.False(t, ok, "peer with blacklisted DataHubURL must not be registered")
-
-	select {
-	case published := <-producer.PublishChannel():
-		t.Fatalf("unexpected Kafka publish for blacklisted DataHubURL: %+v", published)
-	default:
-	}
-
-	require.False(t, s.shouldSkipBannedPeer(remote.String(), "test"),
-		"blacklist match is an operator choice, not a peer protocol violation")
 }
 
 // TestHandleSubtreeTopic_RejectsBlacklistedDataHubURL is a regression test:
@@ -750,35 +759,42 @@ func TestHandleSubtreeTopic_RejectsBlacklistedDataHubURL(t *testing.T) {
 	producer := kafka.NewKafkaAsyncProducerMock()
 	s.subtreeKafkaProducerClient = producer
 
-	remote := mustNewPeerID(t)
-	subtreeHash := chainhash.HashH([]byte("blacklisted subtree")).String()
-	msgBytes, err := json.Marshal(SubtreeMessage{
-		PeerID:     remote.String(),
-		ClientName: "client/1.0",
-		DataHubURL: "http://evil.example",
-		Hash:       subtreeHash,
-	})
-	require.NoError(t, err)
+	for _, dataHubURL := range []string{
+		"http://evil.example",    // exact match
+		"http://evil.example./x", // rooted FQDN (trailing dot) must not bypass the blacklist
+	} {
+		remote := mustNewPeerID(t)
+		subtreeHash := chainhash.HashH([]byte("blacklisted subtree " + dataHubURL)).String()
+		msgBytes, err := json.Marshal(SubtreeMessage{
+			PeerID:     remote.String(),
+			ClientName: "client/1.0",
+			DataHubURL: dataHubURL,
+			Hash:       subtreeHash,
+		})
+		require.NoError(t, err)
 
-	s.handleSubtreeTopic(context.Background(), msgBytes, remote.String())
+		s.handleSubtreeTopic(context.Background(), msgBytes, remote.String())
 
-	select {
-	case notification := <-s.notificationCh:
-		t.Fatalf("unexpected subtree notification for blacklisted DataHubURL: %+v", notification)
-	default:
-	}
+		select {
+		case notification := <-s.notificationCh:
+			t.Fatalf("unexpected subtree notification for blacklisted DataHubURL %s: %+v", dataHubURL, notification)
+		default:
+		}
 
-	select {
-	case published := <-producer.PublishChannel():
-		t.Fatalf("unexpected Kafka publish for blacklisted DataHubURL: %+v", published)
-	default:
+		select {
+		case published := <-producer.PublishChannel():
+			t.Fatalf("unexpected Kafka publish for blacklisted DataHubURL %s: %+v", dataHubURL, published)
+		default:
+		}
 	}
 }
 
-// TestHandleNodeStatusTopic_RejectsBlacklistedBaseURL: node_status stores the
+// TestHandleNodeStatusTopic_StripsBlacklistedBaseURL: node_status stores the
 // announced BaseURL in the peer registry as the peer's DataHub URL (used by
-// catchup), so it must enforce the same blacklist as block/subtree handlers.
-func TestHandleNodeStatusTopic_RejectsBlacklistedBaseURL(t *testing.T) {
+// catchup), so a blacklisted BaseURL must never be persisted. Unlike the
+// block/subtree handlers the message itself is telemetry and is kept: it is
+// still forwarded to WebSocket clients, just with the URL removed.
+func TestHandleNodeStatusTopic_StripsBlacklistedBaseURL(t *testing.T) {
 	s, reg := newServerWithLocalRegistry(t)
 	s.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
 	setServerLocalHeight(t, s, 100)
@@ -794,7 +810,7 @@ func TestHandleNodeStatusTopic_RejectsBlacklistedBaseURL(t *testing.T) {
 	msgBytes, err := json.Marshal(NodeStatusMessage{
 		PeerID:        remote.String(),
 		ClientName:    "client/1.0",
-		BaseURL:       "http://evil.example",
+		BaseURL:       "http://evil.example./api", // rooted FQDN (trailing dot) must not bypass the blacklist
 		BestHeight:    101,
 		BestBlockHash: blockHash,
 	})
@@ -804,10 +820,16 @@ func TestHandleNodeStatusTopic_RejectsBlacklistedBaseURL(t *testing.T) {
 
 	select {
 	case notification := <-s.notificationCh:
-		t.Fatalf("unexpected node_status notification for blacklisted BaseURL: %+v", notification)
+		require.Empty(t, notification.BaseURL, "blacklisted BaseURL must be stripped from the WebSocket notification")
+		require.Equal(t, remote.String(), notification.PeerID)
 	default:
+		t.Fatal("node_status telemetry must still be forwarded to WebSocket clients")
 	}
 
-	_, ok := reg.Get(remote.String())
-	require.False(t, ok, "peer with blacklisted BaseURL must not be registered")
+	got, ok := reg.Get(remote.String())
+	require.True(t, ok, "peer telemetry must still be processed")
+	require.Empty(t, got.DataHubURL, "blacklisted BaseURL must not be stored in the peer registry")
+
+	require.False(t, s.shouldSkipBannedPeer(remote.String(), "test"),
+		"blacklist match is an operator choice, not a peer protocol violation")
 }

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -891,3 +891,35 @@ func TestBlacklistedDataHubURL_StoredBeforeBlacklist_NotUsedForCatchup(t *testin
 	require.NoError(t, err)
 	require.Empty(t, resp.Peers, "peer whose stored DataHubURL is now blacklisted must not be a catchup candidate")
 }
+
+// TestIsBaseURLBlacklisted covers the matcher directly, in particular the two
+// bypasses fixed after review: scheme-less blacklist entries ("evil.example"
+// parses as a URL path, so the entry silently never matched a real full-URL
+// announcement) and hostnames with multiple trailing dots.
+func TestIsBaseURLBlacklisted(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		entry   string
+		want    bool
+	}{
+		{"full_url_entry_exact", "http://evil.example", "http://evil.example", true},
+		{"full_url_entry_other_port_path", "http://evil.example:8080/path", "http://evil.example", true},
+		{"scheme_less_entry_full_url_announcement", "http://evil.example:8080/path", "evil.example", true},
+		{"scheme_less_entry_with_port", "https://evil.example/x", "evil.example:9000", true},
+		{"trailing_dot_announcement", "http://evil.example./x", "http://evil.example", true},
+		{"double_trailing_dot_announcement", "http://evil.example../x", "http://evil.example", true},
+		{"case_insensitive_host", "http://EVIL.example/x", "evil.example", true},
+		{"different_host_not_matched", "http://good.example/x", "evil.example", false},
+		{"unparseable_entry_exact_match_fallback", "http://[bad", "http://[bad", true},
+		{"unparseable_entry_no_match", "http://good.example", "http://[bad", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blacklist := map[string]struct{}{tt.entry: {}}
+			require.Equal(t, tt.want, isBaseURLBlacklisted(tt.baseURL, blacklist),
+				"baseURL %q vs blacklist entry %q", tt.baseURL, tt.entry)
+		})
+	}
+}

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -603,6 +603,11 @@ func TestValidateDataHubURL(t *testing.T) {
 		// Rooted FQDN (trailing dot) must not bypass the checks
 		{"localhost_trailing_dot", "http://localhost./api", true, "localhost"},
 		{"loopback_trailing_dot", "http://127.0.0.1./api", true, "loopback"},
+
+		// Hostname case must not bypass the checks (DNS is case-insensitive)
+		{"localhost_uppercase", "http://LOCALHOST/api", true, "localhost"},
+		{"localhost_mixed_case_trailing_dot", "http://LocalHost./api", true, "localhost"},
+		{"sub_localhost_uppercase", "http://sub.LOCALHOST/api", true, "localhost"},
 	}
 
 	for _, tt := range tests {

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/p2p/p2p_api"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/kafka"
@@ -837,4 +838,54 @@ func TestHandleNodeStatusTopic_StripsBlacklistedBaseURL(t *testing.T) {
 
 	require.False(t, s.shouldSkipBannedPeer(remote.String(), "test"),
 		"blacklist match is an operator choice, not a peer protocol violation")
+}
+
+// TestBlacklistedDataHubURL_StoredBeforeBlacklist_NotUsedForCatchup is the
+// regression for the primary operational case: a peer registers its DataHub
+// URL while the host is not yet blacklisted, the operator then blacklists it.
+// The node_status strip cannot evict the already-stored URL (the registry
+// ignores empty-URL updates), so the blacklist must be enforced at the point
+// of use - GetPeersForCatchup must stop surfacing the peer.
+func TestBlacklistedDataHubURL_StoredBeforeBlacklist_NotUsedForCatchup(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+	setServerLocalHeight(t, s, 100)
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 4)
+
+	// Register the peer's URL BEFORE the host is blacklisted.
+	remote := mustNewPeerID(t)
+	reg.Register(&blockchain.PeerInfo{ID: remote.String(), DataHubURL: "http://evil.example", Storage: "full", Height: 100})
+
+	resp, err := s.GetPeersForCatchup(context.Background(), &p2p_api.GetPeersForCatchupRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Peers, 1, "precondition: peer must be a catchup candidate before the blacklist entry")
+
+	// Operator blacklists the host.
+	s.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
+
+	// A subsequent node_status strips the URL but cannot clear the stored one.
+	blockHash := chainhash.HashH([]byte("stored before blacklist")).String()
+	msgBytes, err := json.Marshal(NodeStatusMessage{
+		PeerID:        remote.String(),
+		ClientName:    "client/1.0",
+		BaseURL:       "http://evil.example",
+		BestHeight:    102,
+		BestBlockHash: blockHash,
+	})
+	require.NoError(t, err)
+	s.handleNodeStatusTopic(context.Background(), msgBytes, remote.String())
+
+	got, ok := reg.Get(remote.String())
+	require.True(t, ok)
+	require.Equal(t, "http://evil.example", got.DataHubURL,
+		"documented limitation: the stored URL survives the strip, which is why point-of-use filtering exists")
+
+	// Point of use: the peer must no longer be handed to catchup.
+	resp, err = s.GetPeersForCatchup(context.Background(), &p2p_api.GetPeersForCatchupRequest{})
+	require.NoError(t, err)
+	require.Empty(t, resp.Peers, "peer whose stored DataHubURL is now blacklisted must not be a catchup candidate")
 }

--- a/services/p2p/sync_coordinator.go
+++ b/services/p2p/sync_coordinator.go
@@ -117,6 +117,8 @@ const (
 // viability filters used by the coordinator when deciding whether we're
 // caught up and when determining whether all eligible peers have been
 // attempted. Keeping this in one place ensures both call sites stay in sync.
+// Coordinator decision paths must use the SyncCoordinator method of the same
+// name, which additionally applies the operator blacklist.
 //
 // These filters — not banned, has a DataHub URL, and sufficient reputation —
 // exclude obviously unsuitable peers. They do
@@ -130,6 +132,25 @@ const (
 // tolerance here.
 func isViableSyncCandidate(p *blockchain.PeerInfo) bool {
 	return !p.IsBanned && p.DataHubURL != "" && p.ReputationScore >= 20
+}
+
+// isViableSyncCandidate layers the operator blacklist on top of the
+// unconditional filters. The caught-up determination (and every other
+// coordinator decision) must agree with peer selection here: isEligible
+// filters blacklisted DataHub URLs out of selection, so a
+// blacklisted-but-ahead peer that still counted as viable would keep
+// isCaughtUp reporting not-caught-up forever while SelectSyncPeer can never
+// pick it.
+func (sc *SyncCoordinator) isViableSyncCandidate(p *blockchain.PeerInfo) bool {
+	if !isViableSyncCandidate(p) {
+		return false
+	}
+
+	if sc.settings != nil && isBaseURLBlacklisted(p.DataHubURL, sc.settings.SubtreeValidation.BlacklistedBaseURLs) {
+		return false
+	}
+
+	return true
 }
 
 func maxUnprovenProbeBudget(settings *settings.Settings) int {
@@ -219,7 +240,7 @@ func peerEligibleForAdvertisedProbe(p *blockchain.PeerInfo, localHeight uint32) 
 }
 
 func (sc *SyncCoordinator) peerEligibleForAdvertisedProbe(p *blockchain.PeerInfo, localHeight uint32) bool {
-	return peerEligibleForAdvertisedProbe(p, localHeight)
+	return sc.isViableSyncCandidate(p) && p.Height > localHeight && p.BlockHash != nil
 }
 
 func (sc *SyncCoordinator) isUnprovenProbeCandidate(p *blockchain.PeerInfo, now time.Time) bool {
@@ -312,7 +333,7 @@ func (sc *SyncCoordinator) isCaughtUp() bool {
 		localHeight = tipHeight
 		peers := sc.listAllPeers()
 		for _, p := range peers {
-			if isViableSyncCandidate(p) && peerAheadByValidatedWork(p, chainWork) {
+			if sc.isViableSyncCandidate(p) && peerAheadByValidatedWork(p, chainWork) {
 				return false
 			}
 		}
@@ -818,7 +839,7 @@ func (sc *SyncCoordinator) selectAndActivateNewPeer(localHeight uint32, oldPeer 
 func (sc *SyncCoordinator) filterEligiblePeersWithTip(peers []*blockchain.PeerInfo, oldPeer string, localHeight uint32, localChainWork []byte, localWorkOK bool) []*blockchain.PeerInfo {
 	validatedPeers := make([]*blockchain.PeerInfo, 0, len(peers))
 	for _, p := range peers {
-		if p.ID == oldPeer || !isViableSyncCandidate(p) {
+		if p.ID == oldPeer || !sc.isViableSyncCandidate(p) {
 			if p.ID == oldPeer {
 				sc.logger.Debugf("[SyncCoordinator] Skipping old peer %s", p.ID)
 			}
@@ -1208,7 +1229,7 @@ func (sc *SyncCoordinator) checkAllPeersAttempted() {
 	syncAttemptCooldown := 1 * time.Minute // Don't retry a peer for at least 1 minute
 
 	for _, p := range peers {
-		if !isViableSyncCandidate(p) {
+		if !sc.isViableSyncCandidate(p) {
 			continue
 		}
 		eligibleByValidatedWork := localWorkOK && peerAheadByValidatedWork(p, localChainWork)

--- a/services/p2p/sync_coordinator.go
+++ b/services/p2p/sync_coordinator.go
@@ -1271,6 +1271,16 @@ func (sc *SyncCoordinator) sendSyncTriggerToKafka(syncPeer string, bestHash stri
 		dataHubURL = peerInfo.DataHubURL
 	}
 
+	// Enforce the operator blacklist on the URL read from the registry: it may
+	// have been stored before its host was blacklisted (the incumbent sync peer
+	// is not re-selected on every trigger) or belong to a forced sync peer,
+	// which bypasses selection eligibility. Deny wins - block validation must
+	// never be pointed at a blacklisted host.
+	if dataHubURL != "" && sc.settings != nil && isBaseURLBlacklisted(dataHubURL, sc.settings.SubtreeValidation.BlacklistedBaseURLs) {
+		sc.logger.Warnf("[sendSyncTriggerToKafka] not sending sync trigger for peer %s: DataHubURL %s is blacklisted", syncPeer, dataHubURL)
+		return
+	}
+
 	sc.logger.Infof("[sendSyncTriggerToKafka] Sending sync trigger with primary URL %s from peer %s", dataHubURL, syncPeer)
 
 	msg := &kafkamessage.KafkaBlockTopicMessage{

--- a/services/p2p/sync_coordinator_test.go
+++ b/services/p2p/sync_coordinator_test.go
@@ -1339,3 +1339,39 @@ func TestSyncCoordinator_ConcurrentSyncDecisions_NoDeadlock(t *testing.T) {
 		require.True(t, found, "current sync peer %s must be a registered peer", current)
 	}
 }
+
+// TestSyncCoordinator_SendSyncTriggerToKafka_RefusesBlacklistedURL: the sync
+// trigger reads the peer's DataHub URL straight from the registry, bypassing
+// selection eligibility. A URL stored before its host was blacklisted (or
+// belonging to a forced sync peer) must not be handed to block validation -
+// the trigger is dropped instead.
+func TestSyncCoordinator_SendSyncTriggerToKafka_RefusesBlacklistedURL(t *testing.T) {
+	sc, reg := newTestSyncCoordinator(t)
+
+	producer := kafka.NewKafkaAsyncProducerMock()
+	sc.blocksKafkaProducerClient = producer
+
+	reg.Register(&blockchain.PeerInfo{
+		ID:         "peer",
+		DataHubURL: "http://evil.example",
+		BlockHash:  syncCoordinatorTestHash(t),
+	})
+
+	// Control: without a blacklist entry the trigger is published.
+	sc.sendSyncTriggerToKafka("peer", syncCoordinatorTestHash(t).String())
+	select {
+	case <-producer.PublishChannel():
+	default:
+		t.Fatal("precondition: sync trigger must be published when the URL is not blacklisted")
+	}
+
+	// Operator blacklists the host after the URL was stored.
+	sc.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
+
+	sc.sendSyncTriggerToKafka("peer", syncCoordinatorTestHash(t).String())
+	select {
+	case published := <-producer.PublishChannel():
+		t.Fatalf("sync trigger with blacklisted DataHubURL must not be published: %+v", published)
+	default:
+	}
+}

--- a/services/p2p/sync_coordinator_test.go
+++ b/services/p2p/sync_coordinator_test.go
@@ -185,6 +185,34 @@ func TestSyncCoordinator_IsCaughtUp_OnlyLowRepPeerIsCaughtUp(t *testing.T) {
 	require.True(t, sc.isCaughtUp())
 }
 
+// TestSyncCoordinator_IsCaughtUp_BlacklistedPeerIsCaughtUp: the caught-up
+// determination must agree with selection about the operator blacklist. A
+// blacklisted-but-ahead peer can never be selected by SelectSyncPeer, so if it
+// still counted as a viable sync candidate here the node would report
+// not-caught-up forever while every selection attempt fails.
+func TestSyncCoordinator_IsCaughtUp_BlacklistedPeerIsCaughtUp(t *testing.T) {
+	sc, reg := newTestSyncCoordinator(t)
+
+	reg.Register(&blockchain.PeerInfo{
+		ID:         "ahead",
+		DataHubURL: "http://evil.example",
+		Height:     100,
+		BlockHash:  syncCoordinatorTestHash(t),
+	})
+	// Boost reputation past 20 so the peer is viable apart from the blacklist.
+	for i := 0; i < 5; i++ {
+		reg.UpdateMetrics("ahead", 0, 0, 0, true, false, false, 100)
+	}
+
+	// Control: the ahead peer keeps us not caught up while its host is allowed.
+	require.False(t, sc.isCaughtUp(), "precondition: ahead non-blacklisted peer means not caught up")
+
+	// Operator blacklists the host after the URL was stored in the registry.
+	sc.settings.SubtreeValidation.BlacklistedBaseURLs = map[string]struct{}{"http://evil.example": {}}
+
+	require.True(t, sc.isCaughtUp(), "blacklisted peer must not keep the node in a not-caught-up state")
+}
+
 func TestSyncCoordinator_HandlePeerDisconnected_RemovesPeer(t *testing.T) {
 	sc, reg := newTestSyncCoordinator(t)
 	pid := mustNewPeerID(t)


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4684.**

### Problem
`handleSubtreeTopic` rejects announcements whose DataHub URL matches the configured blacklist, but `handleBlockTopic` only runs the SSRF check - a blacklisted host is blocked for subtrees yet accepted for blocks, and the resulting catchup fetches blocks from it. `handleNodeStatusTopic` has the same gap: it stores the announced `BaseURL` in the peer registry as the peer's DataHub URL (used by sync/catchup) without a blacklist check.

Further holes surfaced during review:
- Host comparison did not canonicalize: rooted FQDNs (`http://evil.example./`, one or more trailing dots) bypassed the blacklist, and the SSRF localhost guard was case-sensitive and dot-sensitive (`http://LOCALHOST/`, `http://localhost./`, `http://127.0.0.1.`).
- Scheme-less blacklist entries (`evil.example`) parsed as a URL path, extracted no host, and silently never matched a real full-URL announcement - the entry was dead with no warning.
- Gossip-time checks cannot evict a URL stored before its host was blacklisted: the registry ignores empty-URL updates and an active peer never expires, so an operator blacklisting a live peer's host had no effect on catchup.

### Fix
- Factored the URL trust checks into one helper, `checkDataHubURL` (SSRF validation, which counts as a protocol violation on failure, followed by the operator blacklist, which drops the message without penalising the peer), applied in `handleBlockTopic` and `handleSubtreeTopic`. Blacklisted announcements are dropped before WebSocket forwarding, peer registration, and Kafka publish.
- `handleNodeStatusTopic` runs the same two checks inline: node_status is telemetry, so a blacklisted `BaseURL` is stripped from the message (not stored, not forwarded) while the rest of the peer's status still reaches the registry and dashboard.
- `extractHost` and `validateDataHubURL` canonicalize the hostname (lowercase, trim all trailing dots) before comparing, closing the rooted-FQDN and case bypasses.
- Scheme-less blacklist entries are retried in protocol-relative form (`blacklistEntryHost`), so `evil.example` and `evil.example:9000` now match full-URL announcements; entries with no parseable host at all trigger a startup warning in `NewServer` instead of failing silently (exact-match fallback retained).
- The blacklist is also enforced at the point of use, covering URLs stored before the blacklist entry existed: `GetPeersForCatchup` skips peers whose stored DataHubURL is blacklisted, and `PeerSelector.isEligible` refuses them for sync-peer selection. `isBlacklistedBaseURL` was made package-level (`isBaseURLBlacklisted`) so the selector shares the exact same matching logic.
- The caught-up determination agrees with selection about the blacklist: `SyncCoordinator.isViableSyncCandidate` (a method layering the blacklist over the unconditional viability filters) is now used by `isCaughtUp`, `filterEligiblePeersWithTip`, `checkAllPeersAttempted`, and advertised-probe eligibility. Without this, a blacklisted-but-ahead peer kept the node reporting not-caught-up forever while `SelectSyncPeer` could never pick it.

### Tests
Added to `services/p2p`:
- `TestIsBaseURLBlacklisted` - direct matcher table: scheme-less entries (with and without port) against full-URL announcements, single and double trailing dots, host case, unparseable-entry exact-match fallback.
- `TestHandleBlockTopic_RejectsBlacklistedDataHubURL` - blacklisted host (host-level match with different port/path, and the trailing-dot form) produces no notification, no registry entry, no Kafka publish, and no ban score.
- `TestHandleSubtreeTopic_RejectsBlacklistedDataHubURL` - regression guard for the pre-existing subtree behaviour (exact and trailing-dot forms) through the new helper.
- `TestHandleNodeStatusTopic_StripsBlacklistedBaseURL` - blacklisted BaseURL (trailing-dot form) is not stored and not forwarded, while the telemetry itself still reaches the registry and WebSocket clients.
- `TestBlacklistedDataHubURL_StoredBeforeBlacklist_NotUsedForCatchup` - a URL registered before the blacklist entry survives the node_status strip (documented limitation) but `GetPeersForCatchup` no longer surfaces the peer.
- `TestPeerSelector_SelectSyncPeer_SkipsBlacklistedDataHubURL` - a blacklisted peer loses selection to a viable peer and is not selected even as the only candidate.
- `TestSyncCoordinator_IsCaughtUp_BlacklistedPeerIsCaughtUp` - an ahead peer keeps the node not-caught-up while its host is allowed (control), and stops doing so once the host is blacklisted, keeping the caught-up view consistent with selection.
- `validateDataHubURL` table cases for trailing-dot, double-trailing-dot, and uppercase localhost/loopback forms.

Ran:
```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```
All green.



