### PR TITLE
fix(blockchain): refuse to invalidate the genesis block

### DIFF
--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2301,6 +2301,13 @@ func (b *Blockchain) InvalidateBlock(ctx context.Context, request *blockchain_ap
 		return nil, errors.WrapGRPC(errors.NewBlockInvalidError("[Blockchain][InvalidateBlock] request's hash is not valid", err))
 	}
 
+	// Refuse to invalidate the genesis block. The store's recursive CTE would flip the
+	// whole chain invalid in one statement and it could not be undone via reconsiderblock.
+	// Guarded in the store too (defense in depth); reject early here with a clear error.
+	if b.settings != nil && b.settings.ChainCfgParams != nil && blockHash.IsEqual(b.settings.ChainCfgParams.GenesisHash) {
+		return nil, errors.WrapGRPC(errors.NewBlockInvalidError("[Blockchain][InvalidateBlock] cannot invalidate the genesis block"))
+	}
+
 	// invalidate block will also invalidate all child blocks
 	invalidatedHashes, err := b.store.InvalidateBlock(ctx, blockHash)
 	if err != nil {

--- a/services/blockchain/mtp_cache_integration_test.go
+++ b/services/blockchain/mtp_cache_integration_test.go
@@ -163,3 +163,16 @@ func TestMTPCacheIntegration_InvalidateBlockTruncatesCache(t *testing.T) {
 	_, ok = ctx.server.mtpCache.get(3)
 	require.False(t, ok, "height 3 (above invalidated) must be truncated from cache")
 }
+
+// TestServerInvalidateBlock_GenesisGuard verifies the gRPC server rejects an
+// attempt to invalidate the genesis block (defense-in-depth mirror of the guard
+// in the SQL store), so a stray admin invalidateblock call cannot wipe the chain.
+func TestServerInvalidateBlock_GenesisGuard(t *testing.T) {
+	ctx := setup(t)
+
+	_, err := ctx.server.InvalidateBlock(context.Background(), &blockchain_api.InvalidateBlockRequest{
+		BlockHash: ctx.server.settings.ChainCfgParams.GenesisHash.CloneBytes(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot invalidate the genesis block")
+}

--- a/stores/blockchain/sql/InvalidateBlock.go
+++ b/stores/blockchain/sql/InvalidateBlock.go
@@ -62,6 +62,15 @@ import (
 func (s *SQL) InvalidateBlock(ctx context.Context, blockHash *chainhash.Hash) (invalidatedHashes []chainhash.Hash, err error) {
 	s.logger.Debugf("InvalidateBlock %s", blockHash.String())
 
+	// Refuse to invalidate the genesis block. Genesis is the root of the recursive
+	// descendant CTE below, so invalidating it would flip the entire chain to
+	// invalid/off-main-chain in a single statement, and RevalidateBlock (single block,
+	// no recursion) could not undo it. bitcoind and the Java reference node both forbid
+	// marking genesis for exactly this reason.
+	if s.chainParams != nil && blockHash.IsEqual(s.chainParams.GenesisHash) {
+		return nil, errors.NewProcessingError("cannot invalidate the genesis block")
+	}
+
 	exists, err := s.GetBlockExists(ctx, blockHash)
 	if err != nil {
 		return nil, errors.NewStorageError("error checking block exists", err)

--- a/stores/blockchain/sql/InvalidateBlock_test.go
+++ b/stores/blockchain/sql/InvalidateBlock_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/stores/blockchain/options"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -224,3 +225,43 @@ func TestSQLInvalidateBlock(t *testing.T) {
 // 	}
 // 	return err
 // }
+
+// TestSQLInvalidateBlock_GenesisGuard asserts that InvalidateBlock refuses to
+// invalidate the genesis block. Without the guard, the recursive descendant CTE
+// rooted at genesis would flip the entire chain (genesis -> block1 -> block2 ->
+// block3, since block1.HashPrevBlock is the regtest genesis) to invalid and off
+// the main chain in a single statement, and RevalidateBlock could not undo it.
+func TestSQLInvalidateBlock_GenesisGuard(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	s, err := New(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+
+	err = s.insertGenesisTransaction(ulogger.TestLogger{}, tSettings.ChainCfgParams)
+	require.NoError(t, err)
+
+	_, _, err = s.StoreBlock(context.Background(), block1, "", options.WithMinedSet(true))
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block2, "", options.WithMinedSet(true))
+	require.NoError(t, err)
+	_, _, err = s.StoreBlock(context.Background(), block3, "", options.WithMinedSet(true))
+	require.NoError(t, err)
+
+	// Attempt to invalidate the genesis block - must be rejected.
+	hashes, err := s.InvalidateBlock(context.Background(), tSettings.ChainCfgParams.GenesisHash)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot invalidate the genesis block")
+	require.Empty(t, hashes)
+
+	// The chain must be untouched: no block flipped to invalid.
+	for _, b := range []*model.Block{block1, block2, block3} {
+		var invalid bool
+		err = s.db.QueryRowContext(context.Background(),
+			"SELECT invalid FROM blocks WHERE hash = $1", b.Hash().CloneBytes()).Scan(&invalid)
+		require.NoError(t, err)
+		assert.False(t, invalid, "block at height %d must remain valid after rejected genesis invalidation", b.Height)
+	}
+}


### PR DESCRIPTION
## Problem

`SQL.InvalidateBlock` (`stores/blockchain/sql/InvalidateBlock.go`) runs a recursive descendant CTE rooted at the target hash:

```sql
WITH RECURSIVE children AS (
    SELECT ... WHERE hash = $1
    UNION
    SELECT ... INNER JOIN children c ON c.hash = b.previous_hash )
UPDATE blocks SET invalid = true, mined_set = false, on_main_chain = false
WHERE id IN (SELECT id FROM children)
```

Nothing at any layer (`services/rpc/handlers.go` handler → `services/blockchain/Server.go` gRPC → SQL store) checks the target against the genesis hash. Genesis is a real row, so an admin `invalidateblock` RPC on the genesis hash walks every descendant and marks the **entire chain** invalid + off-main-chain in a single statement.

Recovery is worse than bitcoind: `RevalidateBlock` updates only the single named block (`UPDATE ... WHERE hash = $1`, no recursion), so `reconsiderblock` cannot undo a chain-wide invalidation - you would have to reconsider every block individually.

`invalidateblock` is an authenticated operator RPC, so this is an operator-footgun / safety-rail gap rather than an anonymous vector - but the blast radius is maximal and unrecoverable via RPC, which is exactly why bitcoind and the Java reference node both forbid marking genesis.

Found via the Java-POC to Teranode comparative gap analysis (bitcoin-sv/teranode#4693), verified against current `main`.

## Fix

Add a genesis guard at the top of `SQL.InvalidateBlock`, before any DB work:

```go
if s.chainParams != nil && blockHash.IsEqual(s.chainParams.GenesisHash) {
    return nil, errors.NewProcessingError("cannot invalidate the genesis block")
}
```

and mirror it in the blockchain gRPC server (`services/blockchain/Server.go`) for defense in depth. Matches bitcoind's `MarkGenesisException` behaviour.

## Tests

- `TestSQLInvalidateBlock_GenesisGuard` - stores genesis → block1 → block2 → block3 (the regtest fixtures form exactly this chain), asserts genesis invalidation is rejected and every block stays valid. Load-bearing: with the store guard removed the test fails because the whole chain is invalidated.
- `TestServerInvalidateBlock_GenesisGuard` - covers the gRPC server path; verified the server-level guard fires independently (still rejects with the store guard disabled).

## Verification

- `go vet ./stores/blockchain/sql/ ./services/blockchain/` - clean
- `go test` both packages - pass
- `go test -race` on the new tests - pass
- `gofmt` - clean