### PR TITLE
fix(blockvalidation): bounds-check same-block-parent vout in quick validation

### DIFF
--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1049,6 +1049,37 @@ func (b *SubtreeProcessingBatch) Close() {
 	}
 }
 
+// extendTxFromSameBlockParents extends tx's inputs whose parents are present in
+// parents (same-block parents already decoded in this batch), returning whether
+// any input still needs an external (store) lookup.
+//
+// PreviousTxOutIndex comes from the untrusted child tx, so the parent's output
+// count is bounds-checked before indexing: an out-of-range reference returns an
+// error instead of panicking the node with index-out-of-range (issue 1283). This
+// mirrors the guard in services/validator/Validator.go extendTransaction.
+func extendTxFromSameBlockParents(tx *bt.Tx, parents map[chainhash.Hash]*bt.Tx) (needsExternalLookup bool, err error) {
+	for j, input := range tx.Inputs {
+		parentHash := input.PreviousTxIDChainHash()
+
+		parentTx, ok := parents[*parentHash]
+		if !ok {
+			needsExternalLookup = true
+			continue
+		}
+
+		vout := input.PreviousTxOutIndex
+		if parentTx.Outputs == nil || int(vout) >= len(parentTx.Outputs) {
+			return false, errors.NewProcessingError("tx %s input %d references non-existent output %d of same-block parent %s",
+				tx.TxIDChainHash().String(), j, vout, parentHash.String())
+		}
+
+		tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[vout].Satoshis
+		tx.Inputs[j].PreviousTxScript = parentTx.Outputs[vout].LockingScript
+	}
+
+	return needsExternalLookup, nil
+}
+
 // processSubtreeBatch reads and extends a batch of subtrees.
 // This is the shared first phase of both quick and normal validation.
 //
