### PR TITLE
fix(legacy): stop NOT_FOUND ERROR-spam cascade from a failed parent block (#1333)

### DIFF
--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -70,7 +70,18 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	// Lookup previous block height from blockchain
 	_, previousBlockHeaderMeta, err = sm.blockchainClient.GetBlockHeader(ctx, &block.MsgBlock().Header.PrevBlock)
 	if err != nil {
-		sm.logger.Errorf("[HandleBlockDirect][%s] failed to get block header for previous block %s: %s", blockHash.String(), block.MsgBlock().Header.PrevBlock, err)
+		// A missing parent is an expected, recoverable condition: a normal orphan /
+		// out-of-order tip announce, or a descendant of a block that was rejected
+		// upstream. The caller (handleBlockMsg) answers with a getblocks and, for a
+		// known-failed ancestor, short-circuits the descendant cascade (#1333) — so
+		// logging it at ERROR here only produces misleading "previous block
+		// NOT_FOUND" spam. Genuine lookup failures (e.g. storage errors) still ERROR.
+		if errors.Is(err, errors.ErrBlockNotFound) {
+			sm.logger.Debugf("[HandleBlockDirect][%s] previous block %s not found (orphan/out-of-order; caller will request missing blocks): %v", blockHash.String(), block.MsgBlock().Header.PrevBlock, err)
+		} else {
+			sm.logger.Errorf("[HandleBlockDirect][%s] failed to get block header for previous block %s: %s", blockHash.String(), block.MsgBlock().Header.PrevBlock, err)
+		}
+
 		return errors.NewProcessingError("failed to get block header for previous block %s", block.MsgBlock().Header.PrevBlock, err)
 	}
 

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -1662,21 +1662,6 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 		}
 	}
 
-	// Track block size for dynamic in-flight adjustment during headers-first mode.
-	// This allows us to start aggressive (20 blocks) and automatically reduce
-	// to 1 block when encountering large (>2GB) blocks on mainnet.
-	if sm.headersFirstMode.Load() && bmsg.block != nil {
-		blockSize := int64(bmsg.block.SerializeSize())
-		sm.blockSizeTracker.addBlockSize(blockSize)
-
-		dynamicMax := sm.blockSizeTracker.calculateMaxInFlightBlocks()
-		avgSize := sm.blockSizeTracker.getAverageSize()
-		sm.logger.Debugf("[handleBlockMsg][%s] Block size: %d bytes, avg: %d bytes, dynamic max in-flight: %d",
-			bmsg.blockHash, blockSize, avgSize, dynamicMax)
-	}
-
-	sm.logger.Debugf("[handleBlockMsg][%s] calling HandleBlockDirect", bmsg.blockHash)
-
 	// Hand sole ownership of the decoded block to HandleBlockDirect. The
 	// blockHandler goroutine keeps *bmsg alive until the reply is sent, so
 	// leaving the field set would pin the multi-GB wire block (and its decode
@@ -1691,12 +1676,16 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	bmsg.block = nil
 
 	// #1333: if this block's parent recently failed to store/validate, skip the
-	// descendant before any RPC. Each descendant would otherwise fail its parent
-	// lookup and log a misleading "previous block NOT_FOUND" ERROR, burying the
-	// one root failure that matters. Mark this block failed too so the whole
-	// descendant chain is suppressed transitively; refresh the delivering peer's
-	// stall timer (the fault is a rejected ancestor, not the peer); and still
-	// answer with a getblocks so sync recovers once the root block is resolved.
+	// descendant before the block-lookup RPCs. Each descendant would otherwise
+	// fail its parent lookup and log a misleading "previous block NOT_FOUND"
+	// ERROR, burying the one root failure that matters. Mark this block failed too
+	// so the whole descendant chain is suppressed transitively; refresh the
+	// delivering peer's stall timer (the fault is a rejected ancestor, not the
+	// peer); and still answer with a getblocks so sync recovers once the root
+	// block is resolved. Placed before the block-size sampling below (like the
+	// #1187 backoff skip above) so a skipped, re-delivered descendant does not
+	// keep re-sampling its size into the moving average and biasing
+	// calculateMaxInFlightBlocks().
 	if sm.recentlyFailedBlocks != nil {
 		if _, failed := sm.recentlyFailedBlocks.Get(prevBlockHash); failed {
 			sm.recentlyFailedBlocks.Set(bmsg.blockHash, struct{}{})
@@ -1711,6 +1700,21 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 			return nil
 		}
 	}
