### PR TITLE
test(p2p): classify ReportValidatedChainProgress in admin-auth test (fix broken main)

### DIFF
--- a/services/p2p/server_auth_test.go
+++ b/services/p2p/server_auth_test.go
@@ -29,15 +29,16 @@ var publicPeerServiceMethods = map[string]bool{
 	"/p2p_api.PeerService/GetPeerRegistry":    true,
 	"/p2p_api.PeerService/GetPeer":            true,
 	// Internal data-plane reporting
-	"/p2p_api.PeerService/RecordCatchupAttempt":    true,
-	"/p2p_api.PeerService/RecordCatchupSuccess":    true,
-	"/p2p_api.PeerService/RecordCatchupFailure":    true,
-	"/p2p_api.PeerService/RecordCatchupMalicious":  true,
-	"/p2p_api.PeerService/UpdateCatchupReputation": true,
-	"/p2p_api.PeerService/UpdateCatchupError":      true,
-	"/p2p_api.PeerService/ReportValidSubtree":      true,
-	"/p2p_api.PeerService/ReportValidBlock":        true,
-	"/p2p_api.PeerService/RecordBytesDownloaded":   true,
+	"/p2p_api.PeerService/RecordCatchupAttempt":         true,
+	"/p2p_api.PeerService/RecordCatchupSuccess":         true,
+	"/p2p_api.PeerService/RecordCatchupFailure":         true,
+	"/p2p_api.PeerService/RecordCatchupMalicious":       true,
+	"/p2p_api.PeerService/UpdateCatchupReputation":      true,
+	"/p2p_api.PeerService/UpdateCatchupError":           true,
+	"/p2p_api.PeerService/ReportValidSubtree":           true,
+	"/p2p_api.PeerService/ReportValidBlock":             true,
+	"/p2p_api.PeerService/ReportValidatedChainProgress": true,
+	"/p2p_api.PeerService/RecordBytesDownloaded":        true,
 }
 
 // TestAdminProtectedMethodsCoverAllRPCs forces every PeerService RPC to be


### PR DESCRIPTION
## Problem
`TestAdminProtectedMethodsCoverAllRPCs` (`services/p2p/server_auth_test.go`) fails on `main` HEAD:

```
/p2p_api.PeerService/ReportValidatedChainProgress is not classified:
add it to adminProtectedMethods (state-mutating admin RPC) or
publicPeerServiceMethods (read-only or internal data-plane)
```

The RPC shipped without being added to either classification list, so the coverage assertion trips. `test` is a required check, so this blocks **every** open PR against main.

## Fix
Classify `ReportValidatedChainProgress` as **public** (internal data-plane reporting), matching its siblings `ReportValidSubtree` / `ReportValidBlock`. Evidence it is data-plane, not an operator control:

- **Caller is internal**: `services/blockvalidation/peer_metrics_helpers.go` calls it service-to-service; it carries no admin credentials — the exact case `publicPeerServiceMethods` documents ("internal data-plane reporting calls made by other services … that do not carry admin credentials").
- **Handler is telemetry**: it forwards locally validated header-chain progress to the blockchain peer registry, and lives in `handle_catchup_metrics.go` alongside the other public `Record*`/`Report*` reporting RPCs.
- **Not an operator control**: `adminProtectedMethods` is exclusively `BanPeer`/`UnbanPeer`/`ClearBanned`/`AddBanScore`/`ResetReputation`/`ConnectPeer`/`DisconnectPeer`. `ReportValidatedChainProgress` mutates none of that operator surface.

Test-only change; no production behavior. Fixes broken main.

## Verification
```
go test -race -run 'TestAdminProtectedMethodsCoverAllRPCs|TestAuthInterceptor' ./services/p2p/  # ok
go vet ./services/p2p/
```
