### PR TITLE
feat(utxo): replace Store.Spend/Create with a single SpendAndCreate

### DIFF
--- a/cmd/aerospikereader/aerospike_reader_test.go
+++ b/cmd/aerospikereader/aerospike_reader_test.go
@@ -53,7 +53,7 @@ func TestAerospikeReader(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new transaction in the store
-	_, err = store.Create(ctx, tx, 0)
+	_, _, err = store.SpendAndCreate(ctx, tx, 0, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Set the mined block info for the transaction

--- a/cmd/seeder/seeder.go
+++ b/cmd/seeder/seeder.go
@@ -635,10 +635,11 @@ func processUTXO(ctx context.Context, store utxo.Store, utxoWrapper *utxopersist
 		return nil
 	}
 
-	if _, err := store.Create(
+	if _, _, err := store.SpendAndCreate(
 		ctx,
 		tx,
 		utxoWrapper.Height,
+		utxo.WithCreateOnly(),
 		utxo.WithTXID(&utxoWrapper.TxID),
 		utxo.WithSetCoinbase(utxoWrapper.Coinbase),
 		utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 0, BlockHeight: utxoWrapper.Height, SubtreeIdx: 0}),

--- a/cmd/seedimport/seedimport/seedimport.go
+++ b/cmd/seedimport/seedimport/seedimport.go
@@ -78,7 +78,8 @@ func loadWrapper(ctx context.Context, store utxo.Store, w *utxopersister.UTXOWra
 
 	txid := w.TxID
 
-	_, err = store.Create(ctx, tx, w.Height,
+	_, _, err = store.SpendAndCreate(ctx, tx, w.Height,
+		utxo.WithCreateOnly(),
 		utxo.WithTXID(&txid),
 		utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
 			BlockID:        blockID,

--- a/cmd/seedimport/seedimport/seedimport_test.go
+++ b/cmd/seedimport/seedimport/seedimport_test.go
@@ -417,7 +417,7 @@ func TestRunRejectsFooterMismatchAndRollsBack(t *testing.T) {
 	}
 }
 
-// failingCreateStore wraps a utxo.Store and fails Create after failAfter
+// failingCreateStore wraps a utxo.Store and fails SpendAndCreate after failAfter
 // successful calls, to exercise rollback on a mid-stream load error.
 type failingCreateStore struct {
 	utxo.Store
@@ -426,13 +426,13 @@ type failingCreateStore struct {
 	calls     int
 }
 
-func (s *failingCreateStore) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, error) {
+func (s *failingCreateStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
 	s.calls++
 	if s.calls > s.failAfter {
-		return nil, errors.NewStorageError("injected store failure on create #%d", s.calls)
+		return nil, nil, errors.NewStorageError("injected store failure on create #%d", s.calls)
 	}
 
-	return s.Store.Create(ctx, tx, blockHeight, opts...)
+	return s.Store.SpendAndCreate(ctx, tx, blockHeight, opts...)
 }
 
 func TestRunRollsBackOnMidStreamLoadError(t *testing.T) {

--- a/cmd/teranodecli/teranodecli/loadunminedbench.go
+++ b/cmd/teranodecli/teranodecli/loadunminedbench.go
@@ -232,7 +232,7 @@ func populateAerospikeWithTransactions(ctx context.Context, store utxo.Store, co
 				LockingScript: lockingScript,
 			})
 
-			if _, err := store.Create(ctx, tx, currentBlockHeight); err != nil {
+			if _, _, err := store.SpendAndCreate(ctx, tx, currentBlockHeight, utxo.WithCreateOnly()); err != nil {
 				return err
 			}
 

--- a/docs/references/stores/utxo_reference.md
+++ b/docs/references/stores/utxo_reference.md
@@ -192,11 +192,6 @@ type Store interface {
     // Returns status code, status message and any error encountered.
     Health(ctx context.Context, checkLiveness bool) (int, string, error)
 
-    // Create stores a new transaction's outputs as UTXOs and returns associated metadata.
-    // The blockHeight parameter is used to determine coinbase maturity.
-    // Additional options can be specified using CreateOption functions.
-    Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, error)
-
     // Get retrieves UTXO metadata for a given transaction hash.
     // The fields parameter can be used to specify which metadata fields to retrieve.
     // If fields is empty, all fields will be retrieved.
@@ -211,8 +206,13 @@ type Store interface {
     // GetMeta retrieves transaction metadata into the provided data object.
     GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Data) error
 
-    // Spend marks all the UTXOs of the transaction as spent.
-    Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...IgnoreFlags) ([]*Spend, error)
+    // SpendAndCreate spends the transaction's inputs and creates its outputs +
+    // metadata as one logical operation. On create failure other than ErrTxExists,
+    // successful spends are rolled back; ErrTxExists is returned with the spends
+    // left in place. WithCreateOnly() skips the spend phase (coinbase, seeding);
+    // WithSpendOnly() skips the create phase (reorg/conflict helpers). On spend
+    // failure the returned []*Spend carries per-input Err values.
+    SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error)
 
     // Unspend reverses a previous spend operation, marking UTXOs as unspent.
     // This is used during blockchain reorganizations.

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -5126,13 +5126,14 @@ func TestValidateSubtreeBenchmark(t *testing.T) {
 				LockingScript: lockingScript,
 			})
 
-			_, err := utxoStore.Create(context.Background(), parentTx, 1,
+			_, _, err := utxoStore.SpendAndCreate(context.Background(), parentTx, 1,
 				utxo.WithTXID(&allParentHashes[s][i]),
 				utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
 					BlockID:        1,
 					BlockHeight:    1,
 					OnLongestChain: true,
 				}),
+				utxo.WithCreateOnly(),
 			)
 			if err != nil {
 				fmt.Printf("Warning: failed to create parent tx %d-%d: %v\n", s, i, err)

--- a/services/asset/repository/GetLegacyBlock_test.go
+++ b/services/asset/repository/GetLegacyBlock_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bsv-blockchain/teranode/settings"
 	memory_blob "github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -108,7 +109,7 @@ func TestGetLegacyBlockWithSubtreeStore(t *testing.T) {
 	// Create the txs in the utxo store
 	for i, tx := range params.txs {
 		if i != 0 {
-			_, err := ctx.repo.UtxoStore.Create(context.Background(), tx, params.height)
+			_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), tx, params.height, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 	}
@@ -157,7 +158,7 @@ func TestGetLegacyWireBlockWithSubtreeStore(t *testing.T) {
 	// Create the txs in the utxo store
 	for i, tx := range params.txs {
 		if i != 0 {
-			_, err := ctx.repo.UtxoStore.Create(context.Background(), tx, params.height)
+			_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), tx, params.height, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 	}
@@ -388,7 +389,7 @@ func TestWriteTransactionsViaSubtreeStoreStreaming(t *testing.T) {
 
 		// Add all non-coinbase transactions to the UTXO store
 		for i := 1; i < len(txs); i++ {
-			_, err := ctx.repo.UtxoStore.Create(context.Background(), txs[i], testParams.height)
+			_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), txs[i], testParams.height, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -485,7 +486,7 @@ func TestWriteTransactionsViaSubtreeStoreStreaming(t *testing.T) {
 		blockchainClientMock.On("GetBlock", mock.Anything, mock.Anything).Return(block, nil).Once()
 
 		for i := 1; i < len(txs); i++ {
-			_, err := ctx.repo.UtxoStore.Create(context.Background(), txs[i], testParams.height)
+			_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), txs[i], testParams.height, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -563,7 +564,7 @@ func TestWriteTransactionsViaSubtreeStoreStreaming(t *testing.T) {
 		blockchainClientMock.On("GetBlock", mock.Anything, mock.Anything).Return(block, nil).Once()
 
 		for i := 1; i < len(txs); i++ {
-			_, err := ctx.repo.UtxoStore.Create(context.Background(), txs[i], testParams.height)
+			_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), txs[i], testParams.height, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -670,7 +671,7 @@ func TestGetLegacyBlockNoDuplication(t *testing.T) {
 			// Setup UTXO store if needed (for fallback path)
 			if tc.setupUTXOStore {
 				for i := 1; i < len(txs); i++ {
-					_, err := ctx.repo.UtxoStore.Create(context.Background(), txs[i], blockParams.height)
+					_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), txs[i], blockParams.height, utxo.WithCreateOnly())
 					require.NoError(t, err)
 				}
 				// Also need the subtree itself for fallback

--- a/services/asset/repository/GetSubtreeData_test.go
+++ b/services/asset/repository/GetSubtreeData_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/utxopersister/filestorer"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -221,7 +222,7 @@ func setupSubtreeReaderTest(t *testing.T) (*testContext, *subtreepkg.Subtree, []
 	// Create the txs in the utxo store
 	for i, tx := range params.txs {
 		if i != 0 {
-			_, err := ctx.repo.UtxoStore.Create(t.Context(), tx, params.height)
+			_, _, err := ctx.repo.UtxoStore.SpendAndCreate(t.Context(), tx, params.height, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 

--- a/services/asset/repository/subtree_stream_backpressure_test.go
+++ b/services/asset/repository/subtree_stream_backpressure_test.go
@@ -113,7 +113,7 @@ func TestSubtreeStreamingHeadOfLineBackpressure(t *testing.T) {
 
 	// Populate the real utxo store, then wrap it so the head chunk stalls.
 	for i := 1; i < len(txs); i++ {
-		_, err := ctx.repo.UtxoStore.Create(context.Background(), txs[i], testParams.height)
+		_, _, err := ctx.repo.UtxoStore.SpendAndCreate(context.Background(), txs[i], testParams.height, utxo.WithCreateOnly())
 		require.NoError(t, err)
 	}
 

--- a/services/blockassembly/BlockAssembler_test.go
+++ b/services/blockassembly/BlockAssembler_test.go
@@ -448,31 +448,31 @@ func TestBlockAssembly_AddTx(t *testing.T) {
 			}
 		}()
 
-		_, err := testItems.utxoStore.Create(ctx, tx1, 0)
+		_, _, err := testItems.utxoStore.SpendAndCreate(ctx, tx1, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash1, Fee: 111}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx2, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx2, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash2, Fee: 222}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx3, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx3, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash3, Fee: 333}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx4, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx4, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash4, Fee: 110}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx5, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx5, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash5, Fee: 220}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx6, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx6, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash6, Fee: 330}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx7, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx7, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash7, Fee: 6}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
@@ -839,23 +839,23 @@ func TestBlockAssembly_ShouldNotAllowMoreThanOneCoinbaseTx(t *testing.T) {
 			}
 		}()
 
-		_, err := testItems.utxoStore.Create(ctx, tx1, 0)
+		_, _, err := testItems.utxoStore.SpendAndCreate(ctx, tx1, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *subtreepkg.CoinbasePlaceholderHash, Fee: 5000000000}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx2, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx2, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash2, Fee: 222}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx3, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx3, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash3, Fee: 334}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx4, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx4, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash4, Fee: 444}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx5, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx5, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash5, Fee: 555}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
@@ -946,15 +946,15 @@ func TestBlockAssembly_GetMiningCandidate(t *testing.T) {
 			}
 		}()
 
-		_, err := testItems.utxoStore.Create(ctx, tx2, 0)
+		_, _, err := testItems.utxoStore.SpendAndCreate(ctx, tx2, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash2, Fee: 222, SizeInBytes: 222}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx3, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx3, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash3, Fee: 333, SizeInBytes: 333}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx4, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx4, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *hash4, Fee: 444, SizeInBytes: 444}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
@@ -1064,7 +1064,7 @@ func TestBlockAssembly_GetMiningCandidate_MaxBlockSize(t *testing.T) {
 		for i := 1; i < 15; i++ {
 			// nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
 			tx := newTx(uint32(i))
-			_, err := testItems.utxoStore.Create(ctx, tx, 0)
+			_, _, err := testItems.utxoStore.SpendAndCreate(ctx, tx, 0, utxoStore.WithCreateOnly())
 			require.NoError(t, err)
 
 			testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *tx.TxIDChainHash(), Fee: 1000000000, SizeInBytes: 15000}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
@@ -1163,7 +1163,7 @@ func TestBlockAssembly_GetMiningCandidate_MaxBlockSize_LessThanSubtreeSize(t *te
 		for i := 1; i < 4; i++ {
 			// nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
 			tx := newTx(uint32(i))
-			_, err := testItems.utxoStore.Create(ctx, tx, 0)
+			_, _, err := testItems.utxoStore.SpendAndCreate(ctx, tx, 0, utxoStore.WithCreateOnly())
 			require.NoError(t, err)
 
 			testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{Hash: *tx.TxIDChainHash(), Fee: 1000000000, SizeInBytes: 150000}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}}) // 0.15MB
@@ -1269,7 +1269,7 @@ func TestBlockAssembly_CoinbaseSubsidyBugReproduction(t *testing.T) {
 		tx3 := newTx(3)
 
 		// Add transactions to UTXO store and then to block assembler
-		_, err := testItems.utxoStore.Create(ctx, tx1, 0)
+		_, _, err := testItems.utxoStore.SpendAndCreate(ctx, tx1, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{
 			Hash:        *tx1.TxIDChainHash(),
@@ -1277,7 +1277,7 @@ func TestBlockAssembly_CoinbaseSubsidyBugReproduction(t *testing.T) {
 			SizeInBytes: 250,
 		}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx2, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx2, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{
 			Hash:        *tx2.TxIDChainHash(),
@@ -1285,7 +1285,7 @@ func TestBlockAssembly_CoinbaseSubsidyBugReproduction(t *testing.T) {
 			SizeInBytes: 250,
 		}}, []*subtreepkg.TxInpoints{{ParentTxHashes: []chainhash.Hash{}}})
 
-		_, err = testItems.utxoStore.Create(ctx, tx3, 0)
+		_, _, err = testItems.utxoStore.SpendAndCreate(ctx, tx3, 0, utxoStore.WithCreateOnly())
 		require.NoError(t, err)
 		testItems.blockAssembler.AddTxBatch([]subtreepkg.Node{{
 			Hash:        *tx3.TxIDChainHash(),
@@ -2026,7 +2026,7 @@ func TestBlockAssembly_LoadUnminedTransactions_ReseedsMinedTx_WhenUnminedSinceNo
 	// Create a test tx and insert into UTXO store as unmined initially (unmined_since set)
 	tx := newTx(42)
 	txHash := tx.TxIDChainHash()
-	_, err := items.utxoStore.Create(ctx, tx, 0) // blockHeight=0 -> unmined_since set to 0
+	_, _, err := items.utxoStore.SpendAndCreate(ctx, tx, 0, utxoStore.WithCreateOnly()) // blockHeight=0 -> unmined_since set to 0
 	require.NoError(t, err)
 
 	// Mark as mined on longest chain (this should clear unmined_since)
@@ -2072,7 +2072,7 @@ func TestBlockAssembly_LoadUnminedTransactions_ReorgCornerCase_MisUnsetMinedStat
 	// Prepare a mined tx on the main chain
 	tx := newTx(43)
 	txHash := tx.TxIDChainHash()
-	_, err := items.utxoStore.Create(ctx, tx, 0)
+	_, _, err := items.utxoStore.SpendAndCreate(ctx, tx, 0, utxoStore.WithCreateOnly())
 	require.NoError(t, err)
 
 	_, err = items.utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxoStore.MinedBlockInfo{
@@ -2125,9 +2125,9 @@ func TestBlockAssembly_LoadUnminedTransactions_SkipsTransactionsOnCurrentChain(t
 	txHash2 := tx2.TxIDChainHash()
 
 	// Add both transactions to UTXO store as unmined initially
-	_, err := items.utxoStore.Create(ctx, tx1, 0)
+	_, _, err := items.utxoStore.SpendAndCreate(ctx, tx1, 0, utxoStore.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = items.utxoStore.Create(ctx, tx2, 0)
+	_, _, err = items.utxoStore.SpendAndCreate(ctx, tx2, 0, utxoStore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Add the first test block (using existing blockHeader1 pattern)
@@ -2944,7 +2944,7 @@ func TestReset_ConflictDetectionViaValidateInputs(t *testing.T) {
 	txParent.Outputs = []*bt.Output{
 		{Satoshis: 100000, LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14, 0x00, 0x88, 0xac})},
 	}
-	_, err := items.utxoStore.Create(ctx, txParent, 1)
+	_, _, err := items.utxoStore.SpendAndCreate(ctx, txParent, 1, utxoStore.WithCreateOnly())
 	require.NoError(t, err)
 	parentHash := txParent.TxIDChainHash()
 	require.NoError(t, items.utxoStore.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*parentHash}, true))
@@ -2959,7 +2959,7 @@ func TestReset_ConflictDetectionViaValidateInputs(t *testing.T) {
 	txA.Outputs = []*bt.Output{{Satoshis: 90000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
 	const assemblyHeight = uint32(5)
 	require.NoError(t, items.utxoStore.SetBlockHeight(assemblyHeight))
-	_, err = items.utxoStore.Create(ctx, txA, assemblyHeight)
+	_, _, err = items.utxoStore.SpendAndCreate(ctx, txA, assemblyHeight, utxoStore.WithCreateOnly())
 	require.NoError(t, err)
 	txAHash := txA.TxIDChainHash()
 

--- a/services/blockassembly/blockassembly_system_test.go
+++ b/services/blockassembly/blockassembly_system_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/blockchain/options"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	nodehelpers "github.com/bsv-blockchain/teranode/test/nodeHelpers"
 	"github.com/bsv-blockchain/teranode/ulogger"
@@ -302,17 +303,17 @@ func TestShouldAddSubtreesToLongerChain(t *testing.T) {
 	// Add transactions
 	t.Log("Adding transactions...")
 
-	_, err = ba.utxoStore.Create(ctx, testTx1, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx1, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash1, Fee: 111}}, []*subtree.TxInpoints{&parents1})
 
-	_, err = ba.utxoStore.Create(ctx, testTx2, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx2, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash2, Fee: 222}}, []*subtree.TxInpoints{&parents2})
 
-	_, err = ba.utxoStore.Create(ctx, testTx3, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx3, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash3, Fee: 333}}, []*subtree.TxInpoints{&parents3})
@@ -439,16 +440,16 @@ func TestShouldHandleReorg(t *testing.T) {
 	// Add transactions
 	t.Log("Adding transactions...")
 
-	_, err = ba.utxoStore.Create(ctx, testTx1, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx1, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash1, Fee: 111}}, []*subtree.TxInpoints{&parents1})
 
-	_, err = ba.utxoStore.Create(ctx, testTx2, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx2, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash2, Fee: 222}}, []*subtree.TxInpoints{&parents2})
 
-	_, err = ba.utxoStore.Create(ctx, testTx3, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx3, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash3, Fee: 333}}, []*subtree.TxInpoints{&parents3})
 
@@ -679,16 +680,16 @@ func TestShouldHandleReorgWithLongerChain(t *testing.T) {
 	// Add transactions
 	t.Log("Adding transactions...")
 
-	_, err = ba.utxoStore.Create(ctx, testTx1, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx1, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash1, Fee: 111}}, []*subtree.TxInpoints{&parents1})
 
-	_, err = ba.utxoStore.Create(ctx, testTx2, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx2, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash2, Fee: 222}}, []*subtree.TxInpoints{&parents2})
 
