### PR TITLE
fix(p2p): read backoffMultiplier under lock in considerReputationRecovery

### DIFF
--- a/services/p2p/sync_coordinator.go
+++ b/services/p2p/sync_coordinator.go
@@ -1186,11 +1186,15 @@ func (sc *SyncCoordinator) checkAllPeersAttempted() {
 
 // considerReputationRecovery checks if any bad peers should have their reputation reset
 func (sc *SyncCoordinator) considerReputationRecovery() {
+	sc.mu.RLock()
+	backoffMultiplier := sc.backoffMultiplier
+	sc.mu.RUnlock()
+
 	// Calculate cooldown based on how many times we've been in backoff
 	baseCooldown := 5 * time.Minute
-	if sc.backoffMultiplier > 1 {
+	if backoffMultiplier > 1 {
 		// Exponentially increase cooldown if we've been in backoff multiple times
-		cooldownMultiplier := sc.backoffMultiplier / 2
+		cooldownMultiplier := backoffMultiplier / 2
 		if cooldownMultiplier < 1 {
 			cooldownMultiplier = 1
 		}

--- a/services/p2p/sync_coordinator_test.go
+++ b/services/p2p/sync_coordinator_test.go
@@ -245,6 +245,37 @@ func TestSyncCoordinator_ConsiderReputationRecovery_NoCandidatesIsNoOp(t *testin
 	require.GreaterOrEqual(t, got.ReputationScore, 50.0, "healthy peer reputation untouched")
 }
 
+// Exercises concurrent backoff writers against considerReputationRecovery's read of
+// backoffMultiplier; fails under -race if the read is not synchronized.
+func TestSyncCoordinator_ConsiderReputationRecovery_ConcurrentWithBackoffWriters(t *testing.T) {
+	sc, _ := newTestSyncCoordinator(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			sc.enterBackoffMode()
+			sc.mu.Lock()
+			sc.lastAllPeersAttemptTime = time.Now().Add(-time.Hour) // force backoff expiry
+			sc.mu.Unlock()
+			sc.checkAndClearExpiredBackoff() // doubles backoffMultiplier
+			sc.enterBackoffMode()            // re-enter so resetBackoff writes backoffMultiplier
+			sc.resetBackoff()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			sc.considerReputationRecovery()
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestSyncCoordinator_UpdatePeerInfo_RegistersPeer(t *testing.T) {
 	sc, reg := newTestSyncCoordinator(t)
 	pid := mustNewPeerID(t)


### PR DESCRIPTION
**Closes #4720.**

### Problem
`SyncCoordinator.considerReputationRecovery` read `sc.backoffMultiplier` without holding `sc.mu`, while `checkAndClearExpiredBackoff`, `resetBackoff`, and `enterBackoffMode` write it under the lock from other goroutines. This is a data race (fails `-race`) and can miscompute the reputation-recovery cooldown from a torn/stale read.

### Fix
Snapshot `backoffMultiplier` into a local variable under `sc.mu.RLock()` at the start of `considerReputationRecovery` and compute the cooldown from the snapshot. Kept the mutex approach (rather than converting to an atomic) since all other accesses already synchronize via `sc.mu`.

### Tests
Added `TestSyncCoordinator_ConsiderReputationRecovery_ConcurrentWithBackoffWriters`, which runs the backoff writers (`enterBackoffMode` / `checkAndClearExpiredBackoff` / `resetBackoff`) concurrently with `considerReputationRecovery`. Verified it fails with the exact race report on the unfixed code and passes with the fix.

Ran (affected package only):
```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```
All green.