### PR TITLE
fix(utxo): tolerate confirmed ghost spenders in counter-conflicting walk and heal their dangling spends

### DIFF
--- a/services/blockassembly/mark_as_conflicting_test.go
+++ b/services/blockassembly/mark_as_conflicting_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockassembly/subtreeprocessor"
 	"github.com/bsv-blockchain/teranode/settings"
 	utxoStore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/mock"
 )
@@ -43,6 +45,13 @@ func TestMarkAsConflicting_EvictsCascadedDescendants(t *testing.T) {
 	// Level 3: grandchild has no children — BFS terminates
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true).
 		Return([]*utxoStore.Spend{{TxID: &grandchildHash, Vout: 0}}, []chainhash.Hash{}, nil)
+
+	// MarkConflictingRecursively probes each discovered child before recursing
+	// (the ghost filter); both descendants are live records, so the probe finds them.
+	mockStore.On("Get", mock.Anything, &childHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil)
+	mockStore.On("Get", mock.Anything, &grandchildHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil)
 
 	mockStp := &subtreeprocessor.MockSubtreeProcessor{}
 	mockStp.On("Remove", mock.Anything, parentHash).Return(nil).Once()

--- a/services/blockassembly/subtreeprocessor/ConflictingTransactions_test.go
+++ b/services/blockassembly/subtreeprocessor/ConflictingTransactions_test.go
@@ -94,7 +94,7 @@ func TestProcessConflictingTransactions(t *testing.T) {
 	_ = conflictingTxInput.PreviousTxIDAdd(&conflictingParentHash)
 	conflictingTxBody.Inputs = append(conflictingTxBody.Inputs, conflictingTxInput)
 
-	mockUtxoStore.On("Get", mock.Anything, mock.Anything, []fields.FieldName{fields.Utxos}).
+	mockUtxoStore.On("Get", mock.Anything, mock.Anything, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{nil}}, nil)
 	mockUtxoStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{Tx: conflictingTxBody, Conflicting: true}, nil)
 	mockUtxoStore.On("SetConflicting", mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, []chainhash.Hash{}, nil)

--- a/services/blockassembly/subtreeprocessor/ConflictingTransactions_test.go
+++ b/services/blockassembly/subtreeprocessor/ConflictingTransactions_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	txmap "github.com/bsv-blockchain/go-tx-map"
@@ -16,6 +17,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/spend"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -82,8 +84,19 @@ func TestProcessConflictingTransactions(t *testing.T) {
 	_ = losingTxMap.Put(conflictingTx2, 1)
 
 	mockUtxoStore.On("ProcessConflicting", mock.Anything, conflictingNodes).Return(losingTxMap, nil)
-	mockUtxoStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{Conflicting: true}, nil)
-	mockUtxoStore.On("GetCounterConflicting", mock.Anything, mock.Anything).Return([]chainhash.Hash{conflictingTx1, conflictingTx2}, nil)
+
+	// The ghost-aware counter-conflicting walk reads the tx body and its parents
+	// directly: give both conflicting txs the same single-input body whose parent
+	// slot is unspent, so each walk resolves to just the tx itself.
+	conflictingTxBody := bt.NewTx()
+	conflictingTxInput := &bt.Input{PreviousTxOutIndex: 0}
+	conflictingParentHash := chainhash.HashH([]byte("conflicting-parent"))
+	_ = conflictingTxInput.PreviousTxIDAdd(&conflictingParentHash)
+	conflictingTxBody.Inputs = append(conflictingTxBody.Inputs, conflictingTxInput)
+
+	mockUtxoStore.On("Get", mock.Anything, mock.Anything, []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{nil}}, nil)
+	mockUtxoStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{Tx: conflictingTxBody, Conflicting: true}, nil)
 	mockUtxoStore.On("SetConflicting", mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, []chainhash.Hash{}, nil)
 	mockUtxoStore.On("Unspend", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockUtxoStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)

--- a/services/subtreevalidation/counter_conflicting_ghost_test.go
+++ b/services/subtreevalidation/counter_conflicting_ghost_test.go
@@ -51,7 +51,7 @@ func TestCheckCounterConflictingOnCurrentChain_ToleratesGhostSpender(t *testing.
 
 	mockStore.On("Get", mock.Anything, hashMatcher(winningTxHash), []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: winningTx}, nil)
-	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&ghostTxHash, 0)}}, nil)
 	mockStore.On("GetConflictingChildren", mock.Anything, ghostTxHash).
 		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", ghostTxHash))
@@ -63,7 +63,7 @@ func TestCheckCounterConflictingOnCurrentChain_ToleratesGhostSpender(t *testing.
 	// the surviving counter set is just the tx itself
 	mockStore.On("GetMeta", mock.Anything, hashMatcher(winningTxHash), mock.Anything).
 		Return(&meta.Data{}, nil)
-	mockStore.On("Get", mock.Anything, hashMatcher(winningTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren}).
+	mockStore.On("Get", mock.Anything, hashMatcher(winningTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
 		Return(&meta.Data{}, nil)
 
 	u := &Server{utxoStore: mockStore}
@@ -88,7 +88,7 @@ func TestCheckCounterConflictingOnCurrentChain_StillRejectsMinedCounter(t *testi
 
 	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: conflictingTx}, nil)
-	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&counterTxHash, 0)}}, nil)
 	mockStore.On("GetConflictingChildren", mock.Anything, counterTxHash).
 		Return([]chainhash.Hash{}, nil)
@@ -99,9 +99,9 @@ func TestCheckCounterConflictingOnCurrentChain_StillRejectsMinedCounter(t *testi
 	mockStore.On("GetMeta", mock.Anything, hashMatcher(counterTxHash), mock.Anything).
 		Return(&meta.Data{BlockIDs: []uint32{7}}, nil)
 
-	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren}).
+	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
 		Return(&meta.Data{}, nil)
-	mockStore.On("Get", mock.Anything, hashMatcher(counterTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren}).
+	mockStore.On("Get", mock.Anything, hashMatcher(counterTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
 		Return(&meta.Data{}, nil)
 
 	u := &Server{utxoStore: mockStore}

--- a/services/subtreevalidation/counter_conflicting_ghost_test.go
+++ b/services/subtreevalidation/counter_conflicting_ghost_test.go
@@ -1,0 +1,114 @@
+// Package subtreevalidation provides functionality for validating subtrees in a blockchain context.
+package subtreevalidation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func hashMatcher(want chainhash.Hash) interface{} {
+	return mock.MatchedBy(func(h *chainhash.Hash) bool { return h.Equal(want) })
+}
+
+func newGhostTestTx(t *testing.T, parentTxHash chainhash.Hash) *bt.Tx {
+	t.Helper()
+
+	tx := bt.NewTx()
+	input := &bt.Input{PreviousTxOutIndex: 0}
+	require.NoError(t, input.PreviousTxIDAdd(&parentTxHash))
+	tx.Inputs = append(tx.Inputs, input)
+	tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 1000, LockingScript: &bscript.Script{bscript.OpTRUE}})
+
+	return tx
+}
+
+// A conflicting tx whose parent slot records a spender with no store record (a
+// confirmed ghost) must pass the counter-conflicting check: an absent counter
+// has no BlockIDs, so it is not mined on our chain. Before the ghost tolerance
+// this scenario returned a ProcessingError and wedged the block forever.
+func TestCheckCounterConflictingOnCurrentChain_ToleratesGhostSpender(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &utxo.MockUtxostore{}
+
+	parentTxHash := chainhash.HashH([]byte("ghost-parent"))
+	ghostTxHash := chainhash.HashH([]byte("ghost-spender"))
+
+	winningTx := newGhostTestTx(t, parentTxHash)
+	winningTxHash := chainhash.HashH([]byte("ghost-winner"))
+
+	parentTx := newGhostTestTx(t, chainhash.HashH([]byte("ghost-grandparent")))
+
+	mockStore.On("Get", mock.Anything, hashMatcher(winningTxHash), []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&ghostTxHash, 0)}}, nil)
+	mockStore.On("GetConflictingChildren", mock.Anything, ghostTxHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", ghostTxHash))
+	mockStore.On("Get", mock.Anything, hashMatcher(ghostTxHash), []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", ghostTxHash))
+	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: parentTx}, nil)
+
+	// the surviving counter set is just the tx itself
+	mockStore.On("GetMeta", mock.Anything, hashMatcher(winningTxHash), mock.Anything).
+		Return(&meta.Data{}, nil)
+	mockStore.On("Get", mock.Anything, hashMatcher(winningTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren}).
+		Return(&meta.Data{}, nil)
+
+	u := &Server{utxoStore: mockStore}
+
+	err := u.checkCounterConflictingOnCurrentChain(ctx, winningTxHash, map[uint32]bool{7: true})
+
+	require.NoError(t, err)
+	mockStore.AssertExpectations(t)
+}
+
+// A live counter that IS mined on our chain must still be rejected — the ghost
+// tolerance must not weaken the mined-on-our-chain check for present records.
+func TestCheckCounterConflictingOnCurrentChain_StillRejectsMinedCounter(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &utxo.MockUtxostore{}
+
+	parentTxHash := chainhash.HashH([]byte("mined-parent"))
+	counterTxHash := chainhash.HashH([]byte("mined-counter"))
+
+	conflictingTx := newGhostTestTx(t, parentTxHash)
+	conflictingTxHash := chainhash.HashH([]byte("mined-conflicting"))
+
+	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: conflictingTx}, nil)
+	mockStore.On("Get", mock.Anything, hashMatcher(parentTxHash), []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&counterTxHash, 0)}}, nil)
+	mockStore.On("GetConflictingChildren", mock.Anything, counterTxHash).
+		Return([]chainhash.Hash{}, nil)
+
+	mockStore.On("GetMeta", mock.Anything, hashMatcher(conflictingTxHash), mock.Anything).
+		Return(&meta.Data{}, nil)
+	// the live counter is mined in block 7, which is on our current chain
+	mockStore.On("GetMeta", mock.Anything, hashMatcher(counterTxHash), mock.Anything).
+		Return(&meta.Data{BlockIDs: []uint32{7}}, nil)
+
+	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren}).
+		Return(&meta.Data{}, nil)
+	mockStore.On("Get", mock.Anything, hashMatcher(counterTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren}).
+		Return(&meta.Data{}, nil)
+
+	u := &Server{utxoStore: mockStore}
+
+	err := u.checkCounterConflictingOnCurrentChain(ctx, conflictingTxHash, map[uint32]bool{7: true})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxInvalid))
+	mockStore.AssertExpectations(t)
+}

--- a/stores/utxo/aerospike/counter_conflicting_ghost_test.go
+++ b/stores/utxo/aerospike/counter_conflicting_ghost_test.go
@@ -3,6 +3,7 @@ package aerospike_test
 import (
 	"testing"
 
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
@@ -10,8 +11,31 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	"github.com/stretchr/testify/require"
 )
