### PR TITLE
fix(p2p): wire invalid-blocks Kafka consumer exactly once

### DIFF
--- a/daemon/daemon_kafka.go
+++ b/daemon/daemon_kafka.go
@@ -186,6 +186,16 @@ func getKafkaTxmetaConsumerGroup(logger ulogger.Logger, settings *settings.Setti
 	return getKafkaConsumerGroup(logger, kafkaTxmetaConfig, consumerGroupID, true, &settings.Kafka)
 }
 
+// nonNilConsumerGroup returns the consumer group as an interface, mapping a
+// typed nil to a true nil so downstream nil checks behave correctly.
+func nonNilConsumerGroup(group *kafka.KafkaConsumerGroup) kafka.KafkaConsumerGroupI {
+	if group == nil {
+		return nil
+	}
+
+	return group
+}
+
 func getKafkaInvalidBlocksConsumerGroup(logger ulogger.Logger, settings *settings.Settings, consumerGroupID string) (*kafka.KafkaConsumerGroup, error) {
 	kafkaInvalidBlocksConfig := settings.Kafka.InvalidBlocksConfig
 	if kafkaInvalidBlocksConfig == nil {

--- a/daemon/daemon_kafka_test.go
+++ b/daemon/daemon_kafka_test.go
@@ -1,0 +1,18 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/util/kafka"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonNilConsumerGroup(t *testing.T) {
+	// A typed nil must map to a true nil interface so downstream nil checks
+	// (e.g. p2p's startInvalidBlocksConsumer) behave correctly.
+	require.Nil(t, nonNilConsumerGroup(nil))
+
+	group := &kafka.KafkaConsumerGroup{}
+	require.NotNil(t, nonNilConsumerGroup(group))
+	require.Same(t, group, nonNilConsumerGroup(group))
+}

--- a/daemon/daemon_services.go
+++ b/daemon/daemon_services.go
@@ -315,22 +315,21 @@ func (d *Daemon) startP2PService(ctx context.Context, appSettings *settings.Sett
 		return err
 	}
 
+	// These consumers are optional (nil when unconfigured): map typed nils to
+	// true nils so the server's nil checks behave correctly.
 	invalidBlocksKafkaConsumerGroup, err := getKafkaInvalidBlocksConsumerGroup(createLogger("kpib"), appSettings, serviceNameP2P+"."+appSettings.ClientName)
 	if err != nil {
 		return err
 	}
 
-	// Assign only a non-nil consumer group to the interface: a typed nil would
-	// make the server's nil checks pass and silently disable consumption.
-	var invalidBlocksKafkaConsumerClient kafka.KafkaConsumerGroupI
-	if invalidBlocksKafkaConsumerGroup != nil {
-		invalidBlocksKafkaConsumerClient = invalidBlocksKafkaConsumerGroup
-	}
+	invalidBlocksKafkaConsumerClient := nonNilConsumerGroup(invalidBlocksKafkaConsumerGroup)
 
-	invalidSubtreeKafkaConsumerClient, err := getKafkaInvalidSubtreeConsumerGroup(createLogger("kpis"), appSettings, serviceNameP2P+"."+appSettings.ClientName)
+	invalidSubtreeKafkaConsumerGroup, err := getKafkaInvalidSubtreeConsumerGroup(createLogger("kpis"), appSettings, serviceNameP2P+"."+appSettings.ClientName)
 	if err != nil {
 		return err
 	}
+
+	invalidSubtreeKafkaConsumerClient := nonNilConsumerGroup(invalidSubtreeKafkaConsumerGroup)
 
 	// Create Kafka producers for subtrees and blocks
 	var subtreeKafkaProducerClient *kafka.KafkaAsyncProducer

--- a/daemon/daemon_services.go
+++ b/daemon/daemon_services.go
@@ -315,9 +315,16 @@ func (d *Daemon) startP2PService(ctx context.Context, appSettings *settings.Sett
 		return err
 	}
 
-	invalidBlocksKafkaConsumerClient, err := getKafkaInvalidBlocksConsumerGroup(createLogger("kpib"), appSettings, serviceNameP2P+"."+appSettings.ClientName)
+	invalidBlocksKafkaConsumerGroup, err := getKafkaInvalidBlocksConsumerGroup(createLogger("kpib"), appSettings, serviceNameP2P+"."+appSettings.ClientName)
 	if err != nil {
 		return err
+	}
+
+	// Assign only a non-nil consumer group to the interface: a typed nil would
+	// make the server's nil checks pass and silently disable consumption.
+	var invalidBlocksKafkaConsumerClient kafka.KafkaConsumerGroupI
+	if invalidBlocksKafkaConsumerGroup != nil {
+		invalidBlocksKafkaConsumerClient = invalidBlocksKafkaConsumerGroup
 	}
 
 	invalidSubtreeKafkaConsumerClient, err := getKafkaInvalidSubtreeConsumerGroup(createLogger("kpis"), appSettings, serviceNameP2P+"."+appSettings.ClientName)

--- a/docs/references/services/p2p_reference.md
+++ b/docs/references/services/p2p_reference.md
@@ -35,7 +35,6 @@ type Server struct {
     blockTopicName                    string
     subtreeTopicName                  string
     rejectedTxTopicName               string
-    invalidBlocksTopicName            string             // Kafka topic for invalid blocks
     invalidSubtreeTopicName           string             // Kafka topic for invalid subtrees
     nodeStatusTopicName               string             // pubsub topic for node status messages
     topicPrefix                       string             // Chain identifier prefix for topic validation

--- a/docs/references/services/p2p_reference.md
+++ b/docs/references/services/p2p_reference.md
@@ -480,7 +480,7 @@ Records bytes downloaded from a peer via HTTP (typically from their DataHub).
 - `handleSubtreeTopic`: Handles incoming subtree messages and processes subtree data.
 - `handleRejectedTxTopic`: Handles rejected transaction notifications from peers.
 - `handleNodeStatusTopic`: Handles incoming node status update messages.
-- `invalidBlockHandler`: Processes notifications about invalid blocks from Kafka.
+- `processInvalidBlockMessage`: Processes notifications about invalid blocks from Kafka and bans the sending peer.
 - `invalidSubtreeHandler`: Processes notifications about invalid subtrees from Kafka.
 - `rejectedTxHandler`: Processes rejected transaction notifications from Kafka.
 

--- a/docs/references/settings/kafka_settings.md
+++ b/docs/references/settings/kafka_settings.md
@@ -252,9 +252,9 @@ This constraint is validated during consumer creation for both URL-based and dir
 
 ### P2P Service
 
-- Uses `InvalidBlocksConfig` or constructs URL from `InvalidBlocks`, `Hosts`, `Port`
+- Uses `InvalidBlocksConfig` (the consumer is disabled with an error log when unset)
 - Applies TLS settings from KafkaSettings
-- Consumer group: `{topic}-consumer`
+- Consumer group: `p2p.{clientName}`
 
 ### Legacy Service (TLS)
 

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -573,10 +573,7 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	s.rejectedTxKafkaConsumerClient.Start(ctx, s.rejectedTxHandler(ctx), kafka.WithLogErrorAndMoveOn())
 
 	// Handler for invalid blocks Kafka messages
-	if s.invalidBlocksKafkaConsumerClient != nil {
-		s.logger.Infof("[Start] Starting invalid blocks Kafka consumer on topic: %s", s.invalidBlocksTopicName)
-		s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithLogErrorAndMoveOn())
-	}
+	s.startInvalidBlocksConsumer(ctx)
 
 	// Handler for invalid subtrees Kafka messages
 	if s.invalidSubtreeKafkaConsumerClient != nil {

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -575,7 +575,7 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 	// Handler for invalid blocks Kafka messages
 	if s.invalidBlocksKafkaConsumerClient != nil {
 		s.logger.Infof("[Start] Starting invalid blocks Kafka consumer on topic: %s", s.invalidBlocksTopicName)
-		s.invalidBlocksKafkaConsumerClient.Start(ctx, s.invalidBlockHandler(ctx), kafka.WithLogErrorAndMoveOn())
+		s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithLogErrorAndMoveOn())
 	}
 
 	// Handler for invalid subtrees Kafka messages
@@ -648,11 +648,6 @@ func (s *Server) Start(ctx context.Context, readyCh chan<- struct{}) error {
 
 	// disconnect any pre-existing banned peers at startup
 	go s.disconnectPreExistingBannedPeers(ctx)
-
-	// start the invalid blocks consumer
-	if err := s.startInvalidBlockConsumer(ctx); err != nil {
-		return errors.NewServiceError("failed to start invalid blocks consumer", err)
-	}
 
 	// Start periodic cleanup of peer maps
 	s.startPeerMapCleanup(ctx)
@@ -741,40 +736,6 @@ func (s *Server) invalidSubtreeHandler(ctx context.Context) func(msg *kafka.Kafk
 			// Don't return error here, as we want to continue processing messages
 			s.logger.Errorf("[invalidSubtreeHandler] Failed to report invalid subtree from Kafka: %v", err)
 		}
-
-		return nil
-	}
-}
-
-func (s *Server) invalidBlockHandler(ctx context.Context) func(msg *kafka.KafkaMessage) error {
-	return func(msg *kafka.KafkaMessage) error {
-		var (
-			syncing bool
-			err     error
-		)
-
-		if syncing, err = s.isBlockchainSyncingOrCatchingUp(ctx); err != nil {
-			return err
-		}
-
-		if syncing {
-			return nil
-		}
-
-		var m kafkamessage.KafkaInvalidBlockTopicMessage
-		if err := proto.Unmarshal(msg.Value, &m); err != nil {
-			s.logger.Errorf("[invalidBlockHandler] error unmarshalling invalidBlocksMessage: %v", err)
-			return err
-		}
-
-		s.logger.Infof("[invalidBlockHandler] Received invalid block notification via Kafka: %s, reason: %s", m.BlockHash, m.Reason)
-
-		// Use the existing ReportInvalidBlock method to handle the invalid block
-		/*err = s.ReportInvalidBlock(ctx, m.BlockHash, m.Reason)
-		if err != nil {
-			// Don't return error here, as we want to continue processing messages
-			s.logger.Errorf("[invalidBlockHandler] Failed to report invalid block from Kafka: %v", err)
-		}*/
 
 		return nil
 	}

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -127,7 +127,6 @@ type Server struct {
 	blockTopicName                    string
 	subtreeTopicName                  string
 	rejectedTxTopicName               string
-	invalidBlocksTopicName            string                         // Kafka topic for invalid blocks
 	invalidSubtreeTopicName           string                         // Kafka topic for invalid subtrees
 	nodeStatusTopicName               string                         // pubsub topic for node status messages
 	topicPrefix                       string                         // Chain identifier prefix for topic validation
@@ -404,7 +403,6 @@ func NewServer(
 		blockTopicName:                    fmt.Sprintf("%s-%s", topicPrefix, blockTopic),
 		subtreeTopicName:                  fmt.Sprintf("%s-%s", topicPrefix, subtreeTopic),
 		rejectedTxTopicName:               fmt.Sprintf("%s-%s", topicPrefix, rejectedTxTopic),
-		invalidBlocksTopicName:            tSettings.Kafka.InvalidBlocks,
 		invalidSubtreeTopicName:           tSettings.Kafka.InvalidSubtrees,
 		nodeStatusTopicName:               fmt.Sprintf("%s-%s", topicPrefix, nodeStatusTopic),
 		topicPrefix:                       topicPrefix,

--- a/services/p2p/invalid_blocks_consumer_test.go
+++ b/services/p2p/invalid_blocks_consumer_test.go
@@ -52,7 +52,6 @@ func TestStartInvalidBlocksConsumer_BansPeer(t *testing.T) {
 	require.NoError(t, err)
 
 	s.invalidBlocksKafkaConsumerClient = consumer
-	s.invalidBlocksTopicName = topic
 
 	defer func() {
 		require.NoError(t, s.invalidBlocksKafkaConsumerClient.Close())
@@ -105,11 +104,13 @@ func TestProcessInvalidBlockMessage_UnknownBlockIsNotAnError(t *testing.T) {
 	require.Zero(t, info.BanScore, "no ban score must be added when no peer sent the block")
 }
 
-func TestProcessInvalidBlockMessage_UnmarshalErrorIsReturned(t *testing.T) {
+func TestProcessInvalidBlockMessage_MalformedMessageIsSkipped(t *testing.T) {
 	s, _ := newServerWithLocalRegistry(t)
 
+	// A malformed message can never succeed on retry: it must be logged and
+	// skipped, not returned as an error the consumer would retry.
 	err := s.processInvalidBlockMessage(&kafka.KafkaMessage{Value: []byte("not a protobuf message")})
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 type failingBanScoreRegistry struct {
@@ -135,5 +136,5 @@ func TestProcessInvalidBlockMessage_AddBanScoreErrorIsReturned(t *testing.T) {
 	require.Error(t, err)
 
 	_, stillThere := s.blockPeerMap.Load(blockHash)
-	require.True(t, stillThere, "entry must be kept so a retry can still ban the peer")
+	require.True(t, stillThere, "entry must be kept so the consumer's in-process retries can still ban the peer")
 }

--- a/services/p2p/invalid_blocks_consumer_test.go
+++ b/services/p2p/invalid_blocks_consumer_test.go
@@ -1,10 +1,12 @@
 package p2p
 
 import (
+	"context"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/kafka"
@@ -14,10 +16,21 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer guards the wiring in
-// Start(): the injected invalid-blocks consumer is the only consumer and runs
+func mustMarshalInvalidBlockMsg(t *testing.T, blockHash, reason string) []byte {
+	t.Helper()
+
+	msgBytes, err := proto.Marshal(&kafkamessage.KafkaInvalidBlockTopicMessage{
+		BlockHash: blockHash,
+		Reason:    reason,
+	})
+	require.NoError(t, err)
+	return msgBytes
+}
+
+// TestStartInvalidBlocksConsumer_BansPeer guards the wiring in Start(): the
+// injected invalid-blocks consumer is the only consumer and runs
 // processInvalidBlockMessage, which bans the peer that sent the block.
-func TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer(t *testing.T) {
+func TestStartInvalidBlocksConsumer_BansPeer(t *testing.T) {
 	ctx := t.Context()
 
 	s, reg := newServerWithLocalRegistry(t)
@@ -39,6 +52,7 @@ func TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer(t *testing.T) {
 	require.NoError(t, err)
 
 	s.invalidBlocksKafkaConsumerClient = consumer
+	s.invalidBlocksTopicName = topic
 
 	defer func() {
 		require.NoError(t, s.invalidBlocksKafkaConsumerClient.Close())
@@ -48,18 +62,14 @@ func TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer(t *testing.T) {
 	blockHash := "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b"
 	s.storePeerMapEntry(&s.blockPeerMap, blockHash, pid.String(), time.Now())
 
-	// Same wiring as Server.Start: the injected consumer runs the real handler.
-	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithLogErrorAndMoveOn())
+	// The same call Server.Start makes to wire the consumer.
+	s.startInvalidBlocksConsumer(ctx)
 
 	require.Eventually(t, func() bool {
 		return inmemorykafka.GetSharedBroker().HasConsumer(topic)
 	}, 5*time.Second, 10*time.Millisecond, "in-memory consumer never subscribed")
 
-	msgBytes, err := proto.Marshal(&kafkamessage.KafkaInvalidBlockTopicMessage{
-		BlockHash: blockHash,
-		Reason:    "invalid block for wiring test",
-	})
-	require.NoError(t, err)
+	msgBytes := mustMarshalInvalidBlockMsg(t, blockHash, "invalid block for wiring test")
 	require.NoError(t, inmemorykafka.GetSharedBroker().Produce(ctx, topic, nil, msgBytes))
 
 	require.Eventually(t, func() bool {
@@ -69,4 +79,61 @@ func TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer(t *testing.T) {
 		info, ok := reg.Get(pid.String())
 		return ok && info.BanScore > 0
 	}, 5*time.Second, 10*time.Millisecond, "message was not processed by the real invalid-block handler")
+}
+
+func TestStartInvalidBlocksConsumer_NilConsumerIsNoOp(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+	require.Nil(t, s.invalidBlocksKafkaConsumerClient)
+
+	// Must not panic when no consumer was injected (InvalidBlocksConfig unset).
+	s.startInvalidBlocksConsumer(t.Context())
+}
+
+func TestProcessInvalidBlockMessage_UnknownBlockIsNotAnError(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+	pid := mustNewPeerID(t)
+	reg.Register(&blockchain.PeerInfo{ID: pid.String()})
+
+	msgBytes := mustMarshalInvalidBlockMsg(t, "0000000000000000000000000000000000000000000000000000000000000000", "no peer mapped")
+
+	// No blockPeerMap entry: there is no peer to ban, which is not an error.
+	err := s.processInvalidBlockMessage(&kafka.KafkaMessage{Value: msgBytes})
+	require.NoError(t, err)
+
+	info, ok := reg.Get(pid.String())
+	require.True(t, ok)
+	require.Zero(t, info.BanScore, "no ban score must be added when no peer sent the block")
+}
+
+func TestProcessInvalidBlockMessage_UnmarshalErrorIsReturned(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+
+	err := s.processInvalidBlockMessage(&kafka.KafkaMessage{Value: []byte("not a protobuf message")})
+	require.Error(t, err)
+}
+
+type failingBanScoreRegistry struct {
+	blockchain.PeerRegistryClientI
+	err error
+}
+
+func (f *failingBanScoreRegistry) AddBanScore(_ context.Context, _ string, _ string, _ int32) (int32, bool, error) {
+	return 0, false, f.err
+}
+
+func TestProcessInvalidBlockMessage_AddBanScoreErrorIsReturned(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+	pid := mustNewPeerID(t)
+	s.peerRegistry = &failingBanScoreRegistry{err: errors.NewServiceError("registry down")}
+
+	blockHash := "2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c"
+	s.storePeerMapEntry(&s.blockPeerMap, blockHash, pid.String(), time.Now())
+
+	msgBytes := mustMarshalInvalidBlockMsg(t, blockHash, "registry failure")
+
+	err := s.processInvalidBlockMessage(&kafka.KafkaMessage{Value: msgBytes})
+	require.Error(t, err)
+
+	_, stillThere := s.blockPeerMap.Load(blockHash)
+	require.True(t, stillThere, "entry must be kept so a retry can still ban the peer")
 }

--- a/services/p2p/invalid_blocks_consumer_test.go
+++ b/services/p2p/invalid_blocks_consumer_test.go
@@ -1,0 +1,72 @@
+package p2p
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/kafka"
+	inmemorykafka "github.com/bsv-blockchain/teranode/util/kafka/in_memory_kafka"
+	kafkamessage "github.com/bsv-blockchain/teranode/util/kafka/kafka_message"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer guards the wiring in
+// Start(): the injected invalid-blocks consumer is the only consumer and runs
+// processInvalidBlockMessage, which bans the peer that sent the block.
+func TestInvalidBlocksConsumer_BansPeerViaInjectedConsumer(t *testing.T) {
+	ctx := t.Context()
+
+	s, reg := newServerWithLocalRegistry(t)
+	pid := mustNewPeerID(t)
+	reg.Register(&blockchain.PeerInfo{ID: pid.String()})
+
+	const topic = "invalid-blocks-wiring-test"
+
+	kafkaURL, err := url.Parse("memory://localhost:9092/" + topic)
+	require.NoError(t, err)
+
+	consumer, err := kafka.NewKafkaConsumerGroup(kafka.KafkaConsumerConfig{
+		Logger:            ulogger.TestLogger{},
+		URL:               kafkaURL,
+		Topic:             topic,
+		ConsumerGroupID:   "p2p." + topic,
+		AutoCommitEnabled: true,
+	})
+	require.NoError(t, err)
+
+	s.invalidBlocksKafkaConsumerClient = consumer
+
+	defer func() {
+		require.NoError(t, s.invalidBlocksKafkaConsumerClient.Close())
+		inmemorykafka.GetSharedBroker().DropTopic(topic)
+	}()
+
+	blockHash := "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b"
+	s.storePeerMapEntry(&s.blockPeerMap, blockHash, pid.String(), time.Now())
+
+	// Same wiring as Server.Start: the injected consumer runs the real handler.
+	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithLogErrorAndMoveOn())
+
+	require.Eventually(t, func() bool {
+		return inmemorykafka.GetSharedBroker().HasConsumer(topic)
+	}, 5*time.Second, 10*time.Millisecond, "in-memory consumer never subscribed")
+
+	msgBytes, err := proto.Marshal(&kafkamessage.KafkaInvalidBlockTopicMessage{
+		BlockHash: blockHash,
+		Reason:    "invalid block for wiring test",
+	})
+	require.NoError(t, err)
+	require.NoError(t, inmemorykafka.GetSharedBroker().Produce(ctx, topic, nil, msgBytes))
+
+	require.Eventually(t, func() bool {
+		if _, stillThere := s.blockPeerMap.Load(blockHash); stillThere {
+			return false
+		}
+		info, ok := reg.Get(pid.String())
+		return ok && info.BanScore > 0
+	}, 5*time.Second, 10*time.Millisecond, "message was not processed by the real invalid-block handler")
+}

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -617,19 +617,21 @@ func (s *Server) updateStorage(peerID peer.ID, mode string) {
 // this, so Stop() closes the consumer that is actually running.
 func (s *Server) startInvalidBlocksConsumer(ctx context.Context) {
 	if s.invalidBlocksKafkaConsumerClient == nil {
-		s.logger.Warnf("[startInvalidBlocksConsumer] invalid-blocks Kafka consumer not configured (kafka_invalidBlocksConfig unset), peers will not be banned for invalid blocks")
+		s.logger.Errorf("[startInvalidBlocksConsumer] invalid-blocks Kafka consumer not configured (kafka_invalidBlocksConfig unset), peers will not be banned for invalid blocks")
 		return
 	}
 
-	s.logger.Infof("[startInvalidBlocksConsumer] starting invalid blocks Kafka consumer")
-	// Transient handler failures (e.g. peer registry unavailable) are retried
-	// in process with backoff before the offset is committed; after the retries
-	// are exhausted the message is skipped so it cannot stall the partition.
-	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithRetryAndMoveOn(3, 2, time.Second))
+	s.logger.Infof("[startInvalidBlocksConsumer] starting invalid blocks Kafka consumer on topic: %s", s.settings.Kafka.InvalidBlocks)
+	// Transient handler failures (e.g. peer registry unavailable) get two
+	// retries with backoff (three attempts total) before the offset is
+	// committed; after that the message is skipped so it cannot stall the
+	// partition.
+	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithRetryAndMoveOn(2, 2, time.Second))
 }
 
 func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
-	ctx := context.Background()
+	// Use the server context so an in-flight AddBanScore is cancelled at shutdown.
+	ctx := s.gCtx
 
 	var invalidBlockMsg kafkamessage.KafkaInvalidBlockTopicMessage
 	if err := proto.Unmarshal(message.Value, &invalidBlockMsg); err != nil {
@@ -656,7 +658,7 @@ func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
 
 	req := &p2p_api.AddBanScoreRequest{
 		PeerId: peerID,
-		Reason: "invalid_block",
+		Reason: ReasonInvalidBlock,
 	}
 
 	if _, err := s.AddBanScore(ctx, req); err != nil {

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -612,6 +612,18 @@ func (s *Server) updateStorage(peerID peer.ID, mode string) {
 	}
 }
 
+// startInvalidBlocksConsumer starts the injected invalid-blocks Kafka consumer
+// with processInvalidBlockMessage. The consumer field is never reassigned after
+// this, so Stop() closes the consumer that is actually running.
+func (s *Server) startInvalidBlocksConsumer(ctx context.Context) {
+	if s.invalidBlocksKafkaConsumerClient == nil {
+		return
+	}
+
+	s.logger.Infof("[startInvalidBlocksConsumer] Starting invalid blocks Kafka consumer on topic: %s", s.invalidBlocksTopicName)
+	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithLogErrorAndMoveOn())
+}
+
 func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
 	ctx := context.Background()
 

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -617,11 +617,15 @@ func (s *Server) updateStorage(peerID peer.ID, mode string) {
 // this, so Stop() closes the consumer that is actually running.
 func (s *Server) startInvalidBlocksConsumer(ctx context.Context) {
 	if s.invalidBlocksKafkaConsumerClient == nil {
+		s.logger.Warnf("[startInvalidBlocksConsumer] invalid-blocks Kafka consumer not configured (kafka_invalidBlocksConfig unset), peers will not be banned for invalid blocks")
 		return
 	}
 
-	s.logger.Infof("[startInvalidBlocksConsumer] Starting invalid blocks Kafka consumer on topic: %s", s.invalidBlocksTopicName)
-	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithLogErrorAndMoveOn())
+	s.logger.Infof("[startInvalidBlocksConsumer] starting invalid blocks Kafka consumer")
+	// Transient handler failures (e.g. peer registry unavailable) are retried
+	// in process with backoff before the offset is committed; after the retries
+	// are exhausted the message is skipped so it cannot stall the partition.
+	s.invalidBlocksKafkaConsumerClient.Start(ctx, s.processInvalidBlockMessage, kafka.WithRetryAndMoveOn(3, 2, time.Second))
 }
 
 func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
@@ -629,8 +633,9 @@ func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
 
 	var invalidBlockMsg kafkamessage.KafkaInvalidBlockTopicMessage
 	if err := proto.Unmarshal(message.Value, &invalidBlockMsg); err != nil {
-		s.logger.Errorf("failed to unmarshal invalid block message: %v", err)
-		return err
+		// A malformed message can never succeed on retry: log and skip it.
+		s.logger.Errorf("[processInvalidBlockMessage] failed to unmarshal invalid block message: %v", err)
+		return nil
 	}
 
 	blockHash := invalidBlockMsg.GetBlockHash()

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -3,11 +3,9 @@ package p2p
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/url"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -463,108 +461,6 @@ func (s *Server) getPeerIDFromDataHubURL(dataHubURL string) string {
 	return ""
 }
 
-// startInvalidBlockConsumer initializes and starts the Kafka consumer for invalid blocks
-func (s *Server) startInvalidBlockConsumer(ctx context.Context) error {
-	var kafkaURL *url.URL
-
-	var brokerURLs []string
-
-	// Use InvalidBlocksConfig URL if available, otherwise construct one
-	if s.settings.Kafka.InvalidBlocksConfig != nil {
-		s.logger.Infof("Using InvalidBlocksConfig URL: %s", s.settings.Kafka.InvalidBlocksConfig.String())
-		kafkaURL = s.settings.Kafka.InvalidBlocksConfig
-
-		// For non-memory schemes, we need to extract broker URLs from the host
-		if kafkaURL.Scheme != "memory" {
-			brokerURLs = strings.Split(kafkaURL.Host, ",")
-		}
-	} else {
-		// Fall back to the old way of constructing the URL
-		host := s.settings.Kafka.Hosts
-
-		s.logger.Infof("Starting invalid block consumer on topic: %s", s.settings.Kafka.InvalidBlocks)
-		s.logger.Infof("Raw Kafka host from settings: %s", host)
-
-		// Split the host string in case it contains multiple hosts
-		hosts := strings.Split(host, ",")
-		brokerURLs = make([]string, 0, len(hosts))
-
-		// Process each host to ensure it has a port
-		for _, h := range hosts {
-			// Trim any whitespace
-			h = strings.TrimSpace(h)
-
-			// Skip empty hosts
-			if h == "" {
-				continue
-			}
-
-			// Check if the host string contains a port
-			if !strings.Contains(h, ":") {
-				// If no port is specified, use the default Kafka port from settings
-				h = h + ":" + strconv.Itoa(s.settings.Kafka.Port)
-				s.logger.Infof("Added default port to Kafka host: %s", h)
-			}
-
-			brokerURLs = append(brokerURLs, h)
-		}
-
-		if len(brokerURLs) == 0 {
-			return errors.NewConfigurationError("no valid Kafka hosts found")
-		}
-
-		s.logger.Infof("Using Kafka brokers: %v", brokerURLs)
-
-		// Create a valid URL for the Kafka consumer
-		kafkaURLString := fmt.Sprintf("kafka://%s/%s?partitions=%d",
-			brokerURLs[0], // Use the first broker for the URL
-			s.settings.Kafka.InvalidBlocks,
-			s.settings.Kafka.Partitions)
-
-		s.logger.Infof("Kafka URL: %s", kafkaURLString)
-
-		var err error
-
-		kafkaURL, err = url.Parse(kafkaURLString)
-		if err != nil {
-			return errors.NewConfigurationError("invalid Kafka URL: %w", err)
-		}
-	}
-
-	// Create the Kafka consumer config
-	cfg := kafka.KafkaConsumerConfig{
-		Logger:            s.logger,
-		URL:               kafkaURL,
-		BrokersURL:        brokerURLs,
-		Topic:             s.settings.Kafka.InvalidBlocks,
-		Partitions:        s.settings.Kafka.Partitions,
-		ConsumerGroupID:   s.settings.Kafka.InvalidBlocks + "-consumer",
-		AutoCommitEnabled: true,
-		Replay:            false,
-		// TLS/Auth configuration
-		EnableTLS:          s.settings.Kafka.EnableTLS,
-		TLSSkipVerify:      s.settings.Kafka.TLSSkipVerify,
-		TLSCAFile:          s.settings.Kafka.TLSCAFile,
-		TLSCertFile:        s.settings.Kafka.TLSCertFile,
-		TLSKeyFile:         s.settings.Kafka.TLSKeyFile,
-		EnableDebugLogging: s.settings.Kafka.EnableDebugLogging,
-	}
-
-	// Create the Kafka consumer group - this will handle the memory scheme correctly
-	consumer, err := kafka.NewKafkaConsumerGroup(cfg)
-	if err != nil {
-		return errors.NewServiceError("failed to create Kafka consumer", err)
-	}
-
-	// Store the consumer for cleanup
-	s.invalidBlocksKafkaConsumerClient = consumer
-
-	// Start the consumer
-	consumer.Start(ctx, s.processInvalidBlockMessage)
-
-	return nil
-}
-
 // getLocalHeight returns the current local blockchain height.
 func (s *Server) getLocalHeight() uint32 {
 	if s.blockchainClient == nil {
@@ -728,17 +624,17 @@ func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
 	blockHash := invalidBlockMsg.GetBlockHash()
 	reason := invalidBlockMsg.GetReason()
 
-	s.logger.Infof("[handleInvalidBlockMessage] processing invalid block %s: %s", blockHash, reason)
+	s.logger.Infof("[processInvalidBlockMessage] processing invalid block %s: %s", blockHash, reason)
 
 	// Look up the peer ID that sent this block
 	peerID, err := s.getPeerFromMap(&s.blockPeerMap, blockHash, "block")
 	if err != nil {
-		s.logger.Warnf("[handleInvalidBlockMessage] %v", err)
+		s.logger.Warnf("[processInvalidBlockMessage] %v", err)
 		return nil // Not an error, just no peer to ban
 	}
 
 	// Add ban score to the peer
-	s.logger.Infof("[handleInvalidBlockMessage] adding ban score to peer %s for invalid block %s: %s",
+	s.logger.Infof("[processInvalidBlockMessage] adding ban score to peer %s for invalid block %s: %s",
 		peerID, blockHash, reason)
 
 	req := &p2p_api.AddBanScoreRequest{
@@ -747,7 +643,7 @@ func (s *Server) processInvalidBlockMessage(message *kafka.KafkaMessage) error {
 	}
 
 	if _, err := s.AddBanScore(ctx, req); err != nil {
-		s.logger.Errorf("[handleInvalidBlockMessage] error adding ban score to peer %s: %v", peerID, err)
+		s.logger.Errorf("[processInvalidBlockMessage] error adding ban score to peer %s: %v", peerID, err)
 		return err
 	}
 

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -720,7 +720,13 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 				}
 				backoff := time.Duration(options.backoffMultiplier*(i+1)) * options.backoffDurationType
 				logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, options.maxRetries, backoff)
-				time.Sleep(backoff)
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					// Shutdown mid-backoff: return the error without committing
+					// so the message is redelivered after restart.
+					return err
+				}
 			}
 
 			key := ""
@@ -743,7 +749,13 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 				}
 				backoff := time.Duration(options.backoffMultiplier*(i+1)) * options.backoffDurationType
 				logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, options.maxRetries, backoff)
-				time.Sleep(backoff)
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					// Shutdown mid-backoff: return the error without committing
+					// so the message is redelivered after restart.
+					return err
+				}
 			}
 
 			key := ""

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -433,15 +433,16 @@ func (k *KafkaConsumerGroup) Start(ctx context.Context, consumerFn func(message 
 		opt(options)
 	}
 
-	// Apply retry/error handling wrappers
-	consumerFn = wrapConsumerFn(ctx, k.Config.Logger, k.Config.Topic, consumerFn, options)
-
 	// Create internal context and store cancel func before spawning goroutines.
 	// Protected by cancelMu to avoid a data race with Close().
 	internalCtx, cancel := context.WithCancel(ctx)
 	k.cancelMu.Lock()
 	k.cancel = cancel
 	k.cancelMu.Unlock()
+
+	// Apply retry/error handling wrappers, bound to internalCtx so both caller
+	// cancellation and Close() abort an in-flight retry backoff.
+	consumerFn = wrapConsumerFn(internalCtx, k.Config.Logger, k.Config.Topic, consumerFn, options)
 
 	go func() {
 		defer cancel()
@@ -634,11 +635,10 @@ func (k *KafkaConsumerGroup) startInMemory(ctx context.Context, consumerFn func(
 		opt(options)
 	}
 
+	// Reuse the same retry/error wrappers as the real consumer so in-memory
+	// (dev/test) semantics match production, including cancellable backoff.
 	handler := &inMemoryConsumerHandler{
-		logger:     k.Config.Logger,
-		consumerFn: consumerFn,
-		options:    options,
-		topic:      k.Config.Topic,
+		consumerFn: wrapConsumerFn(ctx, k.Config.Logger, k.Config.Topic, consumerFn, options),
 	}
 
 	go func() {
@@ -716,27 +716,33 @@ func messageKey(msg *KafkaMessage) string {
 	return string(msg.Key)
 }
 
-// retryWithBackoff runs fn up to maxRetries times, sleeping with linear backoff
-// between attempts. The backoff aborts immediately when ctx is cancelled so a
-// mid-retry shutdown is not blocked; the last error is returned in that case.
-func retryWithBackoff(ctx context.Context, logger ulogger.Logger, options *consumerOptions, msg *KafkaMessage, fn func(message *KafkaMessage) error) error {
-	var err error
-	for i := 0; i < options.maxRetries; i++ {
+// retryWithBackoff runs fn once plus up to maxRetries retries, sleeping with
+// linear backoff between attempts (never after the last one). It reports
+// cancelled=true when ctx was cancelled mid-backoff, in which case the last
+// error is returned without further attempts.
+func retryWithBackoff(ctx context.Context, logger ulogger.Logger, options *consumerOptions, msg *KafkaMessage, fn func(message *KafkaMessage) error) (cancelled bool, err error) {
+	attempts := max(options.maxRetries, 0) + 1
+
+	for i := range attempts {
 		if err = fn(msg); err == nil {
-			return nil
+			return false, nil
+		}
+
+		if i == attempts-1 {
+			break
 		}
 
 		backoff := time.Duration(options.backoffMultiplier*(i+1)) * options.backoffDurationType
-		logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, options.maxRetries, backoff)
+		logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, attempts, backoff)
 
 		select {
 		case <-time.After(backoff):
 		case <-ctx.Done():
-			return err
+			return true, err
 		}
 	}
 
-	return err
+	return false, err
 }
 
 // wrapConsumerFn applies retry/error handling wrappers to consumer function
@@ -744,12 +750,12 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 	if options.withRetryAndMoveOn {
 		originalFn := consumerFn
 		consumerFn = func(msg *KafkaMessage) error {
-			err := retryWithBackoff(ctx, logger, options, msg, originalFn)
+			cancelled, err := retryWithBackoff(ctx, logger, options, msg, originalFn)
 			if err == nil {
 				return nil
 			}
 
-			if ctx.Err() != nil {
+			if cancelled {
 				// Shutdown mid-backoff: return the error without committing so
 				// the message is redelivered after restart.
 				return err
@@ -763,12 +769,12 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 	if options.withRetryAndStop {
 		originalFn := consumerFn
 		consumerFn = func(msg *KafkaMessage) error {
-			err := retryWithBackoff(ctx, logger, options, msg, originalFn)
+			cancelled, err := retryWithBackoff(ctx, logger, options, msg, originalFn)
 			if err == nil {
 				return nil
 			}
 
-			if ctx.Err() != nil {
+			if cancelled {
 				// Shutdown mid-backoff: return the error without committing so
 				// the message is redelivered after restart.
 				return err
@@ -797,10 +803,7 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 
 // inMemoryConsumerHandler implements the handler for in-memory consumer
 type inMemoryConsumerHandler struct {
-	logger     ulogger.Logger
 	consumerFn func(message *KafkaMessage) error
-	options    *consumerOptions
-	topic      string
 }
 
 func (h *inMemoryConsumerHandler) Setup(_ inmemorykafka.ConsumerGroupSession) error {
@@ -823,32 +826,9 @@ func (h *inMemoryConsumerHandler) ConsumeClaim(session inmemorykafka.ConsumerGro
 			HighWaterMark: claim.HighWaterMarkOffset(),
 		}
 
-		var err error
-		if h.options.withRetryAndMoveOn {
-			for i := 0; i < h.options.maxRetries; i++ {
-				err = h.consumerFn(kafkaMsg)
-				if err == nil {
-					break
-				}
-				time.Sleep(time.Duration(h.options.backoffMultiplier*(i+1)) * h.options.backoffDurationType)
-			}
-			if err != nil {
-				h.logger.Errorf("[kafka_consumer] error processing message, skipping: %v", err)
-			}
-			continue
-		}
-
-		if h.options.withLogErrorAndMoveOn {
-			if err := h.consumerFn(kafkaMsg); err != nil {
-				h.logger.Errorf("[kafka_consumer] error processing message, skipping: %v", err)
-			}
-			continue
-		}
-
+		// consumerFn is pre-wrapped by wrapConsumerFn, so the retry/skip/stop
+		// option semantics here are identical to the real consumer's.
 		if err := h.consumerFn(kafkaMsg); err != nil {
-			if h.options.withRetryAndStop && h.options.stopFn != nil {
-				h.options.stopFn()
-			}
 			return err
 		}
 

--- a/util/kafka/kafka_consumer.go
+++ b/util/kafka/kafka_consumer.go
@@ -707,33 +707,55 @@ func (k *KafkaConsumerGroup) ResumeAll() {
 	}
 }
 
+// messageKey returns the message key as a string for logging, empty when absent.
+func messageKey(msg *KafkaMessage) string {
+	if msg == nil || msg.Key == nil {
+		return ""
+	}
+
+	return string(msg.Key)
+}
+
+// retryWithBackoff runs fn up to maxRetries times, sleeping with linear backoff
+// between attempts. The backoff aborts immediately when ctx is cancelled so a
+// mid-retry shutdown is not blocked; the last error is returned in that case.
+func retryWithBackoff(ctx context.Context, logger ulogger.Logger, options *consumerOptions, msg *KafkaMessage, fn func(message *KafkaMessage) error) error {
+	var err error
+	for i := 0; i < options.maxRetries; i++ {
+		if err = fn(msg); err == nil {
+			return nil
+		}
+
+		backoff := time.Duration(options.backoffMultiplier*(i+1)) * options.backoffDurationType
+		logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, options.maxRetries, backoff)
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return err
+		}
+	}
+
+	return err
+}
+
 // wrapConsumerFn applies retry/error handling wrappers to consumer function
 func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, consumerFn func(message *KafkaMessage) error, options *consumerOptions) func(message *KafkaMessage) error {
 	if options.withRetryAndMoveOn {
 		originalFn := consumerFn
 		consumerFn = func(msg *KafkaMessage) error {
-			var err error
-			for i := 0; i < options.maxRetries; i++ {
-				err = originalFn(msg)
-				if err == nil {
-					return nil
-				}
-				backoff := time.Duration(options.backoffMultiplier*(i+1)) * options.backoffDurationType
-				logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, options.maxRetries, backoff)
-				select {
-				case <-time.After(backoff):
-				case <-ctx.Done():
-					// Shutdown mid-backoff: return the error without committing
-					// so the message is redelivered after restart.
-					return err
-				}
+			err := retryWithBackoff(ctx, logger, options, msg, originalFn)
+			if err == nil {
+				return nil
 			}
 
-			key := ""
-			if msg != nil && msg.Key != nil {
-				key = string(msg.Key)
+			if ctx.Err() != nil {
+				// Shutdown mid-backoff: return the error without committing so
+				// the message is redelivered after restart.
+				return err
 			}
-			logger.Errorf("[kafka_consumer] error processing kafka message on topic %s (key: %s), skipping", topic, key)
+
+			logger.Errorf("[kafka_consumer] error processing kafka message on topic %s (key: %s), skipping", topic, messageKey(msg))
 			return nil
 		}
 	}
@@ -741,28 +763,18 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 	if options.withRetryAndStop {
 		originalFn := consumerFn
 		consumerFn = func(msg *KafkaMessage) error {
-			var err error
-			for i := 0; i < options.maxRetries; i++ {
-				err = originalFn(msg)
-				if err == nil {
-					return nil
-				}
-				backoff := time.Duration(options.backoffMultiplier*(i+1)) * options.backoffDurationType
-				logger.Warnf("[kafka_consumer] retrying processing kafka message... attempt %d/%d, backoff %v", i+1, options.maxRetries, backoff)
-				select {
-				case <-time.After(backoff):
-				case <-ctx.Done():
-					// Shutdown mid-backoff: return the error without committing
-					// so the message is redelivered after restart.
-					return err
-				}
+			err := retryWithBackoff(ctx, logger, options, msg, originalFn)
+			if err == nil {
+				return nil
 			}
 
-			key := ""
-			if msg != nil && msg.Key != nil {
-				key = string(msg.Key)
+			if ctx.Err() != nil {
+				// Shutdown mid-backoff: return the error without committing so
+				// the message is redelivered after restart.
+				return err
 			}
-			logger.Errorf("[kafka_consumer] error processing kafka message on topic %s (key: %s), stopping", topic, key)
+
+			logger.Errorf("[kafka_consumer] error processing kafka message on topic %s (key: %s), stopping", topic, messageKey(msg))
 			if options.stopFn != nil {
 				options.stopFn()
 			}
@@ -773,13 +785,8 @@ func wrapConsumerFn(ctx context.Context, logger ulogger.Logger, topic string, co
 	if options.withLogErrorAndMoveOn {
 		originalFn := consumerFn
 		consumerFn = func(msg *KafkaMessage) error {
-			err := originalFn(msg)
-			if err != nil {
-				key := ""
-				if msg != nil && msg.Key != nil {
-					key = string(msg.Key)
-				}
-				logger.Errorf("[kafka_consumer] error processing kafka message on topic %s (key: %s), skipping: %v", topic, key, err)
+			if err := originalFn(msg); err != nil {
+				logger.Errorf("[kafka_consumer] error processing kafka message on topic %s (key: %s), skipping: %v", topic, messageKey(msg), err)
 			}
 			return nil
 		}

--- a/util/kafka/kafka_consumer_test.go
+++ b/util/kafka/kafka_consumer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -308,4 +309,35 @@ func TestNewKafkaConsumerGroup_AppliesDefaultTimeouts(t *testing.T) {
 			_ = consumer.Close()
 		})
 	}
+}
+
+func TestWrapConsumerFnRetryBackoffIsCancellable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	options := &consumerOptions{
+		withRetryAndMoveOn:  true,
+		maxRetries:          3,
+		backoffMultiplier:   10,
+		backoffDurationType: time.Second, // 10s+20s+30s if the backoff were uninterruptible
+	}
+
+	failErr := errors.NewProcessingError("handler always fails")
+	calls := 0
+	wrapped := wrapConsumerFn(ctx, ulogger.TestLogger{}, "test-topic", func(*KafkaMessage) error {
+		calls++
+		return failErr
+	}, options)
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := wrapped(&KafkaMessage{})
+
+	require.Error(t, err, "cancellation mid-backoff must surface the handler error, not swallow it")
+	require.Less(t, time.Since(start), 5*time.Second, "backoff must abort promptly on context cancellation")
+	require.Equal(t, 1, calls, "no further attempts after the context is cancelled")
 }

--- a/util/kafka/kafka_consumer_test.go
+++ b/util/kafka/kafka_consumer_test.go
@@ -341,3 +341,79 @@ func TestWrapConsumerFnRetryBackoffIsCancellable(t *testing.T) {
 	require.Less(t, time.Since(start), 5*time.Second, "backoff must abort promptly on context cancellation")
 	require.Equal(t, 1, calls, "no further attempts after the context is cancelled")
 }
+
+func TestWrapConsumerFnRetryAndMoveOnExhaustsThenSkips(t *testing.T) {
+	options := &consumerOptions{
+		withRetryAndMoveOn:  true,
+		maxRetries:          3,
+		backoffMultiplier:   1,
+		backoffDurationType: time.Millisecond,
+	}
+
+	calls := 0
+	wrapped := wrapConsumerFn(context.Background(), ulogger.TestLogger{}, "test-topic", func(*KafkaMessage) error {
+		calls++
+		return errors.NewProcessingError("handler always fails")
+	}, options)
+
+	err := wrapped(&KafkaMessage{Key: []byte("some-key")})
+
+	require.NoError(t, err, "exhausted retries must skip the message, not fail the consumer")
+	require.Equal(t, options.maxRetries, calls)
+}
+
+func TestWrapConsumerFnRetrySucceedsAfterFailure(t *testing.T) {
+	options := &consumerOptions{
+		withRetryAndMoveOn:  true,
+		maxRetries:          3,
+		backoffMultiplier:   1,
+		backoffDurationType: time.Millisecond,
+	}
+
+	calls := 0
+	wrapped := wrapConsumerFn(context.Background(), ulogger.TestLogger{}, "test-topic", func(*KafkaMessage) error {
+		calls++
+		if calls == 1 {
+			return errors.NewProcessingError("transient failure")
+		}
+		return nil
+	}, options)
+
+	err := wrapped(&KafkaMessage{})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls, "must stop retrying on the first success")
+}
+
+func TestWrapConsumerFnRetryAndStopCallsStopFn(t *testing.T) {
+	stopped := false
+	options := &consumerOptions{
+		withRetryAndStop:    true,
+		maxRetries:          2,
+		backoffMultiplier:   1,
+		backoffDurationType: time.Millisecond,
+		stopFn:              func() { stopped = true },
+	}
+
+	calls := 0
+	wrapped := wrapConsumerFn(context.Background(), ulogger.TestLogger{}, "test-topic", func(*KafkaMessage) error {
+		calls++
+		return errors.NewProcessingError("handler always fails")
+	}, options)
+
+	err := wrapped(&KafkaMessage{})
+
+	require.NoError(t, err)
+	require.Equal(t, options.maxRetries, calls)
+	require.True(t, stopped, "stopFn must be called after retries are exhausted")
+}
+
+func TestWrapConsumerFnLogErrorAndMoveOnSwallowsError(t *testing.T) {
+	options := &consumerOptions{withLogErrorAndMoveOn: true}
+
+	wrapped := wrapConsumerFn(context.Background(), ulogger.TestLogger{}, "test-topic", func(*KafkaMessage) error {
+		return errors.NewProcessingError("handler fails")
+	}, options)
+
+	require.NoError(t, wrapped(&KafkaMessage{Key: []byte("some-key")}))
+}

--- a/util/kafka/kafka_consumer_test.go
+++ b/util/kafka/kafka_consumer_test.go
@@ -359,7 +359,7 @@ func TestWrapConsumerFnRetryAndMoveOnExhaustsThenSkips(t *testing.T) {
 	err := wrapped(&KafkaMessage{Key: []byte("some-key")})
 
 	require.NoError(t, err, "exhausted retries must skip the message, not fail the consumer")
-	require.Equal(t, options.maxRetries, calls)
+	require.Equal(t, options.maxRetries+1, calls, "one attempt plus maxRetries retries")
 }
 
 func TestWrapConsumerFnRetrySucceedsAfterFailure(t *testing.T) {
@@ -404,7 +404,7 @@ func TestWrapConsumerFnRetryAndStopCallsStopFn(t *testing.T) {
 	err := wrapped(&KafkaMessage{})
 
 	require.NoError(t, err)
-	require.Equal(t, options.maxRetries, calls)
+	require.Equal(t, options.maxRetries+1, calls, "one attempt plus maxRetries retries")
 	require.True(t, stopped, "stopFn must be called after retries are exhausted")
 }
 
@@ -416,4 +416,25 @@ func TestWrapConsumerFnLogErrorAndMoveOnSwallowsError(t *testing.T) {
 	}, options)
 
 	require.NoError(t, wrapped(&KafkaMessage{Key: []byte("some-key")}))
+}
+
+func TestWrapConsumerFnZeroMaxRetriesStillAttemptsOnce(t *testing.T) {
+	stopped := false
+	options := &consumerOptions{
+		withRetryAndStop:    true,
+		maxRetries:          0,
+		backoffMultiplier:   1,
+		backoffDurationType: time.Millisecond,
+		stopFn:              func() { stopped = true },
+	}
+
+	calls := 0
+	wrapped := wrapConsumerFn(context.Background(), ulogger.TestLogger{}, "test-topic", func(*KafkaMessage) error {
+		calls++
+		return errors.NewProcessingError("handler always fails")
+	}, options)
+
+	require.NoError(t, wrapped(&KafkaMessage{}))
+	require.Equal(t, 1, calls, "maxRetries=0 must still attempt the handler once")
+	require.True(t, stopped, "stopFn must be called after the single failed attempt")
 }


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4687.**

### Problem
The invalid-blocks Kafka consumer was started twice. `Start()` started the injected consumer with `invalidBlockHandler`, whose real work (`ReportInvalidBlock`) was commented out - it only unmarshalled and returned nil. Then `startInvalidBlockConsumer` built a second consumer, overwrote `s.invalidBlocksKafkaConsumerClient`, and started it with the real `processInvalidBlockMessage`. The first consumer was leaked (never `Close()`d, unreachable after the overwrite) and ran a fully redundant consumer group (`p2p.<clientName>` vs `<InvalidBlocks>-consumer`), each independently consuming every message.

### Fix
Single consumer, owned by the injected client (the same pattern the invalid-subtrees consumer uses):
- `Start()` wires the injected consumer via a small `startInvalidBlocksConsumer` helper that starts it with the real `s.processInvalidBlockMessage`. The field is never reassigned, so `Stop()` closes the consumer that is actually running.
- Deleted the old `startInvalidBlockConsumer` (~100 lines duplicating consumer construction that `daemon_kafka.go` already handles via `InvalidBlocksConfig`) and the no-op `invalidBlockHandler` with its commented-out `ReportInvalidBlock` block.
- Handler cleanups: log prefixes aligned with the function name, `s.gCtx` instead of `context.Background()` so an in-flight `AddBanScore` is cancelled at shutdown, and the `ReasonInvalidBlock` constant instead of a string literal.

Error handling: the consumer starts with `kafka.WithRetryAndMoveOn(2, 2, time.Second)` - three attempts total with 2s/4s backoff between them - not `WithLogErrorAndMoveOn`. Move-on would commit the offset on error, silently dropping the ban on a transient registry failure while `processInvalidBlockMessage` deliberately keeps its `blockPeerMap` entry for retry. After the retries are exhausted the message is skipped so a poison message cannot stall the partition. Malformed messages return nil from the handler (log and skip) since retrying an unmarshal failure can never succeed. (The old default-path "retry via redelivery" was itself leaky under autocommit: a later message's `MarkCommitRecords` advances the committed offset past the failed record, so redelivery only happened if a restart/rebalance occurred first.)

Retry wrapper rework in `util/kafka` (review follow-ups): the copy-pasted retry loops in `wrapConsumerFn` are now a single `retryWithBackoff` helper (plus `messageKey` for the log lines), with these fixes:
- The backoff selects on `ctx.Done()` and aborts immediately on shutdown, returning the handler error so the in-flight message is not committed and is redelivered after restart. The wrapper is bound to the consumer's `internalCtx`, so both caller cancellation and `Close()` abort it. Cancellation is signalled explicitly (a `cancelled` return), not inferred from `ctx.Err()`, so exhaustion is never misclassified.
- No more pointless backoff sleep after the final attempt.
- `maxRetries` now means retries after the first attempt, and `maxRetries=0` performs exactly one attempt. This is what the executable spec always said: `test/longtest/util/kafka/kafka_test.go` asserts "1 + 3 retries" = 4 invocations for `WithRetryAndMoveOn(3, ...)` and "no retry, handler once + stopFn" for `WithRetryAndStop(0, ...)` - both impossible under the old loop, which ran `maxRetries` total attempts and never invoked the handler at all for 0. Those longtests need Docker and could not be run locally; they run in the dispatched long-tests workflow.
- The in-memory (`memory://`) consumer path now reuses `wrapConsumerFn` instead of its own divergent re-implementation in `inMemoryConsumerHandler.ConsumeClaim` (which had an uninterruptible `time.Sleep` backoff and a `withRetryAndStop` branch that never retried). Since dev/test run with `KAFKA_SCHEMA=memory`, this gives dev/test daemons the same cancellable retry semantics as production.

Unset config: the deleted fallback that built a consumer from `Kafka.Hosts` + `Kafka.InvalidBlocks` is intentionally not restored - no sibling consumer has one and the default config sets `kafka_invalidBlocksConfig`. Instead the unconfigured case logs an **error** (invalid-block banning is a DoS-prevention control per the setting's docstring). That log previously could not fire at all: the daemon passed a typed-nil `*kafka.KafkaConsumerGroup` into the interface parameter, so `!= nil` checks passed and `Start()`'s nil-receiver guard silently no-opped. The typed-nil guard is a shared `nonNilConsumerGroup` helper in `daemon_kafka.go`, applied to both optional consumers (invalid-blocks and invalid-subtrees). The rejected-tx consumer is mandatory (its getter errors when unset), so it needs no guard. Docs updated (`p2p_reference.md`, `kafka_settings.md` - the latter still described the deleted fallback and the old `{topic}-consumer` group).

### Tests
`services/p2p/invalid_blocks_consumer_test.go` (handler and wiring at 100% statement coverage):
- `TestStartInvalidBlocksConsumer_BansPeer`: calls the same `startInvalidBlocksConsumer` that `Start()` uses against the in-memory broker (which now exercises the real `wrapConsumerFn` wiring), produces a `KafkaInvalidBlockTopicMessage`, and asserts the sending peer receives a ban score and the `blockPeerMap` entry is removed.
- `TestStartInvalidBlocksConsumer_NilConsumerIsNoOp`, `TestProcessInvalidBlockMessage_UnknownBlockIsNotAnError`, `TestProcessInvalidBlockMessage_MalformedMessageIsSkipped`, `TestProcessInvalidBlockMessage_AddBanScoreErrorIsReturned`.

`util/kafka/kafka_consumer_test.go` (`messageKey`/`retryWithBackoff` at 100%):
- `TestWrapConsumerFnRetryBackoffIsCancellable`: cancellation mid-backoff aborts immediately, surfaces the handler error, no further attempts.
- `TestWrapConsumerFnRetryAndMoveOnExhaustsThenSkips` / `TestWrapConsumerFnRetryAndStopCallsStopFn`: exhaustion after 1+maxRetries attempts skips / fires stopFn.
- `TestWrapConsumerFnRetrySucceedsAfterFailure`, `TestWrapConsumerFnLogErrorAndMoveOnSwallowsError`, `TestWrapConsumerFnZeroMaxRetriesStillAttemptsOnce`.

`daemon/daemon_kafka_test.go`: `TestNonNilConsumerGroup` (typed nil maps to true nil).

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
ok  github.com/bsv-blockchain/teranode/services/p2p  14.097s
SETTINGS_CONTEXT=test go test -race -count=1 -skip 'TestFlushBytesRegression.*' ./util/kafka/...
ok  github.com/bsv-blockchain/teranode/util/kafka  17.294s
ok  github.com/bsv-blockchain/teranode/util/kafka/in_memory_kafka  2.568s
```
Skipped `TestFlushBytesRegression` tests require Docker (unavailable locally, untouched code paths). `./daemon` builds and vets clean; its test binary does not link locally (known GoBDK cgo issue), so the daemon test runs in CI.

Known pre-existing issues surfaced during review, left out of scope: `InMemoryConsumerGroup.Close()` waits on a WaitGroup nothing `Add`s to and leaks its `Consume` goroutine (test-only harness); the daemon's p2p wiring (`startP2PService`) has no direct test.
