### PR TITLE
fix(p2p): serialize compound sync decisions in SyncCoordinator

### DIFF
--- a/services/p2p/sync_coordinator.go
+++ b/services/p2p/sync_coordinator.go
@@ -32,6 +32,14 @@ type SyncCoordinator struct {
 	// Per-RPC contexts are derived from this when needed.
 	ctx context.Context
 
+	// decisionMu serialises compound sync decisions (clear -> select -> activate)
+	// so only one decision is in flight at a time. Without it, concurrent triggers
+	// from the FSM monitor, periodic evaluation, catchup-failure and disconnect
+	// handlers can each select a peer and emit conflicting Kafka sync triggers, or
+	// clear a peer another path just activated. decisionMu is always acquired
+	// before mu and never while holding mu; mu remains the field-level lock.
+	decisionMu sync.Mutex
+
 	// Current sync state. currentSyncPeer holds the canonical libp2p ID string.
 	mu                         sync.RWMutex
 	currentSyncPeer            string
@@ -381,8 +389,13 @@ func (sc *SyncCoordinator) GetCurrentSyncPeer() string {
 	return sc.currentSyncPeer
 }
 
-// ClearSyncPeer clears the current sync peer
+// ClearSyncPeer clears the current sync peer. It serialises behind any
+// in-flight sync decision so an external clear cannot interleave with a
+// select-and-activate sequence; decision paths that already hold decisionMu
+// call clearSyncPeerIfCurrent directly.
 func (sc *SyncCoordinator) ClearSyncPeer() {
+	sc.decisionMu.Lock()
+	defer sc.decisionMu.Unlock()
 	sc.clearSyncPeerIfCurrent("")
 }
 
@@ -441,6 +454,7 @@ func (sc *SyncCoordinator) syncPeerNoProgressTimedOut(now time.Time) (string, ti
 	return currentPeer, progressAge, progressAge > sc.syncPeerNoProgressLimit()
 }
 
+// clearNoProgressSyncPeer requires decisionMu to be held by the caller.
 func (sc *SyncCoordinator) clearNoProgressSyncPeer(peerID string, progressAge time.Duration) bool {
 	sc.logger.Warnf("[SyncCoordinator] Sync peer %s made no validated progress for %v", peerID, progressAge.Round(time.Second))
 	if err := sc.registry.RecordSyncAttempt(sc.ctx, peerID); err != nil {
@@ -449,12 +463,20 @@ func (sc *SyncCoordinator) clearNoProgressSyncPeer(peerID string, progressAge ti
 	if !sc.clearSyncPeerIfCurrent(peerID) {
 		return false
 	}
-	_ = sc.TriggerSync()
+	_ = sc.triggerSyncLocked()
 	return true
 }
 
 // TriggerSync triggers a new sync operation
 func (sc *SyncCoordinator) TriggerSync() error {
+	sc.decisionMu.Lock()
+	defer sc.decisionMu.Unlock()
+	return sc.triggerSyncLocked()
+}
+
+// triggerSyncLocked runs the select-and-activate decision. It requires
+// decisionMu to be held by the caller.
+func (sc *SyncCoordinator) triggerSyncLocked() error {
 	sc.logger.Debugf("[SyncCoordinator] Sync triggered")
 
 	localHeight := sc.getLocalHeightSafe()
@@ -473,13 +495,14 @@ func (sc *SyncCoordinator) HandlePeerDisconnected(peerID peer.ID) {
 		sc.logger.Warnf("[SyncCoordinator] RemovePeer %s failed: %v", idStr, err)
 	}
 
-	sc.mu.RLock()
-	isSyncPeer := sc.currentSyncPeer == idStr
-	sc.mu.RUnlock()
+	// Check-and-clear under decisionMu so the clear cannot interleave with an
+	// in-flight activation of a different peer.
+	sc.decisionMu.Lock()
+	isSyncPeer := sc.clearSyncPeerIfCurrent(idStr)
+	sc.decisionMu.Unlock()
 
 	if isSyncPeer {
 		sc.logger.Infof("[SyncCoordinator] Sync peer %s disconnected", idStr)
-		sc.ClearSyncPeer()
 
 		// Trigger selection of new sync peer
 		go func() {
@@ -492,6 +515,12 @@ func (sc *SyncCoordinator) HandlePeerDisconnected(peerID peer.ID) {
 // HandleCatchupFailure handles catchup failures
 func (sc *SyncCoordinator) HandleCatchupFailure(reason string) {
 	sc.logger.Infof("[SyncCoordinator] Handling catchup failure: %s", reason)
+
+	// Hold decisionMu across the whole read-record-clear-retrigger sequence so a
+	// concurrent trigger cannot activate a new peer between the read and the clear
+	// (which would wrongly evict the freshly-activated peer).
+	sc.decisionMu.Lock()
+	defer sc.decisionMu.Unlock()
 
 	// Get the failed peer before clearing
 	sc.mu.RLock()
@@ -508,10 +537,10 @@ func (sc *SyncCoordinator) HandleCatchupFailure(reason string) {
 	}
 
 	// Clear current sync peer
-	sc.ClearSyncPeer()
+	sc.clearSyncPeerIfCurrent("")
 
 	// Trigger new sync
-	if err := sc.TriggerSync(); err != nil {
+	if err := sc.triggerSyncLocked(); err != nil {
 		sc.logger.Errorf("[SyncCoordinator] Failed to trigger sync after failure: %v", err)
 	}
 }
@@ -590,12 +619,18 @@ func (sc *SyncCoordinator) monitorFSM(ctx context.Context) {
 	}
 }
 
-// checkFSMState checks FSM state and triggers sync if needed
+// checkFSMState checks FSM state and triggers sync if needed. It holds
+// decisionMu for the whole check so the transition handling and the RUNNING-state
+// activation below run as one serialised sync decision.
 func (sc *SyncCoordinator) checkFSMState(ctx context.Context) {
 	if sc.blockchainClient == nil {
 		sc.logger.Warnf("[SyncCoordinator] No blockchain client available for FSM monitoring")
 		return
 	}
+
+	sc.decisionMu.Lock()
+	defer sc.decisionMu.Unlock()
+
 	sc.refreshProbeBudgetFromLocalTip(ctx)
 
 	// Check if we're in backoff mode
@@ -626,7 +661,8 @@ func (sc *SyncCoordinator) checkFSMState(ctx context.Context) {
 	}
 }
 
-// handleFSMTransition checks for FSM state transitions and handles them
+// handleFSMTransition checks for FSM state transitions and handles them.
+// It requires decisionMu to be held by the caller.
 func (sc *SyncCoordinator) handleFSMTransition(currentState *blockchain_api.FSMStateType) bool {
 	if *currentState == blockchain_api.FSMStateType_RUNNING {
 		// Get current sync peer and check if we should consider this a failure
@@ -648,8 +684,8 @@ func (sc *SyncCoordinator) handleFSMTransition(currentState *blockchain_api.FSMS
 			if !exists {
 				// Peer no longer exists in registry (likely disconnected)
 				sc.logger.Infof("[SyncCoordinator] Sync peer %s no longer in registry, clearing", currentPeer)
-				sc.ClearSyncPeer()
-				_ = sc.TriggerSync()
+				sc.clearSyncPeerIfCurrent("")
+				_ = sc.triggerSyncLocked()
 				return true // Transition handled
 			}
 
@@ -667,22 +703,23 @@ func (sc *SyncCoordinator) handleFSMTransition(currentState *blockchain_api.FSMS
 			if peerAheadByValidatedWork(peerInfo, localChainWork) {
 				sc.logger.Infof("[SyncCoordinator] Sync with peer %s considered failed; peer still has higher validated work",
 					currentPeer)
-				sc.ClearSyncPeer()
-				_ = sc.TriggerSync()
+				sc.clearSyncPeerIfCurrent("")
+				_ = sc.triggerSyncLocked()
 				return true // Transition handled
 			}
 			// We've caught up or surpassed the peer, this is success not failure
 			sc.logger.Infof("[SyncCoordinator] Sync completed successfully with peer %s by validated work", currentPeer)
 			sc.resetBackoff()
-			sc.ClearSyncPeer()
-			_ = sc.TriggerSync()
+			sc.clearSyncPeerIfCurrent("")
+			_ = sc.triggerSyncLocked()
 			return true // Transition handled
 		}
 	}
 	return false // No transition to handle
 }
 
-// handleRunningState handles the FSM RUNNING state logic
+// handleRunningState handles the FSM RUNNING state logic.
+// It requires decisionMu to be held by the caller.
 func (sc *SyncCoordinator) handleRunningState(_ context.Context) {
 	localHeight := sc.getLocalHeightSafe()
 
@@ -705,6 +742,8 @@ func (sc *SyncCoordinator) getLocalHeightSafe() uint32 {
 
 // selectAndActivateNewPeer selects a new sync peer and activates it.
 // oldPeer is the previously selected peer's canonical libp2p ID string (or empty).
+// It requires decisionMu to be held by the caller so the select -> claim ->
+// send-to-Kafka sequence runs as one serialised decision.
 func (sc *SyncCoordinator) selectAndActivateNewPeer(localHeight uint32, oldPeer string) error {
 	if oldPeer != "" {
 		sc.logger.Debugf("[SyncCoordinator] Sync peer %s already active; skipping new activation", oldPeer)
@@ -900,8 +939,13 @@ func (sc *SyncCoordinator) periodicEvaluation(ctx context.Context) {
 	}
 }
 
-// evaluateSyncPeer evaluates current sync peer performance
+// evaluateSyncPeer evaluates current sync peer performance. It holds decisionMu
+// for the whole evaluation so its clear/re-trigger/preempt outcomes cannot
+// interleave with other sync decisions.
 func (sc *SyncCoordinator) evaluateSyncPeer() {
+	sc.decisionMu.Lock()
+	defer sc.decisionMu.Unlock()
+
 	now := time.Now()
 	sc.mu.RLock()
 	currentPeer := sc.currentSyncPeer
@@ -919,16 +963,16 @@ func (sc *SyncCoordinator) evaluateSyncPeer() {
 	}
 	if !exists {
 		sc.logger.Warnf("[SyncCoordinator] Sync peer %s no longer exists", currentPeer)
-		sc.ClearSyncPeer()
-		_ = sc.TriggerSync()
+		sc.clearSyncPeerIfCurrent("")
+		_ = sc.triggerSyncLocked()
 		return
 	}
 
 	// Check if peer has low reputation
 	if peerInfo.ReputationScore < 20.0 {
 		sc.logger.Warnf("[SyncCoordinator] Sync peer %s has low reputation (%.2f)", currentPeer, peerInfo.ReputationScore)
-		sc.ClearSyncPeer()
-		_ = sc.TriggerSync()
+		sc.clearSyncPeerIfCurrent("")
+		_ = sc.triggerSyncLocked()
 		return
 	}
 
@@ -953,8 +997,8 @@ func (sc *SyncCoordinator) evaluateSyncPeer() {
 		// Don't clear peer yet, but look for better peer.
 		if betterPeer := sc.selectNewSyncPeer(); betterPeer != currentPeer && betterPeer != "" {
 			sc.logger.Infof("[SyncCoordinator] Found better sync peer %s", betterPeer)
-			sc.ClearSyncPeer()
-			_ = sc.TriggerSync()
+			sc.clearSyncPeerIfCurrent("")
+			_ = sc.triggerSyncLocked()
 		}
 		return
 	}
@@ -1064,14 +1108,18 @@ func (sc *SyncCoordinator) UpdateBanStatus(peerID peer.ID) {
 		return
 	}
 
-	sc.mu.RLock()
-	isSyncPeer := sc.currentSyncPeer == idStr
-	sc.mu.RUnlock()
+	if !banned {
+		return
+	}
 
-	if isSyncPeer && banned {
+	// Check-clear-retrigger as one serialised decision so the clear cannot evict
+	// a different peer activated by a concurrent trigger.
+	sc.decisionMu.Lock()
+	defer sc.decisionMu.Unlock()
+
+	if sc.clearSyncPeerIfCurrent(idStr) {
 		sc.logger.Warnf("[SyncCoordinator] Sync peer %s got banned", idStr)
-		sc.ClearSyncPeer()
-		_ = sc.TriggerSync()
+		_ = sc.triggerSyncLocked()
 	}
 }
 

--- a/services/p2p/sync_coordinator_test.go
+++ b/services/p2p/sync_coordinator_test.go
@@ -1213,3 +1213,129 @@ func TestSyncCoordinator_MaxUnprovenProbeBudget_Clamp(t *testing.T) {
 
 	require.Equal(t, 0, maxUnprovenProbeBudget(nil), "nil settings must yield a zero budget")
 }
+
+// HandleCatchupFailure must not clear the sync peer while another sync decision is
+// in flight: pre-serialisation, its unconditional clear could evict a peer that a
+// concurrent decision path was still working with, producing duplicate/conflicting
+// activations. The blocked GetBestBlockHeader holds evaluateSyncPeer mid-decision
+// (under decisionMu); HandleCatchupFailure must wait for it rather than clearing.
+func TestSyncCoordinator_HandleCatchupFailure_WaitsForInFlightDecision(t *testing.T) {
+	sc, reg := newTestSyncCoordinator(t)
+
+	reg.Register(&blockchain.PeerInfo{
+		ID:                 "peer-a",
+		DataHubURL:         "http://peer-a",
+		Height:             200,
+		ReputationScore:    50,
+		BlockHash:          syncCoordinatorTestHash(t),
+		ValidatedBlockHash: syncCoordinatorTestHash(t),
+		ValidatedChainWork: []byte{0x05},
+	})
+
+	sc.mu.Lock()
+	sc.currentSyncPeer = "peer-a"
+	sc.mu.Unlock()
+
+	gate := make(chan struct{})
+	entered := make(chan struct{}, 16)
+	client := &blockchain.Mock{}
+	client.On("GetBestBlockHeader", mock.Anything).Run(func(mock.Arguments) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-gate
+	}).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100, ChainWork: []byte{0x02}}, nil)
+	sc.blockchainClient = client
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sc.evaluateSyncPeer() // blocks in GetBestBlockHeader while holding decisionMu
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("evaluateSyncPeer never reached GetBestBlockHeader")
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sc.HandleCatchupFailure("test failure")
+	}()
+
+	// Give HandleCatchupFailure ample time to (wrongly) run its clear if it is not
+	// serialised behind the in-flight decision.
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, "peer-a", sc.GetCurrentSyncPeer(),
+		"HandleCatchupFailure must not clear the sync peer while another decision is in flight")
+
+	close(gate)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("sync decisions deadlocked")
+	}
+}
+
+// Hammers every decision entry point concurrently under -race to guard the
+// decisionMu lock ordering: a regression that acquires decisionMu while holding
+// mu (or re-enters it) hangs this test.
+func TestSyncCoordinator_ConcurrentSyncDecisions_NoDeadlock(t *testing.T) {
+	sc, reg := newTestSyncCoordinator(t)
+	setSyncCoordinatorLocalTip(t, sc, 100, []byte{0x02})
+
+	pid := mustNewPeerID(t)
+	for _, id := range []string{"peer-a", "peer-b", pid.String()} {
+		reg.Register(&blockchain.PeerInfo{
+			ID:                 id,
+			DataHubURL:         "http://" + id,
+			Height:             200,
+			ReputationScore:    50,
+			BlockHash:          syncCoordinatorTestHash(t),
+			ValidatedBlockHash: syncCoordinatorTestHash(t),
+			ValidatedChainWork: []byte{0x05},
+		})
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < 6; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				_ = sc.TriggerSync()
+				sc.evaluateSyncPeer()
+				sc.HandleCatchupFailure("stress")
+				sc.UpdateBanStatus(pid)
+				sc.ClearSyncPeer()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("concurrent sync decisions deadlocked")
+	}
+
+	current := sc.GetCurrentSyncPeer()
+	if current != "" {
+		_, found := reg.Get(current)
+		require.True(t, found, "current sync peer %s must be a registered peer", current)
+	}
+}


### PR DESCRIPTION
### Problem
The sync coordinator's compound clear -> select -> activate sequences were not serialized as a unit. `sc.mu` guarded individual fields, and `claimSelectedSyncPeer` made the claim itself atomic, but the surrounding sequences still interleaved across goroutines: `HandleCatchupFailure`, `UpdateBanStatus`, `evaluateSyncPeer`, and the FSM-transition handler each read the current peer, performed registry/network work, then unconditionally cleared and re-triggered. A concurrent trigger could activate a new peer in between, and the stale clear would evict it - recording duplicate sync attempts and publishing conflicting sync triggers to Kafka. The disconnect handler's check-and-clear could likewise fire between a claim and its Kafka send.

### Fix
Added a dedicated `decisionMu` mutex that serializes every compound sync decision. Entry points (`TriggerSync`, `ClearSyncPeer`, `HandleCatchupFailure`, `HandlePeerDisconnected`, `UpdateBanStatus`, `checkFSMState`, `evaluateSyncPeer`) acquire it; internal paths that already hold it call a new `triggerSyncLocked` and `clearSyncPeerIfCurrent` directly. Lock ordering is strict: `decisionMu` before `sc.mu`, never the reverse, and `sc.mu` remains the field-level lock. The mutex was chosen over a single-consumer channel as the minimal change preserving the existing synchronous call structure. A side benefit: the previously-unlocked `backoffMultiplier` read in `considerReputationRecovery` is now serialized because all its writers run under `decisionMu`.

Residual (pre-existing, out of scope): `HandleCatchupFailure(reason)` does not identify the failed peer, so a late failure report can penalize a peer that legitimately replaced the failed one; fixing this requires widening the Server-to-coordinator interface.

### Tests
- `TestSyncCoordinator_HandleCatchupFailure_WaitsForInFlightDecision` - holds a decision in flight via a blocking `GetBestBlockHeader` and asserts `HandleCatchupFailure` cannot clear the sync peer mid-decision. Fails on the pre-fix code, passes with the fix.
- `TestSyncCoordinator_ConcurrentSyncDecisions_NoDeadlock` - hammers all decision entry points from 6 goroutines under `-race` to guard the lock ordering against deadlock regressions.

Commands run (affected package only):
```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```
All green, including the pre-existing suite.