+
+// buildSpendingTx builds a tx spending the given parent outputs, paying out
+// less than it consumes so the store's fee check on Create passes.
+func buildSpendingTx(t *testing.T, parentTx *bt.Tx, vOuts ...uint32) *bt.Tx {
+	t.Helper()
+
+	newTx := bt.NewTx()
+
+	total := uint64(0)
+	for _, vOut := range vOuts {
+		require.NoError(t, newTx.From(
+			parentTx.TxIDChainHash().String(), vOut,
+			parentTx.Outputs[vOut].LockingScript.String(),
+			parentTx.Outputs[vOut].Satoshis,
+		))
+		total += parentTx.Outputs[vOut].Satoshis
+	}
+
+	require.NoError(t, newTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", total/2))
+
+	return newTx
+}
 
 // TestCounterConflictingGhostSpender_Aerospike reproduces, against real
 // Aerospike, the field failure behind the counter-conflicting wedge (#1320):
@@ -37,26 +61,6 @@ func TestCounterConflictingGhostSpender_Aerospike(t *testing.T) {
 	t.Cleanup(deferFn)
 
 	cleanDB(t, client)
-
-	buildSpendingTx := func(t *testing.T, parentTx *bt.Tx, vOuts ...uint32) *bt.Tx {
-		t.Helper()
-
-		newTx := bt.NewTx()
-
-		total := uint64(0)
-		for _, vOut := range vOuts {
-			require.NoError(t, newTx.From(
-				parentTx.TxIDChainHash().String(), vOut,
-				parentTx.Outputs[vOut].LockingScript.String(),
-				parentTx.Outputs[vOut].Satoshis,
-			))
-			total += parentTx.Outputs[vOut].Satoshis
-		}
-
-		require.NoError(t, newTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", total/2))
-
-		return newTx
-	}
 
 	// tests.ParentTx is the grandparent — tx's input references it and
 	// SetConflicting resolves parents internally.
@@ -117,4 +121,137 @@ func TestCounterConflictingGhostSpender_Aerospike(t *testing.T) {
 	mdParent, err := store.Get(ctx, tx.TxIDChainHash(), fields.Locked)
 	require.NoError(t, err)
 	require.False(t, mdParent.Locked, "parent must be unlocked after step 5")
+}
+
+// TestCounterConflictingGhostDescendant_Aerospike reproduces the depth-2
+// variant of the ghost wedge against real Aerospike: the parent output's
+// spender L is alive (and conflicting-eligible), but L's own output slot
+// records a spender whose record was never created — the same write failure
+// one level deeper. The walk's BFS must skip the ghost descendant, and
+// ProcessConflicting must demote L and let the winner spend the contested
+// slot, with the cascade probing (not choking on) the record-less child.
+func TestCounterConflictingGhostDescendant_Aerospike(t *testing.T) {
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+	t.Cleanup(deferFn)
+
+	cleanDB(t, client)
+
+	_, err := store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+
+	_, err = store.Create(ctx, tx, 1000)
+	require.NoError(t, err)
+
+	// L: the live spender of tx:0 (it also takes tx:1, which keeps its txid
+	// distinct from the winner's — both spend the contested tx:0).
+	liveLoserTx := buildSpendingTx(t, tx, 0, 1)
+	_, err = store.Create(ctx, liveLoserTx, 0)
+	require.NoError(t, err)
+
+	_, err = store.Spend(ctx, liveLoserTx, store.GetBlockHeight()+1)
+	require.NoError(t, err)
+
+	// The ghost descendant: spends L's output through the store, record never
+	// created.
+	ghostTx := buildSpendingTx(t, liveLoserTx, 0)
+	_, err = store.Spend(ctx, ghostTx, store.GetBlockHeight()+1)
+	require.NoError(t, err)
+
+	// The winner: double-spends tx:0, marked conflicting by the validator.
+	conflictingTx := buildSpendingTx(t, tx, 0)
+	_, err = store.Create(ctx, conflictingTx, 1001, utxo.WithConflicting(true))
+	require.NoError(t, err)
+
+	conflictingTxHash := *conflictingTx.TxIDChainHash()
+	liveLoserTxHash := *liveLoserTx.TxIDChainHash()
+
+	// 1. The walk must tolerate the ghost descendant: L is enumerated as the
+	// counter, the ghost is skipped.
+	counterHashes, err := utxo.GetCounterConflictingTxHashes(ctx, store, conflictingTxHash)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []chainhash.Hash{conflictingTxHash, liveLoserTxHash}, counterHashes)
+
+	// 2. Conflict resolution must demote L (the cascade skips the record-less
+	// ghost child) and let the winner spend the contested slot.
+	losingMap, _, err := utxo.ProcessConflicting(ctx, store, store.GetBlockHeight()+1,
+		[]chainhash.Hash{conflictingTxHash}, map[chainhash.Hash]struct{}{})
+	require.NoError(t, err)
+	require.NotNil(t, losingMap)
+
+	md, err := store.Get(ctx, tx.TxIDChainHash(), fields.Utxos)
+	require.NoError(t, err)
+	require.NotNil(t, md.SpendingDatas[0], "contested slot must be spent after resolution")
+	require.True(t, md.SpendingDatas[0].TxID.Equal(conflictingTxHash),
+		"contested slot must be spent by the winner after resolution")
+
+	mdLoser, err := store.Get(ctx, &liveLoserTxHash, fields.Conflicting)
+	require.NoError(t, err)
+	require.True(t, mdLoser.Conflicting, "the live loser must be demoted")
+}
+
+// TestCounterConflictingReapedSpender_Aerospike covers the counterpart of the
+// ghost tolerance: the spender record is absent not because it was never
+// created, but because the DAH pruner reaped it after it was mined and fully
+// spent. The pruner marks every reaped child in its surviving parents'
+// deletedChildren bin; the walk must fail closed on such a spender instead of
+// treating its settled spend as a ghost — clearing it would let a block
+// double-spend a settled output.
+func TestCounterConflictingReapedSpender_Aerospike(t *testing.T) {
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+	t.Cleanup(deferFn)
+
+	cleanDB(t, client)
+
+	_, err := store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+
+	_, err = store.Create(ctx, tx, 1000)
+	require.NoError(t, err)
+
+	// The reaped spender: spent tx:0 and tx:1 through the store; its record is
+	// absent (as after a DAH delete) and the parent's deletedChildren bin lists
+	// it, exactly as the pruner leaves things.
+	reapedTx := buildSpendingTx(t, tx, 0, 1)
+	_, err = store.Spend(ctx, reapedTx, store.GetBlockHeight()+1)
+	require.NoError(t, err)
+
+	keySource := uaerospike.CalculateKeySource(tx.TxIDChainHash(), 0, store.GetUtxoBatchSize())
+	parentKey, aErr := aerospike.NewKey(store.GetNamespace(), store.GetName(), keySource)
+	require.NoError(t, aErr)
+
+	aErr = client.Put(nil, parentKey, aerospike.BinMap{
+		fields.DeletedChildren.String(): map[interface{}]interface{}{
+			reapedTx.TxIDChainHash().String(): true,
+		},
+	})
+	require.NoError(t, aErr)
+
+	conflictingTx := buildSpendingTx(t, tx, 0)
+	_, err = store.Create(ctx, conflictingTx, 1001, utxo.WithConflicting(true))
+	require.NoError(t, err)
+
+	conflictingTxHash := *conflictingTx.TxIDChainHash()
+
+	// 1. The walk must fail closed on the reaped spender, not tolerate it.
+	_, err = utxo.GetCounterConflictingTxHashes(ctx, store, conflictingTxHash)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deletedChildren")
+
+	// 2. Conflict resolution must refuse likewise and leave the settled slot
+	// untouched.
+	_, _, err = utxo.ProcessConflicting(ctx, store, store.GetBlockHeight()+1,
+		[]chainhash.Hash{conflictingTxHash}, map[chainhash.Hash]struct{}{})
+	require.Error(t, err)
+
+	md, err := store.Get(ctx, tx.TxIDChainHash(), fields.Utxos)
+	require.NoError(t, err)
+	require.NotNil(t, md.SpendingDatas[0], "settled slot must still be spent")
+	require.True(t, md.SpendingDatas[0].TxID.Equal(*reapedTx.TxIDChainHash()),
+		"settled slot must remain held by the reaped spender")
 }

--- a/stores/utxo/aerospike/counter_conflicting_ghost_test.go
+++ b/stores/utxo/aerospike/counter_conflicting_ghost_test.go
@@ -1,0 +1,120 @@
+package aerospike_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCounterConflictingGhostSpender_Aerospike reproduces, against real
+// Aerospike, the field failure behind the counter-conflicting wedge (#1320):
+//
+// A multi-input transaction is validated and makes its valid spends, but errors
+// on another input (already spent, or some other failure), so the transaction
+// record itself is never created — while the completed spends survive. The
+// parent outputs are left recording a spender that does not exist (a "ghost").
+// A conflicting transaction spending one of those outputs then cannot be
+// processed: the counter-conflicting walk fails with TX_NOT_FOUND (wedging
+// block validation forever), and even if it passed, the winner could never
+// spend the slot — the Lua spend rejects a mismatched occupant and the unspend
+// ownership check refuses to clear a spend the caller does not own.
+//
+// The test plants exactly that end state, then asserts the walk tolerates the
+// confirmed ghost and ProcessConflicting heals the contested slot — exercising
+// the real Lua unspend ownership check with the recorded ghost spending data.
+func TestCounterConflictingGhostSpender_Aerospike(t *testing.T) {
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	client, store, ctx, deferFn := initAerospike(t, tSettings, logger)
+	t.Cleanup(deferFn)
+
+	cleanDB(t, client)
+
+	buildSpendingTx := func(t *testing.T, parentTx *bt.Tx, vOuts ...uint32) *bt.Tx {
+		t.Helper()
+
+		newTx := bt.NewTx()
+
+		total := uint64(0)
+		for _, vOut := range vOuts {
+			require.NoError(t, newTx.From(
+				parentTx.TxIDChainHash().String(), vOut,
+				parentTx.Outputs[vOut].LockingScript.String(),
+				parentTx.Outputs[vOut].Satoshis,
+			))
+			total += parentTx.Outputs[vOut].Satoshis
+		}
+
+		require.NoError(t, newTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", total/2))
+
+		return newTx
+	}
+
+	// tests.ParentTx is the grandparent — tx's input references it and
+	// SetConflicting resolves parents internally.
+	_, err := store.Create(ctx, tests.ParentTx, 999)
+	require.NoError(t, err)
+
+	_, err = store.Create(ctx, tx, 1000)
+	require.NoError(t, err)
+
+	// The ghost: a multi-input tx spending tx:0 and tx:1 through the store,
+	// whose own record is never created (its validation failed on another input).
+	ghostTx := buildSpendingTx(t, tx, 0, 1)
+	_, err = store.Spend(ctx, ghostTx, store.GetBlockHeight()+1)
+	require.NoError(t, err)
+	// deliberately NO store.Create(ghostTx): the spender record does not exist
+
+	// The conflicting tx spends tx:0 — the slot the ghost holds. The validator
+	// marked it conflicting when its spend collided with the ghost's.
+	conflictingTx := buildSpendingTx(t, tx, 0)
+	_, err = store.Create(ctx, conflictingTx, 1001, utxo.WithConflicting(true))
+	require.NoError(t, err)
+
+	conflictingTxHash := *conflictingTx.TxIDChainHash()
+
+	// 1. The counter-conflicting walk must tolerate the confirmed ghost instead
+	// of failing with TX_NOT_FOUND — this is what unwedges block validation.
+	counterHashes, err := utxo.GetCounterConflictingTxHashes(ctx, store, conflictingTxHash)
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{conflictingTxHash}, counterHashes)
+
+	// 2. Conflict resolution must clear the ghost's dangling spend — passing the
+	// recorded ghost spending data through the Lua unspend ownership check — and
+	// let the winner spend the slot.
+	losingMap, _, err := utxo.ProcessConflicting(ctx, store, store.GetBlockHeight()+1,
+		[]chainhash.Hash{conflictingTxHash}, map[chainhash.Hash]struct{}{})
+	require.NoError(t, err)
+	require.NotNil(t, losingMap)
+
+	md, err := store.Get(ctx, tx.TxIDChainHash(), fields.Utxos)
+	require.NoError(t, err)
+
+	// The contested slot (tx:0) now records the winner.
+	require.NotNil(t, md.SpendingDatas[0], "contested slot must be spent after resolution")
+	require.True(t, md.SpendingDatas[0].TxID.Equal(conflictingTxHash),
+		"contested slot must be spent by the winner after resolution, not the ghost")
+
+	// The ghost's uncontested slot (tx:1) stays as it was: without a record the
+	// ghost's other spends are not enumerable; a slot is healed when contested.
+	require.NotNil(t, md.SpendingDatas[1])
+	require.True(t, md.SpendingDatas[1].TxID.Equal(*ghostTx.TxIDChainHash()),
+		"uncontested ghost slot must be untouched by resolution")
+
+	// The winner is no longer flagged conflicting, and its parent is unlocked.
+	mdWinner, err := store.Get(ctx, &conflictingTxHash, fields.Conflicting)
+	require.NoError(t, err)
+	require.False(t, mdWinner.Conflicting)
+
+	mdParent, err := store.Get(ctx, tx.TxIDChainHash(), fields.Locked)
+	require.NoError(t, err)
+	require.False(t, mdParent.Locked, "parent must be unlocked after step 5")
+}

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -839,6 +839,16 @@ NEXT_BATCH_RECORD:
 
 				items[idx].Data.ConflictingChildren = res
 
+			case fields.DeletedChildren:
+				res, err := processDeletedChildren(bins)
+				if err != nil {
+					items[idx].Err = errors.NewTxInvalidError("could not process deleted children", err)
+
+					continue NEXT_BATCH_RECORD // because there was an error processing the deleted children.
+				}
+
+				items[idx].Data.DeletedChildren = res
+
 			case fields.UnminedSince:
 				unminedSince, ok := bins[key.String()].(int)
 				if ok {
@@ -1142,6 +1152,35 @@ func processConflictingChildren(bins aerospike.BinMap) (conflictingChildren []ch
 	}
 
 	return conflictingChildren, nil
+}
+
+// processDeletedChildren extracts the deletedChildren map from Aerospike bins.
+// The bin is written by the pruner (addDeletedChildren UDF or MapPutItemsOp
+// fallback) and is keyed by the deleted child's txid in hex string form. An
+// absent bin means no child of this record has been reaped.
+func processDeletedChildren(bins aerospike.BinMap) (map[chainhash.Hash]bool, error) {
+	deletedChildrenIfc, ok := bins[fields.DeletedChildren.String()].(map[interface{}]interface{})
+	if !ok {
+		return nil, nil
+	}
+
+	deletedChildren := make(map[chainhash.Hash]bool, len(deletedChildrenIfc))
+
+	for child := range deletedChildrenIfc {
+		childStr, ok := child.(string)
+		if !ok {
+			return nil, errors.NewStorageError("failed to get deleted child")
+		}
+
+		childHash, err := chainhash.NewHashFromStr(childStr)
+		if err != nil {
+			return nil, errors.NewStorageError("failed to parse deleted child hash", err)
+		}
+
+		deletedChildren[*childHash] = true
+	}
+
+	return deletedChildren, nil
 }
 
 // getAllExtraUTXOs retrieves all UTXOs from child records recursively

--- a/stores/utxo/meta/data.go
+++ b/stores/utxo/meta/data.go
@@ -79,6 +79,13 @@ type Data struct {
 	// ConflictingChildren contains the transaction IDs of all transactions that tried to spend this conflicting transaction
 	ConflictingChildren []chainhash.Hash `json:"conflictingChildren"`
 
+	// DeletedChildren contains the transaction IDs of child records the DAH
+	// pruner deleted while this (parent) record survived. A spender recorded in
+	// a parent output slot whose own record is absent but listed here was a
+	// mined, settled spend that was reaped — not a ghost. Maintained by the
+	// aerospike pruner only; not part of the binary serialization.
+	DeletedChildren map[chainhash.Hash]bool `json:"deletedChildren,omitempty"`
+
 	// Locked is a flag indicating if the transaction is locked and not spendable
 	Locked bool `json:"locked"`
 

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -21,7 +21,24 @@ import (
 	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/errgroup"
+)
+
+// prometheusUtxoCounterConflictingGhostSpends counts every confirmed ghost spender
+// tolerated by the counter-conflicting walk: a parent output that still records a
+// spender whose own record no longer exists (e.g. a never-mined conflicting loser
+// purged while the parent still references it). These free functions have no
+// logger, so the counter is the observability surface — each tolerated ghost slot
+// bumps it once.
+var prometheusUtxoCounterConflictingGhostSpends = promauto.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: "teranode",
+		Subsystem: "utxo",
+		Name:      "counter_conflicting_ghost_spends",
+		Help:      "Number of confirmed ghost spender references tolerated by the counter-conflicting walk",
+	},
 )
 
 // step5RetryDelays controls the bounded back-off when SetLocked(false) fails at the very
@@ -122,6 +139,12 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 	losingTxHashesPerConflictingTx := make([][]chainhash.Hash, len(conflictingTxHashes))
 	losingTxHashesPerConflictingTxCount := atomic.Int64{}
 
+	// ghostSpendsPerConflictingTx collects, per winning transaction, the parent
+	// output slots whose recorded spender is a confirmed ghost (record gone). The
+	// walk tolerates those instead of erroring; the slots are cleared below so the
+	// winner can spend them.
+	ghostSpendsPerConflictingTx := make([][]*Spend, len(conflictingTxHashes))
+
 	g, gCtx := errgroup.WithContext(ctx)
 
 	for idx, txHash := range conflictingTxHashes {
@@ -148,8 +171,10 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 			}
 
 			// get the counter conflicting transactions for the current transaction
-			// this includes all the children of the conflicting transaction
-			if losingTxHashesPerConflictingTx[idx], err = s.GetCounterConflicting(gCtx, txHash); err != nil {
+			// this includes all the children of the conflicting transaction. The
+			// ghost-aware walk is used directly (not the Store method) because the
+			// tolerated ghost slots must be cleared before the winner spends them.
+			if losingTxHashesPerConflictingTx[idx], ghostSpendsPerConflictingTx[idx], err = getCounterConflictingTxHashesAndGhostSpends(gCtx, s, txHash); err != nil {
 				return errors.NewProcessingError("[ProcessConflicting][%s] error getting counter conflicting txs", txHash.String(), err)
 			}
 
@@ -188,6 +213,17 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, confli
 
 	allMarkedConflicting = allMarkedHashes
 	step1Committed = true
+
+	// Ghost slots: a confirmed-absent spender still occupies parent output slots
+	// the winners need, and no loser-derived unspend can clear them — the unspend
+	// ownership check only clears a spend the caller owns, and a ghost has no
+	// record to derive that spend from. Clear them together with the loser spends
+	// in step 2, passing the recorded ghost spending data as the expected value,
+	// so the winner's spend in step 3 succeeds and the dangling reference is
+	// healed for good.
+	for _, ghostSpends := range ghostSpendsPerConflictingTx {
+		affectedParentSpends = append(affectedParentSpends, ghostSpends...)
+	}
 
 	// - 2: un-spend txa, marking the input txs as not spendable (txp & txq)
 	if err = s.Unspend(ctx, affectedParentSpends, true); err != nil {
@@ -986,20 +1022,35 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 }
 
 func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhash.Hash) ([]chainhash.Hash, error) {
+	counterConflicting, _, err := getCounterConflictingTxHashesAndGhostSpends(ctx, s, txHash)
+
+	return counterConflicting, err
+}
+
+// getCounterConflictingTxHashesAndGhostSpends is the implementation behind
+// GetCounterConflictingTxHashes. Alongside the counter-conflicting set it returns
+// the "ghost" slots it tolerated: parent outputs whose recorded spender has no
+// store record anymore (confirmed by a direct probe of the spender). A confirmed
+// ghost has no BlockIDs, so it is definitionally not mined on our chain and is
+// excluded from the counter set instead of failing the whole walk with NOT_FOUND —
+// which used to wedge block validation forever on a block referencing such a slot.
+// ProcessConflicting uses the returned ghost slots to clear the dangling spends so
+// the winning transaction can actually spend those outputs.
+func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, txHash chainhash.Hash) ([]chainhash.Hash, []*Spend, error) {
 	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "GetCounterConflictingTxHashes")
 
 	defer deferFn()
 
 	txMeta, err := s.Get(ctx, &txHash, fields.Tx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	counterConflictingMap := make(map[chainhash.Hash]struct{})
 	counterConflictingMap[txHash] = struct{}{}
 
 	// get the unique parent txs
-	parentTxs := make(map[chainhash.Hash][]*chainhash.Hash)
+	parentTxs := make(map[chainhash.Hash][]*spendpkg.SpendingData)
 
 	for _, input := range txMeta.Tx.Inputs {
 		// get the parent tx
@@ -1011,43 +1062,59 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 
 		parentTxMeta, err := s.Get(ctx, parentTxHash, fields.Utxos)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		spendingTxIDs := make([]*chainhash.Hash, len(parentTxMeta.SpendingDatas))
-
-		for idx, spendingData := range parentTxMeta.SpendingDatas {
-			if spendingData == nil {
-				continue
-			}
-
-			spendingTxIDs[idx] = spendingData.TxID
-		}
-
-		parentTxs[*parentTxHash] = spendingTxIDs
+		parentTxs[*parentTxHash] = parentTxMeta.SpendingDatas
 	}
 
+	var ghostSpends []*Spend
+
 	for _, input := range txMeta.Tx.Inputs {
-		parenTxIDS, ok := parentTxs[*input.PreviousTxIDChainHash()]
+		parentSpendingDatas, ok := parentTxs[*input.PreviousTxIDChainHash()]
 		if ok {
 			// check the length of the spending txs, if it's less than the index, then the input is not spent
-			if len(parenTxIDS) <= int(input.PreviousTxOutIndex) {
+			if len(parentSpendingDatas) <= int(input.PreviousTxOutIndex) {
 				// throw an error
-				return nil, errors.NewProcessingError("[GetCounterConflictingTxHashes][%s] cannot process counter conflicting, input %d of %s is out of range (len: %d, %v)", txHash.String(), input.PreviousTxOutIndex, input.PreviousTxIDChainHash().String(), len(parenTxIDS), parenTxIDS)
+				return nil, nil, errors.NewProcessingError("[GetCounterConflictingTxHashes][%s] cannot process counter conflicting, input %d of %s is out of range (len: %d, %v)", txHash.String(), input.PreviousTxOutIndex, input.PreviousTxIDChainHash().String(), len(parentSpendingDatas), parentSpendingDatas)
 			}
 
-			spendingTxID := parenTxIDS[input.PreviousTxOutIndex]
-			if spendingTxID != nil {
-				counterConflictingMap[*spendingTxID] = struct{}{}
+			spendingData := parentSpendingDatas[input.PreviousTxOutIndex]
+			if spendingData != nil && spendingData.TxID != nil {
+				spendingTxID := spendingData.TxID
 
 				childHashes, err := s.GetConflictingChildren(ctx, *spendingTxID)
 				if err != nil {
-					return nil, err
+					if !isNotFoundErr(err) {
+						return nil, nil, err
+					}
+
+					// A NOT_FOUND out of the BFS does not prove the spender itself is
+					// absent — the walk may have failed on a missing descendant of a
+					// live (possibly mined on our chain) spender. Probe the spender
+					// record directly and tolerate only a confirmed ghost; anything
+					// else fails closed with the original error.
+					if _, probeErr := s.Get(ctx, spendingTxID, fields.Conflicting); probeErr == nil || !isNotFoundErr(probeErr) {
+						return nil, nil, err
+					}
+
+					ghostSpend, ghostErr := newGhostSlotSpend(ctx, s, input, spendingData)
+					if ghostErr != nil {
+						return nil, nil, ghostErr
+					}
+
+					prometheusUtxoCounterConflictingGhostSpends.Inc()
+
+					ghostSpends = append(ghostSpends, ghostSpend)
+
+					continue
 				}
+
+				counterConflictingMap[*spendingTxID] = struct{}{}
 
 				for _, childHash := range childHashes {
 					if childHash.Equal(subtree.FrozenBytesTxHash) {
-						return nil, errors.NewProcessingError("[GetCounterConflictingTxHashes][%s] tx has frozen child", spendingTxID.String())
+						return nil, nil, errors.NewProcessingError("[GetCounterConflictingTxHashes][%s] tx has frozen child", spendingTxID.String())
 					}
 
 					counterConflictingMap[childHash] = struct{}{}
@@ -1062,7 +1129,43 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 		counterConflicting = append(counterConflicting, child)
 	}
 
-	// fmt.Printf("counterConflicting: %v\n", counterConflicting)
+	return counterConflicting, ghostSpends, nil
+}
 
-	return counterConflicting, nil
+// isNotFoundErr reports whether err denotes a missing record on any UTXO-store
+// backend: aerospike surfaces ErrTxNotFound, the SQL stores ErrNotFound.
+func isNotFoundErr(err error) bool {
+	return errors.Is(err, errors.ErrTxNotFound) || errors.Is(err, errors.ErrNotFound)
+}
+
+// newGhostSlotSpend builds the Spend that clears a confirmed ghost's dangling
+// spend from its parent output slot. The recorded spending data is passed as the
+// expected value so the store's unspend ownership check lets the clear through.
+// The parent is re-read with its tx body because the utxo hash needs the output's
+// locking script and satoshis.
+func newGhostSlotSpend(ctx context.Context, s Store, input *bt.Input, recorded *spendpkg.SpendingData) (*Spend, error) {
+	parentTxHash := input.PreviousTxIDChainHash()
+
+	parentTxMeta, err := s.Get(ctx, parentTxHash, fields.Tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if parentTxMeta.Tx == nil || int(input.PreviousTxOutIndex) >= len(parentTxMeta.Tx.Outputs) {
+		return nil, errors.NewProcessingError("[GetCounterConflictingTxHashes] cannot build ghost slot spend, output %s:%d not present", parentTxHash.String(), input.PreviousTxOutIndex)
+	}
+
+	output := parentTxMeta.Tx.Outputs[input.PreviousTxOutIndex]
+
+	utxoHash, err := util.UTXOHash(parentTxHash, input.PreviousTxOutIndex, output.LockingScript, output.Satoshis)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Spend{
+		TxID:         parentTxHash,
+		Vout:         input.PreviousTxOutIndex,
+		UTXOHash:     utxoHash,
+		SpendingData: recorded,
+	}, nil
 }

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -570,6 +570,16 @@ func selectCountersForDemotedTx(ctx context.Context, s Store, demotedTx *bt.Tx, 
 
 			candidateMeta, err := s.Get(ctx, &candidate, fields.Tx, fields.Conflicting, fields.CreatedAt)
 			if err != nil {
+				// ConflictingChildren entries are never removed once written: a
+				// conflicting loser purged by the conflicting-branch DAH (or a
+				// healed ghost) stays listed after its record is gone. An absent
+				// candidate cannot be re-promoted whatever the cause — skip it
+				// instead of hard-failing, which would wedge moveBackBlock on
+				// every retry.
+				if isNotFoundErr(err) {
+					continue
+				}
+
 				return nil, errors.NewProcessingError("[selectCountersForDemotedTx][%s] error getting candidate counter", candidate.String(), err)
 			}
 
@@ -859,10 +869,54 @@ func MarkConflictingRecursively(ctx context.Context, s Store, hashes []chainhash
 		for _, child := range spendingChildTxs {
 			if _, ok := visited[child]; !ok {
 				visited[child] = struct{}{}
-				markedOrder = append(markedOrder, child)
 				nextBatch = append(nextBatch, child)
 			}
 		}
+
+		// Probe the discovered children before recursing: a marked record's
+		// output slot can point at a ghost (spends applied, record never
+		// created), and feeding it back into SetConflicting would fail
+		// NOT_FOUND and wedge the whole cascade. A confirmed-absent child
+		// cannot be marked and has no readable descendants — skip it. (The
+		// counter-conflicting walk fails closed on reaped mined spenders
+		// before ProcessConflicting ever cascades here.)
+		if len(nextBatch) > 0 {
+			exists := make([]bool, len(nextBatch))
+			g, gCtx := errgroup.WithContext(ctx)
+
+			for i, child := range nextBatch {
+				i := i
+				child := child
+				g.Go(func() error {
+					if _, probeErr := s.Get(gCtx, &child, fields.Conflicting); probeErr != nil {
+						if isNotFoundErr(probeErr) {
+							return nil
+						}
+
+						return probeErr
+					}
+
+					exists[i] = true
+
+					return nil
+				})
+			}
+
+			if err = g.Wait(); err != nil {
+				return nil, nil, err
+			}
+
+			alive := nextBatch[:0]
+			for i, child := range nextBatch {
+				if exists[i] {
+					markedOrder = append(markedOrder, child)
+					alive = append(alive, child)
+				}
+			}
+
+			nextBatch = alive
+		}
+
 		toProcess = nextBatch
 	}
 
@@ -959,6 +1013,12 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	visited[hash] = struct{}{}
 	currentLevel := []chainhash.Hash{hash}
 
+	// reapedByParent records, per enqueued child, whether the node that
+	// enqueued it lists it in deletedChildren — i.e. the pruner deleted the
+	// child's record after it was mined and fully spent. Written between
+	// levels, read only by the next level's goroutines.
+	reapedByParent := make(map[chainhash.Hash]bool)
+
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
@@ -967,9 +1027,29 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 			i := i
 			current := current
 			g.Go(func() error {
-				txMeta, err := s.Get(gCtx, &current, fields.Utxos, fields.ConflictingChildren)
+				txMeta, err := s.Get(gCtx, &current, fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren)
 				if err != nil {
-					return err
+					// The root's absence is the caller's signal (the counter
+					// walk probes and classifies it) — always propagate it, as
+					// well as any non-NOT_FOUND failure.
+					if current.Equal(hash) || !isNotFoundErr(err) {
+						return err
+					}
+
+					// An absent descendant its parent lists in deletedChildren
+					// was reaped after being mined — the subtree holds settled
+					// history and must not be treated as demotable. Fail closed,
+					// mirroring the counter walk's reaped-spender gate.
+					if reapedByParent[current] {
+						return errors.NewProcessingError("[GetConflictingChildren][%s] descendant %s was reaped after being mined (listed in its parent's deletedChildren)", hash.String(), current.String(), err)
+					}
+
+					// A confirmed-absent ghost descendant (spends applied, record
+					// never created): it cannot be demoted and has no readable
+					// descendants — skip it instead of wedging every consumer of
+					// this walk. results[i] stays nil and the hash is dropped
+					// from the visited set below.
+					return nil
 				}
 				results[i] = txMeta
 				return nil
@@ -981,8 +1061,10 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 		}
 
 		var nextLevel []chainhash.Hash
-		for _, txMeta := range results {
+		for i, txMeta := range results {
 			if txMeta == nil {
+				// tolerated ghost descendant — exclude it from the result set
+				delete(visited, currentLevel[i])
 				continue
 			}
 
@@ -990,6 +1072,7 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 				for _, child := range txMeta.ConflictingChildren {
 					if _, ok := visited[child]; !ok {
 						visited[child] = struct{}{}
+						reapedByParent[child] = txMeta.DeletedChildren[child]
 						nextLevel = append(nextLevel, child)
 					}
 				}
@@ -1001,6 +1084,7 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 						child := *spendingData.TxID
 						if _, ok := visited[child]; !ok {
 							visited[child] = struct{}{}
+							reapedByParent[child] = txMeta.DeletedChildren[child]
 							nextLevel = append(nextLevel, child)
 						}
 					}
@@ -1030,12 +1114,17 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 // getCounterConflictingTxHashesAndGhostSpends is the implementation behind
 // GetCounterConflictingTxHashes. Alongside the counter-conflicting set it returns
 // the "ghost" slots it tolerated: parent outputs whose recorded spender has no
-// store record anymore (confirmed by a direct probe of the spender). A confirmed
-// ghost has no BlockIDs, so it is definitionally not mined on our chain and is
-// excluded from the counter set instead of failing the whole walk with NOT_FOUND —
-// which used to wedge block validation forever on a block referencing such a slot.
-// ProcessConflicting uses the returned ghost slots to clear the dangling spends so
-// the winning transaction can actually spend those outputs.
+// store record anymore (confirmed by a direct probe of the spender). Absence
+// alone does not prove the spender was never mined — DAH housekeeping also reaps
+// mined, fully-spent records — but the pruner records every reaped child in its
+// surviving parents' deletedChildren map, so a spender absent AND listed there
+// is a settled, mined spend and the walk fails closed on it. A spender absent
+// and NOT listed is a genuine ghost: definitionally not mined on our chain, it
+// is excluded from the counter set instead of failing the whole walk with
+// NOT_FOUND — which used to wedge block validation forever on a block
+// referencing such a slot. ProcessConflicting uses the returned ghost slots to
+// clear the dangling spends so the winning transaction can actually spend those
+// outputs.
 func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, txHash chainhash.Hash) ([]chainhash.Hash, []*Spend, error) {
 	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "GetCounterConflictingTxHashes")
 
@@ -1050,7 +1139,7 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 	counterConflictingMap[txHash] = struct{}{}
 
 	// get the unique parent txs
-	parentTxs := make(map[chainhash.Hash][]*spendpkg.SpendingData)
+	parentTxs := make(map[chainhash.Hash]*meta.Data)
 
 	for _, input := range txMeta.Tx.Inputs {
 		// get the parent tx
@@ -1060,19 +1149,22 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 	for parentTx := range parentTxs {
 		parentTxHash := &parentTx
 
-		parentTxMeta, err := s.Get(ctx, parentTxHash, fields.Utxos)
+		// DeletedChildren feeds the reaped-spender check on the ghost tolerance
+		// below.
+		parentTxMeta, err := s.Get(ctx, parentTxHash, fields.Utxos, fields.DeletedChildren)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		parentTxs[*parentTxHash] = parentTxMeta.SpendingDatas
+		parentTxs[*parentTxHash] = parentTxMeta
 	}
 
 	var ghostSpends []*Spend
 
 	for _, input := range txMeta.Tx.Inputs {
-		parentSpendingDatas, ok := parentTxs[*input.PreviousTxIDChainHash()]
+		parentTxMeta, ok := parentTxs[*input.PreviousTxIDChainHash()]
 		if ok {
+			parentSpendingDatas := parentTxMeta.SpendingDatas
 			// check the length of the spending txs, if it's less than the index, then the input is not spent
 			if len(parentSpendingDatas) <= int(input.PreviousTxOutIndex) {
 				// throw an error
@@ -1096,6 +1188,16 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 					// else fails closed with the original error.
 					if _, probeErr := s.Get(ctx, spendingTxID, fields.Conflicting); probeErr == nil || !isNotFoundErr(probeErr) {
 						return nil, nil, err
+					}
+
+					// The probe proves the record is gone, not that the spender was
+					// never mined: DAH housekeeping reaps mined, fully-spent records
+					// too. The pruner marks every reaped child in its surviving
+					// parents' deletedChildren map, so a spender listed there held a
+					// settled, mined spend — clearing its slot would bless a
+					// double-spend of a settled output. Fail closed instead.
+					if parentTxMeta.DeletedChildren[*spendingTxID] {
+						return nil, nil, errors.NewProcessingError("[GetCounterConflictingTxHashes][%s] spender %s of parent %s was reaped after being mined (listed in the parent's deletedChildren) — its settled spend is not a ghost", txHash.String(), spendingTxID.String(), input.PreviousTxIDChainHash().String(), err)
 					}
 
 					ghostSpend, ghostErr := newGhostSlotSpend(ctx, s, input, spendingData)

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -1072,6 +1072,17 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 				for _, child := range txMeta.ConflictingChildren {
 					if _, ok := visited[child]; !ok {
 						visited[child] = struct{}{}
+
+						// The frozen / coinbase-placeholder sentinel is a record-less
+						// pseudo-hash marking a frozen output. It must stay in the
+						// result set so callers' frozen-child checks fire, but must
+						// never be recursed into: a Get would return NOT_FOUND and the
+						// ghost tolerance would silently swallow it, defeating frozen-tx
+						// rejection during conflict resolution.
+						if child.Equal(subtree.CoinbasePlaceholderHashValue) {
+							continue
+						}
+
 						reapedByParent[child] = txMeta.DeletedChildren[child]
 						nextLevel = append(nextLevel, child)
 					}
@@ -1084,6 +1095,13 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 						child := *spendingData.TxID
 						if _, ok := visited[child]; !ok {
 							visited[child] = struct{}{}
+
+							// Frozen output sentinel: keep it in the result for the
+							// caller's frozen check, but do not recurse (see above).
+							if child.Equal(subtree.CoinbasePlaceholderHashValue) {
+								continue
+							}
+
 							reapedByParent[child] = txMeta.DeletedChildren[child]
 							nextLevel = append(nextLevel, child)
 						}

--- a/stores/utxo/process_conflicting_rollback_test.go
+++ b/stores/utxo/process_conflicting_rollback_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -320,6 +321,10 @@ func TestProcessConflictingRollback_CascadeDescendants(t *testing.T) {
 	descendantSpends := []*Spend{{TxID: &descendantHash, Vout: 0}}
 	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(losingSpends, []chainhash.Hash{descendantHash}, nil).Once()
+	// the cascade probes each discovered child before recursing (ghost filter);
+	// the descendant is a live record, so the probe finds it
+	mockStore.On("Get", mock.Anything, &descendantHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{descendantHash}, true).
 		Return(descendantSpends, []chainhash.Hash{}, nil).Once()
 

--- a/stores/utxo/process_conflicting_rollback_test.go
+++ b/stores/utxo/process_conflicting_rollback_test.go
@@ -34,14 +34,13 @@ func TestProcessConflictingRollback_Step3Failure(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          winningTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Times(3)
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+	stubCounterConflictingWalk(mockStore, winningTx, losingTxHash)
 
 	// step 1: MarkConflictingRecursively → SetConflicting(losing, true)
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
 
 	// step 2: Unspend(affectedSpends, true) commits successfully (locks parents)
@@ -58,9 +57,9 @@ func TestProcessConflictingRollback_Step3Failure(t *testing.T) {
 		Tx: losingTx,
 	}, nil).Once()
 	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+		Return([]*Spend{}, nil).Twice()
 	// 3c. SetConflicting(allMarkedHashes, false) — undoes step 1
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 	// 3d. SetLocked(parents, false) — undoes step 2's lock
 	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
@@ -92,13 +91,12 @@ func TestProcessConflictingRollback_RollbackAlsoFails(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          winningTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Times(3)
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+	stubCounterConflictingWalk(mockStore, winningTx, losingTxHash)
 
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
@@ -114,9 +112,9 @@ func TestProcessConflictingRollback_RollbackAlsoFails(t *testing.T) {
 	}, nil).Once()
 	// re-spend losing tx (rollback step 2) succeeds
 	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+		Return([]*Spend{}, nil).Twice()
 	// SetConflicting(false) FAILS — rollback failure
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), false).
 		Return([]*Spend{}, []chainhash.Hash{}, errors.NewProcessingError("set conflicting false failed")).Once()
 	// SetLocked(false) still attempted (best-effort) and succeeds
 	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
@@ -149,13 +147,12 @@ func TestProcessConflictingRollback_Step5RetrySucceeds(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          winningTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Twice()
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+	stubCounterConflictingWalk(mockStore, winningTx, losingTxHash)
 
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
@@ -197,13 +194,12 @@ func TestProcessConflictingRollback_Step5RetryExhausted(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          winningTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Twice()
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+	stubCounterConflictingWalk(mockStore, winningTx, losingTxHash)
 
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
@@ -246,13 +242,12 @@ func TestProcessConflictingRollback_PartialStep3Spend(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          winningTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Times(3)
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+	stubCounterConflictingWalk(mockStore, winningTx, losingTxHash)
 
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil).Once()
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
@@ -276,9 +271,9 @@ func TestProcessConflictingRollback_PartialStep3Spend(t *testing.T) {
 		Tx: losingTx,
 	}, nil).Once()
 	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+		Return([]*Spend{}, nil).Twice()
 	// 3c. SetConflicting(allMarkedHashes, false) — undoes step 1
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 	// 3d. SetLocked(parents, false) — undoes step 2's lock
 	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).
@@ -314,17 +309,16 @@ func TestProcessConflictingRollback_CascadeDescendants(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          winningTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Times(3)
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil).Once()
+	stubCounterConflictingWalk(mockStore, winningTx, losingTxHash)
 
 	// step 1: MarkConflictingRecursively first marks the losing tx and its BFS yields a
 	// descendant. The second SetConflicting call (for the descendant) returns no further
 	// children, terminating the BFS. allMarkedHashes ends up [losingTxHash, descendantHash].
 	losingSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
 	descendantSpends := []*Spend{{TxID: &descendantHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(losingSpends, []chainhash.Hash{descendantHash}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{descendantHash}, true).
 		Return(descendantSpends, []chainhash.Hash{}, nil).Once()
@@ -344,12 +338,12 @@ func TestProcessConflictingRollback_CascadeDescendants(t *testing.T) {
 		Tx: losingTx,
 	}, nil).Once()
 	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+		Return([]*Spend{}, nil).Twice()
 	// 3c. attempt to fetch descendant body — store has nothing for it, surface but continue
 	mockStore.On("Get", mock.Anything, &descendantHash, mock.Anything).
 		Return((*meta.Data)(nil), errors.NewNotFoundError("descendant not found")).Once()
 	// 3d. SetConflicting(allMarkedHashes, false) — clears flag on losing AND descendant
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash, descendantHash}, false).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash, descendantHash), false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 	// 3e. SetLocked(false) on the unique parents marked unspendable
 	mockStore.On("SetLocked", mock.Anything, mock.MatchedBy(func(hs []chainhash.Hash) bool {

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -5,11 +5,15 @@ import (
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -32,16 +36,16 @@ func TestProcessConflicting_Success(t *testing.T) {
 		Conflicting: true,
 	}, nil)
 
-	// Mock GetCounterConflicting call
+	// Stub the counter-conflicting walk: the parent slot records the losing tx
+	// as a live spender, so the walk result is {conflicting tx, losing tx}
 	losingTxHash := createTestHash("losing-tx-1")
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil)
+	stubCounterConflictingWalk(mockStore, testTx, losingTxHash)
 
 	// Mock SetConflicting call for marking losing txs as conflicting
 	affectedSpends := []*Spend{
 		{TxID: &losingTxHash, Vout: 0},
 	}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil)
 
 	// Mock Unspend call
@@ -140,9 +144,11 @@ func TestProcessConflicting_GetCounterConflictingError(t *testing.T) {
 		Conflicting: true,
 	}, nil)
 
-	// Mock GetCounterConflicting call returning error
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{}, errors.NewProcessingError("counter conflicting error"))
+	// The walk fails reading the parent record: the error must surface as the
+	// counter-conflicting failure
+	prevTxHash := createTestHash("prev-tx")
+	mockStore.On("Get", mock.Anything, &prevTxHash, []fields.FieldName{fields.Utxos}).
+		Return(nil, errors.NewProcessingError("counter conflicting error"))
 
 	// Execute test
 	result, _, err := ProcessConflicting(ctx, mockStore, 1, conflictingTxHashes, map[chainhash.Hash]struct{}{})
@@ -168,11 +174,10 @@ func TestProcessConflicting_UnspendError(t *testing.T) {
 		Conflicting: true,
 	}, nil)
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil)
+	stubCounterConflictingWalk(mockStore, createTestTransaction(), losingTxHash)
 
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil)
 
 	// Mock Unspend call returning error
@@ -180,7 +185,7 @@ func TestProcessConflicting_UnspendError(t *testing.T) {
 		Return(errors.NewProcessingError("unspend failed"))
 
 	// step 2 failed → rollback only undoes step 1 (clear conflicting flag).
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil)
 
 	// Execute test
@@ -209,13 +214,12 @@ func TestProcessConflicting_SpendError(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &conflictingTxHash, mock.Anything).Return(&meta.Data{
 		Tx:          testTx,
 		Conflicting: true,
-	}, nil).Once()
+	}, nil).Times(3)
 
-	mockStore.On("GetCounterConflicting", mock.Anything, conflictingTxHash).
-		Return([]chainhash.Hash{losingTxHash}, nil)
+	stubCounterConflictingWalk(mockStore, testTx, losingTxHash)
 
 	affectedSpends := []*Spend{{TxID: &losingTxHash, Vout: 0}}
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, true).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), true).
 		Return(affectedSpends, []chainhash.Hash{}, nil)
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, mock.Anything).Return(nil)
@@ -227,7 +231,10 @@ func TestProcessConflicting_SpendError(t *testing.T) {
 		Err:  errors.NewProcessingError("spend error"),
 	}
 	mockStore.On("Spend", mock.Anything, testTx, mock.Anything, mock.Anything).
