### PR TITLE
fix(errors): strip orphaned %w in errors.New*, sweep call sites, add CI guard (#1332)

### DIFF
--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -161,6 +161,9 @@ jobs:
         run: |
           ./scripts/check_filenames.sh
 
+      - name: Forbid %w in errors.New* format strings
+        run: ./scripts/check_error_wrap_verbs.sh
+
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
+      - name: Forbid %w in errors.New* format strings
+        run: ./scripts/check_error_wrap_verbs.sh
+
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/cmd/resetblockassembly/resetblockassembly.go
+++ b/cmd/resetblockassembly/resetblockassembly.go
@@ -27,21 +27,21 @@ func ResetBlockAssembly(logger ulogger.Logger, settings *settings.Settings, full
 	// Initialize the block assembly service
 	ba, err := blockassembly.NewClient(ctx, logger, settings)
 	if err != nil {
-		return errors.NewConfigurationError("failed to create block assembly client: %w", err)
+		return errors.NewConfigurationError("failed to create block assembly client", err)
 	}
 	defer func() { _ = ba.Close() }()
 
 	if validateInputs {
 		if err = ba.ResetBlockAssemblyValidateInputs(ctx); err != nil {
-			return errors.NewProcessingError("failed to reset block assembly with input validation: %w", err)
+			return errors.NewProcessingError("failed to reset block assembly with input validation", err)
 		}
 	} else if fullReset {
 		if err = ba.ResetBlockAssemblyFully(ctx); err != nil {
-			return errors.NewProcessingError("failed to reset block assembly: %w", err)
+			return errors.NewProcessingError("failed to reset block assembly", err)
 		}
 	} else {
 		if err = ba.ResetBlockAssembly(ctx); err != nil {
-			return errors.NewProcessingError("failed to reset block assembly: %w", err)
+			return errors.NewProcessingError("failed to reset block assembly", err)
 		}
 	}
 

--- a/cmd/rewindblockchain/rewindblockchain/phase1_unmined.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase1_unmined.go
@@ -45,7 +45,7 @@ func (e *env) runCleanupIterator(ctx context.Context, pf *preflightResult, mode 
 		return errors.NewProcessingError("unknown iterator mode %d", mode)
 	}
 	if err != nil {
-		return errors.NewStorageError("failed to open iterator: %w", err)
+		return errors.NewStorageError("failed to open iterator", err)
 	}
 	if it == nil {
 		return nil
@@ -60,7 +60,7 @@ func (e *env) runCleanupIterator(ctx context.Context, pf *preflightResult, mode 
 	for {
 		batch, nextErr := it.Next(ctx)
 		if nextErr != nil {
-			return errors.NewStorageError("iterator Next: %w", nextErr)
+			return errors.NewStorageError("iterator Next", nextErr)
 		}
 		if len(batch) == 0 {
 			return nil

--- a/cmd/rewindblockchain/rewindblockchain/phase2_blocks.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase2_blocks.go
@@ -16,7 +16,7 @@ import (
 func (e *env) phase2Blocks(ctx context.Context, pf *preflightResult) error {
 	for _, b := range pf.deleteList {
 		if err := e.rewindOneBlock(ctx, pf, b); err != nil {
-			return errors.NewProcessingError("rewinding block %s (height %d): %w", b.hash.String(), b.height, err)
+			return errors.NewProcessingError("rewinding block %s (height %d)", b.hash.String(), b.height, err)
 		}
 	}
 	return nil
@@ -25,12 +25,12 @@ func (e *env) phase2Blocks(ctx context.Context, pf *preflightResult) error {
 func (e *env) rewindOneBlock(ctx context.Context, pf *preflightResult, bl blockToDelete) error {
 	block, _, err := e.blockchainStore.GetBlock(ctx, bl.hash)
 	if err != nil {
-		return errors.NewStorageError("GetBlock: %w", err)
+		return errors.NewStorageError("GetBlock", err)
 	}
 
 	subtrees, err := block.GetSubtrees(ctx, e.logger, e.subtreeStore, e.concurrency)
 	if err != nil {
-		return errors.NewStorageError("GetSubtrees: %w", err)
+		return errors.NewStorageError("GetSubtrees", err)
 	}
 
 	collector := newRemovalCollector()
@@ -75,7 +75,7 @@ func (e *env) rewindOneBlock(ctx context.Context, pf *preflightResult, bl blockT
 	}
 
 	if err = e.blockchainStore.DeleteBlock(ctx, bl.hash); err != nil {
-		return errors.NewStorageError("DeleteBlock: %w", err)
+		return errors.NewStorageError("DeleteBlock", err)
 	}
 	e.stats.BlocksDeleted++
 
@@ -91,7 +91,7 @@ func (e *env) deleteCoinbase(ctx context.Context, pf *preflightResult, coinbaseH
 		if isNotFound(err) {
 			return nil
 		}
-		return errors.NewStorageError("Get coinbase %s: %w", coinbaseHash.String(), err)
+		return errors.NewStorageError("Get coinbase %s", coinbaseHash.String(), err)
 	}
 
 	var deletedHits, survivors []uint32
@@ -106,7 +106,7 @@ func (e *env) deleteCoinbase(ctx context.Context, pf *preflightResult, coinbaseH
 		if len(deletedHits) > 0 {
 			removals := []utxo.BlockIDsRemoval{{TxHash: coinbaseHash, BlockIDs: deletedHits}}
 			if err = e.utxoStore.RemoveBlockIDs(ctx, removals); err != nil {
-				return errors.NewStorageError("RemoveBlockIDs coinbase: %w", err)
+				return errors.NewStorageError("RemoveBlockIDs coinbase", err)
 			}
 			e.stats.TxsBlockIDsTrimmed++
 		}
@@ -115,7 +115,7 @@ func (e *env) deleteCoinbase(ctx context.Context, pf *preflightResult, coinbaseH
 
 	if err = e.utxoStore.Delete(ctx, coinbaseHash); err != nil {
 		if !isNotFound(err) {
-			return errors.NewStorageError("Delete coinbase: %w", err)
+			return errors.NewStorageError("Delete coinbase", err)
 		}
 	}
 	e.stats.TxsDeleted++
@@ -130,7 +130,7 @@ func (e *env) deleteSubtreeBlobs(ctx context.Context, pf *preflightResult, subtr
 
 		shared, err := e.blockchainStore.HasBlockBelowHeightContainingSubtree(ctx, sh, pf.target)
 		if err != nil {
-			return errors.NewStorageError("HasBlockBelowHeightContainingSubtree: %w", err)
+			return errors.NewStorageError("HasBlockBelowHeightContainingSubtree", err)
 		}
 		if shared {
 			e.stats.SubtreesSkippedShared++

--- a/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
@@ -41,11 +41,11 @@ func (e *env) phase3Finalize(ctx context.Context, pf *preflightResult) error {
 func (e *env) resetBlockAssemblerState(ctx context.Context, pf *preflightResult) error {
 	header, _, err := e.blockchainStore.GetBlockHeader(ctx, pf.targetHash)
 	if err != nil {
-		return errors.NewStorageError("failed to read target header: %w", err)
+		return errors.NewStorageError("failed to read target header", err)
 	}
 
 	if err = e.blockchainStore.SetState(ctx, blockassembly.StateKey, blockassembly.EncodeState(header, pf.target)); err != nil {
-		return errors.NewStorageError("failed to write state[BlockAssembler]: %w", err)
+		return errors.NewStorageError("failed to write state[BlockAssembler]", err)
 	}
 
 	e.logger.Infof("state[BlockAssembler] rewritten to height %d (%s)", pf.target, pf.targetHash)
@@ -63,7 +63,7 @@ func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult
 			e.logger.Debugf("state[%s] not present: %v", blockPersisterHeightKey, err)
 			return nil
 		}
-		return errors.NewStorageError("failed to read state[%s]: %w", blockPersisterHeightKey, err)
+		return errors.NewStorageError("failed to read state[%s]", blockPersisterHeightKey, err)
 	}
 	if len(existing) == 0 {
 		return nil
@@ -73,7 +73,7 @@ func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult
 	binary.LittleEndian.PutUint32(payload, pf.target)
 
 	if err = e.blockchainStore.SetState(ctx, blockPersisterHeightKey, payload); err != nil {
-		return errors.NewStorageError("failed to rewrite state[%s]: %w", blockPersisterHeightKey, err)
+		return errors.NewStorageError("failed to rewrite state[%s]", blockPersisterHeightKey, err)
 	}
 
 	e.logger.Infof("state[%s] rewritten to %d", blockPersisterHeightKey, pf.target)

--- a/cmd/rewindblockchain/rewindblockchain/phase4_verify.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase4_verify.go
@@ -15,7 +15,7 @@ import (
 func (e *env) phase4Verify(ctx context.Context, pf *preflightResult) error {
 	header, meta, err := e.blockchainStore.GetBestBlockHeader(ctx)
 	if err != nil {
-		return errors.NewStorageError("verify: GetBestBlockHeader: %w", err)
+		return errors.NewStorageError("verify: GetBestBlockHeader", err)
 	}
 
 	if meta.Height != pf.target {

--- a/cmd/rewindblockchain/rewindblockchain/preflight.go
+++ b/cmd/rewindblockchain/rewindblockchain/preflight.go
@@ -117,12 +117,12 @@ func (e *env) resolveTarget(ctx context.Context) (uint32, *chainhash.Hash, error
 
 	stateBytes, err := e.blockchainStore.GetState(ctx, blockassembly.StateKey)
 	if err != nil {
-		return 0, nil, errors.NewStorageError(`failed to read state["BlockAssembler"] (pass --target-height to override): %w`, err)
+		return 0, nil, errors.NewStorageError(`failed to read state["BlockAssembler"] (pass --target-height to override)`, err)
 	}
 
 	header, height, err := blockassembly.DecodeState(stateBytes)
 	if err != nil {
-		return 0, nil, errors.NewProcessingError(`failed to decode state["BlockAssembler"] (pass --target-height to override): %w`, err)
+		return 0, nil, errors.NewProcessingError(`failed to decode state["BlockAssembler"] (pass --target-height to override)`, err)
 	}
 
 	return height, header.Hash(), nil

--- a/cmd/rewindblockchain/rewindblockchain/preflight.go
+++ b/cmd/rewindblockchain/rewindblockchain/preflight.go
@@ -35,7 +35,7 @@ func (e *env) preflight(ctx context.Context) (*preflightResult, error) {
 	// 1. FSM state check.
 	fsmState, err := e.blockchainStore.GetFSMState(ctx)
 	if err != nil {
-		return nil, errors.NewStorageError("failed to read FSM state: %w", err)
+		return nil, errors.NewStorageError("failed to read FSM state", err)
 	}
 
 	normalised := strings.ToUpper(strings.TrimSpace(fsmState))
@@ -55,7 +55,7 @@ func (e *env) preflight(ctx context.Context) (*preflightResult, error) {
 	// 3. Read current tip.
 	_, tipMeta, err := e.blockchainStore.GetBestBlockHeader(ctx)
 	if err != nil {
-		return nil, errors.NewStorageError("failed to read best block: %w", err)
+		return nil, errors.NewStorageError("failed to read best block", err)
 	}
 
 	tip := tipMeta.Height
@@ -110,7 +110,7 @@ func (e *env) resolveTarget(ctx context.Context) (uint32, *chainhash.Hash, error
 		height := uint32(e.opts.TargetHeight)
 		block, err := e.blockchainStore.GetBlockByHeight(ctx, height)
 		if err != nil {
-			return 0, nil, errors.NewStorageError("failed to look up block at target height %d: %w", height, err)
+			return 0, nil, errors.NewStorageError("failed to look up block at target height %d", height, err)
 		}
 		return height, block.Hash(), nil
 	}
@@ -162,7 +162,7 @@ func (e *env) confirmPrompt(r *preflightResult) error {
 	reader := bufio.NewReader(e.opts.Stdin)
 	line, err := reader.ReadString('\n')
 	if err != nil {
-		return errors.NewProcessingError("failed to read confirmation: %w", err)
+		return errors.NewProcessingError("failed to read confirmation", err)
 	}
 
 	line = strings.ToLower(strings.TrimSpace(line))

--- a/cmd/rewindblockchain/rewindblockchain/rewind.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind.go
@@ -80,14 +80,14 @@ func Rewind(ctx context.Context, logger ulogger.Logger, s *settings.Settings, op
 
 	// Phase 0 — UTXO store internal height reset.
 	if err = stores.UTXO.SetBlockHeight(preflightResult.target); err != nil {
-		return stats, errors.NewStorageError("failed to reset UTXO store blockHeight: %w", err)
+		return stats, errors.NewStorageError("failed to reset UTXO store blockHeight", err)
 	}
 
 	logger.Infof("Phase 0 complete: UTXO store blockHeight set to %d", preflightResult.target)
 
 	// Phase 1 — unmined + conflicting cleanup.
 	if err = env.phase1Unmined(ctx, preflightResult); err != nil {
-		return stats, errors.NewProcessingError("Phase 1 failed: %w", err)
+		return stats, errors.NewProcessingError("Phase 1 failed", err)
 	}
 
 	logger.Infof("Phase 1 complete: unmined_purged=%d conflicting_purged=%d",
@@ -95,7 +95,7 @@ func Rewind(ctx context.Context, logger ulogger.Logger, s *settings.Settings, op
 
 	// Phase 2 — block rewind.
 	if err = env.phase2Blocks(ctx, preflightResult); err != nil {
-		return stats, errors.NewProcessingError("Phase 2 failed: %w", err)
+		return stats, errors.NewProcessingError("Phase 2 failed", err)
 	}
 
 	logger.Infof("Phase 2 complete: blocks_deleted=%d txs_deleted=%d blockids_trimmed=%d subtrees_deleted=%d subtrees_skipped_shared=%d",
@@ -104,12 +104,12 @@ func Rewind(ctx context.Context, logger ulogger.Logger, s *settings.Settings, op
 
 	// Phase 3 — finalize.
 	if err = env.phase3Finalize(ctx, preflightResult); err != nil {
-		return stats, errors.NewProcessingError("Phase 3 failed: %w", err)
+		return stats, errors.NewProcessingError("Phase 3 failed", err)
 	}
 
 	if opts.Verify {
 		if err = env.phase4Verify(ctx, preflightResult); err != nil {
-			return stats, errors.NewProcessingError("Phase 4 verify failed: %w", err)
+			return stats, errors.NewProcessingError("Phase 4 verify failed", err)
 		}
 		logger.Infof("Phase 4 verify complete")
 	}
@@ -131,17 +131,17 @@ func resolveStores(ctx context.Context, logger ulogger.Logger, s *settings.Setti
 
 	blockchainStore, err := blockchain.NewStore(logger, s.BlockChain.StoreURL, s)
 	if err != nil {
-		return nil, false, errors.NewConfigurationError("failed to open blockchain store: %w", err)
+		return nil, false, errors.NewConfigurationError("failed to open blockchain store", err)
 	}
 
 	utxoStore, err := utxofactory.NewStore(ctx, logger, s, "rewindblockchain", false)
 	if err != nil {
-		return nil, false, errors.NewConfigurationError("failed to open utxo store: %w", err)
+		return nil, false, errors.NewConfigurationError("failed to open utxo store", err)
 	}
 
 	subtreeStore, err := blob.NewStore(logger, s.SubtreeValidation.SubtreeStore)
 	if err != nil {
-		return nil, false, errors.NewConfigurationError("failed to open subtree blob store: %w", err)
+		return nil, false, errors.NewConfigurationError("failed to open subtree blob store", err)
 	}
 
 	return &Stores{

--- a/cmd/rewindblockchain/rewindblockchain/tx_delete.go
+++ b/cmd/rewindblockchain/rewindblockchain/tx_delete.go
@@ -38,14 +38,14 @@ func newRemovalCollector() *removalCollector {
 func (e *env) flushCollector(ctx context.Context, c *removalCollector) error {
 	if len(c.blockIDTrims) > 0 {
 		if err := e.utxoStore.RemoveBlockIDs(ctx, c.blockIDTrims); err != nil {
-			return errors.NewStorageError("failed to flush block id trims: %w", err)
+			return errors.NewStorageError("failed to flush block id trims", err)
 		}
 		e.stats.TxsBlockIDsTrimmed += len(c.blockIDTrims)
 	}
 
 	if len(c.conflictingChildren) > 0 {
 		if err := e.utxoStore.RemoveFromConflictingChildren(ctx, c.conflictingChildren); err != nil {
-			return errors.NewStorageError("failed to flush conflicting-child removals: %w", err)
+			return errors.NewStorageError("failed to flush conflicting-child removals", err)
 		}
 		e.stats.ParentConflictsCleaned += len(c.conflictingChildren)
 	}
@@ -75,7 +75,7 @@ func (e *env) deleteTxWithParents(ctx context.Context, txHash *chainhash.Hash, p
 			// Already gone — idempotent.
 			return false, nil
 		}
-		return false, errors.NewStorageError("failed to Get tx %s: %w", txHash.String(), err)
+		return false, errors.NewStorageError("failed to Get tx %s", txHash.String(), err)
 	}
 
 	// Partition BlockIDs into surviving vs deleted.
@@ -109,14 +109,14 @@ func (e *env) deleteTxWithParents(ctx context.Context, txHash *chainhash.Hash, p
 	}
 
 	if err = e.utxoStore.PreviousOutputsDecorate(ctx, meta.Tx); err != nil {
-		return false, errors.NewStorageError("PreviousOutputsDecorate %s: %w", txHash.String(), err)
+		return false, errors.NewStorageError("PreviousOutputsDecorate %s", txHash.String(), err)
 	}
 
 	spends := make([]*utxo.Spend, 0, len(meta.Tx.Inputs))
 	for i, input := range meta.Tx.Inputs {
 		utxoHash, hErr := util.UTXOHashFromInput(input)
 		if hErr != nil {
-			return false, errors.NewProcessingError("UTXOHashFromInput tx %s idx %d: %w", txHash.String(), i, hErr)
+			return false, errors.NewProcessingError("UTXOHashFromInput tx %s idx %d", txHash.String(), i, hErr)
 		}
 		spends = append(spends, &utxo.Spend{
 			TxID:         input.PreviousTxIDChainHash(),
@@ -141,14 +141,14 @@ func (e *env) deleteTxWithParents(ctx context.Context, txHash *chainhash.Hash, p
 			// per-input partial-success semantics, switch to single-input
 			// calls and aggregate errors.
 			if !isNotFound(err) {
-				return false, errors.NewStorageError("Unspend tx %s: %w", txHash.String(), err)
+				return false, errors.NewStorageError("Unspend tx %s", txHash.String(), err)
 			}
 		}
 	}
 
 	if err = e.utxoStore.Delete(ctx, txHash); err != nil {
 		if !isNotFound(err) {
-			return false, errors.NewStorageError("Delete tx %s: %w", txHash.String(), err)
+			return false, errors.NewStorageError("Delete tx %s", txHash.String(), err)
 		}
 	}
 

--- a/cmd/teranodecli/teranodecli/loadunminedbench.go
+++ b/cmd/teranodecli/teranodecli/loadunminedbench.go
@@ -41,7 +41,7 @@ func runLoadUnminedBenchmark(txCount int, cpuProfile, memProfile, aerospikeURL s
 		var err error
 		aerospikeURL, cleanup, err = aerospikeutil.InitAerospikeContainer()
 		if err != nil {
-			return errors.NewProcessingError("failed to initialize Aerospike container: %w", err)
+			return errors.NewProcessingError("failed to initialize Aerospike container", err)
 		}
 		defer func() {
 			if err := cleanup(); err != nil {
@@ -57,12 +57,12 @@ func runLoadUnminedBenchmark(txCount int, cpuProfile, memProfile, aerospikeURL s
 	// Parse Aerospike URL and create store
 	aerospikeURI, err := url.Parse(aerospikeURL)
 	if err != nil {
-		return errors.NewProcessingError("failed to parse Aerospike URL: %w", err)
+		return errors.NewProcessingError("failed to parse Aerospike URL", err)
 	}
 
 	aerospikeStore, err = aerospike.New(ctx, ulogger.TestLogger{}, tSettings, aerospikeURI)
 	if err != nil {
-		return errors.NewProcessingError("failed to create Aerospike store: %w", err)
+		return errors.NewProcessingError("failed to create Aerospike store", err)
 	}
 
 	// Setup phase - populate transactions
@@ -93,12 +93,12 @@ func runLoadUnminedBenchmark(txCount int, cpuProfile, memProfile, aerospikeURL s
 	// Start profiling
 	cpuFile, err := os.Create(cpuProfile)
 	if err != nil {
-		return errors.NewProcessingError("failed to create CPU profile: %w", err)
+		return errors.NewProcessingError("failed to create CPU profile", err)
 	}
 	defer cpuFile.Close()
 
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
-		return errors.NewProcessingError("failed to start CPU profile: %w", err)
+		return errors.NewProcessingError("failed to start CPU profile", err)
 	}
 
 	// Run benchmark - iterate through all unmined transactions
@@ -108,7 +108,7 @@ func runLoadUnminedBenchmark(txCount int, cpuProfile, memProfile, aerospikeURL s
 	iterator, err := aerospikeStore.GetUnminedTxIterator()
 	if err != nil {
 		pprof.StopCPUProfile()
-		return errors.NewProcessingError("failed to get iterator: %w", err)
+		return errors.NewProcessingError("failed to get iterator", err)
 	}
 
 	processedCount := int64(0)
@@ -121,7 +121,7 @@ func runLoadUnminedBenchmark(txCount int, cpuProfile, memProfile, aerospikeURL s
 				break
 			}
 			pprof.StopCPUProfile()
-			return errors.NewProcessingError("iterator error: %w", err)
+			return errors.NewProcessingError("iterator error", err)
 		}
 		if batch == nil || len(batch) == 0 {
 			break
@@ -145,13 +145,13 @@ func runLoadUnminedBenchmark(txCount int, cpuProfile, memProfile, aerospikeURL s
 	// Write memory profile
 	memFile, err := os.Create(memProfile)
 	if err != nil {
-		return errors.NewProcessingError("failed to create memory profile: %w", err)
+		return errors.NewProcessingError("failed to create memory profile", err)
 	}
 	defer memFile.Close()
 
 	runtime.GC()
 	if err := pprof.WriteHeapProfile(memFile); err != nil {
-		return errors.NewStorageError("failed to write memory profile: %w", err)
+		return errors.NewStorageError("failed to write memory profile", err)
 	}
 
 	// Calculate throughput
@@ -241,7 +241,7 @@ func populateAerospikeWithTransactions(ctx context.Context, store utxo.Store, co
 	}
 
 	if err := g.Wait(); err != nil {
-		return errors.NewProcessingError("failed to populate Aerospike: %w", err)
+		return errors.NewProcessingError("failed to populate Aerospike", err)
 	}
 
 	duration := time.Since(startTime)

--- a/cmd/teranodecli/teranodecli/subtreebench.go
+++ b/cmd/teranodecli/teranodecli/subtreebench.go
@@ -170,7 +170,7 @@ func runBenchmarkCore(subtreeSize, producers, iterations, duration int, cpuProfi
 	// Create subtree processor
 	stp, err := subtreeprocessor.NewSubtreeProcessor(context.Background(), ulogger.TestLogger{}, tSettings, nil, nil, nil, newSubtreeChan)
 	if err != nil {
-		return benchmarkResult{}, errors.NewProcessingError("failed to create subtree processor: %w", err)
+		return benchmarkResult{}, errors.NewProcessingError("failed to create subtree processor", err)
 	}
 	defer stp.Stop(ctx)
 
@@ -225,12 +225,12 @@ func runBenchmarkCore(subtreeSize, producers, iterations, duration int, cpuProfi
 	// Start CPU profiling AFTER all setup is complete
 	cpuFile, err := os.Create(cpuProfile)
 	if err != nil {
-		return benchmarkResult{}, errors.NewProcessingError("failed to create CPU profile: %w", err)
+		return benchmarkResult{}, errors.NewProcessingError("failed to create CPU profile", err)
 	}
 
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		cpuFile.Close()
-		return benchmarkResult{}, errors.NewProcessingError("failed to start CPU profile: %w", err)
+		return benchmarkResult{}, errors.NewProcessingError("failed to start CPU profile", err)
 	}
 
 	// Measure metrics
@@ -350,13 +350,13 @@ func runBenchmarkCore(subtreeSize, producers, iterations, duration int, cpuProfi
 	// Stop CPU profiling AFTER processing completes (including drain)
 	pprof.StopCPUProfile()
 	if err := cpuFile.Close(); err != nil {
-		return benchmarkResult{}, errors.NewProcessingError("failed to close CPU profile: %w", err)
+		return benchmarkResult{}, errors.NewProcessingError("failed to close CPU profile", err)
 	}
 
 	// Write memory profile immediately after processing
 	memFile, err := os.Create(memProfile)
 	if err != nil {
-		return benchmarkResult{}, errors.NewProcessingError("failed to create memory profile: %w", err)
+		return benchmarkResult{}, errors.NewProcessingError("failed to create memory profile", err)
 	}
 	defer func() {
 		if err := memFile.Close(); err != nil {
@@ -366,7 +366,7 @@ func runBenchmarkCore(subtreeSize, producers, iterations, duration int, cpuProfi
 
 	runtime.GC() // Force GC before memory profile
 	if err := pprof.WriteHeapProfile(memFile); err != nil {
-		return benchmarkResult{}, errors.NewStorageError("failed to write memory profile: %w", err)
+		return benchmarkResult{}, errors.NewStorageError("failed to write memory profile", err)
 	}
 
 	totalCompleted := int(opsCompleted.Load())

--- a/daemon/test_daemon.go
+++ b/daemon/test_daemon.go
@@ -1328,7 +1328,7 @@ func (td *TestDaemon) generateBlocks(t *testing.T, numBlocks uint32) error {
 	// Get current height before generating
 	_, meta, err := td.BlockchainClient.GetBestBlockHeader(td.Ctx)
 	if err != nil {
-		return errors.NewUnknownError("failed to get best block header: %w", err)
+		return errors.NewUnknownError("failed to get best block header", err)
 	}
 	startHeight := meta.Height
 
@@ -1339,13 +1339,13 @@ func (td *TestDaemon) generateBlocks(t *testing.T, numBlocks uint32) error {
 
 		err := td.BlockAssemblyClient.GenerateBlocks(td.Ctx, &blockassembly_api.GenerateBlocksRequest{Count: int32(remaining)})
 		if err != nil {
-			return errors.NewUnknownError("failed to generate %d blocks (batch %d/%d): %w", remaining, generated, numBlocks, err)
+			return errors.NewUnknownError("failed to generate %d blocks (batch %d/%d)", remaining, generated, numBlocks, err)
 		}
 
 		// Wait for this batch of blocks to be available before generating the next batch
 		intermediateTarget := startHeight + generated + remaining
 		if err = td.waitForBlockHeight(t, intermediateTarget, remaining); err != nil {
-			return errors.NewUnknownError("failed waiting for batch %d blocks at height %d: %w", remaining, intermediateTarget, err)
+			return errors.NewUnknownError("failed waiting for batch %d blocks at height %d", remaining, intermediateTarget, err)
 		}
 
 		generated += remaining

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -347,6 +347,12 @@ func (e *Error) GetData(key string) interface{} {
 }
 
 // New creates a new Error instance with the specified code, message, and optional parameters.
+//
+// Pass the causing error as the final argument to wrap it; do NOT use a %w verb
+// in the message. The trailing error is extracted before fmt.Errorf runs, so a
+// %w would be orphaned (rendering "%!w(MISSING)" or a literal "%w"); the wrapped
+// error is rendered by Error() via " -> " instead. Any orphaned %w is stripped
+// defensively, but the errors.New* format strings should simply omit it.
 func New(code ERR, message string, params ...interface{}) *Error {
 	var wErr *Error
 
@@ -362,6 +368,15 @@ func New(code ERR, message string, params ...interface{}) *Error {
 			wErr = &Error{message: err.Error()}
 			params = params[:len(params)-1]
 		}
+	}
+
+	// A trailing error argument was extracted as the wrapped error above, so any
+	// %w verb left in the format string is now orphaned: fmt.Errorf would render
+	// it as %!w(MISSING), or (when no params remain) the literal %w would survive
+	// unformatted. The wrapped error is rendered by Error() via " -> ", so the
+	// verb is redundant here — strip it. Escaped %%w is preserved.
+	if wErr != nil {
+		message = stripOrphanedWrapVerbs(message)
 	}
 
 	// Format the message with the remaining parameters
@@ -406,6 +421,53 @@ func New(code ERR, message string, params ...interface{}) *Error {
 	}
 
 	return returnErr
+}
+
+// stripOrphanedWrapVerbs removes unescaped %w verbs from a format string, together
+// with one immediately preceding separator run (trailing spaces and/or ':', '-',
+// ','), so "GetBlock: %w" -> "GetBlock" and "failed %s: %w" -> "failed %s". Escaped
+// verbs (%%w, i.e. a literal "%w") are preserved. It is only called once a trailing
+// error argument has been extracted as the wrapped error, at which point any %w in
+// the format is orphaned (see New). The scan is escape-aware rather than a regex so
+// that the second % of a %%w sequence is never mistaken for a verb.
+func stripOrphanedWrapVerbs(format string) string {
+	if !strings.Contains(format, "%w") {
+		return format
+	}
+
+	var b strings.Builder
+	b.Grow(len(format))
+
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' {
+			b.WriteByte(format[i])
+			continue
+		}
+
+		// Escaped percent: keep both bytes verbatim so "%%w" stays a literal "%w".
+		if i+1 < len(format) && format[i+1] == '%' {
+			b.WriteString("%%")
+			i++
+
+			continue
+		}
+
+		// Orphaned wrap verb: drop it and tidy any dangling separator that preceded it.
+		if i+1 < len(format) && format[i+1] == 'w' {
+			s := strings.TrimRight(b.String(), " ")
+			s = strings.TrimRight(s, ":-,")
+			s = strings.TrimRight(s, " ")
+			b.Reset()
+			b.WriteString(s)
+			i++
+
+			continue
+		}
+
+		b.WriteByte(format[i])
+	}
+
+	return b.String()
 }
 
 // contains checks if the target error or any of its wrapped errors exist in this error's chain

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2820,6 +2820,13 @@ func TestNewStripsOrphanedWrapVerbs(t *testing.T) {
 			wantContain: []string{"GetBlock hash -> "},
 			wantAbsent:  []string{"%w", "GetBlock hash:"},
 		},
+		{
+			// The ')' inside the format string must not truncate stripping (#1335, ChiR1).
+			name:        "closing paren before trailing %w",
+			build:       func() *Error { return NewStorageError(`read state (pass --flag to override): %w`, inner) },
+			wantContain: []string{"read state (pass --flag to override) -> "},
+			wantAbsent:  []string{"%w", "%!w", "override):"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -2854,6 +2861,8 @@ func TestStripOrphanedWrapVerbs(t *testing.T) {
 		"a [%w] b":             "a [] b",            // mid-string verb dropped, brackets remain
 		"x %w y %w":            "x y",               // both verbs dropped
 		"trailing text %w end": "trailing text end", // verb dropped, surrounding text kept
+		// a ')' inside the format before %w must not confuse stripping (#1335, ChiR1).
+		"read state (pass --flag to override): %w": "read state (pass --flag to override)",
 	}
 
 	for in, want := range cases {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2756,3 +2756,107 @@ func TestSanitizationSecurityScenarios(t *testing.T) {
 		require.Contains(t, userMsg, "operation failed")
 	})
 }
+
+// TestNewStripsOrphanedWrapVerbs verifies that a %w verb left in an errors.New*
+// format string never renders as "%!w(MISSING)" nor survives literally, because
+// the trailing error argument is extracted as the wrapped error before formatting
+// (see issue #1332). The wrapped error is rendered via the " -> " chain instead.
+func TestNewStripsOrphanedWrapVerbs(t *testing.T) {
+	inner := New(ERR_BLOCK_COINBASE_MISSING_HEIGHT, "the coinbase must start with the height")
+
+	tests := []struct {
+		name        string
+		build       func() *Error
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "verbs plus trailing %w (StoreBlock shape)",
+			build: func() *Error {
+				return New(ERR_STORAGE_ERROR, "failed to extract height for block %s (height %d): %w", "abc", 5, inner)
+			},
+			wantContain: []string{"failed to extract height for block abc (height 5)", " -> "},
+			wantAbsent:  []string{"%!w", "%w", "(height 5):"},
+		},
+		{
+			name:        "%w is the only verb",
+			build:       func() *Error { return New(ERR_STORAGE_ERROR, "GetBlock: %w", inner) },
+			wantContain: []string{"GetBlock -> "},
+			wantAbsent:  []string{"%w", "GetBlock:"},
+		},
+		{
+			name:        "escaped %%w preserved",
+			build:       func() *Error { return New(ERR_STORAGE_ERROR, "literal %%w here: %d", 1, inner) },
+			wantContain: []string{"literal %w here: 1"},
+			wantAbsent:  []string{"%!w"},
+		},
+		{
+			name:        "mid-string %w dropped",
+			build:       func() *Error { return New(ERR_SERVICE_ERROR, "[%s] server failed [%w]", "grpc", inner) },
+			wantContain: []string{"[grpc] server failed []"},
+			wantAbsent:  []string{"%!w", "[%w]"},
+		},
+		{
+			name:        "comma separator variant",
+			build:       func() *Error { return New(ERR_STORAGE_ERROR, "load state, %w", inner) },
+			wantContain: []string{"load state -> "},
+			wantAbsent:  []string{"%w", "load state,"},
+		},
+		{
+			name:        "multiple %w dropped",
+			build:       func() *Error { return New(ERR_STORAGE_ERROR, "x %w y %w", inner) },
+			wantContain: []string{"x y"},
+			wantAbsent:  []string{"%w", "%!w"},
+		},
+		{
+			name:        "no %w with wrapped err is byte-identical (hot path)",
+			build:       func() *Error { return New(ERR_STORAGE_ERROR, "plain %s", "value", inner) },
+			wantContain: []string{"plain value", " -> "},
+			wantAbsent:  []string{"%!", "%w"},
+		},
+		{
+			name:        "typed wrapper drops trailing %w",
+			build:       func() *Error { return NewStorageError("GetBlock %s: %w", "hash", inner) },
+			wantContain: []string{"GetBlock hash -> "},
+			wantAbsent:  []string{"%w", "GetBlock hash:"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.build().Error()
+			for _, want := range tc.wantContain {
+				require.Contains(t, got, want, "rendered: %q", got)
+			}
+			for _, absent := range tc.wantAbsent {
+				require.NotContains(t, got, absent, "rendered: %q", got)
+			}
+		})
+	}
+
+	// A message with no wrapped error is left untouched: an unpaired %w with no
+	// error argument still renders per fmt (we do not strip when wErr == nil).
+	noWrap := New(ERR_STORAGE_ERROR, "plain %s", "value")
+	require.Contains(t, noWrap.Error(), "plain value")
+}
+
+// TestStripOrphanedWrapVerbs unit-tests the helper directly for separator edge cases.
+func TestStripOrphanedWrapVerbs(t *testing.T) {
+	cases := map[string]string{
+		"GetBlock: %w":         "GetBlock",
+		"failed %s: %w":        "failed %s",
+		" - %w":                "",
+		", %w":                 "",
+		":%w":                  "",
+		" %w":                  "",
+		"no verb here":         "no verb here",
+		"literal %%w stays":    "literal %%w stays", // escaped %%w is not a verb
+		"a [%w] b":             "a [] b",            // mid-string verb dropped, brackets remain
+		"x %w y %w":            "x y",               // both verbs dropped
+		"trailing text %w end": "trailing text end", // verb dropped, surrounding text kept
+	}
+
+	for in, want := range cases {
+		require.Equal(t, want, stripOrphanedWrapVerbs(in), "input %q", in)
+	}
+}

--- a/scripts/check_error_wrap_verbs.sh
+++ b/scripts/check_error_wrap_verbs.sh
@@ -12,19 +12,27 @@
 #   errors.NewStorageError("failed to read block %s: %w", hash, err)  // WRONG
 #   errors.NewStorageError("failed to read block %s", hash, err)      // RIGHT
 #
-# The errors package itself is excluded: its own unit tests deliberately build
-# %w format strings to exercise the defensive stripping (see issue #1332), and
-# that path is already exempt from these style rules in .golangci.json.
+# The pattern uses `.*%w` rather than `[^)]*%w`: a `)` inside the format string
+# (e.g. "... (pass --flag to override): %w") must NOT truncate the match, or the
+# guard would green-light exactly the shape it forbids (#1335 review, ChiR1).
+#
+# Known line-based blind spots, all handled at runtime by the defensive strip in
+# errors.New so none produce a user-facing %!w:
+#   - a %w on a format-string continuation line (call spans multiple lines)
+#   - a pre-formatted %%w passed through fmt.Sprintf
+#   - a false positive on a comment or doc string that quotes the forbidden shape
+#     (a text grep can't tell code from a comment); low risk, accepted.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Match errors.New / errors.New<Type>Error( ... %w on a single line. Two forms
-# escape a line-based grep (a %w on a format-string continuation line, or a
-# pre-formatted %%w through fmt.Sprintf); those are additionally caught at
-# runtime by the defensive strip in errors.New.
-matches=$(grep -rnE 'errors\.New[A-Za-z]*\([^)]*%w' \
-  --include='*.go' --exclude-dir=vendor --exclude-dir=errors . || true)
+# The errors package's own callers use the unprefixed form (New(...), not
+# errors.New(...)) so they never match this pattern; only its *_test.go files
+# might deliberately construct a prefixed %w string to exercise the strip, so
+# exempt just those rather than excluding the whole package tree (#1335, ChiR2).
+matches=$(grep -rnE 'errors\.New[A-Za-z]*\(.*%w' \
+  --include='*.go' --exclude-dir=vendor . \
+  | grep -vE '^\./errors/[^/]*_test\.go:' || true)
 
 if [ -n "$matches" ]; then
   echo "ERROR: %w found inside errors.New* format string(s)."

--- a/scripts/check_error_wrap_verbs.sh
+++ b/scripts/check_error_wrap_verbs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Forbid the %w verb inside teranode errors.New* format strings.
+#
+# The teranode errors package (errors/errors.go) extracts a trailing error
+# argument as the wrapped error BEFORE calling fmt.Errorf, so any %w left in the
+# format string is orphaned: it renders as "%!w(MISSING)", or (when no other
+# params remain) the literal "%w" survives unformatted. The wrapped error is
+# rendered by Error() via " -> " chaining, so %w is always wrong here.
+#
+# Pass the causing error as the final argument and drop the verb:
+#   errors.NewStorageError("failed to read block %s: %w", hash, err)  // WRONG
+#   errors.NewStorageError("failed to read block %s", hash, err)      // RIGHT
+#
+# The errors package itself is excluded: its own unit tests deliberately build
+# %w format strings to exercise the defensive stripping (see issue #1332), and
+# that path is already exempt from these style rules in .golangci.json.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Match errors.New / errors.New<Type>Error( ... %w on a single line. Two forms
+# escape a line-based grep (a %w on a format-string continuation line, or a
+# pre-formatted %%w through fmt.Sprintf); those are additionally caught at
+# runtime by the defensive strip in errors.New.
+matches=$(grep -rnE 'errors\.New[A-Za-z]*\([^)]*%w' \
+  --include='*.go' --exclude-dir=vendor --exclude-dir=errors . || true)
+
+if [ -n "$matches" ]; then
+  echo "ERROR: %w found inside errors.New* format string(s)."
+  echo "The trailing error argument is extracted as the wrapped error before"
+  echo "formatting, so %w renders as %!w(MISSING) or survives literally."
+  echo "Drop the verb; pass the error as the final argument. Error() renders"
+  echo "the chain via \" -> \"."
+  echo
+  echo "$matches"
+  exit 1
+fi
+
+echo "OK: no %w verbs in errors.New* format strings."

--- a/services/blockassembly/subtreeprocessor/benchmark.go
+++ b/services/blockassembly/subtreeprocessor/benchmark.go
@@ -95,17 +95,17 @@ func RunCreateTransactionMapBenchmark(numSubtrees, txsPerSubtree int, cpuProfile
 
 	utxoStoreURL, err := url.Parse("sqlitememory:///test")
 	if err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to parse utxo store URL: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to parse utxo store URL", err)
 	}
 
 	utxoStore, err := sql.New(ctx, ulogger.TestLogger{}, tSettings, utxoStoreURL)
 	if err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create utxo store: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create utxo store", err)
 	}
 
 	stp, err := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, tSettings, subtreeStore, nil, utxoStore, newSubtreeChan)
 	if err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create subtree processor: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create subtree processor", err)
 	}
 
 	stp.SetCurrentItemsPerFile(1024 * 1024)
@@ -117,30 +117,30 @@ func RunCreateTransactionMapBenchmark(numSubtrees, txsPerSubtree int, cpuProfile
 	for s := 0; s < numSubtrees; s++ {
 		subtree, err := subtreepkg.NewTreeByLeafCount(txsPerSubtree)
 		if err != nil {
-			return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create subtree %d: %w", s, err)
+			return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create subtree %d", s, err)
 		}
 
 		if s == 0 {
 			if err := subtree.AddCoinbaseNode(); err != nil {
-				return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to add coinbase node: %w", err)
+				return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to add coinbase node", err)
 			}
 		}
 
 		for i := 0; i < txsPerSubtree-1; i++ {
 			txHash := chainhash.HashH([]byte(fmt.Sprintf("tx-%d-%d", s, i)))
 			if err := subtree.AddNode(txHash, uint64(s*txsPerSubtree+i+1), 100); err != nil {
-				return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to add node: %w", err)
+				return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to add node", err)
 			}
 		}
 
 		subtreeBytes, err := subtree.Serialize()
 		if err != nil {
-			return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to serialize subtree: %w", err)
+			return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to serialize subtree", err)
 		}
 
 		// DAH = currentBlockHeight + retention. Benchmark runs at height 0, so DAH = retention.
 		if err := subtreeStore.Set(ctx, subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes, options.WithDeleteAt(0+tSettings.GlobalBlockHeightRetention)); err != nil {
-			return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to store subtree: %w", err)
+			return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to store subtree", err)
 		}
 
 		blockSubtreesMap[*subtree.RootHash()] = s
@@ -151,12 +151,12 @@ func RunCreateTransactionMapBenchmark(numSubtrees, txsPerSubtree int, cpuProfile
 	// ===== PROFILING PHASE =====
 	cpuFile, err := os.Create(cpuProfile)
 	if err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create CPU profile: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create CPU profile", err)
 	}
 
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		cpuFile.Close()
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to start CPU profile: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to start CPU profile", err)
 	}
 
 	// Run the benchmark
@@ -167,21 +167,21 @@ func RunCreateTransactionMapBenchmark(numSubtrees, txsPerSubtree int, cpuProfile
 	// Stop CPU profiling
 	pprof.StopCPUProfile()
 	if err := cpuFile.Close(); err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to close CPU profile: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to close CPU profile", err)
 	}
 
 	// Write memory profile
 	runtime.GC()
 	memFile, err := os.Create(memProfile)
 	if err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create memory profile: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to create memory profile", err)
 	}
 	if err := pprof.WriteHeapProfile(memFile); err != nil {
 		memFile.Close()
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to write memory profile: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to write memory profile", err)
 	}
 	if err := memFile.Close(); err != nil {
-		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to close memory profile: %w", err)
+		return CreateTransactionMapBenchmarkResult{}, errors.NewProcessingError("failed to close memory profile", err)
 	}
 
 	// Build result
@@ -236,13 +236,13 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 
 	stp, err := NewSubtreeProcessor(ctx, ulogger.TestLogger{}, tSettings, nil, nil, nil, newSubtreeChan)
 	if err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create subtree processor: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create subtree processor", err)
 	}
 
 	// Initialize current subtree
 	newSubtree, err := subtreepkg.NewTreeByLeafCount(txsPerSubtree * 2)
 	if err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create new subtree: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create new subtree", err)
 	}
 	stp.currentSubtree.Store(newSubtree)
 	stp.chainedSubtrees = nil
@@ -258,7 +258,7 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 	for s := 0; s < numChainedSubtrees; s++ {
 		subtree, err := subtreepkg.NewTreeByLeafCount(txsPerSubtree)
 		if err != nil {
-			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create chained subtree %d: %w", s, err)
+			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create chained subtree %d", s, err)
 		}
 
 		if s == 0 {
@@ -268,7 +268,7 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 		for i := 0; i < txsPerSubtree-1; i++ {
 			txHash := chainhash.HashH([]byte(fmt.Sprintf("tx-chained-%d-%d", s, i)))
 			if err := subtree.AddSubtreeNode(subtreepkg.Node{Hash: txHash, Fee: 100}); err != nil {
-				return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to add chained subtree node: %w", err)
+				return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to add chained subtree node", err)
 			}
 			allTxHashes = append(allTxHashes, txHash)
 		}
@@ -278,13 +278,13 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 	// Create current subtree with transactions
 	currentSubtree, err := subtreepkg.NewTreeByLeafCount(txsPerSubtree)
 	if err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create current subtree: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create current subtree", err)
 	}
 	_ = currentSubtree.AddCoinbaseNode()
 	for i := 0; i < txsPerSubtree-1; i++ {
 		txHash := chainhash.HashH([]byte(fmt.Sprintf("tx-current-%d", i)))
 		if err := currentSubtree.AddSubtreeNode(subtreepkg.Node{Hash: txHash, Fee: 100}); err != nil {
-			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to add current subtree node: %w", err)
+			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to add current subtree node", err)
 		}
 		allTxHashes = append(allTxHashes, txHash)
 	}
@@ -295,7 +295,7 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 	transactionMap := NewSplitSwissMap(1024, len(allTxHashes))
 	for _, hash := range allTxHashes {
 		if err := transactionMap.Put(hash); err != nil {
-			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to put hash in transaction map: %w", err)
+			return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to put hash in transaction map", err)
 		}
 	}
 
@@ -342,12 +342,12 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 	// ===== PROFILING PHASE =====
 	cpuFile, err := os.Create(cpuProfile)
 	if err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create CPU profile: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create CPU profile", err)
 	}
 
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		cpuFile.Close()
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to start CPU profile: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to start CPU profile", err)
 	}
 
 	// Run the benchmark
@@ -358,21 +358,21 @@ func RunProcessRemainderBenchmark(numChainedSubtrees, txsPerSubtree int, cpuProf
 	// Stop CPU profiling
 	pprof.StopCPUProfile()
 	if err := cpuFile.Close(); err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to close CPU profile: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to close CPU profile", err)
 	}
 
 	// Write memory profile
 	runtime.GC()
 	memFile, err := os.Create(memProfile)
 	if err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create memory profile: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to create memory profile", err)
 	}
 	if err := pprof.WriteHeapProfile(memFile); err != nil {
 		memFile.Close()
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to write memory profile: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to write memory profile", err)
 	}
 	if err := memFile.Close(); err != nil {
-		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to close memory profile: %w", err)
+		return ProcessRemainderBenchmarkResult{}, errors.NewProcessingError("failed to close memory profile", err)
 	}
 
 	// Count remainder nodes

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -490,7 +490,7 @@ func (u *Server) fetchHeaders(ctx context.Context, catchupCtx *CatchupContext) e
 
 	result, _, err := u.catchupGetBlockHeaders(ctx, catchupCtx.blockUpTo, catchupCtx.peerID, catchupCtx.baseURL)
 	if err != nil {
-		return errors.NewProcessingError("[catchup][%s] failed to get block headers: %w", catchupCtx.blockUpTo.Hash().String(), err)
+		return errors.NewProcessingError("[catchup][%s] failed to get block headers", catchupCtx.blockUpTo.Hash().String(), err)
 	}
 
 	catchupCtx.headersFetchResult = result

--- a/services/blockvalidation/catchup/helpers.go
+++ b/services/blockvalidation/catchup/helpers.go
@@ -67,7 +67,7 @@ func ParseBlockHeaders(headerBytes []byte) ([]*model.BlockHeader, error) {
 		header, err := model.NewBlockHeaderFromBytes(headerData)
 		if err != nil {
 			// Return immediately on first parse error
-			return nil, errors.NewNetworkInvalidResponseError("failed to parse header at offset %d: %w", i, err)
+			return nil, errors.NewNetworkInvalidResponseError("failed to parse header at offset %d", i, err)
 		}
 
 		// Perform basic header validation
@@ -143,15 +143,15 @@ func FetchHeadersWithRetry(ctx context.Context, logger ulogger.Logger, url strin
 
 			// Categorize raw errors for better handling
 			if errors.Is(err, os.ErrDeadlineExceeded) || strings.Contains(err.Error(), "timeout") {
-				return nil, errors.NewNetworkTimeoutError("request timed out: %w", err)
+				return nil, errors.NewNetworkTimeoutError("request timed out", err)
 			}
 
 			if strings.Contains(err.Error(), "connection refused") {
-				return nil, errors.NewNetworkConnectionRefusedError("peer unavailable: %w", err)
+				return nil, errors.NewNetworkConnectionRefusedError("peer unavailable", err)
 			}
 
 			if strings.Contains(err.Error(), "network") || strings.Contains(err.Error(), "dial") {
-				return nil, errors.NewNetworkError("network error: %w", err)
+				return nil, errors.NewNetworkError("network error", err)
 			}
 
 			return nil, err
@@ -178,7 +178,7 @@ func FetchHeadersWithRetry(ctx context.Context, logger ulogger.Logger, url strin
 func CheckContextCancellation(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
-		return errors.NewContextCanceledError("operation cancelled: %w", ctx.Err())
+		return errors.NewContextCanceledError("operation cancelled", ctx.Err())
 	default:
 		return nil
 	}

--- a/services/blockvalidation/catchup_get_block_headers.go
+++ b/services/blockvalidation/catchup_get_block_headers.go
@@ -297,7 +297,7 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 				return catchup.CreateCatchupResult(
 					allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
 					iteration, failedIterations, false, "Malicious peer detected",
-				), nil, markCatchupFailureReported(errors.NewNetworkPeerMaliciousError("peer returned malicious response: %w", err))
+				), nil, markCatchupFailureReported(errors.NewNetworkPeerMaliciousError("peer returned malicious response", err))
 			}
 
 			return catchup.CreateCatchupResult(
@@ -332,7 +332,7 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 				return catchup.CreateCatchupResult(
 					allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
 					iteration, failedIterations, false, "Malicious headers detected",
-				), nil, errors.NewNetworkPeerMaliciousError("peer sent invalid headers: %w", parseErr)
+				), nil, errors.NewNetworkPeerMaliciousError("peer sent invalid headers", parseErr)
 			}
 
 			// For non-malicious parse errors, still fail but with different error type
@@ -343,7 +343,7 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 			return catchup.CreateCatchupResult(
 				allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
 				iteration, failedIterations, false, "Header parse failed",
-			), nil, errors.NewNetworkInvalidResponseError("failed to parse headers: %w", parseErr)
+			), nil, errors.NewNetworkInvalidResponseError("failed to parse headers", parseErr)
 		}
 
 		// Check if we got any headers
@@ -502,7 +502,7 @@ func (u *Server) getPeerChainTip(ctx context.Context, peerID string) (*chainhash
 	// Get peer info from P2P registry
 	peerInfo, err := u.p2pClient.GetPeer(ctx, peerID)
 	if err != nil {
-		return nil, errors.NewServiceError("failed to get peer info from P2P service: %w", err)
+		return nil, errors.NewServiceError("failed to get peer info from P2P service", err)
 	}
 
 	// Check if peer was found

--- a/services/blockvalidation/peer_metrics_helpers.go
+++ b/services/blockvalidation/peer_metrics_helpers.go
@@ -122,7 +122,7 @@ func markCatchupFailureReported(err error) error {
 	if err == nil {
 		return nil
 	}
-	wrapped := errors.NewProcessingError("catchup failure reported at source: %w", err)
+	wrapped := errors.NewProcessingError("catchup failure reported at source", err)
 	wrapped.SetData(catchupFailureReportedKey, true)
 	return wrapped
 }

--- a/services/blockvalidation/peer_metrics_helpers_test.go
+++ b/services/blockvalidation/peer_metrics_helpers_test.go
@@ -54,7 +54,7 @@ func TestReportCatchupFailureForError_SkipsAlreadyReported(t *testing.T) {
 	t.Run("marker survives teranode error wrapping", func(t *testing.T) {
 		u, client := newServer()
 		// Same shape fetchHeaders produces: ProcessingError wrapping the marked error.
-		err := errors.NewProcessingError("failed to get block headers: %w",
+		err := errors.NewProcessingError("failed to get block headers",
 			markCatchupFailureReported(errors.NewServiceError("http request returned status code [429]")))
 		u.reportCatchupFailureForError(context.Background(), "peer-1", err)
 		require.Equal(t, 0, client.failures)
@@ -76,13 +76,13 @@ func TestMarkCatchupFailureReported_TransparentToErrorCodes(t *testing.T) {
 	// ProcessingError → marker → ServiceError: the ServiceError code must still
 	// match through the foreign marker link (the top-level ErrServiceError
 	// branch routes on this).
-	err := errors.NewProcessingError("wrap: %w",
+	err := errors.NewProcessingError("wrap",
 		markCatchupFailureReported(errors.NewServiceError("http 429")))
 	require.True(t, errors.Is(err, errors.ErrServiceError))
 	require.True(t, catchupFailureAlreadyReported(err))
 
 	// Malicious classification survives the marker too.
-	malicious := errors.NewProcessingError("wrap: %w",
+	malicious := errors.NewProcessingError("wrap",
 		markCatchupFailureReported(errors.NewNetworkPeerMaliciousError("bad headers")))
 	require.True(t, errors.Is(malicious, errors.ErrNetworkPeerMalicious))
 

--- a/services/blockvalidation/testhelpers/mainnet_loader.go
+++ b/services/blockvalidation/testhelpers/mainnet_loader.go
@@ -46,14 +46,14 @@ func loadMainnetBlocks() ([]*model.Block, []*model.BlockHeader, error) {
 		// Read the file
 		data, err := os.ReadFile(testdataPath)
 		if err != nil {
-			cachedMainnetBlocksErr = errors.NewProcessingError("failed to read mainnet blocks file %s: %w", testdataPath, err)
+			cachedMainnetBlocksErr = errors.NewProcessingError("failed to read mainnet blocks file %s", testdataPath, err)
 			return
 		}
 
 		// Parse JSON
 		var testData TestBlockData
 		if err := json.Unmarshal(data, &testData); err != nil {
-			cachedMainnetBlocksErr = errors.NewProcessingError("failed to parse mainnet blocks JSON: %w", err)
+			cachedMainnetBlocksErr = errors.NewProcessingError("failed to parse mainnet blocks JSON", err)
 			return
 		}
 
@@ -65,7 +65,7 @@ func loadMainnetBlocks() ([]*model.Block, []*model.BlockHeader, error) {
 			// Parse the JSON block
 			var blockData map[string]interface{}
 			if err := json.Unmarshal(blockJSON, &blockData); err != nil {
-				cachedMainnetBlocksErr = errors.NewProcessingError("failed to parse block %d JSON: %w", i, err)
+				cachedMainnetBlocksErr = errors.NewProcessingError("failed to parse block %d JSON", i, err)
 				return
 			}
 
@@ -86,7 +86,7 @@ func loadMainnetBlocks() ([]*model.Block, []*model.BlockHeader, error) {
 			if hashStr, ok := headerData["hash_prev_block"].(string); ok {
 				hash, err := chainhash.NewHashFromStr(hashStr)
 				if err != nil {
-					cachedMainnetBlocksErr = errors.NewProcessingError("block %d: invalid prev hash: %w", i, err)
+					cachedMainnetBlocksErr = errors.NewProcessingError("block %d: invalid prev hash", i, err)
 					return
 				}
 				header.HashPrevBlock = hash
@@ -95,7 +95,7 @@ func loadMainnetBlocks() ([]*model.Block, []*model.BlockHeader, error) {
 			if hashStr, ok := headerData["hash_merkle_root"].(string); ok {
 				hash, err := chainhash.NewHashFromStr(hashStr)
 				if err != nil {
-					cachedMainnetBlocksErr = errors.NewProcessingError("block %d: invalid merkle root: %w", i, err)
+					cachedMainnetBlocksErr = errors.NewProcessingError("block %d: invalid merkle root", i, err)
 					return
 				}
 				header.HashMerkleRoot = hash
@@ -108,7 +108,7 @@ func loadMainnetBlocks() ([]*model.Block, []*model.BlockHeader, error) {
 			if bitsStr, ok := headerData["bits"].(string); ok {
 				nBits, err := model.NewNBitFromString(bitsStr)
 				if err != nil {
-					cachedMainnetBlocksErr = errors.NewProcessingError("block %d: invalid bits: %w", i, err)
+					cachedMainnetBlocksErr = errors.NewProcessingError("block %d: invalid bits", i, err)
 					return
 				}
 				header.Bits = *nBits

--- a/services/blockvalidation/testhelpers/testdata_loader.go
+++ b/services/blockvalidation/testhelpers/testdata_loader.go
@@ -53,14 +53,14 @@ func loadTestHeadersFromFile(filename string, cache *[]*model.BlockHeader, once 
 		// Read the file
 		data, err := os.ReadFile(testdataPath)
 		if err != nil {
-			*cacheErr = errors.NewProcessingError("failed to read test headers file %s: %w", testdataPath, err)
+			*cacheErr = errors.NewProcessingError("failed to read test headers file %s", testdataPath, err)
 			return
 		}
 
 		// Parse JSON
 		var testData TestHeaderData
 		if err := json.Unmarshal(data, &testData); err != nil {
-			*cacheErr = errors.NewProcessingError("failed to parse test headers JSON: %w", err)
+			*cacheErr = errors.NewProcessingError("failed to parse test headers JSON", err)
 			return
 		}
 
@@ -69,7 +69,7 @@ func loadTestHeadersFromFile(filename string, cache *[]*model.BlockHeader, once 
 		for i, headerBytes := range testData.Headers {
 			header, err := model.NewBlockHeaderFromBytes(headerBytes)
 			if err != nil {
-				*cacheErr = errors.NewProcessingError("failed to parse header %d: %w", i, err)
+				*cacheErr = errors.NewProcessingError("failed to parse header %d", i, err)
 				return
 			}
 			headers[i] = header

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -1133,7 +1133,7 @@ func (s *Server) handleBlockNotification(ctx context.Context, hash *chainhash.Ha
 
 	h, meta, err := s.blockchainClient.GetBlockHeader(ctx, hash)
 	if err != nil {
-		return errors.NewError("error getting block header and meta for BlockMessage: %w", err)
+		return errors.NewError("error getting block header and meta for BlockMessage", err)
 	}
 
 	if meta.Invalid {
@@ -1153,11 +1153,11 @@ func (s *Server) handleBlockNotification(ctx context.Context, hash *chainhash.Ha
 
 	msgBytes, err = json.Marshal(blockMessage)
 	if err != nil {
-		return errors.NewError("blockMessage - json marshal error: %w", err)
+		return errors.NewError("blockMessage - json marshal error", err)
 	}
 
 	if err = s.P2PClient.Publish(ctx, s.blockTopicName, msgBytes); err != nil {
-		return errors.NewError("blockMessage - publish error: %w", err)
+		return errors.NewError("blockMessage - publish error", err)
 	}
 
 	// Also send a node_status update when best block changes
@@ -1506,14 +1506,14 @@ func (s *Server) handleNodeStatusNotification(ctx context.Context) error {
 
 	msgBytes, err := json.Marshal(nodeStatusMessage)
 	if err != nil {
-		return errors.NewError("nodeStatusMessage - json marshal error: %w", err)
+		return errors.NewError("nodeStatusMessage - json marshal error", err)
 	}
 
 	s.logger.Infof("[handleNodeStatusNotification] P2P publishing node_status to topic %s (height=%d, version=%s, storage=%q)", s.nodeStatusTopicName, nodeStatusMessage.BestHeight, nodeStatusMessage.Version, nodeStatusMessage.Storage)
 	s.logger.Debugf("[handleNodeStatusNotification] JSON payload: %s", string(msgBytes))
 
 	if err = s.P2PClient.Publish(ctx, s.nodeStatusTopicName, msgBytes); err != nil {
-		return errors.NewError("nodeStatusMessage - publish error: %w", err)
+		return errors.NewError("nodeStatusMessage - publish error", err)
 	}
 
 	s.logger.Debugf("[handleNodeStatusNotification] Successfully published node_status message")
@@ -1544,11 +1544,11 @@ func (s *Server) handleSubtreeNotification(ctx context.Context, hash *chainhash.
 
 	msgBytes, err := json.Marshal(subtreeMessage)
 	if err != nil {
-		return errors.NewError("subtreeMessage - json marshal error: %w", err)
+		return errors.NewError("subtreeMessage - json marshal error", err)
 	}
 
 	if err := s.P2PClient.Publish(ctx, s.subtreeTopicName, msgBytes); err != nil {
-		return errors.NewError("subtreeMessage - publish error: %w", err)
+		return errors.NewError("subtreeMessage - publish error", err)
 	}
 
 	return nil
@@ -1580,7 +1580,7 @@ func (s *Server) processBlockchainNotification(ctx context.Context, notification
 	hash, err := chainhash.NewHash(notification.Hash)
 	if err != nil {
 		// Specific error about hash conversion, not logged here, but returned to caller.
-		return errors.NewError(fmt.Sprintf("error getting chainhash from notification hash %s: %%w", notification.Hash), err)
+		return errors.NewError("error getting chainhash from notification hash %s", notification.Hash, err)
 	}
 
 	switch notification.Type {

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -527,7 +527,7 @@ func (s *Server) startInvalidBlockConsumer(ctx context.Context) error {
 
 		kafkaURL, err = url.Parse(kafkaURLString)
 		if err != nil {
-			return errors.NewConfigurationError("invalid Kafka URL: %w", err)
+			return errors.NewConfigurationError("invalid Kafka URL", err)
 		}
 	}
 

--- a/stores/blob/file/file.go
+++ b/stores/blob/file/file.go
@@ -383,7 +383,7 @@ func acquireWritePermit(ctx context.Context) error {
 			return errors.NewServiceUnavailableError("[File] write operation timed out waiting for semaphore permit")
 		}
 
-		return errors.NewStorageError("[File] failed to acquire write permit: %w", err)
+		return errors.NewStorageError("[File] failed to acquire write permit", err)
 	}
 
 	return nil

--- a/stores/blockchain/sql/StoreBlock.go
+++ b/stores/blockchain/sql/StoreBlock.go
@@ -837,12 +837,12 @@ func (s *SQL) getPreviousBlockData(
 func calculateAndPrepareChainWork(previousChainWorkBytes []byte, block *model.Block) ([]byte, error) {
 	prevChainWorkHash, err := chainhash.NewHash(bt.ReverseBytes(previousChainWorkBytes))
 	if err != nil {
-		return nil, errors.NewProcessingError("failed to convert previous chain work bytes to hash for block %s: %w", block.Hash().String(), err)
+		return nil, errors.NewProcessingError("failed to convert previous chain work bytes to hash for block %s", block.Hash().String(), err)
 	}
 
 	cumulativeChainWorkHash, err := getCumulativeChainWork(prevChainWorkHash, block)
 	if err != nil {
-		return nil, errors.NewProcessingError("failed to calculate cumulative chain work for block %s: %w", block.Hash().String(), err)
+		return nil, errors.NewProcessingError("failed to calculate cumulative chain work for block %s", block.Hash().String(), err)
 	}
 
 	cumulativeChainWorkBytes := bt.ReverseBytes(cumulativeChainWorkHash.CloneBytes())
@@ -919,7 +919,7 @@ func (s *SQL) validateCoinbaseHeight(block *model.Block, currentHeight uint32) e
 
 	blockHeight, err := block.ExtractCoinbaseHeight()
 	if err != nil {
-		return errors.NewStorageError("failed to extract coinbase height for block %s (height %d): %w", block.Hash().String(), currentHeight, err)
+		return errors.NewStorageError("failed to extract coinbase height for block %s (height %d)", block.Hash().String(), currentHeight, err)
 	}
 
 	if blockHeight != currentHeight {

--- a/stores/tempstore/badger.go
+++ b/stores/tempstore/badger.go
@@ -69,7 +69,7 @@ func New(opts Options) (*BadgerTempStore, error) {
 	if err != nil {
 		// Clean up directory on failure
 		_ = os.RemoveAll(path)
-		return nil, errors.NewServiceError("failed to open badger: %w", err)
+		return nil, errors.NewServiceError("failed to open badger", err)
 	}
 
 	return &BadgerTempStore{
@@ -223,7 +223,7 @@ func (s *BadgerTempStore) Close() error {
 		if err := s.db.Close(); err != nil {
 			// Still try to clean up
 			_ = os.RemoveAll(s.path)
-			return errors.NewServiceError("failed to close badger: %w", err)
+			return errors.NewServiceError("failed to close badger", err)
 		}
 	}
 

--- a/stores/utxo/aerospike/container_helper_test.go
+++ b/stores/utxo/aerospike/container_helper_test.go
@@ -69,7 +69,7 @@ func waitForAerospikeWritesReady(client *uaerospike.Client) error {
 		return err
 	}
 
-	return errors.NewProcessingError("aerospike namespace %q did not become write-ready after %v: %w", aerospikeNamespace, time.Duration(attempts)*delay, lastErr)
+	return errors.NewProcessingError("aerospike namespace %q did not become write-ready after %v", aerospikeNamespace, time.Duration(attempts)*delay, lastErr)
 }
 
 const (

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -825,7 +825,7 @@ func (s *Store) executeSpendBatch(batchRecords []aerospike.BatchRecordIfc, batch
 		// (key-creation/validation failures) are simply no-ops here, so this
 		// safely covers every remaining item without double-signalling.
 		for idx, bItem := range batch {
-			var sendErr error = errors.NewStorageError("[SPEND_BATCH_LUA][%s] failed to batch spend aerospike map utxo in batchId %d: %d - %w", bItem.spend.TxID.String(), batchID, idx, err)
+			var sendErr error = errors.NewStorageError("[SPEND_BATCH_LUA][%s] failed to batch spend aerospike map utxo in batchId %d idx %d", bItem.spend.TxID.String(), batchID, idx, err)
 			bItem.complete(sendErr)
 		}
 		return err

--- a/stores/utxo/aerospike/spend_expressions.go
+++ b/stores/utxo/aerospike/spend_expressions.go
@@ -363,7 +363,7 @@ func (s *Store) SpendMultiWithExpressions(ctx context.Context, batch []*batchSpe
 		// validation failures) are no-ops here, so this safely covers every
 		// remaining item without racing or double-signalling.
 		for _, bItem := range batch {
-			bItem.complete(errors.NewStorageError("[SPEND_BATCH_EXP] failed to batch spend: %w", err))
+			bItem.complete(errors.NewStorageError("[SPEND_BATCH_EXP] failed to batch spend", err))
 		}
 		return
 	}
@@ -443,7 +443,7 @@ func (s *Store) processSpendBatchResultsExpressions(
 				}
 			}
 
-			bItem.complete(errors.NewStorageError("spend error for %s:%d: %w", bItem.spend.TxID.String(), bItem.spend.Vout, batchRec.Err))
+			bItem.complete(errors.NewStorageError("spend error for %s:%d", bItem.spend.TxID.String(), bItem.spend.Vout, batchRec.Err))
 			errCount++
 			if isInfrastructureFailure(batchRec.Err) {
 				infraErrCount++
@@ -460,7 +460,7 @@ func (s *Store) processSpendBatchResultsExpressions(
 
 		state, err := s.parseSpendState(batchRec.Record.Bins)
 		if err != nil {
-			bItem.complete(errors.NewProcessingError("failed to parse spend state: %w", err))
+			bItem.complete(errors.NewProcessingError("failed to parse spend state", err))
 			errCount++
 			continue
 		}

--- a/test/chaos/scenario_08_block_validation_memory_test.go
+++ b/test/chaos/scenario_08_block_validation_memory_test.go
@@ -506,7 +506,7 @@ func (g *BlockSubtreeGenerator) GenerateSubtree() (*BlockSubtree, error) {
 	for i := 0; i < txCount; i++ {
 		tx, err := g.generateRandomTransaction()
 		if err != nil {
-			return nil, errors.NewProcessingError("failed to generate transaction: %w", err)
+			return nil, errors.NewProcessingError("failed to generate transaction", err)
 		}
 		subtree.Transactions[i] = tx
 	}

--- a/test/chaos/toxiproxy_client.go
+++ b/test/chaos/toxiproxy_client.go
@@ -106,13 +106,13 @@ func (c *ToxiproxyClient) AddSlicer(proxyName string, avgSize, sizeVariation, de
 func (c *ToxiproxyClient) addToxic(proxyName string, toxic Toxic) error {
 	data, err := json.Marshal(toxic)
 	if err != nil {
-		return errors.NewProcessingError("failed to marshal toxic: %w", err)
+		return errors.NewProcessingError("failed to marshal toxic", err)
 	}
 
 	url := fmt.Sprintf("%s/proxies/%s/toxics", c.BaseURL, proxyName)
 	resp, err := c.client.Post(url, "application/json", bytes.NewReader(data))
 	if err != nil {
-		return errors.NewProcessingError("failed to add toxic: %w", err)
+		return errors.NewProcessingError("failed to add toxic", err)
 	}
 	defer resp.Body.Close()
 
@@ -129,12 +129,12 @@ func (c *ToxiproxyClient) RemoveToxic(proxyName, toxicName string) error {
 	url := fmt.Sprintf("%s/proxies/%s/toxics/%s", c.BaseURL, proxyName, toxicName)
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
-		return errors.NewProcessingError("failed to create delete request: %w", err)
+		return errors.NewProcessingError("failed to create delete request", err)
 	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.NewProcessingError("failed to remove toxic: %w", err)
+		return errors.NewProcessingError("failed to remove toxic", err)
 	}
 	defer resp.Body.Close()
 
@@ -150,12 +150,12 @@ func (c *ToxiproxyClient) RemoveToxic(proxyName, toxicName string) error {
 func (c *ToxiproxyClient) RemoveAllToxics(proxyName string) error {
 	toxics, err := c.ListToxics(proxyName)
 	if err != nil {
-		return errors.NewProcessingError("failed to list toxics: %w", err)
+		return errors.NewProcessingError("failed to list toxics", err)
 	}
 
 	for _, toxic := range toxics {
 		if err := c.RemoveToxic(proxyName, toxic.Name); err != nil {
-			return errors.NewProcessingError("failed to remove toxic %s: %w", toxic.Name, err)
+			return errors.NewProcessingError("failed to remove toxic %s", toxic.Name, err)
 		}
 	}
 
@@ -167,7 +167,7 @@ func (c *ToxiproxyClient) ListToxics(proxyName string) ([]Toxic, error) {
 	url := fmt.Sprintf("%s/proxies/%s/toxics", c.BaseURL, proxyName)
 	resp, err := c.client.Get(url)
 	if err != nil {
-		return nil, errors.NewProcessingError("failed to list toxics: %w", err)
+		return nil, errors.NewProcessingError("failed to list toxics", err)
 	}
 	defer resp.Body.Close()
 
@@ -178,7 +178,7 @@ func (c *ToxiproxyClient) ListToxics(proxyName string) ([]Toxic, error) {
 
 	var toxics []Toxic
 	if err := json.NewDecoder(resp.Body).Decode(&toxics); err != nil {
-		return nil, errors.NewProcessingError("failed to decode toxics: %w", err)
+		return nil, errors.NewProcessingError("failed to decode toxics", err)
 	}
 
 	return toxics, nil
@@ -198,19 +198,19 @@ func (c *ToxiproxyClient) DisableProxy(proxyName string) error {
 func (c *ToxiproxyClient) setProxyEnabled(proxyName string, enabled bool) error {
 	data, err := json.Marshal(map[string]bool{"enabled": enabled})
 	if err != nil {
-		return errors.NewProcessingError("failed to marshal proxy state: %w", err)
+		return errors.NewProcessingError("failed to marshal proxy state", err)
 	}
 
 	url := fmt.Sprintf("%s/proxies/%s", c.BaseURL, proxyName)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
-		return errors.NewProcessingError("failed to create request: %w", err)
+		return errors.NewProcessingError("failed to create request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.NewProcessingError("failed to set proxy state: %w", err)
+		return errors.NewProcessingError("failed to set proxy state", err)
 	}
 	defer resp.Body.Close()
 
@@ -227,7 +227,7 @@ func (c *ToxiproxyClient) GetProxy(proxyName string) (*Proxy, error) {
 	url := fmt.Sprintf("%s/proxies/%s", c.BaseURL, proxyName)
 	resp, err := c.client.Get(url)
 	if err != nil {
-		return nil, errors.NewProcessingError("failed to get proxy: %w", err)
+		return nil, errors.NewProcessingError("failed to get proxy", err)
 	}
 	defer resp.Body.Close()
 
@@ -238,7 +238,7 @@ func (c *ToxiproxyClient) GetProxy(proxyName string) (*Proxy, error) {
 
 	var proxy Proxy
 	if err := json.NewDecoder(resp.Body).Decode(&proxy); err != nil {
-		return nil, errors.NewProcessingError("failed to decode proxy: %w", err)
+		return nil, errors.NewProcessingError("failed to decode proxy", err)
 	}
 
 	return &proxy, nil
@@ -247,11 +247,11 @@ func (c *ToxiproxyClient) GetProxy(proxyName string) (*Proxy, error) {
 // ResetProxy removes all toxics and re-enables the proxy
 func (c *ToxiproxyClient) ResetProxy(proxyName string) error {
 	if err := c.RemoveAllToxics(proxyName); err != nil {
-		return errors.NewProcessingError("failed to remove toxics: %w", err)
+		return errors.NewProcessingError("failed to remove toxics", err)
 	}
 
 	if err := c.EnableProxy(proxyName); err != nil {
-		return errors.NewProcessingError("failed to enable proxy: %w", err)
+		return errors.NewProcessingError("failed to enable proxy", err)
 	}
 
 	return nil

--- a/test/consensus/concurrent_parse_test.go
+++ b/test/consensus/concurrent_parse_test.go
@@ -79,7 +79,7 @@ func TestConcurrentScriptParsing(t *testing.T) {
 					for _, script := range testScripts {
 						result, err := parser.ParseScript(script)
 						if err != nil {
-							errs <- errors.NewProcessingError("parser %d iteration %d script '%s': %w",
+							errs <- errors.NewProcessingError("parser %d iteration %d script '%s'",
 								parserIndex, j, script, err)
 							continue
 						}
@@ -143,7 +143,7 @@ func TestConcurrentScriptParsing(t *testing.T) {
 					for _, script := range strictScripts {
 						result, err := parser.ParseScript(script)
 						if err != nil {
-							errs <- errors.NewProcessingError("strict parser %d iteration %d script '%s': %w",
+							errs <- errors.NewProcessingError("strict parser %d iteration %d script '%s'",
 								parserIndex, j, script, err)
 							continue
 						}

--- a/test/utils/helper.go
+++ b/test/utils/helper.go
@@ -1314,7 +1314,7 @@ func WaitForBlockAccepted(ctx context.Context, node TeranodeTestClient, expected
 	for {
 		bestBlockHeader, _, err := node.BlockchainClient.GetBestBlockHeader(ctx)
 		if err != nil {
-			return errors.NewProcessingError("failed to get best block header: %w", err)
+			return errors.NewProcessingError("failed to get best block header", err)
 		}
 
 		if bytes.Equal(expectedHash, bestBlockHeader.Hash().CloneBytes()) {

--- a/util/grpc.go
+++ b/util/grpc.go
@@ -123,7 +123,7 @@ func StartGRPCServer(ctx context.Context, l ulogger.Logger, tSettings *settings.
 	}()
 
 	if err = grpcServer.Serve(listener); err != nil {
-		return errors.NewServiceError("[%s] GRPC server failed [%w]", serviceName, err)
+		return errors.NewServiceError("[%s] GRPC server failed", serviceName, err)
 	}
 
 	return nil

--- a/util/usql/advisory_lock.go
+++ b/util/usql/advisory_lock.go
@@ -40,7 +40,7 @@ func WithAdvisoryLock(ctx context.Context, db *DB, lockID int64, fn func() error
 	// Pin a single connection so lock + unlock run on the same session.
 	conn, err := db.DB.Conn(ctx)
 	if err != nil {
-		return errors.New(errors.ERR_ERROR, "advisory lock %d: failed to acquire connection: %w", lockID, err)
+		return errors.New(errors.ERR_ERROR, "advisory lock %d: failed to acquire connection", lockID, err)
 	}
 	defer func() {
 		// Returns the pinned connection to the pool; the advisory lock must
@@ -50,7 +50,7 @@ func WithAdvisoryLock(ctx context.Context, db *DB, lockID int64, fn func() error
 	}()
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SELECT pg_advisory_lock(%d)", lockID)); err != nil {
-		return errors.New(errors.ERR_ERROR, "failed to acquire advisory lock %d: %w", lockID, err)
+		return errors.New(errors.ERR_ERROR, "failed to acquire advisory lock %d", lockID, err)
 	}
 
 	defer func() {


### PR DESCRIPTION
## What

Fixes #1332.

`errors.New` (`errors/errors.go`) extracts a trailing `error`/`*Error` argument as the wrapped error **before** calling `fmt.Errorf(message, params...)`. Any `%w` verb left in the format string is therefore orphaned:

- other verbs present → `fmt.Errorf` runs one arg short → renders `%!w(MISSING)`
- `%w` is the only verb → `params` is empty, formatting is skipped → the **literal** `%w` survives

The wrapped error is already rendered by `Error()` via ` -> ` chaining, so `%w` is redundant and always wrong in this API. Observed on teratestnet:

```
STORAGE_ERROR (69): failed to extract coinbase height for block ...: %!w(MISSING) -> BLOCK_COINBASE_MISSING_HEIGHT (15): ...
```

## Changes

- **Defensive fix (root cause):** `errors.New` now strips an orphaned `%w` once the trailing error has been extracted. The scan is escape-aware, so an intentional `%%w` (literal `%w`) is preserved; a dangling separator (`: `, ` - `, `, `) left before the verb is tidied. This fixes every current and future render at the source.
- **Call-site sweep:** dropped the redundant `: %w` from the `errors.New*` call sites across the tree (mechanical; the trailing error arg stays and is still chained).
- **CI guard:** `scripts/check_error_wrap_verbs.sh` fails the build if `%w` reappears inside an `errors.New*` format string (the `errors` package is exempt — its tests build such strings deliberately). Wired into the `golangci-lint` job (PR) and the Sonarqube job (main). `forbidigo`/`govet` can't express this rule; see the script header.
- **Tests:** `errors_test.go` covers the StoreBlock shape, `%w`-only, escaped `%%w`, mid-string, separator variants, multiple `%w`, and the no-`%w` hot-path (byte-identical output).

## Verification

- `go build ./...`, `go vet` on changed packages — clean
- `go test ./errors/... ./util/ ./util/usql/... ./services/blockvalidation/... ./services/p2p/...` — green
- `./scripts/check_error_wrap_verbs.sh` — passes (0 remaining)
