### PR TITLE
fix(blockvalidation): run contextual header checks synchronously before optimistic AddBlock

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -500,32 +500,30 @@ type SubtreeStore interface {
 	GetIoReader(ctx context.Context, key []byte, fileType fileformat.FileType, opts ...options.FileOption) (io.ReadCloser, error)
 }
 
-func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore SubtreeStore, txMetaStore utxo.Store, oldBlockIDsMap *txmap.SyncedMap[chainhash.Hash, []uint32],
-	currentChain []*BlockHeader, currentBlockHeaderIDs []uint32, settings *settings.Settings, metaRegenerator SubtreeMetaRegeneratorI) (bool, error) {
-	ctx, _, deferFn := tracing.Tracer("block").Start(ctx, "Valid",
-		tracing.WithHistogram(prometheusBlockValid),
-		tracing.WithLogMessage(logger, "[Block:Valid] called for %s", b.Header.String()),
-	)
-	defer deferFn()
-
-	// 1. Check that the block header hash is less than the target difficulty.
-	headerValid, _, err := b.Header.HasMetTargetDifficulty()
-	if err != nil {
-		return false, errors.NewProcessingError("[BLOCK][%s] error checking target difficulty", b.String(), err)
-	}
-
-	if !headerValid {
-		return false, errors.NewBlockInvalidError("[BLOCK][%s] block header hash is not less than the target difficulty", b.String())
-	}
-
+// CheckHeaderContextual runs the header checks whose outcome depends on wall-clock time
+// (time.Now()) or on the current chain: the 2-hours-in-the-future timestamp bound, the
+// median-time-past rule, and the mandatory block-version floor (BIP34/66/65). It mirrors the
+// timestamp/version portion of bitcoin-sv's ContextualCheckBlockHeader (proof-of-work and nBits
+// are checked separately by the block-validation service, so they are not repeated here).
+//
+// It is the subset of Valid()'s header checks that must be evaluated at block-receipt time. Under
+// optimistic mining Valid() runs in a background goroutine after the block has already been added,
+// so evaluating the 2-hours-in-the-future check there uses a drifted time.Now() and can transiently
+// accept a too-far-future block; the block-validation service calls this synchronously before the
+// optimistic AddBlock to close that gap (issue #1149). Valid() also calls it so the check remains a
+// single source of truth.
+//
+// currentChain is the run of previous headers ending at the block's parent; when empty the
+// median-time-past rule is skipped (same as Valid()). Returns nil when the header passes.
+func (b *Block) CheckHeaderContextual(currentChain []*BlockHeader, settings *settings.Settings, logger ulogger.Logger) error {
 	// 2. Check that the block timestamp is not more than two hours in the future.
 	twoHoursToTheFutureTimestampUint32, err := safeconversion.Int64ToUint32(time.Now().Add(2 * time.Hour).Unix())
 	if err != nil {
-		return false, errors.NewProcessingError("[BLOCK][%s] failed to convert two hours to the future timestamp to uint32", b.String(), err)
+		return errors.NewProcessingError("[BLOCK][%s] failed to convert two hours to the future timestamp to uint32", b.String(), err)
 	}
 
 	if b.Header.Timestamp > twoHoursToTheFutureTimestampUint32 {
-		return false, errors.NewBlockInvalidError("[BLOCK][%s] block timestamp is more than two hours in the future", b.String())
+		return errors.NewBlockInvalidError("[BLOCK][%s] block timestamp is more than two hours in the future", b.String())
 	}
 
 	// 3. Check that the median time past of the block is after the median time past of the last 11 blocks.
@@ -549,19 +547,19 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 		// calculate the median timestamp
 		medianTimestamp, err := CalculateMedianTimestamp(prevTimeStamps)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		b.medianTimestamp, err = safeconversion.Int64ToUint32(medianTimestamp.Unix())
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		// validate that the block's timestamp is after the median timestamp
 		if b.Header.Timestamp <= b.medianTimestamp {
 			// if we're not on a chain that allows blocks to be generated quickly then return an error
 			if !settings.ChainCfgParams.GenerateSupported {
-				return false, errors.NewBlockInvalidError("block timestamp %d is not after median time past of last %d blocks %d", b.Header.Timestamp, pruneLength, medianTimestamp.Unix())
+				return errors.NewBlockInvalidError("block timestamp %d is not after median time past of last %d blocks %d", b.Header.Timestamp, pruneLength, medianTimestamp.Unix())
 			}
 			// otherwise just warn
 			logger.Warnf("block timestamp %d is not after median time past of last %d blocks %d", b.Header.Timestamp, pruneLength, medianTimestamp.Unix())
@@ -572,7 +570,37 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 	// Parity with bitcoin-sv ContextualCheckBlockHeader; must run before body/coinbase checks to
 	// match svnode's bad-version error priority.
 	if err := CheckBlockVersion(b.Header.Version, b.Height, settings.ChainCfgParams); err != nil {
-		return false, errors.NewBlockInvalidError("[BLOCK][%s] outdated block version", b.String(), err)
+		return errors.NewBlockInvalidError("[BLOCK][%s] outdated block version", b.String(), err)
+	}
+
+	return nil
+}
+
+func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore SubtreeStore, txMetaStore utxo.Store, oldBlockIDsMap *txmap.SyncedMap[chainhash.Hash, []uint32],
+	currentChain []*BlockHeader, currentBlockHeaderIDs []uint32, settings *settings.Settings, metaRegenerator SubtreeMetaRegeneratorI) (bool, error) {
+	ctx, _, deferFn := tracing.Tracer("block").Start(ctx, "Valid",
+		tracing.WithHistogram(prometheusBlockValid),
+		tracing.WithLogMessage(logger, "[Block:Valid] called for %s", b.Header.String()),
+	)
+	defer deferFn()
+
+	// 1. Check that the block header hash is less than the target difficulty.
+	headerValid, _, err := b.Header.HasMetTargetDifficulty()
+	if err != nil {
+		return false, errors.NewProcessingError("[BLOCK][%s] error checking target difficulty", b.String(), err)
+	}
+
+	if !headerValid {
+		return false, errors.NewBlockInvalidError("[BLOCK][%s] block header hash is not less than the target difficulty", b.String())
+	}
+
+	// 2, 3, 3b: contextual header checks (2h-future timestamp, median-time-past, block-version
+	// floor). These depend on time.Now() and the current chain, so under optimistic mining they
+	// must be evaluated at block-receipt time rather than only in the background Valid() goroutine
+	// where time.Now() has drifted past receipt. Factored into CheckHeaderContextual so the
+	// optimistic path can run them synchronously before AddBlock (issue #1149).
+	if err := b.CheckHeaderContextual(currentChain, settings, logger); err != nil {
+		return false, err
 	}
 
 	// 4. Check that the coinbase transaction is valid (reward checked later).

--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -522,6 +522,90 @@ func TestBlock_Valid_CoinbaseScriptSigLength(t *testing.T) {
 	})
 }
 
