### PR TITLE
fix(blockvalidation): guard revalidateBlockChan sends against a stopped worker

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -230,6 +230,11 @@ type BlockValidation struct {
 	// revalidateBlockChan receives blocks that need revalidation
 	revalidateBlockChan chan revalidateBlockData
 
+	// revalidateWorkerStopped is closed when the single revalidateBlockChan
+	// consumer (started in start) exits, so producers can select on it and avoid
+	// blocking forever on a full channel after the worker is gone at shutdown.
+	revalidateWorkerStopped chan struct{}
+
 	// stats tracks operational metrics for monitoring
 	stats *gocore.Stat
 
@@ -377,6 +382,7 @@ func NewBlockValidation(ctx context.Context, logger ulogger.Logger, tSettings *s
 		setMinedOverflow:              make(map[chainhash.Hash]struct{}),
 		setMinedOverflowSignal:        make(chan struct{}, 1),
 		revalidateBlockChan:           make(chan revalidateBlockData, 2),
+		revalidateWorkerStopped:       make(chan struct{}),
 		stats:                         gocore.NewStat("blockvalidation"),
 		mmapDir:                       tSettings.BlockValidation.SubtreeMmapDir,
 	}
@@ -726,6 +732,9 @@ func (u *BlockValidation) start(ctx context.Context) error {
 	u.logger.Infof("[BlockValidation:start] starting reValidation goroutine")
 
 	go func() {
+		// Signal producers (site 1's re-enqueue and ReValidateBlock) that this sole
+		// consumer is gone, so they don't block forever on a full channel at shutdown.
+		defer close(u.revalidateWorkerStopped)
 		defer u.logger.Infof("[BlockValidation:start] revalidateBlockChan worker stopped")
 
 		for {
@@ -755,7 +764,13 @@ func (u *BlockValidation) start(ctx context.Context) error {
 					if blockData.retries < 3 {
 						blockData.retries++
 						go func() {
-							u.revalidateBlockChan <- blockData
+							// Guard the re-enqueue: on shutdown the consumer (this
+							// worker) exits, so an unguarded send would leak this
+							// goroutine forever on the full channel.
+							select {
+							case u.revalidateBlockChan <- blockData:
+							case <-ctx.Done():
+							}
 						}()
 					} else {
 						u.logger.Errorf("[BlockValidation:start][%s] failed block revalidation, retries exhausted: %s", blockData.block.String(), err)
@@ -2148,9 +2163,21 @@ func (u *BlockValidation) waitForPreviousBlocksToBeProcessed(ctx context.Context
 // No return value is provided as the operation is asynchronous.
 func (u *BlockValidation) ReValidateBlock(block *model.Block, baseURL string) {
 	u.logger.Errorf("[ValidateBlock][%s] re-validating block", block.String())
-	u.revalidateBlockChan <- revalidateBlockData{
-		block:   block,
-		baseURL: baseURL,
+
+	data := revalidateBlockData{block: block, baseURL: baseURL}
+
+	// Prefer an immediate enqueue whenever the channel has space (this also lets a
+	// stopped-worker test observe the routing decision). Only when the channel is
+	// full do we guard the blocking send: if the sole consumer has stopped
+	// (shutdown), drop rather than block the caller forever.
+	select {
+	case u.revalidateBlockChan <- data:
+	default:
+		select {
+		case u.revalidateBlockChan <- data:
+		case <-u.revalidateWorkerStopped:
+			u.logger.Warnf("[ReValidateBlock][%s] dropped: revalidation worker stopped", block.String())
+		}
 	}
 }
 

--- a/services/blockvalidation/revalidate_block_guard_test.go
+++ b/services/blockvalidation/revalidate_block_guard_test.go
@@ -1,0 +1,43 @@
+package blockvalidation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
+	"github.com/bsv-blockchain/teranode/ulogger"
+)
+
+// TestReValidateBlock_DoesNotBlockAfterWorkerStopped is the regression guard for
+// the remaining half of issue 1151: once the sole revalidateBlockChan consumer has
+// stopped (shutdown), ReValidateBlock must not block the caller forever on a full
+// channel — it drops the request via the revalidateWorkerStopped signal.
+func TestReValidateBlock_DoesNotBlockAfterWorkerStopped(t *testing.T) {
+	u := &BlockValidation{
+		logger:                  ulogger.TestLogger{},
+		revalidateBlockChan:     make(chan revalidateBlockData, 2),
+		revalidateWorkerStopped: make(chan struct{}),
+	}
+
+	// Fill the channel so any further send would block.
+	u.revalidateBlockChan <- revalidateBlockData{}
+	u.revalidateBlockChan <- revalidateBlockData{}
+
+	// Simulate the consumer having exited at shutdown.
+	close(u.revalidateWorkerStopped)
+
+	block := testhelpers.CreateTestBlocks(t, 1)[0]
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		u.ReValidateBlock(block, "")
+	}()
+
+	select {
+	case <-done:
+		// returned promptly — dropped instead of blocking
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReValidateBlock blocked after the revalidation worker stopped")
+	}
+}


### PR DESCRIPTION
## Problem

Closes #1151 (remaining half).

`revalidateBlockChan` (cap 2) has a single consumer started in `start(ctx)`. Two producers sent to it unguarded, so once that consumer exits at shutdown they could block forever on a full channel:
- the retry re-enqueue goroutine in the worker loop (`BlockValidation.go` ~`:763`) leaked a goroutine, and
- `ReValidateBlock` (`~:2151`) blocked its caller.

The issue's **primary** finding — the `setMinedChan` self-send deadlock — was already fixed (non-blocking `enqueueSetMined` + `setMinedOverflow` set). This PR closes the remaining `revalidateBlockChan` half.

## Change

- Add a `revalidateWorkerStopped` channel, closed via `defer` when the sole consumer exits.
- The retry re-enqueue now `select`s on `ctx.Done()` (the worker's own context), so it can't leak at shutdown.
- `ReValidateBlock` prefers a non-blocking send and only falls back to the worker-stopped guard when the channel is genuinely full — so a running node enqueues exactly as before, and only a stopped-worker + full-channel path drops (with a warning) instead of blocking the caller.

No change to validation behaviour; this only affects shutdown/blocking semantics.

## Testing

- New `TestReValidateBlock_DoesNotBlockAfterWorkerStopped`: fills the channel, closes the worker signal, and asserts `ReValidateBlock` returns promptly. Verified load-bearing (blocks/times out on the pre-fix unguarded send).
- The non-blocking-preferred send is required to keep `TestBlockValidation_OptimisticFloaterRetriedDuringCatchup` (issue #1031 regression guard) green — it reads `revalidateBlockChan` directly with the worker disabled, so the enqueue must still succeed when the channel has space.
- `go vet` and `gci` clean; revalidation/floater suite passes.