### PR TITLE
chore: define constants for duplicated string literals (S1192)

### DIFF
--- a/cmd/compare-benchmarks/main.go
+++ b/cmd/compare-benchmarks/main.go
@@ -17,6 +17,11 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 )
 
+const (
+	secOpUnit   = "sec/op"
+	vsBaseLabel = "vs base"
+)
+
 type comparison struct {
 	Name          string
 	BaselineValue string
@@ -120,21 +125,21 @@ func parseBenchstat(output string, threshold, alpha float64) []comparison {
 	noChangeRe := regexp.MustCompile(`~\s+\(p=(\d+\.?\d*)\s+n=\d+\)`)
 
 	scanner := bufio.NewScanner(strings.NewReader(output))
-	currentMetric := "sec/op"
+	currentMetric := secOpUnit
 
 	for scanner.Scan() {
 		line := scanner.Text()
 
 		// Detect metric headers (sec/op, B/op, allocs/op)
-		if strings.Contains(line, "sec/op") && strings.Contains(line, "vs base") {
-			currentMetric = "sec/op"
+		if strings.Contains(line, secOpUnit) && strings.Contains(line, vsBaseLabel) {
+			currentMetric = secOpUnit
 			continue
 		}
-		if strings.Contains(line, "B/op") && strings.Contains(line, "vs base") {
+		if strings.Contains(line, "B/op") && strings.Contains(line, vsBaseLabel) {
 			currentMetric = "B/op"
 			continue
 		}
-		if strings.Contains(line, "allocs/op") && strings.Contains(line, "vs base") {
+		if strings.Contains(line, "allocs/op") && strings.Contains(line, vsBaseLabel) {
 			currentMetric = "allocs/op"
 			continue
 		}
@@ -205,7 +210,7 @@ func parseBenchstat(output string, threshold, alpha float64) []comparison {
 			comp.PValue, _ = strconv.ParseFloat(m[2], 64)
 			comp.HasPValue = true
 
-			if currentMetric == "sec/op" {
+			if currentMetric == secOpUnit {
 				comp.Degraded = comp.PValue < alpha && comp.PercentChange > threshold
 				comp.Improved = comp.PValue < alpha && comp.PercentChange < -threshold
 			}
@@ -218,7 +223,7 @@ func parseBenchstat(output string, threshold, alpha float64) []comparison {
 			pctRe := regexp.MustCompile(`([+-]?\d+\.?\d*)%`)
 			if m := pctRe.FindStringSubmatch(line); m != nil {
 				comp.PercentChange, _ = strconv.ParseFloat(m[1], 64)
-				if currentMetric == "sec/op" {
+				if currentMetric == secOpUnit {
 					comp.Degraded = math.Abs(comp.PercentChange) > threshold && comp.PercentChange > 0
 					comp.Improved = math.Abs(comp.PercentChange) > threshold && comp.PercentChange < 0
 				}
@@ -265,7 +270,7 @@ func generateReport(comparisons []comparison, threshold, alpha float64, baseline
 	// Filter to sec/op only for summary
 	var secComps []comparison
 	for _, c := range comparisons {
-		if c.Metric == "sec/op" {
+		if c.Metric == secOpUnit {
 			secComps = append(secComps, c)
 		}
 	}

--- a/cmd/diagnose/config_checks.go
+++ b/cmd/diagnose/config_checks.go
@@ -8,6 +8,12 @@ import (
 	"github.com/bsv-blockchain/teranode/settings"
 )
 
+const (
+	labelGRPCAdminAPIKey = "gRPC admin API key"
+	valueEmpty           = "(empty)"
+	labelDataFolder      = "Data folder"
+)
+
 func runConfigChecks(s *settings.Settings) []ConfigResult {
 	var results []ConfigResult
 
@@ -239,21 +245,21 @@ func checkSecurity(s *settings.Settings) []ConfigResult {
 	if s.GRPCAdminAPIKey == "" {
 		results = append(results, ConfigResult{
 			Severity:    severity,
-			Check:       "gRPC admin API key",
-			Value:       "(empty)",
+			Check:       labelGRPCAdminAPIKey,
+			Value:       valueEmpty,
 			Recommended: "Set grpc_admin_api_key (32+ chars)",
 		})
 	} else if len(s.GRPCAdminAPIKey) < 16 {
 		results = append(results, ConfigResult{
 			Severity:    SeverityWARN,
-			Check:       "gRPC admin API key",
+			Check:       labelGRPCAdminAPIKey,
 			Value:       fmt.Sprintf("%d chars (weak)", len(s.GRPCAdminAPIKey)),
 			Recommended: "Use at least 16 characters, ideally 32+",
 		})
 	} else {
 		results = append(results, ConfigResult{
 			Severity: SeverityOK,
-			Check:    "gRPC admin API key",
+			Check:    labelGRPCAdminAPIKey,
 			Value:    fmt.Sprintf("%d chars", len(s.GRPCAdminAPIKey)),
 		})
 	}
@@ -268,7 +274,7 @@ func checkKafkaConfig(s *settings.Settings) []ConfigResult {
 		results = append(results, ConfigResult{
 			Severity:    SeverityERROR,
 			Check:       "Kafka hosts",
-			Value:       "(empty)",
+			Value:       valueEmpty,
 			Recommended: "Set KAFKA_HOSTS (e.g. localhost:9092)",
 		})
 	} else {
@@ -392,7 +398,7 @@ func checkP2PConfig(s *settings.Settings) []ConfigResult {
 		results = append(results, ConfigResult{
 			Severity:    SeverityERROR,
 			Check:       "P2P listen addresses",
-			Value:       "(empty)",
+			Value:       valueEmpty,
 			Recommended: "Set p2p_listen_addresses (e.g. /ip4/0.0.0.0/tcp/9905)",
 		})
 	} else {
@@ -652,14 +658,14 @@ func checkDataFolder(s *settings.Settings) []ConfigResult {
 		if os.IsNotExist(err) {
 			results = append(results, ConfigResult{
 				Severity:    SeverityWARN,
-				Check:       "Data folder",
+				Check:       labelDataFolder,
 				Value:       dataFolder,
 				Recommended: "Create the data folder before starting the node",
 			})
 		} else {
 			results = append(results, ConfigResult{
 				Severity:    SeverityERROR,
-				Check:       "Data folder",
+				Check:       labelDataFolder,
 				Value:       fmt.Sprintf("%s (%v)", dataFolder, err),
 				Recommended: "Check permissions on data folder",
 			})
@@ -667,7 +673,7 @@ func checkDataFolder(s *settings.Settings) []ConfigResult {
 	} else if !info.IsDir() {
 		results = append(results, ConfigResult{
 			Severity:    SeverityERROR,
-			Check:       "Data folder",
+			Check:       labelDataFolder,
 			Value:       dataFolder,
 			Recommended: "Path exists but is not a directory",
 		})
@@ -678,7 +684,7 @@ func checkDataFolder(s *settings.Settings) []ConfigResult {
 		if err != nil {
 			results = append(results, ConfigResult{
 				Severity:    SeverityERROR,
-				Check:       "Data folder",
+				Check:       labelDataFolder,
 				Value:       fmt.Sprintf("%s (not writable)", dataFolder),
 				Recommended: "Check write permissions on data folder",
 			})
@@ -688,7 +694,7 @@ func checkDataFolder(s *settings.Settings) []ConfigResult {
 
 			results = append(results, ConfigResult{
 				Severity: SeverityOK,
-				Check:    "Data folder",
+				Check:    labelDataFolder,
 				Value:    fmt.Sprintf("%s (writable)", dataFolder),
 			})
 		}

--- a/cmd/diagnose/health_checks.go
+++ b/cmd/diagnose/health_checks.go
@@ -24,6 +24,18 @@ import (
 	"github.com/ordishs/gocore"
 )
 
+const (
+	svcBlockchainGRPC        = "Blockchain gRPC"
+	svcValidatorGRPC         = "Validator gRPC"
+	svcBlockValidationGRPC   = "Block Validation gRPC"
+	svcBlockAssemblyGRPC     = "Block Assembly gRPC"
+	svcSubtreeValidationGRPC = "Subtree Validation gRPC"
+	svcP2PGRPC               = "P2P gRPC"
+	msgFailedToCreateClient  = "failed to create client"
+	msgNotConfigured         = "not configured"
+	pathHealth               = "/health"
+)
+
 // Clients that are reused across multiple checks are stored here
 // to avoid creating duplicate connections.
 type serviceClients struct {
@@ -105,21 +117,21 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		if clients.blockchain != nil {
 			client := clients.blockchain
 			services = append(services, grpcService{
-				name:    "Blockchain gRPC",
+				name:    svcBlockchainGRPC,
 				address: s.BlockChain.GRPCAddress,
 				check:   func() (int, string, error) { return client.Health(ctx, true) },
 			})
 		} else {
 			services = append(services, grpcService{
-				name:    "Blockchain gRPC",
+				name:    svcBlockchainGRPC,
 				address: s.BlockChain.GRPCAddress,
 				check: func() (int, string, error) {
-					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, "failed to create client")
+					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, msgFailedToCreateClient)
 				},
 			})
 		}
 	} else {
-		services = append(services, grpcService{name: "Blockchain gRPC", skipMsg: skipReason("Blockchain")})
+		services = append(services, grpcService{name: svcBlockchainGRPC, skipMsg: skipReason("Blockchain")})
 	}
 
 	// Validator
@@ -127,20 +139,20 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		client, err := validator.NewClient(ctx, logger, s)
 		if err != nil {
 			services = append(services, grpcService{
-				name:    "Validator gRPC",
+				name:    svcValidatorGRPC,
 				address: s.Validator.GRPCAddress,
 				check:   func() (int, string, error) { return http.StatusServiceUnavailable, "", err },
 			})
 		} else {
 			defer func() { _ = client.Close() }()
 			services = append(services, grpcService{
-				name:    "Validator gRPC",
+				name:    svcValidatorGRPC,
 				address: s.Validator.GRPCAddress,
 				check:   func() (int, string, error) { return client.Health(ctx, true) },
 			})
 		}
 	} else {
-		services = append(services, grpcService{name: "Validator gRPC", skipMsg: skipReason("Validator")})
+		services = append(services, grpcService{name: svcValidatorGRPC, skipMsg: skipReason("Validator")})
 	}
 
 	// Block Validation
@@ -148,21 +160,21 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		if clients.blockValidation != nil {
 			client := clients.blockValidation
 			services = append(services, grpcService{
-				name:    "Block Validation gRPC",
+				name:    svcBlockValidationGRPC,
 				address: s.BlockValidation.GRPCAddress,
 				check:   func() (int, string, error) { return client.Health(ctx, true) },
 			})
 		} else {
 			services = append(services, grpcService{
-				name:    "Block Validation gRPC",
+				name:    svcBlockValidationGRPC,
 				address: s.BlockValidation.GRPCAddress,
 				check: func() (int, string, error) {
-					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, "failed to create client")
+					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, msgFailedToCreateClient)
 				},
 			})
 		}
 	} else {
-		services = append(services, grpcService{name: "Block Validation gRPC", skipMsg: skipReason("BlockValidation")})
+		services = append(services, grpcService{name: svcBlockValidationGRPC, skipMsg: skipReason("BlockValidation")})
 	}
 
 	// Block Assembly
@@ -170,21 +182,21 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		if clients.blockAssembly != nil {
 			client := clients.blockAssembly
 			services = append(services, grpcService{
-				name:    "Block Assembly gRPC",
+				name:    svcBlockAssemblyGRPC,
 				address: s.BlockAssembly.GRPCAddress,
 				check:   func() (int, string, error) { return client.Health(ctx, true) },
 			})
 		} else {
 			services = append(services, grpcService{
-				name:    "Block Assembly gRPC",
+				name:    svcBlockAssemblyGRPC,
 				address: s.BlockAssembly.GRPCAddress,
 				check: func() (int, string, error) {
-					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, "failed to create client")
+					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, msgFailedToCreateClient)
 				},
 			})
 		}
 	} else {
-		services = append(services, grpcService{name: "Block Assembly gRPC", skipMsg: skipReason("BlockAssembly")})
+		services = append(services, grpcService{name: svcBlockAssemblyGRPC, skipMsg: skipReason("BlockAssembly")})
 	}
 
 	// Subtree Validation
@@ -192,7 +204,7 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		client, err := subtreevalidation.NewClient(ctx, logger, s, "diagnose")
 		if err != nil {
 			services = append(services, grpcService{
-				name:    "Subtree Validation gRPC",
+				name:    svcSubtreeValidationGRPC,
 				address: s.SubtreeValidation.GRPCAddress,
 				check:   func() (int, string, error) { return http.StatusServiceUnavailable, "", err },
 			})
@@ -201,13 +213,13 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 				defer func() { _ = cc.Close() }()
 			}
 			services = append(services, grpcService{
-				name:    "Subtree Validation gRPC",
+				name:    svcSubtreeValidationGRPC,
 				address: s.SubtreeValidation.GRPCAddress,
 				check:   func() (int, string, error) { return client.Health(ctx, true) },
 			})
 		}
 	} else {
-		services = append(services, grpcService{name: "Subtree Validation gRPC", skipMsg: skipReason("SubtreeValidation")})
+		services = append(services, grpcService{name: svcSubtreeValidationGRPC, skipMsg: skipReason("SubtreeValidation")})
 	}
 
 	// P2P (uses GetPeers as health indicator - no Health method on ClientI)
@@ -215,7 +227,7 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		if clients.p2p != nil {
 			client := clients.p2p
 			services = append(services, grpcService{
-				name:    "P2P gRPC",
+				name:    svcP2PGRPC,
 				address: s.P2P.GRPCAddress,
 				check: func() (int, string, error) {
 					_, err := client.GetPeers(ctx)
@@ -227,15 +239,15 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 			})
 		} else {
 			services = append(services, grpcService{
-				name:    "P2P gRPC",
+				name:    svcP2PGRPC,
 				address: s.P2P.GRPCAddress,
 				check: func() (int, string, error) {
-					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, "failed to create client")
+					return http.StatusServiceUnavailable, "", errors.New(errors.ERR_SERVICE_UNAVAILABLE, msgFailedToCreateClient)
 				},
 			})
 		}
 	} else {
-		services = append(services, grpcService{name: "P2P gRPC", skipMsg: skipReason("P2P")})
+		services = append(services, grpcService{name: svcP2PGRPC, skipMsg: skipReason("P2P")})
 	}
 
 	var results []HealthResult
@@ -244,7 +256,7 @@ func checkGRPCServices(ctx context.Context, logger ulogger.Logger, s *settings.S
 		if svc.check == nil {
 			msg := svc.skipMsg
 			if msg == "" {
-				msg = "not configured"
+				msg = msgNotConfigured
 			}
 
 			results = append(results, HealthResult{
@@ -288,7 +300,7 @@ func checkHTTPServices(ctx context.Context, s *settings.Settings) []HealthResult
 	// Asset Server
 	if s.Asset.HTTPListenAddress != "" {
 		addr := normalizeHTTPAddress(s.Asset.HTTPListenAddress)
-		results = append(results, checkHTTPEndpoint(ctx, "Asset HTTP", addr, "/health"))
+		results = append(results, checkHTTPEndpoint(ctx, "Asset HTTP", addr, pathHealth))
 	} else {
 		results = append(results, HealthResult{
 			Service: "Asset HTTP",
@@ -301,13 +313,13 @@ func checkHTTPServices(ctx context.Context, s *settings.Settings) []HealthResult
 	// Propagation HTTP
 	if s.Propagation.HTTPListenAddress != "" {
 		addr := normalizeHTTPAddress(s.Propagation.HTTPListenAddress)
-		results = append(results, checkHTTPEndpoint(ctx, "Propagation HTTP", addr, "/health"))
+		results = append(results, checkHTTPEndpoint(ctx, "Propagation HTTP", addr, pathHealth))
 	}
 
 	// Block Persister HTTP
 	if s.BlockPersister.HTTPListenAddress != "" {
 		addr := normalizeHTTPAddress(s.BlockPersister.HTTPListenAddress)
-		results = append(results, checkHTTPEndpoint(ctx, "Block Persister HTTP", addr, "/health"))
+		results = append(results, checkHTTPEndpoint(ctx, "Block Persister HTTP", addr, pathHealth))
 	}
 
 	// RPC
@@ -318,7 +330,7 @@ func checkHTTPServices(ctx context.Context, s *settings.Settings) []HealthResult
 	// Health Check endpoint
 	if s.HealthCheckHTTPListenAddress != "" {
 		addr := normalizeHTTPAddress(s.HealthCheckHTTPListenAddress)
-		results = append(results, checkHTTPEndpoint(ctx, "Health Endpoint", addr, "/health"))
+		results = append(results, checkHTTPEndpoint(ctx, "Health Endpoint", addr, pathHealth))
 	}
 
 	// Profiler (pprof)
@@ -386,7 +398,7 @@ func checkKafka(ctx context.Context, s *settings.Settings) HealthResult {
 			Service: "Kafka",
 			Address: "-",
 			Status:  StatusSKIP,
-			Message: "not configured",
+			Message: msgNotConfigured,
 		}
 	}
 
@@ -421,7 +433,7 @@ func checkAerospike(ctx context.Context, logger ulogger.Logger, s *settings.Sett
 			Service: "Aerospike",
 			Address: "-",
 			Status:  StatusSKIP,
-			Message: "not configured",
+			Message: msgNotConfigured,
 		}
 	}
 
@@ -475,7 +487,7 @@ func checkPostgres(ctx context.Context, s *settings.Settings) HealthResult {
 			Service: "PostgreSQL",
 			Address: "-",
 			Status:  StatusSKIP,
-			Message: "not configured",
+			Message: msgNotConfigured,
 		}
 	}
 
@@ -788,13 +800,13 @@ func isServiceEnabled(formalName string) bool {
 }
 
 // skipReason returns a SKIP message explaining why a service is not checked.
-// If the service is disabled in settings, it says so. Otherwise "not configured".
+// If the service is disabled in settings, it says so. Otherwise msgNotConfigured.
 func skipReason(formalName string) string {
 	if !isServiceEnabled(formalName) {
 		return fmt.Sprintf("disabled (start%s=false)", formalName)
 	}
 
-	return "not configured"
+	return msgNotConfigured
 }
 
 func normalizeHTTPAddress(addr string) string {

--- a/cmd/filereader/file_reader.go
+++ b/cmd/filereader/file_reader.go
@@ -51,6 +51,9 @@ const (
 	numTransactionsFormat     = "Number of transactions: %d\n"    // format for number of transactions
 	previousBlockHashFormat   = "previous block hash:       %s\n" // format for previous block hash
 	stdin                     = "[stdin]"                         // constant for stdin input
+
+	msgErrorReadingSubtree      = "error reading subtree"       // error message for subtree read failures
+	msgErrorReadingHeaderNumber = "error reading header number" // error message for header number read failures
 )
 
 var (
@@ -211,7 +214,7 @@ func handleSubtreeData(br *bufio.Reader, logger ulogger.Logger, settings *settin
 
 	st := &subtree.Subtree{}
 	if err = st.DeserializeFromReader(stReader); err != nil {
-		return errors.NewProcessingError("error reading subtree", err)
+		return errors.NewProcessingError(msgErrorReadingSubtree, err)
 	}
 
 	var sd *subtree.Data
@@ -257,7 +260,7 @@ func handleSubtreeMeta(br *bufio.Reader, logger ulogger.Logger, settings *settin
 	st := &subtree.Subtree{}
 
 	if err = st.DeserializeFromReader(stReader); err != nil {
-		return errors.NewProcessingError("error reading subtree", err)
+		return errors.NewProcessingError(msgErrorReadingSubtree, err)
 	}
 
 	var subtreeMeta *subtree.Meta
@@ -353,7 +356,7 @@ func handleUtxoSet(ctx context.Context, br *bufio.Reader) error {
 	var blockHeight uint32
 
 	if err = binary.Read(br, binary.LittleEndian, &blockHeight); err != nil {
-		return errors.NewProcessingError("error reading header number", err)
+		return errors.NewProcessingError(msgErrorReadingHeaderNumber, err)
 	}
 
 	fmt.Printf(blockHeightFormat, blockHeight)
@@ -413,7 +416,7 @@ func handleUtxoAdditions(ctx context.Context, br *bufio.Reader) error {
 
 	var blockHeight uint32
 	if err = binary.Read(br, binary.LittleEndian, &blockHeight); err != nil {
-		return errors.NewProcessingError("error reading header number", err)
+		return errors.NewProcessingError(msgErrorReadingHeaderNumber, err)
 	}
 
 	fmt.Printf(blockHeightFormat, blockHeight)
@@ -522,7 +525,7 @@ func handleUtxoDeletions(br *bufio.Reader) error {
 	var blockHeight uint32
 
 	if err = binary.Read(br, binary.LittleEndian, &blockHeight); err != nil {
-		return errors.NewProcessingError("error reading header number", err)
+		return errors.NewProcessingError(msgErrorReadingHeaderNumber, err)
 	}
 
 	fmt.Printf(blockHeightFormat, blockHeight)
@@ -557,7 +560,7 @@ func handleUtxoDeletions(br *bufio.Reader) error {
 func handleSubtree(br *bufio.Reader) error {
 	st := &subtree.Subtree{}
 	if err := st.DeserializeFromReader(br); err != nil {
-		return errors.NewProcessingError("error reading subtree", err)
+		return errors.NewProcessingError(msgErrorReadingSubtree, err)
 	}
 
 	fmt.Printf("Subtree root hash: %s\n", st.RootHash())

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -29,6 +29,16 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const (
+	clientSourceName    = "TUI Monitor"
+	statusNotConfigured = "Not configured"
+	namespacePrefix     = "namespace/"
+	timeFormatHMS       = "15:04:05"
+	msgLoading          = "Loading..."
+	labelGRPCAddress    = "gRPC Address"
+	labelGRPCListen     = "gRPC Listen"
+)
+
 // ViewMode represents the current view
 type ViewMode int
 
@@ -166,7 +176,7 @@ func NewModel(logger ulogger.Logger, s *settings.Settings) (*Model, error) {
 	ctx := context.Background()
 
 	// Create blockchain client
-	blockchainClient, err := blockchain.NewClient(ctx, logger, s, "TUI Monitor")
+	blockchainClient, err := blockchain.NewClient(ctx, logger, s, clientSourceName)
 	if err != nil {
 		return nil, errors.NewProcessingError("failed to create blockchain client", err)
 	}
@@ -192,7 +202,7 @@ func NewModel(logger ulogger.Logger, s *settings.Settings) (*Model, error) {
 
 	var blockValClient blockvalidation.Interface
 	if s.BlockValidation.GRPCAddress != "" {
-		blockValClient, _ = blockvalidation.NewClient(ctx, logger, s, "TUI Monitor")
+		blockValClient, _ = blockvalidation.NewClient(ctx, logger, s, clientSourceName)
 	}
 
 	var blockAsmClient blockassembly.ClientI
@@ -202,7 +212,7 @@ func NewModel(logger ulogger.Logger, s *settings.Settings) (*Model, error) {
 
 	var subtreeClient subtreevalidation.Interface
 	if s.SubtreeValidation.GRPCAddress != "" {
-		subtreeClient, _ = subtreevalidation.NewClient(ctx, logger, s, "TUI Monitor")
+		subtreeClient, _ = subtreevalidation.NewClient(ctx, logger, s, clientSourceName)
 	}
 
 	// Create Aerospike client (optional - don't fail if not configured)
@@ -316,7 +326,7 @@ func (m Model) collectAerospikeStats() *AerospikeStats {
 	}
 
 	if m.aerospikeClient == nil {
-		stats.Error = "Not configured"
+		stats.Error = statusNotConfigured
 		return stats
 	}
 
@@ -377,9 +387,9 @@ func (m Model) collectAerospikeStats() *AerospikeStats {
 		// Fallback to common namespace names
 		if namespaceName == "" {
 			for _, ns := range []string{"teranode", "test", "bar"} {
-				nsInfo, err := node.RequestInfo(policy, "namespace/"+ns)
+				nsInfo, err := node.RequestInfo(policy, namespacePrefix+ns)
 				if err == nil {
-					if nsStr, ok := nsInfo["namespace/"+ns]; ok && nsStr != "" {
+					if nsStr, ok := nsInfo[namespacePrefix+ns]; ok && nsStr != "" {
 						namespaceName = ns
 						break
 					}
@@ -434,9 +444,9 @@ func (m Model) collectAerospikeStats() *AerospikeStats {
 
 		// Get namespace statistics for this node
 		if namespaceName != "" {
-			nsInfo, err := node.RequestInfo(policy, "namespace/"+namespaceName)
+			nsInfo, err := node.RequestInfo(policy, namespacePrefix+namespaceName)
 			if err == nil {
-				if nsStr, ok := nsInfo["namespace/"+namespaceName]; ok && nsStr != "" {
+				if nsStr, ok := nsInfo[namespacePrefix+namespaceName]; ok && nsStr != "" {
 					nInfo.NamespaceStats = parseAerospikeInfoString(nsStr)
 					stats.Namespaces[namespaceName] = nInfo.NamespaceStats
 					// Aggregate namespace stats
@@ -572,7 +582,7 @@ func (m Model) collectServiceHealth(ctx context.Context, data *NodeData) {
 		data.ServiceHealth["validator"] = &ServiceHealth{
 			Name:       "Validator",
 			Configured: false,
-			Message:    "Not configured",
+			Message:    statusNotConfigured,
 		}
 	}
 
@@ -586,7 +596,7 @@ func (m Model) collectServiceHealth(ctx context.Context, data *NodeData) {
 		data.ServiceHealth["blockvalidation"] = &ServiceHealth{
 			Name:       "Block Validation",
 			Configured: false,
-			Message:    "Not configured",
+			Message:    statusNotConfigured,
 		}
 	}
 
@@ -600,7 +610,7 @@ func (m Model) collectServiceHealth(ctx context.Context, data *NodeData) {
 		data.ServiceHealth["blockassembly"] = &ServiceHealth{
 			Name:       "Block Assembly",
 			Configured: false,
-			Message:    "Not configured",
+			Message:    statusNotConfigured,
 		}
 	}
 
@@ -614,7 +624,7 @@ func (m Model) collectServiceHealth(ctx context.Context, data *NodeData) {
 		data.ServiceHealth["subtreevalidation"] = &ServiceHealth{
 			Name:       "Subtree Validation",
 			Configured: false,
-			Message:    "Not configured",
+			Message:    statusNotConfigured,
 		}
 	}
 }
@@ -789,7 +799,7 @@ func (m Model) View() string {
 
 	// Status bar
 	b.WriteString("\n")
-	statusLine := fmt.Sprintf("Last updated: %s", m.data.LastUpdated.Format("15:04:05"))
+	statusLine := fmt.Sprintf("Last updated: %s", m.data.LastUpdated.Format(timeFormatHMS))
 	b.WriteString(labelStyle.Render(statusLine))
 
 	// Help
@@ -807,7 +817,7 @@ func (m Model) renderBlockchainPanel() string {
 	content.WriteString("\n")
 
 	if m.data.BlockStats == nil {
-		content.WriteString(labelStyle.Render("Loading..."))
+		content.WriteString(labelStyle.Render(msgLoading))
 		return boxStyle.Width(40).Render(content.String())
 	}
 
@@ -836,7 +846,7 @@ func (m Model) renderFSMPanel() string {
 	content.WriteString("\n")
 
 	if m.data.FSMState == nil {
-		content.WriteString(labelStyle.Render("Loading..."))
+		content.WriteString(labelStyle.Render(msgLoading))
 		return boxStyle.Width(40).Render(content.String())
 	}
 
@@ -886,7 +896,7 @@ func (m Model) renderPeersPanel() string {
 	content.WriteString("\n")
 
 	if m.data.Peers == nil {
-		content.WriteString(labelStyle.Render("Loading..."))
+		content.WriteString(labelStyle.Render(msgLoading))
 		return boxStyle.Width(50).Render(content.String())
 	}
 
@@ -1032,8 +1042,8 @@ func (m Model) renderSettingsView() string {
 
 	// Blockchain settings
 	lines = append(lines, settingSectionStyle.Render("BLOCKCHAIN"))
-	lines = append(lines, m.renderSettingRow("gRPC Address", m.settings.BlockChain.GRPCAddress))
-	lines = append(lines, m.renderSettingRow("gRPC Listen", m.settings.BlockChain.GRPCListenAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCAddress, m.settings.BlockChain.GRPCAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCListen, m.settings.BlockChain.GRPCListenAddress))
 	lines = append(lines, m.renderSettingRow("HTTP Listen", m.settings.BlockChain.HTTPListenAddress))
 	if m.settings.BlockChain.StoreURL != nil {
 		lines = append(lines, m.renderSettingRow("Store", m.settings.BlockChain.StoreURL.String()))
@@ -1041,8 +1051,8 @@ func (m Model) renderSettingsView() string {
 
 	// P2P settings
 	lines = append(lines, settingSectionStyle.Render("P2P"))
-	lines = append(lines, m.renderSettingRow("gRPC Address", m.settings.P2P.GRPCAddress))
-	lines = append(lines, m.renderSettingRow("gRPC Listen", m.settings.P2P.GRPCListenAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCAddress, m.settings.P2P.GRPCAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCListen, m.settings.P2P.GRPCListenAddress))
 	lines = append(lines, m.renderSettingRow("HTTP Address", m.settings.P2P.HTTPAddress))
 	lines = append(lines, m.renderSettingRow("Port", fmt.Sprintf("%d", m.settings.P2P.Port)))
 	lines = append(lines, m.renderSettingRow("Listen Mode", m.settings.P2P.ListenMode))
@@ -1056,14 +1066,14 @@ func (m Model) renderSettingsView() string {
 
 	// Validator settings
 	lines = append(lines, settingSectionStyle.Render("VALIDATOR"))
-	lines = append(lines, m.renderSettingRow("gRPC Address", m.settings.Validator.GRPCAddress))
-	lines = append(lines, m.renderSettingRow("gRPC Listen", m.settings.Validator.GRPCListenAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCAddress, m.settings.Validator.GRPCAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCListen, m.settings.Validator.GRPCListenAddress))
 
 	// Block Assembly settings
 	lines = append(lines, settingSectionStyle.Render("BLOCK ASSEMBLY"))
 	lines = append(lines, m.renderSettingRow("Disabled", fmt.Sprintf("%v", m.settings.BlockAssembly.Disabled)))
-	lines = append(lines, m.renderSettingRow("gRPC Address", m.settings.BlockAssembly.GRPCAddress))
-	lines = append(lines, m.renderSettingRow("gRPC Listen", m.settings.BlockAssembly.GRPCListenAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCAddress, m.settings.BlockAssembly.GRPCAddress))
+	lines = append(lines, m.renderSettingRow(labelGRPCListen, m.settings.BlockAssembly.GRPCListenAddress))
 
 	// Kafka settings
 	lines = append(lines, settingSectionStyle.Render("KAFKA"))
@@ -1238,7 +1248,7 @@ func (m Model) renderHealthView() string {
 
 	// Last checked timestamp
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render(fmt.Sprintf("Last checked: %s", m.data.LastUpdated.Format("15:04:05"))))
+	b.WriteString(labelStyle.Render(fmt.Sprintf("Last checked: %s", m.data.LastUpdated.Format(timeFormatHMS))))
 
 	// Help
 	b.WriteString("\n\n")
@@ -1369,7 +1379,7 @@ func (m Model) renderAerospikeView() string {
 
 	stats := m.data.AerospikeStats
 	if stats == nil {
-		b.WriteString(labelStyle.Render("Loading..."))
+		b.WriteString(labelStyle.Render(msgLoading))
 		b.WriteString("\n\n")
 		b.WriteString(helpStyle.Render("a/esc: back | r: refresh | q: quit"))
 		return b.String()
@@ -1574,7 +1584,7 @@ func (m Model) renderAerospikeView() string {
 
 	// Last updated
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render(fmt.Sprintf("Last updated: %s", m.data.LastUpdated.Format("15:04:05"))))
+	b.WriteString(labelStyle.Render(fmt.Sprintf("Last updated: %s", m.data.LastUpdated.Format(timeFormatHMS))))
 
 	// Help
 	b.WriteString("\n")

--- a/cmd/teranodecli/teranodecli/cli.go
+++ b/cmd/teranodecli/teranodecli/cli.go
@@ -33,6 +33,13 @@ import (
 	"github.com/bsv-blockchain/teranode/util"
 )
 
+const (
+	flagCPUProfile        = "cpu-profile"
+	flagMemProfile        = "mem-profile"
+	usageCPUProfileOutput = "CPU profile output"
+	usageMemProfileOutput = "Memory profile output"
+)
+
 // commandHelp stores the command descriptions
 var commandHelp = map[string]string{
 	"filereader":              "File Reader",
@@ -484,8 +491,8 @@ func Start(args []string, version, commit string) {
 		subtreeSize := cmd.FlagSet.Int("subtree-size", 1_048_576, "Size of subtree")
 		producers := cmd.FlagSet.Int("producers", 16, "Number of producer goroutines")
 		iterations := cmd.FlagSet.Int("iterations", 10_000_000, "Number of transactions to process")
-		cpuProfile := cmd.FlagSet.String("cpu-profile", "cpu.prof", "Output file for CPU profile")
-		memProfile := cmd.FlagSet.String("mem-profile", "mem.prof", "Output file for memory profile")
+		cpuProfile := cmd.FlagSet.String(flagCPUProfile, "cpu.prof", "Output file for CPU profile")
+		memProfile := cmd.FlagSet.String(flagMemProfile, "mem.prof", "Output file for memory profile")
 		duration := cmd.FlagSet.Int("duration", 0, "Duration to run benchmark in seconds (0 for iteration-based, processes all items)")
 
 		cmd.Execute = func(args []string) error {
@@ -493,8 +500,8 @@ func Start(args []string, version, commit string) {
 		}
 	case "loadunminedbench":
 		txCount := cmd.FlagSet.Int("tx-count", 1_000_000, "Number of transactions")
-		cpuProfile := cmd.FlagSet.String("cpu-profile", "loadunmined_cpu.prof", "CPU profile output")
-		memProfile := cmd.FlagSet.String("mem-profile", "loadunmined_mem.prof", "Memory profile output")
+		cpuProfile := cmd.FlagSet.String(flagCPUProfile, "loadunmined_cpu.prof", usageCPUProfileOutput)
+		memProfile := cmd.FlagSet.String(flagMemProfile, "loadunmined_mem.prof", usageMemProfileOutput)
 		aerospikeURL := cmd.FlagSet.String("aerospike-url", "", "Aerospike URL (empty=testcontainer)")
 
 		cmd.Execute = func(args []string) error {
@@ -503,8 +510,8 @@ func Start(args []string, version, commit string) {
 	case "txmapbench":
 		numSubtrees := cmd.FlagSet.Int("subtrees", 100, "Number of subtrees")
 		txsPerSubtree := cmd.FlagSet.Int("txs-per-subtree", 1_048_576, "Transactions per subtree")
-		cpuProfile := cmd.FlagSet.String("cpu-profile", "createtransactionmap_cpu.prof", "CPU profile output")
-		memProfile := cmd.FlagSet.String("mem-profile", "createtransactionmap_mem.prof", "Memory profile output")
+		cpuProfile := cmd.FlagSet.String(flagCPUProfile, "createtransactionmap_cpu.prof", usageCPUProfileOutput)
+		memProfile := cmd.FlagSet.String(flagMemProfile, "createtransactionmap_mem.prof", usageMemProfileOutput)
 
 		cmd.Execute = func(args []string) error {
 			return runCreateTxMapBenchmark(*numSubtrees, *txsPerSubtree, *cpuProfile, *memProfile)
@@ -512,8 +519,8 @@ func Start(args []string, version, commit string) {
 	case "remainderbench":
 		numSubtrees := cmd.FlagSet.Int("subtrees", 100, "Number of subtrees")
 		txsPerSubtree := cmd.FlagSet.Int("txs-per-subtree", 1_048_576, "Transactions per subtree")
-		cpuProfile := cmd.FlagSet.String("cpu-profile", "processremaindertxanddequeue_cpu.prof", "CPU profile output")
-		memProfile := cmd.FlagSet.String("mem-profile", "processremaindertxanddequeue_mem.prof", "Memory profile output")
+		cpuProfile := cmd.FlagSet.String(flagCPUProfile, "processremaindertxanddequeue_cpu.prof", usageCPUProfileOutput)
+		memProfile := cmd.FlagSet.String(flagMemProfile, "processremaindertxanddequeue_mem.prof", usageMemProfileOutput)
 
 		cmd.Execute = func(args []string) error {
 			return runProcessRemainderBenchmark(*numSubtrees, *txsPerSubtree, *cpuProfile, *memProfile)

--- a/cmd/teranodedev/internal/prereq/prereq.go
+++ b/cmd/teranodedev/internal/prereq/prereq.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const labelPythonPyYAML = "Python + PyYAML"
+
 // Result represents one prerequisite check.
 type Result struct {
 	Name    string
@@ -28,7 +30,7 @@ func CheckAll() []Result {
 // HasFailures returns true if any required check failed (Python is optional).
 func HasFailures(results []Result) bool {
 	for _, r := range results {
-		if !r.OK && r.Name != "Python + PyYAML" {
+		if !r.OK && r.Name != labelPythonPyYAML {
 			return true
 		}
 	}
@@ -100,11 +102,11 @@ func checkPython() Result {
 	err := exec.Command("python3", "-c", "import yaml").Run()
 	if err != nil {
 		return Result{
-			Name:    "Python + PyYAML",
+			Name:    labelPythonPyYAML,
 			OK:      false,
 			Message: "not found (optional, needed for some build scripts)",
 		}
 	}
 
-	return Result{Name: "Python + PyYAML", OK: true, Message: "available"}
+	return Result{Name: labelPythonPyYAML, OK: true, Message: "available"}
 }

--- a/compose/chainintegrity/chain_integrity.go
+++ b/compose/chainintegrity/chain_integrity.go
@@ -31,6 +31,8 @@ import (
 	"github.com/bsv-blockchain/teranode/util"
 )
 
+const msgFailedGetUtxoFromStore = "[%s] failed to get utxo %s from utxo store: %s"
+
 // NodeConfig holds the configuration for connecting to a teranode instance from the host
 type NodeConfig struct {
 	Name          string
@@ -499,7 +501,7 @@ func checkNodeIntegrity(nodeConfig NodeConfig, _ int, _ int, debug bool, logfile
 					UTXOHash: utxoHash,
 				})
 				if err != nil {
-					logger.Errorf("[%s] failed to get utxo %s from utxo store: %s", loggerContext, utxoHash, err)
+					logger.Errorf(msgFailedGetUtxoFromStore, loggerContext, utxoHash, err)
 					continue
 				}
 
@@ -509,7 +511,7 @@ func checkNodeIntegrity(nodeConfig NodeConfig, _ int, _ int, debug bool, logfile
 					if utxo.SpendingData != nil {
 						metaData := &meta.Data{}
 						if err := utxoStore.GetMeta(ctx, utxo.SpendingData.TxID, metaData); err != nil {
-							logger.Errorf("[%s] failed to get utxo %s from utxo store: %s", loggerContext, utxoHash, err)
+							logger.Errorf(msgFailedGetUtxoFromStore, loggerContext, utxoHash, err)
 							continue
 						}
 
@@ -672,7 +674,7 @@ func checkNodeIntegrity(nodeConfig NodeConfig, _ int, _ int, debug bool, logfile
 										if utxo.SpendingData != nil {
 											metaData := &meta.Data{}
 											if err := utxoStore.GetMeta(ctx, utxo.SpendingData.TxID, metaData); err != nil {
-												logger.Errorf("[%s] failed to get utxo %s from utxo store: %s", loggerContext, utxoHash, err)
+												logger.Errorf(msgFailedGetUtxoFromStore, loggerContext, utxoHash, err)
 												continue
 											}
 
@@ -714,7 +716,7 @@ func checkNodeIntegrity(nodeConfig NodeConfig, _ int, _ int, debug bool, logfile
 								UTXOHash: utxoHash,
 							})
 							if err != nil {
-								logger.Errorf("[%s] failed to get utxo %s from utxo store: %s", loggerContext, utxoHash, err)
+								logger.Errorf(msgFailedGetUtxoFromStore, loggerContext, utxoHash, err)
 								continue
 							}
 

--- a/services/asset/centrifuge_impl/centrifuge.go
+++ b/services/asset/centrifuge_impl/centrifuge.go
@@ -28,6 +28,8 @@ const (
 	AccessControlAllowOrigin      = "Access-Control-Allow-Origin"
 	AccessControlAllowHeaders     = "Access-Control-Allow-Headers"
 	AccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+
+	centrifugeLogFormat = "[Centrifuge] %s: %s"
 )
 
 const (
@@ -181,13 +183,13 @@ func (c *Centrifuge) Init(_ context.Context) (err error) {
 			// at INFO floods the asset logs, so respect the per-entry level.
 			switch e.Level {
 			case centrifuge.LogLevelError:
-				c.logger.Errorf("[Centrifuge] %s: %s", e.Message, e.Fields)
+				c.logger.Errorf(centrifugeLogFormat, e.Message, e.Fields)
 			case centrifuge.LogLevelWarn:
-				c.logger.Warnf("[Centrifuge] %s: %s", e.Message, e.Fields)
+				c.logger.Warnf(centrifugeLogFormat, e.Message, e.Fields)
 			case centrifuge.LogLevelInfo:
-				c.logger.Infof("[Centrifuge] %s: %s", e.Message, e.Fields)
+				c.logger.Infof(centrifugeLogFormat, e.Message, e.Fields)
 			default:
-				c.logger.Debugf("[Centrifuge] %s: %s", e.Message, e.Fields)
+				c.logger.Debugf(centrifugeLogFormat, e.Message, e.Fields)
 			}
 		},
 	})

--- a/services/asset/httpimpl/GetBlock.go
+++ b/services/asset/httpimpl/GetBlock.go
@@ -17,6 +17,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const errInvalidHeightParameter = "invalid height parameter"
+
 // BlockExtended represents a block with additional information about the next block
 // in the blockchain. It embeds the base Block model and adds the next block hash.
 //
@@ -148,12 +150,12 @@ func (h *HTTP) GetBlockByHeight(mode ReadMode) func(c echo.Context) error {
 
 		height, err := strconv.ParseUint(c.Param("height"), 10, 64)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid height parameter", err).Error())
+			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError(errInvalidHeightParameter, err).Error())
 		}
 
 		heightUint32, err := safeconversion.Uint64ToUint32(height)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid height parameter", err).Error())
+			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError(errInvalidHeightParameter, err).Error())
 		}
 
 		block, err := h.repository.GetBlockByHeight(ctx, heightUint32)
@@ -177,7 +179,7 @@ func (h *HTTP) GetBlockByHeight(mode ReadMode) func(c echo.Context) error {
 
 			nextHeight, err := safeconversion.Uint64ToUint32(height + 1)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid height parameter", err).Error())
+				return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError(errInvalidHeightParameter, err).Error())
 			}
 
 			nextBlock, _ := h.repository.GetBlockByHeight(ctx, nextHeight)

--- a/services/asset/repository/subtree_stream.go
+++ b/services/asset/repository/subtree_stream.go
@@ -18,6 +18,8 @@ const (
 	subtreeNodeRecordSize   = chainhash.HashSize + 16
 	subtreeStreamBufferSize = 32 * 1024
 	subtreePageMaxNodes     = 100 // Keep in sync with HTTP pagination bounds.
+
+	errUnableToReadSubtreeNode = "unable to read subtree node information"
 )
 
 type subtreeStreamHeader struct {
@@ -44,7 +46,7 @@ func readSubtreeStreamHeader(buf *bufio.Reader) (subtreeStreamHeader, error) {
 func readSubtreeNodeRecord(buf *bufio.Reader) ([subtreeNodeRecordSize]byte, error) {
 	var byteBuffer [subtreeNodeRecordSize]byte
 	if _, err := io.ReadFull(buf, byteBuffer[:]); err != nil {
-		return byteBuffer, errors.NewProcessingError("unable to read subtree node information", err)
+		return byteBuffer, errors.NewProcessingError(errUnableToReadSubtreeNode, err)
 	}
 
 	return byteBuffer, nil
@@ -297,9 +299,9 @@ func (r *subtreeNodeHashesReadCloser) Read(p []byte) (int, error) {
 
 			if _, err := io.ReadFull(r.buf, r.nodeBytes[:]); err != nil {
 				if total > 0 {
-					return total, errors.NewProcessingError("unable to read subtree node information", err)
+					return total, errors.NewProcessingError(errUnableToReadSubtreeNode, err)
 				}
-				return 0, errors.NewProcessingError("unable to read subtree node information", err)
+				return 0, errors.NewProcessingError(errUnableToReadSubtreeNode, err)
 			}
 
 			r.pending = r.nodeBytes[:chainhash.HashSize]

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -49,6 +49,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const errServiceNotReadyUnminedLoading = "service not ready - unmined transactions are still being loaded"
+
 var (
 	// addTxBatchGrpc = blockAssemblyStat.NewStat("AddTxBatch_grpc", true)
 
@@ -1353,7 +1355,7 @@ func (ba *BlockAssembly) SubmitMiningSolution(ctx context.Context, req *blockass
 	// Check if unmined transactions are still being loaded
 	if ba.blockAssembler.unminedTransactionsLoading.Load() {
 		ba.logger.Warnf("[SubmitMiningSolution] service not ready - unmined transactions are still being loaded")
-		return nil, errors.NewServiceError("service not ready - unmined transactions are still being loaded")
+		return nil, errors.NewServiceError(errServiceNotReadyUnminedLoading)
 	}
 
 	var responseChan chan error
@@ -1895,7 +1897,7 @@ func (ba *BlockAssembly) ResetBlockAssembly(ctx context.Context, _ *blockassembl
 	// Check if unmined transactions are still being loaded
 	if ba.blockAssembler.unminedTransactionsLoading.Load() {
 		ba.logger.Warnf("[ResetBlockAssembly] service not ready - unmined transactions are still being loaded")
-		return nil, errors.NewServiceError("service not ready - unmined transactions are still being loaded")
+		return nil, errors.NewServiceError(errServiceNotReadyUnminedLoading)
 	}
 
 	ba.blockAssembler.Reset(false)
@@ -1913,7 +1915,7 @@ func (ba *BlockAssembly) ResetBlockAssemblyFully(ctx context.Context, _ *blockas
 	// Check if unmined transactions are still being loaded
 	if ba.blockAssembler.unminedTransactionsLoading.Load() {
 		ba.logger.Warnf("[ResetBlockAssemblyFully] service not ready - unmined transactions are still being loaded")
-		return nil, errors.NewServiceError("service not ready - unmined transactions are still being loaded")
+		return nil, errors.NewServiceError(errServiceNotReadyUnminedLoading)
 	}
 
 	ba.blockAssembler.Reset(true)
@@ -1935,7 +1937,7 @@ func (ba *BlockAssembly) ResetBlockAssemblyValidateInputs(ctx context.Context, _
 
 	if ba.blockAssembler.unminedTransactionsLoading.Load() {
 		ba.logger.Warnf("[ResetBlockAssemblyValidateInputs] service not ready - unmined transactions are still being loaded")
-		return nil, errors.NewServiceError("service not ready - unmined transactions are still being loaded")
+		return nil, errors.NewServiceError(errServiceNotReadyUnminedLoading)
 	}
 
 	ba.blockAssembler.ResetWithInputValidation()
@@ -1956,7 +1958,7 @@ func (ba *BlockAssembly) CheckBlockAssemblyValidateInputs(ctx context.Context, _
 
 	if ba.blockAssembler.unminedTransactionsLoading.Load() {
 		ba.logger.Warnf("[CheckBlockAssemblyValidateInputs] service not ready - unmined transactions are still being loaded")
-		return nil, errors.NewServiceError("service not ready - unmined transactions are still being loaded")
+		return nil, errors.NewServiceError(errServiceNotReadyUnminedLoading)
 	}
 
 	invalidCount, err := ba.blockAssembler.CheckInputValidation(ctx)
@@ -2145,7 +2147,7 @@ func (ba *BlockAssembly) GenerateBlocks(ctx context.Context, req *blockassembly_
 	// Check if unmined transactions are still being loaded
 	if ba.blockAssembler.unminedTransactionsLoading.Load() {
 		ba.logger.Warnf("[GenerateBlocks] service not ready - unmined transactions are still being loaded")
-		return nil, errors.NewServiceError("service not ready - unmined transactions are still being loaded")
+		return nil, errors.NewServiceError(errServiceNotReadyUnminedLoading)
 	}
 
 	if !ba.blockAssembler.settings.ChainCfgParams.GenerateSupported {

--- a/services/blockchain/LocalClient.go
+++ b/services/blockchain/LocalClient.go
@@ -22,6 +22,8 @@ import (
 	"github.com/bsv-blockchain/teranode/util/health"
 )
 
+const errNotImplemented = "not implemented"
+
 // LocalClient implements a blockchain client with direct store access.
 type LocalClient struct {
 	logger       ulogger.Logger     // Logger instance
@@ -550,47 +552,47 @@ func (c *LocalClient) GetBestHeightAndTime(ctx context.Context) (uint32, uint32,
 
 // ScheduleBlobDeletion schedules a blob for deletion at a specific block height.
 func (c *LocalClient) ScheduleBlobDeletion(ctx context.Context, blobKey []byte, fileType string, storeType storetypes.BlobStoreType, deleteAtHeight uint32) (int64, bool, error) {
-	return 0, false, errors.NewProcessingError("not implemented")
+	return 0, false, errors.NewProcessingError(errNotImplemented)
 }
 
 // CancelBlobDeletion cancels a previously scheduled blob deletion.
 func (c *LocalClient) CancelBlobDeletion(ctx context.Context, blobKey []byte, fileType string, storeType storetypes.BlobStoreType) (bool, error) {
-	return false, errors.NewProcessingError("not implemented")
+	return false, errors.NewProcessingError(errNotImplemented)
 }
 
 // ListScheduledDeletions lists scheduled blob deletions with optional filtering.
 func (c *LocalClient) ListScheduledDeletions(ctx context.Context, minHeight, maxHeight uint32, storeType storetypes.BlobStoreType, filterByStore bool, limit, offset int) ([]*blockchain_api.ScheduledDeletion, int, error) {
-	return nil, 0, errors.NewProcessingError("not implemented")
+	return nil, 0, errors.NewProcessingError(errNotImplemented)
 }
 
 // GetPendingBlobDeletions retrieves blob deletions ready for processing at a specific height.
 func (c *LocalClient) GetPendingBlobDeletions(ctx context.Context, height uint32, limit int) ([]*blockchain_api.ScheduledDeletion, error) {
-	return nil, errors.NewProcessingError("not implemented")
+	return nil, errors.NewProcessingError(errNotImplemented)
 }
 
 // RemoveBlobDeletion removes a blob deletion from the schedule.
 func (c *LocalClient) RemoveBlobDeletion(ctx context.Context, deletionID int64) error {
-	return errors.NewProcessingError("not implemented")
+	return errors.NewProcessingError(errNotImplemented)
 }
 
 // IncrementBlobDeletionRetry increments the retry counter for a failed blob deletion.
 func (c *LocalClient) IncrementBlobDeletionRetry(ctx context.Context, deletionID int64, maxRetries int) (bool, int, error) {
-	return false, 0, errors.NewProcessingError("not implemented")
+	return false, 0, errors.NewProcessingError(errNotImplemented)
 }
 
 // CompleteBlobDeletions completes multiple blob deletions in a single batch call.
 func (c *LocalClient) CompleteBlobDeletions(ctx context.Context, completedIDs []int64, failedIDs []int64, maxRetries int) (int, int, error) {
-	return 0, 0, errors.NewProcessingError("not implemented")
+	return 0, 0, errors.NewProcessingError(errNotImplemented)
 }
 
 // AcquireBlobDeletionBatch acquires a batch of deletions with locking.
 func (c *LocalClient) AcquireBlobDeletionBatch(ctx context.Context, height uint32, limit int, lockTimeoutSeconds int) (string, []*blockchain_api.ScheduledDeletion, error) {
-	return "", nil, errors.NewProcessingError("not implemented")
+	return "", nil, errors.NewProcessingError(errNotImplemented)
 }
 
 // CompleteBlobDeletionBatch completes a previously acquired batch.
 func (c *LocalClient) CompleteBlobDeletionBatch(ctx context.Context, batchToken string, completedIDs []int64, failedIDs []int64, maxRetries int) error {
-	return errors.NewProcessingError("not implemented")
+	return errors.NewProcessingError(errNotImplemented)
 }
 
 // GetMedianTimePastForHeights returns the MTP for one or more block heights.

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -56,6 +56,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const errStoreNoBlobDeletion = "blockchain store does not support blob deletion"
+
 // subscriber represents a subscription to blockchain notifications.
 //
 // subscriber encapsulates the connection to a client interested in blockchain events,
@@ -3400,7 +3402,7 @@ func (b *Blockchain) ScheduleBlobDeletion(ctx context.Context, req *blockchain_a
 		ScheduleBlobDeletion(ctx context.Context, req *blockchain_sql.ScheduleRequest) (int64, error)
 	})
 	if !ok {
-		return nil, errors.NewStorageError("blockchain store does not support blob deletion")
+		return nil, errors.NewStorageError(errStoreNoBlobDeletion)
 	}
 
 	schedReq := &blockchain_sql.ScheduleRequest{
@@ -3436,7 +3438,7 @@ func (b *Blockchain) CancelBlobDeletion(ctx context.Context, req *blockchain_api
 		CancelBlobDeletion(ctx context.Context, blobKey []byte, fileType string, storeType int32) error
 	})
 	if !ok {
-		return nil, errors.NewStorageError("blockchain store does not support blob deletion")
+		return nil, errors.NewStorageError(errStoreNoBlobDeletion)
 	}
 
 	err := storeWithBlobDeletion.CancelBlobDeletion(ctx, req.BlobKey, req.FileType, int32(req.StoreType))
@@ -3467,7 +3469,7 @@ func (b *Blockchain) ListScheduledDeletions(ctx context.Context, req *blockchain
 		ListScheduledBlobDeletions(ctx context.Context, filters *blockchain_sql.ListFilters) ([]*blockchain_sql.ScheduledDeletion, int, error)
 	})
 	if !ok {
-		return nil, errors.NewStorageError("blockchain store does not support blob deletion")
+		return nil, errors.NewStorageError(errStoreNoBlobDeletion)
 	}
 
 	filters := &blockchain_sql.ListFilters{
@@ -3513,7 +3515,7 @@ func (b *Blockchain) GetPendingBlobDeletions(ctx context.Context, req *blockchai
 		GetPendingBlobDeletions(ctx context.Context, height uint32, limit int) ([]*blockchain_sql.ScheduledDeletion, error)
 	})
 	if !ok {
-		return nil, errors.NewStorageError("blockchain store does not support blob deletion")
+		return nil, errors.NewStorageError(errStoreNoBlobDeletion)
 	}
 
 	deletions, err := storeWithBlobDeletion.GetPendingBlobDeletions(ctx, req.Height, limit)
@@ -3544,7 +3546,7 @@ func (b *Blockchain) RemoveBlobDeletion(ctx context.Context, req *blockchain_api
 		RemoveBlobDeletion(ctx context.Context, id int64) error
 	})
 	if !ok {
-		return nil, errors.NewStorageError("blockchain store does not support blob deletion")
+		return nil, errors.NewStorageError(errStoreNoBlobDeletion)
 	}
 
 	err := storeWithBlobDeletion.RemoveBlobDeletion(ctx, req.DeletionId)
@@ -3561,7 +3563,7 @@ func (b *Blockchain) IncrementBlobDeletionRetry(ctx context.Context, req *blockc
 		IncrementBlobDeletionRetry(ctx context.Context, id int64, maxRetries int) (shouldRemove bool, newRetryCount int, err error)
 	})
 	if !ok {
-		return nil, errors.NewStorageError("blockchain store does not support blob deletion")
+		return nil, errors.NewStorageError(errStoreNoBlobDeletion)
 	}
 
 	shouldRemove, newRetryCount, err := storeWithBlobDeletion.IncrementBlobDeletionRetry(ctx, req.DeletionId, int(req.MaxRetries))

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -54,6 +54,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const (
+	logValidateBlockGetBlockHeaders      = "[ValidateBlock][%s] GetBlockHeaders"
+	logValidateBlockSetExistsCacheFailed = "[ValidateBlock][%s] failed to set block exists cache: %s"
+)
+
 // ValidateBlockOptions provides optional parameters for block validation.
 // This is primarily used during catchup to optimize performance by reusing
 // cached data rather than fetching it repeatedly.
@@ -1582,9 +1587,9 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		} else {
 			// Fetch headers from blockchain service
 			if opts.IsCatchupMode {
-				ctxLogger.Debugf("[ValidateBlock][%s] GetBlockHeaders", block.Header.Hash().String())
+				ctxLogger.Debugf(logValidateBlockGetBlockHeaders, block.Header.Hash().String())
 			} else {
-				ctxLogger.Infof("[ValidateBlock][%s] GetBlockHeaders", block.Header.Hash().String())
+				ctxLogger.Infof(logValidateBlockGetBlockHeaders, block.Header.Hash().String())
 			}
 
 			// get all X previous block headers, 100 is the default
@@ -1758,7 +1763,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			ctxLogger.Infof("[ValidateBlock][%s] adding block optimistically to blockchain DONE", block.Hash().String())
 
 			if err = u.SetBlockExists(block.Header.Hash()); err != nil {
-				ctxLogger.Errorf("[ValidateBlock][%s] failed to set block exists cache: %s", block.Header.Hash().String(), err)
+				ctxLogger.Errorf(logValidateBlockSetExistsCacheFailed, block.Header.Hash().String(), err)
 			}
 
 			// decouple the tracing context to not cancel the context when finalize the block processing in the background
@@ -1862,7 +1867,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}()
 		} else {
 			// get all 100 previous block headers on the main chain
-			u.logger.Infof("[ValidateBlock][%s] GetBlockHeaders", block.Header.Hash().String())
+			u.logger.Infof(logValidateBlockGetBlockHeaders, block.Header.Hash().String())
 
 			blockHeaders, blockHeadersMeta, err := u.blockchainClient.GetBlockHeaders(ctx, block.Header.HashPrevBlock, 100)
 			if err != nil {
@@ -1986,7 +1991,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}
 
 			if err = u.SetBlockExists(block.Header.Hash()); err != nil {
-				u.logger.Errorf("[ValidateBlock][%s] failed to set block exists cache: %s", block.Header.Hash().String(), err)
+				u.logger.Errorf(logValidateBlockSetExistsCacheFailed, block.Header.Hash().String(), err)
 			}
 
 			u.logger.Infof("[ValidateBlock][%s] adding block to blockchain DONE", block.Hash().String())
@@ -2087,7 +2092,7 @@ func (u *BlockValidation) storeInvalidBlock(ctx context.Context, block *model.Bl
 	} else {
 		// Update cache to reflect that block exists
 		if cacheErr := u.SetBlockExists(block.Header.Hash()); cacheErr != nil {
-			u.logger.Errorf("[ValidateBlock][%s] failed to set block exists cache: %s", block.Header.Hash().String(), cacheErr)
+			u.logger.Errorf(logValidateBlockSetExistsCacheFailed, block.Header.Hash().String(), cacheErr)
 		}
 	}
 

--- a/services/legacy/config.go
+++ b/services/legacy/config.go
@@ -52,6 +52,11 @@ const (
 	defaultMinRelayTxFee           = bsvutil.Amount(1)
 )
 
+const (
+	// unableToParsePrefix is the shared prefix for checkpoint parse errors.
+	unableToParsePrefix = "unable to parse "
+)
+
 // Config provides a unified interface for accessing configuration values from various sources.
 // It supports type-safe retrieval of configuration parameters with optional default values
 // and handles common data types used in legacy protocol configuration.
@@ -275,25 +280,25 @@ func normalizeAddresses(addrs []string, defaultPort string) []string {
 func newCheckpointFromStr(checkpoint string) (chaincfg.Checkpoint, error) {
 	parts := strings.Split(checkpoint, ":")
 	if len(parts) != 2 {
-		return chaincfg.Checkpoint{}, fmt.Errorf("unable to parse "+
+		return chaincfg.Checkpoint{}, fmt.Errorf(unableToParsePrefix+
 			"checkpoint %q -- use the syntax <height>:<hash>",
 			checkpoint)
 	}
 
 	height, err := strconv.ParseInt(parts[0], 10, 32)
 	if err != nil {
-		return chaincfg.Checkpoint{}, fmt.Errorf("unable to parse "+
+		return chaincfg.Checkpoint{}, fmt.Errorf(unableToParsePrefix+
 			"checkpoint %q due to malformed height", checkpoint)
 	}
 
 	if len(parts[1]) == 0 {
-		return chaincfg.Checkpoint{}, fmt.Errorf("unable to parse "+
+		return chaincfg.Checkpoint{}, fmt.Errorf(unableToParsePrefix+
 			"checkpoint %q due to missing hash", checkpoint)
 	}
 
 	hash, err := chainhash.NewHashFromStr(parts[1])
 	if err != nil {
-		return chaincfg.Checkpoint{}, fmt.Errorf("unable to parse "+
+		return chaincfg.Checkpoint{}, fmt.Errorf(unableToParsePrefix+
 			"checkpoint %q due to malformed hash", checkpoint)
 	}
 

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -34,6 +34,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	// txNotFoundInTxMapMsg is the error message used when a transaction hash
+	// cannot be located in the block's txMap.
+	txNotFoundInTxMapMsg = "transaction %s not found in txMap"
+)
+
 func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, blockHash chainhash.Hash, msgBlock *wire.MsgBlock) (err error) {
 	sm.logger.Debugf("[HandleBlockDirect][%s] starting handling block", blockHash.String())
 
@@ -1128,7 +1134,7 @@ func (sm *SyncManager) createUtxos(ctx context.Context, txMap *txmap.SyncedMap[c
 		g.Go(func() error {
 			txWrapper, ok := txMap.Get(txHash)
 			if !ok {
-				return errors.NewProcessingError("transaction %s not found in txMap", txHash.String())
+				return errors.NewProcessingError(txNotFoundInTxMapMsg, txHash.String())
 			}
 
 			createOpts := append(baseOpts[:len(baseOpts):len(baseOpts)], utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
@@ -1300,7 +1306,7 @@ func (sm *SyncManager) PreValidateTransactions(ctx context.Context, txMap *txmap
 				if !ok {
 					// Not found in txMap — non-recoverable, fail immediately
 					mu.Lock()
-					hardFail = errors.NewProcessingError("transaction %s not found in txMap", txHash.String())
+					hardFail = errors.NewProcessingError(txNotFoundInTxMapMsg, txHash.String())
 					mu.Unlock()
 					return nil
 				}
@@ -1550,7 +1556,7 @@ func (sm *SyncManager) extendTransactions(ctx context.Context, bi blockIdent, tx
 		// the coinbase transaction is not part of the txMap
 		txWrapper, found := txMap.Get(txHash)
 		if !found {
-			return errors.NewTxError("transaction %s not found in txMap", txHash.String())
+			return errors.NewTxError(txNotFoundInTxMapMsg, txHash.String())
 		}
 
 		tx := txWrapper.Tx

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -132,6 +132,18 @@ const (
 	// syncPeerTickerInterval is how often we check the current
 	// syncPeer. Set to 30 seconds.
 	syncPeerTickerInterval = 30 * time.Second
+
+	// failedToGetBestBlockHeaderMsg is logged when the best block header
+	// cannot be retrieved from the blockchain client.
+	failedToGetBestBlockHeaderMsg = "Failed to get best block header: %v"
+
+	// failedToConvertBlockHeightInt32Msg is logged when a block height cannot
+	// be safely converted to an int32.
+	failedToConvertBlockHeightInt32Msg = "failed to convert block height to int32: %v"
+
+	// unexpectedFailureAddingInventoryMsg is logged when adding an inventory
+	// vector to a getdata message fails unexpectedly.
+	unexpectedFailureAddingInventoryMsg = "Unexpected failure when adding inventory to getdata message: %v"
 )
 
 // zeroHash is the zero-value hash (all zeros).  It is defined as a convenience.
@@ -672,7 +684,7 @@ func (sm *SyncManager) startSync() {
 
 	bestBlockHeader, bestBlockHeaderMeta, err := sm.blockchainClient.GetBestBlockHeader(sm.ctx)
 	if err != nil {
-		sm.logger.Errorf("Failed to get best block header: %v", err)
+		sm.logger.Errorf(failedToGetBestBlockHeaderMsg, err)
 		return
 	}
 
@@ -1158,13 +1170,13 @@ func (sm *SyncManager) updateSyncPeer(_ *peerSyncState) {
 	bestBlockHeader, bestBlockHeaderMeta, err := sm.blockchainClient.GetBestBlockHeader(sm.ctx)
 	if err != nil {
 		// TODO we should return an error here to the caller
-		sm.logger.Errorf("Failed to get best block header: %v", err)
+		sm.logger.Errorf(failedToGetBestBlockHeaderMsg, err)
 		return
 	}
 
 	bestBlockHeightInt32, err := safeconversion.Uint32ToInt32(bestBlockHeaderMeta.Height)
 	if err != nil {
-		sm.logger.Errorf("failed to convert block height to int32: %v", err)
+		sm.logger.Errorf(failedToConvertBlockHeightInt32Msg, err)
 		return // add return to prevent continuing with invalid height
 	}
 
@@ -1359,7 +1371,7 @@ func (sm *SyncManager) isCurrent(bestBlockHeaderMeta *model.BlockHeaderMeta) boo
 	if len(sm.chainParams.Checkpoints) > 0 {
 		bestBlockHeightInt32, err := safeconversion.Uint32ToInt32(bestBlockHeaderMeta.Height)
 		if err != nil {
-			sm.logger.Errorf("failed to convert block height to int32: %v", err)
+			sm.logger.Errorf(failedToConvertBlockHeightInt32Msg, err)
 		}
 
 		checkpoint := &sm.chainParams.Checkpoints[len(sm.chainParams.Checkpoints)-1]
@@ -1400,7 +1412,7 @@ func (sm *SyncManager) current() bool {
 
 	bestBlockHeightInt32, err := safeconversion.Uint32ToInt32(bestBlockHeaderMeta.Height)
 	if err != nil {
-		sm.logger.Errorf("failed to convert block height to int32: %v", err)
+		sm.logger.Errorf(failedToConvertBlockHeightInt32Msg, err)
 	}
 
 	// No matter what the chain thinks, if we are below the block we are syncing to we are not current.
@@ -1499,7 +1511,7 @@ func (sm *SyncManager) peerStateResolvingPrimary(peer *peerpkg.Peer) (*peerSyncS
 func (sm *SyncManager) requestMissingBlocks(peer *peerpkg.Peer, blockHash chainhash.Hash) {
 	bestBlockHeader, bestBlockHeaderMeta, err := sm.blockchainClient.GetBestBlockHeader(sm.ctx)
 	if err != nil {
-		sm.logger.Errorf("Failed to get best block header: %v", err)
+		sm.logger.Errorf(failedToGetBestBlockHeaderMsg, err)
 		return
 	}
 
@@ -1830,7 +1842,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 		} else {
 			blockHeightInt32, err := safeconversion.Uint32ToInt32(blockHeaderMeta.Height)
 			if err != nil {
-				sm.logger.Errorf("failed to convert block height to int32: %v", err)
+				sm.logger.Errorf(failedToConvertBlockHeightInt32Msg, err)
 			}
 
 			heightUpdate = blockHeightInt32
@@ -1993,7 +2005,7 @@ func (sm *SyncManager) fetchHeaderBlocks() {
 
 		if !haveInv {
 			if err = getDataMessage.AddInvVect(iv); err != nil {
-				sm.logger.Warnf("Unexpected failure when adding inventory to getdata message: %v", err)
+				sm.logger.Warnf(unexpectedFailureAddingInventoryMsg, err)
 				break
 			}
 
@@ -2058,7 +2070,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 
 		bestBlockHeader, bestBlockHeaderMeta, err := sm.blockchainClient.GetBestBlockHeader(sm.ctx)
 		if err != nil {
-			peer.DisconnectWithWarning(fmt.Sprintf("Failed to get best block header: %v", err))
+			peer.DisconnectWithWarning(fmt.Sprintf(failedToGetBestBlockHeaderMsg, err))
 			return
 		}
 
@@ -2250,7 +2262,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		if err == nil {
 			blockHeightInt32, err := safeconversion.Uint32ToInt32(blockHeaderMeta.Height)
 			if err != nil {
-				sm.logger.Errorf("failed to convert block height to int32: %v", err)
+				sm.logger.Errorf(failedToConvertBlockHeightInt32Msg, err)
 			}
 
 			peer.UpdateLastBlockHeight(blockHeightInt32)
@@ -2313,7 +2325,7 @@ outside:
 			// Request the block if there is not already a pending request.
 			if _, exists = sm.requestedBlocks.Get(iv.Hash); !exists {
 				if err = gdmsg.AddInvVect(iv); err != nil {
-					sm.logger.Warnf("Unexpected failure when adding inventory to getdata message: %v", err)
+					sm.logger.Warnf(unexpectedFailureAddingInventoryMsg, err)
 					break outside
 				}
 
@@ -2327,7 +2339,7 @@ outside:
 			// Request the transaction if there is not already a pending request.
 			if _, exists = sm.requestedTxns.Get(iv.Hash); !exists {
 				if err = gdmsg.AddInvVect(iv); err != nil {
-					sm.logger.Warnf("Unexpected failure when adding inventory to getdata message: %v", err)
+					sm.logger.Warnf(unexpectedFailureAddingInventoryMsg, err)
 					break outside
 				}
 
@@ -3262,7 +3274,7 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 	if !config.DisableCheckpoints {
 		bestBlockHeightInt32, err := safeconversion.Uint32ToInt32(bestBlockHeaderMeta.Height)
 		if err != nil {
-			sm.logger.Errorf("failed to convert block height to int32: %v", err)
+			sm.logger.Errorf(failedToConvertBlockHeightInt32Msg, err)
 		}
 
 		// Initialize the next checkpoint based on the current height.

--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -95,6 +95,10 @@ const (
 	// AddRebroadcastInventory drops on full rather than blocking the
 	// hot relay path, so this is best-effort, not lossless.
 	modifyRebroadcastInvBuffer = 1024
+
+	// cantSplitBanPeerMsg is logged when a peer address cannot be split into
+	// host and port during ban handling.
+	cantSplitBanPeerMsg = "can't split ban peer %s %v"
 )
 
 var (
@@ -2415,7 +2419,7 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 func (s *server) handleBanPeerMsg(state *peerState, sp *serverPeer) {
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err != nil {
-		sp.server.logger.Debugf("can't split ban peer %s %v", sp.Addr(), err)
+		sp.server.logger.Debugf(cantSplitBanPeerMsg, sp.Addr(), err)
 		return
 	}
 
@@ -2440,7 +2444,7 @@ func (s *server) handleBanPeerMsg(state *peerState, sp *serverPeer) {
 func (s *server) handleBanPeerForDurationMsg(state *peerState, sp *serverPeer, banUntil int64) {
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err != nil {
-		sp.server.logger.Debugf("can't split ban peer %s %v", sp.Addr(), err)
+		sp.server.logger.Debugf(cantSplitBanPeerMsg, sp.Addr(), err)
 		return
 	}
 
@@ -2468,7 +2472,7 @@ func (s *server) handleBanPeerForDurationMsg(state *peerState, sp *serverPeer, b
 func (s *server) handleUnbanPeerMsg(state *peerState, spAddr bannedPeerAddr) {
 	host, _, err := net.SplitHostPort(string(spAddr))
 	if err != nil {
-		s.logger.Errorf("can't split ban peer %s %v", spAddr, err)
+		s.logger.Errorf(cantSplitBanPeerMsg, spAddr, err)
 		return
 	}
 

--- a/services/legacy/txscript/opcode.go
+++ b/services/legacy/txscript/opcode.go
@@ -19,6 +19,15 @@ import (
 	"golang.org/x/crypto/ripemd160" //nolint:gosec // this is a known safe use of ripemd160
 )
 
+const (
+	// dataPushEncodedPrefix is the shared prefix for minimal-data push errors.
+	dataPushEncodedPrefix = "data push of %d bytes encoded "
+
+	// byteArraysNotSameLengthMsg is the error message for equal-length byte
+	// array comparisons that receive mismatched inputs.
+	byteArraysNotSameLengthMsg = "byte arrays are not the same length"
+)
+
 // An opcode defines the information related to a txscript opcode.  opfunc, if
 // present, is the function to call to perform the opcode on the script.  The
 // current script is passed in as a slice with the first member being the opcode
@@ -695,7 +704,7 @@ func (pop *parsedOpcode) checkMinimalDataPush() error {
 	} else if dataLen <= 75 {
 		if int(opcode) != dataLen {
 			// Should have used a direct push
-			str := fmt.Sprintf("data push of %d bytes encoded "+
+			str := fmt.Sprintf(dataPushEncodedPrefix+
 				"with opcode %s instead of OP_DATA_%d", dataLen,
 				pop.opcode.name, dataLen)
 
@@ -703,7 +712,7 @@ func (pop *parsedOpcode) checkMinimalDataPush() error {
 		}
 	} else if dataLen <= 255 {
 		if opcode != OP_PUSHDATA1 {
-			str := fmt.Sprintf("data push of %d bytes encoded "+
+			str := fmt.Sprintf(dataPushEncodedPrefix+
 				"with opcode %s instead of OP_PUSHDATA1",
 				dataLen, pop.opcode.name)
 
@@ -711,7 +720,7 @@ func (pop *parsedOpcode) checkMinimalDataPush() error {
 		}
 	} else if dataLen <= 65535 {
 		if opcode != OP_PUSHDATA2 {
-			str := fmt.Sprintf("data push of %d bytes encoded "+
+			str := fmt.Sprintf(dataPushEncodedPrefix+
 				"with opcode %s instead of OP_PUSHDATA2",
 				dataLen, pop.opcode.name)
 
@@ -1613,7 +1622,7 @@ func opcodeAnd(op *parsedOpcode, vm *Engine) error {
 	}
 
 	if len(a) != len(b) {
-		return scriptError(ErrInvalidInputLength, "byte arrays are not the same length")
+		return scriptError(ErrInvalidInputLength, byteArraysNotSameLengthMsg)
 	}
 
 	c := make([]byte, len(a))
@@ -1641,7 +1650,7 @@ func opcodeOr(op *parsedOpcode, vm *Engine) error {
 	}
 
 	if len(a) != len(b) {
-		return scriptError(ErrInvalidInputLength, "byte arrays are not the same length")
+		return scriptError(ErrInvalidInputLength, byteArraysNotSameLengthMsg)
 	}
 
 	c := make([]byte, len(a))
@@ -1669,7 +1678,7 @@ func opcodeXor(op *parsedOpcode, vm *Engine) error {
 	}
 
 	if len(a) != len(b) {
-		return scriptError(ErrInvalidInputLength, "byte arrays are not the same length")
+		return scriptError(ErrInvalidInputLength, byteArraysNotSameLengthMsg)
 	}
 
 	c := make([]byte, len(a))

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -53,6 +53,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+const logProcessingNotification = "[processBlockchainNotification] Processing %s notification: %s"
+
 const (
 	banActionAdd = "add" // Action constant for adding a ban
 
@@ -1585,15 +1587,15 @@ func (s *Server) processBlockchainNotification(ctx context.Context, notification
 
 	switch notification.Type {
 	case model.NotificationType_Block:
-		ctxLogger.Infof("[processBlockchainNotification] Processing %s notification: %s", notification.Type, hash.String())
+		ctxLogger.Infof(logProcessingNotification, notification.Type, hash.String())
 		return s.handleBlockNotification(ctx, hash) // These handlers return wrapped errors
 
 	case model.NotificationType_Subtree:
-		ctxLogger.Infof("[processBlockchainNotification] Processing %s notification: %s", notification.Type, hash.String())
+		ctxLogger.Infof(logProcessingNotification, notification.Type, hash.String())
 		return s.handleSubtreeNotification(ctx, hash)
 
 	case model.NotificationType_PeerFailure:
-		ctxLogger.Infof("[processBlockchainNotification] Processing %s notification: %s", notification.Type, hash.String())
+		ctxLogger.Infof(logProcessingNotification, notification.Type, hash.String())
 		return s.handlePeerFailureNotification(ctx, notification)
 
 	default:

--- a/services/p2p/handle_catchup_metrics.go
+++ b/services/p2p/handle_catchup_metrics.go
@@ -13,6 +13,14 @@ import (
 )
 
 const (
+	errPeerRegistryNotInitialized = "peer registry not initialized"
+	errInvalidPeerIDFormat        = "invalid peer ID: %v"
+	errPeerIDRequired             = "peer ID is required"
+	errInvalidPeerID              = "invalid peer ID"
+	errBlockHashRequired          = "block hash is required"
+)
+
+const (
 	// maxReportedChainWorkBytes bounds inbound advisory chainwork on the
 	// ReportValidatedChainProgress RPC. It aliases the registry's single source of
 	// truth so the two stay in lockstep.
@@ -29,11 +37,11 @@ const (
 // also updates the sync backoff tracking fields.
 func (s *Server) RecordCatchupAttempt(ctx context.Context, req *p2p_api.RecordCatchupAttemptRequest) (*p2p_api.RecordCatchupAttemptResponse, error) {
 	if s.peerRegistry == nil {
-		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
-		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+		return &p2p_api.RecordCatchupAttemptResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.RecordCatchupAttempt(ctx, req.PeerId); err != nil {
@@ -46,11 +54,11 @@ func (s *Server) RecordCatchupAttempt(ctx context.Context, req *p2p_api.RecordCa
 // RecordCatchupSuccess records a successful catchup from a peer.
 func (s *Server) RecordCatchupSuccess(ctx context.Context, req *p2p_api.RecordCatchupSuccessRequest) (*p2p_api.RecordCatchupSuccessResponse, error) {
 	if s.peerRegistry == nil {
-		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
-		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+		return &p2p_api.RecordCatchupSuccessResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.RecordCatchupSuccess(ctx, req.PeerId, req.DurationMs); err != nil {
@@ -63,11 +71,11 @@ func (s *Server) RecordCatchupSuccess(ctx context.Context, req *p2p_api.RecordCa
 // RecordCatchupFailure records a failed catchup attempt from a peer.
 func (s *Server) RecordCatchupFailure(ctx context.Context, req *p2p_api.RecordCatchupFailureRequest) (*p2p_api.RecordCatchupFailureResponse, error) {
 	if s.peerRegistry == nil {
-		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
-		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+		return &p2p_api.RecordCatchupFailureResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.RecordCatchupFailure(ctx, req.PeerId); err != nil {
@@ -155,11 +163,11 @@ func blockIncompleteCatchupError(blockHash string) string {
 // RecordCatchupMalicious records malicious behavior detected during catchup.
 func (s *Server) RecordCatchupMalicious(ctx context.Context, req *p2p_api.RecordCatchupMaliciousRequest) (*p2p_api.RecordCatchupMaliciousResponse, error) {
 	if s.peerRegistry == nil {
-		return &p2p_api.RecordCatchupMaliciousResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+		return &p2p_api.RecordCatchupMaliciousResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
-		return &p2p_api.RecordCatchupMaliciousResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+		return &p2p_api.RecordCatchupMaliciousResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.UpdatePeerMetrics(ctx, req.PeerId, 0, 0, 0, false, false, true, 0); err != nil {
@@ -182,11 +190,11 @@ func (s *Server) UpdateCatchupReputation(_ context.Context, _ *p2p_api.UpdateCat
 // UpdateCatchupError records the most recent catchup error reported against a peer.
 func (s *Server) UpdateCatchupError(ctx context.Context, req *p2p_api.UpdateCatchupErrorRequest) (*p2p_api.UpdateCatchupErrorResponse, error) {
 	if s.peerRegistry == nil {
-		return &p2p_api.UpdateCatchupErrorResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+		return &p2p_api.UpdateCatchupErrorResponse{Ok: false}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
-		return &p2p_api.UpdateCatchupErrorResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+		return &p2p_api.UpdateCatchupErrorResponse{Ok: false}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.RecordCatchupError(ctx, req.PeerId, req.ErrorMsg); err != nil {
@@ -200,7 +208,7 @@ func (s *Server) UpdateCatchupError(ctx context.Context, req *p2p_api.UpdateCatc
 // non-banned, with a DataHub URL, sorted by storage preference and reputation.
 func (s *Server) GetPeersForCatchup(ctx context.Context, _ *p2p_api.GetPeersForCatchupRequest) (*p2p_api.GetPeersForCatchupResponse, error) {
 	if s.peerRegistry == nil {
-		return &p2p_api.GetPeersForCatchupResponse{Peers: []*p2p_api.PeerInfoForCatchup{}}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+		return &p2p_api.GetPeersForCatchupResponse{Peers: []*p2p_api.PeerInfoForCatchup{}}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	peers, err := s.peerRegistry.ListPeers(ctx, nil, 0, 0, true, true)
@@ -239,15 +247,15 @@ func (s *Server) ReportValidSubtree(ctx context.Context, req *p2p_api.ReportVali
 	if s.peerRegistry == nil {
 		return &p2p_api.ReportValidSubtreeResponse{
 			Success: false,
-			Message: "peer registry not initialized",
-		}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+			Message: errPeerRegistryNotInitialized,
+		}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if req.PeerId == "" {
 		return &p2p_api.ReportValidSubtreeResponse{
 			Success: false,
-			Message: "peer ID is required",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("peer ID is required"))
+			Message: errPeerIDRequired,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errPeerIDRequired))
 	}
 
 	if req.SubtreeHash == "" {
@@ -260,8 +268,8 @@ func (s *Server) ReportValidSubtree(ctx context.Context, req *p2p_api.ReportVali
 	if _, err := peer.Decode(req.PeerId); err != nil {
 		return &p2p_api.ReportValidSubtreeResponse{
 			Success: false,
-			Message: "invalid peer ID",
-		}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+			Message: errInvalidPeerID,
+		}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.RecordSubtreeReceived(ctx, req.PeerId, 0); err != nil {
@@ -283,29 +291,29 @@ func (s *Server) ReportValidBlock(ctx context.Context, req *p2p_api.ReportValidB
 	if s.peerRegistry == nil {
 		return &p2p_api.ReportValidBlockResponse{
 			Success: false,
-			Message: "peer registry not initialized",
-		}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+			Message: errPeerRegistryNotInitialized,
+		}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if req.PeerId == "" {
 		return &p2p_api.ReportValidBlockResponse{
 			Success: false,
-			Message: "peer ID is required",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("peer ID is required"))
+			Message: errPeerIDRequired,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errPeerIDRequired))
 	}
 
 	if req.BlockHash == "" {
 		return &p2p_api.ReportValidBlockResponse{
 			Success: false,
-			Message: "block hash is required",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("block hash is required"))
+			Message: errBlockHashRequired,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errBlockHashRequired))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
 		return &p2p_api.ReportValidBlockResponse{
 			Success: false,
-			Message: "invalid peer ID",
-		}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+			Message: errInvalidPeerID,
+		}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.RecordBlockReceived(ctx, req.PeerId, 0); err != nil {
@@ -329,15 +337,15 @@ func (s *Server) ReportValidatedChainProgress(ctx context.Context, req *p2p_api.
 	if req.PeerId == "" {
 		return &p2p_api.ReportValidatedChainProgressResponse{
 			Success: false,
-			Message: "peer ID is required",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("peer ID is required"))
+			Message: errPeerIDRequired,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errPeerIDRequired))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
 		return &p2p_api.ReportValidatedChainProgressResponse{
 			Success: false,
-			Message: "invalid peer ID",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("invalid peer ID: %v", err))
+			Message: errInvalidPeerID,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errInvalidPeerIDFormat, err))
 	}
 
 	if req.Height == 0 {
@@ -350,8 +358,8 @@ func (s *Server) ReportValidatedChainProgress(ctx context.Context, req *p2p_api.
 	if req.BlockHash == "" {
 		return &p2p_api.ReportValidatedChainProgressResponse{
 			Success: false,
-			Message: "block hash is required",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("block hash is required"))
+			Message: errBlockHashRequired,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errBlockHashRequired))
 	}
 
 	blockHash, err := chainhash.NewHashFromStr(req.BlockHash)
@@ -411,22 +419,22 @@ func (s *Server) ReportValidBlockHeaders(ctx context.Context, req *p2p_api.Repor
 	if s.peerRegistry == nil {
 		return &p2p_api.ReportValidBlockHeadersResponse{
 			Success: false,
-			Message: "peer registry not initialized",
-		}, errors.WrapGRPC(errors.NewServiceError("peer registry not initialized"))
+			Message: errPeerRegistryNotInitialized,
+		}, errors.WrapGRPC(errors.NewServiceError(errPeerRegistryNotInitialized))
 	}
 
 	if req.PeerId == "" {
 		return &p2p_api.ReportValidBlockHeadersResponse{
 			Success: false,
-			Message: "peer ID is required",
-		}, errors.WrapGRPC(errors.NewInvalidArgumentError("peer ID is required"))
+			Message: errPeerIDRequired,
+		}, errors.WrapGRPC(errors.NewInvalidArgumentError(errPeerIDRequired))
 	}
 
 	if _, err := peer.Decode(req.PeerId); err != nil {
 		return &p2p_api.ReportValidBlockHeadersResponse{
 			Success: false,
-			Message: "invalid peer ID",
-		}, errors.WrapGRPC(errors.NewProcessingError("invalid peer ID: %v", err))
+			Message: errInvalidPeerID,
+		}, errors.WrapGRPC(errors.NewProcessingError(errInvalidPeerIDFormat, err))
 	}
 
 	if err := s.peerRegistry.UpdatePeerMetrics(ctx, req.PeerId, 0, 0, 0, true, false, false, req.DurationMs); err != nil {
@@ -496,7 +504,7 @@ func (s *Server) IsPeerUnhealthy(ctx context.Context, req *p2p_api.IsPeerUnhealt
 	if _, err := peer.Decode(req.PeerId); err != nil {
 		return &p2p_api.IsPeerUnhealthyResponse{
 			IsUnhealthy:     true,
-			Reason:          "invalid peer ID",
+			Reason:          errInvalidPeerID,
 			ReputationScore: 0,
 		}, nil
 	}

--- a/services/rpc/bsvjson/cmdparse.go
+++ b/services/rpc/bsvjson/cmdparse.go
@@ -14,7 +14,15 @@ import (
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 )
 
-const overflowsDestinationType = "overflows destination type %v"
+const (
+	overflowsDestinationType = "overflows destination type %v"
+
+	paramPrefix           = "parameter #%d '%s' "
+	paramMustPrefix       = "parameter #%d '%s' must "
+	paramMustBeTypePrefix = "parameter #%d '%s' must be type "
+	gotTypeSuffix         = "%v (got %v)"
+	parseToTypeSuffix     = "parse to a %v"
+)
 
 // makeParams creates a slice of interface values for the given struct.
 func makeParams(rt reflect.Type, rv reflect.Value) []interface{} {
@@ -153,7 +161,7 @@ func UnmarshalCmd(r *Request) (interface{}, error) {
 			// explicitly detect that error and make it nicer.
 			fieldName := strings.ToLower(rt.Field(i).Name)
 			if jerr, ok := err.(*json.UnmarshalTypeError); ok {
-				str := fmt.Sprintf("parameter #%d '%s' must "+
+				str := fmt.Sprintf(paramMustPrefix+
 					"be type %v (got %v)", i+1, fieldName,
 					jerr.Type, jerr.Value)
 
@@ -322,7 +330,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			reflect.Int64:
 			srcInt := src.Int()
 			if dest.OverflowInt(srcInt) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -336,7 +344,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			reflect.Uint64:
 			srcInt := src.Int()
 			if srcInt < 0 || dest.OverflowUint(uint64(srcInt)) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -346,8 +354,8 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			dest.SetUint(uint64(srcInt))
 
 		default:
-			str := fmt.Sprintf("parameter #%d '%s' must be type "+
-				"%v (got %v)", paramNum, fieldName, destBaseType,
+			str := fmt.Sprintf(paramMustBeTypePrefix+
+				gotTypeSuffix, paramNum, fieldName, destBaseType,
 				srcBaseType)
 
 			return makeError(ErrInvalidType, str)
@@ -362,7 +370,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			reflect.Int64:
 			srcUint := src.Uint()
 			if srcUint > uint64(1<<63)-1 {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -375,7 +383,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			}
 
 			if dest.OverflowInt(srcInt64) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -389,7 +397,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			reflect.Uint64:
 			srcUint := src.Uint()
 			if dest.OverflowUint(srcUint) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -399,8 +407,8 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			dest.SetUint(srcUint)
 
 		default:
-			str := fmt.Sprintf("parameter #%d '%s' must be type "+
-				"%v (got %v)", paramNum, fieldName, destBaseType,
+			str := fmt.Sprintf(paramMustBeTypePrefix+
+				gotTypeSuffix, paramNum, fieldName, destBaseType,
 				srcBaseType)
 
 			return makeError(ErrInvalidType, str)
@@ -410,8 +418,8 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 	case reflect.Float32, reflect.Float64:
 		destKind := dest.Kind()
 		if destKind != reflect.Float32 && destKind != reflect.Float64 {
-			str := fmt.Sprintf("parameter #%d '%s' must be type "+
-				"%v (got %v)", paramNum, fieldName, destBaseType,
+			str := fmt.Sprintf(paramMustBeTypePrefix+
+				gotTypeSuffix, paramNum, fieldName, destBaseType,
 				srcBaseType)
 
 			return makeError(ErrInvalidType, str)
@@ -435,8 +443,8 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 		case reflect.Bool:
 			b, err := strconv.ParseBool(src.String())
 			if err != nil {
-				str := fmt.Sprintf("parameter #%d '%s' must "+
-					"parse to a %v", paramNum, fieldName,
+				str := fmt.Sprintf(paramMustPrefix+
+					parseToTypeSuffix, paramNum, fieldName,
 					destBaseType)
 
 				return makeError(ErrInvalidType, str)
@@ -449,15 +457,15 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			reflect.Int64:
 			srcInt, err := strconv.ParseInt(src.String(), 0, 0)
 			if err != nil {
-				str := fmt.Sprintf("parameter #%d '%s' must "+
-					"parse to a %v", paramNum, fieldName,
+				str := fmt.Sprintf(paramMustPrefix+
+					parseToTypeSuffix, paramNum, fieldName,
 					destBaseType)
 
 				return makeError(ErrInvalidType, str)
 			}
 
 			if dest.OverflowInt(srcInt) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -471,15 +479,15 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 			reflect.Uint32, reflect.Uint64:
 			srcUint, err := strconv.ParseUint(src.String(), 0, 0)
 			if err != nil {
-				str := fmt.Sprintf("parameter #%d '%s' must "+
-					"parse to a %v", paramNum, fieldName,
+				str := fmt.Sprintf(paramMustPrefix+
+					parseToTypeSuffix, paramNum, fieldName,
 					destBaseType)
 
 				return makeError(ErrInvalidType, str)
 			}
 
 			if dest.OverflowUint(srcUint) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -492,15 +500,15 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 		case reflect.Float32, reflect.Float64:
 			srcFloat, err := strconv.ParseFloat(src.String(), 0)
 			if err != nil {
-				str := fmt.Sprintf("parameter #%d '%s' must "+
-					"parse to a %v", paramNum, fieldName,
+				str := fmt.Sprintf(paramMustPrefix+
+					parseToTypeSuffix, paramNum, fieldName,
 					destBaseType)
 
 				return makeError(ErrInvalidType, str)
 			}
 
 			if dest.OverflowFloat(srcFloat) {
-				str := fmt.Sprintf("parameter #%d '%s' "+
+				str := fmt.Sprintf(paramPrefix+
 					overflowsDestinationType,
 					paramNum, fieldName, destBaseType)
 
@@ -520,7 +528,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 
 			err := json.Unmarshal([]byte(src.String()), &concreteVal)
 			if err != nil {
-				str := fmt.Sprintf("parameter #%d '%s' must "+
+				str := fmt.Sprintf(paramMustPrefix+
 					"be valid JSON which unsmarshals to a %v",
 					paramNum, fieldName, destBaseType)
 

--- a/services/rpc/bsvjson/help.go
+++ b/services/rpc/bsvjson/help.go
@@ -12,15 +12,23 @@ import (
 	"text/tabwriter"
 )
 
+// Help description map keys reused across help generation.
+const (
+	helpArgumentsKey     = "help-arguments"
+	helpResultKey        = "help-result"
+	helpResultNothingKey = "help-result-nothing"
+	jsonTypeObjectKey    = "json-type-object"
+)
+
 // baseHelpDescs house the various help labels, types, and example values used
 // when generating help.  The per-command synopsis, field descriptions,
 // conditions, and result descriptions are to be provided by the caller.
 var baseHelpDescs = map[string]string{
 	// Misc help labels and output.
-	"help-arguments":      "Arguments",
+	helpArgumentsKey:      "Arguments",
 	"help-arguments-none": "None",
-	"help-result":         "Result",
-	"help-result-nothing": "Nothing",
+	helpResultKey:         "Result",
+	helpResultNothingKey:  "Nothing",
 	"help-default":        "default",
 	"help-optional":       "optional",
 	"help-required":       "required",
@@ -30,7 +38,7 @@ var baseHelpDescs = map[string]string{
 	"json-type-string":  "string",
 	"json-type-bool":    "boolean",
 	"json-type-array":   "array of ",
-	"json-type-object":  "object",
+	jsonTypeObjectKey:   "object",
 	"json-type-value":   "value",
 
 	// JSON examples.
@@ -64,10 +72,10 @@ func reflectTypeToJSONType(xT descLookupFunc, rt reflect.Type) string {
 			rt.Elem())
 
 	case reflect.Struct:
-		return xT("json-type-object")
+		return xT(jsonTypeObjectKey)
 
 	case reflect.Map:
-		return xT("json-type-object")
+		return xT(jsonTypeObjectKey)
 	}
 
 	return xT("json-type-value")
@@ -436,10 +444,10 @@ func methodHelp(xT descLookupFunc, rtp reflect.Type, defaults map[int]reflect.Va
 
 	// Generate the help for each argument in the command.
 	if argText := argHelp(xT, rtp, defaults, method); argText != "" {
-		help += fmt.Sprintf("\n%s:\n%s", xT("help-arguments"),
+		help += fmt.Sprintf("\n%s:\n%s", xT(helpArgumentsKey),
 			argText)
 	} else {
-		help += fmt.Sprintf("\n%s:\n%s\n", xT("help-arguments"),
+		help += fmt.Sprintf("\n%s:\n%s\n", xT(helpArgumentsKey),
 			xT("help-arguments-none"))
 	}
 
@@ -451,7 +459,7 @@ func methodHelp(xT descLookupFunc, rtp reflect.Type, defaults map[int]reflect.Va
 		fieldDescKey := fmt.Sprintf("%s--result%d", method, i)
 
 		if resultTypes[i] == nil {
-			resultText := xT("help-result-nothing")
+			resultText := xT(helpResultNothingKey)
 			resultTexts = append(resultTexts, resultText)
 
 			continue
@@ -465,14 +473,14 @@ func methodHelp(xT descLookupFunc, rtp reflect.Type, defaults map[int]reflect.Va
 	// result type, also add the condition which triggers it.
 	switch len(resultTexts) {
 	case 0:
-		help += fmt.Sprintf("\n%s:\n%s\n", xT("help-result"), xT("help-result-nothing"))
+		help += fmt.Sprintf("\n%s:\n%s\n", xT(helpResultKey), xT(helpResultNothingKey))
 	case 1:
-		help += fmt.Sprintf("\n%s:\n%s\n", xT("help-result"), resultTexts[0])
+		help += fmt.Sprintf("\n%s:\n%s\n", xT(helpResultKey), resultTexts[0])
 	default:
 		for i, resultText := range resultTexts {
 			condKey := fmt.Sprintf("%s--condition%d", method, i)
 			help += fmt.Sprintf("\n%s (%s):\n%s\n",
-				xT("help-result"), xT(condKey), resultText)
+				xT(helpResultKey), xT(condKey), resultText)
 		}
 	}
 

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -61,6 +61,9 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// txRejectedPrefix is the message prefix used when a raw transaction is rejected.
+const txRejectedPrefix = "TX rejected: "
+
 // live items expire after 10s
 var rpcCallCache = newRPCCache()
 
@@ -848,7 +851,7 @@ func handleSendRawTransaction(ctx context.Context, s *RPCServer, cmd interface{}
 	if err != nil {
 		return nil, &bsvjson.RPCError{
 			Code:    bsvjson.ErrRPCDeserialization,
-			Message: "TX rejected: " + err.Error(),
+			Message: txRejectedPrefix + err.Error(),
 		}
 	}
 
@@ -882,7 +885,7 @@ func handleSendRawTransaction(ctx context.Context, s *RPCServer, cmd interface{}
 			if err = s.utxoStore.PreviousOutputsDecorate(ctx, tx); err != nil {
 				return nil, &bsvjson.RPCError{
 					Code:    bsvjson.ErrRPCVerify,
-					Message: "TX rejected: " + err.Error(),
+					Message: txRejectedPrefix + err.Error(),
 				}
 			}
 			tx.SetExtended(true)
@@ -909,7 +912,7 @@ func handleSendRawTransaction(ctx context.Context, s *RPCServer, cmd interface{}
 	if err != nil {
 		return nil, &bsvjson.RPCError{
 			Code:    bsvjson.ErrRPCVerify,
-			Message: "TX rejected: " + err.Error(),
+			Message: txRejectedPrefix + err.Error(),
 		}
 	}
 

--- a/services/rpc/rpcserverhelp.go
+++ b/services/rpc/rpcserverhelp.go
@@ -36,6 +36,23 @@ import (
 	"github.com/bsv-blockchain/teranode/services/rpc/bsvjson"
 )
 
+// Help description strings reused across multiple command help entries.
+const (
+	descDisassemblyScript = "Disassembly of the script"
+	descTxHash            = "The hash of the transaction"
+	descTxVersion         = "The transaction version"
+	descTxLockTime        = "The transaction lock time"
+	descTxInputs          = "The transaction inputs as JSON objects"
+	descTxOutputs         = "The transaction outputs as JSON objects"
+	descBlockHash         = "The hash of the block"
+	descNumConfirmations  = "The number of confirmations"
+	descBlockVersion      = "The block version"
+	descVerboseFalse      = "verbose=false"
+	descVerboseTrue       = "verbose=true"
+	descUsingTestnet      = "Whether or not server is using testnet"
+	descAnyCurrentErrors  = "Any current errors"
+)
+
 // helpDescsEnUS defines the English descriptions used for the help strings.
 var helpDescsEnUS = map[string]string{
 	// DebugLevelCmd help.
@@ -79,7 +96,7 @@ var helpDescsEnUS = map[string]string{
 	"createrawtransaction--result0":       "Hex-encoded bytes of the serialized transaction",
 
 	// ScriptSig help.
-	"scriptsig-asm": "Disassembly of the script",
+	"scriptsig-asm": descDisassemblyScript,
 	"scriptsig-hex": "Hex-encoded bytes of the script",
 
 	// PrevOut help.
@@ -104,7 +121,7 @@ var helpDescsEnUS = map[string]string{
 	"vin-sequence":    "The script sequence number",
 
 	// ScriptPubKeyResult help.
-	"scriptpubkeyresult-asm":       "Disassembly of the script",
+	"scriptpubkeyresult-asm":       descDisassemblyScript,
 	"scriptpubkeyresult-hex":       "Hex-encoded bytes of the script",
 	"scriptpubkeyresult-reqSigs":   "The number of required signatures",
 	"scriptpubkeyresult-type":      "The type of the script (e.g. 'pubkeyhash')",
@@ -116,18 +133,18 @@ var helpDescsEnUS = map[string]string{
 	"vout-scriptPubKey": "The public key script used to pay coins as a JSON object",
 
 	// TxRawDecodeResult help.
-	"txrawdecoderesult-txid":     "The hash of the transaction",
-	"txrawdecoderesult-version":  "The transaction version",
-	"txrawdecoderesult-locktime": "The transaction lock time",
-	"txrawdecoderesult-vin":      "The transaction inputs as JSON objects",
-	"txrawdecoderesult-vout":     "The transaction outputs as JSON objects",
+	"txrawdecoderesult-txid":     descTxHash,
+	"txrawdecoderesult-version":  descTxVersion,
+	"txrawdecoderesult-locktime": descTxLockTime,
+	"txrawdecoderesult-vin":      descTxInputs,
+	"txrawdecoderesult-vout":     descTxOutputs,
 
 	// DecodeRawTransactionCmd help.
 	"decoderawtransaction--synopsis": "Returns a JSON object representing the provided serialized, hex-encoded transaction.",
 	"decoderawtransaction-hextx":     "Serialized, hex-encoded transaction",
 
 	// DecodeScriptResult help.
-	"decodescriptresult-asm":       "Disassembly of the script",
+	"decodescriptresult-asm":       descDisassemblyScript,
 	"decodescriptresult-reqSigs":   "The number of required signatures",
 	"decodescriptresult-type":      "The type of the script (e.g. 'pubkeyhash')",
 	"decodescriptresult-addresses": "The bitcoin addresses associated with this script",
@@ -183,7 +200,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetBlockCmd help.
 	"getblock--synopsis":   "Returns information about a block given its hash.",
-	"getblock-hash":        "The hash of the block",
+	"getblock-hash":        descBlockHash,
 	"getblock-verbosity":   "Specifies the block format returns",
 	"getblock--condition0": "verbosity=0",
 	"getblock--condition1": "verbosity=1",
@@ -221,11 +238,11 @@ var helpDescsEnUS = map[string]string{
 
 	// TxRawResult help.
 	"txrawresult-hex":           "Hex-encoded transaction",
-	"txrawresult-txid":          "The hash of the transaction",
-	"txrawresult-version":       "The transaction version",
-	"txrawresult-locktime":      "The transaction lock time",
-	"txrawresult-vin":           "The transaction inputs as JSON objects",
-	"txrawresult-vout":          "The transaction outputs as JSON objects",
+	"txrawresult-txid":          descTxHash,
+	"txrawresult-version":       descTxVersion,
+	"txrawresult-locktime":      descTxLockTime,
+	"txrawresult-vin":           descTxInputs,
+	"txrawresult-vout":          descTxOutputs,
 	"txrawresult-blockhash":     "Hash of the block the transaction is part of",
 	"txrawresult-confirmations": "Number of confirmations of the block",
 	"txrawresult-time":          "Transaction time in seconds since 1 Jan 1970 GMT",
@@ -236,12 +253,12 @@ var helpDescsEnUS = map[string]string{
 
 	// SearchRawTransactionsResult help.
 	"searchrawtransactionsresult-hex":           "Hex-encoded transaction",
-	"searchrawtransactionsresult-txid":          "The hash of the transaction",
+	"searchrawtransactionsresult-txid":          descTxHash,
 	"searchrawtransactionsresult-hash":          "The wxtid of the transaction",
-	"searchrawtransactionsresult-version":       "The transaction version",
-	"searchrawtransactionsresult-locktime":      "The transaction lock time",
-	"searchrawtransactionsresult-vin":           "The transaction inputs as JSON objects",
-	"searchrawtransactionsresult-vout":          "The transaction outputs as JSON objects",
+	"searchrawtransactionsresult-version":       descTxVersion,
+	"searchrawtransactionsresult-locktime":      descTxLockTime,
+	"searchrawtransactionsresult-vin":           descTxInputs,
+	"searchrawtransactionsresult-vout":          descTxOutputs,
 	"searchrawtransactionsresult-blockhash":     "Hash of the block the transaction is part of",
 	"searchrawtransactionsresult-confirmations": "Number of confirmations of the block",
 	"searchrawtransactionsresult-time":          "Transaction time in seconds since 1 Jan 1970 GMT",
@@ -257,10 +274,10 @@ var helpDescsEnUS = map[string]string{
 
 	// GetBlockBaseVerboseResult help.
 	"getblockbaseverboseresult-hash":              "The hash of the block (same as provided)",
-	"getblockbaseverboseresult-confirmations":     "The number of confirmations",
+	"getblockbaseverboseresult-confirmations":     descNumConfirmations,
 	"getblockbaseverboseresult-size":              "The size of the block",
 	"getblockbaseverboseresult-height":            "The height of the block in the block chain",
-	"getblockbaseverboseresult-version":           "The block version",
+	"getblockbaseverboseresult-version":           descBlockVersion,
 	"getblockbaseverboseresult-versionHex":        "The block version in hexadecimal",
 	"getblockbaseverboseresult-merkleroot":        "Root hash of the merkle tree",
 	"getblockbaseverboseresult-time":              "The block time in seconds since 1 Jan 1970 GMT",
@@ -281,17 +298,17 @@ var helpDescsEnUS = map[string]string{
 
 	// GetBlockHeaderCmd help.
 	"getblockheader--synopsis":   "Returns information about a block header given its hash.",
-	"getblockheader-hash":        "The hash of the block",
+	"getblockheader-hash":        descBlockHash,
 	"getblockheader-verbose":     "Specifies the block header is returned as a JSON object instead of hex-encoded string",
-	"getblockheader--condition0": "verbose=false",
-	"getblockheader--condition1": "verbose=true",
+	"getblockheader--condition0": descVerboseFalse,
+	"getblockheader--condition1": descVerboseTrue,
 	"getblockheader--result0":    "The block header hash",
 
 	// GetBlockHeaderVerboseResult help.
 	"getblockheaderverboseresult-hash":              "The hash of the block (same as provided)",
-	"getblockheaderverboseresult-confirmations":     "The number of confirmations",
+	"getblockheaderverboseresult-confirmations":     descNumConfirmations,
 	"getblockheaderverboseresult-height":            "The height of the block in the block chain",
-	"getblockheaderverboseresult-version":           "The block version",
+	"getblockheaderverboseresult-version":           descBlockVersion,
 	"getblockheaderverboseresult-versionHex":        "The block version in hexadecimal",
 	"getblockheaderverboseresult-merkleroot":        "Root hash of the merkle tree",
 	"getblockheaderverboseresult-time":              "The block time in seconds since 1 Jan 1970 GMT",
@@ -331,7 +348,7 @@ var helpDescsEnUS = map[string]string{
 	"getblocktemplateresult-sigoplimit":                 "Number of sigops allowed in blocks ",
 	"getblocktemplateresult-sizelimit":                  "Number of bytes allowed in blocks",
 	"getblocktemplateresult-transactions":               "Array of transactions as JSON objects",
-	"getblocktemplateresult-version":                    "The block version",
+	"getblocktemplateresult-version":                    descBlockVersion,
 	"getblocktemplateresult-coinbaseaux":                "Data that should be included in the coinbase signature script",
 	"getblocktemplateresult-coinbasetxn":                "Information about the coinbase transaction",
 	"getblocktemplateresult-coinbasevalue":              "Total amount available for the coinbase in Satoshi",
@@ -361,13 +378,13 @@ var helpDescsEnUS = map[string]string{
 	// GetCFilterCmd help.
 	"getcfilter--synopsis":  "Returns a block's committed filter given its hash.",
 	"getcfilter-filtertype": "The type of filter to return (0=regular)",
-	"getcfilter-hash":       "The hash of the block",
+	"getcfilter-hash":       descBlockHash,
 	"getcfilter--result0":   "The block's committed filter",
 
 	// GetCFilterHeaderCmd help.
 	"getcfilterheader--synopsis":  "Returns a block's compact filter header given its hash.",
 	"getcfilterheader-filtertype": "The type of filter header to return (0=regular)",
-	"getcfilterheader-hash":       "The hash of the block",
+	"getcfilterheader-hash":       descBlockHash,
 	"getcfilterheader--result0":   "The block's gcs filter header",
 
 	// GetConnectionCountCmd help.
@@ -398,9 +415,9 @@ var helpDescsEnUS = map[string]string{
 	"infochainresult-connections":     "The number of connected peers",
 	"infochainresult-proxy":           "The proxy used by the server",
 	"infochainresult-difficulty":      "The current target difficulty",
-	"infochainresult-testnet":         "Whether or not server is using testnet",
+	"infochainresult-testnet":         descUsingTestnet,
 	"infochainresult-relayfee":        "The minimum relay fee for non-free transactions in BTC/KB",
-	"infochainresult-errors":          "Any current errors",
+	"infochainresult-errors":          descAnyCurrentErrors,
 
 	// InfoWalletResult help.
 	"infowalletresult-version":         "The version of the server",
@@ -412,13 +429,13 @@ var helpDescsEnUS = map[string]string{
 	"infowalletresult-connections":     "The number of connected peers",
 	"infowalletresult-proxy":           "The proxy used by the server",
 	"infowalletresult-difficulty":      "The current target difficulty",
-	"infowalletresult-testnet":         "Whether or not server is using testnet",
+	"infowalletresult-testnet":         descUsingTestnet,
 	"infowalletresult-keypoololdest":   "Seconds since 1 Jan 1970 GMT of the oldest pre-generated key in the key pool",
 	"infowalletresult-keypoolsize":     "The number of new keys that are pre-generated",
 	"infowalletresult-unlocked_until":  "The timestamp in seconds since 1 Jan 1970 GMT that the wallet is unlocked for transfers, or 0 if the wallet is locked",
 	"infowalletresult-paytxfee":        "The transaction fee set in BTC/KB",
 	"infowalletresult-relayfee":        "The minimum relay fee for non-free transactions in BTC/KB",
-	"infowalletresult-errors":          "Any current errors",
+	"infowalletresult-errors":          descAnyCurrentErrors,
 
 	// GetHeadersCmd help.
 	"getheaders--synopsis":     "Returns block headers starting with the first known block hash from the request",
@@ -441,13 +458,13 @@ var helpDescsEnUS = map[string]string{
 	"getmininginforesult-currentblocksize": "Size of the latest best block",
 	"getmininginforesult-currentblocktx":   "Number of transactions in the latest best block",
 	"getmininginforesult-difficulty":       "Current target difficulty",
-	"getmininginforesult-errors":           "Any current errors",
+	"getmininginforesult-errors":           descAnyCurrentErrors,
 	"getmininginforesult-generate":         "Whether or not server is set to generate coins",
 	"getmininginforesult-genproclimit":     "Number of processors to use for coin generation (-1 when disabled)",
 	"getmininginforesult-hashespersec":     "Recent hashes per second performance measurement while generating coins",
 	"getmininginforesult-networkhashps":    "Estimated network hashes per second for the most recent blocks",
 	"getmininginforesult-pooledtx":         "Number of transactions in the memory pool",
-	"getmininginforesult-testnet":          "Whether or not server is using testnet",
+	"getmininginforesult-testnet":          descUsingTestnet,
 
 	// GetMiningInfoCmd help.
 	"getmininginfo--synopsis": "Returns a JSON object containing mining-related information.",
@@ -507,29 +524,29 @@ var helpDescsEnUS = map[string]string{
 	// GetRawMempoolCmd help.
 	"getrawmempool--synopsis":   "Returns information about all of the transactions currently in the memory pool.",
 	"getrawmempool-verbose":     "Returns JSON object when true or an array of transaction hashes when false",
-	"getrawmempool--condition0": "verbose=false",
-	"getrawmempool--condition1": "verbose=true",
+	"getrawmempool--condition0": descVerboseFalse,
+	"getrawmempool--condition1": descVerboseTrue,
 	"getrawmempool--result0":    "Array of transaction hashes",
 
 	// GetRawTransactionCmd help.
 	"getrawtransaction--synopsis":   "Returns information about a transaction given its hash.",
-	"getrawtransaction-txid":        "The hash of the transaction",
+	"getrawtransaction-txid":        descTxHash,
 	"getrawtransaction-verbose":     "Specifies the transaction is returned as a JSON object instead of a hex-encoded string",
-	"getrawtransaction--condition0": "verbose=false",
-	"getrawtransaction--condition1": "verbose=true",
+	"getrawtransaction--condition0": descVerboseFalse,
+	"getrawtransaction--condition1": descVerboseTrue,
 	"getrawtransaction--result0":    "Hex-encoded bytes of the serialized transaction",
 
 	// GetTxOutResult help.
 	"gettxoutresult-bestblock":     "The block hash that contains the transaction output",
-	"gettxoutresult-confirmations": "The number of confirmations",
+	"gettxoutresult-confirmations": descNumConfirmations,
 	"gettxoutresult-value":         "The transaction amount in BTC",
 	"gettxoutresult-scriptPubKey":  "The public key script used to pay coins as a JSON object",
-	"gettxoutresult-version":       "The transaction version",
+	"gettxoutresult-version":       descTxVersion,
 	"gettxoutresult-coinbase":      "Whether or not the transaction is a coinbase",
 
 	// GetTxOutCmd help.
 	"gettxout--synopsis":      "Returns information about an unspent transaction output..",
-	"gettxout-txid":           "The hash of the transaction",
+	"gettxout-txid":           descTxHash,
 	"gettxout-vout":           "The index of the output",
 	"gettxout-includemempool": "Include the mempool when true",
 
@@ -577,7 +594,7 @@ var helpDescsEnUS = map[string]string{
 	"sendrawtransaction--synopsis":     "Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.",
 	"sendrawtransaction-hextx":         "Serialized, hex-encoded signed transaction",
 	"sendrawtransaction-allowhighfees": "When true, bypass the absurd-fee ceiling (policy.maxrawtxfee) and submit the transaction even if the absolute fee exceeds it",
-	"sendrawtransaction--result0":      "The hash of the transaction",
+	"sendrawtransaction--result0":      descTxHash,
 
 	// ReconsiderBlockCmd
 	"reconsiderblock--synopsis": "Reconsider a block for validation.",

--- a/services/subtreevalidation/processTxMetaUsingStore.go
+++ b/services/subtreevalidation/processTxMetaUsingStore.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const errProcessTxMetaContextDone = "[processTxMetaUsingStore] context done"
+
 var TxMetaFieldsForDecorate = []fields.FieldName{fields.Fee, fields.SizeInBytes, fields.TxInpoints, fields.Conflicting, fields.BlockIDs, fields.Creating}
 
 // unresolvedMetaDataSlicePool reduces allocation pressure by reusing
@@ -105,7 +107,7 @@ func (u *Server) processTxMetaUsingStore(ctx context.Context, txHashes []chainha
 					select {
 					case <-gCtx.Done(): // Listen for cancellation signal
 						// Return the error that caused the cancellation
-						return errors.NewContextCanceledError("[processTxMetaUsingStore] context done", gCtx.Err())
+						return errors.NewContextCanceledError(errProcessTxMetaContextDone, gCtx.Err())
 
 					default:
 						if txHashes[i+j].Equal(*subtree.CoinbasePlaceholderHash) {
@@ -129,7 +131,7 @@ func (u *Server) processTxMetaUsingStore(ctx context.Context, txHashes []chainha
 				select {
 				case <-gCtx.Done(): // Listen for cancellation signal
 					// Return the error that caused the cancellation
-					return errors.NewContextCanceledError("[processTxMetaUsingStore] context done", gCtx.Err())
+					return errors.NewContextCanceledError(errProcessTxMetaContextDone, gCtx.Err())
 				default:
 					missingTxThresholdInt32, err := safeconversion.IntToInt32(missingTxThreshold)
 					if err != nil {
@@ -197,7 +199,7 @@ func (u *Server) processTxMetaUsingStore(ctx context.Context, txHashes []chainha
 					select {
 					case <-gCtx.Done(): // Listen for cancellation signal
 						// Return the error that caused the cancellation
-						return errors.NewContextCanceledError("[processTxMetaUsingStore] context done", gCtx.Err())
+						return errors.NewContextCanceledError(errProcessTxMetaContextDone, gCtx.Err())
 
 					default:
 						txHash := txHashes[i+j]
@@ -248,7 +250,7 @@ func (u *Server) processTxMetaUsingStore(ctx context.Context, txHashes []chainha
 		}
 
 		if err := g.Wait(); err != nil {
-			return int(missed.Load()), errors.NewContextCanceledError("[processTxMetaUsingStore] context done", err)
+			return int(missed.Load()), errors.NewContextCanceledError(errProcessTxMetaContextDone, err)
 		}
 
 		return int(missed.Load()), nil

--- a/stores/blockchain/sql/GetChainTips.go
+++ b/stores/blockchain/sql/GetChainTips.go
@@ -19,6 +19,8 @@ const (
 	statusInvalid      = "invalid"       // The block is invalid
 )
 
+const errFailedQueryParentBlock = "failed to query parent block"
+
 // GetChainTips retrieves information about all known tips in the block tree.
 func (s *SQL) GetChainTips(ctx context.Context) ([]*model.ChainTip, error) {
 	ctx, _, deferFn := tracing.Tracer("blockchain").Start(ctx, "sql:GetChainTips")
@@ -215,7 +217,7 @@ func (s *SQL) calculateBranchLength(ctx context.Context, tipHashBytes []byte) (u
 		}
 		var nextParentID uint32
 		if err := s.db.QueryRowContext(ctx, `SELECT parent_id FROM blocks WHERE id = $1`, parentID).Scan(&nextParentID); err != nil {
-			return branchLength, errors.NewStorageError("failed to query parent block", err)
+			return branchLength, errors.NewStorageError(errFailedQueryParentBlock, err)
 		}
 		currentID = parentID
 		parentID = nextParentID
@@ -247,7 +249,7 @@ func (s *SQL) calculateBranchLengthSQL(ctx context.Context, tipHashBytes []byte,
 			if errors.Is(err, sql.ErrNoRows) {
 				break
 			}
-			return 0, errors.NewStorageError("failed to query parent block", err)
+			return 0, errors.NewStorageError(errFailedQueryParentBlock, err)
 		}
 
 		if !parentID.Valid {
@@ -303,7 +305,7 @@ func (s *SQL) isBlockInMainChain(ctx context.Context, blockHash, mainChainTipHas
 			if errors.Is(err, sql.ErrNoRows) {
 				return false, nil
 			}
-			return false, errors.NewStorageError("failed to query parent block", err)
+			return false, errors.NewStorageError(errFailedQueryParentBlock, err)
 		}
 
 		if !parentID.Valid {

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -28,6 +28,8 @@ import (
 	"modernc.org/sqlite"
 )
 
+const errBlockAlreadyExistsInDB = "block already exists in the database: %s"
+
 // StoreBlock persists a new block to the database and updates chain state.
 // This implements the blockchain.Store.StoreBlock interface method.
 //
@@ -690,19 +692,19 @@ func (*SQL) parseSQLError(err error, block *model.Block) error {
 	// check whether this is a postgres exists constraint error (pgx driver)
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == usql.PgErrUniqueViolation {
-		return errors.NewBlockExistsError("block already exists in the database: %s", block.Hash().String(), err)
+		return errors.NewBlockExistsError(errBlockAlreadyExistsInDB, block.Hash().String(), err)
 	}
 
 	// check whether this is a postgres exists constraint error (lib/pq fallback)
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) && pqErr.Code == usql.PgErrUniqueViolation {
-		return errors.NewBlockExistsError("block already exists in the database: %s", block.Hash().String(), err)
+		return errors.NewBlockExistsError(errBlockAlreadyExistsInDB, block.Hash().String(), err)
 	}
 
 	// check whether this is a sqlite exists constraint error
 	var sqliteErr *sqlite.Error
 	if errors.As(err, &sqliteErr) && (sqliteErr.Code()&0xff) == SQLITE_CONSTRAINT {
-		return errors.NewBlockExistsError("block already exists in the database: %s", block.Hash().String(), err)
+		return errors.NewBlockExistsError(errBlockAlreadyExistsInDB, block.Hash().String(), err)
 	}
 
 	// otherwise, return the generic error

--- a/stores/blockchain/sql/sql.go
+++ b/stores/blockchain/sql/sql.go
@@ -52,6 +52,8 @@ import (
 // several minutes, and the cached results (parent_id walks) are immutable.
 const chainWalkCacheTTL = 10 * time.Minute
 
+const errCouldNotCreateBlocksTable = "could not create blocks table"
+
 // blockIDReservationTTL bounds how long a block-id reservation (AssignBlockID)
 // survives in the in-memory L1 cache without a commit. Reservations are normally
 // cleared on commit; the TTL only reclaims L1 entries for blocks that are fetched
@@ -626,7 +628,7 @@ func createPostgresSchemaUnlocked(db *usql.DB, withIndexes bool) error {
 	  );
 	`); err != nil {
 		_ = db.Close()
-		return errors.NewStorageError("could not create blocks table", err)
+		return errors.NewStorageError(errCouldNotCreateBlocksTable, err)
 	}
 
 	// block_id_reservations durably backs the in-memory AssignBlockID cache so a
@@ -909,7 +911,7 @@ func createSqliteSchema(db *usql.DB) error {
 	  );
 	`); err != nil {
 		_ = db.Close()
-		return errors.NewStorageError("could not create blocks table", err)
+		return errors.NewStorageError(errCouldNotCreateBlocksTable, err)
 	}
 
 	if _, err := db.Exec(`
@@ -943,7 +945,7 @@ func createSqliteSchema(db *usql.DB) error {
 	  );
 	`); err != nil {
 		_ = db.Close()
-		return errors.NewStorageError("could not create blocks table", err)
+		return errors.NewStorageError(errCouldNotCreateBlocksTable, err)
 	}
 
 	// block_id_reservations: see the Postgres schema for rationale. Durably backs

--- a/stores/utxo/aerospike/conflict_wal.go
+++ b/stores/utxo/aerospike/conflict_wal.go
@@ -31,6 +31,8 @@ const (
 	walBinStartedAt   = "startedAt"
 )
 
+const errWALRecordMissingBin = "[PendingConflictIntents] WAL record missing or invalid %s bin"
+
 // conflictWALSet returns the dedicated set name for this store's WAL.
 func (s *Store) conflictWALSet() string {
 	return s.setName + conflictWALSetSuffix
@@ -139,27 +141,27 @@ func (s *Store) PendingConflictIntents(ctx context.Context) ([]utxo.ConflictInte
 
 		kind, ok := record.Bins[walBinKind].(string)
 		if !ok {
-			return nil, errors.NewStorageError("[PendingConflictIntents] WAL record missing or invalid %s bin", walBinKind)
+			return nil, errors.NewStorageError(errWALRecordMissingBin, walBinKind)
 		}
 
 		blockHeight, ok := record.Bins[walBinBlockHeight].(int)
 		if !ok {
-			return nil, errors.NewStorageError("[PendingConflictIntents] WAL record missing or invalid %s bin", walBinBlockHeight)
+			return nil, errors.NewStorageError(errWALRecordMissingBin, walBinBlockHeight)
 		}
 
 		blockHashBytes, ok := record.Bins[walBinBlockHash].([]byte)
 		if !ok {
-			return nil, errors.NewStorageError("[PendingConflictIntents] WAL record missing or invalid %s bin", walBinBlockHash)
+			return nil, errors.NewStorageError(errWALRecordMissingBin, walBinBlockHash)
 		}
 
 		txHashesBytes, ok := record.Bins[walBinTxHashes].([]byte)
 		if !ok {
-			return nil, errors.NewStorageError("[PendingConflictIntents] WAL record missing or invalid %s bin", walBinTxHashes)
+			return nil, errors.NewStorageError(errWALRecordMissingBin, walBinTxHashes)
 		}
 
 		startedAt, ok := record.Bins[walBinStartedAt].(int)
 		if !ok {
-			return nil, errors.NewStorageError("[PendingConflictIntents] WAL record missing or invalid %s bin", walBinStartedAt)
+			return nil, errors.NewStorageError(errWALRecordMissingBin, walBinStartedAt)
 		}
 
 		bh, err := chainhash.NewHash(blockHashBytes)

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -89,6 +89,8 @@ var (
 	previousOutputsDecorateStat = gocoreStat.NewStat("PreviousOutputsDecorate").AddRanges(0, 1, 100, 1_000, 10_000, 100_000)
 )
 
+const errCouldNotReadInput = "could not read input"
+
 // batchGetItemData holds the result of a batch get operation
 type batchGetItemData struct {
 	Data *meta.Data // Retrieved data
@@ -498,7 +500,7 @@ func (s *Store) getTxFromBins(bins aerospike.BinMap) (tx *bt.Tx, err error) {
 
 			_, err = tx.Inputs[i].ReadFromExtended(bytes.NewReader(input))
 			if err != nil {
-				return nil, errors.NewTxInvalidError("could not read input", err)
+				return nil, errors.NewTxInvalidError(errCouldNotReadInput, err)
 			}
 		}
 	}
@@ -779,7 +781,7 @@ NEXT_BATCH_RECORD:
 
 							_, err = tx.Inputs[i].ReadFromExtended(bytes.NewReader(input))
 							if err != nil {
-								return errors.NewTxInvalidError("could not read input", err)
+								return errors.NewTxInvalidError(errCouldNotReadInput, err)
 							}
 						}
 					}
@@ -986,7 +988,7 @@ func processInputsToTxInpoints(bins aerospike.BinMap) (txInpoints subtree.TxInpo
 
 		_, err = tx.Inputs[i].ReadFromExtended(bytes.NewReader(input))
 		if err != nil {
-			return txInpoints, errors.NewProcessingError("could not read input", err)
+			return txInpoints, errors.NewProcessingError(errCouldNotReadInput, err)
 		}
 	}
 

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -39,6 +39,8 @@ var _ pruner.Service = (*Service)(nil)
 
 var IndexName, _ = gocore.Config().Get("pruner_IndexName", "pruner_dah_index")
 
+const errParentUpdateOpsFailed = "%d parent update operations failed"
+
 // TimeoutError indicates that a query operation timed out or encountered a network error.
 // This error type is used to distinguish retriable timeout errors from other errors.
 type TimeoutError struct {
@@ -1708,7 +1710,7 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 
 	if parentErrors > 0 {
 		s.logger.Errorf("Combined cleanup: %d parent update errors (first: %v)", parentErrors, firstParentErr)
-		return errors.NewStorageError("%d parent update operations failed", parentErrors, firstParentErr)
+		return errors.NewStorageError(errParentUpdateOpsFailed, parentErrors, firstParentErr)
 	}
 	if deleteErrors > 0 {
 		s.logger.Errorf("Combined cleanup: %d deletion errors (first: %v)", deleteErrors, firstDeleteErr)
@@ -1840,7 +1842,7 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 	}
 
 	if errorCount > 0 {
-		return errors.NewStorageError("%d parent update operations failed", errorCount)
+		return errors.NewStorageError(errParentUpdateOpsFailed, errorCount)
 	}
 
 	if successCount > 0 {
@@ -1904,7 +1906,7 @@ func (s *Service) executeBatchParentUpdatesBatchWrite(ctx context.Context, updat
 	}
 
 	if errorCount > 0 {
-		return errors.NewStorageError("%d parent update operations failed", errorCount)
+		return errors.NewStorageError(errParentUpdateOpsFailed, errorCount)
 	}
 
 	if successCount > 0 {

--- a/stores/utxo/factory/utxo.go
+++ b/stores/utxo/factory/utxo.go
@@ -76,6 +76,8 @@ import (
 	"github.com/bsv-blockchain/teranode/ulogger"
 )
 
+const errGettingBestHeightAndTime = "[UTXOStore] error getting best height and time for %s: %v"
+
 var availableDatabases = map[string]func(ctx context.Context, logger ulogger.Logger, tSettings *settings.Settings, url *url.URL) (utxo.Store, error){}
 
 // NewStore creates a new UTXO store implementation based on the settings.
@@ -137,9 +139,9 @@ func NewStore(ctx context.Context, logger ulogger.Logger, tSettings *settings.Se
 			blockHeight, medianBlockTime, err := blockchainClient.GetBestHeightAndTime(ctx)
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
-					logger.Infof("[UTXOStore] error getting best height and time for %s: %v", source, err)
+					logger.Infof(errGettingBestHeightAndTime, source, err)
 				} else {
-					logger.Warnf("[UTXOStore] error getting best height and time for %s: %v", source, err)
+					logger.Warnf(errGettingBestHeightAndTime, source, err)
 				}
 			} else if blockHeight > 0 {
 				logger.Debugf("[UTXOStore] setting block height to %d", blockHeight)
@@ -170,9 +172,9 @@ func NewStore(ctx context.Context, logger ulogger.Logger, tSettings *settings.Se
 							blockHeight, medianBlockTime, err = blockchainClient.GetBestHeightAndTime(ctx)
 							if err != nil {
 								if errors.Is(err, context.Canceled) {
-									logger.Infof("[UTXOStore] error getting best height and time for %s: %v", source, err)
+									logger.Infof(errGettingBestHeightAndTime, source, err)
 								} else {
-									logger.Errorf("[UTXOStore] error getting best height and time for %s: %v", source, err)
+									logger.Errorf(errGettingBestHeightAndTime, source, err)
 								}
 							} else if blockHeight > 0 {
 								logger.Debugf("[UTXOStore] updated block height to %d and median time to %d for %s", blockHeight, medianBlockTime, source)

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -82,6 +82,12 @@ import (
 	sqlite3 "modernc.org/sqlite/lib"
 )
 
+const (
+	errOutputNotFound           = "output %s:%d not found"
+	errFailedCreateSpendingData = "failed to create spending data from bytes"
+	errSQLUpdatingTransactions  = "SQL error updating transactions: %v"
+)
+
 // batchSpend represents a single UTXO spend request in a batch.
 // Mirrors aerospike/spend.go batchSpend struct.
 type batchSpend struct {
@@ -2214,7 +2220,7 @@ func (s *Store) trySendSpendBatchBulk(batch []*batchSpend) (retryable bool) {
 		spend := item.spend
 		r, found := resultMap[i]
 		if !found {
-			validationErrors[i] = errors.NewTxNotFoundError("output %s:%d not found", spend.TxID, spend.Vout)
+			validationErrors[i] = errors.NewTxNotFoundError(errOutputNotFound, spend.TxID, spend.Vout)
 			continue
 		}
 
@@ -2240,7 +2246,7 @@ func (s *Store) trySendSpendBatchBulk(batch []*batchSpend) (retryable bool) {
 			if spend.SpendingData != nil && !bytes.Equal(r.spendingDataBytes, spend.SpendingData.Bytes()) {
 				existingSpendData, parseErr := spendpkg.NewSpendingDataFromBytes(r.spendingDataBytes)
 				if parseErr != nil {
-					validationErrors[i] = errors.NewProcessingError("failed to create spending data from bytes", parseErr)
+					validationErrors[i] = errors.NewProcessingError(errFailedCreateSpendingData, parseErr)
 					continue
 				}
 				validationErrors[i] = errors.NewUtxoSpentError(*spend.TxID, spend.Vout, *spend.UTXOHash, existingSpendData)
@@ -2295,7 +2301,7 @@ func (s *Store) trySendSpendBatchBulk(batch []*batchSpend) (retryable bool) {
 				spend := batch[u.batchIdx].spend
 				existingSpendData, parseErr := spendpkg.NewSpendingDataFromBytes(entry.spendingData)
 				if parseErr != nil {
-					validationErrors[u.batchIdx] = errors.NewProcessingError("failed to create spending data from bytes", parseErr)
+					validationErrors[u.batchIdx] = errors.NewProcessingError(errFailedCreateSpendingData, parseErr)
 				} else {
 					validationErrors[u.batchIdx] = errors.NewUtxoSpentError(*spend.TxID, spend.Vout, *spend.UTXOHash, existingSpendData)
 				}
@@ -2705,7 +2711,7 @@ func (s *Store) trySendSpendBatchPerRow(batch []*batchSpend) (retryable bool) {
 		)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				validationErrors[i] = errors.NewTxNotFoundError("output %s:%d not found", spend.TxID, spend.Vout)
+				validationErrors[i] = errors.NewTxNotFoundError(errOutputNotFound, spend.TxID, spend.Vout)
 				continue
 			}
 			if isDeadlock(err) {
@@ -2742,7 +2748,7 @@ func (s *Store) trySendSpendBatchPerRow(batch []*batchSpend) (retryable bool) {
 			if spend.SpendingData != nil && !bytes.Equal(spendingDataBytes, spend.SpendingData.Bytes()) {
 				existingSpendData, parseErr := spendpkg.NewSpendingDataFromBytes(spendingDataBytes)
 				if parseErr != nil {
-					validationErrors[i] = errors.NewProcessingError("failed to create spending data from bytes", parseErr)
+					validationErrors[i] = errors.NewProcessingError(errFailedCreateSpendingData, parseErr)
 					continue
 				}
 				validationErrors[i] = errors.NewUtxoSpentError(*spend.TxID, spend.Vout, *spend.UTXOHash, existingSpendData)
@@ -3069,7 +3075,7 @@ func (s *Store) Unspend(ctx context.Context, spends []*utxo.Spend, flagAsLocked 
 				// still runs; the only real error here is a missing row.
 				if err = txn.QueryRowContext(ctx, qFindTxID, spend.TxID[:], spend.Vout).Scan(&transactionID); err != nil {
 					if errors.Is(err, sql.ErrNoRows) {
-						return errors.NewNotFoundError("output %s:%d not found", spend.TxID, spend.Vout)
+						return errors.NewNotFoundError(errOutputNotFound, spend.TxID, spend.Vout)
 					}
 
 					return err
@@ -3352,7 +3358,7 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 			`, inClause3)
 			args := append([]interface{}{newDAH}, inArgs3...)
 			if _, err = txn.ExecContext(ctx, qUpdate, args...); err != nil {
-				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+				return nil, errors.NewStorageError(errSQLUpdatingTransactions, err)
 			}
 		} else {
 			inClause3, inArgs3 := buildINClause(existingHashBytes, 1)
@@ -3362,7 +3368,7 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 				WHERE hash IN %s
 			`, inClause3)
 			if _, err = txn.ExecContext(ctx, qUpdate, inArgs3...); err != nil {
-				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+				return nil, errors.NewStorageError(errSQLUpdatingTransactions, err)
 			}
 		}
 	} else {
@@ -3386,7 +3392,7 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 				WHERE hash IN %s
 			`, inClause3)
 			if _, err = txn.ExecContext(ctx, qUpdate, inArgs3...); err != nil {
-				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+				return nil, errors.NewStorageError(errSQLUpdatingTransactions, err)
 			}
 
 			// Step 2: Set unmined_since only for transactions with no remaining block_ids
@@ -3417,7 +3423,7 @@ func (s *Store) setMinedMultiChunk(ctx context.Context, hashes []*chainhash.Hash
 				WHERE hash IN %s
 			`, inClause3)
 			if _, err = txn.ExecContext(ctx, qUpdate, inArgs3...); err != nil {
-				return nil, errors.NewStorageError("SQL error updating transactions: %v", err)
+				return nil, errors.NewStorageError(errSQLUpdatingTransactions, err)
 			}
 		}
 	}

--- a/stores/utxo/sql/unmined_iterator.go
+++ b/stores/utxo/sql/unmined_iterator.go
@@ -12,6 +12,8 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 )
 
+const errFailedCloseIterator = "failed to close iterator: %v"
+
 // unminedTxIterator implements utxo.UnminedTxIterator for SQL
 type unminedTxIterator struct {
 	store *Store
@@ -86,7 +88,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 	more := it.rows.Next()
 	if !more {
 		if err := it.Close(); err != nil {
-			it.store.logger.Warnf("failed to close iterator: %v", err)
+			it.store.logger.Warnf(errFailedCloseIterator, err)
 		}
 
 		return nil, nil
@@ -105,7 +107,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 
 	if err := it.rows.Scan(&id, &txID, &fee, &sizeInBytes, &insertedAt, &locked, &isCoinbase, &unminedSince); err != nil {
 		if err := it.Close(); err != nil {
-			it.store.logger.Warnf("failed to close iterator: %v", err)
+			it.store.logger.Warnf(errFailedCloseIterator, err)
 		}
 
 		it.err = err
@@ -129,7 +131,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 	rows, err := it.store.db.QueryContext(ctx, q2, id)
 	if err != nil {
 		if err := it.Close(); err != nil {
-			it.store.logger.Warnf("failed to close iterator: %v", err)
+			it.store.logger.Warnf(errFailedCloseIterator, err)
 		}
 
 		it.err = err
@@ -159,7 +161,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 
 		if err = rows.Scan(&previousTxHashBytes, &previousTxIdx, &input.PreviousTxSatoshis, &input.PreviousTxScript, &input.UnlockingScript, &input.SequenceNumber); err != nil {
 			if err = it.Close(); err != nil {
-				it.store.logger.Warnf("failed to close iterator: %v", err)
+				it.store.logger.Warnf(errFailedCloseIterator, err)
 			}
 
 			return nil, err
@@ -169,7 +171,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 		previousTxHash, err = chainhash.NewHash(previousTxHashBytes)
 		if err != nil {
 			if err = it.Close(); err != nil {
-				it.store.logger.Warnf("failed to close iterator: %v", err)
+				it.store.logger.Warnf(errFailedCloseIterator, err)
 			}
 
 			return nil, err
@@ -177,7 +179,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 
 		if err = input.PreviousTxIDAdd(previousTxHash); err != nil {
 			if err = it.Close(); err != nil {
-				it.store.logger.Warnf("failed to close iterator: %v", err)
+				it.store.logger.Warnf(errFailedCloseIterator, err)
 			}
 
 			return nil, err
@@ -189,7 +191,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 	txInpoints, err := subtree.NewTxInpointsFromInputs(tx.Inputs)
 	if err != nil {
 		if err = it.Close(); err != nil {
-			it.store.logger.Warnf("failed to close iterator: %v", err)
+			it.store.logger.Warnf(errFailedCloseIterator, err)
 		}
 
 		return nil, errors.NewProcessingError("failed to create tx inpoints from inputs", err)
@@ -208,7 +210,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 	rows2, err := it.store.db.QueryContext(ctx, q3, id)
 	if err != nil {
 		if err := it.Close(); err != nil {
-			it.store.logger.Warnf("failed to close iterator: %v", err)
+			it.store.logger.Warnf(errFailedCloseIterator, err)
 		}
 
 		it.err = err
@@ -223,7 +225,7 @@ func (it *unminedTxIterator) readOne(ctx context.Context) (*utxo.UnminedTransact
 
 		if err = rows2.Scan(&blockId); err != nil {
 			if err = it.Close(); err != nil {
-				it.store.logger.Warnf("failed to close iterator: %v", err)
+				it.store.logger.Warnf(errFailedCloseIterator, err)
 			}
 
 			return nil, err

--- a/util/aerospike.go
+++ b/util/aerospike.go
@@ -19,6 +19,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const aerospikeInvalidValueMsg = "[Aerospike] Invalid value %s=%v"
+
 var aerospikeConnectionMutex sync.Mutex
 var aerospikeConnections map[string]*uaerospike.Client
 
@@ -736,7 +738,7 @@ func getQueryBool(url *url.URL, key string, defaultValue bool, logger ulogger.Lo
 
 	valueBool, err := strconv.ParseBool(value)
 	if err != nil {
-		return defaultValue, errors.NewInvalidArgumentError("[Aerospike] Invalid value %s=%v", key, value, err)
+		return defaultValue, errors.NewInvalidArgumentError(aerospikeInvalidValueMsg, key, value, err)
 	}
 
 	logger.Infof("[Aerospike] %s=%t", key, valueBool)
@@ -753,7 +755,7 @@ func getQueryInt(url *url.URL, key string, defaultValue int, logger ulogger.Logg
 
 	valueInt, err := strconv.Atoi(value)
 	if err != nil {
-		return defaultValue, errors.NewInvalidArgumentError("[Aerospike] Invalid value %s=%v", key, value, err)
+		return defaultValue, errors.NewInvalidArgumentError(aerospikeInvalidValueMsg, key, value, err)
 	}
 
 	logger.Infof("[Aerospike] %s=%d", key, valueInt)
@@ -770,7 +772,7 @@ func getQueryDuration(url *url.URL, key string, defaultValue time.Duration, logg
 
 	valueDuration, err := time.ParseDuration(value)
 	if err != nil {
-		return defaultValue, errors.NewInvalidArgumentError("[Aerospike] Invalid value %s=%v", key, value, err)
+		return defaultValue, errors.NewInvalidArgumentError(aerospikeInvalidValueMsg, key, value, err)
 	}
 
 	logger.Infof("[Aerospike] %s=%s", key, valueDuration.String())
@@ -787,7 +789,7 @@ func getQueryFloat64(url *url.URL, key string, defaultValue float64, logger ulog
 
 	valueFloat64, err := strconv.ParseFloat(value, 64)
 	if err != nil {
-		return defaultValue, errors.NewInvalidArgumentError("[Aerospike] Invalid value %s=%v", key, value, err)
+		return defaultValue, errors.NewInvalidArgumentError(aerospikeInvalidValueMsg, key, value, err)
 	}
 
 	logger.Infof("[Aerospike] %s=%f", key, valueFloat64)

--- a/util/merkleproof/merkle_proof.go
+++ b/util/merkleproof/merkle_proof.go
@@ -11,6 +11,8 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 )
 
+const errMsgInvalidSubtreeIndex = "invalid subtree index"
+
 // MerkleProof represents a complete merkle proof for a transaction in a block.
 // It contains all necessary information to verify that a transaction is included
 // in a specific block following the SPV (Simplified Payment Verification) protocol.
@@ -166,7 +168,7 @@ func ConstructMerkleProof(txID *chainhash.Hash, repo MerkleProofConstructor) (*M
 
 	// Validate subtree index
 	if subtreeIdx < 0 || subtreeIdx >= len(block.Subtrees) {
-		return nil, terr.NewProcessingError("invalid subtree index")
+		return nil, terr.NewProcessingError(errMsgInvalidSubtreeIndex)
 	}
 
 	// Get the subtree hash
@@ -425,7 +427,7 @@ func ConstructSubtreeMerkleProof(subtreeHash *chainhash.Hash, repo MerkleProofCo
 
 	// Validate subtree index
 	if subtreeIdx < 0 || subtreeIdx >= len(block.Subtrees) {
-		return nil, terr.NewProcessingError("invalid subtree index")
+		return nil, terr.NewProcessingError(errMsgInvalidSubtreeIndex)
 	}
 
 	// Verify the subtree hash matches
@@ -589,7 +591,7 @@ func GenerateBlockMerkleProof(subtrees []*chainhash.Hash, subtreeIndex int) ([]*
 	}
 
 	if subtreeIndex < 0 || subtreeIndex >= len(subtrees) {
-		return nil, nil, terr.NewProcessingError("invalid subtree index")
+		return nil, nil, terr.NewProcessingError(errMsgInvalidSubtreeIndex)
 	}
 
 	// Handle special case of single subtree


### PR DESCRIPTION
## What

Resolves the **104 open `go:S1192`** findings ("Define a constant instead of duplicating this literal N times"), flagged **HIGH** severity in SonarQube, across **45 files**.

Each duplicated string literal is now an unexported package-level constant, with every occurrence in the same file replaced by that constant.

## Why

`go:S1192` is the top HIGH-severity rule by count on the project. The fixes are individually trivial and collectively clear the whole rule.

## Approach

Purely mechanical and behaviour-preserving:
- Constant values are byte-identical to the literals they replace, so log/error messages, `Printf`/`Errorf` format strings, CLI flag names, RPC help text and UI labels are unchanged at runtime.
- Constants are scoped to the same package/file as the literal; names are distinct within each package.
- Overlapping-prefix literals (e.g. `"parameter #%d '%s' "` vs `"parameter #%d '%s' must "` in `bsvjson/cmdparse.go`, and `"invalid peer ID"` vs `"invalid peer ID: %v"` in `handle_catchup_metrics.go`) were handled by matching complete quoted tokens only, so no longer literal was corrupted.
- No logic changes, no `_test.go` files, and no generated code touched.

## Files

45 files across `cmd/`, `compose/`, `daemon/`, `services/` (rpc, legacy, blockassembly, blockchain, blockvalidation, p2p, asset, subtreevalidation, utxopersister), `stores/` (blockchain/sql, txmetacache, utxo/{aerospike,sql,factory}) and `util/`.

## Verification

- `go build` across all source trees (untagged) and `go build -tags aerospike ./stores/utxo/aerospike/...` - clean
- `go vet` on all modified packages - clean
- `gofmt -l` on all 45 files - clean
- Test files in all modified packages compile; ran representative package suites (`stores/txmetacache`, `util/merkleproof`, `services/rpc/bsvjson`, `services/blockchain`) - pass
- Spot-checked several literals to confirm each now appears exactly once (the constant definition)