### PR TITLE
fix(uaerospike): make overload-retry backoff cancellable on Close

### DIFF
--- a/util/uaerospike/client.go
+++ b/util/uaerospike/client.go
@@ -218,6 +218,14 @@ type Client struct {
 	// isn't warranted here; revisit if a scan is ever added to a shutdown-critical
 	// path.
 	drainMu sync.RWMutex
+
+	// closed is signalled by Close to abort in-flight overload-retry backoff so a
+	// shutdown is not stalled for up to the retry budget (maxElapsed) while a
+	// BatchOperate is parked in backoff holding the drain RLock. closeOnce guards
+	// the single close. A zero-value Client leaves closed nil, which simply means
+	// the backoff runs to completion (such clients are never Close()d).
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 // beginOp registers an in-flight BatchOperate, blocking a concurrent Close from
@@ -252,6 +260,14 @@ func (c *Client) endOp() { c.drainMu.RUnlock() }
 //     the one being closed. If that path ever becomes reachable under load, close
 //     outside the mutex (snapshot+delete under lock, Close after unlock).
 func (c *Client) Close() {
+	// Signal any in-flight overload-retry backoff to abort BEFORE blocking on the
+	// drain lock. A BatchOperate parked in backoff holds the drain RLock, so
+	// without this signal Close would wait out the full retry budget (maxElapsed,
+	// ~2 min by default) before acquiring the exclusive Lock.
+	if c.closed != nil {
+		c.closeOnce.Do(func() { close(c.closed) })
+	}
+
 	c.drainMu.Lock()
 	defer c.drainMu.Unlock()
 
@@ -281,6 +297,7 @@ func NewClient(hostname string, port int, opts ...ClientOption) (*Client, error)
 		stats:         NewClientStats(),
 		overloadRetry: cfg.overloadRetry,
 		logger:        cfg.logger,
+		closed:        make(chan struct{}),
 	}, nil
 }
 
@@ -353,6 +370,7 @@ func NewClientWithPolicyAndHostOpts(policy *aerospike.ClientPolicy, hosts []*aer
 		stats:         NewClientStats(),
 		overloadRetry: cfg.overloadRetry,
 		logger:        cfg.logger,
+		closed:        make(chan struct{}),
 	}, nil
 }
 