+
+	// Track block size for dynamic in-flight adjustment during headers-first mode.
+	// This allows us to start aggressive (20 blocks) and automatically reduce
+	// to 1 block when encountering large (>2GB) blocks on mainnet.
+	if sm.headersFirstMode.Load() {
+		blockSize := int64(msgBlock.SerializeSize())
+		sm.blockSizeTracker.addBlockSize(blockSize)
+
+		dynamicMax := sm.blockSizeTracker.calculateMaxInFlightBlocks()
+		avgSize := sm.blockSizeTracker.getAverageSize()
+		sm.logger.Debugf("[handleBlockMsg][%s] Block size: %d bytes, avg: %d bytes, dynamic max in-flight: %d",
+			bmsg.blockHash, blockSize, avgSize, dynamicMax)
+	}
+
+	sm.logger.Debugf("[handleBlockMsg][%s] calling HandleBlockDirect", bmsg.blockHash)
 
 	// Process the block directly. A missing-parent error (ErrBlockNotFound)
 	// always triggers a getblocks request from our best block so block

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -102,6 +102,16 @@ const (
 	// WithMaxSize bound on orphanTxs).
 	blockFailureBackoffMaxTracked = 1024
 
+	// recentlyFailedBlocksTTL is how long a block hash that failed to
+	// store/validate is remembered so its descendants can be short-circuited
+	// instead of each re-running HandleBlockDirect and logging a misleading
+	// "previous block NOT_FOUND" ERROR (#1333). Entries self-evict after this
+	// window and are deleted on a successful (re)process, so a transiently
+	// failed parent that later stores unblocks its descendants automatically.
+	// Independent of the #1187 backoff knobs so the cascade suppression works
+	// even when that backoff is disabled.
+	recentlyFailedBlocksTTL = 10 * time.Minute
+
 	// maxRequestedBlocks is the maximum number of requested block
 	// hashes to store in memory.
 	maxRequestedBlocks = wire.MaxInvPerMsg
@@ -473,10 +483,17 @@ type SyncManager struct {
 	// concurrency against an already-struggling UTXO store (#1187). Keyed by
 	// block hash; entries self-evict after Legacy.BlockFailureBackoffMaxDuration.
 	blockFailureBackoff *expiringmap.ExpiringMap[chainhash.Hash, *blockFailureState]
-	syncPeerMu          sync.RWMutex // protects syncPeer and syncPeerState
-	syncPeer            *peerpkg.Peer
-	syncPeerState       *syncPeerState
-	peerStates          *txmap.SyncedMap[*peerpkg.Peer, *peerSyncState]
+	// recentlyFailedBlocks tracks block hashes that just failed to store/validate
+	// so their already-queued descendants are skipped before any RPC instead of
+	// each failing their parent lookup and logging a misleading "previous block
+	// NOT_FOUND" ERROR (#1333). Keyed by block hash; TTL-bounded and size-capped,
+	// deleted on successful (re)process. A skipped descendant records its own hash
+	// too, so the whole descendant chain is suppressed transitively.
+	recentlyFailedBlocks *expiringmap.ExpiringMap[chainhash.Hash, struct{}]
+	syncPeerMu           sync.RWMutex // protects syncPeer and syncPeerState
+	syncPeer             *peerpkg.Peer
+	syncPeerState        *syncPeerState
+	peerStates           *txmap.SyncedMap[*peerpkg.Peer, *peerSyncState]
 
 	// blockBacklog counts blocks sitting in the local processing pipeline:
 	// queued in blockHandler's blockQueue plus the one inside handleBlockMsg.
@@ -1471,6 +1488,34 @@ func (sm *SyncManager) peerStateResolvingPrimary(peer *peerpkg.Peer) (*peerSyncS
 }
 
 // handleBlockMsg handles block messages from all peers.
+// requestMissingBlocks answers a missing-parent condition by sending a getblocks
+// message from our best block, so block validation can proceed in order. In the
+// legacy sync protocol the orphan tip also doubles as the batch-continuation
+// signal, so this must fire even when the missing parent is a known-failed block
+// (#1333) — otherwise sync stalls until the stall detector rotates the peer.
+// PushGetBlocksMsg filters duplicate requests and the peer only invs blocks past
+// the locator fork point, so a redundant request costs one inv message at most.
+// Errors are logged and swallowed; the request is best-effort.
+func (sm *SyncManager) requestMissingBlocks(peer *peerpkg.Peer, blockHash chainhash.Hash) {
+	bestBlockHeader, bestBlockHeaderMeta, err := sm.blockchainClient.GetBestBlockHeader(sm.ctx)
+	if err != nil {
+		sm.logger.Errorf("Failed to get best block header: %v", err)
+		return
+	}
+
+	// Create a block locator starting from our best block.
+	locator, err := sm.blockchainClient.GetBlockLocator(sm.ctx, bestBlockHeader.Hash(), bestBlockHeaderMeta.Height)
+	if err != nil {
+		sm.logger.Errorf("Failed to get block locator for the block hash %s: %v", blockHash, err)
+		return
+	}
+
+	zeroHash := chainhash.Hash{}
+	if err = peer.PushGetBlocksMsg(locator, &zeroHash); err != nil {
+		sm.logger.Errorf("Failed to send getblocks message: %v", err)
+	}
+}
+
 func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	sm.logger.Debugf("[handleBlockMsg][%s] received block height %d from %s", bmsg.blockHash, bmsg.blockHeight, bmsg.peer)
 	peer := bmsg.peer
@@ -1645,6 +1690,28 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	prevBlockHash := msgBlock.Header.PrevBlock
 	bmsg.block = nil
 
+	// #1333: if this block's parent recently failed to store/validate, skip the
+	// descendant before any RPC. Each descendant would otherwise fail its parent
+	// lookup and log a misleading "previous block NOT_FOUND" ERROR, burying the
+	// one root failure that matters. Mark this block failed too so the whole
+	// descendant chain is suppressed transitively; refresh the delivering peer's
+	// stall timer (the fault is a rejected ancestor, not the peer); and still
+	// answer with a getblocks so sync recovers once the root block is resolved.
+	if sm.recentlyFailedBlocks != nil {
+		if _, failed := sm.recentlyFailedBlocks.Get(prevBlockHash); failed {
+			sm.recentlyFailedBlocks.Set(bmsg.blockHash, struct{}{})
+			sm.logger.Debugf("[handleBlockMsg][%s] parent %s recently failed to store/validate; skipping descendant (root failure already logged)", bmsg.blockHash, prevBlockHash)
+
+			if sps, ok := sm.syncPeerStateFor(peer); ok {
+				sps.updateLastBlockTime()
+			}
+
+			sm.requestMissingBlocks(peer, bmsg.blockHash)
+
+			return nil
+		}
+	}
+
 	// Process the block directly. A missing-parent error (ErrBlockNotFound)
 	// always triggers a getblocks request from our best block so block
 	// validation can proceed in order — see the orphan-continuation note below.
@@ -1664,31 +1731,22 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 			sm.logger.Infof("Block %v has missing parent %v, requesting missing blocks",
 				bmsg.blockHash, prevBlockHash)
 
-			bestBlockHeader, bestBlockHeaderMeta, err := sm.blockchainClient.GetBestBlockHeader(sm.ctx)
-			if err != nil {
-				sm.logger.Errorf("Failed to get best block header: %v", err)
-				return nil
-			}
-			// Create a block locator starting from the parent hash
-			locator, err := sm.blockchainClient.GetBlockLocator(sm.ctx, bestBlockHeader.Hash(), bestBlockHeaderMeta.Height)
-			if err != nil {
-				sm.logger.Errorf("Failed to get block locator for the block hash %s: %v",
-					bmsg.blockHash, err)
-				return nil
-			}
-
-			// Send a getblocks message to request missing blocks
-			zeroHash := chainhash.Hash{}
-			if err = peer.PushGetBlocksMsg(locator, &zeroHash); err != nil {
-				sm.logger.Errorf("Failed to send getblocks message: %v", err)
-
-				return nil
-			}
+			sm.requestMissingBlocks(peer, bmsg.blockHash)
 
 			return nil
 		} else {
 			if errors.Is(err, context.Canceled) || errors.IsContextError(err) {
 				return nil
+			}
+
+			// Remember this block failed to store/validate so its already-queued
+			// descendants are short-circuited above rather than each failing their
+			// parent lookup and logging a misleading "previous block NOT_FOUND"
+			// ERROR (#1333). Covers both transient and permanent failures — from a
+			// descendant's view the parent is missing either way; the TTL and the
+			// delete-on-success below heal the transient case.
+			if sm.recentlyFailedBlocks != nil {
+				sm.recentlyFailedBlocks.Set(bmsg.blockHash, struct{}{})
 			}
 
 			// Transient local-infrastructure failures (not peer faults): service
@@ -1723,6 +1781,12 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	// future failure starts a fresh count rather than inheriting a stale one (#1187).
 	if sm.blockFailureBackoff != nil {
 		sm.blockFailureBackoff.Delete(bmsg.blockHash)
+	}
+
+	// Also clear any cascade-suppression marker (#1333): this hash now stores, so
+	// its descendants must no longer be short-circuited as children of a failure.
+	if sm.recentlyFailedBlocks != nil {
+		sm.recentlyFailedBlocks.Delete(bmsg.blockHash)
 	}
 
 	// Meta-data about the new block this peer is reporting. We use this
@@ -2989,6 +3053,10 @@ func (sm *SyncManager) Stop() error {
 		sm.blockFailureBackoff.Stop()
 	}
 
+	if sm.recentlyFailedBlocks != nil {
+		sm.recentlyFailedBlocks.Stop()
+	}
+
 	// DC15 / review C1: quiesce Put then drain the tx-announce batcher before
 	// tearing down transports.
 	sm.closeTxAnnounceBatcher()
@@ -3180,6 +3248,12 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 	// error return would leak that goroutine, since the caller receives a nil
 	// SyncManager and can never call Stop() (#1187, review).
 	sm.blockFailureBackoff = newBlockFailureBackoffMap(tSettings.Legacy.BlockFailureBackoffBase, tSettings.Legacy.BlockFailureBackoffMaxDuration, tSettings.Legacy.PeerProcessingTimeout)
+
+	// Tracks recently-failed block hashes so descendants of an unstored/rejected
+	// block are short-circuited rather than triggering a NOT_FOUND ERROR cascade
+	// (#1333). Like blockFailureBackoff this starts a background eviction goroutine
+	// stopped only via Stop(), so build it after the last fallible step above.
+	sm.recentlyFailedBlocks = expiringmap.New[chainhash.Hash, struct{}](recentlyFailedBlocksTTL).WithMaxSize(blockFailureBackoffMaxTracked)
 
 	if !config.DisableCheckpoints {
 		bestBlockHeightInt32, err := safeconversion.Uint32ToInt32(bestBlockHeaderMeta.Height)

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/kafka"
 	kafkamessage "github.com/bsv-blockchain/teranode/util/kafka/kafka_message"
 	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/bsv-blockchain/teranode/util/test/mocklogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1015,16 +1016,17 @@ func newBackoffTestManager(t *testing.T, blockchainClient *blockchain2.Mock, blo
 	state.requestedBlocks.Set(blockHash, struct{}{})
 
 	sm := &SyncManager{
-		ctx:                 context.Background(),
-		logger:              ulogger.TestLogger{},
-		settings:            tSettings,
-		chainParams:         &chaincfg.MainNetParams,
-		blockchainClient:    blockchainClient,
-		peerStates:          txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
-		requestedBlocks:     expiringmap.New[chainhash.Hash, struct{}](time.Minute),
-		blockFailureBackoff: expiringmap.New[chainhash.Hash, *blockFailureState](time.Minute),
+		ctx:                  context.Background(),
+		logger:               ulogger.TestLogger{},
+		settings:             tSettings,
+		chainParams:          &chaincfg.MainNetParams,
+		blockchainClient:     blockchainClient,
+		peerStates:           txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+		requestedBlocks:      expiringmap.New[chainhash.Hash, struct{}](time.Minute),
+		blockFailureBackoff:  expiringmap.New[chainhash.Hash, *blockFailureState](time.Minute),
+		recentlyFailedBlocks: expiringmap.New[chainhash.Hash, struct{}](time.Minute),
 	}
-	t.Cleanup(func() { sm.requestedBlocks.Stop(); sm.blockFailureBackoff.Stop() })
+	t.Cleanup(func() { sm.requestedBlocks.Stop(); sm.blockFailureBackoff.Stop(); sm.recentlyFailedBlocks.Stop() })
 	sm.peerStates.Set(p, state)
 	sm.requestedBlocks.Set(blockHash, struct{}{})
 
@@ -1318,6 +1320,152 @@ func TestHandleBlockMsg_BackoffClearedOnSuccess(t *testing.T) {
 
 	_, ok := sm.blockFailureBackoff.Get(blockHash)
 	require.False(t, ok, "backoff entry should be cleared after a successful block")
+}
+
+// TestHandleBlockMsg_FailedParentCascadeShortCircuits verifies the #1333 fix: a
+// block whose parent recently failed to store/validate is skipped before any RPC
+// (no GetBlockExists / GetBlockHeader), logs no ERROR, is itself marked failed so
+// the cascade is suppressed transitively, and still triggers the getblocks
+// recovery so sync resumes once the root is resolved.
+func TestHandleBlockMsg_FailedParentCascadeShortCircuits(t *testing.T) {
+	failedParent := chainhash.Hash{0xAA}
+	msgBlock := wire.NewMsgBlock(wire.NewBlockHeader(1, &failedParent, &chainhash.Hash{}, 0, 0))
+	blockHash := msgBlock.Header.BlockHash()
+
+	catchingBlocks := blockchain2.FSMStateCATCHINGBLOCKS
+	bestHeader := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
+
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&catchingBlocks, nil)
+	blockchainClient.On("GetBestBlockHeader", mock.Anything).Return(bestHeader, &model.BlockHeaderMeta{Height: 100}, nil)
+	blockchainClient.On("GetBlockLocator", mock.Anything, mock.Anything, mock.Anything).Return([]*chainhash.Hash{bestHeader.Hash()}, nil)
+
+	sm, p := newBackoffTestManager(t, blockchainClient, blockHash)
+	ml := mocklogger.NewTestLogger()
+	sm.logger = ml
+
+	// The parent is already known-failed.
+	sm.recentlyFailedBlocks.Set(failedParent, struct{}{})
+
+	err := sm.handleBlockMsg(&blockQueueMsg{
+		block:       msgBlock,
+		blockHash:   blockHash,
+		blockHeight: 101,
+		peer:        p,
+	})
+
+	require.NoError(t, err, "a short-circuited descendant returns nil (recovered via getblocks)")
+
+	// Short-circuited before HandleBlockDirect: no block lookup RPCs ran.
+	blockchainClient.AssertNotCalled(t, "GetBlockExists", mock.Anything, mock.Anything)
+	blockchainClient.AssertNotCalled(t, "GetBlockHeader", mock.Anything, mock.Anything)
+
+	// Transitively marked so this block's own descendants are also suppressed.
+	_, marked := sm.recentlyFailedBlocks.Get(blockHash)
+	require.True(t, marked, "a skipped descendant must itself be marked failed")
+
+	// Recovery still fired, and no misleading ERROR was logged.
+	blockchainClient.AssertCalled(t, "GetBlockLocator", mock.Anything, mock.Anything, mock.Anything)
+	ml.AssertNumberOfCalls(t, "Errorf", 0)
+}
+
+// TestHandleBlockMsg_FailedBlockRecorded verifies a block that fails to
+// store/validate is recorded in recentlyFailedBlocks so its descendants can be
+// short-circuited (#1333).
+func TestHandleBlockMsg_FailedBlockRecorded(t *testing.T) {
+	prevHash := chainhash.Hash{0x01}
+	msgBlock := wire.NewMsgBlock(wire.NewBlockHeader(1, &prevHash, &chainhash.Hash{}, 0, 0))
+	blockHash := msgBlock.Header.BlockHash()
+
+	catchingBlocks := blockchain2.FSMStateCATCHINGBLOCKS
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&catchingBlocks, nil)
+	blockchainClient.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, errors.NewStorageError("boom"))
+
+	sm, p := newBackoffTestManager(t, blockchainClient, blockHash)
+
+	err := sm.handleBlockMsg(&blockQueueMsg{
+		block:       msgBlock,
+		blockHash:   blockHash,
+		blockHeight: 101,
+		peer:        p,
+	})
+
+	require.Error(t, err)
+	_, ok := sm.recentlyFailedBlocks.Get(blockHash)
+	require.True(t, ok, "a failed block should be recorded so its descendants are short-circuited")
+}
+
+// TestHandleBlockMsg_FailedBlockClearedOnSuccess verifies a successful (re)process
+// clears the cascade-suppression marker so descendants are no longer skipped (#1333).
+func TestHandleBlockMsg_FailedBlockClearedOnSuccess(t *testing.T) {
+	prevHash := chainhash.Hash{0x01}
+	msgBlock := wire.NewMsgBlock(wire.NewBlockHeader(1, &prevHash, &chainhash.Hash{}, 0, 0))
+	blockHash := msgBlock.Header.BlockHash()
+
+	catchingBlocks := blockchain2.FSMStateCATCHINGBLOCKS
+	bestHeader := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
+
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&catchingBlocks, nil)
+	// Block already exists -> HandleBlockDirect returns nil immediately.
+	blockchainClient.On("GetBlockExists", mock.Anything, mock.Anything).Return(true, nil)
+	blockchainClient.On("GetBestBlockHeader", mock.Anything).Return(bestHeader, &model.BlockHeaderMeta{Height: 100}, nil)
+
+	sm, p := newBackoffTestManager(t, blockchainClient, blockHash)
+	sm.rejectedTxns = txmap.NewSyncedMap[chainhash.Hash, struct{}](100)
+	sm.blockSizeTracker = newBlockSizeTracker(10)
+	sm.recentlyFailedBlocks.Set(blockHash, struct{}{})
+
+	_ = sm.handleBlockMsg(&blockQueueMsg{
+		block:       msgBlock,
+		blockHash:   blockHash,
+		blockHeight: 101,
+		peer:        p,
+	})
+
+	_, ok := sm.recentlyFailedBlocks.Get(blockHash)
+	require.False(t, ok, "cascade-suppression marker should be cleared after a successful block")
+}
+
+// TestHandleBlockMsg_OrphanNotMarkedFailed verifies a normal orphan (parent not
+// yet known, but no ancestor was rejected) is NOT recorded as failed: its parent
+// is genuinely still in flight, and it must log at DEBUG rather than ERROR (#1333).
+func TestHandleBlockMsg_OrphanNotMarkedFailed(t *testing.T) {
+	prevHash := chainhash.Hash{0x02}
+	msgBlock := wire.NewMsgBlock(wire.NewBlockHeader(1, &prevHash, &chainhash.Hash{}, 0, 0))
+	blockHash := msgBlock.Header.BlockHash()
+
+	catchingBlocks := blockchain2.FSMStateCATCHINGBLOCKS
+	bestHeader := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
+
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.On("GetFSMCurrentState", mock.Anything).Return(&catchingBlocks, nil)
+	blockchainClient.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
+	// Parent lookup misses -> ErrBlockNotFound -> normal orphan path.
+	blockchainClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return(nil, nil, errors.NewBlockNotFoundError("not found"))
+	blockchainClient.On("GetBestBlockHeader", mock.Anything).Return(bestHeader, &model.BlockHeaderMeta{Height: 100}, nil)
+	blockchainClient.On("GetBlockLocator", mock.Anything, mock.Anything, mock.Anything).Return([]*chainhash.Hash{bestHeader.Hash()}, nil)
+
+	sm, p := newBackoffTestManager(t, blockchainClient, blockHash)
+	ml := mocklogger.NewTestLogger()
+	sm.logger = ml
+
+	err := sm.handleBlockMsg(&blockQueueMsg{
+		block:       msgBlock,
+		blockHash:   blockHash,
+		blockHeight: 101,
+		peer:        p,
+	})
+
+	require.NoError(t, err)
+
+	// A normal orphan is not "known-bad" — its parent is genuinely still in flight.
+	_, ok := sm.recentlyFailedBlocks.Get(blockHash)
+	require.False(t, ok, "a normal orphan must not be recorded as failed")
+
+	// The missing-parent lookup in HandleBlockDirect logs at DEBUG, not ERROR.
+	ml.AssertNumberOfCalls(t, "Errorf", 0)
 }
 
 // TestHandleCheckSyncPeer_LocalBacklog verifies the stall detector does not


