### PR TITLE
fix(p2p): make syncConnectionTimes cleanup reachable and bound the map

### DIFF
--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -1240,40 +1240,46 @@ func (s *Server) getNodeStatusMessage(ctx context.Context) *notificationMsg {
 	// Get current sync peer
 	syncPeer := s.getSyncPeer()
 	if syncPeer != "" {
-		if syncPeer != "" {
-			syncPeerID = syncPeer.String()
+		syncPeerID = syncPeer.String()
 
-			// Track when we first connected to this sync peer
-			if existingTime, ok := s.syncConnectionTimes.Load(syncPeerID); ok {
-				syncConnectedAt = existingTime.(int64)
-			} else {
-				// First time connecting to this sync peer
-				syncConnectedAt = time.Now().Unix()
-				s.syncConnectionTimes.Store(syncPeerID, syncConnectedAt)
-				s.logger.Debugf("[handleNodeStatusNotification] Recording sync connection time for peer %s: %d", syncPeerID, syncConnectedAt)
-			}
-
-			// Get sync peer's height and block hash
-			for _, peerInfo := range s.P2PClient.GetPeers() {
-				if peerInfo.ID == syncPeer.String() {
-					// Get the peer's best block hash from registry
-					if pInfo, exists := s.getPeer(syncPeer); exists {
-						if pInfo.BlockHash != nil {
-							syncPeerBlockHash = pInfo.BlockHash.String()
-						}
-
-						syncPeerHeight = pInfo.Height
-					}
-					break
-				}
-			}
+		// Track when we first connected to this sync peer
+		if existingTime, ok := s.syncConnectionTimes.Load(syncPeerID); ok {
+			syncConnectedAt = existingTime.(int64)
 		} else {
-			// No sync peer - clear any old connection time tracking
-			s.syncConnectionTimes.Range(func(key, value interface{}) bool {
-				s.syncConnectionTimes.Delete(key)
-				return true
-			})
+			// First time connecting to this sync peer
+			syncConnectedAt = time.Now().Unix()
+			s.syncConnectionTimes.Store(syncPeerID, syncConnectedAt)
+			s.logger.Debugf("[handleNodeStatusNotification] Recording sync connection time for peer %s: %d", syncPeerID, syncConnectedAt)
 		}
+
+		// Drop entries for previous sync peers so the map only tracks the current one
+		s.syncConnectionTimes.Range(func(key, value any) bool {
+			if key != syncPeerID {
+				s.syncConnectionTimes.Delete(key)
+			}
+			return true
+		})
+
+		// Get sync peer's height and block hash
+		for _, peerInfo := range s.P2PClient.GetPeers() {
+			if peerInfo.ID == syncPeer.String() {
+				// Get the peer's best block hash from registry
+				if pInfo, exists := s.getPeer(syncPeer); exists {
+					if pInfo.BlockHash != nil {
+						syncPeerBlockHash = pInfo.BlockHash.String()
+					}
+
+					syncPeerHeight = pInfo.Height
+				}
+				break
+			}
+		}
+	} else {
+		// No sync peer - clear any old connection time tracking
+		s.syncConnectionTimes.Range(func(key, value any) bool {
+			s.syncConnectionTimes.Delete(key)
+			return true
+		})
 	}
 
 	// Get peer ID safely

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -150,6 +150,46 @@ func TestGetNodeStatusMessage_CountsOnlyConnectedPeers(t *testing.T) {
 	require.Equal(t, 2, msg.ConnectedPeersCount, "gossiped/disconnected registry peers must not be counted")
 }
 
+// TestGetNodeStatusMessage_SyncConnectionTimesBounded is a regression test:
+// syncConnectionTimes must not grow unbounded — entries for previous sync peers
+// are pruned on rotation, and the map is cleared when there is no sync peer.
+func TestGetNodeStatusMessage_SyncConnectionTimesBounded(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+	s.P2PClient = &MockServerP2PClient{peerID: mustNewPeerID(t)}
+	s.syncCoordinator = &SyncCoordinator{}
+
+	pidA := mustNewPeerID(t)
+	pidB := mustNewPeerID(t)
+
+	syncMapLen := func() int {
+		n := 0
+		s.syncConnectionTimes.Range(func(_, _ any) bool { n++; return true })
+		return n
+	}
+
+	// Sync peer A selected: its connection time is recorded.
+	s.syncCoordinator.currentSyncPeer = pidA.String()
+	msg := s.getNodeStatusMessage(context.Background())
+	require.NotNil(t, msg)
+	_, ok := s.syncConnectionTimes.Load(pidA.String())
+	require.True(t, ok, "current sync peer must be tracked")
+	require.Equal(t, 1, syncMapLen())
+
+	// Rotate to sync peer B: A's stale entry is pruned.
+	s.syncCoordinator.currentSyncPeer = pidB.String()
+	s.getNodeStatusMessage(context.Background())
+	_, ok = s.syncConnectionTimes.Load(pidA.String())
+	require.False(t, ok, "previous sync peer entry must be pruned on rotation")
+	_, ok = s.syncConnectionTimes.Load(pidB.String())
+	require.True(t, ok, "current sync peer must be tracked after rotation")
+	require.Equal(t, 1, syncMapLen())
+
+	// No sync peer: the map is cleared.
+	s.syncCoordinator.currentSyncPeer = ""
+	s.getNodeStatusMessage(context.Background())
+	require.Zero(t, syncMapLen(), "map must be cleared when there is no sync peer")
+}
+
 func TestServerHelpers_GetSyncPeer_NoCoordinator(t *testing.T) {
 	s, _ := newServerWithLocalRegistry(t)
 	require.Empty(t, s.getSyncPeer())


### PR DESCRIPTION
**Closes #4686.**

### Problem
In `getNodeStatusMessage` (`services/p2p/Server.go`), the `else` branch that clears `syncConnectionTimes` was nested under a duplicated `if syncPeer != ""` condition, making it unreachable. Entries stored for each sync peer were never removed, so the map grew unbounded over the node's lifetime - one permanent entry per distinct sync peer.

### Fix
- Removed the duplicated inner condition so the `else` now clears the map whenever there is no sync peer.
- Additionally prunes entries for previous sync peers when a sync peer is set. This covers direct peer-to-peer rotation (A to B without an intermediate "no sync peer" state), which the unnesting alone would still leak on. The map now holds at most one entry.

### Tests
Added `TestGetNodeStatusMessage_SyncConnectionTimesBounded` in `services/p2p/server_helpers_test.go`, verifying the connection time is recorded for the current sync peer, stale entries are pruned on rotation, and the map is cleared when no sync peer is selected.

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
ok  github.com/bsv-blockchain/teranode/services/p2p
```