+// TestBlock_CheckHeaderContextual exercises the header checks factored out of Valid() so the
+// optimistic-mining path can run them synchronously at block-receipt time (issue #1149): the
+// 2-hours-in-the-future timestamp bound, the median-time-past rule, and the block-version floor.
+func TestBlock_CheckHeaderContextual(t *testing.T) {
+	logger := ulogger.TestLogger{}
+
+	// buildBlock returns a coinbase-only block whose header carries the given timestamp; height 1
+	// keeps it below every BIP34/66/65 activation on the params used below, so the version check
+	// never fires and each subtest isolates the timestamp/MTP behaviour under test.
+	buildBlock := func(t *testing.T, timestamp uint32) *Block {
+		t.Helper()
+
+		bits, err := NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		header := &BlockHeader{
+			Version:        1,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      timestamp,
+			Bits:           *bits,
+			Nonce:          1,
+		}
+
+		coinbase, err := bt.NewTxFromString(CoinbaseHex)
+		require.NoError(t, err)
+
+		block, err := NewBlock(header, coinbase, []*chainhash.Hash{}, 1, 123, 1, 0)
+		require.NoError(t, err)
+
+		return block
+	}
+
+	t.Run("timestamp more than two hours in the future is rejected at call time", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		block := buildBlock(t, uint32(time.Now().Add(3*time.Hour).Unix())) // nolint:gosec
+
+		err := block.CheckHeaderContextual([]*BlockHeader{}, tSettings, logger)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "two hours in the future")
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	})
+
+	t.Run("current timestamp is accepted", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		block := buildBlock(t, uint32(time.Now().Unix())) // nolint:gosec
+
+		require.NoError(t, block.CheckHeaderContextual([]*BlockHeader{}, tSettings, logger))
+	})
+
+	t.Run("timestamp just under two hours in the future is accepted", func(t *testing.T) {
+		tSettings := test.CreateBaseTestSettings(t)
+		block := buildBlock(t, uint32(time.Now().Add(2*time.Hour-time.Minute).Unix())) // nolint:gosec
+
+		require.NoError(t, block.CheckHeaderContextual([]*BlockHeader{}, tSettings, logger))
+	})
+
+	t.Run("timestamp not after median time past is rejected when generate is not supported", func(t *testing.T) {
+		// Mainnet params have GenerateSupported == false, so an MTP violation is a hard error
+		// (on regtest it is only a warning). BIP34Height is 227931, so height 1 stays below the
+		// version floor and the version check does not interfere.
+		tSettings := test.CreateBaseTestSettings(t)
+		mainParams := chaincfg.MainNetParams
+		tSettings.ChainCfgParams = &mainParams
+
+		now := uint32(time.Now().Unix()) // nolint:gosec
+
+		// 11 previous headers all stamped "now"; their median is "now".
+		currentChain := make([]*BlockHeader, 11)
+		for i := range currentChain {
+			currentChain[i] = &BlockHeader{Timestamp: now}
+		}
+
+		// Block timestamp equal to the median violates the strictly-after rule, while staying
+		// well inside the 2-hours-in-the-future bound so the earlier check passes.
+		block := buildBlock(t, now)
+
+		err := block.CheckHeaderContextual(currentChain, tSettings, logger)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "median time past")
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	})
+}
+
 // TestBlock_NewBlockFromMsgBlock_ComprehensiveCoverage tests various paths in NewBlockFromMsgBlock
 func TestBlock_NewBlockFromMsgBlock_ComprehensiveCoverage(t *testing.T) {
 	t.Run("nil msgBlock error", func(t *testing.T) {

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1726,6 +1726,24 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			// NOTE: We do NOT cache the block here as subtrees are not yet loaded.
 			// The block will be cached after subtrees are validated in the background goroutine.
 
+			// Run the contextual header checks (2h-future timestamp, median-time-past, block-version
+			// floor) synchronously at receipt time BEFORE optimistically adding the block. The full
+			// block.Valid() runs later in the background goroutine below, where a drifted time.Now()
+			// would evaluate the 2-hours-in-the-future bound against background-execution time and
+			// let a too-far-future block be transiently accepted then reverted (issue #1149). These
+			// checks use the same blockHeaders snapshot the background Valid() consumes.
+			if err = block.CheckHeaderContextual(blockHeaders, u.settings, ctxLogger); err != nil {
+				if errors.Is(err, errors.ErrBlockInvalid) {
+					if !opts.IsRevalidation {
+						u.storeInvalidBlock(ctx, block, opts.PeerID, err.Error())
+					}
+
+					return errors.NewBlockInvalidError("[ValidateBlock][%s] block header failed contextual validation", block.Header.Hash().String(), err)
+				}
+
+				return err
+			}
+
 			ctxLogger.Infof("[ValidateBlock][%s] adding block optimistically to blockchain", block.Hash().String())
 
 			if err := u.computeAndSetCoinbaseBUMP(ctx, block); err != nil {

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -3778,6 +3778,104 @@ func TestBlockValidation_OptimisticMining_InValidBlock(t *testing.T) {
 	}
 }
 
+// TestBlockValidation_OptimisticMining_RejectsFutureTimestampSynchronously proves the issue #1149
+// fix: under optimistic mining, a block whose timestamp is more than two hours in the future is
+// rejected synchronously at receipt time, BEFORE it is optimistically added to the chain. Before
+// the fix the 2-hours-in-the-future check ran only in the background block.Valid() goroutine, so
+// ValidateBlock returned nil and the too-far-future block was transiently added then reverted.
+func TestBlockValidation_OptimisticMining_RejectsFutureTimestampSynchronously(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.OptimisticMining = true
+
+	privateKey, _ := bec.NewPrivateKey()
+	address, _ := bscript.NewAddressFromPublicKey(privateKey.PubKey(), true)
+	coinbaseTx := bt.NewTx()
+	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
+	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
+	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
+
+	subtree, _ := subtreepkg.NewTreeByLeafCount(2)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	subtreeHashes := []*chainhash.Hash{subtree.RootHash()}
+	nodeBytes, err := subtree.SerializeNodes()
+	require.NoError(t, err)
+
+	httpmock.RegisterResponder("GET", `=~^/subtree/[a-z0-9]+\z`, httpmock.NewBytesResponder(200, nodeBytes))
+
+	nBits, _ := model.NewNBitFromString("207fffff")
+	// Timestamp three hours in the future — past the two-hour bound.
+	blockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  tSettings.ChainCfgParams.GenesisHash,
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Add(3 * time.Hour).Unix()), //nolint:gosec
+		Bits:           *nBits,
+		Nonce:          0,
+	}
+
+	for {
+		if ok, _, _ := blockHeader.HasMetTargetDifficulty(); ok {
+			break
+		}
+
+		blockHeader.Nonce++
+	}
+
+	block, _ := model.NewBlock(
+		blockHeader,
+		coinbaseTx,
+		subtreeHashes,
+		uint64(subtree.Length()),  //nolint:gosec
+		uint64(coinbaseTx.Size()), //nolint:gosec
+		100, 0,
+	)
+
+	mockBlockchain := &blockchain.Mock{}
+	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil)
+	// storeInvalidBlock persists the rejected block with WithInvalid(true); the accept-path AddBlock
+	// must never fire. Both would match here, so we additionally assert the background path never runs.
+	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, mock.Anything).Return(nil)
+	// GetBlockHeaderIDs is only reached inside the optimistic background goroutine, which must not
+	// start when the header is rejected synchronously — mark it Maybe so a regression (block added
+	// optimistically) surfaces via the AssertNotCalled check below rather than a missing-mock panic.
+	mockBlockchain.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{1}, nil).Maybe()
+	mockBlockchain.On("InvalidateBlock", mock.Anything, mock.Anything).Return([]chainhash.Hash{}, nil).Maybe()
+	mockBlockchain.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	mockBlockchain.On("GetBlocksSubtreesNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	subChan := make(chan *blockchain_api.Notification, 1)
+	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
+	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
+	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil)
+	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100}, nil)
+	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil)
+
+	txMetaStore, subtreeValidationClient, _, txStore, subtreeStore, deferFunc := setup(t)
+	defer deferFunc()
+
+	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, txMetaStore, nil, subtreeValidationClient)
+
+	subtreeBytes, err := subtree.Serialize()
+	require.NoError(t, err)
+	err = subtreeStore.Set(context.Background(), subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes)
+	require.NoError(t, err)
+
+	// The block must be rejected synchronously, with the future-timestamp reason surfaced directly
+	// from ValidateBlock rather than swallowed by the optimistic background goroutine.
+	err = bv.ValidateBlock(ctx, block, "test", false)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	require.Contains(t, err.Error(), "two hours in the future")
+
+	// The optimistic background goroutine (which alone calls GetBlockHeaderIDs) must never start,
+	// confirming the rejection happened before the optimistic AddBlock.
+	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
+}
+
 // TestBlockValidation_SetMined_UpdatesTxMeta ensures that after block validation, calling setTxMined marks all block transactions as mined in the txMetaStore.
 func TestBlockValidation_SetMined_UpdatesTxMeta(t *testing.T) {
 	initPrometheusMetrics()


### PR DESCRIPTION
## Summary

Closes #1149.

Under optimistic mining (default on) a block is added and mined before `block.Valid()` runs in a background goroutine. That goroutine evaluated the 2-hours-in-the-future timestamp check (and the median-time-past and block-version-floor checks) against a `time.Now()` that had drifted past block-receipt time, so a too-far-future or MTP-violating block could be transiently accepted and mined, then reverted, instead of being rejected up front like a non-optimistic validator would.

## Fix

- **`model/Block.go`**: factor the header checks whose outcome depends on wall-clock time or the current chain - the 2-hours-in-the-future bound, median-time-past, and BIP34/66/65 version floor - out of `block.Valid()` into a new `Block.CheckHeaderContextual` method. `Valid()` still calls it, so it stays a single source of truth and the non-optimistic path is unchanged.
- **`services/blockvalidation/BlockValidation.go`**: call `CheckHeaderContextual` synchronously in the optimistic path **before** `AddBlock`, storing the block invalid and returning on failure.
- Proof-of-work and nBits are already checked synchronously by the service before the optimistic add, so they stay put and are not repeated.

This is the subset of `Valid()`'s header checks that must be evaluated at receipt time; the expensive subtree/tx checks remain in the background goroutine.

## Tests

- `model.TestBlock_CheckHeaderContextual` - unit-covers the extracted checks: a `now+3h` timestamp is rejected at call time, a just-under-2h timestamp is accepted, and an MTP violation is rejected when generate is not supported.
- `blockvalidation.TestBlockValidation_OptimisticMining_RejectsFutureTimestampSynchronously` - drives a `now+3h` block through the optimistic path and asserts it is rejected synchronously (`ErrBlockInvalid`, "two hours in the future") and that the optimistic background goroutine never starts.

The service test is load-bearing: without the fix `ValidateBlock` returns nil and the block is added then reverted in the background.

## Verification

- `go test ./model/ ./services/blockvalidation/` - both suites pass (blockvalidation full run ~274s)
- New tests pass under `-race`
- `go vet` clean; `gci` / `gofmt` clean