-		Return([]*Spend{spendWithError}, errors.NewTxInvalidError("spend failed"))
+		Return([]*Spend{spendWithError}, errors.NewTxInvalidError("spend failed")).Once()
+	// rollback re-spends the winning tx too (it is part of the marked cascade)
+	mockStore.On("Spend", mock.Anything, testTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil).Once()
 
 	// step-3 failure rollback path: re-fetch losing tx body, re-spend it, clear conflicting,
 	// unlock parents. (No partial successful step-3 spends — the only spend has Err != nil.)
@@ -236,7 +243,7 @@ func TestProcessConflicting_SpendError(t *testing.T) {
 	}, nil).Once()
 	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
 		Return([]*Spend{}, nil).Once()
-	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
+	mockStore.On("SetConflicting", mock.Anything, hashSetMatcher(conflictingTxHash, losingTxHash), false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil)
 	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).Return(nil)
 
@@ -911,4 +918,264 @@ func createTestTransactionWithInputs(parentTxHash chainhash.Hash, inputIndex uin
 	tx.Outputs = append(tx.Outputs, output)
 
 	return tx
+}
+
+// ghostSpendsToleratedCounterValue reads the current value of the
+// teranode_utxo_counter_conflicting_ghost_spends counter from the default
+// prometheus registry, returning 0 when the metric is not registered yet.
+func ghostSpendsToleratedCounterValue(t *testing.T) float64 {
+	t.Helper()
+
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() == "teranode_utxo_counter_conflicting_ghost_spends" {
+			return mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+
+	return 0
+}
+
+// A parent output records a spender whose own record no longer exists (a
+// "ghost", e.g. a never-mined conflicting loser purged by the reaper while the
+// parent still references it). The walk must probe the spender itself and,
+// once confirmed absent, exclude it from the counter-conflicting set instead
+// of failing the whole walk with TX_NOT_FOUND.
+func TestGetCounterConflictingTxHashes_ToleratesConfirmedGhostSpender(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	winningTx := createTestTransaction()
+	winningTxHash := createTestHash("winning-tx")
+	parentTxHash := *winningTx.Inputs[0].PreviousTxIDChainHash()
+	ghostTxHash := createTestHash("ghost-spender-tx")
+
+	parentTx := createTestParentTransaction()
+
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&ghostTxHash, 0)}}, nil)
+	mockStore.On("GetConflictingChildren", mock.Anything, ghostTxHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", ghostTxHash))
+	// the probe confirms the spender record itself is gone
+	mockStore.On("Get", mock.Anything, &ghostTxHash, []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", ghostTxHash))
+	// the ghost-slot build re-reads the parent with its tx body for the utxo hash
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: parentTx}, nil)
+
+	counterBefore := ghostSpendsToleratedCounterValue(t)
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, winningTxHash)
+
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{winningTxHash}, result)
+	require.Equal(t, counterBefore+1, ghostSpendsToleratedCounterValue(t))
+	mockStore.AssertExpectations(t)
+}
+
+// A NOT_FOUND out of the BFS does not prove the spender is absent — the walk
+// may have failed on a missing descendant while the spender itself is alive
+// (and possibly mined on our chain). The probe must detect the live spender
+// and fail closed by propagating the original error.
+func TestGetCounterConflictingTxHashes_FailsClosedWhenSpenderAliveAndDescendantMissing(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	winningTx := createTestTransaction()
+	winningTxHash := createTestHash("winning-tx")
+	parentTxHash := *winningTx.Inputs[0].PreviousTxIDChainHash()
+	spenderTxHash := createTestHash("live-spender-tx")
+
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&spenderTxHash, 0)}}, nil)
+	// the BFS fails on a missing descendant of the (live) spender
+	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("descendant not found"))
+	// the probe finds the spender record alive
+	mockStore.On("Get", mock.Anything, &spenderTxHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil)
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, winningTxHash)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxNotFound))
+	require.Nil(t, result)
+	mockStore.AssertExpectations(t)
+}
+
+// When the probe itself fails with anything other than NOT_FOUND, the ghost is
+// unconfirmed and the walk must fail closed by propagating the original error.
+func TestGetCounterConflictingTxHashes_FailsClosedWhenProbeErrors(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	winningTx := createTestTransaction()
+	winningTxHash := createTestHash("winning-tx")
+	parentTxHash := *winningTx.Inputs[0].PreviousTxIDChainHash()
+	spenderTxHash := createTestHash("maybe-ghost-tx")
+
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&spenderTxHash, 0)}}, nil)
+	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", spenderTxHash))
+	mockStore.On("Get", mock.Anything, &spenderTxHash, []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewStorageError("backend unavailable"))
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, winningTxHash)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxNotFound))
+	require.Nil(t, result)
+	mockStore.AssertExpectations(t)
+}
+
+// A missing parent record erases the whole spend graph for that input; the
+// walk must keep failing closed rather than dereference a missing slot.
+func TestGetCounterConflictingTxHashes_FailsClosedOnMissingParent(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	winningTx := createTestTransaction()
+	winningTxHash := createTestHash("winning-tx")
+	parentTxHash := *winningTx.Inputs[0].PreviousTxIDChainHash()
+
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", parentTxHash))
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, winningTxHash)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxNotFound))
+	require.Nil(t, result)
+	mockStore.AssertExpectations(t)
+}
+
+// Resolution over a confirmed ghost must not only tolerate the ghost in the
+// walk: the parent slot still records the ghost's spend, which no loser-derived
+// unspend can clear (ownership check). ProcessConflicting must clear that slot
+// explicitly — passing the recorded ghost spending data as the expected value —
+// so the winner's spend in step 3 can succeed and the dangling ref is healed.
+func TestProcessConflicting_HealsConfirmedGhostSlot(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	winningTx := createTestTransaction()
+	winningTxHash := createTestHash("winning-tx")
+	parentTxHash := *winningTx.Inputs[0].PreviousTxIDChainHash()
+	ghostTxHash := createTestHash("ghost-spender-tx")
+
+	parentTx := createTestParentTransaction()
+	ghostSpendingData := spend.NewSpendingData(&ghostTxHash, 0)
+
+	expectedUtxoHash, err := util.UTXOHash(&parentTxHash, 0, parentTx.Outputs[0].LockingScript, parentTx.Outputs[0].Satoshis)
+	require.NoError(t, err)
+
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx, fields.BlockIDs, fields.Conflicting}).
+		Return(&meta.Data{Tx: winningTx, Conflicting: true}, nil)
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{ghostSpendingData}}, nil)
+	mockStore.On("GetConflictingChildren", mock.Anything, ghostTxHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", ghostTxHash))
+	mockStore.On("Get", mock.Anything, &ghostTxHash, []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", ghostTxHash))
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: parentTx}, nil)
+
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{winningTxHash}, true).
+		Return([]*Spend{}, []chainhash.Hash{}, nil)
+
+	// step 2 must include the ghost slot, with the recorded ghost spend as the
+	// expected spending data so the store's ownership check lets it clear
+	mockStore.On("Unspend", mock.Anything, mock.MatchedBy(func(spends []*Spend) bool {
+		if len(spends) != 1 {
+			return false
+		}
+
+		sp := spends[0]
+
+		return sp.TxID.Equal(parentTxHash) && sp.Vout == 0 &&
+			sp.UTXOHash.Equal(*expectedUtxoHash) &&
+			sp.SpendingData != nil && sp.SpendingData.TxID.Equal(ghostTxHash)
+	}), mock.Anything).Return(nil)
+
+	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return([]*Spend{}, nil)
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{winningTxHash}, false).
+		Return([]*Spend{}, []chainhash.Hash{}, nil)
+	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{parentTxHash}, false).
+		Return(nil)
+
+	losingMap, _, err := ProcessConflicting(ctx, mockStore, 1, []chainhash.Hash{winningTxHash}, map[chainhash.Hash]struct{}{})
+
+	require.NoError(t, err)
+	require.NotNil(t, losingMap)
+	mockStore.AssertExpectations(t)
+}
+
+// createTestParentTransaction builds a parent tx with a spendable output so
+// the ghost-slot tests can compute a real utxo hash for output 0.
+func createTestParentTransaction() *bt.Tx {
+	tx := bt.NewTx()
+
+	input := &bt.Input{
+		PreviousTxOutIndex: 0,
+	}
+	prevTxHash := createTestHash("grandparent-tx")
+	_ = input.PreviousTxIDAdd(&prevTxHash)
+	tx.Inputs = append(tx.Inputs, input)
+
+	tx.Outputs = append(tx.Outputs, &bt.Output{
+		Satoshis:      1000,
+		LockingScript: &bscript.Script{bscript.OpTRUE},
+	})
+
+	return tx
+}
+
+// hashSetMatcher matches a []chainhash.Hash argument against an expected set,
+// ignoring order — the counter-conflicting walk builds its result from a map.
+func hashSetMatcher(want ...chainhash.Hash) interface{} {
+	return mock.MatchedBy(func(hs []chainhash.Hash) bool {
+		if len(hs) != len(want) {
+			return false
+		}
+
+		seen := make(map[chainhash.Hash]struct{}, len(hs))
+		for _, h := range hs {
+			seen[h] = struct{}{}
+		}
+
+		for _, w := range want {
+			if _, ok := seen[w]; !ok {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
+// stubCounterConflictingWalk wires the store calls the ghost-aware counter-
+// conflicting walk makes for a root tx built by the createTestTransaction
+// helpers: the parent slot records spenderTxHash as a live spender with no
+// conflicting children of its own. The walk result is {root, spender}.
+func stubCounterConflictingWalk(mockStore *MockUtxostore, rootTx *bt.Tx, spenderTxHash chainhash.Hash) {
+	parentTxHash := *rootTx.Inputs[0].PreviousTxIDChainHash()
+
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&spenderTxHash, 0)}}, nil).Once()
+	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
+		Return([]chainhash.Hash{}, nil).Once()
 }

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -147,7 +147,7 @@ func TestProcessConflicting_GetCounterConflictingError(t *testing.T) {
 	// The walk fails reading the parent record: the error must surface as the
 	// counter-conflicting failure
 	prevTxHash := createTestHash("prev-tx")
-	mockStore.On("Get", mock.Anything, &prevTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &prevTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(nil, errors.NewProcessingError("counter conflicting error"))
 
 	// Execute test
@@ -270,6 +270,11 @@ func TestMarkConflictingRecursively_Success(t *testing.T) {
 
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{txHash}, true).
 		Return(affectedSpends, childTxs, nil)
+
+	// the cascade probes each discovered child before recursing (ghost filter);
+	// the child is a live record, so the probe finds it
+	mockStore.On("Get", mock.Anything, &childHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil)
 
 	// Mock recursive call for child transactions
 	childAffectedSpends := []*Spend{{TxID: &childHash, Vout: 0}}
@@ -956,7 +961,7 @@ func TestGetCounterConflictingTxHashes_ToleratesConfirmedGhostSpender(t *testing
 
 	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: winningTx}, nil)
-	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&ghostTxHash, 0)}}, nil)
 	mockStore.On("GetConflictingChildren", mock.Anything, ghostTxHash).
 		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", ghostTxHash))
