### PR TITLE
MvP-4690 Enforce mandatory block-version floors (BIP34/66/65)

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -46,8 +46,37 @@ var bufioReaderPool = sync.Pool{
 
 const GenesisBlockID = 0
 
-// LastV1Block https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
-const LastV1Block = 227_835
+// heightAtOrAfterActivation reports whether block height h is at or after an activation height
+// taken from chaincfg. chaincfg activation heights are int32 and non-negative for BIP34/65/66; a
+// negative value (should not occur) is treated as "never active" so it can never wrongly reject.
+func heightAtOrAfterActivation(h uint32, activation int32) bool {
+	if activation < 0 {
+		return false
+	}
+
+	return h >= uint32(activation)
+}
+
+// CheckBlockVersion enforces the BIP34/66/65 mandatory version floors, mirroring bitcoin-sv
+// ContextualCheckBlockHeader (validation.cpp:5918-5924). version is compared as a SIGNED int32
+// exactly as svnode compares CBlockHeader::nVersion, so a high-bit version (e.g. 0xffffffff -> -1)
+// is treated as below the floor. Genesis (height 0) is exempt, matching svnode which never runs
+// this check on the genesis block. Returns a BlockInvalidError carrying the bad-version token.
+func CheckBlockVersion(version uint32, height uint32, params *chaincfg.Params) error {
+	if height == 0 {
+		return nil
+	}
+
+	v := int32(version)
+	if (v < 2 && heightAtOrAfterActivation(height, params.BIP0034Height)) ||
+		(v < 3 && heightAtOrAfterActivation(height, params.BIP0066Height)) ||
+		(v < 4 && heightAtOrAfterActivation(height, params.BIP0065Height)) {
+		return errors.NewBlockInvalidError(
+			"bad-version(0x%08x) rejected nVersion=0x%08x block", version, version)
+	}
+
+	return nil
+}
 
 var (
 	emptyTX = &bt.Tx{}
@@ -539,6 +568,13 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 		}
 	}
 
+	// 3b. Reject outdated block versions once the matching upgrade has activated (BIP34/66/65).
+	// Parity with bitcoin-sv ContextualCheckBlockHeader; must run before body/coinbase checks to
+	// match svnode's bad-version error priority.
+	if err := CheckBlockVersion(b.Header.Version, b.Height, settings.ChainCfgParams); err != nil {
+		return false, errors.NewBlockInvalidError("[BLOCK][%s] outdated block version", b.String(), err)
+	}
+
 	// 4. Check that the coinbase transaction is valid (reward checked later).
 	if b.CoinbaseTx == nil {
 		return false, errors.NewBlockInvalidError("[BLOCK][%s] block has no coinbase tx", b.String())
@@ -571,8 +607,14 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 
 	// TODO - do this another way, if necessary
 
-	// 5. Check that the coinbase transaction includes the correct block height.
-	if b.Header.Version > 1 && b.Height > LastV1Block {
+	// 5. Check that the coinbase transaction includes the correct block height (BIP34).
+	// Parity with bitcoin-sv ContextualCheckBlock: enforced for every block at/after BIP34Height.
+	// Version < 2 blocks are already rejected above (bad-version), so no version sub-condition here.
+	// The explicit b.Height > 0 guard is MANDATORY: on teratestnet/tstn BIP0034Height == 0, so
+	// heightAtOrAfterActivation(0, 0) is true and a height-0 (genesis-like) block driven through
+	// Valid() would otherwise attempt ExtractCoinbaseHeight — contradicting the genesis exemption
+	// that CheckBlockVersion already applies. svnode never runs this check on genesis.
+	if b.Height > 0 && heightAtOrAfterActivation(b.Height, settings.ChainCfgParams.BIP0034Height) {
 		height, err := b.ExtractCoinbaseHeight()
 		if err != nil {
 			return false, errors.NewBlockInvalidError("[BLOCK][%s] error extracting coinbase height", b.String(), err)

--- a/model/Block.go
+++ b/model/Block.go
@@ -597,15 +597,11 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 		return false, errors.NewBlockInvalidError("[BLOCK][%s] bad coinbase length", b.String())
 	}
 
-	// We can only calculate the height from coinbase transactions in block versions 2 and higher
-
 	// https://en.bitcoin.it/wiki/BIP_0034
-	// BIP-34 was created to force miners to add the block height to the coinbase tx.
-	// This BIP came into effect at block 227,835, which is after the first halving
-	// at block 210,000.  Therefore, until this happened, we do not know the actual
-	// height of the block we are checking for.
-
-	// TODO - do this another way, if necessary
+	// BIP-34 forces miners to encode the block height in the coinbase tx. It activates per network
+	// at ChainCfgParams.BIP0034Height; before that height the coinbase need not encode the height, so
+	// the check below is skipped. Enforcement is height-driven and version-independent — blocks below
+	// the mandatory version floor are already rejected above by CheckBlockVersion.
 
 	// 5. Check that the coinbase transaction includes the correct block height (BIP34).
 	// Parity with bitcoin-sv ContextualCheckBlock: enforced for every block at/after BIP34Height.

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -372,7 +372,8 @@ func TestBlock_Valid_ComprehensiveCoverage(t *testing.T) {
 		coinbase, err := bt.NewTxFromString(CoinbaseHex)
 		require.NoError(t, err)
 
-		// Set a height at which the coinbase-height validation path is exercised
+		// With regtest params (CreateBaseTestSettings) BIP34 activates at 1e8, so height 300000 is
+		// below it and the coinbase-height check is not reached.
 		const testHeight = 300000
 		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, testHeight, 0)
 		require.NoError(t, err)
@@ -380,9 +381,9 @@ func TestBlock_Valid_ComprehensiveCoverage(t *testing.T) {
 		ctx := context.Background()
 		logger := ulogger.TestLogger{}
 
-		// This should hit the coinbase height validation path
+		// Exercises Block.Valid past the version floor (a v2 header is not below any active floor)
+		// without reaching the coinbase-height check. No assertions — this is a code-path smoke case.
 		valid, err := block.Valid(ctx, logger, nil, createTestUTXOStore(t), txmap.NewSyncedMap[chainhash.Hash, []uint32](), []*BlockHeader{}, []uint32{}, tSettings, nil)
-		// Will likely fail due to height mismatch, but we're testing the code path
 		_ = valid
 		_ = err
 	})

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -372,8 +372,9 @@ func TestBlock_Valid_ComprehensiveCoverage(t *testing.T) {
 		coinbase, err := bt.NewTxFromString(CoinbaseHex)
 		require.NoError(t, err)
 
-		// Set height higher than LastV1Block to trigger height validation
-		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, LastV1Block+100, 0)
+		// Set a height at which the coinbase-height validation path is exercised
+		const testHeight = 300000
+		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, testHeight, 0)
 		require.NoError(t, err)
 
 		ctx := context.Background()

--- a/model/block_version_test.go
+++ b/model/block_version_test.go
@@ -69,6 +69,21 @@ func TestCheckBlockVersion(t *testing.T) {
 	}
 }
 
