### PR TITLE
fix(alert): bounds-check parent tx outputs before indexing in node handlers

### DIFF
--- a/services/alert/node.go
+++ b/services/alert/node.go
@@ -305,8 +305,14 @@ func (n *Node) AddToConsensusBlacklist(ctx context.Context, funds []models.Fund)
 			continue
 		}
 
+		// guard against a nil parent tx or an out-of-range vout before indexing the outputs
+		if parentTxMeta.Tx == nil || int(vout) >= len(parentTxMeta.Tx.Outputs) {
+			response.NotProcessed = append(response.NotProcessed, n.getAddToConsensusBlacklistResponse(fund, errors.NewError("parent tx output %d not found", vout))...)
+			continue
+		}
+
 		// calculate the utxo hash from the output script
-		utxoHash, err := util.UTXOHashFromOutput(parentTxMeta.Tx.TxIDChainHash(), parentTxMeta.Tx.Outputs[fund.TxOut.Vout], vout)
+		utxoHash, err := util.UTXOHashFromOutput(parentTxMeta.Tx.TxIDChainHash(), parentTxMeta.Tx.Outputs[vout], vout)
 		if err != nil {
 			response.NotProcessed = append(response.NotProcessed, n.getAddToConsensusBlacklistResponse(fund, err)...)
 			continue
@@ -405,6 +411,12 @@ func (n *Node) AddToConfiscationTransactionWhitelist(ctx context.Context, txs []
 			parentTxMeta, err := n.utxoStore.Get(ctx, txIn.PreviousTxIDChainHash(), fields.Tx)
 			if err != nil {
 				response.NotProcessed = append(response.NotProcessed, n.getAddToConfiscationTransactionWhitelistResponse(tx.TxIDChainHash().String(), err)...)
+				continue
+			}
+
+			// guard against a nil parent tx or an out-of-range input index before indexing the outputs
+			if parentTxMeta.Tx == nil || int(txIn.PreviousTxOutIndex) >= len(parentTxMeta.Tx.Outputs) {
+				response.NotProcessed = append(response.NotProcessed, n.getAddToConfiscationTransactionWhitelistResponse(tx.TxIDChainHash().String(), errors.NewError("parent tx output %d not found", txIn.PreviousTxOutIndex))...)
 				continue
 			}
 

--- a/services/alert/node.go
+++ b/services/alert/node.go
@@ -305,8 +305,11 @@ func (n *Node) AddToConsensusBlacklist(ctx context.Context, funds []models.Fund)
 			continue
 		}
 
-		// guard against a nil parent tx or an out-of-range vout before indexing the outputs
-		if parentTxMeta.Tx == nil || int(vout) >= len(parentTxMeta.Tx.Outputs) {
+		// guard against a nil parent tx, an out-of-range vout, or a nil output element before
+		// indexing the outputs (external outputs-only parents can have nil holes at in-range indices)
+		if parentTxMeta.Tx == nil ||
+			uint64(vout) >= uint64(len(parentTxMeta.Tx.Outputs)) ||
+			parentTxMeta.Tx.Outputs[vout] == nil {
 			response.NotProcessed = append(response.NotProcessed, n.getAddToConsensusBlacklistResponse(fund, errors.NewError("parent tx output %d not found", vout))...)
 			continue
 		}
@@ -414,8 +417,11 @@ func (n *Node) AddToConfiscationTransactionWhitelist(ctx context.Context, txs []
 				continue
 			}
 
-			// guard against a nil parent tx or an out-of-range input index before indexing the outputs
-			if parentTxMeta.Tx == nil || int(txIn.PreviousTxOutIndex) >= len(parentTxMeta.Tx.Outputs) {
+			// guard against a nil parent tx, an out-of-range input index, or a nil output element before
+			// indexing the outputs (external outputs-only parents can have nil holes at in-range indices)
+			if parentTxMeta.Tx == nil ||
+				uint64(txIn.PreviousTxOutIndex) >= uint64(len(parentTxMeta.Tx.Outputs)) ||
+				parentTxMeta.Tx.Outputs[txIn.PreviousTxOutIndex] == nil {
 				response.NotProcessed = append(response.NotProcessed, n.getAddToConfiscationTransactionWhitelistResponse(tx.TxIDChainHash().String(), errors.NewError("parent tx output %d not found", txIn.PreviousTxOutIndex))...)
 				continue
 			}

--- a/services/alert/node_test.go
+++ b/services/alert/node_test.go
@@ -287,3 +287,102 @@ func TestNode_getAddToConsensusBlacklistResponse(t *testing.T) {
 		require.Nil(t, utxoSpend.SpendingData)
 	})
 }
+
+// TestNode_AddToConsensusBlacklist_OutOfRangeVout ensures a fund referencing a
+// vout beyond the parent tx's output count is rejected gracefully rather than
+// panicking with an index-out-of-range on parentTxMeta.Tx.Outputs.
+func TestNode_AddToConsensusBlacklist_OutOfRangeVout(t *testing.T) {
+	ctx := context.Background()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	logger := ulogger.NewErrorTestLogger(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	_ = utxoStore.SetBlockHeight(101)
+
+	_, err = utxoStore.Create(ctx, tx, 101)
+	require.NoError(t, err)
+
+	node := NewNodeConfig(ulogger.TestLogger{}, nil, utxoStore, nil, nil, nil, tSettings)
+
+	// tx has 10 outputs; vout 99 is out of range
+	funds := []models.Fund{{
+		TxOut: models.TxOut{
+			TxId: tx.TxIDChainHash().String(),
+			Vout: 99,
+		},
+		EnforceAtHeight: []models.Enforce{
+			{
+				Start: 101,
+				Stop:  999999999,
+			},
+		},
+	}}
+
+	response, err := node.AddToConsensusBlacklist(ctx, funds)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(response.NotProcessed))
+	require.Contains(t, response.NotProcessed[0].Reason, "output 99 not found")
+}
+
+// TestNode_AddToConfiscationTransactionWhitelist_OutOfRangeInputIndex ensures a
+// confiscation transaction whose input references a vout beyond the parent tx's
+// output count is rejected gracefully rather than panicking on
+// parentTxMeta.Tx.Outputs.
+func TestNode_AddToConfiscationTransactionWhitelist_OutOfRangeInputIndex(t *testing.T) {
+	ctx := context.Background()
+
+	tSettings := test.CreateBaseTestSettings(t)
+	logger := ulogger.NewErrorTestLogger(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	_ = utxoStore.SetBlockHeight(101)
+
+	_, err = utxoStore.Create(ctx, tx, 101)
+	require.NoError(t, err)
+
+	node := NewNodeConfig(ulogger.TestLogger{}, nil, utxoStore, nil, nil, nil, tSettings)
+
+	privateKey, err := bec.NewPrivateKey()
+	require.NoError(t, err)
+
+	lockingScript, err := bscript.NewP2PKHFromPubKeyBytes(privateKey.PubKey().Compressed())
+	require.NoError(t, err)
+
+	// build a confiscation tx whose only input spends parent vout 99 (out of range)
+	confiscationTransaction := bt.Tx{}
+	err = confiscationTransaction.FromUTXOs([]*bt.UTXO{{
+		TxIDHash:       tx.TxIDChainHash(),
+		Vout:           99,
+		LockingScript:  lockingScript,
+		Satoshis:       tx.Outputs[0].Satoshis,
+		SequenceNumber: bt.DefaultSequenceNumber,
+	}}...)
+	require.NoError(t, err)
+
+	_ = confiscationTransaction.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", tx.Outputs[0].Satoshis)
+
+	confiscation := []models.ConfiscationTransactionDetails{{
+		ConfiscationTransaction: models.ConfiscationTransaction{
+			EnforceAtHeight: 102,
+			Hex:             confiscationTransaction.String(),
+		},
+	}}
+
+	response, err := node.AddToConfiscationTransactionWhitelist(ctx, confiscation)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(response.NotProcessed))
+	require.Contains(t, response.NotProcessed[0].Reason, "output 99 not found")
+}

--- a/services/alert/node_test.go
+++ b/services/alert/node_test.go
@@ -12,10 +12,12 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
 	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -385,4 +387,124 @@ func TestNode_AddToConfiscationTransactionWhitelist_OutOfRangeInputIndex(t *test
 
 	require.Equal(t, 1, len(response.NotProcessed))
 	require.Contains(t, response.NotProcessed[0].Reason, "output 99 not found")
+}
+
+// TestNode_AddToConsensusBlacklist_NilParentOutput covers the two defensive
+// branches the sqlitememory store cannot produce: a parent meta.Data with a nil
+// Tx, and a parent Tx whose Outputs slice has an in-range nil element (as built
+// by the external outputs-only fetch path in aerospike get.go, which pads the
+// slice and leaves spent/unstored indices nil). Both must degrade to a
+// NotProcessed entry rather than a nil-pointer panic. A testify MockUtxostore is
+// used because the real store always returns a fully-populated, non-nil Tx.
+func TestNode_AddToConsensusBlacklist_NilParentOutput(t *testing.T) {
+	ctx := context.Background()
+	tSettings := test.CreateBaseTestSettings(t)
+
+	enforce := []models.Enforce{{Start: 101, Stop: 999999999}}
+
+	t.Run("nil Tx", func(t *testing.T) {
+		mockStore := &utxo.MockUtxostore{}
+		mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).
+			Return(&meta.Data{Tx: nil}, nil)
+
+		node := NewNodeConfig(ulogger.TestLogger{}, nil, mockStore, nil, nil, nil, tSettings)
+
+		funds := []models.Fund{{
+			TxOut:           models.TxOut{TxId: tx.TxIDChainHash().String(), Vout: 0},
+			EnforceAtHeight: enforce,
+		}}
+
+		response, err := node.AddToConsensusBlacklist(ctx, funds)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(response.NotProcessed))
+		require.Contains(t, response.NotProcessed[0].Reason, "output 0 not found")
+	})
+
+	t.Run("in-range nil output element", func(t *testing.T) {
+		holeTx := tx.Clone()
+		holeTx.Outputs[1] = nil // in-range index, nil element
+
+		mockStore := &utxo.MockUtxostore{}
+		mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).
+			Return(&meta.Data{Tx: holeTx}, nil)
+
+		node := NewNodeConfig(ulogger.TestLogger{}, nil, mockStore, nil, nil, nil, tSettings)
+
+		funds := []models.Fund{{
+			TxOut:           models.TxOut{TxId: tx.TxIDChainHash().String(), Vout: 1},
+			EnforceAtHeight: enforce,
+		}}
+
+		response, err := node.AddToConsensusBlacklist(ctx, funds)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(response.NotProcessed))
+		require.Contains(t, response.NotProcessed[0].Reason, "output 1 not found")
+	})
+}
+
+// TestNode_AddToConfiscationTransactionWhitelist_NilParentOutput mirrors the
+// nil-Tx and in-range-nil-element coverage for the confiscation handler, whose
+// guard dominates three downstream Outputs[...] dereferences.
+func TestNode_AddToConfiscationTransactionWhitelist_NilParentOutput(t *testing.T) {
+	ctx := context.Background()
+	tSettings := test.CreateBaseTestSettings(t)
+
+	// build a confiscation tx whose only input spends parent vout 1
+	buildConfiscation := func(t *testing.T) []models.ConfiscationTransactionDetails {
+		t.Helper()
+
+		privateKey, err := bec.NewPrivateKey()
+		require.NoError(t, err)
+
+		lockingScript, err := bscript.NewP2PKHFromPubKeyBytes(privateKey.PubKey().Compressed())
+		require.NoError(t, err)
+
+		confiscationTransaction := bt.Tx{}
+		err = confiscationTransaction.FromUTXOs([]*bt.UTXO{{
+			TxIDHash:       tx.TxIDChainHash(),
+			Vout:           1,
+			LockingScript:  lockingScript,
+			Satoshis:       tx.Outputs[1].Satoshis,
+			SequenceNumber: bt.DefaultSequenceNumber,
+		}}...)
+		require.NoError(t, err)
+
+		_ = confiscationTransaction.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", tx.Outputs[1].Satoshis)
+
+		return []models.ConfiscationTransactionDetails{{
+			ConfiscationTransaction: models.ConfiscationTransaction{
+				EnforceAtHeight: 102,
+				Hex:             confiscationTransaction.String(),
+			},
+		}}
+	}
+
+	t.Run("nil Tx", func(t *testing.T) {
+		mockStore := &utxo.MockUtxostore{}
+		mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).
+			Return(&meta.Data{Tx: nil}, nil)
+
+		node := NewNodeConfig(ulogger.TestLogger{}, nil, mockStore, nil, nil, nil, tSettings)
+
+		response, err := node.AddToConfiscationTransactionWhitelist(ctx, buildConfiscation(t))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(response.NotProcessed))
+		require.Contains(t, response.NotProcessed[0].Reason, "output 1 not found")
+	})
+
+	t.Run("in-range nil output element", func(t *testing.T) {
+		holeTx := tx.Clone()
+		holeTx.Outputs[1] = nil // in-range index, nil element
+
+		mockStore := &utxo.MockUtxostore{}
+		mockStore.On("Get", mock.Anything, mock.Anything, mock.Anything).
+			Return(&meta.Data{Tx: holeTx}, nil)
+
+		node := NewNodeConfig(ulogger.TestLogger{}, nil, mockStore, nil, nil, nil, tSettings)
+
+		response, err := node.AddToConfiscationTransactionWhitelist(ctx, buildConfiscation(t))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(response.NotProcessed))
+		require.Contains(t, response.NotProcessed[0].Reason, "output 1 not found")
+	})
 }