@@ -977,6 +982,122 @@ func TestGetCounterConflictingTxHashes_ToleratesConfirmedGhostSpender(t *testing
 	mockStore.AssertExpectations(t)
 }
 
+// An absent spender record is not necessarily a ghost: DAH housekeeping reaps
+// mined, fully-spent records too, and marks each reaped child in its surviving
+// parents' deletedChildren map. A spender confirmed absent by the probe but
+// listed there held a settled, mined spend — tolerating it would clear the
+// slot and bless a block that double-spends a settled output. The walk must
+// fail closed instead.
+func TestGetCounterConflictingTxHashes_FailsClosedOnReapedMinedSpender(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	winningTx := createTestTransaction()
+	winningTxHash := createTestHash("winning-tx")
+	parentTxHash := *winningTx.Inputs[0].PreviousTxIDChainHash()
+	reapedTxHash := createTestHash("reaped-mined-spender-tx")
+
+	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: winningTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
+		Return(&meta.Data{
+			SpendingDatas:   []*spend.SpendingData{spend.NewSpendingData(&reapedTxHash, 0)},
+			DeletedChildren: map[chainhash.Hash]bool{reapedTxHash: true},
+		}, nil)
+	mockStore.On("GetConflictingChildren", mock.Anything, reapedTxHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", reapedTxHash))
+	// the probe confirms the record is gone — but the parent says it was reaped,
+	// not never-created
+	mockStore.On("Get", mock.Anything, &reapedTxHash, []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", reapedTxHash))
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, winningTxHash)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	mockStore.AssertExpectations(t)
+}
+
+// A ghost can also sit one level deeper: a live conflicting loser whose output
+// slot records a spender that has no record (spends applied, record never
+// created). The BFS must skip such a confirmed-absent descendant instead of
+// failing the whole walk with NOT_FOUND — which wedged block validation just
+// like the depth-1 case.
+func TestGetConflictingChildren_ToleratesGhostDescendant(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	rootHash := createTestHash("live-loser-root")
+	ghostChildHash := createTestHash("ghost-descendant")
+
+	bfsFields := []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}
+
+	mockStore.On("Get", mock.Anything, &rootHash, bfsFields).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&ghostChildHash, 0)}}, nil)
+	mockStore.On("Get", mock.Anything, &ghostChildHash, bfsFields).
+		Return(nil, errors.NewTxNotFoundError("%v not found", ghostChildHash))
+
+	children, err := GetConflictingChildren(ctx, mockStore, rootHash)
+
+	require.NoError(t, err)
+	require.Empty(t, children, "the ghost descendant must not appear in the result")
+	mockStore.AssertExpectations(t)
+}
+
+// An absent descendant listed in its parent's deletedChildren was reaped after
+// being mined — the subtree holds settled history and must not be treated as
+// demotable. The BFS fails closed, mirroring the counter walk's reaped gate.
+func TestGetConflictingChildren_FailsClosedOnReapedDescendant(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	rootHash := createTestHash("live-loser-root")
+	reapedChildHash := createTestHash("reaped-descendant")
+
+	bfsFields := []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}
+
+	mockStore.On("Get", mock.Anything, &rootHash, bfsFields).
+		Return(&meta.Data{
+			SpendingDatas:   []*spend.SpendingData{spend.NewSpendingData(&reapedChildHash, 0)},
+			DeletedChildren: map[chainhash.Hash]bool{reapedChildHash: true},
+		}, nil)
+	mockStore.On("Get", mock.Anything, &reapedChildHash, bfsFields).
+		Return(nil, errors.NewTxNotFoundError("%v not found", reapedChildHash))
+
+	children, err := GetConflictingChildren(ctx, mockStore, rootHash)
+
+	require.Error(t, err)
+	require.Nil(t, children)
+	mockStore.AssertExpectations(t)
+}
+
+// The cascade discovers children from the SpendingDatas of the records it just
+// marked — which can include a ghost (spends applied, record never created).
+// Feeding the ghost back into SetConflicting would fail NOT_FOUND and wedge
+// the cascade; it must be probed and skipped instead.
+func TestMarkConflictingRecursively_SkipsGhostChild(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	loserHash := createTestHash("live-loser")
+	ghostChildHash := createTestHash("ghost-spending-child")
+
+	loserSpends := []*Spend{{TxID: &loserHash, Vout: 0}}
+	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{loserHash}, true).
+		Return(loserSpends, []chainhash.Hash{ghostChildHash}, nil)
+	// the probe of the discovered child finds no record — a ghost
+	mockStore.On("Get", mock.Anything, &ghostChildHash, []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", ghostChildHash))
+
+	spends, markedHashes, err := MarkConflictingRecursively(ctx, mockStore, []chainhash.Hash{loserHash})
+
+	require.NoError(t, err)
+	require.Equal(t, loserSpends, spends)
+	require.Equal(t, []chainhash.Hash{loserHash}, markedHashes,
+		"the ghost child was never marked and must not appear in the marked set")
+	mockStore.AssertExpectations(t)
+}
+
 // A NOT_FOUND out of the BFS does not prove the spender is absent — the walk
 // may have failed on a missing descendant while the spender itself is alive
 // (and possibly mined on our chain). The probe must detect the live spender