@@ -1146,27 +1177,12 @@ func (u *BlockValidation) processSubtreeBatch(
 
 			// Try to extend from same-block parents first
 			if !tx.IsExtended() {
-				needsExternalLookup := false
-				for j, input := range tx.Inputs {
-					parentHash := input.PreviousTxIDChainHash()
-					if parentTx, ok := extendedTxsFromPrevBatches[*parentHash]; ok {
-						// PreviousTxOutIndex comes from the (untrusted) child tx; bound it
-						// against the same-block parent's output count before indexing, else a
-						// crafted block panics the node with index-out-of-range (issue 1283).
-						// Mirrors the guard in services/validator/Validator.go extendTransaction.
-						vout := input.PreviousTxOutIndex
-						if parentTx.Outputs == nil || int(vout) >= len(parentTx.Outputs) {
-							cancelReaders()
-							return nil, errors.NewProcessingError("[processSubtreeBatch][%s] tx %s input %d references non-existent output %d of same-block parent %s",
-								block.Hash().String(), tx.TxIDChainHash().String(), j, vout, parentHash.String())
-						}
-
-						tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[vout].Satoshis
-						tx.Inputs[j].PreviousTxScript = parentTx.Outputs[vout].LockingScript
-					} else {
-						needsExternalLookup = true
-					}
+				needsExternalLookup, extendErr := extendTxFromSameBlockParents(tx, extendedTxsFromPrevBatches)
+				if extendErr != nil {
+					cancelReaders()
+					return nil, errors.NewProcessingError("[processSubtreeBatch][%s] same-block parent extension failed", block.Hash().String(), extendErr)
 				}
+
 				if needsExternalLookup {
 					txsNeedingExtension = append(txsNeedingExtension, tx)
 				}
@@ -1607,26 +1623,11 @@ func (u *BlockValidation) extendBatch(
 
 			// Try to extend from same-block parents first
 			if !tx.IsExtended() {
-				needsExternalLookup := false
-				for j, input := range tx.Inputs {
-					parentHash := input.PreviousTxIDChainHash()
-					if parentTx, ok := extendedTxs[*parentHash]; ok {
-						// PreviousTxOutIndex comes from the (untrusted) child tx; bound it
-						// against the same-block parent's output count before indexing, else a
-						// crafted block panics the node with index-out-of-range (issue 1283).
-						// Mirrors the guard in services/validator/Validator.go extendTransaction.
-						vout := input.PreviousTxOutIndex
-						if parentTx.Outputs == nil || int(vout) >= len(parentTx.Outputs) {
-							return errors.NewProcessingError("[extendBatch][%s] tx %s input %d references non-existent output %d of same-block parent %s",
-								block.Hash().String(), tx.TxIDChainHash().String(), j, vout, parentHash.String())
-						}
-
-						tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[vout].Satoshis
-						tx.Inputs[j].PreviousTxScript = parentTx.Outputs[vout].LockingScript
-					} else {
-						needsExternalLookup = true
-					}
+				needsExternalLookup, extendErr := extendTxFromSameBlockParents(tx, extendedTxs)
+				if extendErr != nil {
+					return errors.NewProcessingError("[extendBatch][%s] same-block parent extension failed", block.Hash().String(), extendErr)
 				}
+
 				if needsExternalLookup {
 					txsNeedingExtension = append(txsNeedingExtension, tx)
 				}

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1150,8 +1150,19 @@ func (u *BlockValidation) processSubtreeBatch(
 				for j, input := range tx.Inputs {
 					parentHash := input.PreviousTxIDChainHash()
 					if parentTx, ok := extendedTxsFromPrevBatches[*parentHash]; ok {
-						tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[input.PreviousTxOutIndex].Satoshis
-						tx.Inputs[j].PreviousTxScript = parentTx.Outputs[input.PreviousTxOutIndex].LockingScript
+						// PreviousTxOutIndex comes from the (untrusted) child tx; bound it
+						// against the same-block parent's output count before indexing, else a
+						// crafted block panics the node with index-out-of-range (issue 1283).
+						// Mirrors the guard in services/validator/Validator.go extendTransaction.
+						vout := input.PreviousTxOutIndex
+						if parentTx.Outputs == nil || int(vout) >= len(parentTx.Outputs) {
+							cancelReaders()
+							return nil, errors.NewProcessingError("[processSubtreeBatch][%s] tx %s input %d references non-existent output %d of same-block parent %s",
+								block.Hash().String(), tx.TxIDChainHash().String(), j, vout, parentHash.String())
+						}
+
+						tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[vout].Satoshis
+						tx.Inputs[j].PreviousTxScript = parentTx.Outputs[vout].LockingScript
 					} else {
 						needsExternalLookup = true
 					}
@@ -1600,8 +1611,18 @@ func (u *BlockValidation) extendBatch(
 				for j, input := range tx.Inputs {
 					parentHash := input.PreviousTxIDChainHash()
 					if parentTx, ok := extendedTxs[*parentHash]; ok {
-						tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[input.PreviousTxOutIndex].Satoshis
-						tx.Inputs[j].PreviousTxScript = parentTx.Outputs[input.PreviousTxOutIndex].LockingScript
+						// PreviousTxOutIndex comes from the (untrusted) child tx; bound it
+						// against the same-block parent's output count before indexing, else a
+						// crafted block panics the node with index-out-of-range (issue 1283).
+						// Mirrors the guard in services/validator/Validator.go extendTransaction.
+						vout := input.PreviousTxOutIndex
+						if parentTx.Outputs == nil || int(vout) >= len(parentTx.Outputs) {
+							return errors.NewProcessingError("[extendBatch][%s] tx %s input %d references non-existent output %d of same-block parent %s",
+								block.Hash().String(), tx.TxIDChainHash().String(), j, vout, parentHash.String())
+						}
+
+						tx.Inputs[j].PreviousTxSatoshis = parentTx.Outputs[vout].Satoshis
+						tx.Inputs[j].PreviousTxScript = parentTx.Outputs[vout].LockingScript
 					} else {
 						needsExternalLookup = true
 					}

--- a/services/blockvalidation/quick_validate_test.go
+++ b/services/blockvalidation/quick_validate_test.go
@@ -338,6 +338,47 @@ func TestCreateAndSpendUTXOsForBatch_UpdatesExistingTransactions(t *testing.T) {
 	})
 }
 
+// TestExtendBatch_SameBlockParentVoutBounds is the regression guard for issue 1283:
+// a same-block-parent input whose PreviousTxOutIndex is out of range must fail the
+// block cleanly instead of panicking with index-out-of-range.
+func TestExtendBatch_SameBlockParentVoutBounds(t *testing.T) {
+	// Parent with a single output: vout 0 is valid, anything >= 1 is out of range.
+	parent := bt.NewTx()
+	parent.Outputs = append(parent.Outputs, &bt.Output{Satoshis: 1000, LockingScript: &bscript.Script{}})
+	parentHash := *parent.TxIDChainHash()
+
+	// newChild builds a non-extended child (nil PreviousTxScript) referencing the
+	// same-block parent at the given vout.
+	newChild := func(t *testing.T, vout uint32) *bt.Tx {
+		t.Helper()
+		child := bt.NewTx()
+		in := &bt.Input{PreviousTxOutIndex: vout}
+		require.NoError(t, in.PreviousTxIDAdd(&parentHash))
+		child.Inputs = append(child.Inputs, in)
+		require.False(t, child.IsExtended(), "child must be non-extended to exercise the extend path")
+		return child
+	}
+
+	extendedTxs := map[chainhash.Hash]*bt.Tx{parentHash: parent}
+
+	suite := NewCatchupTestSuite(t)
+	defer suite.Cleanup()
+
+	block := testhelpers.CreateTestBlocks(t, 1)[0]
+
+	batch := &SubtreeProcessingBatch{
+		subtreeData: []*subtreepkg.Data{{Txs: []*bt.Tx{newChild(t, 5)}}}, // vout 5 on a 1-output parent
+		batchStart:  0,
+		batchEnd:    1,
+	}
+
+	// Before the fix this panicked with index-out-of-range; now it must return a
+	// clean per-block error.
+	err := suite.Server.blockValidation.extendBatch(suite.Ctx, block, batch, extendedTxs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-existent output")
+}
+
 func TestQuickValidateBlock_IncompleteBlockNilCoinbase(t *testing.T) {
 	t.Run("nil coinbase returns ErrBlockIncomplete", func(t *testing.T) {
 		suite := NewCatchupTestSuite(t)

--- a/services/blockvalidation/quick_validate_test.go
+++ b/services/blockvalidation/quick_validate_test.go
@@ -338,9 +338,70 @@ func TestCreateAndSpendUTXOsForBatch_UpdatesExistingTransactions(t *testing.T) {
 	})
 }
 
-// TestExtendBatch_SameBlockParentVoutBounds is the regression guard for issue 1283:
-// a same-block-parent input whose PreviousTxOutIndex is out of range must fail the
-// block cleanly instead of panicking with index-out-of-range.
+// TestExtendTxFromSameBlockParents covers the shared same-block-parent extend
+// helper, including the issue 1283 bounds check that turns an out-of-range vout
+// into an error instead of an index-out-of-range panic.
+func TestExtendTxFromSameBlockParents(t *testing.T) {
+	// Parent with two outputs: vout 0 and 1 are valid, >= 2 is out of range.
+	parent := bt.NewTx()
+	parent.Outputs = append(parent.Outputs,
+		&bt.Output{Satoshis: 1000, LockingScript: &bscript.Script{}},
+		&bt.Output{Satoshis: 2000, LockingScript: &bscript.Script{}},
+	)
+	parentHash := *parent.TxIDChainHash()
+
+	childWithVout := func(t *testing.T, vout uint32, parentID chainhash.Hash) *bt.Tx {
+		t.Helper()
+		child := bt.NewTx()
+		in := &bt.Input{PreviousTxOutIndex: vout}
+		require.NoError(t, in.PreviousTxIDAdd(&parentID))
+		child.Inputs = append(child.Inputs, in)
+		require.False(t, child.IsExtended(), "child must be non-extended to exercise the extend path")
+		return child
+	}
+
+	parents := map[chainhash.Hash]*bt.Tx{parentHash: parent}
+
+	t.Run("in-range vout extends the input", func(t *testing.T) {
+		child := childWithVout(t, 1, parentHash)
+
+		needsExternal, err := extendTxFromSameBlockParents(child, parents)
+		require.NoError(t, err)
+		require.False(t, needsExternal)
+		require.Equal(t, uint64(2000), child.Inputs[0].PreviousTxSatoshis)
+		require.NotNil(t, child.Inputs[0].PreviousTxScript)
+	})
+
+	t.Run("out-of-range vout returns error, no panic", func(t *testing.T) {
+		child := childWithVout(t, 2, parentHash) // parent only has outputs 0 and 1
+
+		_, err := extendTxFromSameBlockParents(child, parents)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-existent output")
+	})
+
+	t.Run("parent absent from map needs external lookup", func(t *testing.T) {
+		child := childWithVout(t, 0, parentHash)
+
+		needsExternal, err := extendTxFromSameBlockParents(child, map[chainhash.Hash]*bt.Tx{})
+		require.NoError(t, err)
+		require.True(t, needsExternal)
+	})
+
+	t.Run("parent with no outputs returns error", func(t *testing.T) {
+		emptyParent := bt.NewTx()
+		emptyHash := *emptyParent.TxIDChainHash()
+		child := childWithVout(t, 0, emptyHash)
+
+		_, err := extendTxFromSameBlockParents(child, map[chainhash.Hash]*bt.Tx{emptyHash: emptyParent})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-existent output")
+	})
+}
+
+// TestExtendBatch_SameBlockParentVoutBounds is the end-to-end regression guard for
+// issue 1283: a same-block-parent input whose PreviousTxOutIndex is out of range
+// must fail the block cleanly instead of panicking with index-out-of-range.
 func TestExtendBatch_SameBlockParentVoutBounds(t *testing.T) {
 	// Parent with a single output: vout 0 is valid, anything >= 1 is out of range.
 	parent := bt.NewTx()
@@ -375,6 +436,71 @@ func TestExtendBatch_SameBlockParentVoutBounds(t *testing.T) {
 	// Before the fix this panicked with index-out-of-range; now it must return a
 	// clean per-block error.
 	err := suite.Server.blockValidation.extendBatch(suite.Ctx, block, batch, extendedTxs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-existent output")
+}
+
+// TestProcessSubtreeBatch_SameBlockParentVoutBounds drives the SEQUENTIAL
+// quick-validation path (processBlockSubtrees -> processBlockSubtreesSequential ->
+// processSubtreeBatch) through the issue 1283 bounds-check error branch.
+//
+// The crafted subtree holds a same-block PARENT tx (1 output) followed by a
+// non-extended CHILD tx whose input references the parent at vout 5 (out of
+// range). processSubtreeBatch builds its in-batch parent map as it iterates the
+// subtree's Txs, so the parent (Txs[1], after the coinbase at Txs[0]) is in the
+// map by the time the child (Txs[2]) is extended. extendTxFromSameBlockParents
+// then returns the "non-existent output" error, which processSubtreeBatch wraps
+// as "same-block parent extension failed". Before the fix this panicked with
+// index-out-of-range; now it must return a clean per-block error.
+func TestProcessSubtreeBatch_SameBlockParentVoutBounds(t *testing.T) {
+	suite := NewCatchupTestSuite(t)
+	defer suite.Cleanup()
+
+	// Force the sequential path (processSubtreeBatch) rather than the pipeline.
+	suite.Server.blockValidation.settings.BlockValidation.SubtreeBatchPrefetchDepth = 0
+
+	// Real coinbase for Txs[0] (readSubtree requires subtree 0, index 0 to be a coinbase).
+	coinbaseTx := transactions.CreateTestTransactionChainWithCount(t, 2)[0]
+
+	// Same-block parent with a single output: vout 0 is valid, anything >= 1 is out of range.
+	parent := bt.NewTx()
+	parent.Outputs = append(parent.Outputs, &bt.Output{Satoshis: 1000, LockingScript: &bscript.Script{}})
+
+	// Non-extended child whose only input references the parent at vout 5 (out of range).
+	child := bt.NewTx()
+	in := &bt.Input{PreviousTxOutIndex: 5}
+	require.NoError(t, in.PreviousTxIDAdd(parent.TxIDChainHash()))
+	child.Inputs = append(child.Inputs, in)
+	require.False(t, child.IsExtended(), "child must be non-extended to exercise the extend path")
+
+	block := testhelpers.CreateTestBlocks(t, 1)[0]
+	block.CoinbaseTx = coinbaseTx
+
+	// Subtree nodes: coinbase, parent, child (order must match the subtree data below).
+	subtree, err := subtreepkg.NewIncompleteTreeByLeafCount(3)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	require.NoError(t, subtree.AddNode(*parent.TxIDChainHash(), 1, 1))
+	require.NoError(t, subtree.AddNode(*child.TxIDChainHash(), 2, 2))
+
+	subtreeBytes, err := subtree.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, suite.Server.subtreeStore.Set(suite.Ctx, subtree.RootHash()[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes))
+
+	subtreeData := subtreepkg.NewSubtreeData(subtree)
+	require.NoError(t, subtreeData.AddTx(coinbaseTx, 0))
+	require.NoError(t, subtreeData.AddTx(parent, 1)) // parent before child so it lands in the in-batch map
+	require.NoError(t, subtreeData.AddTx(child, 2))
+	subtreeDataBytes, err := subtreeData.Serialize()
+	require.NoError(t, err)
+	require.NoError(t, suite.Server.subtreeStore.Set(suite.Ctx, subtree.RootHash()[:], fileformat.FileTypeSubtreeData, subtreeDataBytes))
+
+	block.Subtrees = []*chainhash.Hash{subtree.RootHash()}
+
+	// Must return a clean error (not panic) whose chain mentions the out-of-range output.
+	require.NotPanics(t, func() {
+		_, err = suite.Server.blockValidation.processBlockSubtrees(suite.Ctx, block, false)
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-existent output")
 }


### PR DESCRIPTION
## Problem

Closes #1283.

The two same-block-parent fast paths in quick validation index `parentTx.Outputs[input.PreviousTxOutIndex]` with no bounds check, and `PreviousTxOutIndex` (vout) comes straight from an untrusted child transaction:

- `services/blockvalidation/quick_validate.go` `processSubtreeBatch` (via `extendedTxsFromPrevBatches`)
- `services/blockvalidation/quick_validate.go` `extendBatch` (via `extendedTxs`)

A peer-served below-checkpoint block whose child input references a non-existent vout of a same-block parent triggers `index out of range` and panics the node during catchup/IBD, before the post-processing merkle-root check can reject the block.

## Change

Guard both sites with a width-safe bounds check (`parentTx.Outputs == nil || int(vout) >= len(parentTx.Outputs)`) that returns a `ProcessingError`, converting the panic into a clean per-block validation failure. A valid checkpointed block never has an out-of-range vout, so no legitimate path changes behaviour. This mirrors the guard already in `services/validator/Validator.go` `extendTransaction` (from #1243 / #1275), which does not cover these two catchup-path sites. The `processSubtreeBatch` guard cancels the reader errgroup before returning so its context is not leaked.

## Testing

- New regression test `TestExtendBatch_SameBlockParentVoutBounds` exercises a non-extended child referencing an out-of-range vout of a same-block parent; it panics on the pre-fix code and returns a clean error with the fix.
- `go vet` clean; the broader quick-validate / batch test suite passes.