### PR DESCRIPTION
## What

Fixes #1333.

When a block fails to store/validate, legacy `netsync` kept processing its already-queued descendants. Each descendant failed its parent lookup at `handle_block.go` and logged an `ERROR`, so a single bad/unstored block (root cause on teratestnet: block 1 failing the BIP34 coinbase-height parser, #1332) produced an unbounded cascade of misleading `previous block NOT_FOUND` errors that buried the one error that mattered.

## Changes

- **Short-circuit the cascade.** `handleBlockMsg` now tracks recently-failed block hashes in a TTL-bounded, size-capped `expiringmap` (10 min TTL, 1024 cap, deleted on a successful reprocess). A block whose parent is a known-failed hash is skipped **before the block-lookup RPCs** (no `GetBlockExists`/`GetBlockHeader`) and before the headers-first block-size sampling, marked failed itself so the whole descendant chain is suppressed transitively, and its delivering peer's stall timer is refreshed (the fault is a rejected ancestor, not the peer). The skip still fires the existing getblocks recovery (`GetBestBlockHeader` + `GetBlockLocator`), so sync resumes once the root block is resolved.
- **Log level.** `HandleBlockDirect` logs a missing parent (`ErrBlockNotFound`) at `DEBUG` — it's an expected orphan / out-of-order / rejected-ancestor condition the caller recovers from. Genuine lookup failures (e.g. storage errors) still log at `ERROR`. Net effect: the root rejection is logged once at `ERROR`; descendants produce no `ERROR` spam.
- **Refactor.** Extracted the getblocks recovery into `requestMissingBlocks`, shared by the new skip path and the existing orphan path.

The map is independent of the #1187 `blockFailureBackoff` knobs so cascade suppression works even when that backoff is disabled; both maps are nil-guarded (struct-literal test managers) and stopped in `Stop()`.

## Verification

- `go test ./services/legacy/netsync/` — green (incl. the #1187 backoff suite, unchanged)
- `go vet`, `gofmt`, `golangci-lint run ./services/legacy/netsync/` — clean
- New tests: cascade short-circuit (no RPC, no `ERROR`, transitive mark, getblocks fired), record-on-failure, clear-on-success, normal-orphan-not-marked.