### PR TITLE
fix(asset): back off centrifuge p2p dial, stop ERROR-spam when no peer present (#1334)

### DIFF
--- a/services/asset/centrifuge_impl/centrifuge.go
+++ b/services/asset/centrifuge_impl/centrifuge.go
@@ -4,6 +4,7 @@ package centrifuge_impl
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/retry"
 	"github.com/centrifugal/centrifuge"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -27,6 +29,28 @@ const (
 	AccessControlAllowHeaders     = "Access-Control-Allow-Headers"
 	AccessControlAllowCredentials = "Access-Control-Allow-Credentials"
 )
+
+const (
+	// p2p dial retry backoff (#1334): on a stack with no reachable p2p server the
+	// dial fails repeatedly; back off exponentially and log at DEBUG after the
+	// first failure instead of an ERROR every second.
+	p2pDialInitialBackoff = 1 * time.Second
+	p2pDialBackoffFactor  = 2.0
+	p2pDialMaxBackoff     = 60 * time.Second
+)
+
+// sleepWithContext sleeps for d, returning early if ctx is cancelled. It is the
+// default for Centrifuge.sleepWithContext and keeps shutdown prompt during a long
+// dial backoff.
+func sleepWithContext(ctx context.Context, d time.Duration) {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
 
 // Centrifuge manages real-time blockchain data broadcasting to WebSocket clients.
 // It provides pub/sub for blockchain events (new blocks, node status updates) using
@@ -45,6 +69,11 @@ type Centrifuge struct {
 	cachedCurrentNodeStatus *notificationMsg // Cached current node status for new clients
 	currentNodePeerID       string           // Track the current node's peer ID
 	statusMutex             sync.RWMutex     // Protects cachedCurrentNodeStatus and currentNodePeerID
+
+	// Test seams for the p2p dial loop (#1334), defaulted in New. Overridden in
+	// tests to drive dial outcomes and backoff timing without real DNS or sleeps.
+	dialWebsocket    func(urlStr string) (*websocket.Conn, *http.Response, error)
+	sleepWithContext func(ctx context.Context, d time.Duration)
 }
 
 // notificationMsg represents a notification message relayed to WebSocket clients.
@@ -112,6 +141,10 @@ func New(logger ulogger.Logger, tSettings *settings.Settings, repo *repository.R
 		repository: repo,
 		baseURL:    assetHTTPAddress,
 		httpServer: httpServer,
+		dialWebsocket: func(urlStr string) (*websocket.Conn, *http.Response, error) {
+			return websocket.DefaultDialer.Dial(urlStr, nil)
+		},
+		sleepWithContext: sleepWithContext,
 	}
 
 	// Only set blockchainClient if repo is not nil
@@ -265,7 +298,12 @@ func (c *Centrifuge) Start(ctx context.Context, addr string) error {
 func (c *Centrifuge) startP2PListener(ctx context.Context) error {
 	p2pServerAddress := c.settings.P2P.HTTPAddress
 	if p2pServerAddress == "" {
-		return errors.NewConfigurationError("p2p_httpAddress not found in config")
+		// No p2p server configured — skip the listener rather than failing the
+		// whole asset service. The global default is localhost:9906, so an empty
+		// value is explicit operator intent (e.g. a legacy-only stack). Centrifuge
+		// only sources messages from the p2p websocket, so it is simply inert here.
+		c.logger.Warnf("[Centrifuge] p2p_httpAddress not configured - skipping p2p listener; live block/node status updates will be unavailable")
+		return nil
 	}
 
 	u := url.URL{Scheme: "ws", Host: p2pServerAddress, Path: "/p2p-ws"}
@@ -291,28 +329,77 @@ func (c *Centrifuge) startP2PListener(ctx context.Context) error {
 //   - client: Atomic pointer to the WebSocket connection
 //   - clientConnected: Atomic boolean indicating connection status
 func (c *Centrifuge) connect(ctx context.Context, u url.URL, client *atomic.Pointer[websocket.Conn], clientConnected *atomic.Bool) {
+	dial := c.dialWebsocket
+	if dial == nil {
+		dial = func(urlStr string) (*websocket.Conn, *http.Response, error) {
+			return websocket.DefaultDialer.Dial(urlStr, nil)
+		}
+	}
+
+	sleep := c.sleepWithContext
+	if sleep == nil {
+		sleep = sleepWithContext
+	}
+
+	// failures counts consecutive dial failures; backoff grows exponentially while
+	// they persist so a stack with no reachable p2p server does not log an ERROR
+	// every second (#1334). Both reset on a successful connect.
+	var failures int
+
+	backoff := p2pDialInitialBackoff
+
 	for {
 		select {
 		case <-ctx.Done():
 			c.logger.Infof("[Centrifuge] p2p client shutting down")
 			return
 		default:
+			// While connected, poll once a second so a dropped connection (flipped
+			// by readMessages) is redialed promptly.
+			wait := 1 * time.Second
+
 			if !clientConnected.Load() {
-				c.logger.Infof("[Centrifuge] dialing p2p server at: %s", u.String())
-				websocketClient, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+				c.logger.Debugf("[Centrifuge] dialing p2p server at: %s", u.String())
+				websocketClient, _, err := dial(u.String())
 
 				if err != nil {
-					c.logger.Errorf("[Centrifuge] error dialing p2p server: %v", err)
+					failures++
+
+					switch {
+					case failures > 1:
+						// Steady-state noise stays at DEBUG.
+						c.logger.Debugf("[Centrifuge] error dialing p2p server (attempt %d, next retry in %s): %v", failures, backoff, err)
+					default:
+						// First failure of a streak: one WARN, with a config hint when
+						// the host cannot be resolved (the common "no p2p service here" case).
+						var dnsErr *net.DNSError
+						if errors.As(err, &dnsErr) {
+							c.logger.Warnf("[Centrifuge] cannot resolve p2p server host %q: %v - retrying with backoff (further attempts logged at DEBUG); if this deployment has no p2p service, set asset_centrifuge_disable=true or leave p2p_httpAddress empty", u.Host, err)
+						} else {
+							c.logger.Warnf("[Centrifuge] error dialing p2p server %s: %v - retrying with backoff (further attempts logged at DEBUG)", u.String(), err)
+						}
+					}
+
 					client.Store(nil)
+
+					wait = backoff
+					backoff = retry.CappedExponentialBackoff(backoff, p2pDialBackoffFactor, p2pDialMaxBackoff)
 				} else {
-					c.logger.Infof("[Centrifuge] connected to p2p server on: %s", u.String())
+					if failures > 0 {
+						c.logger.Infof("[Centrifuge] connected to p2p server on: %s (after %d failed attempt(s))", u.String(), failures)
+					} else {
+						c.logger.Infof("[Centrifuge] connected to p2p server on: %s", u.String())
+					}
+
 					clientConnected.Store(true)
 					client.Store(websocketClient)
+
+					failures = 0
+					backoff = p2pDialInitialBackoff
 				}
 			}
 
-			// retrying in 1 second
-			time.Sleep(1 * time.Second)
+			sleep(ctx, wait)
 		}
 	}
 }

--- a/services/asset/centrifuge_impl/centrifuge.go
+++ b/services/asset/centrifuge_impl/centrifuge.go
@@ -329,6 +329,8 @@ func (c *Centrifuge) startP2PListener(ctx context.Context) error {
 //   - client: Atomic pointer to the WebSocket connection
 //   - clientConnected: Atomic boolean indicating connection status
 func (c *Centrifuge) connect(ctx context.Context, u url.URL, client *atomic.Pointer[websocket.Conn], clientConnected *atomic.Bool) {
+	// dial and sleep are set by New for every Centrifuge; the nil-guards only cover
+	// a zero-value struct-literal construction (defence, not a live path).
 	dial := c.dialWebsocket
 	if dial == nil {
 		dial = func(urlStr string) (*websocket.Conn, *http.Response, error) {
@@ -343,8 +345,12 @@ func (c *Centrifuge) connect(ctx context.Context, u url.URL, client *atomic.Poin
 
 	// failures counts consecutive dial failures; backoff grows exponentially while
 	// they persist so a stack with no reachable p2p server does not log an ERROR
-	// every second (#1334). Both reset on a successful connect.
-	var failures int
+	// every second (#1334). cappedWarned ensures the "still failing" reminder is
+	// emitted only once per streak. All three reset on a successful connect.
+	var (
+		failures     int
+		cappedWarned bool
+	)
 
 	backoff := p2pDialInitialBackoff
 
@@ -384,6 +390,15 @@ func (c *Centrifuge) connect(ctx context.Context, u url.URL, client *atomic.Poin
 
 					wait = backoff
 					backoff = retry.CappedExponentialBackoff(backoff, p2pDialBackoffFactor, p2pDialMaxBackoff)
+
+					// Once the backoff saturates at the cap, emit a single WARN so a
+					// permanently peerless node leaves a durable breadcrumb that it is
+					// still retrying — otherwise it goes silent at INFO level after the
+					// first WARN. Reset on a successful connect below.
+					if backoff >= p2pDialMaxBackoff && !cappedWarned {
+						cappedWarned = true
+						c.logger.Warnf("[Centrifuge] still cannot reach p2p server %s after %d attempts; continuing to retry every %s (set asset_centrifuge_disable=true if this deployment has no p2p service)", u.String(), failures, p2pDialMaxBackoff)
+					}
 				} else {
 					if failures > 0 {
 						c.logger.Infof("[Centrifuge] connected to p2p server on: %s (after %d failed attempt(s))", u.String(), failures)
@@ -396,6 +411,7 @@ func (c *Centrifuge) connect(ctx context.Context, u url.URL, client *atomic.Poin
 
 					failures = 0
 					backoff = p2pDialInitialBackoff
+					cappedWarned = false
 				}
 			}
 

--- a/services/asset/centrifuge_impl/centrifuge_test.go
+++ b/services/asset/centrifuge_impl/centrifuge_test.go
@@ -3,6 +3,7 @@ package centrifuge_impl
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,10 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/asset/httpimpl"
 	"github.com/bsv-blockchain/teranode/services/asset/repository"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test/mocklogger"
 	"github.com/centrifugal/centrifuge"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -971,7 +974,7 @@ func TestCentrifuge_Start(t *testing.T) {
 	logger := ulogger.TestLogger{}
 	mockRepo := &repository.Repository{}
 
-	t.Run("Start fails with missing P2P address", func(t *testing.T) {
+	t.Run("Start skips p2p listener when address missing", func(t *testing.T) {
 		mockHTTP, err := createTestHTTP(logger, mockRepo)
 		require.NoError(t, err)
 
@@ -980,7 +983,7 @@ func TestCentrifuge_Start(t *testing.T) {
 				HTTPAddress: "http://localhost:8080",
 			},
 			P2P: settings.P2PSettings{
-				HTTPAddress: "", // Missing P2P address
+				HTTPAddress: "", // No p2p address -> listener skipped, service still runs
 			},
 		}
 
@@ -999,10 +1002,10 @@ func TestCentrifuge_Start(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 
-		// Start should fail due to missing P2P address
+		// With no p2p address the listener is skipped (WARN) and Start runs until
+		// the context is cancelled, returning nil rather than erroring (#1334).
 		err = c.Start(ctx, "localhost:9999")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "p2p_httpAddress not found in config")
+		require.NoError(t, err)
 	})
 
 	t.Run("Start with valid P2P address and mock server", func(t *testing.T) {
@@ -1160,6 +1163,132 @@ func TestCentrifuge_connect(t *testing.T) {
 		// Connection should not be established
 		assert.False(t, clientConnected.Load())
 		assert.Nil(t, client.Load())
+	})
+}
+
+// TestCentrifuge_connectBackoff covers the #1334 fix: a failing p2p dial backs off
+// exponentially (capped) and logs at WARN once then DEBUG, instead of an ERROR
+// every second; the backoff resets after a successful connect; and a context
+// cancellation during backoff returns promptly.
+func TestCentrifuge_connectBackoff(t *testing.T) {
+	mockRepo := &repository.Repository{}
+
+	newCentrifuge := func(t *testing.T, logger ulogger.Logger) *Centrifuge {
+		t.Helper()
+
+		mockHTTP, err := createTestHTTP(ulogger.TestLogger{}, mockRepo)
+		require.NoError(t, err)
+
+		tSettings := &settings.Settings{
+			Asset: settings.AssetSettings{HTTPAddress: "http://localhost:8080"},
+			P2P:   settings.P2PSettings{HTTPAddress: "peer:9906"},
+		}
+
+		c, err := New(logger, tSettings, mockRepo, mockHTTP)
+		require.NoError(t, err)
+
+		return c
+	}
+
+	dialURL := url.URL{Scheme: "ws", Host: "peer:9906", Path: "/p2p-ws"}
+
+	t.Run("backoff grows and caps; one WARN then DEBUG, never ERROR", func(t *testing.T) {
+		ml := mocklogger.NewTestLogger()
+		c := newCentrifuge(t, ml)
+
+		c.dialWebsocket = func(string) (*websocket.Conn, *http.Response, error) {
+			return nil, nil, errors.NewProcessingError("connection refused")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var waits []time.Duration
+		c.sleepWithContext = func(_ context.Context, d time.Duration) {
+			waits = append(waits, d)
+			if len(waits) >= 8 {
+				cancel()
+			}
+		}
+
+		c.connect(ctx, dialURL, &atomic.Pointer[websocket.Conn]{}, &atomic.Bool{})
+
+		require.Equal(t, []time.Duration{
+			1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
+			16 * time.Second, 32 * time.Second, 60 * time.Second, 60 * time.Second,
+		}, waits, "backoff must grow 2x and cap at 60s")
+		ml.AssertNumberOfCalls(t, "Errorf", 0)
+		ml.AssertNumberOfCalls(t, "Warnf", 1)
+	})
+
+	t.Run("unresolvable host logs a WARN with a config hint, never ERROR", func(t *testing.T) {
+		ml := mocklogger.NewTestLogger()
+		c := newCentrifuge(t, ml)
+
+		c.dialWebsocket = func(string) (*websocket.Conn, *http.Response, error) {
+			return nil, nil, &net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{Err: "server misbehaving", Name: "peer"}}
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		c.sleepWithContext = func(_ context.Context, _ time.Duration) { cancel() }
+
+		c.connect(ctx, dialURL, &atomic.Pointer[websocket.Conn]{}, &atomic.Bool{})
+
+		ml.AssertNumberOfCalls(t, "Errorf", 0)
+		ml.AssertNumberOfCalls(t, "Warnf", 1)
+	})
+
+	t.Run("backoff resets after a successful connect", func(t *testing.T) {
+		ml := mocklogger.NewTestLogger()
+		c := newCentrifuge(t, ml)
+
+		attempts := 0
+		c.dialWebsocket = func(string) (*websocket.Conn, *http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return &websocket.Conn{}, nil, nil // first dial succeeds
+			}
+
+			return nil, nil, errors.NewProcessingError("connection refused") // subsequent dials fail
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		clientConnected := &atomic.Bool{}
+
+		var waits []time.Duration
+		c.sleepWithContext = func(_ context.Context, d time.Duration) {
+			waits = append(waits, d)
+			// Drop the connection after the successful dial so the loop re-dials and
+			// starts a fresh failure streak; its backoff must restart at 1s.
+			clientConnected.Store(false)
+			if len(waits) >= 4 {
+				cancel()
+			}
+		}
+
+		c.connect(ctx, dialURL, &atomic.Pointer[websocket.Conn]{}, clientConnected)
+
+		require.Equal(t, []time.Duration{
+			1 * time.Second, // poll after the successful connect
+			1 * time.Second, // fresh streak resets to the initial backoff
+			2 * time.Second,
+			4 * time.Second,
+		}, waits)
+		ml.AssertNumberOfCalls(t, "Warnf", 1) // one WARN for the post-reconnect streak
+	})
+
+	t.Run("returns promptly when context is cancelled during backoff", func(t *testing.T) {
+		c := newCentrifuge(t, ulogger.TestLogger{}) // real sleepWithContext (default)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		c.dialWebsocket = func(string) (*websocket.Conn, *http.Response, error) {
+			cancel() // cancel the context on the first dial, mid-loop
+			return nil, nil, errors.NewProcessingError("connection refused")
+		}
+
+		start := time.Now()
+		c.connect(ctx, dialURL, &atomic.Pointer[websocket.Conn]{}, &atomic.Bool{})
+		require.Less(t, time.Since(start), 500*time.Millisecond,
+			"context-aware sleep must interrupt the backoff wait on cancellation")
 	})
 }
 
@@ -1766,12 +1895,11 @@ func TestCentrifuge_StartP2PListener(t *testing.T) {
 		c, err := New(logger, tSettings, mockRepo, mockHTTP)
 		require.NoError(t, err)
 
-		// Skip the Start() call that requires HTTP server setup
-		// We can test startP2PListener logic by checking settings validation
-		if c.settings.P2P.HTTPAddress == "" {
-			// This would fail in startP2PListener
-			assert.Empty(t, c.settings.P2P.HTTPAddress)
-		}
+		// An unset p2p address is skipped gracefully (WARN + nil) rather than
+		// erroring, so the asset service keeps running without a p2p server (#1334).
+		// Returns immediately without spawning the connect/readMessages goroutines.
+		err = c.startP2PListener(context.Background())
+		require.NoError(t, err)
 	})
 }
 

--- a/services/asset/centrifuge_impl/centrifuge_test.go
+++ b/services/asset/centrifuge_impl/centrifuge_test.go
@@ -3,6 +3,7 @@ package centrifuge_impl
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1170,6 +1171,49 @@ func TestCentrifuge_connect(t *testing.T) {
 // exponentially (capped) and logs at WARN once then DEBUG, instead of an ERROR
 // every second; the backoff resets after a successful connect; and a context
 // cancellation during backoff returns promptly.
+// capturingLogger records the formatted log message per level so tests can assert
+// on message content, which mocklogger.MockLogger (call-counts only) cannot — e.g.
+// to confirm the DNS-hint WARN branch actually ran, not just that some WARN fired
+// (#1337 review). It embeds MockLogger for the rest of the ulogger.Logger surface.
+type capturingLogger struct {
+	*mocklogger.MockLogger
+
+	mu   sync.Mutex
+	msgs map[string][]string
+}
+
+func newCapturingLogger() *capturingLogger {
+	return &capturingLogger{MockLogger: mocklogger.NewTestLogger(), msgs: make(map[string][]string)}
+}
+
+func (l *capturingLogger) capture(level, format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs[level] = append(l.msgs[level], fmt.Sprintf(format, args...))
+}
+
+func (l *capturingLogger) Warnf(format string, args ...interface{}) {
+	l.MockLogger.Warnf(format, args...)
+	l.capture("Warnf", format, args...)
+}
+
+func (l *capturingLogger) Debugf(format string, args ...interface{}) {
+	l.MockLogger.Debugf(format, args...)
+	l.capture("Debugf", format, args...)
+}
+
+func (l *capturingLogger) Errorf(format string, args ...interface{}) {
+	l.MockLogger.Errorf(format, args...)
+	l.capture("Errorf", format, args...)
+}
+
+func (l *capturingLogger) messages(level string) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return append([]string(nil), l.msgs[level]...)
+}
+
 func TestCentrifuge_connectBackoff(t *testing.T) {
 	mockRepo := &repository.Repository{}
 
@@ -1192,8 +1236,8 @@ func TestCentrifuge_connectBackoff(t *testing.T) {
 
 	dialURL := url.URL{Scheme: "ws", Host: "peer:9906", Path: "/p2p-ws"}
 
-	t.Run("backoff grows and caps; one WARN then DEBUG, never ERROR", func(t *testing.T) {
-		ml := mocklogger.NewTestLogger()
+	t.Run("backoff grows and caps; WARN at start and at the cap, DEBUG between, never ERROR", func(t *testing.T) {
+		ml := newCapturingLogger()
 		c := newCentrifuge(t, ml)
 
 		c.dialWebsocket = func(string) (*websocket.Conn, *http.Response, error) {
@@ -1216,12 +1260,29 @@ func TestCentrifuge_connectBackoff(t *testing.T) {
 			1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
 			16 * time.Second, 32 * time.Second, 60 * time.Second, 60 * time.Second,
 		}, waits, "backoff must grow 2x and cap at 60s")
-		ml.AssertNumberOfCalls(t, "Errorf", 0)
-		ml.AssertNumberOfCalls(t, "Warnf", 1)
+
+		require.Empty(t, ml.messages("Errorf"), "must never log at ERROR")
+
+		// Two WARNs per streak: the first failure, then a single "still failing"
+		// breadcrumb once the backoff saturates at the cap.
+		warns := ml.messages("Warnf")
+		require.Len(t, warns, 2)
+		require.Contains(t, warns[0], "retrying with backoff")
+		require.Contains(t, warns[1], "still cannot reach")
+
+		// The DEBUG lines between must carry the attempt/backoff detail.
+		hasDetail := false
+		for _, d := range ml.messages("Debugf") {
+			if strings.Contains(d, "attempt") && strings.Contains(d, "next retry") {
+				hasDetail = true
+				break
+			}
+		}
+		require.True(t, hasDetail, "steady-state DEBUG lines should carry attempt/backoff detail")
 	})
 
-	t.Run("unresolvable host logs a WARN with a config hint, never ERROR", func(t *testing.T) {
-		ml := mocklogger.NewTestLogger()
+	t.Run("unresolvable host logs a WARN carrying the config hint, never ERROR", func(t *testing.T) {
+		ml := newCapturingLogger()
 		c := newCentrifuge(t, ml)
 
 		c.dialWebsocket = func(string) (*websocket.Conn, *http.Response, error) {
@@ -1233,8 +1294,14 @@ func TestCentrifuge_connectBackoff(t *testing.T) {
 
 		c.connect(ctx, dialURL, &atomic.Pointer[websocket.Conn]{}, &atomic.Bool{})
 
-		ml.AssertNumberOfCalls(t, "Errorf", 0)
-		ml.AssertNumberOfCalls(t, "Warnf", 1)
+		require.Empty(t, ml.messages("Errorf"))
+
+		// Assert the specific DNS-hint branch ran, not just that some WARN fired:
+		// the message must name the unresolvable host and carry the config hint.
+		warns := ml.messages("Warnf")
+		require.Len(t, warns, 1)
+		require.Contains(t, warns[0], "cannot resolve p2p server host")
+		require.Contains(t, warns[0], "asset_centrifuge_disable")
 	})
 
 	t.Run("backoff resets after a successful connect", func(t *testing.T) {


### PR DESCRIPTION
## What

Fixes #1334.

On a stack with no reachable p2p server (e.g. the legacy-only teratestnet / quickstart compose stacks, context `docker.m`, where the `peer` service is commented out), `centrifuge.connect()` retried the dial ~once per second and logged every failure at `ERROR`, spamming the asset logs indefinitely:

```
ERROR | centrifuge.go:305 | asset | [Centrifuge] error dialing p2p server: dial tcp: lookup peer on 127.0.0.11:53: server misbehaving
... (~1/sec, continuous)
```

## Changes

- **Backoff + log-downgrade in `connect()`.** Failed dials now back off exponentially (1s → 60s cap, via the existing `util/retry.CappedExponentialBackoff`). The first failure of a streak logs once at `WARN` — with a config hint when the host can't be resolved (`*net.DNSError`) — and subsequent failures log at `DEBUG`. Both the failure count and backoff reset on a successful connect, so a peer that appears late still reconnects within ≤60s. DNS failures do **not** stop the loop (they're routinely transient in compose/k8s). The inter-attempt sleep is context-aware, so shutdown stays prompt during a long backoff.
- **Graceful skip on empty address.** `startP2PListener` now logs a `WARN` and returns `nil` when `p2p_httpAddress` is empty, instead of failing the whole asset service (the global default is `localhost:9906`, so empty is explicit operator intent).

No compose/config changes: with the backoff in place, an occasional `WARN`/`DEBUG` on a peerless stack is fine, so there's no need to flip `asset_centrifuge_disable` in the shipped compose files.

Dial and sleep are injected via unexported struct seams (defaulted in `New`) so the backoff timing and dial outcomes are testable without real DNS or sleeps.

## Verification

- `go test ./services/asset/centrifuge_impl/` — green
- `go vet`, `gofmt`, `golangci-lint run` — clean
- New tests: backoff growth/cap + log levels, DNS-hint WARN, reset-after-reconnect, prompt shutdown during backoff, empty-address skip.