+// TestCheckBlockVersionErrorToken pins the exact svnode-style reject token, so the formatted
+// message stays byte-compatible with bitcoin-sv's bad-version(0x%08x) / rejected nVersion=0x%08x
+// text (the unsigned version is used for both hex fields).
+func TestCheckBlockVersionErrorToken(t *testing.T) {
+	mainParams := chaincfg.MainNetParams
+
+	err := CheckBlockVersion(1, 227931, &mainParams) // v1 at BIP34
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-version(0x00000001) rejected nVersion=0x00000001 block")
+
+	err = CheckBlockVersion(0xffffffff, 300000, &mainParams) // signed -1, below the floor
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-version(0xffffffff) rejected nVersion=0xffffffff block")
+}
+
 // TestCheckBlockVersionGenesisExemptTeraTestNet checks that a v1 genesis on a network whose
 // BIP0034Height is 0 (teratestnet/tstn) is not rejected, matching svnode which never runs the
 // header-version check on the genesis block.
@@ -80,7 +95,7 @@ func TestCheckBlockVersionGenesisExemptTeraTestNet(t *testing.T) {
 }
 
 // TestBlockValidRejectsOutdatedVersion drives the full Block.Valid path and asserts that the
-// version floor is enforced there (§3.1) and that a v1 block at/after BIP34 no longer bypasses
+// version floor is enforced there and that a v1 block at/after BIP34 no longer bypasses
 // validation but is rejected earlier with bad-version.
 func TestBlockValidRejectsOutdatedVersion(t *testing.T) {
 	blockHeaderBytes, err := hex.DecodeString(block1Header)
@@ -131,8 +146,8 @@ func TestBlockValidRejectsOutdatedVersion(t *testing.T) {
 }
 
 // TestBlockValidGenesisExemption drives the full Block.Valid path for a height-0 block on a network
-// whose BIP0034Height is 0 (teratestnet). It proves both the version exemption (§3.1/§3.3) and the
-// mandatory b.Height > 0 guard on the coinbase-height gate (§3.4): without that guard,
+// whose BIP0034Height is 0 (teratestnet). It proves both the version exemption and the
+// mandatory b.Height > 0 guard on the coinbase-height gate: without that guard,
 // heightAtOrAfterActivation(0, 0) would be true and Block.Valid would attempt ExtractCoinbaseHeight
 // and reject the genesis block.
 func TestBlockValidGenesisExemption(t *testing.T) {

--- a/model/block_version_test.go
+++ b/model/block_version_test.go
@@ -1,0 +1,165 @@
+package model
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckBlockVersion exercises the BIP34/66/65 version floor against the mainnet, regtest and
+// teratestnet activation heights, mirroring bitcoin-sv ContextualCheckBlockHeader
+// (validation.cpp:5918-5924): version < 2/3/4 is rejected at or after BIP34/66/65Height.
+func TestCheckBlockVersion(t *testing.T) {
+	// Copy the package params to avoid mutating the shared globals.
+	mainParams := chaincfg.MainNetParams          // BIP34=227931, BIP66=363725, BIP65=388381
+	regtestParams := chaincfg.RegressionNetParams // BIP34=100000000, BIP66=1251, BIP65=1351
+
+	tests := []struct {
+		name       string
+		version    uint32
+		height     uint32
+		params     *chaincfg.Params
+		wantReject bool
+	}{
+		// Mainnet boundary matrix.
+		{"v1 below BIP34", 1, 227930, &mainParams, false},
+		{"v1 at BIP34", 1, 227931, &mainParams, true},
+		{"v2 at BIP34", 2, 227931, &mainParams, false},
+		{"v2 below BIP66", 2, 363724, &mainParams, false},
+		{"v2 at BIP66", 2, 363725, &mainParams, true},
+		{"v3 at BIP66", 3, 363725, &mainParams, false},
+		{"v3 below BIP65", 3, 388380, &mainParams, false},
+		{"v3 at BIP65", 3, 388381, &mainParams, true},
+		{"v4 at BIP65", 4, 388381, &mainParams, false},
+		{"v4 high height", 4, 900000, &mainParams, false},
+		{"0x20000000 high height", 0x20000000, 900000, &mainParams, false},
+
+		// Signedness: high-bit versions are negative int32 and therefore below every floor.
+		{"0xffffffff (signed -1) at 300000", 0xffffffff, 300000, &mainParams, true},
+		{"0x80000000 (signed high bit) at 300000", 0x80000000, 300000, &mainParams, true},
+		{"0x20000000 at 300000", 0x20000000, 300000, &mainParams, false},
+
+		// Regtest: proves the OR across BIP34/66/65 (BIP66 engages at 1251).
+		{"regtest v1 at 100", 1, 100, &regtestParams, false},
+		{"regtest v1 at 1000", 1, 1000, &regtestParams, false},
+		{"regtest v1 at BIP66", 1, 1251, &regtestParams, true},
+
+		// Genesis is always exempt, even where BIP0034Height == 0.
+		{"genesis v1", 1, 0, &mainParams, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckBlockVersion(tt.version, tt.height, tt.params)
+			if tt.wantReject {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "bad-version")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCheckBlockVersionGenesisExemptTeraTestNet checks that a v1 genesis on a network whose
+// BIP0034Height is 0 (teratestnet/tstn) is not rejected, matching svnode which never runs the
+// header-version check on the genesis block.
+func TestCheckBlockVersionGenesisExemptTeraTestNet(t *testing.T) {
+	teraParams := chaincfg.TeraTestNetParams // BIP34=BIP65=BIP66=0
+	require.NoError(t, CheckBlockVersion(1, 0, &teraParams))
+	// A non-genesis v1 block on the same network must be rejected (floor active from height 1).
+	require.Error(t, CheckBlockVersion(1, 1, &teraParams))
+}
+
+// TestBlockValidRejectsOutdatedVersion drives the full Block.Valid path and asserts that the
+// version floor is enforced there (§3.1) and that a v1 block at/after BIP34 no longer bypasses
+// validation but is rejected earlier with bad-version.
+func TestBlockValidRejectsOutdatedVersion(t *testing.T) {
+	blockHeaderBytes, err := hex.DecodeString(block1Header)
+	require.NoError(t, err)
+
+	coinbase, err := bt.NewTxFromString(CoinbaseHex)
+	require.NoError(t, err)
+
+	mainParams := chaincfg.MainNetParams
+
+	t.Run("v1 at mainnet height 300000 is rejected as bad-version", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.ChainCfgParams = &mainParams
+
+		blockHeader, err := NewBlockHeaderFromBytes(blockHeaderBytes)
+		require.NoError(t, err)
+		blockHeader.Version = 1
+
+		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, 300000, 0)
+		require.NoError(t, err)
+
+		valid, err := block.Valid(context.Background(), ulogger.TestLogger{}, nil, createTestUTXOStore(t),
+			txmap.NewSyncedMap[chainhash.Hash, []uint32](), []*BlockHeader{}, []uint32{}, tSettings, nil)
+		require.False(t, valid)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad-version")
+	})
+
+	t.Run("v2 at mainnet height 300000 passes the version floor and reaches the coinbase-height check", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		tSettings.ChainCfgParams = &mainParams
+
+		blockHeader, err := NewBlockHeaderFromBytes(blockHeaderBytes)
+		require.NoError(t, err)
+		blockHeader.Version = 2
+
+		block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, 300000, 0)
+		require.NoError(t, err)
+
+		_, err = block.Valid(context.Background(), ulogger.TestLogger{}, nil, createTestUTXOStore(t),
+			txmap.NewSyncedMap[chainhash.Hash, []uint32](), []*BlockHeader{}, []uint32{}, tSettings, nil)
+		// A v2 block must never be rejected by the version floor at this height; if it fails a later
+		// (e.g. coinbase-height) check that is fine, but the error must not be bad-version.
+		if err != nil {
+			require.NotContains(t, err.Error(), "bad-version")
+		}
+	})
+}
+
+// TestBlockValidGenesisExemption drives the full Block.Valid path for a height-0 block on a network
+// whose BIP0034Height is 0 (teratestnet). It proves both the version exemption (§3.1/§3.3) and the
+// mandatory b.Height > 0 guard on the coinbase-height gate (§3.4): without that guard,
+// heightAtOrAfterActivation(0, 0) would be true and Block.Valid would attempt ExtractCoinbaseHeight
+// and reject the genesis block.
+func TestBlockValidGenesisExemption(t *testing.T) {
+	blockHeaderBytes, err := hex.DecodeString(block1Header)
+	require.NoError(t, err)
+
+	coinbase, err := bt.NewTxFromString(CoinbaseHex)
+	require.NoError(t, err)
+
+	teraParams := chaincfg.TeraTestNetParams
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.ChainCfgParams = &teraParams
+
+	blockHeader, err := NewBlockHeaderFromBytes(blockHeaderBytes)
+	require.NoError(t, err)
+	blockHeader.Version = 1
+
+	block, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, 0, 0)
+	require.NoError(t, err)
+
+	_, err = block.Valid(context.Background(), ulogger.TestLogger{}, nil, createTestUTXOStore(t),
+		txmap.NewSyncedMap[chainhash.Hash, []uint32](), []*BlockHeader{}, []uint32{}, tSettings, nil)
+	// Whether or not later body checks pass, the height-0 block must never be rejected for its
+	// version or for a coinbase-height mismatch.
+	if err != nil {
+		require.NotContains(t, err.Error(), "bad-version")
+		require.NotContains(t, err.Error(), "coinbase height")
+		require.NotContains(t, err.Error(), "does not match block height")
+	}
+}

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -40,6 +40,13 @@ const (
 	// pendingBlocksPollInterval is the interval at which the block assembler
 	// polls for pending blocks during startup
 	pendingBlocksPollInterval = 1 * time.Second
+
+	// miningCandidateVersion is the block version advertised in mining candidates: 0x20000000 is
+	// the BIP9/versionbits base (top three bits 001, no deployment bits) and clears the BIP34/66/65
+	// mandatory floor (>= 4). Used for both the normal and empty-block candidates rather than
+	// inheriting the tip's version: at an activation boundary the tip can validly carry the old
+	// floor while the next block requires the new one, so an inherited version could be rejected.
+	miningCandidateVersion uint32 = 0x20000000
 )
 
 // create state strings for the processor