-	_, err = ba.utxoStore.Create(ctx, testTx3, 0)
+	_, _, err = ba.utxoStore.SpendAndCreate(ctx, testTx3, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	ba.blockAssembler.AddTxBatch([]subtree.Node{{Hash: *testHash3, Fee: 333}}, []*subtree.TxInpoints{&parents3})
 

--- a/services/blockassembly/conflict_intent_replay_test.go
+++ b/services/blockassembly/conflict_intent_replay_test.go
@@ -195,7 +195,7 @@ func TestReplayPendingConflictIntents_StaleForwardHealed(t *testing.T) {
 	_ = parentIn.PreviousTxIDAdd(&chainhash.Hash{7, 7, 7})
 	parent.Inputs = []*bt.Input{parentIn}
 	parent.Outputs = []*bt.Output{{Satoshis: 100000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
-	_, err := store.Create(ctx, parent, 1)
+	_, _, err := store.SpendAndCreate(ctx, parent, 1, utxo.WithCreateOnly())
 	require.NoError(t, err)
 	parentHash := parent.TxIDChainHash()
 	require.NoError(t, store.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*parentHash}, true))
@@ -205,9 +205,9 @@ func TestReplayPendingConflictIntents_StaleForwardHealed(t *testing.T) {
 	require.NoError(t, txL.From(parentHash.String(), 0, parent.Outputs[0].LockingScript.String(), parent.Outputs[0].Satoshis))
 	txL.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 	txL.Outputs = []*bt.Output{{Satoshis: 90000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
-	_, err = store.Create(ctx, txL, 10)
+	_, _, err = store.SpendAndCreate(ctx, txL, 10, utxo.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = store.Spend(ctx, txL, store.GetBlockHeight()+1)
+	_, _, err = store.SpendAndCreate(ctx, txL, store.GetBlockHeight()+1, utxo.WithSpendOnly())
 	require.NoError(t, err)
 
 	// W: the would-be forward winner, left Conflicting=true.
@@ -215,7 +215,7 @@ func TestReplayPendingConflictIntents_StaleForwardHealed(t *testing.T) {
 	require.NoError(t, txW.From(parentHash.String(), 0, parent.Outputs[0].LockingScript.String(), parent.Outputs[0].Satoshis))
 	txW.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 	txW.Outputs = []*bt.Output{{Satoshis: 80000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
-	_, err = store.Create(ctx, txW, 10, utxo.WithConflicting(true))
+	_, _, err = store.SpendAndCreate(ctx, txW, 10, utxo.WithConflicting(true), utxo.WithCreateOnly())
 	require.NoError(t, err)
 	txWHash := txW.TxIDChainHash()
 
@@ -274,7 +274,7 @@ func TestReplayPendingConflictIntents_StaleReverseHealed(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &demoted, mock.Anything).Return(&meta.Data{Tx: demotedTx, Conflicting: true}, nil)
 	mockStore.On("GetCounterConflicting", mock.Anything, demoted).Return([]chainhash.Hash{}, nil)
 	mockStore.On("Unspend", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)
+	mockStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, nil)
 	mockStore.On("SetConflicting", mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, []chainhash.Hash{}, nil)
 	mockStore.On("SetLocked", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -285,7 +285,7 @@ func TestReplayPendingConflictIntents_StaleReverseHealed(t *testing.T) {
 	b.replayPendingConflictIntents(context.Background())
 
 	require.Contains(t, spy.completed, intent.IntentID(), "a stale reverse intent must be healed (forward re-applied) and cleared from the WAL")
-	mockStore.AssertCalled(t, "Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertCalled(t, "SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestReplayPendingConflictIntents_RealStoreReverseConverges is the crash-
@@ -313,7 +313,7 @@ func TestReplayPendingConflictIntents_RealStoreReverseConverges(t *testing.T) {
 	_ = parentIn.PreviousTxIDAdd(&chainhash.Hash{9, 9, 9})
 	parent.Inputs = []*bt.Input{parentIn}
 	parent.Outputs = []*bt.Output{{Satoshis: 100000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
-	_, err := store.Create(ctx, parent, 1)
+	_, _, err := store.SpendAndCreate(ctx, parent, 1, utxo.WithCreateOnly())
 	require.NoError(t, err)
 	parentHash := parent.TxIDChainHash()
 	require.NoError(t, store.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*parentHash}, true))
@@ -323,7 +323,7 @@ func TestReplayPendingConflictIntents_RealStoreReverseConverges(t *testing.T) {
 	require.NoError(t, txD.From(parentHash.String(), 0, parent.Outputs[0].LockingScript.String(), parent.Outputs[0].Satoshis))
 	txD.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 	txD.Outputs = []*bt.Output{{Satoshis: 90000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
-	_, err = store.Create(ctx, txD, 10, utxo.WithConflicting(true))
+	_, _, err = store.SpendAndCreate(ctx, txD, 10, utxo.WithConflicting(true), utxo.WithCreateOnly())
 	require.NoError(t, err)
 	txDHash := txD.TxIDChainHash()
 
@@ -333,9 +333,9 @@ func TestReplayPendingConflictIntents_RealStoreReverseConverges(t *testing.T) {
 	require.NoError(t, txC.From(parentHash.String(), 0, parent.Outputs[0].LockingScript.String(), parent.Outputs[0].Satoshis))
 	txC.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 	txC.Outputs = []*bt.Output{{Satoshis: 80000, LockingScript: bscript.NewFromBytes([]byte{0x52})}}
-	_, err = store.Create(ctx, txC, 10)
+	_, _, err = store.SpendAndCreate(ctx, txC, 10, utxo.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = store.Spend(ctx, txC, store.GetBlockHeight()+1)
+	_, _, err = store.SpendAndCreate(ctx, txC, store.GetBlockHeight()+1, utxo.WithSpendOnly())
 	require.NoError(t, err)
 
 	// The reverse for txD is already fully applied; only the WAL completion was

--- a/services/blockassembly/load_unmined_benchmark_test.go
+++ b/services/blockassembly/load_unmined_benchmark_test.go
@@ -151,7 +151,7 @@ func benchmarkLoadUnminedTransactions(b *testing.B, txCount int) {
 			tx := transactions[j]
 
 			// Create with unmined status (no block info)
-			_, err = utxoStore.Create(ctx, tx, 1)
+			_, _, err = utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(b, err)
 		}
 
@@ -342,21 +342,21 @@ func BenchmarkLoadUnminedTransactions_MixedStates(b *testing.B) {
 	for i, tx := range transactions {
 		switch i % 4 {
 		case 0, 1: // 50% unmined
-			_, err = utxoStore.Create(ctx, tx, 100)
+			_, _, err = utxoStore.SpendAndCreate(ctx, tx, 100, utxo.WithCreateOnly())
 			require.NoError(b, err)
 
 		case 2: // 25% already mined in main chain
-			_, err = utxoStore.Create(ctx, tx, 100, utxo.WithMinedBlockInfo(
+			_, _, err = utxoStore.SpendAndCreate(ctx, tx, 100, utxo.WithMinedBlockInfo(
 				utxo.MinedBlockInfo{
 					BlockID:     uint32(5 + (i % 5)),
 					BlockHeight: uint32(5 + (i % 5)),
 					SubtreeIdx:  1,
 				},
-			))
+			), utxo.WithCreateOnly())
 			require.NoError(b, err)
 
 		case 3: // 25% locked
-			meta, err := utxoStore.Create(ctx, tx, 100)
+			meta, _, err := utxoStore.SpendAndCreate(ctx, tx, 100, utxo.WithCreateOnly())
 			require.NoError(b, err)
 
 			err = utxoStore.SetLocked(ctx, []chainhash.Hash{*meta.Tx.TxIDChainHash()}, true)

--- a/services/blockassembly/load_unmined_disk_sort_test.go
+++ b/services/blockassembly/load_unmined_disk_sort_test.go
@@ -36,7 +36,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		transactions := generateTestTransactionsForDiskSort(t, 10)
 
 		for _, tx := range transactions {
-			_, err := utxoStore.Create(ctx, tx, 1)
+			_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -63,7 +63,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		transactions := generateTestTransactionsForDiskSort(t, 5)
 
 		for i, tx := range transactions {
-			_, err := utxoStore.Create(ctx, tx, 1)
+			_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 			// Sleep a tiny bit to ensure different CreatedAt timestamps
 			if i < len(transactions)-1 {
@@ -90,17 +90,17 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		for i, tx := range transactions {
 			if i%2 == 0 {
 				// Unmined
-				_, err := utxoStore.Create(ctx, tx, 1)
+				_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 				require.NoError(t, err)
 			} else {
 				// Mined in a block on the main chain (block ID 0 is genesis)
-				_, err := utxoStore.Create(ctx, tx, 1, utxo.WithMinedBlockInfo(
+				_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithMinedBlockInfo(
 					utxo.MinedBlockInfo{
 						BlockID:     0,
 						BlockHeight: 0,
 						SubtreeIdx:  1,
 					},
-				))
+				), utxo.WithCreateOnly())
 				require.NoError(t, err)
 			}
 		}
@@ -123,7 +123,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		// Create all as unmined
 		var txHashes []chainhash.Hash
 		for _, tx := range transactions {
-			meta, err := utxoStore.Create(ctx, tx, 1)
+			meta, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 			txHashes = append(txHashes, *meta.Tx.TxIDChainHash())
 		}
@@ -169,7 +169,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		transactions := generateTestTransactionsForDiskSort(t, 5)
 
 		for _, tx := range transactions {
-			_, err := utxoStore.Create(ctx, tx, 1)
+			_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -190,7 +190,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		transactions := generateTestTransactionsForDiskSort(t, 3)
 
 		for _, tx := range transactions {
-			_, err := utxoStore.Create(ctx, tx, 1)
+			_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -214,7 +214,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		transactions := generateTestTransactionsForDiskSort(t, 5)
 
 		for _, tx := range transactions {
-			_, err := utxoStore.Create(ctx, tx, 1)
+			_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 
@@ -236,7 +236,7 @@ func TestLoadUnminedTransactionsWithDiskSort(t *testing.T) {
 		transactions := generateTestTransactionsForDiskSort(t, 5)
 
 		for _, tx := range transactions {
-			_, err := utxoStore.Create(ctx, tx, 1)
+			_, _, err := utxoStore.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 			require.NoError(t, err)
 		}
 

--- a/services/blockassembly/reset_moveforward_getsubtrees_test.go
+++ b/services/blockassembly/reset_moveforward_getsubtrees_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockassembly/subtreeprocessor"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -85,7 +86,7 @@ func TestReset_MoveForwardGetSubtreesFailure_PreservesMined(t *testing.T) {
 		Satoshis:      100_000,
 		LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0xac}),
 	}}
-	_, err := items.utxoStore.Create(ctx, txAlone, 1)
+	_, _, err := items.utxoStore.SpendAndCreate(ctx, txAlone, 1, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	txAloneHash := txAlone.TxIDChainHash()
 	require.NoError(t, items.utxoStore.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*txAloneHash}, true))

--- a/services/blockassembly/subtreeprocessor/ConflictingTransactions_test.go
+++ b/services/blockassembly/subtreeprocessor/ConflictingTransactions_test.go
@@ -86,7 +86,7 @@ func TestProcessConflictingTransactions(t *testing.T) {
 	mockUtxoStore.On("GetCounterConflicting", mock.Anything, mock.Anything).Return([]chainhash.Hash{conflictingTx1, conflictingTx2}, nil)
 	mockUtxoStore.On("SetConflicting", mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, []chainhash.Hash{}, nil)
 	mockUtxoStore.On("Unspend", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockUtxoStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)
+	mockUtxoStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, nil)
 	mockUtxoStore.On("SetLocked", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Mock the markConflictingTxsInSubtrees method

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -4984,10 +4984,11 @@ func (stp *SubtreeProcessor) processCoinbaseUtxos(ctx context.Context, block *mo
 	stp.logger.Debugf("[SubtreeProcessor][%s] height %d storeCoinbaseTx %s blockID %d", block.Header.Hash().String(), blockHeight, block.CoinbaseTx.TxIDChainHash().String(), block.ID)
 	// we pass in the block height we are working on here, since the utxo store will recognize the tx as
 	// a coinbase and add the correct spending height, which should be + 99
-	if _, err = stp.utxoStore.Create(
+	if _, _, err = stp.utxoStore.SpendAndCreate(
 		ctx,
 		block.CoinbaseTx,
 		blockHeight,
+		utxostore.WithCreateOnly(),
 		utxostore.WithMinedBlockInfo(
 			utxostore.MinedBlockInfo{
 				BlockID:     block.ID,

--- a/services/blockassembly/subtreeprocessor/move_forward_drain_loss_test.go
+++ b/services/blockassembly/subtreeprocessor/move_forward_drain_loss_test.go
@@ -37,8 +37,8 @@ type errOnCreateUtxoStore struct {
 
 func (e *errOnCreateUtxoStore) SupportsOutpointOnlySpend() bool { return false }
 
-func (e *errOnCreateUtxoStore) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxostore.CreateOption) (*meta.Data, error) {
-	return nil, e.err
+func (e *errOnCreateUtxoStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxostore.CreateOption) (*meta.Data, []*utxostore.Spend, error) {
+	return nil, nil, e.err
 }
 
 // TestMoveForwardBlockDrainLoss_BatchesLostOnPostDrainError demonstrates

--- a/services/blockassembly/subtreeprocessor/reorg_mark_partition_test.go
+++ b/services/blockassembly/subtreeprocessor/reorg_mark_partition_test.go
@@ -216,11 +216,11 @@ func createMinedTx(t *testing.T, ctx context.Context, store utxostore.Store, vou
 	require.NoError(t, tx.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 100000000))
 	tx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 
-	_, err = store.Create(ctx, tx, 1, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = store.SpendAndCreate(ctx, tx, 1, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:        blockID,
 		BlockHeight:    1,
 		OnLongestChain: true,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	return *tx.TxIDChainHash()

--- a/services/blockchain/server_test.go
+++ b/services/blockchain/server_test.go
@@ -243,7 +243,7 @@ func mockBlock(ctx *testContext, t *testing.T) *model.Block {
 	require.NoError(t, subtree.AddCoinbaseNode())
 	require.NoError(t, subtree.AddNode(*hash1, 100, 0))
 
-	_, err = ctx.utxoStore.Create(context.Background(), tx1, 0)
+	_, _, err = ctx.utxoStore.SpendAndCreate(context.Background(), tx1, 0, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	tSettings := test.CreateBaseTestSettings(t)

--- a/services/blockpersister/Server_test.go
+++ b/services/blockpersister/Server_test.go
@@ -990,6 +990,9 @@ func (m *MockUTXOStore) GetMeta(ctx context.Context, hash *chainhash.Hash, txMet
 func (m *MockUTXOStore) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...utxo.IgnoreFlags) ([]*utxo.Spend, error) {
 	return nil, nil
 }
+func (m *MockUTXOStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	return nil, nil, nil
+}
 func (m *MockUTXOStore) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked ...bool) error {
 	return nil
 }

--- a/services/blockvalidation/BlockValidation_difficulty_test.go
+++ b/services/blockvalidation/BlockValidation_difficulty_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/stretchr/testify/mock"
@@ -330,7 +331,7 @@ func TestValidateBlock_ValidDifficulty(t *testing.T) {
 	require.NoError(t, subtreeData.AddTx(coinbaseTx, 0))
 
 	// Store TX metadata for validation
-	_, err = utxoStore.Create(ctx, coinbaseTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(ctx, coinbaseTx, 0, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Create previous block header

--- a/services/blockvalidation/BlockValidation_error_test.go
+++ b/services/blockvalidation/BlockValidation_error_test.go
@@ -187,9 +187,10 @@ func createCoinbaseAndChildTx(t *testing.T) (*bt.Tx, *bt.Tx, *bec.PrivateKey, *b
 }
 
 func storeTxsInUtxoStore(t *testing.T, utxoStore utxo.Store, coinbaseTx, childTx *bt.Tx, opts ...utxo.CreateOption) {
-	_, err := utxoStore.Create(context.Background(), coinbaseTx, 0, opts...)
+	createOpts := append([]utxo.CreateOption{utxo.WithCreateOnly()}, opts...)
+	_, _, err := utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 0, createOpts...)
 	require.NoError(t, err)
-	_, err = utxoStore.Create(context.Background(), childTx, 0, opts...)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), childTx, 0, createOpts...)
 	require.NoError(t, err)
 }
 

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -388,19 +388,19 @@ func TestBlockValidationValidateBlockSmall(t *testing.T) {
 
 	// Create a grandparent transaction for parentTx
 	grandParentForParentTx := newTx(1000) // Create without parent
-	_, err = utxoStore.Create(context.Background(), grandParentForParentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}))
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), grandParentForParentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Add parentTx to UTXO store since tx1, tx2, tx3, tx4 all reference it as their parent
 	// Use WithMinedBlockInfo to set BlockID to 0 (GenesisBlockID) so validation passes
-	_, err = utxoStore.Create(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}))
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Create tx1 to reference parentTx instead of using the hex string version
 	// This ensures the parent relationship is under our control
 	// Use version 10 to differentiate from tx2 which uses version 1
 	tx1New := newTx(10, parentTx.TxIDChainHash())
-	_, err = utxoStore.Create(context.Background(), tx1New, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx1New, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Update hashes to use the new transactions
@@ -414,17 +414,17 @@ func TestBlockValidationValidateBlockSmall(t *testing.T) {
 
 	require.NoError(t, subtreeData.AddTx(tx1New, 1))
 
-	_, err = utxoStore.Create(context.Background(), tx2, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx2, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	require.NoError(t, subtreeData.AddTx(tx2, 2))
 
-	_, err = utxoStore.Create(context.Background(), tx3, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx3, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	require.NoError(t, subtreeData.AddTx(tx3, 3))
 
-	_, err = utxoStore.Create(context.Background(), tx4, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx4, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	nodeBytes, err := subtree.SerializeNodes()
@@ -538,7 +538,7 @@ func TestBlockValidationValidateBlock(t *testing.T) {
 		// This ensures that when we create child transactions, their parents exist
 		// Use WithMinedBlockInfo to set BlockID to 0 (GenesisBlockID) so validation passes
 		parentTx := newTx(uint32(i + 10000)) // Create parent without parent (no second param)
-		_, err = utxoStore.Create(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}))
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}), utxostore.WithCreateOnly())
 		require.NoError(t, err)
 
 		//nolint:gosec
@@ -549,7 +549,7 @@ func TestBlockValidationValidateBlock(t *testing.T) {
 
 		fees += 100
 
-		_, err = utxoStore.Create(context.Background(), tx, 0)
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), tx, 0, utxostore.WithCreateOnly())
 		require.NoError(t, err)
 	}
 
@@ -671,7 +671,7 @@ func TestBlockValidationShouldNotAllowDuplicateCoinbasePlaceholder(t *testing.T)
 
 	require.True(t, coinbase.IsCoinbase())
 
-	_, err = utxoStore.Create(context.Background(), coinbase, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), coinbase, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	subtree, err := subtreepkg.NewTreeByLeafCount(4)
@@ -759,7 +759,7 @@ func TestBlockValidationShouldNotAllowDuplicateCoinbaseTx(t *testing.T) {
 
 	require.True(t, coinbase.IsCoinbase())
 
-	_, err = utxoStore.Create(context.Background(), coinbase, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), coinbase, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	subtree, err := subtreepkg.NewTreeByLeafCount(4)
@@ -846,7 +846,7 @@ func TestInvalidBlockWithoutGenesisBlock(t *testing.T) {
 
 	// Create parent transaction for tx2, tx3, tx4 (they all reference parentTx)
 	// Use WithMinedBlockInfo to set BlockID to 0 (GenesisBlockID) so validation passes
-	_, err = utxoStore.Create(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}))
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Create tx1 with a parent reference to parentTx
@@ -862,16 +862,16 @@ func TestInvalidBlockWithoutGenesisBlock(t *testing.T) {
 	require.NoError(t, subtreeMeta.SetTxInpointsFromTx(tx2))
 	require.NoError(t, subtreeMeta.SetTxInpointsFromTx(tx3))
 
-	_, err = utxoStore.Create(context.Background(), tx1Test, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx1Test, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = utxoStore.Create(context.Background(), tx2, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx2, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = utxoStore.Create(context.Background(), tx3, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx3, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = utxoStore.Create(context.Background(), tx4, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx4, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	nodeBytes, err := subtree.SerializeNodes()
@@ -976,7 +976,7 @@ func TestInvalidChainWithoutGenesisBlock(t *testing.T) {
 
 	txns := []*bt.Tx{tx1, tx2, tx3, tx4}
 	for i, tx := range txns {
-		_, err := utxoStore.Create(context.Background(), tx, 0)
+		_, _, err := utxoStore.SpendAndCreate(context.Background(), tx, 0, utxostore.WithCreateOnly())
 		require.NoError(t, err, "Failed to store tx%d: %v", i+1, tx.TxIDChainHash())
 		t.Logf("Stored tx%d: %s", i+1, tx.TxIDChainHash())
 	}
@@ -1118,7 +1118,7 @@ func TestBlockValidationMerkleTreeValidation(t *testing.T) {
 		// This ensures that when we create child transactions, their parents exist
 		// Use WithMinedBlockInfo to set BlockID to 0 (GenesisBlockID) so validation passes
 		parentTx := newTx(uint32(i + 10000)) // Create parent without parent (no second param)
-		_, err = utxoStore.Create(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}))
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), parentTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 0, BlockHeight: 0}), utxostore.WithCreateOnly())
 		require.NoError(t, err)
 
 		tx := newTx(uint32(i), parentTx.TxIDChainHash()) //nolint:gosec
@@ -1128,7 +1128,7 @@ func TestBlockValidationMerkleTreeValidation(t *testing.T) {
 
 		fees += 100
 
-		_, err = utxoStore.Create(context.Background(), tx, 0)
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), tx, 0, utxostore.WithCreateOnly())
 		require.NoError(t, err)
 	}
 
@@ -1275,7 +1275,7 @@ func TestBlockValidationRequestMissingTransaction(t *testing.T) {
 
 	// Store all transactions except tx3 (which will be our missing transaction)
 	for _, tx := range txs[:3] { // Store all except tx3
-		_, err := utxoStore.Create(context.Background(), tx, 100)
+		_, _, err := utxoStore.SpendAndCreate(context.Background(), tx, 100, utxostore.WithCreateOnly())
 		require.NoError(t, err)
 	}
 
@@ -1837,9 +1837,9 @@ func createValidBlock(t *testing.T, tSettings *settings.Settings, txMetaStore ut
 	require.NoError(t, err)
 
 	// Store transactions in txMetaStore
-	_, err = txMetaStore.Create(context.Background(), coinbaseTx, 0)
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = txMetaStore.Create(context.Background(), tx1, 0)
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), tx1, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Create a subtree with coinbase and tx1
@@ -1929,11 +1929,11 @@ func TestBlockValidation_DoubleSpendInBlock(t *testing.T) {
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
 
 	// add the coinbase to the utxo store
-	_, err = utxoStore.Create(t.Context(), coinbaseTx, 1, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = utxoStore.SpendAndCreate(t.Context(), coinbaseTx, 1, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 1,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Two double-spend txs
@@ -1960,11 +1960,11 @@ func TestBlockValidation_DoubleSpendInBlock(t *testing.T) {
 	_ = tx2.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
 	// Store in utxoStore
-	_, err = utxoStore.Create(context.Background(), tx1, 2)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx1, 2, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// since this was a double spend it should be marked as conflicting
-	_, err = utxoStore.Create(context.Background(), tx2, 2, utxostore.WithConflicting(true))
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx2, 2, utxostore.WithConflicting(true), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	err = utxoStore.SetBlockHeight(2)
@@ -2087,9 +2087,9 @@ func TestBlockValidation_InvalidTransactionChainOrdering(t *testing.T) {
 	_ = tx2.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
 	// Store in txMetaStore
-	_, _ = txMetaStore.Create(context.Background(), coinbaseTx, 0)
-	_, _ = txMetaStore.Create(context.Background(), tx1, 0)
-	_, _ = txMetaStore.Create(context.Background(), tx2, 0)
+	_, _, _ = txMetaStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
+	_, _, _ = txMetaStore.SpendAndCreate(context.Background(), tx1, 0, utxostore.WithCreateOnly())
+	_, _, _ = txMetaStore.SpendAndCreate(context.Background(), tx2, 0, utxostore.WithCreateOnly())
 
 	// Subtree: coinbase, tx2, tx1 (wrong order: tx2 before tx1)
 	subtree, _ := subtreepkg.NewTreeByLeafCount(4)
@@ -2180,11 +2180,11 @@ func TestBlockValidation_InvalidParentBlock(t *testing.T) {
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
 
-	_, err = txMetaStore.Create(t.Context(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(t.Context(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 0,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Normal tx spending coinbase
@@ -2199,8 +2199,8 @@ func TestBlockValidation_InvalidParentBlock(t *testing.T) {
 	_ = tx1.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
 	// Store transactions
-	_, _ = txMetaStore.Create(context.Background(), coinbaseTx, 0)
-	_, _ = txMetaStore.Create(context.Background(), tx1, 0)
+	_, _, _ = txMetaStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
+	_, _, _ = txMetaStore.SpendAndCreate(context.Background(), tx1, 0, utxostore.WithCreateOnly())
 
 	// Subtree: coinbase, tx1
 	subtree, _ := subtreepkg.NewTreeByLeafCount(2)
@@ -2863,11 +2863,11 @@ func TestBlockValidation_ParentAndChildInSameBlock(t *testing.T) {
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
 
-	_, err = txMetaStore.Create(t.Context(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(t.Context(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 0,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// parentTx spends coinbase
@@ -2903,25 +2903,25 @@ func TestBlockValidation_ParentAndChildInSameBlock(t *testing.T) {
 	_ = childTx2.AddP2PKHOutputFromAddress(address.AddressString, parentTx.Outputs[0].Satoshis-1000)
 	_ = childTx2.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
-	_, err = txMetaStore.Create(context.Background(), parentTx, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), parentTx, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     101,
 		BlockHeight: 101,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = txMetaStore.Create(context.Background(), childTx1, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), childTx1, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     101,
 		BlockHeight: 101,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = txMetaStore.Create(context.Background(), childTx2, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), childTx2, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     101,
 		BlockHeight: 101,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Subtree: coinbase, tx1, tx2 (correct order)
@@ -3020,11 +3020,11 @@ func TestBlockValidation_TransactionChainInSameBlock(t *testing.T) {
 			blockHeight = 101
 		}
 
-		_, err := txMetaStore.Create(context.Background(), tx, blockID, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+		_, _, err := txMetaStore.SpendAndCreate(context.Background(), tx, blockID, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 			BlockID:     blockID,
 			BlockHeight: blockHeight,
 			SubtreeIdx:  0,
-		}))
+		}), utxostore.WithCreateOnly())
 		require.NoError(t, err)
 	}
 
@@ -3146,9 +3146,9 @@ func TestBlockValidation_DuplicateTransactionInBlock(t *testing.T) {
 	_ = normalTx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
 	// Store both in txMetaStore
-	_, err = txMetaStore.Create(context.Background(), coinbaseTx, 0)
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = txMetaStore.Create(context.Background(), normalTx, 0)
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), normalTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Build subtree with coinbase and the same normalTx twice
@@ -3377,11 +3377,11 @@ func setupRevalidateBlockTest(t *testing.T) (*BlockValidation, *model.Block, *bl
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
 
-	_, err := txMetaStore.Create(t.Context(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err := txMetaStore.SpendAndCreate(t.Context(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 0,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// parentTx spends coinbase
@@ -3417,25 +3417,25 @@ func setupRevalidateBlockTest(t *testing.T) (*BlockValidation, *model.Block, *bl
 	_ = childTx2.AddP2PKHOutputFromAddress(address.AddressString, parentTx.Outputs[0].Satoshis-1000)
 	_ = childTx2.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
-	_, err = txMetaStore.Create(context.Background(), parentTx, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), parentTx, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     101,
 		BlockHeight: 101,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = txMetaStore.Create(context.Background(), childTx1, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), childTx1, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     101,
 		BlockHeight: 101,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = txMetaStore.Create(context.Background(), childTx2, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), childTx2, 101, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     101,
 		BlockHeight: 101,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Subtree: coinbase, tx1, tx2 (correct order)
@@ -3814,13 +3814,13 @@ func TestBlockValidation_SetMined_UpdatesTxMeta(t *testing.T) {
 	_ = childTx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
 	// Store both in txMetaStore
-	_, err = txMetaStore.Create(context.Background(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 0,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = txMetaStore.Create(context.Background(), childTx, 0)
+	_, _, err = txMetaStore.SpendAndCreate(context.Background(), childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Build subtree with coinbase and normalTx
@@ -3939,13 +3939,13 @@ func TestBlockValidation_SetMinedChan_TriggersSetTxMined(t *testing.T) {
 	_ = childTx.AddP2PKHOutputFromAddress(address.AddressString, 49*100000000)
 	_ = childTx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
-	_, err := utxoStore.Create(context.Background(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err := utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 0,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = utxoStore.Create(context.Background(), childTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	subtree, err := subtreepkg.NewTreeByLeafCount(2)
@@ -4338,13 +4338,13 @@ func TestBlockValidation_BlockchainSubscription_TriggersSetMined(t *testing.T) {
 	_ = childTx.AddP2PKHOutputFromAddress(address.AddressString, 49*100000000)
 	_ = childTx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: privateKey})
 
-	_, err := utxoStore.Create(context.Background(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
+	_, _, err := utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{
 		BlockID:     0,
 		BlockHeight: 0,
 		SubtreeIdx:  0,
-	}))
+	}), utxostore.WithCreateOnly())
 	require.NoError(t, err)
-	_, err = utxoStore.Create(context.Background(), childTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	subtree, err := subtreepkg.NewTreeByLeafCount(2)
@@ -4648,13 +4648,13 @@ func TestBlockValidation_BlockValidMissingParent_NotPersistedInvalid(t *testing.
 	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
-	_, err = utxoStore.Create(context.Background(), coinbaseTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Child tx that spends the EXTERNAL parentTx fixture. parentTx is deliberately NOT placed
 	// in the block and NOT in the utxo store, so block.Valid's parent lookup will miss it.
 	childTx := newTx(7, parentTx.TxIDChainHash())
-	_, err = utxoStore.Create(context.Background(), childTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Subtree: coinbase + childTx.
@@ -4766,13 +4766,13 @@ func TestBlockValidation_FloaterPersistedInvalidWhenCaughtUp(t *testing.T) {
 	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
-	_, err = utxoStore.Create(context.Background(), coinbaseTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Child tx that spends the EXTERNAL parentTx fixture. parentTx is deliberately NOT placed
 	// in the block and NOT in the utxo store, so block.Valid's parent lookup will miss it.
 	childTx := newTx(7, parentTx.TxIDChainHash())
-	_, err = utxoStore.Create(context.Background(), childTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Subtree: coinbase + childTx.

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	blobmemory "github.com/bsv-blockchain/teranode/stores/blob/memory"
 	blockchain_store "github.com/bsv-blockchain/teranode/stores/blockchain"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
@@ -1663,13 +1664,13 @@ func TestServer_ValidateBlock_TransientMissingParent_ReturnsIncomplete(t *testin
 	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
-	_, err = utxoStore.Create(context.Background(), coinbaseTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Child tx that spends the EXTERNAL parentTx fixture. parentTx is deliberately NOT placed
 	// in the block and NOT in the utxo store, so block.Valid's parent lookup will miss it.
 	childTx := newTx(7, parentTx.TxIDChainHash())
-	_, err = utxoStore.Create(context.Background(), childTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Subtree: coinbase + childTx.

--- a/services/blockvalidation/catchup_test_suite.go
+++ b/services/blockvalidation/catchup_test_suite.go
@@ -77,9 +77,6 @@ func (s *CatchupTestSuite) setupMocks() {
 	s.MockValidator = &validator.MockValidator{UtxoStore: s.MockUTXOStore}
 	s.HttpMock = testhelpers.NewHTTPMockSetup(s.T)
 
-	// Provide a permissive default for Spend to avoid unexpected calls from concurrent validation goroutines.
-	s.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil).Maybe()
-
 	// Permissive default for GetBlockByHeight — used by locator capping when
 	// blockchain height > UTXO height. Returns error so capping falls back to blockchain height.
 	s.MockBlockchain.On("GetBlockByHeight", mock.Anything, mock.Anything).

--- a/services/blockvalidation/floater_fsm_gated_test.go
+++ b/services/blockvalidation/floater_fsm_gated_test.go
@@ -61,12 +61,12 @@ func buildFloaterBlock(t *testing.T, utxoStore utxostore.Store, subtreeStore blo
 	require.NoError(t, coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0))
 	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
 	require.NoError(t, coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000))
-	_, err = utxoStore.Create(ctx, coinbaseTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(ctx, coinbaseTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	// The FLOATER PARENT: in the UTXO store, but created WITHOUT mined-block
 	// info so its BlockIDs stay empty. It is deliberately NOT added to the block.
-	_, err = utxoStore.Create(ctx, parentTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(ctx, parentTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	parentMeta, err := utxoStore.Get(ctx, parentTx.TxIDChainHash())
@@ -77,7 +77,7 @@ func buildFloaterBlock(t *testing.T, utxoStore utxostore.Store, subtreeStore blo
 	// single input referencing parentTx, so getParentTxMetaBlockIDs resolves to
 	// the unconfirmed parent rather than to an in-block tx via b.txMap.
 	childTx := newTx(7, parentTx.TxIDChainHash())
-	_, err = utxoStore.Create(ctx, childTx, 0)
+	_, _, err = utxoStore.SpendAndCreate(ctx, childTx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	subtree, err := subtreepkg.NewTreeByLeafCount(2)

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -1284,11 +1284,12 @@ func (u *BlockValidation) createAndSpendUTXOsForBatch(ctx context.Context, block
 
 			sIdx := globalSubtreeIdx
 			createG.Go(func() error {
-				_, err := u.utxoStore.Create(createCtx, tx, block.Height, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
-					BlockID:     block.ID,
-					BlockHeight: block.Height,
-					SubtreeIdx:  sIdx,
-				}), utxo.WithLocked(lockUTXOs), utxo.WithSkipExtendedInputs(outpointOnly))
+				_, _, err := u.utxoStore.SpendAndCreate(createCtx, tx, block.Height, utxo.WithCreateOnly(),
+					utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+						BlockID:     block.ID,
+						BlockHeight: block.Height,
+						SubtreeIdx:  sIdx,
+					}), utxo.WithLocked(lockUTXOs), utxo.WithSkipExtendedInputs(outpointOnly))
 				if err != nil {
 					if errors.Is(err, errors.ErrTxExists) {
 						// Transaction already exists - collect it for mined info update
@@ -1379,7 +1380,8 @@ func (u *BlockValidation) spendBatchWithRetry(ctx context.Context, block *model.
 		for _, tx := range pending {
 			tx := tx
 			spendG.Go(func() error {
-				if _, err := u.utxoStore.Spend(spendCtx, tx, block.Height, utxo.IgnoreFlags{IgnoreLocked: true, SkipUTXOHashCheck: outpointOnly}); err != nil {
+				if _, _, err := u.utxoStore.SpendAndCreate(spendCtx, tx, block.Height, utxo.WithSpendOnly(),
+					utxo.WithIgnoreLocked(true), utxo.WithSkipUTXOHashCheck(outpointOnly)); err != nil {
 					if errors.IsRetryableError(err) {
 						mu.Lock()
 						retryable = append(retryable, tx)

--- a/services/blockvalidation/quick_validate_spend_retry_test.go
+++ b/services/blockvalidation/quick_validate_spend_retry_test.go
@@ -19,17 +19,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// spendRetrySpyStore wraps NullStore; SpendAndCreate behaviour is scripted per tx hash.
+// spendRetrySpyStore wraps NullStore; spend-phase SpendAndCreate behaviour is
+// scripted per tx hash, while create-phase calls fall through to NullStore so
+// the create leg of createAndSpendUTXOsForBatch stays exercised.
 type spendRetrySpyStore struct {
 	*nullstore.NullStore
 	mu sync.Mutex
-	// failuresLeft[txid] = how many times SpendAndCreate should fail with failErr[txid]
+	// failuresLeft[txid] = how many times a spend-phase call should fail with failErr[txid]
 	failuresLeft map[chainhash.Hash]int
 	failErr      map[chainhash.Hash]error
 	spendCalls   atomic.Int64
 }
 
-func (s *spendRetrySpyStore) SpendAndCreate(_ context.Context, tx *bt.Tx, _ uint32, _ ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+func (s *spendRetrySpyStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	options, err := utxo.ParseCreateOptions(opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if options.CreateOnly {
+		return s.NullStore.SpendAndCreate(ctx, tx, blockHeight, opts...)
+	}
+
 	s.spendCalls.Add(1)
 	h := *tx.TxIDChainHash()
 	s.mu.Lock()

--- a/services/blockvalidation/quick_validate_spend_retry_test.go
+++ b/services/blockvalidation/quick_validate_spend_retry_test.go
@@ -12,32 +12,33 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/nullstore"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/stretchr/testify/require"
 )
 
-// spendRetrySpyStore wraps NullStore; Spend behaviour is scripted per tx hash.
+// spendRetrySpyStore wraps NullStore; SpendAndCreate behaviour is scripted per tx hash.
 type spendRetrySpyStore struct {
 	*nullstore.NullStore
 	mu sync.Mutex
-	// failuresLeft[txid] = how many times Spend should fail with failErr[txid]
+	// failuresLeft[txid] = how many times SpendAndCreate should fail with failErr[txid]
 	failuresLeft map[chainhash.Hash]int
 	failErr      map[chainhash.Hash]error
 	spendCalls   atomic.Int64
 }
 
-func (s *spendRetrySpyStore) Spend(_ context.Context, tx *bt.Tx, _ uint32, _ ...utxo.IgnoreFlags) ([]*utxo.Spend, error) {
+func (s *spendRetrySpyStore) SpendAndCreate(_ context.Context, tx *bt.Tx, _ uint32, _ ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
 	s.spendCalls.Add(1)
 	h := *tx.TxIDChainHash()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if n, ok := s.failuresLeft[h]; ok && n > 0 {
 		s.failuresLeft[h] = n - 1
-		return nil, s.failErr[h]
+		return nil, nil, s.failErr[h]
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
 func newSpendRetryHarness(t *testing.T, spy *spendRetrySpyStore) (*BlockValidation, *model.Block, []*bt.Tx) {

--- a/services/blockvalidation/quick_validate_test.go
+++ b/services/blockvalidation/quick_validate_test.go
@@ -124,12 +124,12 @@ func TestQuickValidateBlock(t *testing.T) {
 		// Setup Get expectation for checking existing transactions (used for BlockID reuse on retry)
 		suite.MockUTXOStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return((*meta.Data)(nil), errors.NewNotFoundError("not found"))
 
-		// Setup UTXO store expectations for all transactions (including coinbase)
+		// Setup UTXO store expectations for creating all transactions (including coinbase)
 		// Use mock.Anything for the transaction since the order may vary
-		suite.MockUTXOStore.On("Create", mock.Anything, mock.Anything, uint32(100), mock.Anything).Return(&meta.Data{}, nil)
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, uint32(100), matchCreateOnly()).Return(&meta.Data{}, nil, nil)
 
-		// Setup UTXO store expectations for spending transactions (context, tx, ignoreFlags)
-		suite.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)
+		// Setup UTXO store expectations for spending transactions
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, matchSpendOnly()).Return(nil, []*utxo.Spend{}, nil)
 
 		// Setup SetLocked expectation for unlocking UTXOs after AddBlock
 		suite.MockUTXOStore.On("SetLocked", mock.Anything, mock.Anything, false).Return(nil)
@@ -239,22 +239,21 @@ func TestCreateAndSpendUTXOsForBatch_UpdatesExistingTransactions(t *testing.T) {
 			batchEnd:   2,
 		}
 
-		// Mock Create to succeed (no ErrTxExists)
-		suite.MockUTXOStore.On("Create", mock.Anything, mock.Anything, uint32(100), mock.Anything).
-			Return(&meta.Data{}, nil).Maybe()
+		// Mock the create phase to succeed (no ErrTxExists)
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, uint32(100), matchCreateOnly()).
+			Return(&meta.Data{}, nil, nil).Maybe()
 
-		// Mock Spend - need to clear the default and set our own
-		suite.MockUTXOStore.ExpectedCalls = filterCalls(suite.MockUTXOStore.ExpectedCalls, "Spend")
-		suite.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return([]*utxo.Spend{}, nil).Maybe()
+		// Mock the spend phase
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, matchSpendOnly()).
+			Return(nil, []*utxo.Spend{}, nil).Maybe()
 
 		// SetMinedMulti should NOT be called since all txs are new
 
 		err := suite.Server.blockValidation.createAndSpendUTXOsForBatch(suite.Ctx, block, batch)
 		require.NoError(t, err)
 
-		// Verify Create was called for each transaction
-		suite.MockUTXOStore.AssertNumberOfCalls(t, "Create", 2)
+		// Verify the create phase ran for each transaction
+		require.Equal(t, 2, countCreatePhaseCalls(suite.MockUTXOStore))
 		// Verify SetMinedMulti was NOT called
 		suite.MockUTXOStore.AssertNotCalled(t, "SetMinedMulti", mock.Anything, mock.Anything, mock.Anything)
 	})
@@ -280,9 +279,9 @@ func TestCreateAndSpendUTXOsForBatch_UpdatesExistingTransactions(t *testing.T) {
 			batchEnd:   2,
 		}
 
-		// Mock Create to return ErrTxExists for all transactions
-		suite.MockUTXOStore.On("Create", mock.Anything, mock.Anything, uint32(100), mock.Anything).
-			Return((*meta.Data)(nil), errors.ErrTxExists).Maybe()
+		// Mock the create phase to return ErrTxExists for all transactions
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, uint32(100), matchCreateOnly()).
+			Return((*meta.Data)(nil), nil, errors.ErrTxExists).Maybe()
 
 		// Mock SetMinedMulti - should be called with both transaction hashes
 		suite.MockUTXOStore.On("SetMinedMulti", mock.Anything, mock.MatchedBy(func(hashes []*chainhash.Hash) bool {
@@ -291,10 +290,9 @@ func TestCreateAndSpendUTXOsForBatch_UpdatesExistingTransactions(t *testing.T) {
 			return info.BlockID == 50 && info.BlockHeight == 100
 		})).Return(map[chainhash.Hash][]uint32{}, nil).Once()
 
-		// Mock Spend - clear default and set our own
-		suite.MockUTXOStore.ExpectedCalls = filterCalls(suite.MockUTXOStore.ExpectedCalls, "Spend")
-		suite.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return([]*utxo.Spend{}, nil).Maybe()
+		// Mock the spend phase
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, matchSpendOnly()).
+			Return(nil, []*utxo.Spend{}, nil).Maybe()
 
 		err := suite.Server.blockValidation.createAndSpendUTXOsForBatch(suite.Ctx, block, batch)
 		require.NoError(t, err)
@@ -324,9 +322,9 @@ func TestCreateAndSpendUTXOsForBatch_UpdatesExistingTransactions(t *testing.T) {
 			batchEnd:   1,
 		}
 
-		// Mock Create to return ErrTxExists
-		suite.MockUTXOStore.On("Create", mock.Anything, mock.Anything, uint32(100), mock.Anything).
-			Return((*meta.Data)(nil), errors.ErrTxExists).Maybe()
+		// Mock the create phase to return ErrTxExists
+		suite.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, uint32(100), matchCreateOnly()).
+			Return((*meta.Data)(nil), nil, errors.ErrTxExists).Maybe()
 
 		// Mock SetMinedMulti to return an error
 		suite.MockUTXOStore.On("SetMinedMulti", mock.Anything, mock.Anything, mock.Anything).
@@ -552,6 +550,39 @@ func filterCalls(calls []*mock.Call, methodToRemove string) []*mock.Call {
 	return filtered
 }
 
+// parseCreateOptions applies opts to a fresh CreateOptions for inspection.
+func parseCreateOptions(opts []utxo.CreateOption) *utxo.CreateOptions {
+	o := &utxo.CreateOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+// matchCreateOnly matches the create-phase SpendAndCreate call (WithCreateOnly).
+func matchCreateOnly() interface{} {
+	return mock.MatchedBy(func(opts []utxo.CreateOption) bool { return parseCreateOptions(opts).CreateOnly })
+}
+
+// matchSpendOnly matches the spend-phase SpendAndCreate call (WithSpendOnly).
+func matchSpendOnly() interface{} {
+	return mock.MatchedBy(func(opts []utxo.CreateOption) bool { return parseCreateOptions(opts).SpendOnly })
+}
+
+// countCreatePhaseCalls counts recorded SpendAndCreate calls that carried WithCreateOnly.
+func countCreatePhaseCalls(m *utxo.MockUtxostore) int {
+	count := 0
+
+	for _, c := range m.Calls {
+		if c.Method == "SpendAndCreate" && parseCreateOptions(c.Arguments.Get(3).([]utxo.CreateOption)).CreateOnly {
+			count++
+		}
+	}
+
+	return count
+}
+
 // setCheckpointSlice replaces the checkpoint set on the suite's settings with the given
 // slice. It copies ChainCfgParams first so it never mutates the shared (global) chaincfg.Params.
 func setCheckpointSlice(t *testing.T, s *CatchupTestSuite, cps []chaincfg.Checkpoint) {
@@ -610,19 +641,19 @@ func assertCreatedLocked(t *testing.T, m *utxo.MockUtxostore, wantLocked bool) {
 	t.Helper()
 	found := false
 	for _, c := range m.Calls {
-		if c.Method != "Create" {
+		if c.Method != "SpendAndCreate" {
 			continue
 		}
 		opts, ok := c.Arguments.Get(3).([]utxo.CreateOption)
-		require.True(t, ok, "Create 4th arg should be []utxo.CreateOption")
-		o := &utxo.CreateOptions{}
-		for _, opt := range opts {
-			opt(o)
+		require.True(t, ok, "SpendAndCreate 4th arg should be []utxo.CreateOption")
+		o := parseCreateOptions(opts)
+		if !o.CreateOnly {
+			continue
 		}
-		require.Equal(t, wantLocked, o.Locked, "Create WithLocked flag mismatch")
+		require.Equal(t, wantLocked, o.Locked, "SpendAndCreate WithLocked flag mismatch")
 		found = true
 	}
-	require.True(t, found, "expected at least one Create call")
+	require.True(t, found, "expected at least one create-phase SpendAndCreate call")
 }
 
 // assertCreatedSkipExtended asserts every Create call carried WithSkipExtendedInputs(want).
@@ -632,19 +663,19 @@ func assertCreatedSkipExtended(t *testing.T, m *utxo.MockUtxostore, want bool) {
 	t.Helper()
 	found := false
 	for _, c := range m.Calls {
-		if c.Method != "Create" {
+		if c.Method != "SpendAndCreate" {
 			continue
 		}
 		opts, ok := c.Arguments.Get(3).([]utxo.CreateOption)
-		require.True(t, ok, "Create 4th arg should be []utxo.CreateOption")
-		o := &utxo.CreateOptions{}
-		for _, opt := range opts {
-			opt(o)
+		require.True(t, ok, "SpendAndCreate 4th arg should be []utxo.CreateOption")
+		o := parseCreateOptions(opts)
+		if !o.CreateOnly {
+			continue
 		}
-		require.Equal(t, want, o.SkipExtendedInputs, "Create WithSkipExtendedInputs flag mismatch")
+		require.Equal(t, want, o.SkipExtendedInputs, "SpendAndCreate WithSkipExtendedInputs flag mismatch")
 		found = true
 	}
-	require.True(t, found, "expected at least one Create call")
+	require.True(t, found, "expected at least one create-phase SpendAndCreate call")
 }
 
 // assertSpentSkipUTXOHashCheck asserts every Spend call carried IgnoreFlags.SkipUTXOHashCheck(want).
@@ -654,16 +685,19 @@ func assertSpentSkipUTXOHashCheck(t *testing.T, m *utxo.MockUtxostore, want bool
 	t.Helper()
 	found := false
 	for _, c := range m.Calls {
-		if c.Method != "Spend" {
+		if c.Method != "SpendAndCreate" {
 			continue
 		}
-		flags, ok := c.Arguments.Get(3).([]utxo.IgnoreFlags)
-		require.True(t, ok, "Spend 4th arg should be []utxo.IgnoreFlags")
-		require.NotEmpty(t, flags, "Spend should carry an IgnoreFlags")
-		require.Equal(t, want, flags[0].SkipUTXOHashCheck, "Spend SkipUTXOHashCheck flag mismatch")
+		opts, ok := c.Arguments.Get(3).([]utxo.CreateOption)
+		require.True(t, ok, "SpendAndCreate 4th arg should be []utxo.CreateOption")
+		o := parseCreateOptions(opts)
+		if !o.SpendOnly {
+			continue
+		}
+		require.Equal(t, want, o.IgnoreFlags.SkipUTXOHashCheck, "SpendAndCreate SkipUTXOHashCheck flag mismatch")
 		found = true
 	}
-	require.True(t, found, "expected at least one Spend call")
+	require.True(t, found, "expected at least one spend-phase SpendAndCreate call")
 }
 
 // buildOneSubtreeBlock builds a block with one subtree (coinbase + 2 txs) and stores its
@@ -717,8 +751,8 @@ func setupQuickValidateMocks(s *CatchupTestSuite) {
 	s.MockBlockchain.On("AddBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.MockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.MockUTXOStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return((*meta.Data)(nil), errors.NewNotFoundError("not found"))
-	s.MockUTXOStore.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{}, nil)
-	s.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)
+	s.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, matchCreateOnly()).Return(&meta.Data{}, nil, nil)
+	s.MockUTXOStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, matchSpendOnly()).Return(nil, []*utxo.Spend{}, nil)
 	s.MockUTXOStore.On("SetLocked", mock.Anything, mock.Anything, false).Return(nil).Maybe()
 	s.MockValidator.Errors = []error{nil, nil, nil}
 }
@@ -851,9 +885,6 @@ func TestQuickValidate_OutpointOnly_NoDecorate_ZeroFees(t *testing.T) {
 		// Place a high checkpoint so height 500 is firmly below it.
 		setCheckpoints(t, suite, 1_000_000)
 		setupQuickValidateMocks(suite)
-		// Replace the 3-arg Spend default from setupQuickValidateMocks with a 4-arg one.
-		suite.MockUTXOStore.ExpectedCalls = filterCalls(suite.MockUTXOStore.ExpectedCalls, "Spend")
-		suite.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil).Maybe()
 		// The block has coinbase + 3 regular txs; validator needs 4 nil errors.
 		suite.MockValidator.Errors = []error{nil, nil, nil, nil}
 		return suite
@@ -1048,7 +1079,7 @@ func TestSkipUnspendableTxStorageDuringCatchup_EndToEnd(t *testing.T) {
 			transactions.WithCoinbaseData(1, "/genesis/"),
 			transactions.WithP2PKHOutputs(2, 5000, publicKey),
 		)
-		_, err := store.Create(ctx, parentTx, 0, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 1, BlockHeight: 1}))
+		_, _, err := store.SpendAndCreate(ctx, parentTx, 0, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 1, BlockHeight: 1}), utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// opReturnTx: spends output 0 of parent, produces only an OP_RETURN (unspendable).
@@ -1128,7 +1159,7 @@ func TestSkipUnspendableTxStorageDuringCatchup_EndToEnd(t *testing.T) {
 			transactions.WithCoinbaseData(1, "/genesis/"),
 			transactions.WithP2PKHOutputs(1, 5000, publicKey),
 		)
-		_, err := store.Create(ctx, parentTx, 0, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 1, BlockHeight: 1}))
+		_, _, err := store.SpendAndCreate(ctx, parentTx, 0, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 1, BlockHeight: 1}), utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		opReturnTx := bt.NewTx()
@@ -1190,8 +1221,6 @@ func TestOutpointOnly_MetricIncrementsBelowOnly(t *testing.T) {
 		suite.Server.blockValidation.settings.BlockValidation.QuickValidateSkipUtxoLock = true
 		setCheckpoints(t, suite, 1000)
 		setupQuickValidateMocks(suite)
-		suite.MockUTXOStore.ExpectedCalls = filterCalls(suite.MockUTXOStore.ExpectedCalls, "Spend")
-		suite.MockUTXOStore.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil).Maybe()
 
 		block := buildOneSubtreeBlock(t, suite, 500)
 

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1126,7 +1126,9 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 				SubtreeIdx:  0, // legacy path produces a single subtree at index 0
 			}))
 
-			if _, err := sm.utxoStore.Create(gCtx, txWrapper.Tx, blockHeightUint32, createOpts...); err != nil {
+			createOpts = append(createOpts, utxo.WithCreateOnly())
+
+			if _, _, err := sm.utxoStore.SpendAndCreate(gCtx, txWrapper.Tx, blockHeightUint32, createOpts...); err != nil {
 				if errors.Is(err, errors.ErrTxExists) {
 					existingTxsMu.Lock()
 					existingTxHashes = append(existingTxHashes, &txHash)

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -1120,13 +1120,14 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 				return errors.NewProcessingError("transaction %s not found in txMap", txHash.String())
 			}
 
-			createOpts := append(baseOpts[:len(baseOpts):len(baseOpts)], utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
-				BlockID:     blockID,
-				BlockHeight: blockHeightUint32,
-				SubtreeIdx:  0, // legacy path produces a single subtree at index 0
-			}))
-
-			createOpts = append(createOpts, utxo.WithCreateOnly())
+			createOpts := append(baseOpts[:len(baseOpts):len(baseOpts)],
+				utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+					BlockID:     blockID,
+					BlockHeight: blockHeightUint32,
+					SubtreeIdx:  0, // legacy path produces a single subtree at index 0
+				}),
+				utxo.WithCreateOnly(),
+			)
 
 			if _, _, err := sm.utxoStore.SpendAndCreate(gCtx, txWrapper.Tx, blockHeightUint32, createOpts...); err != nil {
 				if errors.Is(err, errors.ErrTxExists) {

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -1061,9 +1061,9 @@ func newChunkingTestSetup(t *testing.T, totalTxs, batchSize, routines int) (
 
 	// Every Create returns ErrTxExists so every hash flows into existingTxHashes
 	// and the merge path executes — that's what we're exercising.
-	mockStore.On("Create",
+	mockStore.On("SpendAndCreate",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return((*meta.Data)(nil), errors.ErrTxExists)
+	).Return((*meta.Data)(nil), nil, errors.ErrTxExists)
 
 	sm := &SyncManager{
 		settings:  tSettings,

--- a/services/legacy/netsync/unified_parity_test.go
+++ b/services/legacy/netsync/unified_parity_test.go
@@ -159,7 +159,7 @@ func makeSpendValidator(store utxo.Store) *validator.MockValidator {
 		if tx.IsCoinbase() {
 			return &meta.Data{}, nil
 		}
-		if _, err := store.Spend(ctx, tx, 500, utxo.IgnoreFlags{SkipUTXOHashCheck: true, IgnoreLocked: true}); err != nil {
+		if _, _, err := store.SpendAndCreate(ctx, tx, 500, utxo.WithSpendOnly(), utxo.WithSkipUTXOHashCheck(true), utxo.WithIgnoreLocked(true)); err != nil {
 			return nil, err
 		}
 		return &meta.Data{}, nil
@@ -222,12 +222,13 @@ func runDirectCreateSpend(t *testing.T, ctx context.Context, corpus *parityCorpu
 		for _, bsvTx := range txs[1:] {
 			btTx, convErr := wireMsgTxToBt(t, bsvTx.MsgTx())
 			require.NoError(t, convErr, "Run B: wire→bt.Tx conversion failed")
-			_, err := storeB.Create(ctx, btTx, height,
+			_, _, err := storeB.SpendAndCreate(ctx, btTx, height,
 				utxo.WithSkipExtendedInputs(true),
 				utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
 					BlockID:     blockID,
 					BlockHeight: height,
 				}),
+				utxo.WithCreateOnly(),
 			)
 			require.NoError(t, err, "Run B Create failed for tx in block %d", height)
 		}
@@ -237,9 +238,8 @@ func runDirectCreateSpend(t *testing.T, ctx context.Context, corpus *parityCorpu
 		for _, bsvTx := range txs[1:] {
 			btTx, convErr := wireMsgTxToBt(t, bsvTx.MsgTx())
 			require.NoError(t, convErr, "Run B: wire→bt.Tx conversion failed")
-			_, err := storeB.Spend(ctx, btTx, height,
-				utxo.IgnoreFlags{SkipUTXOHashCheck: true, IgnoreLocked: true},
-			)
+			_, _, err := storeB.SpendAndCreate(ctx, btTx, height,
+				utxo.WithSpendOnly(), utxo.WithSkipUTXOHashCheck(true), utxo.WithIgnoreLocked(true))
 			require.NoError(t, err, "Run B Spend failed for tx in block %d", height)
 		}
 	}

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -288,7 +288,7 @@ func TestProcessTransaction(t *testing.T) {
 		txs := transactions.CreateTestTransactionChainWithCount(t, 3)
 
 		// Add the first transaction (coinbase) to UTXO store
-		_, err := utxoStore.Create(ctx, txs[0], 1)
+		_, _, err := utxoStore.SpendAndCreate(ctx, txs[0], 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Use the second transaction (non-coinbase) for testing
@@ -1278,7 +1278,7 @@ func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {
 		}
 
 		// Add the first transaction to the store
-		_, err = utxoStore.Create(t.Context(), txs[1], 1)
+		_, _, err = utxoStore.SpendAndCreate(t.Context(), txs[1], 1, utxo.WithCreateOnly())
 		require.NoError(t, err, "processTransactionInternal should not return an error for valid transaction")
 
 		tx2NotExtended, err := bt.NewTxFromBytes(txs[2].Bytes())
@@ -1309,7 +1309,7 @@ func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {
 		txs := transactions.CreateTestTransactionChainWithCount(t, 5)
 
 		// Add the first transaction to the store
-		_, err = utxoStore.Create(t.Context(), txs[1], 1)
+		_, _, err = utxoStore.SpendAndCreate(t.Context(), txs[1], 1, utxo.WithCreateOnly())
 		require.NoError(t, err, "processTransactionInternal should not return an error for valid transaction")
 
 		g := errgroup.Group{}
@@ -1801,7 +1801,7 @@ func TestProcessTransaction_BatchHandlerLimit(t *testing.T) {
 		}
 
 		txs := transactions.CreateTestTransactionChainWithCount(t, 3)
-		_, err := utxoStore.Create(ctx, txs[0], 1)
+		_, _, err := utxoStore.SpendAndCreate(ctx, txs[0], 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		req := &propagation_api.ProcessTransactionRequest{Tx: txs[1].ExtendedBytes()}
@@ -1827,7 +1827,7 @@ func TestProcessTransaction_BatchHandlerLimit(t *testing.T) {
 		}
 
 		txs := transactions.CreateTestTransactionChainWithCount(t, 3)
-		_, err := utxoStore.Create(ctx, txs[0], 1)
+		_, _, err := utxoStore.SpendAndCreate(ctx, txs[0], 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		req := &propagation_api.ProcessTransactionRequest{Tx: txs[1].ExtendedBytes()}
@@ -1896,7 +1896,7 @@ func TestProcessTransactionBatch_BatchConcurrencyLimit(t *testing.T) {
 
 		// Create transactions
 		txs := transactions.CreateTestTransactionChainWithCount(t, 4)
-		_, err := utxoStore.Create(ctx, txs[0], 1)
+		_, _, err := utxoStore.SpendAndCreate(ctx, txs[0], 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Process a batch — should succeed even with concurrency limit of 1
@@ -1929,7 +1929,7 @@ func TestProcessTransactionBatch_BatchConcurrencyLimit(t *testing.T) {
 		}
 
 		txs := transactions.CreateTestTransactionChainWithCount(t, 4)
-		_, err := utxoStore.Create(ctx, txs[0], 1)
+		_, _, err := utxoStore.SpendAndCreate(ctx, txs[0], 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		req := &propagation_api.ProcessTransactionBatchRequest{

--- a/services/subtreevalidation/SubtreeValidation_test.go
+++ b/services/subtreevalidation/SubtreeValidation_test.go
@@ -79,16 +79,16 @@ func TestBlockValidationValidateSubtree(t *testing.T) {
 		require.NoError(t, subtree.AddNode(*hash3, 123, 0))
 		require.NoError(t, subtree.AddNode(*hash4, 123, 0))
 
-		_, err = txMetaStore.Create(context.Background(), tx1, 0)
+		_, _, err = txMetaStore.SpendAndCreate(context.Background(), tx1, 0, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = txMetaStore.Create(context.Background(), tx2, 0)
+		_, _, err = txMetaStore.SpendAndCreate(context.Background(), tx2, 0, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = txMetaStore.Create(context.Background(), tx3, 0)
+		_, _, err = txMetaStore.SpendAndCreate(context.Background(), tx3, 0, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = txMetaStore.Create(context.Background(), tx4, 0)
+		_, _, err = txMetaStore.SpendAndCreate(context.Background(), tx4, 0, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		nodeBytes, err := subtree.SerializeNodes()
@@ -274,10 +274,10 @@ func TestValidateSubtreeInternal_DuplicateTxid(t *testing.T) {
 	utxoStore, validatorClient, txStore, subtreeStore, blockchainClient, deferFunc := setup(t)
 	defer deferFunc()
 
-	_, err := utxoStore.Create(context.Background(), tx1, 0)
+	_, _, err := utxoStore.SpendAndCreate(context.Background(), tx1, 0, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = utxoStore.Create(context.Background(), tx2, 0)
+	_, _, err = utxoStore.SpendAndCreate(context.Background(), tx2, 0, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	txHashes := []chainhash.Hash{*subtreepkg.CoinbasePlaceholderHash, *hash1, *hash2, *hash1}
@@ -846,19 +846,19 @@ func TestSubtreeValidationWhenBlessMissingTransactions(t *testing.T) {
 		coinbaseTx, tx1, tx2, tx3, tx4, tx5, tx6 := txs[0], txs[1], txs[2], txs[3], txs[4], txs[5], txs[6]
 
 		// Store initial transactions in txMetaStore
-		_, err := utxoStore.Create(context.Background(), coinbaseTx, 1)
+		_, _, err := utxoStore.SpendAndCreate(context.Background(), coinbaseTx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = utxoStore.Create(context.Background(), tx1, 1)
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), tx1, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = utxoStore.Create(context.Background(), tx2, 1)
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), tx2, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = utxoStore.Create(context.Background(), tx3, 1)
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), tx3, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = utxoStore.Create(context.Background(), tx4, 1)
+		_, _, err = utxoStore.SpendAndCreate(context.Background(), tx4, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Create subtrees
@@ -1018,10 +1018,10 @@ func Test_checkCounterConflictingOnCurrentChain(t *testing.T) {
 			utxoStore: utxoStore,
 		}
 
-		_, err = s.utxoStore.Create(ctx, parentTx1, 123)
+		_, _, err = s.utxoStore.SpendAndCreate(ctx, parentTx1, 123, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = s.utxoStore.Create(ctx, tx1, 123)
+		_, _, err = s.utxoStore.SpendAndCreate(ctx, tx1, 123, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Call the checkCounterConflictingOnCurrentChain method
@@ -1046,20 +1046,20 @@ func Test_checkCounterConflictingOnCurrentChain(t *testing.T) {
 			utxoStore: utxoStore,
 		}
 
-		_, err = s.utxoStore.Create(ctx, parentTx1, 122)
+		_, _, err = s.utxoStore.SpendAndCreate(ctx, parentTx1, 122, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		tx1DoubleSpend := tx1.Clone()
 		tx1DoubleSpend.Version = 2
 
 		// spend the parent tx with tx2
-		_, err = s.utxoStore.Spend(ctx, tx1DoubleSpend, 122)
+		_, _, err = s.utxoStore.SpendAndCreate(ctx, tx1DoubleSpend, 122, utxo.WithSpendOnly())
 		require.NoError(t, err)
 
-		_, err = s.utxoStore.Create(ctx, tx1DoubleSpend, 122)
+		_, _, err = s.utxoStore.SpendAndCreate(ctx, tx1DoubleSpend, 122, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = s.utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
+		_, _, err = s.utxoStore.SpendAndCreate(ctx, tx1, 123, utxo.WithConflicting(true), utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Call the checkCounterConflictingOnCurrentChain method, should be OK since tx1DoubleSpend has not been mined

--- a/services/subtreevalidation/check_block_subtrees_assembled_path_test.go
+++ b/services/subtreevalidation/check_block_subtrees_assembled_path_test.go
@@ -274,8 +274,8 @@ func TestCheckBlockSubtrees_AssembledPath_SkipLevelAndMixedParent(t *testing.T) 
 	// G, P, C as unknown — the bug-triggering shape for skip-level.
 	mockStore := server.utxoStore.(*utxo.MockUtxostore)
 	mockStore.ExpectedCalls = nil
-	mockStore.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(&utxometa.Data{}, nil).Maybe()
+	mockStore.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(&utxometa.Data{}, nil, nil).Maybe()
 	mockStore.On("GetBlockHeight").Return(uint32(100)).Maybe()
 	mockStore.On("GetMeta", mock.Anything, mock.Anything).
 		Return(&utxometa.Data{}, nil).Maybe()

--- a/services/subtreevalidation/check_block_subtrees_test.go
+++ b/services/subtreevalidation/check_block_subtrees_test.go
@@ -133,9 +133,9 @@ func TestCheckBlockSubtrees(t *testing.T) {
 		require.NoError(t, err)
 
 		// Mock UTXO store Create method
-		server.utxoStore.(*utxo.MockUtxostore).On("Create",
+		server.utxoStore.(*utxo.MockUtxostore).On("SpendAndCreate",
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(&utxometa.Data{}, nil)
+			Return(&utxometa.Data{}, nil, nil)
 
 		// Mock validator to return success - set up the validator client to succeed
 		mockValidator := server.validatorClient.(*validator.MockValidator)
@@ -400,9 +400,9 @@ func TestCheckBlockSubtrees(t *testing.T) {
 		require.NoError(t, err)
 
 		// Mock UTXO store Create method
-		server.utxoStore.(*utxo.MockUtxostore).On("Create",
+		server.utxoStore.(*utxo.MockUtxostore).On("SpendAndCreate",
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(&utxometa.Data{}, nil)
+			Return(&utxometa.Data{}, nil, nil)
 
 		// Mock validator and blockchain client
 		mockValidator := server.validatorClient.(*validator.MockValidator)
@@ -2287,9 +2287,9 @@ func setupTestServer(t *testing.T) (*Server, func()) {
 	// Mock UTXO store
 	mockUtxoStore := &utxo.MockUtxostore{}
 	// Set up default mock for Create method
-	mockUtxoStore.On("Create",
+	mockUtxoStore.On("SpendAndCreate",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(&utxometa.Data{}, nil).Maybe()
+		Return(&utxometa.Data{}, nil, nil).Maybe()
 	// Set up default mock for BatchDecorate method
 	mockUtxoStore.On("BatchDecorate",
 		mock.Anything, mock.Anything, mock.Anything).

--- a/services/subtreevalidation/subtree_size_benchmark_test.go
+++ b/services/subtreevalidation/subtree_size_benchmark_test.go
@@ -572,9 +572,9 @@ func setupBenchmarkServer(t *testing.T) (*Server, func()) {
 		mock.Anything, blockchain.FSMStateRUNNING).
 		Return(true, nil).Maybe()
 
-	server.utxoStore.(*utxo.MockUtxostore).On("Create",
+	server.utxoStore.(*utxo.MockUtxostore).On("SpendAndCreate",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(&utxometa.Data{}, nil).Maybe()
+		Return(&utxometa.Data{}, nil, nil).Maybe()
 
 	mockValidator := server.validatorClient.(*validator.MockValidator)
 	mockValidator.UtxoStore = server.utxoStore
@@ -604,9 +604,9 @@ func setupBenchmarkServerForBench(b *testing.B) (*Server, func()) {
 		mock.Anything, blockchain.FSMStateRUNNING).
 		Return(true, nil).Maybe()
 
-	server.utxoStore.(*utxo.MockUtxostore).On("Create",
+	server.utxoStore.(*utxo.MockUtxostore).On("SpendAndCreate",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(&utxometa.Data{}, nil).Maybe()
+		Return(&utxometa.Data{}, nil, nil).Maybe()
 
 	mockValidator := server.validatorClient.(*validator.MockValidator)
 	mockValidator.UtxoStore = server.utxoStore

--- a/services/validator/Mock.go
+++ b/services/validator/Mock.go
@@ -121,7 +121,8 @@ func (m *MockValidator) ValidateWithOptions(ctx context.Context, tx *bt.Tx, bloc
 	}
 
 	if m.UtxoStore != nil {
-		return m.UtxoStore.Create(context.Background(), tx, 0)
+		md, _, err := m.UtxoStore.SpendAndCreate(context.Background(), tx, 0, utxo.WithCreateOnly())
+		return md, err
 	}
 
 	return util.TxMetaDataFromTx(tx)

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -814,8 +814,26 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 		utxoMapErr error
 	)
 
-	// this will reverse the spends if there is an error
-	if spentUtxos, err = v.spendUtxos(decoupledCtx, tx, blockHeight, validationOptions.IgnoreLocked, validationOptions.OutpointOnlySpend); err != nil {
+	// the option blockAssemblyDisabled is false by default
+	blockAssemblyEnabled := !v.settings.BlockAssembly.Disabled
+	addToBlockAssembly := blockAssemblyEnabled && validationOptions.AddTXToBlockAssembly
+
+	// spend the tx's inputs and create its outputs + metadata in one store
+	// operation; the store reverses the spends if the create fails (except on
+	// ErrTxExists, which leaves the spends in place and is handled below)
+	if txMetaData, spentUtxos, err = v.spendAndCreateInUtxoStore(decoupledCtx, tx, blockHeight, addToBlockAssembly, validationOptions); err != nil {
+		if errors.Is(err, errors.ErrTxExists) {
+			// create phase: the tx already exists in the store
+			v.logger.Debugf("[Validate][%s] tx already exists in store, not sending to block assembly: %v", txID, err)
+
+			txMetaData = &meta.Data{}
+			if err = v.utxoStore.GetMeta(decoupledCtx, tx.TxIDChainHash(), txMetaData); err != nil {
+				return nil, errors.NewProcessingError("[Validate][%s] failed to get tx meta data from store", txID, err)
+			}
+
+			return txMetaData, nil
+		}
+
 		if errors.Is(err, errors.ErrUtxoError) {
 			saveAsConflicting := false
 
@@ -918,47 +936,7 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 		return nil, err
 	}
 
-	// the option blockAssemblyDisabled is false by default
-	blockAssemblyEnabled := !v.settings.BlockAssembly.Disabled
-	addToBlockAssembly := blockAssemblyEnabled && validationOptions.AddTXToBlockAssembly
-
-	if !validationOptions.SkipUtxoCreation {
-		// store the transaction in the UTXO store, marking it as locked if we are going to add it to the block assembly
-		//
-		// CONTRACT (below-checkpoint outpoint-only fast path): when OutpointOnlySpend is
-		// set the tx is deliberately un-decorated (no parent satoshis/scripts), so EVERY
-		// UTXO-store Create reachable on this path MUST thread WithSkipExtendedInputs(true)
-		// — otherwise store.Create runs GetFees over zero parent satoshis and hard-fails the
-		// block. This coupling is NOT enforced by a runtime guard (unlike the
-		// OutpointOnlySpend => SkipScriptValidation precondition checked earlier), so any new
-		// create seam added on this path must repeat it. The conflicting-fallback create
-		// above threads the same option for this reason.
-		var createExtraOpts []utxo.CreateOption
-		if validationOptions.OutpointOnlySpend {
-			createExtraOpts = append(createExtraOpts, utxo.WithSkipExtendedInputs(true))
-		}
-		txMetaData, err = v.CreateInUtxoStore(decoupledCtx, tx, blockHeight, false, addToBlockAssembly, createExtraOpts...)
-		if err != nil {
-			if errors.Is(err, errors.ErrTxExists) {
-				v.logger.Debugf("[Validate][%s] tx already exists in store, not sending to block assembly: %v", txID, err)
-
-				txMetaData = &meta.Data{}
-				if err = v.utxoStore.GetMeta(decoupledCtx, tx.TxIDChainHash(), txMetaData); err != nil {
-					return nil, errors.NewProcessingError("[Validate][%s] failed to get tx meta data from store", txID, err)
-				}
-
-				return txMetaData, nil
-			}
-
-			v.logger.Errorf("[Validate][%s] error registering tx in metaStore: %v", txID, err)
-
-			if reverseErr := v.reverseSpends(decoupledCtx, spentUtxos); reverseErr != nil {
-				err = errors.NewProcessingError("[Validate][%s] error reversing utxo spends: %v", txID, reverseErr, err)
-			}
-
-			return nil, errors.NewProcessingError("[Validate][%s] error registering tx in metaStore", txID, err)
-		}
-	} else {
+	if validationOptions.SkipUtxoCreation {
 		// create the tx meta needed for the block assembly
 		if validationOptions.OutpointOnlySpend {
 			txMetaData, err = util.TxMetaDataFromTxNoFee(tx)
@@ -1212,7 +1190,8 @@ func (v *Validator) TriggerBatcher() {
 	// Noop
 }
 
-// CreateInUtxoStore stores transaction metadata in the UTXO store.
+// CreateInUtxoStore stores transaction metadata in the UTXO store without
+// spending any inputs (SpendAndCreate with WithCreateOnly).
 // Returns transaction metadata and error if storage fails.
 // Extra create options (e.g. utxo.WithSkipExtendedInputs) may be passed via extraOpts
 // for specialised call sites; the zero-arg call is byte-identical to the original.
@@ -1224,6 +1203,7 @@ func (v *Validator) CreateInUtxoStore(ctx context.Context, tx *bt.Tx, blockHeigh
 	defer deferFn()
 
 	createOptions := []utxo.CreateOption{
+		utxo.WithCreateOnly(),
 		utxo.WithConflicting(markAsConflicting),
 	}
 
@@ -1233,7 +1213,7 @@ func (v *Validator) CreateInUtxoStore(ctx context.Context, tx *bt.Tx, blockHeigh
 
 	createOptions = append(createOptions, extraOpts...)
 
-	txMetaData, err := v.utxoStore.Create(ctx, tx, blockHeight, createOptions...)
+	txMetaData, _, err := v.utxoStore.SpendAndCreate(ctx, tx, blockHeight, createOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -1521,32 +1501,52 @@ func (v *Validator) sendTxMetaBatchV2(batch []*txmetaBatchItem) {
 	}
 }
 
-// spendUtxos attempts to spend the UTXOs referenced by transaction inputs.
-// Returns the spent UTXOs and error if spending fails.
-// skipUTXOHashCheck must be true on the outpoint-only below-checkpoint path so
-// the store resolves spends via outpoint lookup without a UTXO-hash comparison.
-func (v *Validator) spendUtxos(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreLocked bool, skipUTXOHashCheck bool) ([]*utxo.Spend, error) {
+// spendAndCreateInUtxoStore spends the UTXOs referenced by the transaction's
+// inputs and stores the transaction's outputs + metadata in one store operation.
+// The store rolls the spends back when the create phase fails with anything
+// other than ErrTxExists. With Options.SkipUtxoCreation only the spend phase
+// runs and the returned metadata is nil.
+//
+// CONTRACT (below-checkpoint outpoint-only fast path): when OutpointOnlySpend is
+// set the tx is deliberately un-decorated (no parent satoshis/scripts), so EVERY
+// UTXO-store create reachable on this path MUST thread WithSkipExtendedInputs(true)
+// — otherwise the store runs GetFees over zero parent satoshis and hard-fails the
+// block. This coupling is NOT enforced by a runtime guard (unlike the
+// OutpointOnlySpend => SkipScriptValidation precondition checked earlier), so any
+// new create seam added on this path must repeat it. The conflicting-fallback
+// create in validateInternal threads the same option for this reason.
+// SkipUTXOHashCheck must likewise be set on that path so the store resolves
+// spends via outpoint lookup without a UTXO-hash comparison.
+func (v *Validator) spendAndCreateInUtxoStore(ctx context.Context, tx *bt.Tx, blockHeight uint32,
+	addToBlockAssembly bool, validationOptions *Options) (*meta.Data, []*utxo.Spend, error) {
 	ctx, span, deferFn := tracing.Tracer("validator").Start(ctx, "spendUtxos",
 		tracing.WithHistogram(prometheusTransactionSpendUtxos),
 	)
 	defer deferFn()
 
-	var (
-		err error
-	)
+	opts := []utxo.CreateOption{
+		utxo.WithIgnoreLocked(validationOptions.IgnoreLocked),
+	}
 
-	spends, err := v.utxoStore.Spend(ctx, tx, blockHeight, utxo.IgnoreFlags{
-		IgnoreConflicting: false,
-		IgnoreLocked:      ignoreLocked,
-		SkipUTXOHashCheck: skipUTXOHashCheck,
-	})
+	if validationOptions.OutpointOnlySpend {
+		opts = append(opts, utxo.WithSkipUTXOHashCheck(true), utxo.WithSkipExtendedInputs(true))
+	}
+
+	if validationOptions.SkipUtxoCreation {
+		opts = append(opts, utxo.WithSpendOnly())
+	} else if addToBlockAssembly {
+		// mark the tx as locked, since we are going to add it to the block assembly
+		opts = append(opts, utxo.WithLocked(true))
+	}
+
+	txMetaData, spends, err := v.utxoStore.SpendAndCreate(ctx, tx, blockHeight, opts...)
 	if err != nil {
 		span.RecordError(err)
 
-		return spends, errors.NewProcessingError("validator: UTXO Store spend failed for %s", tx.TxIDChainHash().String(), err)
+		return txMetaData, spends, errors.NewProcessingError("validator: UTXO Store spend and create failed for %s", tx.TxIDChainHash().String(), err)
 	}
 
-	return spends, nil
+	return txMetaData, spends, nil
 }
 
 // sendToBlockAssembler sends validated transaction data to the block assembler.
@@ -1568,31 +1568,6 @@ func (v *Validator) sendToBlockAssembler(ctx context.Context, bData *blockassemb
 		span.RecordError(e)
 
 		return e
-	}
-
-	return nil
-}
-
-// reverseSpends reverses previously spent UTXOs in case of validation failure.
-// Attempts up to 3 retries with exponential backoff.
-// Returns error if UTXO reversal fails.
-func (v *Validator) reverseSpends(ctx context.Context, spentUtxos []*utxo.Spend) error {
-	ctx, span, deferFn := tracing.Tracer("validator").Start(ctx, "reverseSpends")
-	defer deferFn()
-
-	for retries := uint(0); retries < 3; retries++ {
-		if errReset := v.utxoStore.Unspend(ctx, spentUtxos); errReset != nil {
-			if retries < 2 {
-				backoff := time.Duration(1<<retries) * time.Second
-				v.logger.Errorf("error resetting utxos, retrying in %s: %v", backoff.String(), errReset)
-				time.Sleep(backoff)
-			} else {
-				span.RecordError(errReset)
-				return errors.NewProcessingError("error resetting utxos", errReset)
-			}
-		} else {
-			break
-		}
 	}
 
 	return nil

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -913,6 +913,14 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 				return txMetaData, err
 			}
 		} else if errors.Is(err, errors.ErrTxNotFound) {
+			// PHASE ASSUMPTION: this branch (and the ErrUtxoError branch above) assumes the
+			// error originated in the SPEND phase of SpendAndCreate — today no create path
+			// emits ErrTxNotFound or ErrUtxoError, and no spend path emits ErrTxExists.
+			// An atomic SpendAndCreate implementation (Postgres tx, Aerospike-native) whose
+			// create phase can surface ErrTxNotFound (e.g. an internal parent lookup) MUST
+			// NOT let it escape untagged, or a failed create gets misread here as a
+			// DAH-evicted parent and the tx is wrongly treated as blessed.
+			//
 			// The parent transaction was not found. This can legitimately happen when the parent has been DAH-evicted
 			// long after the child was mined. Only short-circuit if the stored metadata confirms prior full validation:
 			//   - tx has been included in at least one block (BlockIDs non-empty), AND
@@ -1519,7 +1527,12 @@ func (v *Validator) sendTxMetaBatchV2(batch []*txmetaBatchItem) {
 // spends via outpoint lookup without a UTXO-hash comparison.
 func (v *Validator) spendAndCreateInUtxoStore(ctx context.Context, tx *bt.Tx, blockHeight uint32,
 	addToBlockAssembly bool, validationOptions *Options) (*meta.Data, []*utxo.Spend, error) {
-	ctx, span, deferFn := tracing.Tracer("validator").Start(ctx, "spendUtxos",
+	// NOTE: prometheusTransactionSpendUtxos keeps its name for dashboard
+	// continuity but now measures the combined spend+create (and any rollback),
+	// not just the spend. The primary path no longer records
+	// prometheusValidatorSetTxMeta (storeTxInUtxoMap) — that histogram only sees
+	// the conflicting-fallback create via CreateInUtxoStore.
+	ctx, span, deferFn := tracing.Tracer("validator").Start(ctx, "spendAndCreateUtxos",
 		tracing.WithHistogram(prometheusTransactionSpendUtxos),
 	)
 	defer deferFn()

--- a/services/validator/Validator_coverage_test.go
+++ b/services/validator/Validator_coverage_test.go
@@ -388,117 +388,9 @@ func TestValidator_SendTxMetaToKafka_NilProducer(t *testing.T) {
 	assert.NotNil(t, hash)
 }
 
-func TestValidator_ReverseSpends_Success(t *testing.T) {
-	ctx := context.Background()
-	logger := ulogger.TestLogger{}
-
-	nullStore, _ := nullstore.NewNullStore()
-	settings := test.CreateBaseTestSettings(t)
-
-	validator, err := New(ctx, logger, settings, nullStore, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-
-	v := validator.(*Validator)
-
-	// Test reverseSpends directly with empty spends (should succeed)
-	err = v.reverseSpends(ctx, []*utxo.Spend{})
-	assert.NoError(t, err)
-}
-
-func TestValidator_ReverseSpends_WithRetries(t *testing.T) {
-	ctx := context.Background()
-	logger := ulogger.TestLogger{}
-
-	// Create a mock UTXO store that will fail on Unspend calls
-	mockStore := &utxo.MockUtxostore{}
-	settings := test.CreateBaseTestSettings(t)
-
-	validator, err := New(ctx, logger, settings, mockStore, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-
-	v := validator.(*Validator)
-
-	// Create some dummy spends with proper hash
-	testHash, _ := chainhash.NewHashFromStr("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-	spends := []*utxo.Spend{
-		{
-			TxID: testHash,
-			Vout: 0,
-		},
-	}
-
-	// Mock will return success after retries
-	mockStore.On("Unspend", mock.Anything, spends, mock.Anything).Return(nil).Once()
-
-	err = v.reverseSpends(ctx, spends)
-	assert.NoError(t, err)
-
-	mockStore.AssertExpectations(t)
-}
-
-func TestValidator_ReverseSpends_WithRetriesAndFailure(t *testing.T) {
-	ctx := context.Background()
-	logger := ulogger.TestLogger{}
-
-	// Create a mock UTXO store that will fail on Unspend calls
-	mockStore := &utxo.MockUtxostore{}
-	settings := test.CreateBaseTestSettings(t)
-
-	validator, err := New(ctx, logger, settings, mockStore, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-
-	v := validator.(*Validator)
-
-	// Create some dummy spends with proper hash
-	testHash, _ := chainhash.NewHashFromStr("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-	spends := []*utxo.Spend{
-		{
-			TxID: testHash,
-			Vout: 0,
-		},
-	}
-
-	// Mock will fail first 2 times, then succeed on 3rd try
-	mockStore.On("Unspend", mock.Anything, spends, mock.Anything).Return(assert.AnError).Twice()
-	mockStore.On("Unspend", mock.Anything, spends, mock.Anything).Return(nil).Once()
-
-	err = v.reverseSpends(ctx, spends)
-	assert.NoError(t, err)
-
-	mockStore.AssertExpectations(t)
-}
-
-func TestValidator_ReverseSpends_AllRetriesFail(t *testing.T) {
-	ctx := context.Background()
-	logger := ulogger.TestLogger{}
-
-	// Create a mock UTXO store that will always fail
-	mockStore := &utxo.MockUtxostore{}
-	settings := test.CreateBaseTestSettings(t)
-
-	validator, err := New(ctx, logger, settings, mockStore, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-
-	v := validator.(*Validator)
-
-	// Create some dummy spends with proper hash
-	testHash, _ := chainhash.NewHashFromStr("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-	spends := []*utxo.Spend{
-		{
-			TxID: testHash,
-			Vout: 0,
-		},
-	}
-
-	// Mock will always fail (3 times)
-	mockStore.On("Unspend", mock.Anything, spends, mock.Anything).Return(assert.AnError).Times(3)
-
-	err = v.reverseSpends(ctx, spends)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error resetting utxos")
-
-	mockStore.AssertExpectations(t)
-}
+// The reverseSpends retry logic moved into utxo.SequentialSpendAndCreate; its
+// behavior (empty spends, transient retries, all-retries-fail) is covered by
+// TestSequentialSpendAndCreate in stores/utxo/spend_and_create_test.go.
 
 func XTestValidator_ValidateInternal_SpendUtxosError_WithConflicting(t *testing.T) {
 	ctx := context.Background()
@@ -540,10 +432,10 @@ func XTestValidator_ValidateInternal_SpendUtxosError_WithConflicting(t *testing.
 	mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{}, nil)
 
 	// Mock spendUtxos to return UTXO error with spends containing errors
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return(spends, errors.NewUtxoError("utxo error", errors.ErrUtxoError))
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, spends, errors.NewUtxoError("utxo error", errors.ErrUtxoError))
 
 	// Mock CreateInUtxoStore for conflicting transaction
-	mockStore.On("Create", mock.Anything, tx, uint32(100), mock.Anything).Return(&meta.Data{}, nil)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, uint32(100), mock.Anything).Return(&meta.Data{}, nil, nil)
 
 	options := &Options{
 		CreateConflicting: true, // Enable conflicting creation
@@ -585,10 +477,12 @@ func TestValidator_ValidateInternal_CreateConflicting_TxAlreadyExists(t *testing
 
 	mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{}, nil)
 	mockStore.On("GetBlockState").Return(utxo.BlockState{Height: 100, MedianTime: 1000000000})
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return(spends, errors.NewUtxoError("utxo error", errors.ErrUtxoError))
+	// The main spend-and-create fails with a spend-phase utxo error (Once so the
+	// conflicting-fallback create below matches the second expectation).
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, spends, errors.NewUtxoError("utxo error", errors.ErrUtxoError)).Once()
 
 	// CreateInUtxoStore returns ErrTxExists — tx was already validated via P2P
-	mockStore.On("Create", mock.Anything, tx, uint32(100), mock.Anything).Return(&meta.Data{}, errors.NewTxExistsError("already exists"))
+	mockStore.On("SpendAndCreate", mock.Anything, tx, uint32(100), mock.Anything).Return(&meta.Data{}, nil, errors.NewTxExistsError("already exists"))
 
 	// GetMeta succeeds — tx exists in store (not yet marked conflicting)
 	mockStore.On("GetMeta", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -636,7 +530,7 @@ func XTestValidator_ValidateInternal_SpendUtxosError_TxNotFound(t *testing.T) {
 	mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{}, nil)
 
 	// Mock spendUtxos to return TxNotFound error (parent DAH'd)
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, errors.ErrTxNotFound)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, errors.ErrTxNotFound)
 
 	// Mock GetMeta to return existing tx (already blessed)
 	existingMeta := &meta.Data{Tx: tx}
@@ -681,7 +575,7 @@ func XTestValidator_ValidateInternal_SpendUtxosError_TxNotFound_NotInStore(t *te
 	mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&meta.Data{}, nil)
 
 	// Mock spendUtxos to return TxNotFound error
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, errors.ErrTxNotFound)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, errors.ErrTxNotFound)
 
 	// Mock GetMeta to also fail (tx not in store)
 	mockStore.On("GetMeta", mock.Anything, tx.TxIDChainHash()).Return(nil, errors.ErrTxNotFound)
@@ -726,7 +620,7 @@ func XTestValidator_ValidateInternal_SpendUtxosError_GeneralError(t *testing.T) 
 	mockStore.On("GetBlockHeight").Return(uint32(100))
 
 	// Mock spendUtxos to return a general error (not UTXO or TxNotFound)
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, assert.AnError)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, assert.AnError)
 
 	options := &Options{}
 
@@ -767,13 +661,14 @@ func TestValidator_ValidateInternal_UTXOError_ConflictingTxCreation(t *testing.T
 	mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(parentTxMeta, nil)
 	mockStore.On("GetBlockState").Return(utxo.BlockState{Height: 100, MedianTime: 1000000000})
 
-	// Mock spendUtxos to return UTXO error with conflicting spend
+	// Mock the spend phase to return UTXO error with conflicting spend (Once so
+	// the conflicting-fallback create below matches the second expectation)
 	spends := []*utxo.Spend{{TxID: &chainhash.Hash{}, Vout: 0, Err: errors.ErrSpent}}
 	utxoErr := errors.NewUtxoError("utxo error", errors.ErrUtxoError)
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return(spends, utxoErr)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, spends, utxoErr).Once()
 
 	// Mock CreateInUtxoStore for conflicting transaction
-	mockStore.On("Create", mock.Anything, tx, uint32(100), mock.Anything).Return(&meta.Data{}, nil)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, uint32(100), mock.Anything).Return(&meta.Data{}, nil, nil)
 
 	options := &Options{CreateConflicting: true}
 	_, err = v.validateInternal(ctx, tx, 100, options)
@@ -812,7 +707,7 @@ func TestValidator_ValidateInternal_TxNotFoundError_ExistingTx(t *testing.T) {
 	mockStore.On("GetBlockState").Return(utxo.BlockState{Height: 100, MedianTime: 1000000000})
 
 	// Mock spendUtxos to return TxNotFound error
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, errors.NewTxNotFoundError("tx not found"))
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, errors.NewTxNotFoundError("tx not found"))
 
 	// Mock GetMeta to return existing tx already mined and not flagged — legitimate DAH-evicted-parent case.
 	existingMeta := &meta.Data{Tx: tx, BlockIDs: []uint32{1, 2}}
@@ -866,7 +761,7 @@ func TestValidate_TxNotFoundShortcut(t *testing.T) {
 		parentTxMeta := &meta.Data{Tx: coinbaseTx, BlockHeights: []uint32{}}
 		mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(parentTxMeta, nil)
 		mockStore.On("GetBlockState").Return(utxo.BlockState{Height: 100, MedianTime: 1000000000})
-		mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, errors.NewTxNotFoundError("tx not found"))
+		mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, errors.NewTxNotFoundError("tx not found"))
 		if getMetaErr != nil {
 			mockStore.On("GetMeta", mock.Anything, mock.Anything, mock.Anything).Return(getMetaErr)
 		} else {
@@ -980,7 +875,7 @@ func TestValidator_ValidateInternal_GeneralSpendError(t *testing.T) {
 
 	// Mock spendUtxos to return a general error
 	generalErr := errors.NewProcessingError("general spending error")
-	mockStore.On("Spend", mock.Anything, tx, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, generalErr)
+	mockStore.On("SpendAndCreate", mock.Anything, tx, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, generalErr)
 
 	options := &Options{}
 	_, err = v.validateInternal(ctx, tx, 100, options)

--- a/services/validator/http_server_test.go
+++ b/services/validator/http_server_test.go
@@ -52,7 +52,7 @@ func TestHTTPEndpoints(t *testing.T) {
 		}
 		utxoMock.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(metaData, nil)
 
-		// Mock the Spend method with empty slice of *utxo.Spend for the return value
+		// Mock the SpendAndCreate method with empty slice of *utxo.Spend for the return value
 		utxoMock.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, nil)
 
 		// Create a new server
@@ -107,7 +107,7 @@ func TestHTTPEndpoints(t *testing.T) {
 		}
 		utxoMock.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(metaData, nil)
 
-		// Mock the Spend method with empty slice of *utxo.Spend for the return value
+		// Mock the SpendAndCreate method with empty slice of *utxo.Spend for the return value
 		utxoMock.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, nil)
 
 		// Create a new server

--- a/services/validator/http_server_test.go
+++ b/services/validator/http_server_test.go
@@ -53,7 +53,7 @@ func TestHTTPEndpoints(t *testing.T) {
 		utxoMock.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(metaData, nil)
 
 		// Mock the Spend method with empty slice of *utxo.Spend for the return value
-		utxoMock.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)
+		utxoMock.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, nil)
 
 		// Create a new server
 		server := validator.NewServer(logger, tSettings, utxoMock, nil, nil, nil, nil, nil, nil)
@@ -108,7 +108,7 @@ func TestHTTPEndpoints(t *testing.T) {
 		utxoMock.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(metaData, nil)
 
 		// Mock the Spend method with empty slice of *utxo.Spend for the return value
-		utxoMock.On("Spend", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*utxo.Spend{}, nil)
+		utxoMock.On("SpendAndCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, []*utxo.Spend{}, nil)
 
 		// Create a new server
 		server := validator.NewServer(logger, tSettings, utxoMock, nil, nil, nil, nil, nil, nil)

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -623,48 +623,6 @@ func (t *TxMetaCache) BatchDecorate(ctx context.Context, hashes []*utxo.Unresolv
 	return nil
 }
 
-// Create adds a new transaction to the system, updating both the underlying store and the cache.
-// This is typically called when a new transaction is seen, either from the mempool or in a block.
-//
-// Parameters:
-// - ctx: Context for the operation
-// - tx: The transaction to create metadata for
-// - blockHeight: The current blockchain height
-// - opts: Optional creation options such as block information
-//
-// Returns:
-// - The created transaction metadata
-// - Error if creation fails
-//
-// This method delegates the creation to the underlying store and then adds the result to the cache.
-func (t *TxMetaCache) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, error) {
-	txMeta, err := t.utxoStore.Create(ctx, tx, blockHeight, opts...)
-	if err != nil {
-		return txMeta, err
-	}
-
-	options := &utxo.CreateOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	var txHash *chainhash.Hash
-
-	if options.TxID != nil {
-		txHash = options.TxID
-	} else {
-		txHash = tx.TxIDChainHash()
-	}
-
-	// add to cache, but only if the blockIDs have not been set
-	if len(txMeta.BlockIDs) == 0 && !txMeta.Conflicting {
-		// don't return errors from SetCache, as it is not critical if the cache fails to set
-		_ = t.SetCache(txHash, txMeta)
-	}
-
-	return txMeta, nil
-}
-
 // SetMined marks a transaction as mined in the underlying store and evicts it
 // from the cache. The cache is populated on read only for txs with no block IDs
 // and not flagged conflicting (see GetMeta), so a newly mined tx must not stay
@@ -916,19 +874,35 @@ func (t *TxMetaCache) GetSpend(ctx context.Context, spend *utxo.Spend) (*utxo.Sp
 	return t.utxoStore.GetSpend(ctx, spend)
 }
 
-// Spend marks UTXOs as spent by a transaction.
-// This method delegates directly to the underlying UTXO store without caching.
-//
-// Parameters:
-// - ctx: Context for the operation
-// - tx: The transaction that spends the UTXOs
-// - ignoreFlags: Optional flags to modify spending behavior
-//
-// Returns:
-// - Array of Spend objects representing the spent UTXOs
-// - Error if the spend operation fails
-func (t *TxMetaCache) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...utxo.IgnoreFlags) ([]*utxo.Spend, error) {
-	return t.utxoStore.Spend(ctx, tx, blockHeight, ignoreFlags...)
+// SpendAndCreate delegates the combined spend+create operation to the underlying
+// store and caches the returned metadata the same way Create does. The metadata
+// is nil (and nothing is cached) on error or with WithSpendOnly.
+func (t *TxMetaCache) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	txMeta, spends, err := t.utxoStore.SpendAndCreate(ctx, tx, blockHeight, opts...)
+	if err != nil || txMeta == nil {
+		return txMeta, spends, err
+	}
+
+	options := &utxo.CreateOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	var txHash *chainhash.Hash
+
+	if options.TxID != nil {
+		txHash = options.TxID
+	} else {
+		txHash = tx.TxIDChainHash()
+	}
+
+	// add to cache, but only if the blockIDs have not been set
+	if len(txMeta.BlockIDs) == 0 && !txMeta.Conflicting {
+		// don't return errors from SetCache, as it is not critical if the cache fails to set
+		_ = t.SetCache(txHash, txMeta)
+	}
+
+	return txMeta, spends, nil
 }
 
 // Unspend marks previously spent UTXOs as unspent.

--- a/stores/txmetacache/txmetacache_test.go
+++ b/stores/txmetacache/txmetacache_test.go
@@ -58,7 +58,7 @@ func Test_txMetaCache_GetMeta(t *testing.T) {
 		c, err := NewTxMetaCache(ctx, settings.NewSettings(), ulogger.TestLogger{}, utxoStore, Unallocated)
 		require.NoError(t, err)
 
-		metaCreated, err := c.Create(ctx, coinbaseTx, 100)
+		metaCreated, _, err := c.SpendAndCreate(ctx, coinbaseTx, 100, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		hash, _ := chainhash.NewHashFromStr("a6fa2d4d23292bef7e13ffbb8c03168c97c457e1681642bf49b3e2ba7d26bb89")
@@ -81,7 +81,7 @@ func Test_txMetaCache_GetMeta(t *testing.T) {
 		c, err := NewTxMetaCache(ctx, settings.NewSettings(), ulogger.TestLogger{}, nativeUtxoStore, Native)
 		require.NoError(t, err)
 
-		metaCreated, err := c.Create(ctx, coinbaseTx, 100)
+		metaCreated, _, err := c.SpendAndCreate(ctx, coinbaseTx, 100, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		hash, _ := chainhash.NewHashFromStr("a6fa2d4d23292bef7e13ffbb8c03168c97c457e1681642bf49b3e2ba7d26bb89")
@@ -860,7 +860,7 @@ func Test_TxMetaCache_BatchDecorate(t *testing.T) {
 	}
 
 	// Pre-populate the underlying store with test data
-	_, err = cache.utxoStore.Create(ctx, tests.Tx, 100)
+	_, _, err = cache.utxoStore.SpendAndCreate(ctx, tests.Tx, 100, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	// Set up some cache entries
@@ -986,7 +986,7 @@ func Test_TxMetaCache_MiningOperations(t *testing.T) {
 	cache := c.(*TxMetaCache)
 
 	// First create a transaction in the store
-	_, err = cache.Create(ctx, coinbaseTx, 100)
+	_, _, err = cache.SpendAndCreate(ctx, coinbaseTx, 100, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	hash := coinbaseTx.TxIDChainHash()

--- a/stores/utxo/Interface.go
+++ b/stores/utxo/Interface.go
@@ -19,19 +19,14 @@
 //
 //	store := // initialize your UTXO store implementation
 //
-//	// Create UTXOs from a transaction
-//	metadata, err := store.Create(ctx, transaction, blockHeight)
+//	// Spend the transaction's inputs and create its outputs in one operation
+//	metadata, spends, err := store.SpendAndCreate(ctx, transaction, blockHeight)
 //
-//	// Spend UTXOs
-//	spends := []*Spend{
-//	    {
-//	        TxID: txID,
-//	        Vout: 0,
-//	        UTXOHash: utxoHash,
-//	        SpendingTxID: spendingTxID,
-//	    },
-//	}
-//	err = store.Spend(ctx, spends, blockHeight)
+//	// Only create the transaction's outputs (e.g. coinbase, no inputs to spend)
+//	metadata, _, err = store.SpendAndCreate(ctx, coinbaseTx, blockHeight, WithCreateOnly())
+//
+//	// Only spend the transaction's inputs
+//	_, spends, err = store.SpendAndCreate(ctx, transaction, blockHeight, WithSpendOnly())
 package utxo
 
 import (
@@ -259,6 +254,11 @@ type CreateOptions struct {
 	Conflicting        bool
 	Locked             bool
 	SkipExtendedInputs bool
+
+	// SpendAndCreate-specific options.
+	IgnoreFlags IgnoreFlags // spend-phase flags (ignored with CreateOnly)
+	CreateOnly  bool        // skip the spend phase
+	SpendOnly   bool        // skip the create phase
 }
 
 // WithMinedBlockInfo returns a CreateOption that sets the block IDs for a UTXO.
@@ -317,6 +317,49 @@ func WithSkipExtendedInputs(b bool) CreateOption {
 	}
 }
 
+// WithIgnoreConflicting makes the spend phase of SpendAndCreate ignore the
+// conflicting flag on the UTXOs being spent.
+func WithIgnoreConflicting(b bool) CreateOption {
+	return func(o *CreateOptions) {
+		o.IgnoreFlags.IgnoreConflicting = b
+	}
+}
+
+// WithIgnoreLocked makes the spend phase of SpendAndCreate ignore the locked
+// flag on the UTXOs being spent.
+func WithIgnoreLocked(b bool) CreateOption {
+	return func(o *CreateOptions) {
+		o.IgnoreFlags.IgnoreLocked = b
+	}
+}
+
+// WithSkipUTXOHashCheck disables the per-input utxo-hash integrity comparison in
+// the spend phase of SpendAndCreate. Set ONLY on the gated below-checkpoint
+// outpoint-only path (see IgnoreFlags.SkipUTXOHashCheck).
+func WithSkipUTXOHashCheck(b bool) CreateOption {
+	return func(o *CreateOptions) {
+		o.IgnoreFlags.SkipUTXOHashCheck = b
+	}
+}
+
+// WithCreateOnly makes SpendAndCreate skip the spend phase: only the
+// transaction's outputs and metadata are stored (coinbase, seeding, and batch
+// flows whose inputs are spent elsewhere).
+func WithCreateOnly() CreateOption {
+	return func(o *CreateOptions) {
+		o.CreateOnly = true
+	}
+}
+
+// WithSpendOnly makes SpendAndCreate skip the create phase: only the
+// transaction's inputs are spent (reorg/conflict helpers and batch flows whose
+// outputs are created elsewhere).
+func WithSpendOnly() CreateOption {
+	return func(o *CreateOptions) {
+		o.SpendOnly = true
+	}
+}
+
 type MinedBlockInfo struct {
 	BlockID        uint32
 	BlockHeight    uint32
@@ -364,11 +407,6 @@ type Store interface {
 	// caller must treat a context error as "drain not confirmed complete".
 	Close(ctx context.Context) error
 
-	// Create stores a new transaction's outputs as UTXOs and returns associated metadata.
-	// The blockHeight parameter is used to determine coinbase maturity.
-	// Additional options can be specified using CreateOption functions.
-	Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, error)
-
 	// Get retrieves UTXO metadata for a given transaction hash.
 	// The fields parameter can be used to specify which metadata fields to retrieve.
 	// If fields is empty, all fields will be retrieved.
@@ -382,8 +420,23 @@ type Store interface {
 
 	// Blockchain specific functions
 
-	// Spend marks all the UTXOs of the transaction as spent.
-	Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...IgnoreFlags) ([]*Spend, error)
+	// SpendAndCreate spends tx's inputs and creates its outputs + metadata as one
+	// logical operation. Implementations SHOULD make this atomic (followup work);
+	// the current shared sequential implementation spends, then creates, and
+	// unspends on create failure (except ErrTxExists — see below).
+	//
+	// Semantics (contract for all implementations):
+	//   - Default: spend inputs, then create outputs. On create failure other than
+	//     ErrTxExists, successful spends are rolled back before returning.
+	//   - ErrTxExists from the create phase is returned to the caller WITH the
+	//     spends left in place; the caller decides what to do with the existing tx.
+	//   - WithCreateOnly(): skip the spend phase (coinbase, seeding, batch flows
+	//     whose inputs are spent elsewhere). Returned []*Spend is nil.
+	//   - WithSpendOnly(): skip the create phase (reorg/conflict helpers, batch
+	//     flows whose outputs are created elsewhere). Returned *meta.Data is nil.
+	//   - On spend failure the returned []*Spend carries per-input Err values for
+	//     caller inspection (conflict detection).
+	SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error)
 
 	// Unspend reverses a previous spend operation, marking UTXOs as unspent.
 	// This is used during blockchain reorganizations.

--- a/stores/utxo/Interface.go
+++ b/stores/utxo/Interface.go
@@ -335,7 +335,9 @@ func WithIgnoreLocked(b bool) CreateOption {
 
 // WithSkipUTXOHashCheck disables the per-input utxo-hash integrity comparison in
 // the spend phase of SpendAndCreate. Set ONLY on the gated below-checkpoint
-// outpoint-only path (see IgnoreFlags.SkipUTXOHashCheck).
+// outpoint-only path (see IgnoreFlags.SkipUTXOHashCheck). The Aerospike store
+// does not implement the outpoint-only fast path and treats this flag as a
+// no-op (see SupportsOutpointOnlySpend).
 func WithSkipUTXOHashCheck(b bool) CreateOption {
 	return func(o *CreateOptions) {
 		o.IgnoreFlags.SkipUTXOHashCheck = b
@@ -436,6 +438,12 @@ type Store interface {
 	//     flows whose outputs are created elsewhere). Returned *meta.Data is nil.
 	//   - On spend failure the returned []*Spend carries per-input Err values for
 	//     caller inspection (conflict detection).
+	//   - When the create phase fails and the spends were rolled back, the
+	//     returned []*Spend is nil; a non-nil slice alongside a non-nil error
+	//     means the spends are still in effect (ErrTxExists, or rollback failure).
+	//   - Transactions with no inputs to spend (synthesized seed txs) must pass
+	//     WithCreateOnly(); backend behaviour for a default-mode spend of a
+	//     zero-input tx is undefined.
 	SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error)
 
 	// Unspend reverses a previous spend operation, marking UTXOs as unspent.

--- a/stores/utxo/aerospike/aerospike_server_test.go
+++ b/stores/utxo/aerospike/aerospike_server_test.go
@@ -1663,6 +1663,48 @@ func TestSmokeTests(t *testing.T) {
 		tests.UnspendIdempotent(t, store)
 	})
 
+	t.Run("aerospike_spend_and_create", func(t *testing.T) {
+		err := store.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreate(t, store)
+	})
+
+	t.Run("aerospike_spend_and_create_create_only", func(t *testing.T) {
+		err := store.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateCreateOnly(t, store)
+	})
+
+	t.Run("aerospike_spend_and_create_spend_only", func(t *testing.T) {
+		err := store.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateSpendOnly(t, store)
+	})
+
+	t.Run("aerospike_spend_and_create_tx_exists_keeps_spends", func(t *testing.T) {
+		err := store.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateTxExistsKeepsSpends(t, store)
+	})
+
+	t.Run("aerospike_spend_and_create_spend_error_surfaces_per_input", func(t *testing.T) {
+		err := store.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateSpendErrorSurfacesPerInput(t, store)
+	})
+
+	t.Run("aerospike_spend_and_create_invalid_options", func(t *testing.T) {
+		err := store.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateInvalidOptions(t, store)
+	})
+
 	t.Run("aerospike_conflict_WAL_crash_recovery", func(t *testing.T) {
 		tests.ConflictWALCrashRecovery(t, store)
 	})

--- a/stores/utxo/aerospike/create_test.go
+++ b/stores/utxo/aerospike/create_test.go
@@ -570,7 +570,7 @@ func TestStore_TwoPhaseCommit(t *testing.T) {
 
 	tx := td.CreateTransaction(t, block1.CoinbaseTx)
 
-	txMeta, err := td.UtxoStore.Create(td.Ctx, tx, 0)
+	txMeta, _, err := td.UtxoStore.SpendAndCreate(td.Ctx, tx, 0, utxo.WithCreateOnly())
 	require.NoError(t, err)
 
 	// err = td.PropagationClient.ProcessTransaction(td.Ctx, tx)

--- a/stores/utxo/aerospike/longest_chain_production_bench_test.go
+++ b/stores/utxo/aerospike/longest_chain_production_bench_test.go
@@ -149,7 +149,7 @@ func createProductionLikeTransactions(b *testing.B, ctx context.Context, store u
 		g.Go(func() error {
 			tx := createRealisticTransaction(seedOffset + i)
 
-			_, err := store.Create(gCtx, tx, uint32(100000+(seedOffset+i)%1000))
+			_, _, err := store.SpendAndCreate(gCtx, tx, uint32(100000+(seedOffset+i)%1000), utxo.WithCreateOnly())
 			if err != nil {
 				return err
 			}

--- a/stores/utxo/aerospike/spend_and_create.go
+++ b/stores/utxo/aerospike/spend_and_create.go
@@ -1,0 +1,15 @@
+package aerospike
+
+import (
+	"context"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+)
+
+// SpendAndCreate implements utxo.Store. It delegates to the shared sequential
+// implementation; an atomic Aerospike-native implementation is a followup.
+func (s *Store) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	return utxo.SequentialSpendAndCreate(ctx, s.logger, s, tx, blockHeight, opts...)
+}

--- a/stores/utxo/conflict_wal_wrap_test.go
+++ b/stores/utxo/conflict_wal_wrap_test.go
@@ -104,8 +104,8 @@ func TestReverseProcessConflicting_WALLifecycleOnSuccess(t *testing.T) {
 		Return(nil).Once()
 	mockStore.On("Get", mock.Anything, &counterHash, mock.Anything).
 		Return(&meta.Data{Tx: counterTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, counterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, counterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{counterHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 

--- a/stores/utxo/factory/aerospike.go
+++ b/stores/utxo/factory/aerospike.go
@@ -26,7 +26,7 @@
 //	}
 //
 //	// Use the store
-//	metadata, err := store.Create(ctx, tx, blockHeight)
+//	metadata, _, err := store.SpendAndCreate(ctx, tx, blockHeight, utxo.WithCreateOnly())
 //
 // # Features
 //

--- a/stores/utxo/factory/sql.go
+++ b/stores/utxo/factory/sql.go
@@ -24,7 +24,7 @@
 //	}
 //
 //	// Use the store
-//	metadata, err := store.Create(ctx, tx, blockHeight)
+//	metadata, _, err := store.SpendAndCreate(ctx, tx, blockHeight, utxo.WithCreateOnly())
 //
 // # Features
 //

--- a/stores/utxo/factory/utxo.go
+++ b/stores/utxo/factory/utxo.go
@@ -24,7 +24,7 @@
 //	}
 //
 //	// Use the store
-//	metadata, err := store.Create(ctx, tx, blockHeight)
+//	metadata, _, err := store.SpendAndCreate(ctx, tx, blockHeight, utxo.WithCreateOnly())
 //
 // # Features
 //

--- a/stores/utxo/factory/utxo_test.go
+++ b/stores/utxo/factory/utxo_test.go
@@ -88,6 +88,10 @@ func (m *MockUTXOStore) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32
 	return nil, nil
 }
 
+func (m *MockUTXOStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	return nil, nil, nil
+}
+
 func (m *MockUTXOStore) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked ...bool) error {
 	return nil
 }

--- a/stores/utxo/logger/logger.go
+++ b/stores/utxo/logger/logger.go
@@ -138,45 +138,6 @@ func (s *Store) Close(ctx context.Context) error {
 	return s.store.Close(ctx)
 }
 
-func (s *Store) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, error) {
-	data, err := s.store.Create(ctx, tx, blockHeight, opts...)
-	inputDetails := make([]string, len(tx.Inputs))
-
-	for i, input := range tx.Inputs {
-		inputDetails[i] = fmt.Sprintf("{Input %d: PreviousTxID %s, PreviousTxOutIndex %d, SequenceNumber %d}",
-			i, input.PreviousTxIDChainHash(), input.PreviousTxOutIndex, input.SequenceNumber)
-	}
-
-	outputDetails := make([]string, len(tx.Outputs))
-	skipLogging := false
-
-	for i, output := range tx.Outputs {
-		if output == nil {
-			skipLogging = true
-			break
-		}
-
-		outputDetails[i] = fmt.Sprintf("{Output %d: Satoshis %d}",
-			i, output.Satoshis)
-	}
-
-	if !skipLogging {
-		s.logger.Debugf("[UTXOStore][logger][Create] tx %s, inputs: [%s], outputs: [%s], isCoinbase %t, blockHeight %d, lockTime %d, version %d, data %s, err %v : %s",
-			tx.TxIDChainHash(),
-			strings.Join(inputDetails, ", "),
-			strings.Join(outputDetails, ", "),
-			tx.IsCoinbase(),
-			blockHeight,
-			tx.LockTime,
-			tx.Version,
-			data.String(),
-			err,
-			caller())
-	}
-
-	return data, err
-}
-
 func (s *Store) GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Data) error {
 	err := s.store.GetMeta(ctx, hash, data)
 	s.logger.Debugf("[UTXOStore][logger][GetMeta] hash %s data %v err %v : %s", hash.String(), data, err, caller())
@@ -191,18 +152,32 @@ func (s *Store) Get(ctx context.Context, hash *chainhash.Hash, fields ...fields.
 	return data, err
 }
 
-func (s *Store) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...utxo.IgnoreFlags) ([]*utxo.Spend, error) {
-	spends, err := s.store.Spend(ctx, tx, blockHeight, ignoreFlags...)
-	spendDetails := make([]string, len(spends))
+// SpendAndCreate delegates the combined spend+create operation to the wrapped store.
+func (s *Store) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	data, spends, err := s.store.SpendAndCreate(ctx, tx, blockHeight, opts...)
 
-	for i, spend := range spends {
-		spendDetails[i] = fmt.Sprintf("{SpendingData: %v, TxID: %s, Vout: %d}", spend.SpendingData, spend.TxID, spend.Vout)
+	// a tx with a nil output cannot be serialized for its txid
+	skipLogging := false
+
+	for _, output := range tx.Outputs {
+		if output == nil {
+			skipLogging = true
+			break
+		}
 	}
 
-	s.logger.Debugf("[UTXOStore][logger][Spend] spends: [%s], blockHeight: %d, err: %v : %s",
-		strings.Join(spendDetails, ", "), s.store.GetBlockHeight(), err, caller())
+	if !skipLogging {
+		spendDetails := make([]string, len(spends))
 
-	return spends, err
+		for i, spend := range spends {
+			spendDetails[i] = fmt.Sprintf("{SpendingData: %v, TxID: %s, Vout: %d}", spend.SpendingData, spend.TxID, spend.Vout)
+		}
+
+		s.logger.Debugf("[UTXOStore][logger][SpendAndCreate] tx %s, blockHeight %d, spends: [%s], data %v, err %v : %s",
+			tx.TxIDChainHash(), blockHeight, strings.Join(spendDetails, ", "), data, err, caller())
+	}
+
+	return data, spends, err
 }
 
 func (s *Store) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked ...bool) error {

--- a/stores/utxo/logger/logger.go
+++ b/stores/utxo/logger/logger.go
@@ -167,14 +167,38 @@ func (s *Store) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint3
 	}
 
 	if !skipLogging {
+		inputDetails := make([]string, len(tx.Inputs))
+
+		for i, input := range tx.Inputs {
+			inputDetails[i] = fmt.Sprintf("{Input %d: PreviousTxID %s, PreviousTxOutIndex %d, SequenceNumber %d}",
+				i, input.PreviousTxIDChainHash(), input.PreviousTxOutIndex, input.SequenceNumber)
+		}
+
+		outputDetails := make([]string, len(tx.Outputs))
+
+		for i, output := range tx.Outputs {
+			outputDetails[i] = fmt.Sprintf("{Output %d: Satoshis %d}",
+				i, output.Satoshis)
+		}
+
 		spendDetails := make([]string, len(spends))
 
 		for i, spend := range spends {
 			spendDetails[i] = fmt.Sprintf("{SpendingData: %v, TxID: %s, Vout: %d}", spend.SpendingData, spend.TxID, spend.Vout)
 		}
 
-		s.logger.Debugf("[UTXOStore][logger][SpendAndCreate] tx %s, blockHeight %d, spends: [%s], data %v, err %v : %s",
-			tx.TxIDChainHash(), blockHeight, strings.Join(spendDetails, ", "), data, err, caller())
+		s.logger.Debugf("[UTXOStore][logger][SpendAndCreate] tx %s, inputs: [%s], outputs: [%s], spends: [%s], isCoinbase %t, blockHeight %d, lockTime %d, version %d, data %v, err %v : %s",
+			tx.TxIDChainHash(),
+			strings.Join(inputDetails, ", "),
+			strings.Join(outputDetails, ", "),
+			strings.Join(spendDetails, ", "),
+			tx.IsCoinbase(),
+			blockHeight,
+			tx.LockTime,
+			tx.Version,
+			data,
+			err,
+			caller())
 	}
 
 	return data, spends, err

--- a/stores/utxo/logger/logger_test.go
+++ b/stores/utxo/logger/logger_test.go
@@ -79,11 +79,6 @@ func TestSupportsOutpointOnlySpend_Delegates(t *testing.T) {
 	}
 }
 
-func (m *MockStore) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, error) {
-	args := m.Called(ctx, tx, blockHeight, opts)
-	return args.Get(0).(*meta.Data), args.Error(1)
-}
-
 func (m *MockStore) GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Data) error {
 	args := m.Called(ctx, hash, data)
 	if result := args.Get(0); result != nil {
@@ -97,9 +92,20 @@ func (m *MockStore) Get(ctx context.Context, hash *chainhash.Hash, fieldsArg ...
 	return args.Get(0).(*meta.Data), args.Error(1)
 }
 
-func (m *MockStore) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...utxo.IgnoreFlags) ([]*utxo.Spend, error) {
-	args := m.Called(ctx, tx, ignoreFlags)
-	return args.Get(0).([]*utxo.Spend), args.Error(1)
+func (m *MockStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	args := m.Called(ctx, tx, blockHeight, opts)
+
+	var md *meta.Data
+	if args.Get(0) != nil {
+		md = args.Get(0).(*meta.Data)
+	}
+
+	var spends []*utxo.Spend
+	if args.Get(1) != nil {
+		spends = args.Get(1).([]*utxo.Spend)
+	}
+
+	return md, spends, args.Error(2)
 }
 
 func (m *MockStore) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked ...bool) error {
@@ -420,7 +426,7 @@ func TestHealth(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
-func TestCreate(t *testing.T) {
+func TestSpendAndCreate(t *testing.T) {
 	logger := ulogger.TestLogger{}
 	mockStore := &MockStore{}
 	store := New(context.Background(), logger, mockStore).(*Store)
@@ -429,35 +435,16 @@ func TestCreate(t *testing.T) {
 	tx := createTestTx(1)
 	blockHeight := uint32(100)
 	expectedData := createTestMetaData()
-	expectedErr := errors.NewError("create error")
+	expectedSpends := []*utxo.Spend{createTestSpend(1), createTestSpend(2)}
+	expectedErr := errors.NewError("spend and create error")
 
-	mockStore.On("Create", ctx, tx, blockHeight, mock.Anything).Return(expectedData, expectedErr)
+	mockStore.On("SpendAndCreate", ctx, tx, blockHeight, mock.Anything).Return(expectedData, expectedSpends, expectedErr)
 
-	data, err := store.Create(ctx, tx, blockHeight)
+	data, spends, err := store.SpendAndCreate(ctx, tx, blockHeight)
 
 	assert.Equal(t, expectedData, data)
+	assert.Equal(t, expectedSpends, spends)
 	assert.Equal(t, expectedErr, err)
-	mockStore.AssertExpectations(t)
-}
-
-func TestCreate_SkipLogging(t *testing.T) {
-	logger := ulogger.TestLogger{}
-	mockStore := &MockStore{}
-	store := New(context.Background(), logger, mockStore).(*Store)
-
-	ctx := context.Background()
-	tx := createTestTx(1)
-	// Create a transaction with nil output to trigger skipLogging
-	tx.Outputs[0] = nil
-	blockHeight := uint32(100)
-	expectedData := createTestMetaData()
-
-	mockStore.On("Create", ctx, tx, blockHeight, mock.Anything).Return(expectedData, nil)
-
-	data, err := store.Create(ctx, tx, blockHeight)
-
-	assert.Equal(t, expectedData, data)
-	assert.NoError(t, err)
 	mockStore.AssertExpectations(t)
 }
 
@@ -497,27 +484,6 @@ func TestGet(t *testing.T) {
 	data, err := store.Get(ctx, hash, fieldsToGet...)
 
 	assert.Equal(t, expectedData, data)
-	assert.Equal(t, expectedErr, err)
-	mockStore.AssertExpectations(t)
-}
-
-func TestSpend(t *testing.T) {
-	logger := ulogger.TestLogger{}
-	mockStore := &MockStore{}
-	store := New(context.Background(), logger, mockStore).(*Store)
-
-	ctx := context.Background()
-	tx := createTestTx(1)
-	ignoreFlags := []utxo.IgnoreFlags{{IgnoreConflicting: true, IgnoreLocked: false}}
-	expectedSpends := []*utxo.Spend{createTestSpend(1), createTestSpend(2)}
-	expectedErr := errors.NewError("spend error")
-
-	mockStore.On("GetBlockHeight").Return(uint32(100))
-	mockStore.On("Spend", ctx, tx, ignoreFlags).Return(expectedSpends, expectedErr)
-
-	spends, err := store.Spend(ctx, tx, store.GetBlockHeight()+1, ignoreFlags...)
-
-	assert.Equal(t, expectedSpends, spends)
 	assert.Equal(t, expectedErr, err)
 	mockStore.AssertExpectations(t)
 }
@@ -883,7 +849,7 @@ func TestLoggerIntegration(t *testing.T) {
 	// Setup expectations
 	mockStore.On("SetBlockHeight", blockHeight).Return(nil)
 	mockStore.On("GetBlockHeight").Return(blockHeight)
-	mockStore.On("Create", ctx, tx, blockHeight, mock.Anything).Return(metaData, nil)
+	mockStore.On("SpendAndCreate", ctx, tx, blockHeight, mock.Anything).Return(metaData, nil, nil)
 	mockStore.On("GetMeta", ctx, hash, mock.Anything).Return(metaData, nil)
 
 	// Execute operations
@@ -893,7 +859,7 @@ func TestLoggerIntegration(t *testing.T) {
 	retrievedHeight := store.GetBlockHeight()
 	assert.Equal(t, blockHeight, retrievedHeight)
 
-	createdData, err := store.Create(ctx, tx, blockHeight)
+	createdData, _, err := store.SpendAndCreate(ctx, tx, blockHeight)
 	require.NoError(t, err)
 	assert.Equal(t, metaData, createdData)
 
@@ -959,9 +925,9 @@ func TestLoggerWithComplexData(t *testing.T) {
 	blockHeight := uint32(200)
 	expectedData := createTestMetaData()
 
-	mockStore.On("Create", ctx, tx, blockHeight, mock.Anything).Return(expectedData, nil)
+	mockStore.On("SpendAndCreate", ctx, tx, blockHeight, mock.Anything).Return(expectedData, nil, nil)
 
-	data, err := store.Create(ctx, tx, blockHeight)
+	data, _, err := store.SpendAndCreate(ctx, tx, blockHeight)
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedData, data)
@@ -1056,9 +1022,9 @@ func TestCreateWithNilOutputs(t *testing.T) {
 	blockHeight := uint32(100)
 	expectedData := createTestMetaData()
 
-	mockStore.On("Create", ctx, tx, blockHeight, mock.Anything).Return(expectedData, nil)
+	mockStore.On("SpendAndCreate", ctx, tx, blockHeight, mock.Anything).Return(expectedData, nil, nil)
 
-	data, err := store.Create(ctx, tx, blockHeight)
+	data, _, err := store.SpendAndCreate(ctx, tx, blockHeight)
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedData, data)

--- a/stores/utxo/mock.go
+++ b/stores/utxo/mock.go
@@ -107,6 +107,24 @@ func (m *MockUtxostore) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32
 	return args.Get(0).([]*Spend), args.Error(1)
 }
 
+// SpendAndCreate mocks the combined spend+create operation in the UTXO store.
+// Returns the configured mock responses for metadata, spends and error.
+func (m *MockUtxostore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error) {
+	args := m.Called(ctx, tx, blockHeight, opts)
+
+	var md *meta.Data
+	if args.Get(0) != nil {
+		md = args.Get(0).(*meta.Data)
+	}
+
+	var spends []*Spend
+	if args.Get(1) != nil {
+		spends = args.Get(1).([]*Spend)
+	}
+
+	return md, spends, args.Error(2)
+}
+
 // Unspend mocks the reversal of transaction output spending in the UTXO store.
 // Returns the configured mock response for transaction unspending operations.
 func (m *MockUtxostore) Unspend(ctx context.Context, spends []*Spend, flagAsLocked ...bool) error {

--- a/stores/utxo/nullstore/nullstore.go
+++ b/stores/utxo/nullstore/nullstore.go
@@ -169,21 +169,15 @@ func (m *NullStore) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ig
 
 // SpendAndCreate implements utxo.Store as a no-op combination of Spend and Create.
 func (m *NullStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
-	options := &utxo.CreateOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	if options.CreateOnly && options.SpendOnly {
-		return nil, nil, errors.NewInvalidArgumentError("SpendAndCreate: WithCreateOnly and WithSpendOnly are mutually exclusive")
+	options, err := utxo.ParseCreateOptions(opts...)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var spends []*utxo.Spend
 
 	if !options.CreateOnly {
-		var err error
-
-		spends, err = m.Spend(ctx, tx, blockHeight)
+		spends, err = m.Spend(ctx, tx, blockHeight, options.IgnoreFlags)
 		if err != nil {
 			return nil, spends, err
 		}

--- a/stores/utxo/nullstore/nullstore.go
+++ b/stores/utxo/nullstore/nullstore.go
@@ -167,6 +167,40 @@ func (m *NullStore) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ig
 	return nil, nil
 }
 
+// SpendAndCreate implements utxo.Store as a no-op combination of Spend and Create.
+func (m *NullStore) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	options := &utxo.CreateOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.CreateOnly && options.SpendOnly {
+		return nil, nil, errors.NewInvalidArgumentError("SpendAndCreate: WithCreateOnly and WithSpendOnly are mutually exclusive")
+	}
+
+	var spends []*utxo.Spend
+
+	if !options.CreateOnly {
+		var err error
+
+		spends, err = m.Spend(ctx, tx, blockHeight)
+		if err != nil {
+			return nil, spends, err
+		}
+
+		if options.SpendOnly {
+			return nil, spends, nil
+		}
+	}
+
+	md, err := m.Create(ctx, tx, blockHeight, opts...)
+	if err != nil {
+		return nil, spends, err
+	}
+
+	return md, spends, nil
+}
+
 func (m *NullStore) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked ...bool) error {
 	return nil
 }

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -253,10 +253,8 @@ func ProcessConflicting(ctx context.Context, s Store, blockHeight uint32, blockH
 	var tErr *errors.Error
 
 	for _, tx := range winningTxs {
-		spends, spendErr := s.Spend(ctx, tx, blockHeight, IgnoreFlags{
-			IgnoreConflicting: true,
-			IgnoreLocked:      true,
-		})
+		_, spends, spendErr := s.SpendAndCreate(ctx, tx, blockHeight, WithSpendOnly(),
+			WithIgnoreConflicting(true), WithIgnoreLocked(true))
 		// Capture per-input partial successes regardless of overall outcome so the rollback
 		// can undo them via Unspend(false) (parents at step 3 entry were unlocked-by-us, so
 		// the unspend MUST NOT relock).
@@ -450,10 +448,8 @@ func ReverseProcessConflicting(ctx context.Context, s Store, blockHeight uint32,
 				continue
 			}
 
-			if _, spendErr := s.Spend(ctx, counterMeta.Tx, blockHeight, IgnoreFlags{
-				IgnoreConflicting: true,
-				IgnoreLocked:      true,
-			}); spendErr != nil {
+			if _, _, spendErr := s.SpendAndCreate(ctx, counterMeta.Tx, blockHeight, WithSpendOnly(),
+				WithIgnoreConflicting(true), WithIgnoreLocked(true)); spendErr != nil {
 				return nil, nil, errors.NewProcessingError("[ReverseProcessConflicting][%s] error spending counter %s", demotedHash.String(), counterHash.String(), spendErr)
 			}
 
@@ -808,7 +804,8 @@ func rollbackProcessConflicting(ctx context.Context, s Store, conflictingTxHashe
 				continue
 			}
 
-			if _, e := s.Spend(ctx, txMeta.Tx, blockHeight, IgnoreFlags{IgnoreConflicting: true, IgnoreLocked: true}); e != nil {
+			if _, _, e := s.SpendAndCreate(ctx, txMeta.Tx, blockHeight, WithSpendOnly(),
+				WithIgnoreConflicting(true), WithIgnoreLocked(true)); e != nil {
 				rollbackErr = errors.Join(rollbackErr, errors.NewProcessingError("rollback step 2 (re-spend tx %s) failed", h.String(), e))
 			}
 		}

--- a/stores/utxo/process_conflicting_rollback_test.go
+++ b/stores/utxo/process_conflicting_rollback_test.go
@@ -48,8 +48,8 @@ func TestProcessConflictingRollback_Step3Failure(t *testing.T) {
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
 
 	// step 3: Spend(winningTx) FAILS — no per-input partial successes
-	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
 
 	// rollback expectations (reverse order):
 	// 3a. step-3 had no successful spends → no Unspend call for step3SuccessfulSpends
@@ -57,8 +57,8 @@ func TestProcessConflictingRollback_Step3Failure(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
 		Tx: losingTx,
 	}, nil).Once()
-	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	// 3c. SetConflicting(allMarkedHashes, false) — undoes step 1
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
@@ -104,8 +104,8 @@ func TestProcessConflictingRollback_RollbackAlsoFails(t *testing.T) {
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
 
 	// step 3 fails
-	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
 
 	// rollback path:
 	// re-fetch losing tx
@@ -113,8 +113,8 @@ func TestProcessConflictingRollback_RollbackAlsoFails(t *testing.T) {
 		Tx: losingTx,
 	}, nil).Once()
 	// re-spend losing tx (rollback step 2) succeeds
-	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	// SetConflicting(false) FAILS — rollback failure
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, errors.NewProcessingError("set conflicting false failed")).Once()
@@ -160,8 +160,8 @@ func TestProcessConflictingRollback_Step5RetrySucceeds(t *testing.T) {
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
 
-	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 
 	mockStore.On("SetConflicting", mock.Anything, conflictingTxHashes, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
@@ -208,8 +208,8 @@ func TestProcessConflictingRollback_Step5RetryExhausted(t *testing.T) {
 
 	mockStore.On("Unspend", mock.Anything, affectedSpends, []bool{true}).Return(nil).Once()
 
-	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 
 	mockStore.On("SetConflicting", mock.Anything, conflictingTxHashes, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
@@ -265,8 +265,8 @@ func TestProcessConflictingRollback_PartialStep3Spend(t *testing.T) {
 	successSpend := &Spend{TxID: &parent1, Vout: 0}
 	failSpend := &Spend{TxID: &parent2, Vout: 0, Err: errors.NewProcessingError("input-level spend failure")}
 
-	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
-		Return([]*Spend{successSpend, failSpend}, errors.NewTxInvalidError("aggregate spend failed")).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{successSpend, failSpend}, errors.NewTxInvalidError("aggregate spend failed")).Once()
 
 	// rollback expectations (reverse order):
 	// 3a. step-3 partial successes are undone with flagAsLocked=false
@@ -275,8 +275,8 @@ func TestProcessConflictingRollback_PartialStep3Spend(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
 		Tx: losingTx,
 	}, nil).Once()
-	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	// 3c. SetConflicting(allMarkedHashes, false) — undoes step 1
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
@@ -334,8 +334,8 @@ func TestProcessConflictingRollback_CascadeDescendants(t *testing.T) {
 		Return(nil).Once()
 
 	// step 3: Spend(winningTx) FAILS — no per-input partial successes.
-	mockStore.On("Spend", mock.Anything, winningTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, winningTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, errors.NewTxInvalidError("spend failed")).Once()
 
 	// rollback path:
 	// 3a. step-3 had no successful spends → no Unspend call for partial spends.
@@ -343,8 +343,8 @@ func TestProcessConflictingRollback_CascadeDescendants(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
 		Tx: losingTx,
 	}, nil).Once()
-	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	// 3c. attempt to fetch descendant body — store has nothing for it, surface but continue
 	mockStore.On("Get", mock.Anything, &descendantHash, mock.Anything).
 		Return((*meta.Data)(nil), errors.NewNotFoundError("descendant not found")).Once()

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -48,7 +48,7 @@ func TestProcessConflicting_Success(t *testing.T) {
 	mockStore.On("Unspend", mock.Anything, affectedSpends, mock.Anything).Return(nil)
 
 	// Mock Spend call for winning transaction
-	mockStore.On("Spend", mock.Anything, testTx, mock.Anything, mock.Anything).Return([]*Spend{}, nil)
+	mockStore.On("SpendAndCreate", mock.Anything, testTx, mock.Anything, mock.Anything).Return(nil, []*Spend{}, nil)
 
 	// Mock SetConflicting call for marking winning txs as not conflicting
 	mockStore.On("SetConflicting", mock.Anything, conflictingTxHashes, false).
@@ -226,16 +226,16 @@ func TestProcessConflicting_SpendError(t *testing.T) {
 		Vout: 0,
 		Err:  errors.NewProcessingError("spend error"),
 	}
-	mockStore.On("Spend", mock.Anything, testTx, mock.Anything, mock.Anything).
-		Return([]*Spend{spendWithError}, errors.NewTxInvalidError("spend failed"))
+	mockStore.On("SpendAndCreate", mock.Anything, testTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{spendWithError}, errors.NewTxInvalidError("spend failed"))
 
 	// step-3 failure rollback path: re-fetch losing tx body, re-spend it, clear conflicting,
 	// unlock parents. (No partial successful step-3 spends — the only spend has Err != nil.)
 	mockStore.On("Get", mock.Anything, &losingTxHash, mock.Anything).Return(&meta.Data{
 		Tx: losingTx,
 	}, nil).Once()
-	mockStore.On("Spend", mock.Anything, losingTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, losingTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{losingTxHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil)
 	mockStore.On("SetLocked", mock.Anything, []chainhash.Hash{losingTxHash}, false).Return(nil)

--- a/stores/utxo/reverse_process_conflicting_test.go
+++ b/stores/utxo/reverse_process_conflicting_test.go
@@ -98,8 +98,8 @@ func TestReverseProcessConflicting_RestoresOriginalSpender(t *testing.T) {
 		Return(&meta.Data{Tx: counterTx}, nil).Once()
 
 	// Re-spend parent UTXO with counter.
-	mockStore.On("Spend", mock.Anything, counterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, counterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 
 	// Step 5 — UnmarkConflictingRecursively([counter]) flips counter +
 	// descendants back to Conflicting=false.
@@ -202,8 +202,8 @@ func TestReverseProcessConflicting_PartialStateRetryCompletes(t *testing.T) {
 	// Unmark counter.
 	mockStore.On("Get", mock.Anything, &counterHash, mock.Anything).
 		Return(&meta.Data{Tx: counterTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, counterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, counterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{counterHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 
@@ -256,8 +256,8 @@ func TestReverseProcessConflicting_DConflictingButParentStillPointsToD(t *testin
 		Return(nil).Once()
 	mockStore.On("Get", mock.Anything, &counterHash, mock.Anything).
 		Return(&meta.Data{Tx: counterTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, counterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, counterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{counterHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 
@@ -624,8 +624,8 @@ func TestReverseProcessConflicting_PicksOldestCounterByCreatedAt(t *testing.T) {
 	// Only the oldest counter gets the Spend + Unmark sequence.
 	mockStore.On("Get", mock.Anything, &oldestHash, mock.Anything).
 		Return(&meta.Data{Tx: oldestTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, oldestTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, oldestTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{oldestHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 
@@ -682,8 +682,8 @@ func TestReverseProcessConflicting_TiebreakOnEqualCreatedAtByHash(t *testing.T) 
 
 	mockStore.On("Get", mock.Anything, &lowerHashCounter, mock.Anything).
 		Return(&meta.Data{Tx: lowerCounterTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, lowerCounterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, lowerCounterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{lowerHashCounter}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, nil).Once()
 
@@ -928,8 +928,8 @@ func TestReverseProcessConflicting_CounterSpendErrorPropagates(t *testing.T) {
 
 	mockStore.On("Get", mock.Anything, &counterHash, mock.Anything).
 		Return(&meta.Data{Tx: counterTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, counterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, errors.NewProcessingError("spend failed")).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, counterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, errors.NewProcessingError("spend failed")).Once()
 
 	_, _, err := ReverseProcessConflicting(ctx, mockStore, 1, chainhash.Hash{}, []chainhash.Hash{demotedHash})
 
@@ -967,8 +967,8 @@ func TestReverseProcessConflicting_CounterUnmarkErrorPropagates(t *testing.T) {
 		Return(nil).Once()
 	mockStore.On("Get", mock.Anything, &counterHash, mock.Anything).
 		Return(&meta.Data{Tx: counterTx}, nil).Once()
-	mockStore.On("Spend", mock.Anything, counterTx, mock.Anything, mock.Anything).
-		Return([]*Spend{}, nil).Once()
+	mockStore.On("SpendAndCreate", mock.Anything, counterTx, mock.Anything, mock.Anything).
+		Return(nil, []*Spend{}, nil).Once()
 	mockStore.On("SetConflicting", mock.Anything, []chainhash.Hash{counterHash}, false).
 		Return([]*Spend{}, []chainhash.Hash{}, errors.NewProcessingError("unmark failed")).Once()
 

--- a/stores/utxo/spend_and_create.go
+++ b/stores/utxo/spend_and_create.go
@@ -14,9 +14,31 @@ import (
 // rollback attempts. A variable so tests can shorten it.
 var unspendRetryBackoffBase = time.Second
 
-// sequentialStore is the subset of a concrete store's methods needed by
-// SequentialSpendAndCreate.
-type sequentialStore interface {
+// ParseCreateOptions applies opts to a fresh CreateOptions and validates the
+// combination. Every Store implementation of SpendAndCreate should use this so
+// option validation stays identical across backends.
+//
+// Combinations that are ignored rather than rejected: with SpendOnly the
+// create-side fields (MinedBlockInfos, TxID, IsCoinbase, Frozen, Conflicting,
+// Locked, SkipExtendedInputs) are unused; with CreateOnly the IgnoreFlags are
+// unused.
+func ParseCreateOptions(opts ...CreateOption) (*CreateOptions, error) {
+	options := &CreateOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.CreateOnly && options.SpendOnly {
+		return nil, errors.NewInvalidArgumentError("SpendAndCreate: WithCreateOnly and WithSpendOnly are mutually exclusive")
+	}
+
+	return options, nil
+}
+
+// SequentialStore is the subset of a concrete store's methods needed by
+// SequentialSpendAndCreate. Out-of-tree backends that want the sequential
+// behaviour implement these three methods and delegate.
+type SequentialStore interface {
 	Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, error)
 	Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...IgnoreFlags) ([]*Spend, error)
 	Unspend(ctx context.Context, spends []*Spend, flagAsLocked ...bool) error
@@ -27,22 +49,20 @@ type sequentialStore interface {
 // spends back (with retries) when the create fails with anything other than
 // ErrTxExists. Concrete stores delegate to it until they implement SpendAndCreate
 // atomically (Postgres transactions, Aerospike-specific logic).
-func SequentialSpendAndCreate(ctx context.Context, logger ulogger.Logger, s sequentialStore,
+//
+// Returned spends: nil when the create failed and the rollback succeeded (the
+// spends are no longer in effect); the live spends when the create failed with
+// ErrTxExists or the rollback itself failed.
+func SequentialSpendAndCreate(ctx context.Context, logger ulogger.Logger, s SequentialStore,
 	tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error) {
-	options := &CreateOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	if options.CreateOnly && options.SpendOnly {
-		return nil, nil, errors.NewInvalidArgumentError("SpendAndCreate: WithCreateOnly and WithSpendOnly are mutually exclusive")
+	options, err := ParseCreateOptions(opts...)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var spends []*Spend
 
 	if !options.CreateOnly {
-		var err error
-
 		spends, err = s.Spend(ctx, tx, blockHeight, options.IgnoreFlags)
 		if err != nil {
 			return nil, spends, err
@@ -60,25 +80,35 @@ func SequentialSpendAndCreate(ctx context.Context, logger ulogger.Logger, s sequ
 			return nil, spends, err
 		}
 
-		if rollbackErr := unspendWithRetry(ctx, logger, s, spends); rollbackErr != nil {
-			return nil, spends, errors.NewProcessingError("SpendAndCreate: error reversing utxo spends: %v", rollbackErr, err)
+		if len(spends) > 0 {
+			if rollbackErr := unspendWithRetry(ctx, logger, s, spends); rollbackErr != nil {
+				return nil, spends, errors.NewProcessingError("SpendAndCreate: error reversing utxo spends: %v", rollbackErr, err)
+			}
 		}
 
-		return nil, spends, err
+		return nil, nil, err
 	}
 
 	return md, spends, nil
 }
 
 // unspendWithRetry reverses spends with up to 3 attempts and exponential backoff,
-// ported from the validator's reverseSpends.
-func unspendWithRetry(ctx context.Context, logger ulogger.Logger, s sequentialStore, spends []*Spend) error {
+// ported from the validator's reverseSpends. The backoff aborts early when ctx
+// is cancelled.
+func unspendWithRetry(ctx context.Context, logger ulogger.Logger, s SequentialStore, spends []*Spend) error {
 	for retries := uint(0); retries < 3; retries++ {
 		if errReset := s.Unspend(ctx, spends); errReset != nil {
 			if retries < 2 {
 				backoff := time.Duration(1<<retries) * unspendRetryBackoffBase
 				logger.Errorf("error resetting utxos, retrying in %s: %v", backoff.String(), errReset)
-				time.Sleep(backoff)
+
+				timer := time.NewTimer(backoff)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return errors.NewProcessingError("error resetting utxos, context cancelled during retry backoff", errors.Join(errReset, ctx.Err()))
+				case <-timer.C:
+				}
 			} else {
 				return errors.NewProcessingError("error resetting utxos", errReset)
 			}

--- a/stores/utxo/spend_and_create.go
+++ b/stores/utxo/spend_and_create.go
@@ -1,0 +1,91 @@
+package utxo
+
+import (
+	"context"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/ulogger"
+)
+
+// unspendRetryBackoffBase is the base delay for the exponential backoff between
+// rollback attempts. A variable so tests can shorten it.
+var unspendRetryBackoffBase = time.Second
+
+// sequentialStore is the subset of a concrete store's methods needed by
+// SequentialSpendAndCreate.
+type sequentialStore interface {
+	Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, error)
+	Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignoreFlags ...IgnoreFlags) ([]*Spend, error)
+	Unspend(ctx context.Context, spends []*Spend, flagAsLocked ...bool) error
+}
+
+// SequentialSpendAndCreate implements the Store.SpendAndCreate contract as the
+// original two-call sequence: spend the inputs, create the outputs, and roll the
+// spends back (with retries) when the create fails with anything other than
+// ErrTxExists. Concrete stores delegate to it until they implement SpendAndCreate
+// atomically (Postgres transactions, Aerospike-specific logic).
+func SequentialSpendAndCreate(ctx context.Context, logger ulogger.Logger, s sequentialStore,
+	tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error) {
+	options := &CreateOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.CreateOnly && options.SpendOnly {
+		return nil, nil, errors.NewInvalidArgumentError("SpendAndCreate: WithCreateOnly and WithSpendOnly are mutually exclusive")
+	}
+
+	var spends []*Spend
+
+	if !options.CreateOnly {
+		var err error
+
+		spends, err = s.Spend(ctx, tx, blockHeight, options.IgnoreFlags)
+		if err != nil {
+			return nil, spends, err
+		}
+
+		if options.SpendOnly {
+			return nil, spends, nil
+		}
+	}
+
+	md, err := s.Create(ctx, tx, blockHeight, opts...)
+	if err != nil {
+		if errors.Is(err, errors.ErrTxExists) {
+			// the tx already exists; leave the spends in place for the caller to decide
+			return nil, spends, err
+		}
+
+		if rollbackErr := unspendWithRetry(ctx, logger, s, spends); rollbackErr != nil {
+			return nil, spends, errors.NewProcessingError("SpendAndCreate: error reversing utxo spends: %v", rollbackErr, err)
+		}
+
+		return nil, spends, err
+	}
+
+	return md, spends, nil
+}
+
+// unspendWithRetry reverses spends with up to 3 attempts and exponential backoff,
+// ported from the validator's reverseSpends.
+func unspendWithRetry(ctx context.Context, logger ulogger.Logger, s sequentialStore, spends []*Spend) error {
+	for retries := uint(0); retries < 3; retries++ {
+		if errReset := s.Unspend(ctx, spends); errReset != nil {
+			if retries < 2 {
+				backoff := time.Duration(1<<retries) * unspendRetryBackoffBase
+				logger.Errorf("error resetting utxos, retrying in %s: %v", backoff.String(), errReset)
+				time.Sleep(backoff)
+			} else {
+				return errors.NewProcessingError("error resetting utxos", errReset)
+			}
+		} else {
+			break
+		}
+	}
+
+	return nil
+}

--- a/stores/utxo/spend_and_create_test.go
+++ b/stores/utxo/spend_and_create_test.go
@@ -1,0 +1,204 @@
+package utxo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSequentialStore struct {
+	spends     []*Spend
+	spendErr   error
+	createMeta *meta.Data
+	createErr  error
+	// unspendErrs is popped once per Unspend call; nil result when exhausted.
+	unspendErrs []error
+
+	spendCalls   int
+	createCalls  int
+	unspendCalls int
+	unspentWith  []*Spend
+	spendFlags   []IgnoreFlags
+}
+
+func (f *fakeSequentialStore) Spend(_ context.Context, _ *bt.Tx, _ uint32, ignoreFlags ...IgnoreFlags) ([]*Spend, error) {
+	f.spendCalls++
+	f.spendFlags = ignoreFlags
+
+	return f.spends, f.spendErr
+}
+
+func (f *fakeSequentialStore) Create(_ context.Context, _ *bt.Tx, _ uint32, _ ...CreateOption) (*meta.Data, error) {
+	f.createCalls++
+
+	return f.createMeta, f.createErr
+}
+
+func (f *fakeSequentialStore) Unspend(_ context.Context, spends []*Spend, _ ...bool) error {
+	f.unspendCalls++
+	f.unspentWith = spends
+
+	if len(f.unspendErrs) > 0 {
+		err := f.unspendErrs[0]
+		f.unspendErrs = f.unspendErrs[1:]
+
+		return err
+	}
+
+	return nil
+}
+
+func shortenUnspendBackoff(t *testing.T) {
+	t.Helper()
+
+	orig := unspendRetryBackoffBase
+	unspendRetryBackoffBase = time.Millisecond
+
+	t.Cleanup(func() { unspendRetryBackoffBase = orig })
+}
+
+func TestSequentialSpendAndCreate(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tx := bt.NewTx()
+
+	t.Run("happy path spends then creates", func(t *testing.T) {
+		f := &fakeSequentialStore{
+			spends:     []*Spend{{}},
+			createMeta: &meta.Data{},
+		}
+
+		md, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		require.NoError(t, err)
+		require.Same(t, f.createMeta, md)
+		require.Len(t, spends, 1)
+		require.Equal(t, 1, f.spendCalls)
+		require.Equal(t, 1, f.createCalls)
+		require.Equal(t, 0, f.unspendCalls)
+	})
+
+	t.Run("ignore flags are passed to the spend phase", func(t *testing.T) {
+		f := &fakeSequentialStore{createMeta: &meta.Data{}}
+
+		_, _, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100,
+			WithIgnoreLocked(true), WithSkipUTXOHashCheck(true))
+		require.NoError(t, err)
+		require.Len(t, f.spendFlags, 1)
+		require.True(t, f.spendFlags[0].IgnoreLocked)
+		require.True(t, f.spendFlags[0].SkipUTXOHashCheck)
+		require.False(t, f.spendFlags[0].IgnoreConflicting)
+	})
+
+	t.Run("spend failure returns per-input spends and skips create", func(t *testing.T) {
+		spendErr := errors.NewUtxoError("boom")
+		f := &fakeSequentialStore{
+			spends:   []*Spend{{Err: errors.ErrSpent}},
+			spendErr: spendErr,
+		}
+
+		md, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		require.ErrorIs(t, err, errors.ErrUtxoError)
+		require.Nil(t, md)
+		require.Len(t, spends, 1)
+		require.Equal(t, 0, f.createCalls)
+		require.Equal(t, 0, f.unspendCalls)
+	})
+
+	t.Run("create failure rolls back the spends", func(t *testing.T) {
+		f := &fakeSequentialStore{
+			spends:    []*Spend{{}, {}},
+			createErr: errors.NewProcessingError("create blew up"),
+		}
+
+		md, _, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		require.ErrorIs(t, err, errors.ErrProcessing)
+		require.Nil(t, md)
+		require.Equal(t, 1, f.unspendCalls)
+		require.Same(t, f.spends[0], f.unspentWith[0])
+		require.Len(t, f.unspentWith, 2)
+	})
+
+	t.Run("create ErrTxExists keeps the spends in place", func(t *testing.T) {
+		f := &fakeSequentialStore{
+			spends:    []*Spend{{}},
+			createErr: errors.NewTxExistsError("already there"),
+		}
+
+		md, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		require.ErrorIs(t, err, errors.ErrTxExists)
+		require.Nil(t, md)
+		require.Len(t, spends, 1)
+		require.Equal(t, 0, f.unspendCalls)
+	})
+
+	t.Run("rollback retries transient unspend failures", func(t *testing.T) {
+		shortenUnspendBackoff(t)
+
+		f := &fakeSequentialStore{
+			spends:      []*Spend{{}},
+			createErr:   errors.NewProcessingError("create blew up"),
+			unspendErrs: []error{errors.NewStorageError("t1"), errors.NewStorageError("t2")},
+		}
+
+		_, _, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		require.ErrorIs(t, err, errors.ErrProcessing)
+		require.Equal(t, 3, f.unspendCalls)
+	})
+
+	t.Run("rollback failure after all retries is reported with the create error", func(t *testing.T) {
+		shortenUnspendBackoff(t)
+
+		f := &fakeSequentialStore{
+			spends:    []*Spend{{}},
+			createErr: errors.NewProcessingError("create blew up"),
+			unspendErrs: []error{
+				errors.NewStorageError("u1"),
+				errors.NewStorageError("u2"),
+				errors.NewStorageError("u3"),
+			},
+		}
+
+		_, _, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		require.Error(t, err)
+		require.Equal(t, 3, f.unspendCalls)
+		require.Contains(t, err.Error(), "create blew up")
+		require.Contains(t, err.Error(), "u3")
+	})
+
+	t.Run("create only skips the spend phase", func(t *testing.T) {
+		f := &fakeSequentialStore{createMeta: &meta.Data{}}
+
+		md, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100, WithCreateOnly())
+		require.NoError(t, err)
+		require.Same(t, f.createMeta, md)
+		require.Nil(t, spends)
+		require.Equal(t, 0, f.spendCalls)
+		require.Equal(t, 1, f.createCalls)
+	})
+
+	t.Run("spend only skips the create phase", func(t *testing.T) {
+		f := &fakeSequentialStore{spends: []*Spend{{}}}
+
+		md, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100, WithSpendOnly())
+		require.NoError(t, err)
+		require.Nil(t, md)
+		require.Len(t, spends, 1)
+		require.Equal(t, 1, f.spendCalls)
+		require.Equal(t, 0, f.createCalls)
+	})
+
+	t.Run("create only and spend only together are rejected", func(t *testing.T) {
+		f := &fakeSequentialStore{}
+
+		_, _, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100, WithCreateOnly(), WithSpendOnly())
+		require.ErrorIs(t, err, errors.ErrInvalidArgument)
+		require.Equal(t, 0, f.spendCalls)
+		require.Equal(t, 0, f.createCalls)
+	})
+}

--- a/stores/utxo/spend_and_create_test.go
+++ b/stores/utxo/spend_and_create_test.go
@@ -116,12 +116,41 @@ func TestSequentialSpendAndCreate(t *testing.T) {
 			createErr: errors.NewProcessingError("create blew up"),
 		}
 
-		md, _, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
+		md, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100)
 		require.ErrorIs(t, err, errors.ErrProcessing)
 		require.Nil(t, md)
+		require.Nil(t, spends, "rolled-back spends must not be returned as live")
 		require.Equal(t, 1, f.unspendCalls)
 		require.Same(t, f.spends[0], f.unspentWith[0])
 		require.Len(t, f.unspentWith, 2)
+	})
+
+	t.Run("create-only create failure never touches Unspend", func(t *testing.T) {
+		f := &fakeSequentialStore{
+			createErr: errors.NewProcessingError("create blew up"),
+		}
+
+		_, spends, err := SequentialSpendAndCreate(ctx, logger, f, tx, 100, WithCreateOnly())
+		require.ErrorIs(t, err, errors.ErrProcessing)
+		require.Nil(t, spends)
+		require.Equal(t, 0, f.spendCalls)
+		require.Equal(t, 0, f.unspendCalls)
+	})
+
+	t.Run("rollback backoff aborts when the context is cancelled", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		f := &fakeSequentialStore{
+			spends:      []*Spend{{}},
+			createErr:   errors.NewProcessingError("create blew up"),
+			unspendErrs: []error{errors.NewStorageError("t1")},
+		}
+
+		_, _, err := SequentialSpendAndCreate(cancelledCtx, logger, f, tx, 100)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context cancelled")
+		require.Equal(t, 1, f.unspendCalls)
 	})
 
 	t.Run("create ErrTxExists keeps the spends in place", func(t *testing.T) {

--- a/stores/utxo/sql/spend_and_create.go
+++ b/stores/utxo/sql/spend_and_create.go
@@ -1,0 +1,16 @@
+package sql
+
+import (
+	"context"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+)
+
+// SpendAndCreate implements utxo.Store. It delegates to the shared sequential
+// implementation; an atomic implementation using a database transaction is a
+// followup.
+func (s *Store) SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...utxo.CreateOption) (*meta.Data, []*utxo.Spend, error) {
+	return utxo.SequentialSpendAndCreate(ctx, s.logger, s, tx, blockHeight, opts...)
+}

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -1071,6 +1071,60 @@ func Test_SmokeTests(t *testing.T) {
 		tests.SpendIdempotent(t, db)
 	})
 
+	t.Run("spend and create", func(t *testing.T) {
+		db, _ := setup(ctx, t)
+
+		err := db.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreate(t, db)
+	})
+
+	t.Run("spend and create create only", func(t *testing.T) {
+		db, _ := setup(ctx, t)
+
+		err := db.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateCreateOnly(t, db)
+	})
+
+	t.Run("spend and create spend only", func(t *testing.T) {
+		db, _ := setup(ctx, t)
+
+		err := db.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateSpendOnly(t, db)
+	})
+
+	t.Run("spend and create tx exists keeps spends", func(t *testing.T) {
+		db, _ := setup(ctx, t)
+
+		err := db.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateTxExistsKeepsSpends(t, db)
+	})
+
+	t.Run("spend and create spend error surfaces per input", func(t *testing.T) {
+		db, _ := setup(ctx, t)
+
+		err := db.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateSpendErrorSurfacesPerInput(t, db)
+	})
+
+	t.Run("spend and create invalid options", func(t *testing.T) {
+		db, _ := setup(ctx, t)
+
+		err := db.Delete(ctx, tests.TXHash)
+		require.NoError(t, err)
+
+		tests.SpendAndCreateInvalidOptions(t, db)
+	})
+
 	t.Run("set mined with spent", func(t *testing.T) {
 		db, _ := setup(ctx, t)
 

--- a/stores/utxo/tests/getandlockchildren_test.go
+++ b/stores/utxo/tests/getandlockchildren_test.go
@@ -75,7 +75,7 @@ func TestGetAndLockChildren(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the transaction in store
-		_, err = store.Create(ctx, tx, 1)
+		_, _, err = store.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		txHash := *tx.TxIDChainHash()
@@ -113,14 +113,14 @@ func TestGetAndLockChildren(t *testing.T) {
 		childTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 
 		// Create both transactions in store
-		_, err = store.Create(ctx, parentTx, 1)
+		_, _, err = store.SpendAndCreate(ctx, parentTx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = store.Create(ctx, childTx, 1)
+		_, _, err = store.SpendAndCreate(ctx, childTx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Spend the parent's output with child transaction
-		_, err = store.Spend(ctx, childTx, store.GetBlockHeight()+1, utxo.IgnoreFlags{})
+		_, _, err = store.SpendAndCreate(ctx, childTx, store.GetBlockHeight()+1, utxo.WithSpendOnly())
 		require.NoError(t, err)
 
 		parentHash := *parentTx.TxIDChainHash()
@@ -180,21 +180,21 @@ func TestGetAndLockChildren(t *testing.T) {
 		grandchildTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
 
 		// Create all transactions in store
-		_, err = store.Create(ctx, parentTx, 1)
+		_, _, err = store.SpendAndCreate(ctx, parentTx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
-		_, err = store.Create(ctx, child1Tx, 1)
+		_, _, err = store.SpendAndCreate(ctx, child1Tx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
-		_, err = store.Create(ctx, child2Tx, 1)
+		_, _, err = store.SpendAndCreate(ctx, child2Tx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
-		_, err = store.Create(ctx, grandchildTx, 1)
+		_, _, err = store.SpendAndCreate(ctx, grandchildTx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		// Spend outputs to establish parent-child relationships
-		_, err = store.Spend(ctx, child1Tx, store.GetBlockHeight()+1, utxo.IgnoreFlags{})
+		_, _, err = store.SpendAndCreate(ctx, child1Tx, store.GetBlockHeight()+1, utxo.WithSpendOnly())
 		require.NoError(t, err)
-		_, err = store.Spend(ctx, child2Tx, store.GetBlockHeight()+1, utxo.IgnoreFlags{})
+		_, _, err = store.SpendAndCreate(ctx, child2Tx, store.GetBlockHeight()+1, utxo.WithSpendOnly())
 		require.NoError(t, err)
-		_, err = store.Spend(ctx, grandchildTx, store.GetBlockHeight()+1, utxo.IgnoreFlags{})
+		_, _, err = store.SpendAndCreate(ctx, grandchildTx, store.GetBlockHeight()+1, utxo.WithSpendOnly())
 		require.NoError(t, err)
 
 		parentHash := *parentTx.TxIDChainHash()
@@ -244,7 +244,7 @@ func TestGetAndLockChildren(t *testing.T) {
 			"2f6b52de3d7c88ac00000000")
 		require.NoError(t, err)
 
-		_, err = store.Create(ctx, tx, 1)
+		_, _, err = store.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		txHash := *tx.TxIDChainHash()
@@ -271,7 +271,7 @@ func TestGetAndLockChildren(t *testing.T) {
 			"2f6b52de3d7c88ac00000000")
 		require.NoError(t, err)
 
-		_, err = store.Create(ctx, tx, 1)
+		_, _, err = store.SpendAndCreate(ctx, tx, 1, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		txHash := *tx.TxIDChainHash()

--- a/stores/utxo/tests/pruner_unmined_test.go
+++ b/stores/utxo/tests/pruner_unmined_test.go
@@ -109,7 +109,7 @@ func TestStoreAgnosticPreserveParentsOfOldUnminedTransactions(t *testing.T) {
 				height := storedHeights[i]
 
 				// Create unmined transaction by not specifying block info
-				_, err := store.Create(ctx, tx, height) // unmined_since will be set to the block height parameter
+				_, _, err := store.SpendAndCreate(ctx, tx, height, utxo.WithCreateOnly()) // unmined_since will be set to the block height parameter
 				require.NoError(t, err, "Failed to create transaction %d at height %d", i, height)
 			}
 
@@ -203,7 +203,7 @@ func TestStoreAgnosticPreserveParentsOfOldUnminedTransactions_EdgeCases(t *testi
 				// Store at heights 8, 9, 10 (current height 10, cutoff would be 5)
 				for i, tx := range testTxs {
 					height := uint32(8 + i) //nolint:gosec // i is limited to 0-2 by testTxs slice
-					_, err := store.Create(ctx, tx, height)
+					_, _, err := store.SpendAndCreate(ctx, tx, height, utxo.WithCreateOnly())
 					require.NoError(t, err)
 				}
 
@@ -237,7 +237,7 @@ func TestStoreAgnosticQueryOldUnminedTransactions(t *testing.T) {
 
 			// Store transactions with different heights
 			for i, tx := range testTxs {
-				_, err := store.Create(ctx, tx, storedHeights[i])
+				_, _, err := store.SpendAndCreate(ctx, tx, storedHeights[i], utxo.WithCreateOnly())
 				require.NoError(t, err)
 			}
 
@@ -285,19 +285,19 @@ func TestCleanupWithMixedTransactionTypes(t *testing.T) {
 
 			// Create transactions with different states:
 			// 1. Old unmined transaction (should be deleted)
-			_, err := store.Create(ctx, testTxs[0], 2) // unmined, stored at height 2
+			_, _, err := store.SpendAndCreate(ctx, testTxs[0], 2, utxo.WithCreateOnly()) // unmined, stored at height 2
 			require.NoError(t, err)
 
 			// 2. Recent unmined transaction (should remain)
-			_, err = store.Create(ctx, testTxs[1], 8) // unmined, stored at height 8
+			_, _, err = store.SpendAndCreate(ctx, testTxs[1], 8, utxo.WithCreateOnly()) // unmined, stored at height 8
 			require.NoError(t, err)
 
 			// 3. Old mined transaction (should remain - mined transactions are not cleaned)
-			_, err = store.Create(ctx, testTxs[2], 2, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 1, BlockHeight: 2}))
+			_, _, err = store.SpendAndCreate(ctx, testTxs[2], 2, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 1, BlockHeight: 2}), utxo.WithCreateOnly())
 			require.NoError(t, err)
 
 			// 4. Recent mined transaction (should remain)
-			_, err = store.Create(ctx, testTxs[3], 8, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 2, BlockHeight: 8}))
+			_, _, err = store.SpendAndCreate(ctx, testTxs[3], 8, utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{BlockID: 2, BlockHeight: 8}), utxo.WithCreateOnly())
 			require.NoError(t, err)
 
 			// Verify initial state

--- a/stores/utxo/tests/tests.go
+++ b/stores/utxo/tests/tests.go
@@ -100,14 +100,14 @@ func Store(t *testing.T, db utxostore.Store) {
 	require.Equal(t, testSpend0.TxID.String(), resp.Tx.TxID())
 
 	_, _, err = db.SpendAndCreate(context.Background(), Tx, 1000, utxostore.WithCreateOnly())
-	require.Error(t, err, errors.ErrTxExists)
+	require.ErrorIs(t, err, errors.ErrTxExists)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
 	_, _, err = db.SpendAndCreate(context.Background(), spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	_, _, err = db.SpendAndCreate(context.Background(), Tx, 1000, utxostore.WithCreateOnly())
-	require.Error(t, err, errors.ErrSpent)
+	require.ErrorIs(t, err, errors.ErrTxExists)
 }
 
 func Spend(t *testing.T, db utxostore.Store) {

--- a/stores/utxo/tests/tests.go
+++ b/stores/utxo/tests/tests.go
@@ -92,32 +92,32 @@ var (
 func Store(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 
-	_, err := db.Create(ctx, Tx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	resp, err := db.Get(ctx, testSpend0.TxID)
 	require.NoError(t, err)
 	require.Equal(t, testSpend0.TxID.String(), resp.Tx.TxID())
 
-	_, err = db.Create(context.Background(), Tx, 1000)
+	_, _, err = db.SpendAndCreate(context.Background(), Tx, 1000, utxostore.WithCreateOnly())
 	require.Error(t, err, errors.ErrTxExists)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
-	_, err = db.Spend(context.Background(), spendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(context.Background(), spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
-	_, err = db.Create(context.Background(), Tx, 1000)
+	_, _, err = db.SpendAndCreate(context.Background(), Tx, 1000, utxostore.WithCreateOnly())
 	require.Error(t, err, errors.ErrSpent)
 }
 
 func Spend(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 
-	_, err := db.Create(ctx, Tx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
-	_, err = db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	resp, err := db.Get(ctx, Tx.TxIDChainHash())
@@ -128,7 +128,7 @@ func Spend(t *testing.T, db utxostore.Store) {
 	spendTx2.Outputs = spendTx2.Outputs[1:]
 
 	// try to spend with different txid
-	spends, err := db.Spend(context.Background(), spendTx2, db.GetBlockHeight()+1)
+	_, spends, err := db.SpendAndCreate(context.Background(), spendTx2, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.ErrorIs(t, err, errors.ErrUtxoError)
 
 	// check the individual spend error
@@ -139,11 +139,11 @@ func Spend(t *testing.T, db utxostore.Store) {
 func Restore(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 
-	_, err := db.Create(ctx, Tx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
-	_, err = db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	// Build the unspend record with the SpendingData GetSpends populated inside Spend(spendTx).
@@ -170,12 +170,12 @@ func Restore(t *testing.T, db utxostore.Store) {
 func UnspendIdempotent(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 
-	_, err := db.Create(ctx, Tx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, Tx.TxIDChainHash()) }()
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
-	_, err = db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	restoreSpends := []*utxostore.Spend{{
@@ -202,14 +202,14 @@ func Freeze(t *testing.T, db utxostore.Store) {
 
 	tSettings := test.CreateBaseTestSettings(t)
 
-	_, err := db.Create(ctx, Tx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	err = db.FreezeUTXOs(ctx, spends, tSettings)
 	require.NoError(t, err)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
-	spends, err := db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, spends, err := db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.ErrorIs(t, err, errors.ErrUtxoError)
 	require.ErrorIs(t, spends[0].Err, errors.ErrFrozen)
 
@@ -228,7 +228,7 @@ func Freeze(t *testing.T, db utxostore.Store) {
 	require.Equal(t, int(utxostore.Status_OK), resp.Status)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
-	_, err = db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	resp, err = db.GetSpend(ctx, testSpend0)
@@ -249,7 +249,7 @@ func ReAssign(t *testing.T, db utxostore.Store) {
 	err := db.SetBlockHeight(101)
 	require.NoError(t, err)
 
-	_, err = db.Create(ctx, Tx, 0)
+	_, _, err = db.SpendAndCreate(ctx, Tx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
@@ -300,18 +300,18 @@ func ReAssign(t *testing.T, db utxostore.Store) {
 	require.Nil(t, resp.SpendingData)
 
 	// try to spend the old utxo, should fail
-	_, err = db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.Error(t, err)
 
 	// try to spend the new utxo, should fail, block height not reached
-	_, err = db.Spend(ctx, spendTx2, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx2, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.Error(t, err)
 
 	err = db.SetBlockHeight(1101)
 	require.NoError(t, err)
 
 	// try to spend the new utxo, should succeed
-	_, err = db.Spend(ctx, spendTx2, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, spendTx2, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 }
 
@@ -321,7 +321,7 @@ func SetMined(t *testing.T, db utxostore.Store) {
 	err := db.SetBlockHeight(101)
 	require.NoError(t, err)
 
-	_, err = db.Create(ctx, Tx, 0)
+	_, _, err = db.SpendAndCreate(ctx, Tx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	blockIDsMap, err := db.SetMinedMulti(ctx, []*chainhash.Hash{TXHash}, utxostore.MinedBlockInfo{BlockID: 123, BlockHeight: 101, SubtreeIdx: 2})
@@ -364,15 +364,15 @@ func SetMined(t *testing.T, db utxostore.Store) {
 func Conflicting(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 
-	_, err := db.Create(ctx, ParentTx, 999)
+	_, _, err := db.SpendAndCreate(ctx, ParentTx, 999, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
-	_, err = db.Create(ctx, Tx, 1000, utxostore.WithConflicting(true))
+	_, _, err = db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithConflicting(true), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 
 	_ = spendTx.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
 
-	spends, err := db.Spend(ctx, spendTx, db.GetBlockHeight()+1)
+	_, spends, err := db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.ErrorIs(t, err, errors.ErrUtxoError)
 	require.ErrorIs(t, spends[0].Err, errors.ErrTxConflicting)
 
@@ -546,8 +546,6 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 	require.NoError(t, db.SetBlockHeight(20))
 
-	ignoreFlags := utxostore.IgnoreFlags{IgnoreConflicting: true, IgnoreLocked: true}
-
 	// --- Forward: ProcessConflicting end-state is winner=non-conflicting,
 	// loser=conflicting, parent[0] spent by winner, parent unlocked. ---
 	forwardCases := []struct {
@@ -559,7 +557,7 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 			name: "forward_after_step1_mark", seed: 0x31,
 			// losers marked, parent[0] still -> L, unlocked.
 			build: func(t *testing.T, parent, txW, txL *bt.Tx) {
-				_, err := db.Spend(ctx, txL, db.GetBlockHeight()+1)
+				_, _, err := db.SpendAndCreate(ctx, txL, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 				require.NoError(t, err)
 				_, _, err = db.SetConflicting(ctx, []chainhash.Hash{*txW.TxIDChainHash(), *txL.TxIDChainHash()}, true)
 				require.NoError(t, err)
@@ -580,7 +578,7 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 			build: func(t *testing.T, parent, txW, txL *bt.Tx) {
 				_, _, err := db.SetConflicting(ctx, []chainhash.Hash{*txW.TxIDChainHash(), *txL.TxIDChainHash()}, true)
 				require.NoError(t, err)
-				_, err = db.Spend(ctx, txW, db.GetBlockHeight()+1, ignoreFlags)
+				_, _, err = db.SpendAndCreate(ctx, txW, db.GetBlockHeight()+1, utxostore.WithSpendOnly(), utxostore.WithIgnoreConflicting(true), utxostore.WithIgnoreLocked(true))
 				require.NoError(t, err)
 				require.NoError(t, db.SetLocked(ctx, []chainhash.Hash{*parent.TxIDChainHash()}, true))
 			},
@@ -591,7 +589,7 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 			build: func(t *testing.T, parent, txW, txL *bt.Tx) {
 				_, _, err := db.SetConflicting(ctx, []chainhash.Hash{*txL.TxIDChainHash()}, true)
 				require.NoError(t, err)
-				_, err = db.Spend(ctx, txW, db.GetBlockHeight()+1, ignoreFlags)
+				_, _, err = db.SpendAndCreate(ctx, txW, db.GetBlockHeight()+1, utxostore.WithSpendOnly(), utxostore.WithIgnoreConflicting(true), utxostore.WithIgnoreLocked(true))
 				require.NoError(t, err)
 				require.NoError(t, db.SetLocked(ctx, []chainhash.Hash{*parent.TxIDChainHash()}, true))
 			},
@@ -601,16 +599,16 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 	for _, tc := range forwardCases {
 		t.Run(tc.name, func(t *testing.T) {
 			parent := crashParentTx(tc.seed)
-			_, err := db.Create(ctx, parent, 1)
+			_, _, err := db.SpendAndCreate(ctx, parent, 1, utxostore.WithCreateOnly())
 			require.NoError(t, err)
 			require.NoError(t, db.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*parent.TxIDChainHash()}, true))
 
 			txL := crashSpendTx(t, parent, 90000)
-			_, err = db.Create(ctx, txL, db.GetBlockHeight())
+			_, _, err = db.SpendAndCreate(ctx, txL, db.GetBlockHeight(), utxostore.WithCreateOnly())
 			require.NoError(t, err)
 
 			txW := crashSpendTx(t, parent, 80000)
-			_, err = db.Create(ctx, txW, db.GetBlockHeight(), utxostore.WithConflicting(true))
+			_, _, err = db.SpendAndCreate(ctx, txW, db.GetBlockHeight(), utxostore.WithConflicting(true), utxostore.WithCreateOnly())
 			require.NoError(t, err)
 
 			tc.build(t, parent, txW, txL)
@@ -646,7 +644,7 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 			build: func(t *testing.T, parent, txD, txC *bt.Tx) {
 				_, _, err := db.SetConflicting(ctx, []chainhash.Hash{*txD.TxIDChainHash()}, true)
 				require.NoError(t, err)
-				_, err = db.Spend(ctx, txD, db.GetBlockHeight()+1, ignoreFlags)
+				_, _, err = db.SpendAndCreate(ctx, txD, db.GetBlockHeight()+1, utxostore.WithSpendOnly(), utxostore.WithIgnoreConflicting(true), utxostore.WithIgnoreLocked(true))
 				require.NoError(t, err)
 			},
 		},
@@ -664,7 +662,7 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 			build: func(t *testing.T, parent, txD, txC *bt.Tx) {
 				_, _, err := db.SetConflicting(ctx, []chainhash.Hash{*txD.TxIDChainHash()}, true)
 				require.NoError(t, err)
-				_, err = db.Spend(ctx, txC, db.GetBlockHeight()+1, ignoreFlags)
+				_, _, err = db.SpendAndCreate(ctx, txC, db.GetBlockHeight()+1, utxostore.WithSpendOnly(), utxostore.WithIgnoreConflicting(true), utxostore.WithIgnoreLocked(true))
 				require.NoError(t, err)
 			},
 		},
@@ -673,18 +671,18 @@ func ConflictWALCrashRecovery(t *testing.T, db utxostore.Store) {
 	for _, tc := range reverseCases {
 		t.Run(tc.name, func(t *testing.T) {
 			parent := crashParentTx(tc.seed)
-			_, err := db.Create(ctx, parent, 1)
+			_, _, err := db.SpendAndCreate(ctx, parent, 1, utxostore.WithCreateOnly())
 			require.NoError(t, err)
 			require.NoError(t, db.MarkTransactionsOnLongestChain(ctx, []chainhash.Hash{*parent.TxIDChainHash()}, true))
 
 			// C: counter / original spender — conflicting + in parent.ConflictingChildren.
 			txC := crashSpendTx(t, parent, 80000)
-			_, err = db.Create(ctx, txC, db.GetBlockHeight(), utxostore.WithConflicting(true))
+			_, _, err = db.SpendAndCreate(ctx, txC, db.GetBlockHeight(), utxostore.WithConflicting(true), utxostore.WithCreateOnly())
 			require.NoError(t, err)
 
 			// D: the demoted winner.
 			txD := crashSpendTx(t, parent, 90000)
-			_, err = db.Create(ctx, txD, db.GetBlockHeight())
+			_, _, err = db.SpendAndCreate(ctx, txD, db.GetBlockHeight(), utxostore.WithCreateOnly())
 			require.NoError(t, err)
 
 			tc.build(t, parent, txD, txC)
@@ -728,7 +726,7 @@ func Sanity(t *testing.T, db utxostore.Store) {
 		err = stx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", i+2_000_000)
 		require.NoError(t, err)
 
-		_, err = db.Create(ctx, stx, 100)
+		_, _, err = db.SpendAndCreate(ctx, stx, 100, utxostore.WithCreateOnly())
 		require.NoError(t, err)
 
 		// create spending tx
@@ -737,7 +735,7 @@ func Sanity(t *testing.T, db utxostore.Store) {
 		require.NoError(t, spentTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", i))
 		require.NoError(t, spentTx.ChangeToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", &bt.FeeQuote{}))
 
-		_, err = db.Spend(ctx, spentTx, db.GetBlockHeight()+1)
+		_, _, err = db.SpendAndCreate(ctx, spentTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		require.NoError(t, err)
 
 		txs = append(txs, stx)
@@ -774,12 +772,12 @@ func Benchmark(b *testing.B, db utxostore.Store) {
 	_ = spentTx.ChangeToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", &bt.FeeQuote{})
 
 	for i := 0; i < b.N; i++ {
-		_, err := db.Create(ctx, Tx, 100)
+		_, _, err := db.SpendAndCreate(ctx, Tx, 100, utxostore.WithCreateOnly())
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		spends, err = db.Spend(ctx, spentTx, db.GetBlockHeight()+1)
+		_, spends, err = db.SpendAndCreate(ctx, spentTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -815,7 +813,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		require.NoError(t, nonExistentSpendTx.From(nonExistentHash.String(), 0, Tx.Outputs[0].LockingScript.String(), Tx.Outputs[0].Satoshis))
 		require.NoError(t, nonExistentSpendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-		resultSpends, err := db.Spend(ctx, nonExistentSpendTx, db.GetBlockHeight()+1)
+		_, resultSpends, err := db.SpendAndCreate(ctx, nonExistentSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		require.Error(t, err)
 		require.ErrorIs(t, err, errors.ErrUtxoError)
 		require.NotEmpty(t, resultSpends)
@@ -826,7 +824,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		// Create a unique tx for this sub-test
 		uniqueTx := newTestTx(t, 3_000_000)
 
-		_, err := db.Create(ctx, uniqueTx, 1000)
+		_, _, err := db.SpendAndCreate(ctx, uniqueTx, 1000, utxostore.WithCreateOnly())
 		require.NoError(t, err)
 		defer func() { _ = db.Delete(ctx, uniqueTx.TxIDChainHash()) }()
 
@@ -840,7 +838,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		))
 		require.NoError(t, tamperedSpendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-		resultSpends, err := db.Spend(ctx, tamperedSpendTx, db.GetBlockHeight()+1)
+		_, resultSpends, err := db.SpendAndCreate(ctx, tamperedSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		require.Error(t, err)
 		require.ErrorIs(t, err, errors.ErrUtxoError)
 		require.NotEmpty(t, resultSpends)
@@ -861,7 +859,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		coinbaseTx.Inputs = []*bt.Input{coinbaseInput}
 		require.NoError(t, coinbaseTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 5_000_000_000))
 
-		_, err := db.Create(ctx, coinbaseTx, 1000, utxostore.WithSetCoinbase(true))
+		_, _, err := db.SpendAndCreate(ctx, coinbaseTx, 1000, utxostore.WithSetCoinbase(true), utxostore.WithCreateOnly())
 		require.NoError(t, err)
 		defer func() { _ = db.Delete(ctx, coinbaseTx.TxIDChainHash()) }()
 
@@ -876,7 +874,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		))
 		require.NoError(t, coinbaseSpendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-		resultSpends, err := db.Spend(ctx, coinbaseSpendTx, 1000)
+		_, resultSpends, err := db.SpendAndCreate(ctx, coinbaseSpendTx, 1000, utxostore.WithSpendOnly())
 		require.Error(t, err)
 		require.ErrorIs(t, err, errors.ErrUtxoError)
 		require.NotEmpty(t, resultSpends)
@@ -888,7 +886,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		// Create a unique tx for this sub-test using a fresh transaction
 		uniqueTx := newTestTx(t, 5_000_000)
 
-		_, err := db.Create(ctx, uniqueTx, 1000)
+		_, _, err := db.SpendAndCreate(ctx, uniqueTx, 1000, utxostore.WithCreateOnly())
 		require.NoError(t, err)
 		defer func() { _ = db.Delete(ctx, uniqueTx.TxIDChainHash()) }()
 
@@ -901,7 +899,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		))
 		require.NoError(t, spendTx1.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-		_, err = db.Spend(ctx, spendTx1, db.GetBlockHeight()+1)
+		_, _, err = db.SpendAndCreate(ctx, spendTx1, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		require.NoError(t, err)
 
 		// Second spend with a DIFFERENT spending tx → double spend
@@ -913,7 +911,7 @@ func SpendErrorTypes(t *testing.T, db utxostore.Store) {
 		))
 		require.NoError(t, spendTx2.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 2000)) // different amount → different txid
 
-		resultSpends, err := db.Spend(ctx, spendTx2, db.GetBlockHeight()+1)
+		_, resultSpends, err := db.SpendAndCreate(ctx, spendTx2, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		require.Error(t, err)
 		require.ErrorIs(t, err, errors.ErrUtxoError)
 		require.NotEmpty(t, resultSpends)
@@ -961,7 +959,7 @@ func SetLockedBehavior(t *testing.T, db utxostore.Store) {
 	// Create a unique tx for this test
 	uniqueTx := newTestTx(t, 6_000_000)
 
-	_, err := db.Create(ctx, uniqueTx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, uniqueTx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, uniqueTx.TxIDChainHash()) }()
 
@@ -998,7 +996,7 @@ func SetLockedBehavior(t *testing.T, db utxostore.Store) {
 	))
 	require.NoError(t, lockedSpendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-	resultSpends, err := db.Spend(ctx, lockedSpendTx, db.GetBlockHeight()+1)
+	_, resultSpends, err := db.SpendAndCreate(ctx, lockedSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.Error(t, err)
 	require.ErrorIs(t, err, errors.ErrUtxoError)
 	require.NotEmpty(t, resultSpends)
@@ -1014,7 +1012,7 @@ func SetLockedBehavior(t *testing.T, db utxostore.Store) {
 	require.Equal(t, int(utxostore.Status_OK), resp.Status)
 
 	// Now spending should succeed
-	_, err = db.Spend(ctx, lockedSpendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, lockedSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 }
 
@@ -1032,12 +1030,12 @@ func SetConflictingBehavior(t *testing.T, db utxostore.Store) {
 	ctx := context.Background()
 
 	// Need a parent for Tx's input so conflicting child tracking works
-	_, err := db.Create(ctx, ParentTx, 999)
+	_, _, err := db.SpendAndCreate(ctx, ParentTx, 999, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, ParentTx.TxIDChainHash()) }()
 
 	// Create Tx marked as conflicting — Tx's input references ParentTx
-	_, err = db.Create(ctx, Tx, 1000, utxostore.WithConflicting(true))
+	_, _, err = db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithConflicting(true), utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, Tx.TxIDChainHash()) }()
 
@@ -1069,7 +1067,7 @@ func SetConflictingBehavior(t *testing.T, db utxostore.Store) {
 	))
 	require.NoError(t, conflictingSpendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-	resultSpends, err := db.Spend(ctx, conflictingSpendTx, db.GetBlockHeight()+1)
+	_, resultSpends, err := db.SpendAndCreate(ctx, conflictingSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.Error(t, err)
 	require.ErrorIs(t, err, errors.ErrUtxoError)
 	require.NotEmpty(t, resultSpends)
@@ -1096,7 +1094,7 @@ func SetMinedUnminedSince(t *testing.T, db utxostore.Store) {
 
 	// Create Tx as unmined. Pass blockHeight=200 as the height when it was received.
 	// Since no WithMinedBlockInfo option is provided, unmined_since will be set to 200.
-	_, err = db.Create(ctx, Tx, 200)
+	_, _, err = db.SpendAndCreate(ctx, Tx, 200, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, Tx.TxIDChainHash()) }()
 
@@ -1148,7 +1146,7 @@ func SpendIdempotent(t *testing.T, db utxostore.Store) {
 	// Create a unique tx for this test
 	uniqueTx := newTestTx(t, 7_000_000)
 
-	_, err := db.Create(ctx, uniqueTx, 1000)
+	_, _, err := db.SpendAndCreate(ctx, uniqueTx, 1000, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, uniqueTx.TxIDChainHash()) }()
 
@@ -1162,11 +1160,11 @@ func SpendIdempotent(t *testing.T, db utxostore.Store) {
 	require.NoError(t, idempotentSpendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
 	// First spend succeeds
-	_, err = db.Spend(ctx, idempotentSpendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, idempotentSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	// Second spend with the SAME spending tx should be idempotent (no error)
-	_, err = db.Spend(ctx, idempotentSpendTx, db.GetBlockHeight()+1)
+	_, _, err = db.SpendAndCreate(ctx, idempotentSpendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 	require.NoError(t, err, "re-spending with the same spending tx should be idempotent")
 }
 
@@ -1181,7 +1179,7 @@ func SetMinedWithSpent(t *testing.T, db utxostore.Store) {
 	require.NoError(t, err)
 
 	// Create Tx as unmined
-	_, err = db.Create(ctx, Tx, 0)
+	_, _, err = db.SpendAndCreate(ctx, Tx, 0, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, Tx.TxIDChainHash()) }()
 
@@ -1195,7 +1193,7 @@ func SetMinedWithSpent(t *testing.T, db utxostore.Store) {
 		))
 		require.NoError(t, spendingTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
 
-		_, err = db.Spend(ctx, spendingTx, db.GetBlockHeight()+1)
+		_, _, err = db.SpendAndCreate(ctx, spendingTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
 		require.NoError(t, err, "spending output %d should succeed", vout)
 	}
 
@@ -1265,7 +1263,7 @@ func MinedThenSpendAllPrunes(t *testing.T, db utxostore.Store, prunerSvc pruner.
 	require.NoError(t, db.SetBlockHeight(mineHeight))
 
 	// Parent is referenced by Tx's input; create first (unmined is fine for this test).
-	_, err := db.Create(ctx, ParentTx, mineHeight-1)
+	_, _, err := db.SpendAndCreate(ctx, ParentTx, mineHeight-1, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, ParentTx.TxIDChainHash()) }()
 
@@ -1273,7 +1271,7 @@ func MinedThenSpendAllPrunes(t *testing.T, db utxostore.Store, prunerSvc pruner.
 	// real production flow (tx arrives, gets validated, later a block includes it).
 	// Creating directly with WithMinedBlockInfo would skip the mined-transition path
 	// that the disk-bloat bug was observed under.
-	_, err = db.Create(ctx, Tx, mineHeight)
+	_, _, err = db.SpendAndCreate(ctx, Tx, mineHeight, utxostore.WithCreateOnly())
 	require.NoError(t, err)
 	defer func() { _ = db.Delete(ctx, Tx.TxIDChainHash()) }()
 
@@ -1303,7 +1301,7 @@ func MinedThenSpendAllPrunes(t *testing.T, db utxostore.Store, prunerSvc pruner.
 			out.Satoshis,
 		))
 		require.NoError(t, spendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
-		_, err = db.Spend(ctx, spendTx, mineHeight+1)
+		_, _, err = db.SpendAndCreate(ctx, spendTx, mineHeight+1, utxostore.WithSpendOnly())
 		require.NoError(t, err, "spending output %d should succeed", i)
 	}
 
@@ -1322,4 +1320,163 @@ func MinedThenSpendAllPrunes(t *testing.T, db utxostore.Store, prunerSvc pruner.
 	_, err = db.Get(ctx, txHash)
 	require.Error(t, err, "tx must be deleted by pruner after all outputs are spent on a mined, on-longest-chain tx")
 	require.True(t, errors.Is(err, errors.ErrTxNotFound), "expected ErrTxNotFound, got %v", err)
+}
+
+// newSpendAndCreateTx builds an extended transaction spending output `vout` of Tx.
+// The satoshi amount makes the txid unique per test case.
+func newSpendAndCreateTx(t *testing.T, vout uint32, satoshis uint64) *bt.Tx {
+	t.Helper()
+
+	tx := bt.NewTx()
+	require.NoError(t, tx.FromUTXOs(&bt.UTXO{
+		TxIDHash:      Tx.TxIDChainHash(),
+		Vout:          vout,
+		LockingScript: Tx.Outputs[vout].LockingScript,
+		Satoshis:      Tx.Outputs[vout].Satoshis,
+	}))
+	tx.Inputs[0].UnlockingScript = dummyUnlockingScript
+	require.NoError(t, tx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", satoshis))
+
+	return tx
+}
+
+// SpendAndCreate proves the combined call spends the tx's inputs and creates its
+// outputs in one operation.
+func SpendAndCreate(t *testing.T, db utxostore.Store) {
+	ctx := context.Background()
+
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	spendingTx := newSpendAndCreateTx(t, 0, 1001)
+	_ = db.Delete(ctx, spendingTx.TxIDChainHash())
+
+	md, resultSpends, err := db.SpendAndCreate(ctx, spendingTx, db.GetBlockHeight()+1)
+	require.NoError(t, err)
+	require.NotNil(t, md)
+	require.Len(t, resultSpends, 1)
+
+	// the parent output is spent by spendingTx
+	resp, err := db.GetSpend(ctx, testSpend0)
+	require.NoError(t, err)
+	require.Equal(t, int(utxostore.Status_SPENT), resp.Status)
+	require.NotNil(t, resp.SpendingData)
+	require.Equal(t, spendingTx.TxIDChainHash().String(), resp.SpendingData.TxID.String())
+
+	// spendingTx's own outputs were created
+	created, err := db.Get(ctx, spendingTx.TxIDChainHash())
+	require.NoError(t, err)
+	require.Equal(t, spendingTx.TxIDChainHash().String(), created.Tx.TxID())
+}
+
+// SpendAndCreateCreateOnly proves WithCreateOnly skips the spend phase entirely.
+func SpendAndCreateCreateOnly(t *testing.T, db utxostore.Store) {
+	ctx := context.Background()
+
+	md, resultSpends, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+	require.NotNil(t, md)
+	require.Nil(t, resultSpends)
+
+	resp, err := db.Get(ctx, Tx.TxIDChainHash())
+	require.NoError(t, err)
+	require.Equal(t, Tx.TxIDChainHash().String(), resp.Tx.TxID())
+
+	// creating again surfaces ErrTxExists, same as the old Create
+	_, _, err = db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
+	require.ErrorIs(t, err, errors.ErrTxExists)
+}
+
+// SpendAndCreateSpendOnly proves WithSpendOnly spends the inputs without creating
+// the transaction itself.
+func SpendAndCreateSpendOnly(t *testing.T, db utxostore.Store) {
+	ctx := context.Background()
+
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	spendingTx := newSpendAndCreateTx(t, 1, 2001)
+	_ = db.Delete(ctx, spendingTx.TxIDChainHash())
+
+	md, resultSpends, err := db.SpendAndCreate(ctx, spendingTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())
+	require.NoError(t, err)
+	require.Nil(t, md)
+	require.Len(t, resultSpends, 1)
+
+	// the parent output is spent
+	utxoHash1, err := util.UTXOHashFromOutput(Tx.TxIDChainHash(), Tx.Outputs[1], 1)
+	require.NoError(t, err)
+
+	resp, err := db.GetSpend(ctx, &utxostore.Spend{TxID: Tx.TxIDChainHash(), Vout: 1, UTXOHash: utxoHash1})
+	require.NoError(t, err)
+	require.Equal(t, int(utxostore.Status_SPENT), resp.Status)
+
+	// but the spending tx was NOT created
+	_, err = db.Get(ctx, spendingTx.TxIDChainHash())
+	require.ErrorIs(t, err, errors.ErrTxNotFound)
+}
+
+// SpendAndCreateTxExistsKeepsSpends proves the documented ErrTxExists contract:
+// when the create phase finds the tx already stored, the error is returned WITHOUT
+// rolling back the spends made in the spend phase.
+func SpendAndCreateTxExistsKeepsSpends(t *testing.T, db utxostore.Store) {
+	ctx := context.Background()
+
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	spendingTx := newSpendAndCreateTx(t, 2, 3001)
+	_ = db.Delete(ctx, spendingTx.TxIDChainHash())
+
+	// pre-create the spending tx without spending its input
+	_, _, err = db.SpendAndCreate(ctx, spendingTx, db.GetBlockHeight()+1, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	// combined call: spend phase succeeds, create phase hits ErrTxExists
+	_, resultSpends, err := db.SpendAndCreate(ctx, spendingTx, db.GetBlockHeight()+1)
+	require.ErrorIs(t, err, errors.ErrTxExists)
+	require.Len(t, resultSpends, 1)
+
+	// the spend must still be in place
+	utxoHash2, err := util.UTXOHashFromOutput(Tx.TxIDChainHash(), Tx.Outputs[2], 2)
+	require.NoError(t, err)
+
+	resp, err := db.GetSpend(ctx, &utxostore.Spend{TxID: Tx.TxIDChainHash(), Vout: 2, UTXOHash: utxoHash2})
+	require.NoError(t, err)
+	require.Equal(t, int(utxostore.Status_SPENT), resp.Status)
+}
+
+// SpendAndCreateSpendErrorSurfacesPerInput proves a spend-phase failure carries
+// per-input errors in the returned spends (conflict detection contract) and that
+// the create phase never runs.
+func SpendAndCreateSpendErrorSurfacesPerInput(t *testing.T, db utxostore.Store) {
+	ctx := context.Background()
+
+	_, _, err := db.SpendAndCreate(ctx, Tx, 1000, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	winner := newSpendAndCreateTx(t, 3, 4001)
+	loser := newSpendAndCreateTx(t, 3, 4002)
+	_ = db.Delete(ctx, winner.TxIDChainHash())
+	_ = db.Delete(ctx, loser.TxIDChainHash())
+
+	_, _, err = db.SpendAndCreate(ctx, winner, db.GetBlockHeight()+1)
+	require.NoError(t, err)
+
+	_, resultSpends, err := db.SpendAndCreate(ctx, loser, db.GetBlockHeight()+1)
+	require.ErrorIs(t, err, errors.ErrUtxoError)
+	require.Len(t, resultSpends, 1)
+	require.ErrorIs(t, resultSpends[0].Err, errors.ErrSpent)
+	require.Equal(t, winner.TxIDChainHash().String(), resultSpends[0].ConflictingTxID.String())
+
+	// the loser must not have been created
+	_, err = db.Get(ctx, loser.TxIDChainHash())
+	require.ErrorIs(t, err, errors.ErrTxNotFound)
+}
+
+// SpendAndCreateInvalidOptions proves combining WithCreateOnly and WithSpendOnly
+// is rejected.
+func SpendAndCreateInvalidOptions(t *testing.T, db utxostore.Store) {
+	_, _, err := db.SpendAndCreate(context.Background(), Tx, 1000, utxostore.WithCreateOnly(), utxostore.WithSpendOnly())
+	require.ErrorIs(t, err, errors.ErrInvalidArgument)
 }

--- a/stores/utxo/tests/unmined_iterator_test.go
+++ b/stores/utxo/tests/unmined_iterator_test.go
@@ -102,16 +102,16 @@ func testUnminedTxIterator(t *testing.T, utxoStoreURL string) {
 		err = store.SetBlockHeight(currentBlockHeight)
 		require.NoError(t, err)
 
-		tx1Meta, err := store.Create(ctx, tx1, currentBlockHeight)
+		tx1Meta, _, err := store.SpendAndCreate(ctx, tx1, currentBlockHeight, utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = store.Create(ctx, tx2, currentBlockHeight, utxo.WithMinedBlockInfo(
+		_, _, err = store.SpendAndCreate(ctx, tx2, currentBlockHeight, utxo.WithMinedBlockInfo(
 			utxo.MinedBlockInfo{
 				BlockID:     1,
 				BlockHeight: 1,
 				SubtreeIdx:  1,
 			},
-		))
+		), utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		it, err := store.GetUnminedTxIterator()
@@ -146,22 +146,22 @@ func testUnminedTxIterator(t *testing.T, utxoStoreURL string) {
 		require.NoError(t, store.Delete(ctx, tx1.TxIDChainHash()))
 		require.NoError(t, store.Delete(ctx, tx2.TxIDChainHash()))
 
-		_, err = store.Create(ctx, tx1, 0, utxo.WithMinedBlockInfo(
+		_, _, err = store.SpendAndCreate(ctx, tx1, 0, utxo.WithMinedBlockInfo(
 			utxo.MinedBlockInfo{
 				BlockID:     2,
 				BlockHeight: 2,
 				SubtreeIdx:  2,
 			},
-		))
+		), utxo.WithCreateOnly())
 		require.NoError(t, err)
 
-		_, err = store.Create(ctx, tx2, 0, utxo.WithMinedBlockInfo(
+		_, _, err = store.SpendAndCreate(ctx, tx2, 0, utxo.WithMinedBlockInfo(
 			utxo.MinedBlockInfo{
 				BlockID:     2,
 				BlockHeight: 2,
 				SubtreeIdx:  2,
 			},
-		))
+		), utxo.WithCreateOnly())
 		require.NoError(t, err)
 
 		it, err := store.GetUnminedTxIterator()

--- a/test/e2e/daemon/wip/tnb_test.go
+++ b/test/e2e/daemon/wip/tnb_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
 	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/teranode/daemon"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,7 +82,7 @@ func TestUTXOValidation(t *testing.T) {
 	err = anotherTx.FillAllInputs(ctx, &unlocker.Getter{PrivateKey: pk})
 	require.NoError(t, err)
 
-	_, err = td.UtxoStore.Spend(ctx, tx, 1)
+	_, _, err = td.UtxoStore.SpendAndCreate(ctx, tx, 1, utxostore.WithSpendOnly())
 	require.NoError(t, err)
 
 	err = td.PropagationClient.ProcessTransaction(ctx, anotherTx)


### PR DESCRIPTION
## What

Replaces `Spend()` and `Create()` on `utxo.Store` with a single method:

```go
SpendAndCreate(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts ...CreateOption) (*meta.Data, []*Spend, error)
```

The store now owns the spend/create pairing, so follow-ups can make it atomic per backend (Postgres transaction, Aerospike-native logic). This PR is interface + caller migration only — every store implements the new method via a shared sequential helper that reproduces today's behaviour exactly.

## Contract

- Default: spend inputs, then create outputs. On create failure other than `ErrTxExists` the spends are rolled back inside the store (retry/backoff ported verbatim from the validator's `reverseSpends`).
- `ErrTxExists` from the create phase is returned with the spends left in place — matches the validator's existing handling; the caller decides.
- `WithCreateOnly()` skips the spend phase (coinbase, seeder, legacy netsync, quick-validate phase 1).
- `WithSpendOnly()` skips the create phase (quick-validate phase 2, conflict/reorg helpers, `SkipUtxoCreation`).
- Spend-phase `IgnoreFlags` fold into `CreateOptions` via `WithIgnoreLocked` / `WithIgnoreConflicting` / `WithSkipUTXOHashCheck`.
- On spend failure the returned `[]*Spend` carries per-input errors, so conflict detection is unchanged.

## Changes

- `stores/utxo/Interface.go`: new method + options; `Create`/`Spend` removed from the interface. Concrete stores keep them as struct methods — the helper composes them.
- `stores/utxo/spend_and_create.go`: `SequentialSpendAndCreate`, the shared sequential implementation all backends delegate to (aerospike, sql, nullstore; the logger and txmetacache wrappers delegate, txmetacache caches returned meta as its `Create` wrapper did).
- Validator `validateInternal` makes one store call; the create-failure rollback moved into the store; the conflicting-fallback, `ErrTxExists` and DAH-evicted branches are unchanged.
- `quick_validate` keeps its two-phase batch structure via the `*Only` options.
- New conformance tests in `stores/utxo/tests` (combined path, create-only, spend-only, ErrTxExists-keeps-spends, per-input spend errors, invalid option combo), wired into the sqlite and aerospike suites; unit tests for the helper cover rollback and retry.

## Verification

- `go build ./...`, `go vet ./...` clean
- `make test`: 11839 tests pass (`-race`, incl. Postgres and Aerospike container suites)
- `make lint` (`--new-from-rev main`): 0 issues; `staticcheck` clean on touched packages

## Follow-ups

- Postgres: wrap `SpendAndCreate` in a DB transaction.
- Aerospike: native atomic implementation.
- Decide whether the ErrTxExists-keeps-spends contract survives real atomicity (flagged in the method godoc).