@@ -992,7 +1113,7 @@ func TestGetCounterConflictingTxHashes_FailsClosedWhenSpenderAliveAndDescendantM
 
 	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: winningTx}, nil)
-	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&spenderTxHash, 0)}}, nil)
 	// the BFS fails on a missing descendant of the (live) spender
 	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
@@ -1022,7 +1143,7 @@ func TestGetCounterConflictingTxHashes_FailsClosedWhenProbeErrors(t *testing.T) 
 
 	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: winningTx}, nil)
-	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&spenderTxHash, 0)}}, nil)
 	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
 		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", spenderTxHash))
@@ -1049,7 +1170,7 @@ func TestGetCounterConflictingTxHashes_FailsClosedOnMissingParent(t *testing.T) 
 
 	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: winningTx}, nil)
-	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(nil, errors.NewTxNotFoundError("%v not found", parentTxHash))
 
 	result, err := GetCounterConflictingTxHashes(ctx, mockStore, winningTxHash)
@@ -1084,7 +1205,7 @@ func TestProcessConflicting_HealsConfirmedGhostSlot(t *testing.T) {
 		Return(&meta.Data{Tx: winningTx, Conflicting: true}, nil)
 	mockStore.On("Get", mock.Anything, &winningTxHash, []fields.FieldName{fields.Tx}).
 		Return(&meta.Data{Tx: winningTx}, nil)
-	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{ghostSpendingData}}, nil)
 	mockStore.On("GetConflictingChildren", mock.Anything, ghostTxHash).
 		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", ghostTxHash))
