### PR TITLE
fix(p2p): classify ReportValidatedChainProgress in RPC auth coverage test

### DIFF
--- a/services/p2p/server_auth_test.go
+++ b/services/p2p/server_auth_test.go
@@ -29,15 +29,16 @@ var publicPeerServiceMethods = map[string]bool{
 	"/p2p_api.PeerService/GetPeerRegistry":    true,
 	"/p2p_api.PeerService/GetPeer":            true,
 	// Internal data-plane reporting
-	"/p2p_api.PeerService/RecordCatchupAttempt":    true,
-	"/p2p_api.PeerService/RecordCatchupSuccess":    true,
-	"/p2p_api.PeerService/RecordCatchupFailure":    true,
-	"/p2p_api.PeerService/RecordCatchupMalicious":  true,
-	"/p2p_api.PeerService/UpdateCatchupReputation": true,
-	"/p2p_api.PeerService/UpdateCatchupError":      true,
-	"/p2p_api.PeerService/ReportValidSubtree":      true,
-	"/p2p_api.PeerService/ReportValidBlock":        true,
-	"/p2p_api.PeerService/RecordBytesDownloaded":   true,
+	"/p2p_api.PeerService/RecordCatchupAttempt":         true,
+	"/p2p_api.PeerService/RecordCatchupSuccess":         true,
+	"/p2p_api.PeerService/RecordCatchupFailure":         true,
+	"/p2p_api.PeerService/RecordCatchupMalicious":       true,
+	"/p2p_api.PeerService/UpdateCatchupReputation":      true,
+	"/p2p_api.PeerService/UpdateCatchupError":           true,
+	"/p2p_api.PeerService/ReportValidSubtree":           true,
+	"/p2p_api.PeerService/ReportValidBlock":             true,
+	"/p2p_api.PeerService/ReportValidatedChainProgress": true,
+	"/p2p_api.PeerService/RecordBytesDownloaded":        true,
 }
 
 // TestAdminProtectedMethodsCoverAllRPCs forces every PeerService RPC to be


### PR DESCRIPTION
### Problem
`TestAdminProtectedMethodsCoverAllRPCs` (added in #1257) fails on main: the `ReportValidatedChainProgress` RPC landed alongside that PR and is not classified as either admin-protected or public, so the classification check trips exactly as designed.

### Fix
Classify `ReportValidatedChainProgress` as an internal data-plane reporting RPC in `publicPeerServiceMethods`. It is called continuously by block validation (`services/blockvalidation/peer_metrics_helpers.go`) through the p2p client to report locally validated header-chain progress - the same family as `ReportValidBlock`/`ReportValidSubtree`, not an admin operation, so it must stay reachable without the admin API key.

### Tests
```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```
Full p2p package green, including the previously failing `TestAdminProtectedMethodsCoverAllRPCs`.