--- a/util/uaerospike/overload_retry.go
+++ b/util/uaerospike/overload_retry.go
@@ -121,6 +121,19 @@ func isOverloadError(err aerospike.Error) bool {
 // each backoff sleep and re-acquired before the retry: the server isn't
 // seeing the op while we sleep, so holding the slot would only starve other
 // callers (see the loop body and reacquirePermit).
+// sleepOrAbort waits for d, or returns true early if the client is being closed.
+// A true return tells the overload-retry loop to stop retrying so shutdown is not
+// stalled for the remaining retry budget. A nil closed channel (zero-value Client
+// that is never Close()d) makes the select fall through to the full wait.
+func (c *Client) sleepOrAbort(d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return false
+	case <-c.closed:
+		return true
+	}
+}
+
 func (c *Client) retryOnOverload(do func() aerospike.Error) aerospike.Error {
 	err := do()
 	if err == nil || !isOverloadError(err) || !c.overloadRetry.enabled() {
@@ -154,8 +167,15 @@ func (c *Client) retryOnOverload(do func() aerospike.Error) aerospike.Error {
 		// other callers (turning sustained overload into an ErrTimeout storm).
 		// Re-take it (blocking, never timing out) before the retry.
 		c.releasePermit()
-		time.Sleep(wait)
+		aborted := c.sleepOrAbort(wait)
 		c.reacquirePermit()
+
+		// Stop retrying if Close fired during the backoff: keep the permit
+		// balanced (release/reacquire stay paired) and surface the last error.
+		if aborted {
+			c.logOverloadGiveUp(attempt, err)
+			return err
+		}
 
 		backoff = retry.CappedExponentialBackoff(backoff, overloadRetryBackoffFactor, c.overloadRetry.maxBackoff)
 
@@ -232,8 +252,15 @@ func (c *Client) retryBatchOnOverload(records []aerospike.BatchRecordIfc, do fun
 		// holding it during the sleep only starves other callers. Re-take it
 		// (blocking, never timing out) before the retry.
 		c.releasePermit()
-		time.Sleep(wait)
+		aborted := c.sleepOrAbort(wait)
 		c.reacquirePermit()
+
+		// Stop retrying if Close fired during the backoff: keep the permit
+		// balanced (release/reacquire stay paired) and surface the last error.
+		if aborted {
+			c.logOverloadGiveUp(attempt, logErr)
+			return batchOverloadError(err, failed)
+		}
 
 		backoff = retry.CappedExponentialBackoff(backoff, overloadRetryBackoffFactor, c.overloadRetry.maxBackoff)
 

--- a/util/uaerospike/overload_retry_test.go
+++ b/util/uaerospike/overload_retry_test.go
@@ -481,3 +481,67 @@ func TestRetryBatchOnOverload(t *testing.T) {
 		require.Equal(t, 1, calls)
 	})
 }
+
+// TestRetryOnOverload_AbortsOnClose is the regression guard for issue 1270: a
+// retry loop parked in overload backoff must return promptly when Close signals
+// shutdown, rather than running out the full maxElapsed budget.
+func TestRetryOnOverload_AbortsOnClose(t *testing.T) {
+	t.Run("single-record retry aborts", func(t *testing.T) {
+		// Long budget so a non-cancellable loop would run for ~2 minutes.
+		c := newOverloadTestClient(2*time.Minute, 100*time.Millisecond, 500*time.Millisecond)
+		c.closed = make(chan struct{})
+
+		done := make(chan aerospike.Error, 1)
+		start := time.Now()
+
+		go func() {
+			done <- c.retryOnOverload(func() aerospike.Error {
+				return overloadErr(types.DEVICE_OVERLOAD) // never recovers
+			})
+		}()
+
+		time.Sleep(30 * time.Millisecond) // let it enter backoff
+		c.Close()
+
+		select {
+		case err := <-done:
+			require.True(t, err.Matches(types.DEVICE_OVERLOAD))
+			require.Less(t, time.Since(start), 5*time.Second,
+				"retry must abort on Close, not run the full maxElapsed budget")
+		case <-time.After(10 * time.Second):
+			t.Fatal("retryOnOverload did not return after Close")
+		}
+	})
+
+	t.Run("batch retry aborts", func(t *testing.T) {
+		c := newOverloadTestClient(2*time.Minute, 100*time.Millisecond, 500*time.Millisecond)
+		c.closed = make(chan struct{})
+
+		records := newTestBatchRecords(t, 2)
+		done := make(chan aerospike.Error, 1)
+		start := time.Now()
+
+		go func() {
+			done <- c.retryBatchOnOverload(records, func(recs []aerospike.BatchRecordIfc) aerospike.Error {
+				for _, rec := range recs {
+					// Mark every record overloaded so the loop never converges.
+					br := rec.BatchRec()
+					br.ResultCode = types.DEVICE_OVERLOAD
+					br.Err = overloadErr(types.DEVICE_OVERLOAD)
+				}
+				return overloadErr(types.DEVICE_OVERLOAD)
+			})
+		}()
+
+		time.Sleep(30 * time.Millisecond)
+		c.Close()
+
+		select {
+		case <-done:
+			require.Less(t, time.Since(start), 5*time.Second,
+				"batch retry must abort on Close, not run the full maxElapsed budget")
+		case <-time.After(10 * time.Second):
+			t.Fatal("retryBatchOnOverload did not return after Close")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Closes #1270.

The overload-retry loop (`retryOnOverload` / `retryBatchOnOverload`) backs off with a bare, uncancellable `time.Sleep(wait)` (`util/uaerospike/overload_retry.go`), and `BatchOperate` holds the drain read-lock for the whole loop (via `beginOp`/`endOp`). `Close()` takes the exclusive drain lock, so a `BatchOperate` parked in overload backoff makes `Close` block for up to the full retry budget (`maxElapsed`, ~2 min by default) before it can shut the client down. A plain context does not help, because the signal must fire *before* `Close` blocks on the lock.

## Change

- Add a `closed` channel (guarded by `sync.Once`) to `Client`. `Close()` signals it **before** acquiring the drain `Lock`.
- Both retry loops replace `time.Sleep(wait)` with a `select` over `time.After(wait)` and `<-c.closed`; on close they stop retrying and return the last overload error.
- The connection-permit `releasePermit`/`reacquirePermit` stay paired across the wait so the semaphore is never imbalanced on the abort path.
- A zero-value `Client` (never `Close()`d, e.g. some unit tests) leaves the channel nil, so the `select` falls through to the full wait, preserving prior behaviour.

## Testing

- New `TestRetryOnOverload_AbortsOnClose` (single-record and batch variants): a loop parked in backoff with a 2-minute budget returns in well under 5s once `Close` fires. Verified load-bearing (both subtests time out on the pre-fix `time.Sleep`) and race-clean.
- Full `util/uaerospike` package passes under `-race`; `go vet` clean.