@@ -1174,7 +1295,7 @@ func hashSetMatcher(want ...chainhash.Hash) interface{} {
 func stubCounterConflictingWalk(mockStore *MockUtxostore, rootTx *bt.Tx, spenderTxHash chainhash.Hash) {
 	parentTxHash := *rootTx.Inputs[0].PreviousTxIDChainHash()
 
-	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos}).
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
 		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&spenderTxHash, 0)}}, nil).Once()
 	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
 		Return([]chainhash.Hash{}, nil).Once()

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -1071,6 +1071,35 @@ func TestGetConflictingChildren_FailsClosedOnReapedDescendant(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+// A frozen output records the record-less frozen/coinbase-placeholder sentinel
+// as its spender. The BFS must surface that sentinel in the result set (so the
+// caller's frozen-child check fires) WITHOUT recursing into it — recursing
+// would Get a NOT_FOUND record that the ghost tolerance then silently swallows,
+// defeating frozen-tx rejection during conflict resolution. The absence of any
+// Get stub for the sentinel proves it is never dereferenced: a recursion would
+// panic the mock as an unexpected call.
+func TestGetConflictingChildren_SurfacesFrozenSentinelWithoutRecursing(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	rootHash := createTestHash("frozen-loser-root")
+	frozenSentinel := subtree.CoinbasePlaceholderHashValue
+
+	bfsFields := []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}
+
+	// the live loser's frozen output points at the sentinel
+	mockStore.On("Get", mock.Anything, &rootHash, bfsFields).
+		Return(&meta.Data{SpendingDatas: []*spend.SpendingData{spend.NewSpendingData(&frozenSentinel, 0)}}, nil)
+	// deliberately NO stub for Get(frozenSentinel, ...): it must not be recursed
+
+	children, err := GetConflictingChildren(ctx, mockStore, rootHash)
+
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{frozenSentinel}, children,
+		"the frozen sentinel must be returned so the caller's frozen check can fire")
+	mockStore.AssertExpectations(t)
+}
+
 // The cascade discovers children from the SpendingDatas of the records it just
 // marked — which can include a ghost (spends applied, record never created).
 // Feeding the ghost back into SetConflicting would fail NOT_FOUND and wedge

