### PR TITLE
fix(model): decode BIP34 coinbase height with SV Node CScriptNum parity (#1142)

### DIFF
--- a/model/Block_test.go
+++ b/model/Block_test.go
@@ -2099,8 +2099,16 @@ func TestGenesisBytesFromModelBlock(t *testing.T) {
 
 func TestBlock_ExtractCoinbaseHeight(t *testing.T) {
 	t.Run("valid coinbase with height", func(t *testing.T) {
-		// Use the existing coinbase transaction from the test constants
-		coinbaseTx, err := bt.NewTxFromString(CoinbaseHex)
+		// Build a canonical coinbase via the production path. GetCoinbaseParts/makeCoinbase1 encode
+		// the height minimally (matching SV Node), so it round-trips through the strict extractor.
+		// The shared CoinbaseHex constant uses a legacy non-minimal 3-byte height push and is
+		// deliberately not used here (extracting it would now, correctly, fail SV Node parity).
+		const wantHeight = uint32(1019)
+
+		c1, c2, err := GetCoinbaseParts(wantHeight, 5000000000, "/m2-us/", []string{"1DkmRkb5iQFkDu4NBysog5bugnsyx7kwtn"})
+		require.NoError(t, err)
+
+		coinbaseTx, err := bt.NewTxFromBytes(BuildCoinbase(c1, c2, "0000000000000000", "00000000"))
 		require.NoError(t, err)
 
 		blockHeaderBytes, _ := hex.DecodeString(block1Header)
@@ -2112,7 +2120,7 @@ func TestBlock_ExtractCoinbaseHeight(t *testing.T) {
 
 		height, err := b.ExtractCoinbaseHeight()
 		require.NoError(t, err)
-		assert.Equal(t, uint32(1019), height) // Height extracted from coinbase scriptSig
+		assert.Equal(t, wantHeight, height) // Height extracted from coinbase scriptSig
 	})
 
 	t.Run("no coinbase transaction", func(t *testing.T) {

--- a/model/GetCoinbaseParts.go
+++ b/model/GetCoinbaseParts.go
@@ -182,7 +182,7 @@ func makeCoinbase1(height uint32, coinbaseText string) []byte {
 	// BIP34 block height, encoded canonically (CScript() << nHeight) so it is minimally encoded and
 	// accepted by SV Node and by Teranode's own coinbase-height parser. A fixed 3-byte push is
 	// non-minimal below height 32768 and truncates above 16777215.
-	arbitraryData = append(arbitraryData, util.EncodeCoinbaseHeightPush(int64(height))...)
+	arbitraryData = append(arbitraryData, util.EncodeCoinbaseHeightPush(height)...)
 	arbitraryData = append(arbitraryData, []byte(coinbaseText)...)
 
 	// Arbitrary data should leave enough space for the extra nonce

--- a/model/GetCoinbaseParts.go
+++ b/model/GetCoinbaseParts.go
@@ -44,6 +44,7 @@ import (
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	base58 "github.com/bsv-blockchain/go-sdk/compat/base58" //nolint:depguard
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/util"
 )
 
 // BuildCoinbase recombines the different parts of the coinbase transaction.
@@ -177,12 +178,11 @@ func makeCoinbaseOutputTransactions(coinbaseValue uint64, walletAddresses []stri
 func makeCoinbase1(height uint32, coinbaseText string) []byte {
 	spaceForExtraNonce := 12
 
-	blockHeightBytes := make([]byte, 4)
-	binary.LittleEndian.PutUint32(blockHeightBytes, height) // Block height
-
 	arbitraryData := []byte{}
-	arbitraryData = append(arbitraryData, 0x03)
-	arbitraryData = append(arbitraryData, blockHeightBytes[:3]...)
+	// BIP34 block height, encoded canonically (CScript() << nHeight) so it is minimally encoded and
+	// accepted by SV Node and by Teranode's own coinbase-height parser. A fixed 3-byte push is
+	// non-minimal below height 32768 and truncates above 16777215.
+	arbitraryData = append(arbitraryData, util.EncodeCoinbaseHeightPush(int64(height))...)
 	arbitraryData = append(arbitraryData, []byte(coinbaseText)...)
 
 	// Arbitrary data should leave enough space for the extra nonce

--- a/model/GetCoinbaseParts_test.go
+++ b/model/GetCoinbaseParts_test.go
@@ -3,9 +3,12 @@ package model
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -439,6 +442,35 @@ func TestMakeCoinbase1_EdgeCases(t *testing.T) {
 		// The difference should be less than the full long text length
 		assert.Less(t, resultLongDiff, len(longText))
 	})
+}
+
+// TestMakeCoinbase1HeightRoundTrip verifies that the height Teranode encodes into its own coinbase
+// (via makeCoinbase1 → GetCoinbaseParts → BuildCoinbase) is decoded back to the same value by the
+// coinbase-height extractor, across the small-int, single-byte, multi-byte and sign-pad encoding
+// boundaries. This is the producer/consumer contract the strict (SV Node parity) extractor depends
+// on: a non-minimal producer would make Teranode reject its own mined blocks.
+func TestMakeCoinbase1HeightRoundTrip(t *testing.T) {
+	const walletAddress = "1DkmRkb5iQFkDu4NBysog5bugnsyx7kwtn"
+
+	heights := []uint32{1, 2, 16, 17, 100, 127, 128, 255, 256, 1000, 12345, 32767, 32768, 518847, 4294967295}
+
+	for _, h := range heights {
+		t.Run(fmt.Sprintf("height_%d", h), func(t *testing.T) {
+			c1, c2, err := GetCoinbaseParts(h, 5000000000, "/teranode/", []string{walletAddress})
+			require.NoError(t, err)
+
+			// 12 bytes of extra nonce, matching the space makeCoinbase1 reserves in the scriptSig length.
+			coinbase := BuildCoinbase(c1, c2, "0000000000000000", "00000000")
+
+			tx, err := bt.NewTxFromBytes(coinbase)
+			require.NoError(t, err)
+			require.True(t, tx.IsCoinbase())
+
+			height, err := util.ExtractCoinbaseHeight(tx)
+			require.NoError(t, err)
+			require.Equal(t, h, height)
+		})
+	}
 }
 
 func TestMakeCoinbase2_Comprehensive(t *testing.T) {

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -132,8 +132,11 @@ func TestValidate_CoinbaseTransaction(t *testing.T) {
 		panic(err)
 	}
 
-	height, err := util.ExtractCoinbaseHeight(coinbase)
-	require.NoError(t, err)
+	// model.CoinbaseHex encodes height 1019 with a legacy non-minimal 3-byte push, which the strict
+	// (SV Node parity) extractor now rejects. This test only needs a block-height context to exercise
+	// that Validate refuses a coinbase transaction, so use the height literally rather than extracting
+	// it. Height-extraction parity is covered in util/coinbase_test.go and model/*_test.go.
+	const height = uint32(1019)
 
 	_, err = v.Validate(context.Background(), coinbase, height, WithSkipPolicyChecks(true))
 	require.Error(t, err)

--- a/util/coinbase.go
+++ b/util/coinbase.go
@@ -84,8 +84,8 @@ func extractCoinbaseHeightAndText(sigScript bscript.Script, raw bool) (uint32, s
 	}
 
 	// Enforce canonical minimal encoding (SV Node prefix-equality parity): the consumed prefix must
-	// equal CScript() << value byte-for-byte.
-	if !bytes.Equal(EncodeCoinbaseHeightPush(value), sigScript[:consumed]) {
+	// equal CScript() << value byte-for-byte. value is guaranteed to be in [0, MaxUint32] here.
+	if !bytes.Equal(EncodeCoinbaseHeightPush(uint32(value)), sigScript[:consumed]) {
 		return 0, arbitraryText, errors.NewBlockCoinbaseMissingHeightError("the coinbase signature script block height is not minimally encoded")
 	}
 
@@ -187,20 +187,21 @@ func decodeScriptNum(b []byte) int64 {
 }
 
 // EncodeCoinbaseHeightPush returns the canonical BIP34 coinbase-height push for height, matching
-// bitcoin-sv's CScript() << nHeight (push_int64):
+// bitcoin-sv's CScript() << nHeight (push_int64) for non-negative heights:
 //
 //   - 0        => OP_0
 //   - 1..16    => OP_1..OP_16
 //   - otherwise => a minimal-length CScriptNum push (0x01<b>, 0x02<b><b>, ...)
 //
 // It is the single source of truth for the encoding: extractCoinbaseHeightAndText uses it to enforce
-// SV Node parity, and makeCoinbase1 uses it to build Teranode's own coinbase. height must be
-// non-negative (block heights always are).
-func EncodeCoinbaseHeightPush(height int64) []byte {
+// SV Node parity, and makeCoinbase1 uses it to build Teranode's own coinbase. The uint32 argument
+// makes the non-negative contract explicit — block heights are always non-negative and fit in
+// uint32, and OP_1NEGATE (the push_int64 case for -1) can never be a height.
+func EncodeCoinbaseHeightPush(height uint32) []byte {
 	switch {
 	case height == 0:
 		return []byte{bscript.Op0}
-	case height >= 1 && height <= 16:
+	case height <= 16:
 		return []byte{bscript.Op1 + byte(height-1)}
 	default:
 		num := encodeScriptNumMinimal(height)
@@ -212,32 +213,18 @@ func EncodeCoinbaseHeightPush(height int64) []byte {
 	}
 }
 
-// encodeScriptNumMinimal encodes n as a minimal little-endian sign-magnitude CScriptNum (the byte
-// form pushed by bitcoin-sv's CScriptNum::serialize), appending a padding byte when the top bit
+// encodeScriptNumMinimal encodes a non-negative n as a minimal little-endian CScriptNum (the byte
+// form pushed by bitcoin-sv's CScriptNum::serialize), appending a 0x00 padding byte when the top bit
 // would otherwise be misread as the sign.
-func encodeScriptNumMinimal(n int64) []byte {
-	if n == 0 {
-		return nil
-	}
-
-	negative := n < 0
-	if negative {
-		n = -n
-	}
-
+func encodeScriptNumMinimal(n uint32) []byte {
 	var result []byte
 	for n > 0 {
 		result = append(result, byte(n&0xff))
 		n >>= 8
 	}
 
-	switch {
-	case result[len(result)-1]&0x80 == 0 && negative:
-		result[len(result)-1] |= 0x80
-	case result[len(result)-1]&0x80 != 0 && negative:
-		result = append(result, 0x80)
-	case result[len(result)-1]&0x80 != 0:
-		result = append(result, 0x00)
+	if len(result) > 0 && result[len(result)-1]&0x80 != 0 {
+		result = append(result, 0x00) // sign-bit pad
 	}
 
 	return result

--- a/util/coinbase.go
+++ b/util/coinbase.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"bytes"
 	"encoding/binary"
+	"math"
 	"strings"
 	"unicode"
 
@@ -13,10 +15,9 @@ import (
 const (
 	// minerSlashTruncationCount defines the number of slashes after which to truncate miner tags
 	minerSlashTruncationCount = 2
-	// validHeightEncodingLengths defines the valid byte lengths for height encoding (2 or 3 bytes)
-	validHeightEncodingLength2 = 2
-	validHeightEncodingLength3 = 3
-	// maxHeightBytes is the maximum allowed bytes for serialized height
+	// maxHeightBytes is the maximum allowed number of data bytes in the coinbase height push.
+	// Canonical BIP34 heights never exceed 5 bytes (a uint32 encoded as a CScriptNum); 8 is a
+	// defensive upper bound that also caps how many bytes decodeScriptNum has to consider.
 	maxHeightBytes = 8
 	// unicodeReplacementChar is the Unicode replacement character to filter out
 	unicodeReplacementChar = 0xFFFD
@@ -54,34 +55,192 @@ func ExtractCoinbaseMinerRaw(coinbaseTx *bt.Tx, raw bool) (string, error) {
 	return miner, err
 }
 
+// extractCoinbaseHeightAndText parses the BIP34 block height and the trailing arbitrary text from a
+// coinbase signature script.
+//
+// The height is the first data push of the script. It is decoded with real Bitcoin script
+// push-opcode semantics (OP_0, OP_1..OP_16, direct pushes, OP_PUSHDATA1/2/4) and interpreted as a
+// CScriptNum, then the encoding is required to be the canonical minimal push. This matches
+// bitcoin-sv's ContextualCheckBlock, which builds expect = CScript() << nHeight and requires the
+// scriptSig to begin with exactly those bytes: a non-minimal push, an OP_PUSHDATA-prefixed push, a
+// wrong small-int form, or a negative/out-of-range value all fail that prefix-equality check, so we
+// reject them here too. This keeps Teranode's accept/reject behaviour in parity with SV Node.
+//
+// On a decode/parity failure that still yielded a valid push boundary, the arbitrary text is
+// returned alongside the error (best-effort) so ExtractCoinbaseMinerRaw — which suppresses
+// ErrBlockCoinbaseMissingHeight — can still surface a miner tag for legacy non-canonical coinbases.
 func extractCoinbaseHeightAndText(sigScript bscript.Script, raw bool) (uint32, string, error) {
-	if len(sigScript) < 1 {
-		return 0, "", errors.NewBlockCoinbaseMissingHeightError("the coinbase signature script must start with the length of the serialized block height")
+	value, consumed, err := decodeCoinbaseHeightPush(sigScript)
+	if err != nil {
+		return 0, "", err
 	}
 
-	serializedLen := int(sigScript[0])
+	arbitraryText := textForMode(string(sigScript[consumed:]), raw)
 
-	if len(sigScript[1:]) < serializedLen {
-		return 0, "", errors.NewBlockCoinbaseMissingHeightError("the coinbase signature script must start with the serialized block height")
+	// Reject negative or out-of-range heights. OP_1NEGATE and sign-bit CScriptNums decode negative;
+	// a value above MaxUint32 can never match a real block height and would overflow the cast below.
+	if value < 0 || value > math.MaxUint32 {
+		return 0, arbitraryText, errors.NewBlockCoinbaseMissingHeightError("the coinbase signature script block height is not a valid height")
 	}
 
-	serializedHeightBytes := sigScript[1 : serializedLen+1]
-	if len(serializedHeightBytes) > maxHeightBytes {
-		return 0, "", errors.NewBlockCoinbaseMissingHeightError("serialized block height too large")
+	// Enforce canonical minimal encoding (SV Node prefix-equality parity): the consumed prefix must
+	// equal CScript() << value byte-for-byte.
+	if !bytes.Equal(EncodeCoinbaseHeightPush(value), sigScript[:consumed]) {
+		return 0, arbitraryText, errors.NewBlockCoinbaseMissingHeightError("the coinbase signature script block height is not minimally encoded")
 	}
 
-	heightBytes := make([]byte, 8)
-	copy(heightBytes, serializedHeightBytes)
-	serializedHeight := binary.LittleEndian.Uint64(heightBytes)
+	return uint32(value), arbitraryText, nil
+}
 
-	arbitraryTextBytes := sigScript[serializedLen+1:]
-	arbitraryText := string(arbitraryTextBytes)
-
+// textForMode returns the coinbase arbitrary text either raw or run through the miner sanitizer.
+func textForMode(text string, raw bool) string {
 	if raw {
-		return uint32(serializedHeight), arbitraryText, nil
+		return text
 	}
 
-	return uint32(serializedHeight), extractMiner(arbitraryText), nil
+	return extractMiner(text)
+}
+
+// decodeCoinbaseHeightPush reads the first data push of a coinbase scriptSig using Bitcoin script
+// push-opcode semantics and returns the pushed value interpreted as a CScriptNum together with the
+// number of script bytes the push occupied. It does not enforce minimal encoding; the caller does
+// that by re-encoding the value canonically. All failures return ErrBlockCoinbaseMissingHeight so
+// that the miner-display path (which suppresses that error) keeps working.
+func decodeCoinbaseHeightPush(s bscript.Script) (int64, int, error) {
+	missing := func(msg string) (int64, int, error) {
+		return 0, 0, errors.NewBlockCoinbaseMissingHeightError(msg)
+	}
+
+	if len(s) < 1 {
+		return missing("the coinbase signature script must start with the serialized block height")
+	}
+
+	op := s[0]
+
+	// pushData reads a length-prefixed push whose header (opcode + length bytes) is headerLen bytes
+	// long and whose data length is n, returning the decoded CScriptNum and total bytes consumed.
+	pushData := func(headerLen int, n uint64) (int64, int, error) {
+		if n > maxHeightBytes {
+			return missing("serialized block height too large")
+		}
+
+		end := headerLen + int(n)
+		if len(s) < end {
+			return missing("the coinbase signature script is too short for the serialized block height")
+		}
+
+		return decodeScriptNum(s[headerLen:end]), end, nil
+	}
+
+	switch {
+	case op == bscript.Op0: // OP_0 pushes an empty array => value 0
+		return 0, 1, nil
+	case op == bscript.Op1NEGATE: // OP_1NEGATE => -1 (rejected as an invalid height by the caller)
+		return -1, 1, nil
+	case op >= bscript.Op1 && op <= bscript.Op16: // OP_1..OP_16 => small integers 1..16
+		return int64(op-bscript.Op1) + 1, 1, nil
+	case op >= bscript.OpDATA1 && op <= bscript.OpDATA75: // direct push of `op` bytes
+		return pushData(1, uint64(op))
+	case op == bscript.OpPUSHDATA1:
+		if len(s) < 2 {
+			return missing("the coinbase signature script is too short for an OP_PUSHDATA1 block height")
+		}
+
+		return pushData(2, uint64(s[1]))
+	case op == bscript.OpPUSHDATA2:
+		if len(s) < 3 {
+			return missing("the coinbase signature script is too short for an OP_PUSHDATA2 block height")
+		}
+
+		return pushData(3, uint64(binary.LittleEndian.Uint16(s[1:3])))
+	case op == bscript.OpPUSHDATA4:
+		if len(s) < 5 {
+			return missing("the coinbase signature script is too short for an OP_PUSHDATA4 block height")
+		}
+
+		return pushData(5, uint64(binary.LittleEndian.Uint32(s[1:5])))
+	default: // first opcode is not a data push, so no block height is present
+		return missing("the coinbase signature script must start with the serialized block height")
+	}
+}
+
+// decodeScriptNum decodes up to maxHeightBytes bytes as a Bitcoin CScriptNum: little-endian,
+// sign-magnitude, where the most-significant bit of the last byte is the sign. The caller guarantees
+// len(b) <= maxHeightBytes (8), so the magnitude always fits in a uint64 after the sign bit is
+// cleared and the result fits in int64.
+func decodeScriptNum(b []byte) int64 {
+	if len(b) == 0 {
+		return 0
+	}
+
+	var mag uint64
+	for i := 0; i < len(b); i++ {
+		mag |= uint64(b[i]) << (8 * uint(i))
+	}
+
+	if b[len(b)-1]&0x80 != 0 {
+		mag &^= uint64(0x80) << (8 * uint(len(b)-1)) // clear the sign bit
+		return -int64(mag)
+	}
+
+	return int64(mag)
+}
+
+// EncodeCoinbaseHeightPush returns the canonical BIP34 coinbase-height push for height, matching
+// bitcoin-sv's CScript() << nHeight (push_int64):
+//
+//   - 0        => OP_0
+//   - 1..16    => OP_1..OP_16
+//   - otherwise => a minimal-length CScriptNum push (0x01<b>, 0x02<b><b>, ...)
+//
+// It is the single source of truth for the encoding: extractCoinbaseHeightAndText uses it to enforce
+// SV Node parity, and makeCoinbase1 uses it to build Teranode's own coinbase. height must be
+// non-negative (block heights always are).
+func EncodeCoinbaseHeightPush(height int64) []byte {
+	switch {
+	case height == 0:
+		return []byte{bscript.Op0}
+	case height >= 1 && height <= 16:
+		return []byte{bscript.Op1 + byte(height-1)}
+	default:
+		num := encodeScriptNumMinimal(height)
+		out := make([]byte, 0, len(num)+1)
+		out = append(out, byte(len(num)))
+		out = append(out, num...)
+
+		return out
+	}
+}
+
+// encodeScriptNumMinimal encodes n as a minimal little-endian sign-magnitude CScriptNum (the byte
+// form pushed by bitcoin-sv's CScriptNum::serialize), appending a padding byte when the top bit
+// would otherwise be misread as the sign.
+func encodeScriptNumMinimal(n int64) []byte {
+	if n == 0 {
+		return nil
+	}
+
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+
+	var result []byte
+	for n > 0 {
+		result = append(result, byte(n&0xff))
+		n >>= 8
+	}
+
+	switch {
+	case result[len(result)-1]&0x80 == 0 && negative:
+		result[len(result)-1] |= 0x80
+	case result[len(result)-1]&0x80 != 0 && negative:
+		result = append(result, 0x80)
+	case result[len(result)-1]&0x80 != 0:
+		result = append(result, 0x00)
+	}
+
+	return result
 }
 
 func extractMiner(data string) string {

--- a/util/coinbase_test.go
+++ b/util/coinbase_test.go
@@ -3,12 +3,14 @@ package util
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,10 +26,24 @@ func TestExtractHeightAndMiner(t *testing.T) {
 		minerError     bool
 	}{
 		{
-			name:           "3-byte height 4105 with m5-cc1 miner",
-			tx:             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff18030910002f6d352d6363312fdcce95f3c057431c486ae662ffffffff0a0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac00000000",
-			expectedHeight: 4105,
-			expectedMiner:  "/m5-cc1/",
+			// Non-minimal 3-byte push (0x03 0910 00) of height 4105 — the encoding the old
+			// makeCoinbase1 emitted. Canonical is the 2-byte push 0x02 0910, so SV Node rejects it and
+			// so does the parser now. Height extraction errors; miner display still works because
+			// ExtractCoinbaseMiner suppresses the missing-height error and returns best-effort text.
+			name:          "non-minimal 3-byte height 4105 with m5-cc1 miner is rejected",
+			tx:            "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff18030910002f6d352d6363312fdcce95f3c057431c486ae662ffffffff0a0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac0065cd1d000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88ac00000000",
+			expectedMiner: "/m5-cc1/",
+			heightError:   true,
+			minerError:    false,
+		},
+		{
+			// Teratestnet block 1 regression (issue #1142): coinbase scriptSig starts with 0x51
+			// (OP_1), the canonical BIP34 encoding of height 1. The old parser read 0x51 as a length
+			// of 81 bytes and returned BLOCK_COINBASE_MISSING_HEIGHT, stalling from-genesis IBD.
+			name:           "teratestnet block 1 OP_1 height with Galts-Gulch miner",
+			tx:             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1251000f222f47616c74732d47756c63682f22ffffffff0100f2052a010000001976a914042848a901a9f0d79eb42c52813a7646c4a81bfd88ac00000000",
+			expectedHeight: 1,
+			expectedMiner:  "/Galts-Gulch/",
 		},
 		{
 			name:           "2 byte teratestnet-v2 miner",
@@ -59,14 +75,6 @@ func TestExtractHeightAndMiner(t *testing.T) {
 			expectedHeight: 856618,
 			expectedMiner:  "/qdlnk/",
 		},
-		{
-			name:           "testnet pre-BIP34 transaction",
-			tx:             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4a60248ab1830b9f12c743e837ef4feb32dda0739ee6e3aaf3b24aa86883c592f2f3a20df867825d91bc096f3260b20ae49176d3bb8d02a107af4065a59fffeb9235fc991145224be83446ffffffff01e0850a2a010000002321038a6ca672c189b3af86b9894fcd40a3af6bbae7b45db9ee89258c848b68d66af3ac00000000",
-			expectedHeight: 0,
-			expectedMiner:  "",
-			heightError:    true,
-			minerError:     false, // Error is suppressed for ExtractCoinbaseMiner
-		},
 	}
 
 	for _, tc := range testCases {
@@ -95,6 +103,27 @@ func TestExtractHeightAndMiner(t *testing.T) {
 	}
 }
 
+// TestExtractCoinbaseHeightPreBIP34RealTx documents that a real pre-BIP34 testnet coinbase whose
+// scriptSig happens to begin with 0x60 (OP_16) now decodes to height 16 under push-opcode semantics,
+// where the old length-prefix parser errored. This is not a consensus change: both consensus call
+// sites skip blocks below the network's BIP34 activation height, so this coinbase is never height-
+// checked in production. The trailing bytes are arbitrary extranonce data; only the height decode
+// and the absence of an error are asserted (the sanitized miner is meaningless binary noise).
+func TestExtractCoinbaseHeightPreBIP34RealTx(t *testing.T) {
+	const txHex = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4a60248ab1830b9f12c743e837ef4feb32dda0739ee6e3aaf3b24aa86883c592f2f3a20df867825d91bc096f3260b20ae49176d3bb8d02a107af4065a59fffeb9235fc991145224be83446ffffffff01e0850a2a010000002321038a6ca672c189b3af86b9894fcd40a3af6bbae7b45db9ee89258c848b68d66af3ac00000000"
+
+	tx, err := bt.NewTxFromString(txHex)
+	require.NoError(t, err)
+
+	height, err := ExtractCoinbaseHeight(tx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(16), height)
+
+	// Miner extraction must not error on this input (its value is arbitrary binary noise).
+	_, err = ExtractCoinbaseMiner(tx)
+	require.NoError(t, err)
+}
+
 // TestExtractCoinbaseHeightAndText_Scripts tests direct script parsing
 func TestExtractCoinbaseHeightAndTextScripts(t *testing.T) {
 	testCases := []struct {
@@ -104,6 +133,7 @@ func TestExtractCoinbaseHeightAndTextScripts(t *testing.T) {
 		expectedMiner  string
 		expectError    bool
 	}{
+		// --- accepts: canonical encodings ---
 		{
 			name:           "3-byte height 807495 with taal.com miner",
 			script:         "0347520c2f7461616c2e636f6d2f79b010ec60689edf8d3a0000",
@@ -111,17 +141,72 @@ func TestExtractCoinbaseHeightAndTextScripts(t *testing.T) {
 			expectedMiner:  "/taal.com/",
 		},
 		{
-			name:           "3-byte height 0 with no miner",
-			script:         "03000000",
+			name:           "OP_0 height 0",
+			script:         "00",
 			expectedHeight: 0,
 			expectedMiner:  "",
 		},
 		{
-			name:           "2-byte height 1 with satoshi miner",
-			script:         "0201002f7361746f7368692f",
+			name:           "OP_1 height 1 (teratestnet block 1) with Galts-Gulch miner",
+			script:         "51000f222f47616c74732d47756c63682f22",
+			expectedHeight: 1,
+			expectedMiner:  "/Galts-Gulch/",
+		},
+		{
+			name:           "OP_1 height 1 with satoshi miner (canonical form of old fixture)",
+			script:         "512f7361746f7368692f",
 			expectedHeight: 1,
 			expectedMiner:  "/satoshi/",
 		},
+		{
+			name:           "OP_16 height 16",
+			script:         "60",
+			expectedHeight: 16,
+			expectedMiner:  "",
+		},
+		{
+			name:           "1-byte push height 17",
+			script:         "0111",
+			expectedHeight: 17,
+			expectedMiner:  "",
+		},
+		{
+			name:           "2-byte push height 128 (sign-bit pad)",
+			script:         "028000",
+			expectedHeight: 128,
+			expectedMiner:  "",
+		},
+		{
+			name:           "2-byte push height 255 (sign-bit pad)",
+			script:         "02ff00",
+			expectedHeight: 255,
+			expectedMiner:  "",
+		},
+		{
+			name:           "2-byte push height 256",
+			script:         "020001",
+			expectedHeight: 256,
+			expectedMiner:  "",
+		},
+		{
+			name:           "2-byte push height 4105 (canonical m5-cc1) with miner",
+			script:         "0209102f6d352d6363312f",
+			expectedHeight: 4105,
+			expectedMiner:  "/m5-cc1/",
+		},
+		{
+			name:           "3-byte push height 518847",
+			script:         "03bfea07",
+			expectedHeight: 518847,
+			expectedMiner:  "",
+		},
+		{
+			name:           "4-byte push height 67305985 (minimal, still accepted)",
+			script:         "0401020304",
+			expectedHeight: 0x4030201,
+			expectError:    false,
+		},
+		// --- rejects: invalid or non-canonical encodings (SV Node parity) ---
 		{
 			name:        "empty script",
 			script:      "",
@@ -133,10 +218,59 @@ func TestExtractCoinbaseHeightAndTextScripts(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:           "unsupported 4-byte length",
-			script:         "0401020304",
-			expectedHeight: 0x4030201,
-			expectError:    false,
+			name:        "non-minimal 2-byte push of height 1 (canonical is OP_1)",
+			script:      "0201002f7361746f7368692f",
+			expectError: true,
+		},
+		{
+			name:        "non-minimal 3-byte push of height 0 (canonical is OP_0)",
+			script:      "03000000",
+			expectError: true,
+		},
+		{
+			name:        "non-minimal 3-byte push of height 4105 (canonical is 2-byte)",
+			script:      "030910002f6d352d6363312f",
+			expectError: true,
+		},
+		{
+			name:        "non-minimal 4-byte push of height 518847 (canonical is 3-byte)",
+			script:      "04bfea0700",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA1 push of height 518847 (never canonical)",
+			script:      "4c03bfea07",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA2 push of height 518847 (never canonical)",
+			script:      "4d0300bfea07",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA4 push of height 518847 (never canonical)",
+			script:      "4e03000000bfea07",
+			expectError: true,
+		},
+		{
+			name:        "OP_1NEGATE is not a valid height",
+			script:      "4f",
+			expectError: true,
+		},
+		{
+			name:        "1-byte push of -1 (sign bit set) is not a valid height",
+			script:      "0181",
+			expectError: true,
+		},
+		{
+			name:        "push longer than maxHeightBytes",
+			script:      "090102030405060708ff",
+			expectError: true,
+		},
+		{
+			name:        "first opcode is not a data push",
+			script:      "a90102",
+			expectError: true,
 		},
 	}
 
@@ -148,6 +282,7 @@ func TestExtractCoinbaseHeightAndTextScripts(t *testing.T) {
 			height, miner, err := extractCoinbaseHeightAndText(*script, false)
 			if tc.expectError {
 				require.Error(t, err)
+				require.ErrorIs(t, err, errors.ErrBlockCoinbaseMissingHeight)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedHeight, height)
@@ -357,6 +492,62 @@ func TestExtractCoinbaseMinerRaw(t *testing.T) {
 			defaultMiner, err := ExtractCoinbaseMiner(tx)
 			require.NoError(t, err)
 			assert.Equal(t, sanitized, defaultMiner)
+		})
+	}
+}
+
+// referenceHeightPush is a deliberately independent implementation of bitcoin-sv's
+// CScript() << nHeight (push_int64). It is written separately from the production
+// EncodeCoinbaseHeightPush so the round-trip test below cross-checks the two against each other
+// rather than against a shared implementation. n must be non-negative (block heights always are).
+func referenceHeightPush(n int64) []byte {
+	if n == 0 {
+		return []byte{0x00} // OP_0
+	}
+
+	if n >= 1 && n <= 16 {
+		return []byte{byte(0x50 + n)} // OP_1..OP_16
+	}
+
+	// minimal little-endian magnitude bytes; append 0x00 if the top bit would read as the sign
+	var num []byte
+	for v := n; v > 0; v >>= 8 {
+		num = append(num, byte(v&0xff))
+	}
+
+	if num[len(num)-1]&0x80 != 0 {
+		num = append(num, 0x00)
+	}
+
+	return append([]byte{byte(len(num))}, num...)
+}
+
+// TestCoinbaseHeightPushRoundTrip cross-checks the canonical encoder against an independent
+// reference and verifies that every canonically-encoded height round-trips back through the
+// extractor. This is the oracle test for SV Node encoding parity.
+func TestCoinbaseHeightPushRoundTrip(t *testing.T) {
+	// push of the 15-byte tag "\"/Galts-Gulch/\"", appended after the height so the extractor also
+	// has trailing arbitrary text to skip over.
+	const minerTagHex = "0f222f47616c74732d47756c63682f22"
+
+	heights := []int64{0, 1, 2, 16, 17, 127, 128, 255, 256, 1000, 21111, 227931, 518847, 4294967295}
+
+	for _, h := range heights {
+		t.Run(fmt.Sprintf("height_%d", h), func(t *testing.T) {
+			ref := referenceHeightPush(h)
+
+			// 1. the production encoder matches the independent reference encoder.
+			require.Equal(t, ref, EncodeCoinbaseHeightPush(h), "canonical encoding mismatch")
+
+			// 2. the encoded height round-trips back through the extractor to the same value, and the
+			//    trailing tag is still recovered.
+			script, err := bscript.NewFromHexString(hex.EncodeToString(ref) + minerTagHex)
+			require.NoError(t, err)
+
+			height, miner, err := extractCoinbaseHeightAndText(*script, false)
+			require.NoError(t, err)
+			require.Equal(t, uint32(h), height) //nolint:gosec // h is a non-negative height <= MaxUint32
+			require.Equal(t, "/Galts-Gulch/", miner)
 		})
 	}
 }

--- a/util/coinbase_test.go
+++ b/util/coinbase_test.go
@@ -218,6 +218,36 @@ func TestExtractCoinbaseHeightAndTextScripts(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "OP_DATA3 declares 3 bytes, only 2 present",
+			script:      "03bfea",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA1 with no length byte",
+			script:      "4c",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA1 declares 3 bytes, only 2 present",
+			script:      "4c03bfea",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA2 with truncated length header",
+			script:      "4d03",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA4 with truncated length header",
+			script:      "4e030000",
+			expectError: true,
+		},
+		{
+			name:        "OP_PUSHDATA4 declares 3 bytes, payload truncated",
+			script:      "4e03000000",
+			expectError: true,
+		},
+		{
 			name:        "non-minimal 2-byte push of height 1 (canonical is OP_1)",
 			script:      "0201002f7361746f7368692f",
 			expectError: true,
@@ -499,13 +529,13 @@ func TestExtractCoinbaseMinerRaw(t *testing.T) {
 // referenceHeightPush is a deliberately independent implementation of bitcoin-sv's
 // CScript() << nHeight (push_int64). It is written separately from the production
 // EncodeCoinbaseHeightPush so the round-trip test below cross-checks the two against each other
-// rather than against a shared implementation. n must be non-negative (block heights always are).
-func referenceHeightPush(n int64) []byte {
+// rather than against a shared implementation. Heights are always non-negative, hence uint32.
+func referenceHeightPush(n uint32) []byte {
 	if n == 0 {
 		return []byte{0x00} // OP_0
 	}
 
-	if n >= 1 && n <= 16 {
+	if n <= 16 {
 		return []byte{byte(0x50 + n)} // OP_1..OP_16
 	}
 
@@ -530,7 +560,7 @@ func TestCoinbaseHeightPushRoundTrip(t *testing.T) {
 	// has trailing arbitrary text to skip over.
 	const minerTagHex = "0f222f47616c74732d47756c63682f22"
 
-	heights := []int64{0, 1, 2, 16, 17, 127, 128, 255, 256, 1000, 21111, 227931, 518847, 4294967295}
+	heights := []uint32{0, 1, 2, 16, 17, 127, 128, 255, 256, 1000, 21111, 227931, 518847, 4294967295}
 
 	for _, h := range heights {
 		t.Run(fmt.Sprintf("height_%d", h), func(t *testing.T) {
@@ -546,7 +576,7 @@ func TestCoinbaseHeightPushRoundTrip(t *testing.T) {
 
 			height, miner, err := extractCoinbaseHeightAndText(*script, false)
 			require.NoError(t, err)
-			require.Equal(t, uint32(h), height) //nolint:gosec // h is a non-negative height <= MaxUint32
+			require.Equal(t, h, height)
 			require.Equal(t, "/Galts-Gulch/", miner)
 		})
 	}


### PR DESCRIPTION
Closes #1142.

## Problem

`util/coinbase.go` `extractCoinbaseHeightAndText` read the first coinbase scriptSig byte as a raw length prefix (`serializedLen := int(sigScript[0])`), not as a Bitcoin script push opcode. Consequences:

- **`OP_1..OP_16` (heights 1–16) errored** — `0x51` was read as "length 81", overran the script, and returned `BLOCK_COINBASE_MISSING_HEIGHT`. This hard-blocks teratestnet from-genesis IBD: block 1's coinbase starts with `OP_1`, so the node stalls at stored height 0 and every later block fails with `previous block NOT_FOUND`. Surfaced by #1301, which correctly switched BIP34 enforcement to per-network `BIP0034Height` (0 on teratestnet/tstn), so extraction now runs from block 1.
- **Non-minimal and `OP_PUSHDATA`-prefixed encodings that SV Node rejects were silently accepted** — a latent BIP34 consensus divergence.

## Fix

Decode the first push with real push-opcode semantics (`OP_0`, `OP_1NEGATE`, `OP_1..OP_16`, direct pushes, `OP_PUSHDATA1/2/4`) as a CScriptNum, reject negative / out-of-range values, then require the encoding to be the canonical minimal push by re-encoding the decoded value and comparing the consumed prefix byte-for-byte.

This is the exact equivalent of bitcoin-sv `ContextualCheckBlock`, which builds `expect = CScript() << nHeight` and requires the scriptSig to start with those bytes. Result: bit-for-bit accept/reject parity with SV Node. Teranode's parse-then-compare architecture is preserved — the parity lands entirely in the extractor, so `Block.Valid` and `validateCoinbaseHeight` (gating + `height != b.Height`) are unchanged.

### Coupled builder fix

`model/GetCoinbaseParts.go` `makeCoinbase1` emitted a **fixed 3-byte** height push (`0x03` + 3 LE bytes). That is non-minimal below height 32768 and truncates at/above 16777216, so the strict extractor would reject Teranode's own mined blocks on BIP34-at-0 networks. It now encodes the height canonically via the shared `EncodeCoinbaseHeightPush`, matching SV Node and the extractor.

## Encoding reference

| Height | Canonical push | Form |
|--------|----------------|------|
| 0 | `00` | OP_0 |
| 1–16 | `51`..`60` | OP_1..OP_16 |
| 17 | `01 11` | 1-byte ScriptNum |
| 128 | `02 80 00` | sign-bit pad |
| 518847 | `03 bf ea 07` | 3-byte ScriptNum |

Rejected (non-canonical): `02 01 00` (should be OP_1), `04 bf ea 07 00`, `4c 03 bf ea 07` (OP_PUSHDATA1), `4f` (OP_1NEGATE), pushes > 8 bytes.

## Tests

- `util`: full accept/reject tables at script and tx level; teratestnet block-1 regression (`51 00 0f 22…` → height 1, `/Galts-Gulch/`); cross-check round-trip against an independent reference encoder for 14 heights (0/1/16/17/…/MaxUint32).
- `model`: producer→consumer round-trip through `GetCoinbaseParts`/`BuildCoinbase` across the encoding boundaries.

## Verification

`go build ./...`, `go vet`, `gofmt`, `gci`, `golangci-lint` clean. Green: `util`, `model`, `stores/blockchain/sql`, `services/blockvalidation`, `services/validator`, `services/subtreevalidation`, `services/asset/repository`, `services/blockassembly` (+ mining), `util/merkleproof`, `util/bump`.

Live teratestnet spot-checked (heights 1 / 1000 / 26800) — all canonical, so strict validation accepts every existing block and unblocks IBD with no re-sync risk for that network.

## Deploy note

Only throwaway internal dev clusters previously mined with the old non-minimal `makeCoinbase1` output at low heights can't re-IBD from genesis under strict parity and need a reset (SV Node would reject those chains too). teratestnet and mainnet are unaffected.