@@ -1530,7 +1537,7 @@ func (b *BlockAssembler) GetMiningCandidate(ctx context.Context) (*model.MiningC
 		Id:                  id,
 		PreviousHash:        previousHash[:],
 		CoinbaseValue:       totalFees + blockSubsidy,
-		Version:             0x20000000,
+		Version:             miningCandidateVersion,
 		NBits:               nBits.CloneBytes(),
 		Height:              baBestBlockHeight + 1, // next block height
 		Time:                timeNowUint32,
@@ -1598,14 +1605,12 @@ func (b *BlockAssembler) generateEmptyBlockCandidate(bestBlockHeader *model.Bloc
 	copy(id[:], bestBlockHeader.Hash()[:])
 	id[0] ^= 0xFF
 
+	// Version uses miningCandidateVersion (same as the main candidate) rather than the tip's version.
 	miningCandidate := &model.MiningCandidate{
 		Id:                  id[:],
 		PreviousHash:        bestBlockHeader.Hash()[:],
 		CoinbaseValue:       blockSubsidy,
-		// Use the same safe version as the main mining candidate (0x20000000, >= 4) rather than
-		// inheriting the tip's version: at an activation boundary the tip can validly carry the old
-		// floor while the next block requires the new one, so an inherited version could be rejected.
-		Version:             0x20000000,
+		Version:             miningCandidateVersion,
 		NBits:               nBits[:],
 		Time:                timeNowUint32,
 		Height:              nextBlockHeight,

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -1602,7 +1602,10 @@ func (b *BlockAssembler) generateEmptyBlockCandidate(bestBlockHeader *model.Bloc
 		Id:                  id[:],
 		PreviousHash:        bestBlockHeader.Hash()[:],
 		CoinbaseValue:       blockSubsidy,
-		Version:             bestBlockHeader.Version,
+		// Use the same safe version as the main mining candidate (0x20000000, >= 4) rather than
+		// inheriting the tip's version: at an activation boundary the tip can validly carry the old
+		// floor while the next block requires the new one, so an inherited version could be rejected.
+		Version:             0x20000000,
 		NBits:               nBits[:],
 		Time:                timeNowUint32,
 		Height:              nextBlockHeight,

--- a/services/blockassembly/empty_block_version_test.go
+++ b/services/blockassembly/empty_block_version_test.go
@@ -1,0 +1,26 @@
+package blockassembly
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateEmptyBlockCandidateUsesSafeVersion proves that the empty mining candidate does not
+// inherit the tip's block version (§3.5). Inheriting an old version at an activation boundary would
+// make Teranode mine a block below the new floor that it (and the network) must reject. The tip
+// here is genesis (v1); the candidate must nevertheless carry the safe 0x20000000 version, matching
+// the main mining candidate path.
+func TestGenerateEmptyBlockCandidateUsesSafeVersion(t *testing.T) {
+	server, _ := setupServer(t)
+	require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+	bestHeader, meta, err := server.blockchainClient.GetBestBlockHeader(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, bestHeader)
+
+	candidate, _, err := server.blockAssembler.generateEmptyBlockCandidate(bestHeader, meta.Height)
+	require.NoError(t, err)
+	require.NotNil(t, candidate)
+	require.Equal(t, uint32(0x20000000), candidate.Version)
+}

--- a/services/blockassembly/empty_block_version_test.go
+++ b/services/blockassembly/empty_block_version_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestGenerateEmptyBlockCandidateUsesSafeVersion proves that the empty mining candidate does not
-// inherit the tip's block version (§3.5). Inheriting an old version at an activation boundary would
+// inherit the tip's block version. Inheriting an old version at an activation boundary would
 // make Teranode mine a block below the new floor that it (and the network) must reject. The tip
 // here is genesis (v1); the candidate must nevertheless carry the safe 0x20000000 version, matching
 // the main mining candidate path.

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1519,10 +1519,10 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		// block.Valid (and on the quick-validation catchup path), which runs with the block's settled
 		// height. We deliberately do NOT also run it as an outer prefilter here. svnode rejects
 		// bad-version in ContextualCheckBlockHeader ahead of the body/coinbase checks; teranode does not
-		// replicate that exact error ordering at this outer stage, so a below-floor block that ALSO lacks
-		// coinbase data can surface as block-incomplete or bad-coinbase-length here rather than
-		// bad-version. This is a deliberate non-parity in error priority only: such a block is still
-		// rejected — by block.Valid — and the reject carries the bad-version token.
+		// replicate that exact error ordering at this outer stage. A complete below-floor block is
+		// rejected by block.Valid with the bad-version token; a below-floor block that ALSO fails the
+		// outer coinbase prechecks below returns earlier with the documented non-parity reason
+		// (block-incomplete or bad-coinbase-length) instead. Either way the block is rejected.
 		if block.CoinbaseTx == nil || block.CoinbaseTx.Inputs == nil || len(block.CoinbaseTx.Inputs) == 0 {
 			// Use BlockIncomplete rather than BlockInvalid — a missing coinbase likely means the peer
 			// doesn't have full block data (e.g. seeded peer). Don't store as invalid so we can

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1514,19 +1514,15 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}
 		}
 
-		// Reject outdated block versions before any coinbase/body inspection, mirroring bitcoin-sv
-		// ContextualCheckBlockHeader error priority: bad-version is rejected ahead of body checks.
-		// block.Height is already trusted at this point (it drives the checkpoint/difficulty decision
-		// below). block.Valid enforces the same floor authoritatively; this outer check only ensures a
-		// below-floor block surfaces as bad-version rather than as an incomplete/bad-coinbase error.
-		if err := model.CheckBlockVersion(block.Header.Version, block.Height, u.settings.ChainCfgParams); err != nil {
-			if !opts.IsRevalidation {
-				u.storeInvalidBlock(ctx, block, opts.PeerID, "bad block version")
-			}
-
-			return errors.NewBlockInvalidError("[ValidateBlock][%s] outdated block version", block.Header.Hash().String(), err)
-		}
-
+		// NOTE on block-version (BIP34/66/65) enforcement and error ordering:
+		// The mandatory version floor is enforced authoritatively by model.CheckBlockVersion inside
+		// block.Valid (and on the quick-validation catchup path), which runs with the block's settled
+		// height. We deliberately do NOT also run it as an outer prefilter here. svnode rejects
+		// bad-version in ContextualCheckBlockHeader ahead of the body/coinbase checks; teranode does not
+		// replicate that exact error ordering at this outer stage, so a below-floor block that ALSO lacks
+		// coinbase data can surface as block-incomplete or bad-coinbase-length here rather than
+		// bad-version. This is a deliberate non-parity in error priority only: such a block is still
+		// rejected — by block.Valid — and the reject carries the bad-version token.
 		if block.CoinbaseTx == nil || block.CoinbaseTx.Inputs == nil || len(block.CoinbaseTx.Inputs) == 0 {
 			// Use BlockIncomplete rather than BlockInvalid — a missing coinbase likely means the peer
 			// doesn't have full block data (e.g. seeded peer). Don't store as invalid so we can

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1514,6 +1514,19 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}
 		}
 
+		// Reject outdated block versions before any coinbase/body inspection, mirroring bitcoin-sv
+		// ContextualCheckBlockHeader error priority: bad-version is rejected ahead of body checks.
+		// block.Height is already trusted at this point (it drives the checkpoint/difficulty decision
+		// below). block.Valid enforces the same floor authoritatively; this outer check only ensures a
+		// below-floor block surfaces as bad-version rather than as an incomplete/bad-coinbase error.
+		if err := model.CheckBlockVersion(block.Header.Version, block.Height, u.settings.ChainCfgParams); err != nil {
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, "bad block version")
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] outdated block version", block.Header.Hash().String(), err)
+		}
+
 		if block.CoinbaseTx == nil || block.CoinbaseTx.Inputs == nil || len(block.CoinbaseTx.Inputs) == 0 {
 			// Use BlockIncomplete rather than BlockInvalid — a missing coinbase likely means the peer
 			// doesn't have full block data (e.g. seeded peer). Don't store as invalid so we can

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -3289,6 +3289,13 @@ func setupTestCatchupServer(t *testing.T) (*Server, *blockchain.Mock, *utxo.Mock
 		CoinbaseMaturity:         100,
 		MaxCoinbaseScriptSigSize: 100,    // Default value for mainnet
 		SubsidyReductionInterval: 210000, // Bitcoin halving interval
+		// Not active - permit version 1 blocks (go-chaincfg's regtest BIP34 sentinel). Catchup
+		// fixtures replay real mainnet v1 blocks at synthetic heights, which the block-version floor
+		// would otherwise reject; the zero-value default (0) would make every v1 block above genesis
+		// invalid.
+		BIP0034Height: 100000000,
+		BIP0065Height: 100000000,
+		BIP0066Height: 100000000,
 	}
 
 	mockBlockchainClient := &blockchain.Mock{}
@@ -3397,6 +3404,13 @@ func setupTestCatchupServerWithConfig(t *testing.T, config *testhelpers.TestServ
 		CoinbaseMaturity:         config.CoinbaseMaturity,
 		MaxCoinbaseScriptSigSize: 100,    // Default value for mainnet
 		SubsidyReductionInterval: 210000, // Bitcoin halving interval
+		// Not active - permit version 1 blocks (go-chaincfg's regtest BIP34 sentinel). Catchup
+		// fixtures replay real mainnet v1 blocks at synthetic heights, which the block-version floor
+		// would otherwise reject; the zero-value default (0) would make every v1 block above genesis
+		// invalid.
+		BIP0034Height: 100000000,
+		BIP0065Height: 100000000,
+		BIP0066Height: 100000000,
 	}
 
 	mockBlockchainClient := &blockchain.Mock{}

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -198,6 +198,12 @@ func (u *BlockValidation) quickValidateBlock(ctx context.Context, block *model.B
 	)
 	defer deferFn()
 
+	// Enforce the block-version floor before any body/coinbase inspection (header-first parity
+	// with svnode ContextualCheckBlockHeader). Needs only header version, height, and params.
+	if err := model.CheckBlockVersion(block.Header.Version, block.Height, u.settings.ChainCfgParams); err != nil {
+		return errors.NewBlockInvalidError("[quickValidateBlock][%s] outdated block version", block.Hash().String(), err)
+	}
+
 	// Reject blocks without a valid coinbase (e.g. from seeded peers that don't have full block data)
 	if block.CoinbaseTx == nil || len(block.CoinbaseTx.Inputs) == 0 {
 		return errors.NewBlockIncompleteError("[quickValidateBlock][%s] coinbase tx is nil or has no inputs, peer may not have full block data", block.Hash().String())
@@ -263,6 +269,12 @@ func (u *BlockValidation) quickValidateBlockAsync(ctx context.Context, block *mo
 		tracing.WithLogMessage(u.logger, "[quickValidateBlockAsync][%s] performing async quick validation for checkpointed block at height %d", block.Hash().String(), block.Height),
 	)
 	defer deferFn()
+
+	// Enforce the block-version floor before any body/coinbase inspection (header-first parity
+	// with svnode ContextualCheckBlockHeader). Needs only header version, height, and params.
+	if err := model.CheckBlockVersion(block.Header.Version, block.Height, u.settings.ChainCfgParams); err != nil {
+		return errors.NewBlockInvalidError("[quickValidateBlockAsync][%s] outdated block version", block.Hash().String(), err)
+	}
 
 	// Reject blocks without a valid coinbase (e.g. from seeded peers that don't have full block data)
 	if block.CoinbaseTx == nil || len(block.CoinbaseTx.Inputs) == 0 {

--- a/services/blockvalidation/quick_validate_version_test.go
+++ b/services/blockvalidation/quick_validate_version_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestQuickValidateBlockRejectsOutdatedVersion proves that the quick-validation catchup path
-// enforces the BIP34/66/65 version floor (§3.2). A below-floor block that reaches the checkpoint
+// enforces the BIP34/66/65 version floor. A below-floor block that reaches the checkpoint
 // fast path must be rejected with bad-version before any body/coinbase inspection, matching svnode
 // ContextualCheckBlockHeader. Height 200_000_000 is at/after BIP34 on every network, so a v1 block
 // there is always below the floor regardless of the test network's chaincfg params.

--- a/services/blockvalidation/quick_validate_version_test.go
+++ b/services/blockvalidation/quick_validate_version_test.go
@@ -1,0 +1,42 @@
+package blockvalidation
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQuickValidateBlockRejectsOutdatedVersion proves that the quick-validation catchup path
+// enforces the BIP34/66/65 version floor (§3.2). A below-floor block that reaches the checkpoint
+// fast path must be rejected with bad-version before any body/coinbase inspection, matching svnode
+// ContextualCheckBlockHeader. Height 200_000_000 is at/after BIP34 on every network, so a v1 block
+// there is always below the floor regardless of the test network's chaincfg params.
+func TestQuickValidateBlockRejectsOutdatedVersion(t *testing.T) {
+	t.Run("quickValidateBlock", func(t *testing.T) {
+		suite := NewCatchupTestSuite(t)
+		defer suite.Cleanup()
+
+		block := testhelpers.CreateTestBlocks(t, 1)[0]
+		block.Height = 200_000_000
+		block.Header.Version = 1
+
+		err := suite.Server.blockValidation.quickValidateBlock(suite.Ctx, block, "test", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad-version")
+	})
+
+	t.Run("quickValidateBlockAsync", func(t *testing.T) {
+		suite := NewCatchupTestSuite(t)
+		defer suite.Cleanup()
+
+		block := testhelpers.CreateTestBlocks(t, 1)[0]
+		block.Height = 200_000_000
+		block.Header.Version = 1
+
+		writeJobsChan := make(chan *SubtreeWriteJob, 1)
+		err := suite.Server.blockValidation.quickValidateBlockAsync(suite.Ctx, block, "test", "", writeJobsChan)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad-version")
+	})
+}

--- a/services/subtreevalidation/check_block_subtrees_unconfirmed_parent_bdk_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unconfirmed_parent_bdk_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-chaincfg"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
@@ -149,6 +150,12 @@ func buildRealBDKCandidateBlock(t *testing.T, server *Server, childTx *bt.Tx) *m
 	// Well under the 25-BTC subsidy at height 257727 (+ fees), so
 	// checkBlockRewardAndFees passes.
 	require.NoError(t, coinbaseTx.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1_000_000))
+	// BIP34-encode the candidate height (257727) into the coinbase scriptSig: PUSH(3) + the height
+	// as little-endian bytes (0x03EEBF). Since the coinbase-height check in Block.Valid is now
+	// height-driven and the header version satisfies the floor, the encoded height must match.
+	// Done before the merkle root is computed so the header commits to this coinbase.
+	heightScriptSig := bscript.Script{0x03, 0xbf, 0xee, 0x03}
+	coinbaseTx.Inputs[0].UnlockingScript = &heightScriptSig
 
 	merkleRoot, err := subtree.RootHashWithReplaceRootNode(coinbaseTx.TxIDChainHash(), 0, uint64(coinbaseTx.Size())) //nolint:gosec
 	require.NoError(t, err)
@@ -157,7 +164,7 @@ func buildRealBDKCandidateBlock(t *testing.T, server *Server, childTx *bt.Tx) *m
 	require.NoError(t, err)
 
 	header := &model.BlockHeader{
-		Version:        1, // version 1 → no BIP34 coinbase-height check in Valid
+		Version:        0x20000000, // satisfies the BIP34/66/65 version floor at this mainnet height
 		HashPrevBlock:  &chainhash.Hash{},
 		HashMerkleRoot: merkleRoot,
 		Timestamp:      uint32(time.Now().Unix()), //nolint:gosec

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -898,16 +898,22 @@ func (s *SQL) validateCoinbaseHeight(block *model.Block, currentHeight uint32) e
 	// activation height, taken from chaincfg (mirroring bitcoin-sv ContextualCheckBlock). Below-floor
 	// versions are rejected earlier by the block-version floor, so there is no version sub-condition
 	// here. A negative activation height (should not occur) is treated as "never active".
+	//
+	// The currentHeight > 0 guard mirrors model/Block.go Block.Valid and is MANDATORY on networks
+	// with BIP0034Height == 0 (teratestnet/tstn): there height 0 is at/after activation, so without
+	// the guard a genesis (height-0) block routed here would attempt extraction, contradicting the
+	// genesis exemption. svnode never runs this check on genesis.
 	if block.CoinbaseTx == nil {
 		return nil
 	}
 
 	bip34Height := s.chainParams.BIP0034Height
-	postBIP34 := bip34Height >= 0 && currentHeight >= uint32(bip34Height)
+	postBIP34 := currentHeight > 0 && bip34Height >= 0 && currentHeight >= uint32(bip34Height)
 	if !postBIP34 {
-		// Below BIP34 activation the coinbase need not encode the height, and svnode never
-		// inspects it here (ContextualCheckBlock, validation.cpp:6039). Skip extraction to avoid
-		// ~227k wasted parses and warnings during a mainnet IBD.
+		// Below BIP34 activation the coinbase need not encode the height, and svnode never inspects it
+		// here (ContextualCheckBlock, validation.cpp:6039). Skip the per-block extraction that would
+		// otherwise run for every pre-activation block during a from-genesis IBD (most well-formed early
+		// coinbases succeed silently; warnings came from first byte > 8 or empty/too-short scripts).
 		return nil
 	}
 

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -873,7 +873,7 @@ func calculateAndPrepareChainWork(previousChainWorkBytes []byte, block *model.Bl
 //   - For blocks before the network's BIP34 activation height, validation is skipped
 //     (below-floor versions are already rejected by the block-version check)
 //
-// 2. Height Extraction:
+// 2. Height Extraction (only performed at or after BIP34 activation):
 //   - Accesses the coinbase transaction (first transaction in the block)
 //   - Examines the first input's script for the encoded height value
 //   - Uses Bitcoin's script parsing rules to extract the height as a number
@@ -904,24 +904,23 @@ func (s *SQL) validateCoinbaseHeight(block *model.Block, currentHeight uint32) e
 
 	bip34Height := s.chainParams.BIP0034Height
 	postBIP34 := bip34Height >= 0 && currentHeight >= uint32(bip34Height)
+	if !postBIP34 {
+		// Below BIP34 activation the coinbase need not encode the height, and svnode never
+		// inspects it here (ContextualCheckBlock, validation.cpp:6039). Skip extraction to avoid
+		// ~227k wasted parses and warnings during a mainnet IBD.
+		return nil
+	}
 
 	blockHeight, err := block.ExtractCoinbaseHeight()
 	if err != nil {
-		if !postBIP34 {
-			// Log warning for pre-BIP34 blocks where extraction might fail legitimately
-			s.logger.Warnf("failed to extract coinbase height for block %s (height %d), pre-BIP34 activation: %v", block.Hash(), currentHeight, err)
-			return nil // Don't fail validation for pre-BIP34 blocks
-		}
-		// Fail for post-BIP34 blocks if extraction fails
 		return errors.NewStorageError("failed to extract coinbase height for block %s (height %d): %w", block.Hash().String(), currentHeight, err)
 	}
 
-	// Check height match only if extraction succeeded and after BIP34 activation
-	if postBIP34 && blockHeight != currentHeight {
+	if blockHeight != currentHeight {
 		return errors.NewStorageError("coinbase transaction height (%d) does not match block height (%d) for block %s", blockHeight, currentHeight, block.Hash().String())
 	}
 
-	return nil // No validation needed or validation passed
+	return nil
 }
 
 // calculateMedianTimePastForHeight calculates the Median Time Past (MTP) for a given block height.

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -893,29 +893,31 @@ func calculateAndPrepareChainWork(previousChainWorkBytes []byte, block *model.Bl
 //   - error: ValidationError if the coinbase height doesn't match or can't be extracted,
 //     or nil if validation passes or isn't required for this block
 func (s *SQL) validateCoinbaseHeight(block *model.Block, currentHeight uint32) error {
-	// Check that the coinbase transaction includes the correct block height for all
-	// blocks that are version 2 or higher. BIP34 activation height is 227835.
-	// Also check if CoinbaseTx exists.
-	if block.CoinbaseTx != nil && block.Header.Version > 1 {
-		blockHeight, err := block.ExtractCoinbaseHeight()
-		if err != nil {
-			// Define BIP34 activation height (consider getting from chainParams)
-			bip34ActivationHeight := uint32(227835)
-			if currentHeight < bip34ActivationHeight {
-				// Log warning for pre-BIP34 blocks where extraction might fail legitimately
-				s.logger.Warnf("failed to extract coinbase height for block %s (height %d), pre-BIP34 activation: %v", block.Hash(), currentHeight, err)
-				return nil // Don't fail validation for pre-BIP34 blocks
-			}
-			// Fail for post-BIP34 blocks if extraction fails
-			return errors.NewStorageError("failed to extract coinbase height for block %s (height %d): %w", block.Hash().String(), currentHeight, err)
-		}
+	// Enforce the BIP34 coinbase-height rule for every block at or after the network's BIP34
+	// activation height, taken from chaincfg (mirroring bitcoin-sv ContextualCheckBlock). Below-floor
+	// versions are rejected earlier by the block-version floor, so there is no version sub-condition
+	// here. A negative activation height (should not occur) is treated as "never active".
+	if block.CoinbaseTx == nil {
+		return nil
+	}
 
-		// Define BIP34 activation height again (or use variable from above)
-		bip34ActivationHeight := uint32(227835)
-		// Check height match only if extraction succeeded and after BIP34 activation
-		if currentHeight >= bip34ActivationHeight && blockHeight != currentHeight {
-			return errors.NewStorageError("coinbase transaction height (%d) does not match block height (%d) for block %s", blockHeight, currentHeight, block.Hash().String())
+	bip34Height := s.chainParams.BIP0034Height
+	postBIP34 := bip34Height >= 0 && currentHeight >= uint32(bip34Height)
+
+	blockHeight, err := block.ExtractCoinbaseHeight()
+	if err != nil {
+		if !postBIP34 {
+			// Log warning for pre-BIP34 blocks where extraction might fail legitimately
+			s.logger.Warnf("failed to extract coinbase height for block %s (height %d), pre-BIP34 activation: %v", block.Hash(), currentHeight, err)
+			return nil // Don't fail validation for pre-BIP34 blocks
 		}
+		// Fail for post-BIP34 blocks if extraction fails
+		return errors.NewStorageError("failed to extract coinbase height for block %s (height %d): %w", block.Hash().String(), currentHeight, err)
+	}
+
+	// Check height match only if extraction succeeded and after BIP34 activation
+	if postBIP34 && blockHeight != currentHeight {
+		return errors.NewStorageError("coinbase transaction height (%d) does not match block height (%d) for block %s", blockHeight, currentHeight, block.Hash().String())
 	}
 
 	return nil // No validation needed or validation passed

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -852,12 +852,12 @@ func calculateAndPrepareChainWork(previousChainWorkBytes []byte, block *model.Bl
 
 // validateCoinbaseHeight ensures that blocks comply with BIP34 requirements.
 // BIP34 requires that the coinbase transaction must include the correct block height
-// in its first input script for all blocks version 2 or higher after the activation height.
+// in its first input script for all blocks at or after the network's BIP34 activation height.
 //
 // This function implements an important Bitcoin consensus rule defined in BIP34
-// (Bitcoin Improvement Proposal 34), which was activated at block height 227,836 on
-// the main Bitcoin network. The rule requires miners to include the block height in
-// the coinbase transaction's input script, providing several important benefits:
+// (Bitcoin Improvement Proposal 34), which activates per network at the height carried on the
+// chain parameters (s.chainParams.BIP0034Height). The rule requires miners to include the block
+// height in the coinbase transaction's input script, providing several important benefits:
 //
 //  1. Prevents coinbase transaction hash collisions that could occur when miners
 //     used identical coinbase transactions in different blocks
@@ -869,8 +869,9 @@ func calculateAndPrepareChainWork(previousChainWorkBytes []byte, block *model.Bl
 // The implementation performs a systematic validation process:
 //
 // 1. Applicability Check:
-//   - Determines if BIP34 validation applies based on block version and height
-//   - For blocks before the activation height or with version < 2, validation is skipped
+//   - Determines if BIP34 validation applies based on the block height
+//   - For blocks before the network's BIP34 activation height, validation is skipped
+//     (below-floor versions are already rejected by the block-version check)
 //
 // 2. Height Extraction:
 //   - Accesses the coinbase transaction (first transaction in the block)

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/stores/blockchain/options"
 	"github.com/bsv-blockchain/teranode/ulogger"
@@ -470,16 +471,17 @@ func TestValidateCoinbaseHeight_NoValidationNeeded(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close(context.Background())
 
-	// Test block with version 1 (no BIP34 validation required)
-	blockVersion1 := &model.Block{
+	// Height 100 is below the (regtest) BIP34 activation height, so the coinbase-height rule is not
+	// enforced regardless of the header version.
+	blockBelowBIP34 := &model.Block{
 		Header: &model.BlockHeader{
 			Version: 1,
 		},
 		CoinbaseTx: block1.CoinbaseTx,
 	}
 
-	err = s.validateCoinbaseHeight(blockVersion1, 100)
-	assert.NoError(t, err)
+	err = s.validateCoinbaseHeight(blockBelowBIP34, 100)
+	require.NoError(t, err)
 }
 
 func TestValidateCoinbaseHeight_NoCoinbaseTx(t *testing.T) {
@@ -512,9 +514,9 @@ func TestValidateCoinbaseHeight_PreBIP34(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close(context.Background())
 
-	// Test with block height before BIP34 activation
-	err = s.validateCoinbaseHeight(block1, 100) // height < 227835
-	assert.NoError(t, err)                      // Should not fail for pre-BIP34 blocks
+	// Test with block height before the network's BIP34 activation height (from chaincfg)
+	err = s.validateCoinbaseHeight(block1, 100) // height < BIP0034Height
+	require.NoError(t, err)                      // Should not fail for pre-BIP34 blocks
 }
 
 func TestGetCumulativeChainWork_Success(t *testing.T) {
@@ -783,20 +785,43 @@ func TestValidateCoinbaseHeight_PostBIP34InvalidHeight(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close(context.Background())
 
-	// Create a block that would be post-BIP34 but with invalid coinbase height extraction
-	// This test verifies the BIP34 validation logic, though exact behavior depends on
-	// the ExtractCoinbaseHeight implementation
+	// Exercise the validation code path at a mid-range height. On the default (regtest) params this
+	// height is still below BIP34 (100000000), so extraction is not enforced; see
+	// TestValidateCoinbaseHeight_ChainCfgDriven for deterministic post-BIP34 enforcement on mainnet.
 	postBIP34Height := uint32(250000)
 
-	// Test with a block that has version > 1 at post-BIP34 height
 	err = s.validateCoinbaseHeight(block1, postBIP34Height)
 	// The result depends on whether block1's coinbase contains valid height encoding
 	// This test verifies the code path is exercised
 	if err != nil {
-		t.Logf("BIP34 validation failed as expected for height %d: %v", postBIP34Height, err)
+		t.Logf("coinbase-height validation returned an error for height %d: %v", postBIP34Height, err)
 	} else {
-		t.Logf("BIP34 validation passed for height %d", postBIP34Height)
+		t.Logf("coinbase-height validation passed for height %d", postBIP34Height)
 	}
+}
+
+// TestValidateCoinbaseHeight_ChainCfgDriven proves the coinbase-height gate is now driven by the
+// network's chaincfg BIP34 activation height rather than the old hardcoded 227835, and that the
+// version sub-condition has been dropped (§3.6). Uses mainnet params (BIP34=227931).
+func TestValidateCoinbaseHeight_ChainCfgDriven(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	mainParams := chaincfg.MainNetParams
+	tSettings.ChainCfgParams = &mainParams
+
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close(context.Background())
+
+	// Below mainnet BIP34 (227931): no enforcement, even for a v1 block.
+	require.NoError(t, s.validateCoinbaseHeight(block1, 100))
+
+	// At/after mainnet BIP34: block1's coinbase does not encode height 300000, so it is rejected —
+	// enforcement is height-driven and no longer skipped by a version sub-condition.
+	err = s.validateCoinbaseHeight(block1, 300000)
+	require.Error(t, err)
 }
 
 func TestStoreBlock_SubtreeProcessing(t *testing.T) {

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -802,7 +802,7 @@ func TestValidateCoinbaseHeight_PostBIP34InvalidHeight(t *testing.T) {
 
 // TestValidateCoinbaseHeight_ChainCfgDriven proves the coinbase-height gate is now driven by the
 // network's chaincfg BIP34 activation height rather than the old hardcoded 227835, and that the
-// version sub-condition has been dropped (§3.6). Uses mainnet params (BIP34=227931).
+// version sub-condition has been dropped. Uses mainnet params (BIP34=227931).
 func TestValidateCoinbaseHeight_ChainCfgDriven(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 	mainParams := chaincfg.MainNetParams

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -519,6 +519,33 @@ func TestValidateCoinbaseHeight_PreBIP34(t *testing.T) {
 	require.NoError(t, err)                     // Should not fail for pre-BIP34 blocks
 }
 
+func TestValidateCoinbaseHeight_GenesisExemptOnZeroBIP34(t *testing.T) {
+	// On networks with BIP0034Height == 0 (teratestnet/tstn), height 0 is at/after activation, so
+	// without the currentHeight > 0 guard the genesis block would attempt coinbase-height extraction
+	// and mismatch. The guard (mirroring model/Block.go Block.Valid) must keep genesis exempt.
+	tSettings := test.CreateBaseTestSettings(t)
+	teraParams := chaincfg.TeraTestNetParams // BIP0034Height == 0
+	tSettings.ChainCfgParams = &teraParams
+
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	defer s.Close(context.Background())
+
+	// block1's coinbase does not encode height 0, so extraction would mismatch if it ran.
+	genesisLikeBlock := &model.Block{
+		Header: &model.BlockHeader{
+			Version: 1,
+		},
+		CoinbaseTx: block1.CoinbaseTx,
+	}
+
+	err = s.validateCoinbaseHeight(genesisLikeBlock, 0)
+	require.NoError(t, err)
+}
+
 func TestGetCumulativeChainWork_Success(t *testing.T) {
 	// Test cumulative chain work calculation
 	zeroHash := &chainhash.Hash{}

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -516,7 +516,7 @@ func TestValidateCoinbaseHeight_PreBIP34(t *testing.T) {
 
 	// Test with block height before the network's BIP34 activation height (from chaincfg)
 	err = s.validateCoinbaseHeight(block1, 100) // height < BIP0034Height
-	require.NoError(t, err)                      // Should not fail for pre-BIP34 blocks
+	require.NoError(t, err)                     // Should not fail for pre-BIP34 blocks
 }
 
 func TestGetCumulativeChainWork_Success(t *testing.T) {


### PR DESCRIPTION
Resolve https://github.com/bitcoin-sv/teranode/issues/4690

## What

Teranode never rejected a block for carrying an outdated header version, and it gated its BIP34
coinbase-height check on `Header.Version > 1`, so a version-1 block skipped coinbase-height
verification entirely. This change brings Teranode into consensus parity with the reference
implementation.

- **New `model.CheckBlockVersion(version, height, params)`** — rejects `version < 2/3/4` at or after
  the network's `BIP0034Height` / `BIP0066Height` / `BIP0065Height`, mirroring bitcoin-sv
  `ContextualCheckBlockHeader` (`validation.cpp:5918-5924`). The version is compared as a **signed
  `int32`**, exactly as svnode compares `CBlockHeader::nVersion`, so a high-bit version (e.g.
  `0xffffffff` → `-1`) is treated as below the floor. Genesis (height 0) is exempt, matching svnode
  which never runs this check on the genesis block. The reject carries the `bad-version(0x%08x)`
  token for string parity.
- **Enforced on every active-chain acceptance path** — called from `Block.Valid` (before any
  body/coinbase checks, matching svnode's error priority) and as the first check in both
  quick-validation catchup functions (`quickValidateBlock` / `quickValidateBlockAsync`). The
  quick-path redundancy is deliberate defence-in-depth over the checkpoint guarantee.
  `Block.Valid` is the authoritative enforcement point; the block-validation service's outer coinbase
  prechecks are intentionally left ahead of the version floor. A complete below-floor block is
  rejected by `Block.Valid` with the `bad-version` token; a below-floor block that also fails those
  outer coinbase prechecks is rejected earlier with the documented non-parity reason
  (incomplete/bad-coinbase) instead. Either way the block is rejected — a deliberate error-priority
  non-parity only.
- **Retired `LastV1Block` (227835)** and moved the BIP34 coinbase-height gate onto
  `ChainCfgParams.BIP0034Height`, height-driven and version-independent (a `b.Height > 0` guard
  preserves the genesis exemption on networks where `BIP0034Height == 0`). This closes the v1
  coinbase-height bypass and the 227835-vs-227931 boundary discrepancy.
- **Empty mining candidate** now uses the safe `0x20000000` version instead of inheriting the tip's
  version, so Teranode never mines a below-floor block at an activation boundary.
- **SQL blockchain store** — `validateCoinbaseHeight` now derives its activation height from
  `chainParams.BIP0034Height` and no longer skips v1 blocks via a version sub-condition, removing a
  second copy of the stale hardcoded height and version bypass.

## Why

Consensus parity with bitcoin-sv `ContextualCheckBlockHeader` (`validation.cpp:5918-5924`) and
`ContextualCheckBlock` (`validation.cpp:6039`). At a height where the rest of the network rejects an
outdated-version block, Teranode previously accepted it (and additionally skipped BIP34
coinbase-height verification for v1 blocks) — a chain-split vector in the dangerous direction.

**Chain-split analysis:** this change is net split-*reducing*. Every block on the live
mainnet/testnet chains already satisfies the floor (they are, by definition, the chains svnode
accepted), so no historic block can be rejected during IBD/catchup. The activation heights are
sourced from `go-chaincfg`, which matches svnode's mainnet/testnet/regtest values exactly, and the
rule uses the same operator (`>=`), the same height variable (the block's own height), the same
signed comparison, and the same genesis exemption as svnode — so it rejects exactly what svnode
rejects and introduces no new reverse-split on mainnet/testnet/regtest.

## Deliberately out of scope

- **Main mining candidate** (`BlockAssembler.go:1533`): already `0x20000000`; safe.
- **Catchup header validators** (`catchup/header_validation.go`): stateless header helpers with no
  height/params in scope; the floor is contextual and every active-chain acceptance path already
  enforces it.
- **RPC reject mapping** (`services/rpc/Server.go:454-455`): commented-out and unused; left as-is.

## Note for maintainers — STN BIP65/66

`go-chaincfg` sets STN `BIP0065Height`/`BIP0066Height` to 1251/1351, but svnode `CStnParams`
assigns only `BIP34Height` and leaves BIP65/66 unset (`chainparams.cpp:1212`), so exact STN BIP65/66
parity cannot be confirmed from svnode source. This change uses go-chaincfg's values (Teranode's own
source of truth). STN is a non-value test network; please confirm the intended STN BIP65/66 behaviour.