--- a/stores/utxo/reverse_process_conflicting_test.go
+++ b/stores/utxo/reverse_process_conflicting_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
 	"github.com/stretchr/testify/assert"
@@ -1071,4 +1072,37 @@ func TestSpendsForTx(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, got)
 	})
+}
+
+// ConflictingChildren entries are never removed once written: a conflicting
+// loser purged by the conflicting-branch DAH (or a healed ghost) stays listed
+// in its parent's bin after its record is gone. The counter selection must
+// skip such dangling entries — an absent candidate cannot be re-promoted
+// whatever the cause — instead of hard-failing and wedging moveBackBlock.
+func TestSelectCountersForDemotedTx_SkipsDanglingConflictingChild(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	parentHash := createTestHash("dangling-parent")
+	demotedHash := createTestHash("dangling-demoted")
+	purgedHash := createTestHash("dangling-purged-loser")
+	counterHash := createTestHash("dangling-counter")
+
+	demotedTx := createSpendableTestTransaction(parentHash, 0)
+	counterTx := createSpendableTestTransaction(parentHash, 0)
+
+	mockStore.On("Get", mock.Anything, &parentHash, []fields.FieldName{fields.ConflictingChildren}).
+		Return(&meta.Data{ConflictingChildren: []chainhash.Hash{purgedHash, counterHash}}, nil)
+	// the purged loser: still listed, record long reaped
+	mockStore.On("Get", mock.Anything, &purgedHash, []fields.FieldName{fields.Tx, fields.Conflicting, fields.CreatedAt}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", purgedHash))
+	mockStore.On("Get", mock.Anything, &counterHash, []fields.FieldName{fields.Tx, fields.Conflicting, fields.CreatedAt}).
+		Return(&meta.Data{Tx: counterTx, Conflicting: true, CreatedAt: 42}, nil)
+
+	result, err := selectCountersForDemotedTx(ctx, mockStore, demotedTx, map[chainhash.Hash]struct{}{demotedHash: {}})
+
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{counterHash}, result,
+		"the live counter must still be selected after skipping the dangling entry")
+	mockStore.AssertExpectations(t)
 }

