### PR TITLE
MvP-4691 blockassembly: reject P2SH coinbase outputs on mining submission

### DIFF
--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -1383,6 +1383,113 @@ func TestBlock_ValidWithOneTransaction(t *testing.T) {
 	require.False(t, hasTransactionsReferencingOldBlocks)
 }
 
+// TestBlockValid_AcceptsP2SHCoinbaseOutput pins accept-side parity with bitcoin-sv:
+// CheckBlock/CheckCoinbase never runs the P2SH output scan on the coinbase (the
+// bad-txns-vout-p2sh rule in CheckRegularTransaction applies to non-coinbase
+// transactions only), so a peer block whose coinbase pays to a P2SH-shaped output is
+// consensus-valid and Block.Valid must accept it. Rejecting it here would make the
+// node reject blocks the rest of the network accepts. The mining-side guard against
+// *originating* such a coinbase lives in blockassembly SubmitMiningSolution and must
+// never be mirrored into this validation path.
+func TestBlockValid_AcceptsP2SHCoinbaseOutput(t *testing.T) {
+	validateWithCoinbase := func(t *testing.T, coinbase *bt.Tx) (bool, error) {
+		t.Helper()
+
+		tSettings := test.CreateBaseTestSettings(t)
+
+		// The pin must hold at a POST-Genesis height: a (wrong) Genesis-gated
+		// P2SH rejection added to Block.Valid would not fire at height 0.
+		// Regression params: GenesisActivationHeight=10000, BIP0034Height is
+		// unreachable (BIP34 coinbase-height check stays off), BIP65/66 floors
+		// require header version 4 at this height.
+		height := tSettings.ChainCfgParams.GenesisActivationHeight + 1
+
+		// The coinbase may claim at most fees+subsidy at this height (all outputs count).
+		for _, out := range coinbase.Outputs {
+			out.Satoshis = 0
+		}
+		coinbase.Outputs[0].Satoshis = util.GetBlockSubsidyForHeight(height, tSettings.ChainCfgParams)
+
+		// Easy-difficulty header bound to this coinbase (merkle root of a
+		// coinbase-only block is the coinbase txid).
+		bits, err := NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blockHeader := &BlockHeader{
+			Version:        4,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: coinbase.TxIDChainHash(),
+			Timestamp:      uint32(time.Now().Unix()), // nolint:gosec
+			Bits:           *bits,
+			Nonce:          0,
+		}
+
+		// Grind the nonce until the easy target is met; HasMetTargetDifficulty
+		// returns an error (not just false) for a miss, so only `ok` matters here.
+		for {
+			ok, _, _ := blockHeader.HasMetTargetDifficulty()
+			if ok {
+				break
+			}
+
+			require.Less(t, blockHeader.Nonce, uint32(1_000_000), "could not grind a nonce meeting the easy target")
+			blockHeader.Nonce++
+		}
+
+		b, err := NewBlock(blockHeader, coinbase, []*chainhash.Hash{}, 1, 123, height, 0)
+		require.NoError(t, err)
+
+		subtreeStore, err := null.New(ulogger.TestLogger{})
+		require.NoError(t, err)
+
+		utxoStoreURL, err := url.Parse("sqlitememory:///test")
+		require.NoError(t, err)
+
+		utxoStore, err := sql.New(context.Background(), ulogger.TestLogger{}, tSettings, utxoStoreURL)
+		require.NoError(t, err)
+
+		currentChain := make([]*BlockHeader, 11)
+		currentChainIDs := make([]uint32, 11)
+
+		for i := 0; i < 11; i++ {
+			currentChain[i] = &BlockHeader{
+				HashPrevBlock:  &chainhash.Hash{},
+				HashMerkleRoot: &chainhash.Hash{},
+				Timestamp:      blockHeader.Timestamp - 100 - uint32(i), // nolint:gosec
+			}
+			currentChainIDs[i] = uint32(i) // nolint:gosec
+		}
+
+		oldBlockIDs := txmap.NewSyncedMap[chainhash.Hash, []uint32]()
+
+		return b.Valid(context.Background(), ulogger.TestLogger{}, subtreeStore, utxoStore, oldBlockIDs, currentChain, currentChainIDs, tSettings, nil)
+	}
+
+	t.Run("control: unmodified coinbase is accepted", func(t *testing.T) {
+		coinbase, err := bt.NewTxFromString(CoinbaseHex)
+		require.NoError(t, err)
+
+		v, err := validateWithCoinbase(t, coinbase)
+		require.NoError(t, err)
+		require.True(t, v)
+	})
+
+	t.Run("P2SH coinbase output is accepted", func(t *testing.T) {
+		coinbase, err := bt.NewTxFromString(CoinbaseHex)
+		require.NoError(t, err)
+
+		// Redirect the payout to the exact P2SH shape svnode's IsP2SH tests:
+		// OP_HASH160 <20-byte push> OP_EQUAL.
+		p2shScript, err := bscript.NewFromHexString("a914000000000000000000000000000000000000000087")
+		require.NoError(t, err)
+		coinbase.Outputs[0].LockingScript = p2shScript
+
+		v, err := validateWithCoinbase(t, coinbase)
+		require.NoError(t, err)
+		require.True(t, v)
+	})
+}
+
 func TestGetAndValidateSubtrees(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 	blockHeaderBytes, _ := hex.DecodeString(block1Header)

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -1386,7 +1386,10 @@ func TestBlock_ValidWithOneTransaction(t *testing.T) {
 // TestBlockValid_AcceptsP2SHCoinbaseOutput pins accept-side parity with bitcoin-sv:
 // CheckBlock/CheckCoinbase never runs the P2SH output scan on the coinbase (the
 // bad-txns-vout-p2sh rule in CheckRegularTransaction applies to non-coinbase
-// transactions only), so a peer block whose coinbase pays to a P2SH-shaped output is
+// transactions only — svnode validation.cpp:611-623, DoS 100, on both the mempool and
+// block-consensus paths; the mining RPCs reuse the same bad-txns-vout-p2sh string via
+// HasP2SHOutput, but that is a separate mining-side emitter, not the consensus rule), so
+// a peer block whose coinbase pays to a P2SH-shaped output is
 // consensus-valid and Block.Valid must accept it. Rejecting it here would make the
 // node reject blocks the rest of the network accepts. The mining-side guard against
 // *originating* such a coinbase lives in blockassembly SubmitMiningSolution and must

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1495,6 +1495,12 @@ func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSub
 	}
 
 	bestBlockHeader, _ := ba.blockAssembler.CurrentBlock()
+	if bestBlockHeader == nil {
+		// CurrentBlock() returns (nil, 0) before the best block is loaded (early
+		// startup / post-reset). Fail cleanly instead of dereferencing nil below.
+		return nil, errors.NewProcessingError("[BlockAssembly][%s] no current best block yet", jobID)
+	}
+
 	if bestBlockHeader.HashPrevBlock.IsEqual(hashPrevBlock) {
 		return nil, errors.NewProcessingError("[BlockAssembly][%s] candidate is stale: chain has already advanced past its parent", jobID)
 	}
@@ -2299,6 +2305,12 @@ func (ba *BlockAssembly) generateBlock(ctx context.Context, address *string) err
 
 	// Store the current best block hash before submission
 	previousBestHeader, _ := ba.blockAssembler.CurrentBlock()
+	if previousBestHeader == nil {
+		// CurrentBlock() returns (nil, 0) before the best block is loaded; return a
+		// clean error rather than panicking on previousBestHeader.Hash() below.
+		return errors.NewProcessingError("[generateBlock] no current best block yet")
+	}
+
 	previousBestHash := previousBestHeader.Hash()
 
 	resp, err := ba.submitMiningSolution(ctx, req)
@@ -2332,6 +2344,13 @@ func (ba *BlockAssembly) waitForBestBlockHeaderUpdate(ctx context.Context, previ
 			return nil
 		case <-ticker.C:
 			currentBestHeader, _ := ba.blockAssembler.CurrentBlock()
+			if currentBestHeader == nil {
+				// Best block not loaded yet (CurrentBlock() returns nil); treat this
+				// tick as "not ready" and keep polling until it loads or waitCtx times
+				// out. Do not error — a nil header is exactly what this loop waits for.
+				continue
+			}
+
 			currentBestHash := currentBestHeader.Hash()
 			if !currentBestHash.IsEqual(previousBestHash) {
 				// Best block has been updated

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1432,6 +1432,11 @@ func validateCoinbaseForSubmission(jobID string, coinbaseTx *bt.Tx) error {
 	// originate a block whose coinbase pays to a P2SH output. This is a local mining
 	// guard, NOT a consensus rule — peer blocks with a P2SH coinbase are valid on the
 	// network and must never be rejected in Block.Valid or block validation.
+	//
+	// This is placed at the shared submission convergence deliberately, not only on the
+	// pool branch: bitcoin-sv's generateBlocks carries the identical guard on the
+	// generate/generatetoaddress path (rpc/mining.cpp:199), so guarding here keeps
+	// GenerateBlocks in parity with upstream rather than making Teranode stricter.
 	if coinbaseHasP2SHOutput(coinbaseTx) {
 		return errors.NewProcessingError("[BlockAssembly][%s] bad-txns-vout-p2sh: coinbase pays to a P2SH output", jobID)
 	}

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1659,6 +1659,11 @@ func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSub
 
 	ba.logger.Debugf("[BlockAssembly][%s][%s] add block to blockchain", jobID, block.Header.Hash())
 	ba.logger.Debugf("[BlockAssembly][%s][%s] block difficulty: %s", jobID, block.Header.Hash(), block.Header.Bits.CalculateDifficulty().String())
+	// Safe without a nil check: the guard at the top of this function already established a
+	// non-nil best block, and no production path clears bestBlock back to nil once loaded
+	// (every writer stores a fresh non-nil BestBlockInfo), so CurrentBlock() cannot return
+	// nil here — the .Timestamp deref below (evaluated eagerly as a Debugf arg regardless
+	// of log level) therefore cannot panic.
 	bestBlockHeader, _ = ba.blockAssembler.CurrentBlock()
 	ba.logger.Debugf("[BlockAssembly][%s][%s] time since previous block: %s", jobID, block.Header.Hash(), time.Since(time.Unix(int64(bestBlockHeader.Timestamp), 0)).String())
 
@@ -2306,8 +2311,13 @@ func (ba *BlockAssembly) generateBlock(ctx context.Context, address *string) err
 	// Store the current best block hash before submission
 	previousBestHeader, _ := ba.blockAssembler.CurrentBlock()
 	if previousBestHeader == nil {
-		// CurrentBlock() returns (nil, 0) before the best block is loaded; return a
-		// clean error rather than panicking on previousBestHeader.Hash() below.
+		// Defensive: GetMiningCandidate and Mine above have already succeeded here, which
+		// implies a loaded best block, so this branch is not reached in normal operation
+		// (and is not exercised by the test suite, which always starts the assembler —
+		// Start sets bestBlock synchronously). Without it, previousBestHeader.Hash() below
+		// — which is nil-safe, so this is a bogus-hash logic bug, not a panic — would
+		// derive previousBestHash from a nil header and compare against a garbage value.
+		// Return a clean error instead.
 		return errors.NewProcessingError("[generateBlock] no current best block yet")
 	}
 
@@ -2345,9 +2355,11 @@ func (ba *BlockAssembly) waitForBestBlockHeaderUpdate(ctx context.Context, previ
 		case <-ticker.C:
 			currentBestHeader, _ := ba.blockAssembler.CurrentBlock()
 			if currentBestHeader == nil {
-				// Best block not loaded yet (CurrentBlock() returns nil); treat this
-				// tick as "not ready" and keep polling until it loads or waitCtx times
-				// out. Do not error — a nil header is exactly what this loop waits for.
+				// Best block not loaded yet (CurrentBlock() returns nil). Skip this tick
+				// and keep polling until it loads or waitCtx times out. Without this,
+				// Hash() below — nil-safe, so no panic — would derive a bogus hash from
+				// the nil header that spuriously fails the "changed" check and returns
+				// early. Do not error — a nil header is exactly what this loop waits for.
 				continue
 			}
 

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1415,6 +1415,52 @@ func (ba *BlockAssembly) SubmitMiningSolution(ctx context.Context, req *blockass
 	}, err
 }
 
+// validateCoinbaseForSubmission runs the final coinbase checks shared by both
+// submitMiningSolution branches (pool-supplied req.CoinbaseTx and the recreated
+// candidate coinbase). Both branches MUST converge on this single call so a
+// future refactor cannot leave one branch unguarded.
+func validateCoinbaseForSubmission(jobID string, coinbaseTx *bt.Tx) error {
+	if coinbaseTx == nil {
+		return errors.NewProcessingError("[BlockAssembly][%s] coinbase transaction is nil", jobID)
+	}
+
+	if len(coinbaseTx.Inputs) != 1 {
+		return errors.NewProcessingError("[BlockAssembly][%s] coinbase transaction must have exactly one input after processing, got %d", jobID, len(coinbaseTx.Inputs))
+	}
+
+	// Parity with bitcoin-sv's mining RPCs (HasP2SHOutput in rpc/mining.cpp): refuse to
+	// originate a block whose coinbase pays to a P2SH output. This is a local mining
+	// guard, NOT a consensus rule — peer blocks with a P2SH coinbase are valid on the
+	// network and must never be rejected in Block.Valid or block validation.
+	if coinbaseHasP2SHOutput(coinbaseTx) {
+		return errors.NewProcessingError("[BlockAssembly][%s] bad-txns-vout-p2sh: coinbase pays to a P2SH output", jobID)
+	}
+
+	return nil
+}
+
+// coinbaseHasP2SHOutput reports whether any output locking script matches the exact
+// pay-to-script-hash shape bitcoin-sv's IsP2SH tests (script.cpp): 23 bytes,
+// OP_HASH160 (0xa9), a 20-byte push (0x14), OP_EQUAL (0x87).
+func coinbaseHasP2SHOutput(tx *bt.Tx) bool {
+	if tx == nil {
+		return false
+	}
+
+	for _, out := range tx.Outputs {
+		if out == nil || out.LockingScript == nil {
+			continue
+		}
+
+		s := out.LockingScript.Bytes()
+		if len(s) == 23 && s[0] == 0xa9 && s[1] == 0x14 && s[22] == 0x87 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSubmissionRequest) (*blockassembly_api.OKResponse, error) {
 	jobID := util.ReverseAndHexEncodeSlice(req.SubmitMiningSolutionRequest.Id)
 
@@ -1486,8 +1532,8 @@ func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSub
 	}
 
 	// Final validation: ensure coinbase is valid (defense-in-depth)
-	if len(coinbaseTx.Inputs) != 1 {
-		return nil, errors.NewProcessingError("[BlockAssembly][%s] coinbase transaction must have exactly one input after processing, got %d", jobID, len(coinbaseTx.Inputs))
+	if err = validateCoinbaseForSubmission(jobID, coinbaseTx); err != nil {
+		return nil, err
 	}
 
 	coinbaseTxIDHash := coinbaseTx.TxIDChainHash()

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -356,3 +356,43 @@ func TestSubmitMiningSolution_RejectsP2SHCoinbaseOutput(t *testing.T) {
 		}
 	})
 }
+
+// TestGenerateBlock_RejectsP2SHCoinbaseOutput exercises the generate path end to end
+// (generateBlock -> Mine(address) -> CreateCoinbaseTxCandidateForAddress ->
+// AddressToScript -> submitMiningSolution -> validateCoinbaseForSubmission). Because the
+// P2SH guard lives at the shared submission convergence, mining to a P2SH payout address
+// must be rejected with bad-txns-vout-p2sh, matching bitcoin-sv's generateBlocks guard
+// (rpc/mining.cpp:199).
+func TestGenerateBlock_RejectsP2SHCoinbaseOutput(t *testing.T) {
+	server, _ := setupServer(t)
+	require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+	// Testnet P2SH address (base58 script-hash version byte 0xc4, leading '2').
+	// AddressToScript switches on the decoded version byte and accepts this regardless of
+	// the configured network, emitting the 23-byte OP_HASH160 <20-byte hash> OP_EQUAL
+	// coinbase output script that the guard detects.
+	p2shAddress := "2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br"
+
+	err := server.generateBlock(t.Context(), &p2shAddress)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad-txns-vout-p2sh")
+}
+
+// TestGenerateBlock_AllowsP2PKHCoinbaseOutput is the non-P2SH companion: a standard P2PKH
+// payout address produces an ordinary coinbase output that the guard must NOT reject. The
+// generate path may still fail deeper in the pipeline (block assembly/submission) or wait
+// up to ~5s in waitForBestBlockHeaderUpdate on the success path; either is acceptable —
+// the assertion is only that the P2SH guard specifically does not fire.
+func TestGenerateBlock_AllowsP2PKHCoinbaseOutput(t *testing.T) {
+	server, _ := setupServer(t)
+	require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+	// Testnet P2PKH address (base58 pubkey-hash version byte 0x6f, leading 'n'); produces
+	// a standard OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG coinbase output.
+	p2pkhAddress := "n2ZNV88uQbede7C5M5jzi6SyG4GVVr5JTt"
+
+	err := server.generateBlock(t.Context(), &p2pkhAddress)
+	if err != nil {
+		require.NotContains(t, err.Error(), "bad-txns-vout-p2sh")
+	}
+}

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockassembly/blockassembly_api"
+	"github.com/bsv-blockchain/teranode/services/blockassembly/subtreeprocessor"
 	"github.com/bsv-blockchain/teranode/util/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -394,5 +397,65 @@ func TestGenerateBlock_AllowsP2PKHCoinbaseOutput(t *testing.T) {
 	err := server.generateBlock(t.Context(), &p2pkhAddress)
 	if err != nil {
 		require.NotContains(t, err.Error(), "bad-txns-vout-p2sh")
+	}
+}
+
+// TestSubmitMiningSolution_NoCurrentBlock verifies that the stale-candidate check no
+// longer panics when the block assembler has not loaded a best block yet
+// (CurrentBlock() returns nil, e.g. early startup / post-reset). newServerForChanTest
+// wires a zero-value BlockAssembler (bestBlock unset), and a job is preloaded so the
+// call gets past the jobStore lookup and PreviousHash decode and reaches the guard.
+func TestSubmitMiningSolution_NoCurrentBlock(t *testing.T) {
+	s, _ := newServerForChanTest(t)
+
+	// 32-byte job id (chainhash requires exactly 32 bytes).
+	idBytes := make([]byte, 32)
+	idBytes[0] = 0x01
+
+	id, err := chainhash.NewHash(idBytes)
+	require.NoError(t, err)
+
+	// Preload a job keyed by the same id, with a valid 32-byte PreviousHash so the
+	// decode at the top of submitMiningSolution succeeds and execution reaches the
+	// CurrentBlock() guard.
+	s.jobStore.Set(*id, &subtreeprocessor.Job{
+		ID: id,
+		MiningCandidate: &model.MiningCandidate{
+			Id:           idBytes,
+			PreviousHash: make([]byte, 32),
+		},
+	}, time.Minute)
+
+	resp, err := s.submitMiningSolution(context.Background(), &BlockSubmissionRequest{
+		SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{Id: idBytes},
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "no current best block")
+}
+
+// TestWaitForBestBlockHeaderUpdate_ToleratesNilCurrentBlock verifies that the polling
+// loop skips ticks where CurrentBlock() returns nil (best block not loaded) without
+// panicking, and returns cleanly once the context times out. newServerForChanTest's
+// zero-value BlockAssembler returns nil on every tick, so the loop only exits via the
+// context deadline.
+func TestWaitForBestBlockHeaderUpdate_ToleratesNilCurrentBlock(t *testing.T) {
+	s, _ := newServerForChanTest(t)
+
+	// Short deadline so waitCtx (derived from this ctx) fires quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	prevHash, err := chainhash.NewHash(make([]byte, 32))
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- s.waitForBestBlockHeaderUpdate(ctx, prevHash) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForBestBlockHeaderUpdate did not return after context timeout")
 	}
 }

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -2,9 +2,12 @@ package blockassembly
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/teranode/services/blockassembly/blockassembly_api"
 	"github.com/bsv-blockchain/teranode/util/testutil"
 	"github.com/stretchr/testify/require"
@@ -191,4 +194,165 @@ func TestSubmitMiningSolution_ResponseWait_Success(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("SubmitMiningSolution did not complete a successful submission")
 	}
+}
+
+// p2shLockingScript is the exact 23-byte pay-to-script-hash shape bitcoin-sv's
+// IsP2SH tests: OP_HASH160 (0xa9) <20-byte push (0x14)> OP_EQUAL (0x87).
+const p2shLockingScriptHex = "a914000000000000000000000000000000000000000087"
+
+// TestCoinbaseHasP2SHOutput pins the helper to the exact svnode IsP2SH shape:
+// only a 23-byte OP_HASH160 <20-byte push> OP_EQUAL script matches; near-miss
+// shapes (wrong length, wrong leading/trailing opcode) must not.
+func TestCoinbaseHasP2SHOutput(t *testing.T) {
+	mkTx := func(scripts ...[]byte) *bt.Tx {
+		tx := bt.NewTx()
+		for _, s := range scripts {
+			ls := bscript.Script(s)
+			tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 0, LockingScript: &ls})
+		}
+
+		return tx
+	}
+
+	p2sh, err := hex.DecodeString(p2shLockingScriptHex)
+	require.NoError(t, err)
+
+	p2pkh, err := hex.DecodeString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+
+	wrongLeadingOp := append([]byte{}, p2sh...)
+	wrongLeadingOp[0] = 0xa8 // OP_SHA256 instead of OP_HASH160
+
+	wrongTrailingOp := append([]byte{}, p2sh...)
+	wrongTrailingOp[22] = 0x88 // OP_EQUALVERIFY instead of OP_EQUAL
+
+	wrongPushLen := append([]byte{}, p2sh...)
+	wrongPushLen[1] = 0x13 // 19-byte push marker (still 23 bytes long)
+
+	tests := []struct {
+		name string
+		tx   *bt.Tx
+		want bool
+	}{
+		{"exact P2SH shape", mkTx(p2sh), true},
+		{"P2SH among other outputs", mkTx(p2pkh, p2sh), true},
+		{"P2PKH only", mkTx(p2pkh), false},
+		{"truncated (22 bytes)", mkTx(p2sh[:22]), false},
+		{"extended (24 bytes)", mkTx(append(append([]byte{}, p2sh...), 0x00)), false},
+		{"wrong leading opcode", mkTx(wrongLeadingOp), false},
+		{"wrong trailing opcode", mkTx(wrongTrailingOp), false},
+		{"wrong push length marker", mkTx(wrongPushLen), false},
+		{"empty script", mkTx([]byte{}), false},
+		{"no outputs", bt.NewTx(), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, coinbaseHasP2SHOutput(tt.tx))
+		})
+	}
+
+	t.Run("nil locking script", func(t *testing.T) {
+		tx := bt.NewTx()
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 0, LockingScript: nil})
+		require.False(t, coinbaseHasP2SHOutput(tx))
+	})
+
+	t.Run("nil tx", func(t *testing.T) {
+		require.False(t, coinbaseHasP2SHOutput(nil))
+	})
+}
+
+// TestValidateCoinbaseForSubmission unit-tests the convergence point both
+// submitMiningSolution branches (pool-supplied and recreated coinbase) must go
+// through. The recreated branch cannot produce a P2SH output through public
+// configuration (payout addresses derive from wallet public keys, always
+// P2PKH), so this direct test is what pins the guard for that branch: any
+// refactor that stops routing a branch through validateCoinbaseForSubmission
+// must consciously touch this seam.
+func TestValidateCoinbaseForSubmission(t *testing.T) {
+	p2sh, err := hex.DecodeString(p2shLockingScriptHex)
+	require.NoError(t, err)
+
+	p2pkh, err := hex.DecodeString("76a914000000000000000000000000000000000000000088ac")
+	require.NoError(t, err)
+
+	mkCoinbase := func(script []byte) *bt.Tx {
+		tx := bt.NewTx()
+		tx.Inputs = append(tx.Inputs, &bt.Input{})
+		ls := bscript.Script(script)
+		tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 0, LockingScript: &ls})
+
+		return tx
+	}
+
+	t.Run("P2SH output rejected", func(t *testing.T) {
+		err := validateCoinbaseForSubmission("job", mkCoinbase(p2sh))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad-txns-vout-p2sh")
+	})
+
+	t.Run("P2PKH output accepted", func(t *testing.T) {
+		require.NoError(t, validateCoinbaseForSubmission("job", mkCoinbase(p2pkh)))
+	})
+
+	t.Run("nil coinbase rejected", func(t *testing.T) {
+		require.Error(t, validateCoinbaseForSubmission("job", nil))
+	})
+
+	t.Run("wrong input count rejected", func(t *testing.T) {
+		tx := mkCoinbase(p2pkh)
+		tx.Inputs = append(tx.Inputs, &bt.Input{})
+		err := validateCoinbaseForSubmission("job", tx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exactly one input")
+	})
+}
+
+// TestSubmitMiningSolution_RejectsP2SHCoinbaseOutput verifies the local mining
+// guard: a pool-supplied coinbase paying to a P2SH output is refused with
+// bad-txns-vout-p2sh (parity with bitcoin-sv's mining RPCs), while an
+// unmodified candidate coinbase is not rejected by that guard.
+func TestSubmitMiningSolution_RejectsP2SHCoinbaseOutput(t *testing.T) {
+	server, _ := setupServer(t)
+	require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+	candidate, err := server.GetMiningCandidate(t.Context(), &blockassembly_api.GetMiningCandidateRequest{})
+	require.NoError(t, err)
+
+	t.Run("P2SH coinbase output rejected", func(t *testing.T) {
+		coinbaseTx, err := candidate.CreateCoinbaseTxCandidate(server.settings)
+		require.NoError(t, err)
+
+		p2shScript, err := bscript.NewFromHexString(p2shLockingScriptHex)
+		require.NoError(t, err)
+		coinbaseTx.Outputs[0].LockingScript = p2shScript
+
+		resp, err := server.submitMiningSolution(t.Context(), &BlockSubmissionRequest{
+			SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{
+				Id:         candidate.Id,
+				CoinbaseTx: coinbaseTx.Bytes(),
+			},
+		})
+		require.Error(t, err)
+		require.Nil(t, resp)
+		require.Contains(t, err.Error(), "bad-txns-vout-p2sh")
+	})
+
+	t.Run("non-P2SH coinbase not rejected by the guard", func(t *testing.T) {
+		coinbaseTx, err := candidate.CreateCoinbaseTxCandidate(server.settings)
+		require.NoError(t, err)
+
+		_, err = server.submitMiningSolution(t.Context(), &BlockSubmissionRequest{
+			SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{
+				Id:         candidate.Id,
+				CoinbaseTx: coinbaseTx.Bytes(),
+			},
+		})
+		// The submission may still fail deeper in the pipeline (e.g. proof of
+		// work); the guard specifically must not fire.
+		if err != nil {
+			require.NotContains(t, err.Error(), "bad-txns-vout-p2sh")
+		}
+	})
 }

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -346,14 +346,23 @@ func TestSubmitMiningSolution_RejectsP2SHCoinbaseOutput(t *testing.T) {
 		coinbaseTx, err := candidate.CreateCoinbaseTxCandidate(server.settings)
 		require.NoError(t, err)
 
+		// Pin the fixture as a genuine non-P2SH coinbase, so the NotContains assertion
+		// below is not vacuous on the input side.
+		require.False(t, coinbaseHasP2SHOutput(coinbaseTx))
+
 		_, err = server.submitMiningSolution(t.Context(), &BlockSubmissionRequest{
 			SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{
 				Id:         candidate.Id,
 				CoinbaseTx: coinbaseTx.Bytes(),
 			},
 		})
-		// The submission may still fail deeper in the pipeline (e.g. proof of
-		// work); the guard specifically must not fire.
+		// What this proves: the guard does NOT fire on a genuine non-P2SH coinbase (an
+		// over-broad guard that wrongly matched a standard output would surface
+		// bad-txns-vout-p2sh here). What it does NOT prove: that the guard is present —
+		// deleting it only removes rejections, so this stays green either way. Guard
+		// removal is covered by TestCoinbaseHasP2SHOutput and TestValidateCoinbaseForSubmission.
+		// The submission may still fail deeper in the pipeline (e.g. proof of work); only
+		// the absence of the P2SH rejection is asserted.
 		if err != nil {
 			require.NotContains(t, err.Error(), "bad-txns-vout-p2sh")
 		}
@@ -382,10 +391,15 @@ func TestGenerateBlock_RejectsP2SHCoinbaseOutput(t *testing.T) {
 }
 
 // TestGenerateBlock_AllowsP2PKHCoinbaseOutput is the non-P2SH companion: a standard P2PKH
-// payout address produces an ordinary coinbase output that the guard must NOT reject. The
-// generate path may still fail deeper in the pipeline (block assembly/submission) or wait
-// up to ~5s in waitForBestBlockHeaderUpdate on the success path; either is acceptable —
-// the assertion is only that the P2SH guard specifically does not fire.
+// payout address produces an ordinary coinbase output that the guard must NOT reject.
+//
+// What this proves: the guard does NOT fire for a genuine non-P2SH coinbase (asserted
+// directly on the coinbase built from this address along generateBlock's own path). What
+// it does NOT prove: that the guard is present — deleting it only removes rejections, so
+// the NotContains below stays green either way; guard removal is covered by
+// TestCoinbaseHasP2SHOutput and TestValidateCoinbaseForSubmission. The generate path may
+// also fail deeper in the pipeline (block assembly/submission) or wait up to ~5s in
+// waitForBestBlockHeaderUpdate on the success path; either is acceptable.
 func TestGenerateBlock_AllowsP2PKHCoinbaseOutput(t *testing.T) {
 	server, _ := setupServer(t)
 	require.NoError(t, server.blockAssembler.Start(t.Context()))
@@ -394,7 +408,19 @@ func TestGenerateBlock_AllowsP2PKHCoinbaseOutput(t *testing.T) {
 	// a standard OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG coinbase output.
 	p2pkhAddress := "n2ZNV88uQbede7C5M5jzi6SyG4GVVr5JTt"
 
-	err := server.generateBlock(t.Context(), &p2pkhAddress)
+	// Reconstruct the coinbase along the same path generateBlock uses (Mine ->
+	// CreateCoinbaseTxCandidateForAddress) to confirm this address yields a genuine
+	// non-P2SH coinbase, so the NotContains assertion below is not vacuous on the input
+	// side. Only the random extranonce varies between builds; the output-script shape is
+	// deterministic for a given address, so this matches the coinbase generateBlock builds.
+	candidate, err := server.GetMiningCandidate(t.Context(), &blockassembly_api.GetMiningCandidateRequest{})
+	require.NoError(t, err)
+
+	coinbaseTx, err := candidate.CreateCoinbaseTxCandidateForAddress(server.settings, &p2pkhAddress)
+	require.NoError(t, err)
+	require.False(t, coinbaseHasP2SHOutput(coinbaseTx))
+
+	err = server.generateBlock(t.Context(), &p2pkhAddress)
 	if err != nil {
 		require.NotContains(t, err.Error(), "bad-txns-vout-p2sh")
 	}
@@ -450,11 +476,20 @@ func TestWaitForBestBlockHeaderUpdate_ToleratesNilCurrentBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan error, 1)
+	start := time.Now()
+
 	go func() { done <- s.waitForBestBlockHeaderUpdate(ctx, prevHash) }()
 
 	select {
 	case err := <-done:
 		require.NoError(t, err)
+		// Regression guard: with the nil-header check present, every 10ms tick is skipped
+		// and the loop only exits when waitCtx (~200ms) fires. If the check were dropped,
+		// the first tick (~10ms) would derive a bogus (non-matching) hash from the nil
+		// header — Hash() is nil-safe, so no panic — and return almost immediately. Both
+		// exit paths return nil, so only this elapsed floor distinguishes the two: 150ms
+		// sits well below the 200ms deadline yet far above the ~10ms early-exit.
+		require.GreaterOrEqual(t, time.Since(start), 150*time.Millisecond)
 	case <-time.After(2 * time.Second):
 		t.Fatal("waitForBestBlockHeaderUpdate did not return after context timeout")
 	}


### PR DESCRIPTION
Resolves https://github.com/bitcoin-sv/teranode/issues/4691

## Why

The issue claimed Teranode could mine a block with a P2SH coinbase output that SV
nodes would reject, forking itself off the network. Verification against bitcoin-sv,
BDK, and Teranode sources refuted that: in bitcoin-sv the `bad-txns-vout-p2sh` rule
(`CheckRegularTransaction`) applies to non-coinbase transactions only, and
`CheckCoinbase` — the consensus path for the coinbase — never inspects output scripts.
A P2SH-coinbase block is therefore consensus-valid network-wide, and Teranode's
acceptance behaviour already matches svnode exactly (verdict: no consensus bug).

What svnode does have is a **local mining guard**: its mining RPCs
(`generateblocks` / `submitblock` / `submitminingsolution`, via `HasP2SHOutput` in
`rpc/mining.cpp`) refuse to *originate* such a block, protecting the miner from paying
the reward into an output that post-Genesis degrades to an anyone-can-spend hash
puzzle. Teranode's `SubmitMiningSolution` lacked that guard — a miner- or pool-supplied
coinbase template paying to P2SH was assembled and announced unchecked. This PR closes
that gap.

## What

- `SubmitMiningSolution` now rejects a coinbase paying to a P2SH-shaped output
  (exact svnode `IsP2SH` shape: 23 bytes, `OP_HASH160 <20-byte push> OP_EQUAL`) with
  `bad-txns-vout-p2sh`. Both coinbase sources (pool-supplied template and internally
  recreated candidate) converge through one shared check
  (`validateCoinbaseForSubmission`).
- Deliberately **not** added to `Block.Valid` or any block-validation path: svnode's
  `CheckBlock`/`CheckCoinbase` accepts a P2SH coinbase from peers, so rejecting it
  during validation would itself create a consensus divergence — the opposite of the
  issue's intent.

## Tests

- Guard: exact-shape and near-miss cases, end-to-end rejection of a pool-supplied
  P2SH coinbase, non-P2SH control, nil-safety, shared-check seam
  (`services/blockassembly/submit_mining_solution_test.go`).
- Accept-side regression pin: `TestBlockValid_AcceptsP2SHCoinbaseOutput`
  (`model/Block_test.go`) validates a P2SH-coinbase block at a post-Genesis height and
  asserts `Block.Valid` accepts it, so a future attempt to move this guard into the
  validation path fails loudly.
- `go build`, `go vet`, `go test -race` on the touched packages, and lint: all green.