### PR DESCRIPTION
## Problem

The alert-service `Node` handlers indexed `parentTxMeta.Tx.Outputs[...]` with a vout taken from the incoming alert message, without bounds-checking it against the parent transaction's output count, and dereferenced `parentTxMeta.Tx` without a nil check:

- **`AddToConsensusBlacklist`** (`services/alert/node.go`) - indexed `Outputs[fund.TxOut.Vout]`, where `Vout` comes from the fund in the alert message.
- **`AddToConfiscationTransactionWhitelist`** - indexed `Outputs[txIn.PreviousTxOutIndex]` at three sites, where `PreviousTxOutIndex` comes from a confiscation transaction parsed from attacker-supplied hex.

A vout beyond the parent's outputs, or a parent whose `Tx` field is unpopulated, panics with `index out of range` / nil-pointer, taking down the alert-service goroutine. Same unguarded-index class as the fixes for #1283 / #1244.

Reachability is gated behind alert-signature verification (these methods dispatch only after the alert library verifies the message against configured alert keys), so this is a robustness / defense-in-depth fix rather than an anonymous DoS - but a validly-signed alert referencing a vout the parent doesn't have (operator error, or a pruned/mismatched parent) still crashes the service today.

## Fix

Guard both sites: on a nil `Tx` or an out-of-range index, append to the existing `NotProcessed` response with a `"parent tx output N not found"` reason instead of indexing. One guard in the confiscation handler covers all three uses. The consensus-blacklist site now also indexes with the already-validated `vout` (uint32) for consistency.

## Tests

Two regression tests (`TestNode_AddToConsensusBlacklist_OutOfRangeVout`, `TestNode_AddToConfiscationTransactionWhitelist_OutOfRangeInputIndex`) drive an out-of-range vout (99 against a 10-output parent) through the real `sqlitememory` store and assert a graceful `NotProcessed` response. Both panic with `index out of range [99] with length 10` when the guard is removed, and pass with it.

## Verification

- `go test -tags testtxmetacache ./services/alert/` - pass
- `go test -race` on the affected tests - pass
- `go vet ./services/alert/` - clean
- `gofmt` - clean