--- a/stores/utxo/setconflicting_cascade_bug_test.go
+++ b/stores/utxo/setconflicting_cascade_bug_test.go
@@ -5,9 +5,18 @@ import (
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// expectLiveChildProbe registers the ghost-filter probe MarkConflictingRecursively
+// performs on every discovered spending child, answering that the record exists.
+func expectLiveChildProbe(mockStore *MockUtxostore, childHash *chainhash.Hash) {
+	mockStore.On("Get", mock.Anything, childHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil)
+}
 
 // TestSetConflicting_MustCascadeToChildren verifies that marking a parent tx
 // conflicting via MarkConflictingRecursively also cascades to all spending children.
@@ -21,6 +30,7 @@ func TestSetConflicting_MustCascadeToChildren(t *testing.T) {
 	parentSpends := []*Spend{{TxID: &parentHash, Vout: 0}}
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
 		Return(parentSpends, []chainhash.Hash{childHash}, nil)
+	expectLiveChildProbe(mockStore, &childHash)
 
 	childSpends := []*Spend{{TxID: &childHash, Vout: 0}}
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
@@ -48,6 +58,7 @@ func TestSetConflicting_CallerMustCascade(t *testing.T) {
 
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
 		Return([]*Spend{{TxID: &parentHash, Vout: 0}}, []chainhash.Hash{childHash}, nil)
+	expectLiveChildProbe(mockStore, &childHash)
 
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
 		Return([]*Spend{{TxID: &childHash, Vout: 0}}, []chainhash.Hash{}, nil)
@@ -70,9 +81,11 @@ func TestMarkConflictingRecursively_DoesCascade(t *testing.T) {
 
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{parentHash}, true).
 		Return([]*Spend{{TxID: &parentHash, Vout: 0}}, []chainhash.Hash{childHash}, nil)
+	expectLiveChildProbe(mockStore, &childHash)
 
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{childHash}, true).
 		Return([]*Spend{{TxID: &childHash, Vout: 0}}, []chainhash.Hash{grandchildHash}, nil)
+	expectLiveChildProbe(mockStore, &grandchildHash)
 
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{grandchildHash}, true).
 		Return([]*Spend{{TxID: &grandchildHash, Vout: 0}}, []chainhash.Hash{}, nil)

--- a/stores/utxo/sql/counter_conflicting_ghost_test.go
+++ b/stores/utxo/sql/counter_conflicting_ghost_test.go
@@ -1,0 +1,98 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCounterConflictingGhostSpender_WalkToleratesGhost reproduces, against a
+// real store, the field failure behind the counter-conflicting wedge (#1320):
+//
+// A multi-input transaction is validated and makes its valid spends, but errors
+// on another input (already spent, or any other failure), so the transaction
+// record itself is never created — while the completed spends survive. The
+// parent outputs are left recording a spender that does not exist (a "ghost").
+// When a conflicting transaction spending one of those outputs is later
+// processed, the counter-conflicting walk used to fail with TX_NOT_FOUND (block
+// wedged forever), and conflict resolution could never spend the slot because
+// the ghost's dangling spend was unclearable.
+//
+// The test plants exactly that end state (the ghost's spends applied through the
+// store, its record never created), then asserts the walk tolerates the ghost.
+//
+// The full resolution flow (ProcessConflicting healing the contested slot) is
+// covered against real Aerospike in
+// stores/utxo/aerospike/counter_conflicting_ghost_test.go — it cannot run here:
+// SetConflicting opens a write transaction and then reads via the pool, which
+// self-deadlocks on SQLite (see setconflicting_cascade_test.go).
+func TestCounterConflictingGhostSpender_WalkToleratesGhost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, parentTx := setup(ctx, t)
+
+	_, err := store.Create(ctx, parentTx, 0)
+	require.NoError(t, err)
+
+	// The ghost: a multi-input tx spending both parent outputs through the store,
+	// whose own record is never created (its validation failed on another input).
+	ghostTx := spendingTxWithFee(t, parentTx, 0, 1)
+	_, err = store.Spend(ctx, ghostTx, store.GetBlockHeight()+1)
+	require.NoError(t, err)
+	// deliberately NO store.Create(ghostTx): the spender record does not exist
+
+	// The conflicting tx spends parent output 0 — the slot the ghost holds. The
+	// validator marked it conflicting when its spend collided with the ghost's;
+	// create it in that state (a conflicting tx holds no spends of its own).
+	conflictingTx := spendingTxWithFee(t, parentTx, 0)
+	_, err = store.Create(ctx, conflictingTx, 0, utxo.WithConflicting(true))
+	require.NoError(t, err)
+
+	conflictingTxHash := *conflictingTx.TxIDChainHash()
+
+	// 1. The counter-conflicting walk must tolerate the confirmed ghost instead
+	// of failing with TX_NOT_FOUND — this is what unwedges block validation.
+	counterHashes, err := utxo.GetCounterConflictingTxHashes(ctx, store, conflictingTxHash)
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{conflictingTxHash}, counterHashes)
+
+	// Both ghost slots are still recorded as spent by the ghost — the tolerance
+	// is read-side only; healing happens in ProcessConflicting (aerospike test).
+	utxoHash0, err := util.UTXOHashFromOutput(parentTx.TxIDChainHash(), parentTx.Outputs[0], 0)
+	require.NoError(t, err)
+
+	resp, err := store.GetSpend(ctx, &utxo.Spend{TxID: parentTx.TxIDChainHash(), Vout: 0, UTXOHash: utxoHash0})
+	require.NoError(t, err)
+	require.NotNil(t, resp.SpendingData)
+	require.True(t, resp.SpendingData.TxID.Equal(*ghostTx.TxIDChainHash()),
+		"the walk must not modify the dangling slot")
+}
+
+// spendingTxWithFee builds a tx spending the given parent outputs, paying out
+// less than it consumes so the store's fee check on Create passes.
+func spendingTxWithFee(t *testing.T, parentTx *bt.Tx, vOuts ...uint32) *bt.Tx {
+	t.Helper()
+
+	newTx := bt.NewTx()
+
+	total := uint64(0)
+	for _, vOut := range vOuts {
+		require.NoError(t, newTx.From(parentTx.TxIDChainHash().String(), vOut, parentTx.Outputs[vOut].LockingScript.String(), parentTx.Outputs[vOut].Satoshis))
+		total += parentTx.Outputs[vOut].Satoshis
+	}
+
+	require.NoError(t, newTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", total/2))
+
+	for _, input := range newTx.Inputs {
+		input.UnlockingScript = &bscript.Script{bscript.OpTRUE}
+	}
+
+	return newTx
+}


### PR DESCRIPTION
Closes #1320. v0.15 line only — main gets a different fix. Write-side cause tracked in #1214.

## Problem

A multi-input tx makes its valid spends, errors on another input, and its record is never created — the parent outputs are left recording a spender that does not exist (a ghost). A block containing a conflicting tx over such a slot wedges the node twice:

1. **Subtree validation**: `GetCounterConflictingTxHashes` fails with `TX_NOT_FOUND`, `checkCounterConflictingOnCurrentChain` turns it into a fatal `ProcessingError`, and both the legacy `HandleBlockDirect` and catchup `CheckBlockSubtreesRequest` paths retry the same block forever.
2. **Block assembly**: fixing (1) alone just moves the wedge. `moveForwardBlock` feeds the blessed winner to `ProcessConflicting`, which runs the same walk — and even with a tolerant walk, step-3 `Spend(winner)` fails `SPENT`: the Lua spend rejects a mismatched occupant, and no loser-derived unspend can clear a ghost's spend (the unspend ownership check only clears a spend the caller owns, and a ghost has no record to derive it from).

## Fix

- The walk probes a spender whose conflict BFS returns NOT_FOUND and tolerates only a **confirmed-absent** spender: excluded from the counter set, reported as a ghost slot (parent txid, vout, utxohash, recorded spending data).
- The probe is not optional. `GetConflictingChildren` is a BFS — NOT_FOUND can mean a missing *descendant* of a live spender, possibly mined on our chain within the mined-check horizon (retention×2 = 576 blocks vs 288-block record retention). Dropping the spender in that case would bless a same-chain double-spend, no reorg needed. The issue's original prescription had this hole; with the probe, a live spender with a missing descendant stays fail-closed.
- `ProcessConflicting` appends the ghost slots to the step-2 unspend, passing the recorded ghost spending data as the expected value — this passes the ownership check on both backends, the winner spends the slot in step 3, and the dangling reference is healed permanently. The heal is monotonic under rollback: a cleared slot stays cleared, and the retry converges (the walk then sees an unspent slot).
- Fail closed, unchanged: the tx-under-check missing, a missing parent record, an inconclusive probe, and all `GetMeta`/children errors in `checkCounterConflictingOnCurrentChain`.
- Observability: every tolerated ghost increments `teranode_utxo_counter_conflicting_ghost_spends` (the free functions have no logger, so a counter is the surface — same conclusion #1239 reached).

`Store.GetCounterConflicting` keeps its signature; `ProcessConflicting` calls the ghost-aware walk directly because it needs the slots.

## Tests

- `stores/utxo/aerospike/counter_conflicting_ghost_test.go` — end-to-end against real Aerospike: ghost planted through the store API (multi-input spends applied, record never created), walk tolerates, `ProcessConflicting` heals the contested slot through the real Lua ownership check, winner spends, uncontested ghost slot untouched, parent unlocked.
- `stores/utxo/sql/counter_conflicting_ghost_test.go` — walk tolerance on sqlitememory (resolution can't run there: `SetConflicting` write-txn + pool reads self-deadlock on SQLite, see `setconflicting_cascade_test.go`).
- `services/subtreevalidation/counter_conflicting_ghost_test.go` — ghost validates; a live mined counter still rejects.
- Unit tests for the fail-closed partition (live spender + missing descendant, missing parent, probe error) and the resolution orchestration. Existing `ProcessConflicting` mock tests rewritten to stub the walk realistically — the old `GetCounterConflicting` stubs wrongly excluded the winner from the loser set.

`go test -race` green on `stores/utxo`, `stores/utxo/sql`, `services/subtreevalidation`, `services/blockassembly/subtreeprocessor`, `stores/txmetacache`. Pre-existing failures in `stores/utxo/sql` (Postgres container tests, `TestMinedThenSpendAllPrunes_SQLite`) fail identically on the clean release/v0.15 baseline.

## Accepted residuals

- A counter genuinely mined on our chain and DAH-pruned (≥~288 deep, inside the 576-block horizon) is indistinguishable from a ghost once its record is gone; tolerance waves it through. Exploiting it costs a miner a full block for a tx other implementations reject anyway. The marker discriminator that closes this band stays deferred, per the issue.
- Frozen-child checks are skipped for a genuine root ghost's subtree (a freeze sitting strictly below a pruned spender). Narrow; the probe cannot close it.
- The Lua conflicting-branch DAH (`teranode.lua:985-995`) reaps flagged records ignoring `blockIDs` — undermines "absent ⟹ not mined" independently of this fix. Separate issue to follow.