### PR TITLE
fix(rewindblockchain): never move BlockPersisterHeight forward on rewind (#1340)

### DIFF
--- a/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
@@ -78,6 +78,38 @@ func (e *env) readBlockPersisterHeight(ctx context.Context) (uint32, bool, error
 	return binary.LittleEndian.Uint32(existing), true, nil
 }
 
+// blockPersisterGroundTruth derives the block persister's real position from the
+// blocks table — the lowest block with persisted_at IS NULL, minus one — which
+// is the same derivation block persister performs on startup
+// (services/blockpersister/Server.go:322-334). The state key is only a cache of
+// this; the table is the truth.
+//
+// known is false when there is no pending block above genesis to derive from,
+// or when the query fails. Diagnostics only, so a failure is logged and never
+// fatal. The query is backed by idx_not_persisted_height
+// (stores/blockchain/sql/sql.go:786), so it stays cheap on a full chain.
+//
+// Genesis is skipped: it carries persisted_at IS NULL for the life of the
+// database, so it would otherwise mask every real pending block. Block
+// persister skips it the same way, via its blocks[0].Height > 0 guard — hence
+// asking for two rows, since an unpersisted genesis always sorts first.
+func (e *env) blockPersisterGroundTruth(ctx context.Context) (uint32, bool) {
+	blocks, err := e.blockchainStore.GetBlocksNotPersisted(ctx, 2)
+	if err != nil {
+		e.logger.Debugf("could not derive the real block persister position: %v", err)
+		return 0, false
+	}
+
+	for _, b := range blocks {
+		if b.Height == 0 {
+			continue
+		}
+		return b.Height - 1, true
+	}
+
+	return 0, false
+}
+
 // resetBlockPersisterHeight moves the persisted height down to the target. It
 // never moves it forward: when the block persister is behind the target —
 // normal on a recently-resynced node — the value is left alone.

--- a/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
@@ -52,20 +52,52 @@ func (e *env) resetBlockAssemblerState(ctx context.Context, pf *preflightResult)
 	return nil
 }
 
-// resetBlockPersisterHeight writes the persisted height down to the target.
-// The underlying value is a LE uint32 — see services/blockpersister/Server.go.
-func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult) error {
+// readBlockPersisterHeight reads and decodes state["BlockPersisterHeight"].
+// known is false when the key is absent, empty, or too short to decode — in
+// those cases the caller cannot assume anything about the persister's real
+// position. Genuine storage failures are returned as errors.
+func (e *env) readBlockPersisterHeight(ctx context.Context) (uint32, bool, error) {
 	existing, err := e.blockchainStore.GetState(ctx, blockPersisterHeightKey)
 	if err != nil {
 		// SQL blockchain store returns sql.ErrNoRows directly for missing keys;
 		// future implementations may wrap into errors.ErrNotFound.
 		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, errors.ErrNotFound) {
 			e.logger.Debugf("state[%s] not present: %v", blockPersisterHeightKey, err)
-			return nil
+			return 0, false, nil
 		}
-		return errors.NewStorageError("failed to read state[%s]", blockPersisterHeightKey, err)
+		return 0, false, errors.NewStorageError("failed to read state[%s]", blockPersisterHeightKey, err)
 	}
+
 	if len(existing) == 0 {
+		return 0, false, nil
+	}
+
+	if len(existing) < 4 {
+		e.logger.Warnf("state[%s] is %d bytes, too short to decode as LE uint32; leaving it untouched", blockPersisterHeightKey, len(existing))
+		return 0, false, nil
+	}
+
+	return binary.LittleEndian.Uint32(existing), true, nil
+}
+
+// resetBlockPersisterHeight moves the persisted height down to the target. It
+// never moves it forward: when the block persister is behind the target —
+// normal on a recently-resynced node — the value is left alone. Raising it
+// would tell the pruner's safe-prune calculation and the p2p storage-mode check
+// that blocks were persisted when they were not. The underlying value is a LE
+// uint32 — see services/blockpersister/Server.go.
+func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult) error {
+	existingHeight, known, err := e.readBlockPersisterHeight(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !known {
+		return nil
+	}
+
+	if existingHeight <= pf.target {
+		e.logger.Infof("state[%s]=%d already at/below target %d; leaving it untouched", blockPersisterHeightKey, existingHeight, pf.target)
 		return nil
 	}
 
@@ -76,7 +108,7 @@ func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult
 		return errors.NewStorageError("failed to rewrite state[%s]", blockPersisterHeightKey, err)
 	}
 
-	e.logger.Infof("state[%s] rewritten to %d", blockPersisterHeightKey, pf.target)
+	e.logger.Infof("state[%s] rewritten from %d down to %d", blockPersisterHeightKey, existingHeight, pf.target)
 	return nil
 }
 

--- a/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
@@ -68,10 +68,8 @@ func (e *env) readBlockPersisterHeight(ctx context.Context) (uint32, bool, error
 		return 0, false, errors.NewStorageError("failed to read state[%s]", blockPersisterHeightKey, err)
 	}
 
-	if len(existing) == 0 {
-		return 0, false, nil
-	}
-
+	// A present-but-empty row (len 0) is as undecodable as a truncated one, and
+	// is the more anomalous of the two — both take the same warning.
 	if len(existing) < 4 {
 		e.logger.Warnf("state[%s] is %d bytes, too short to decode as LE uint32; leaving it untouched", blockPersisterHeightKey, len(existing))
 		return 0, false, nil
@@ -82,16 +80,25 @@ func (e *env) readBlockPersisterHeight(ctx context.Context) (uint32, bool, error
 
 // resetBlockPersisterHeight moves the persisted height down to the target. It
 // never moves it forward: when the block persister is behind the target —
-// normal on a recently-resynced node — the value is left alone. Raising it
-// would tell the pruner's safe-prune calculation and the p2p storage-mode check
-// that blocks were persisted when they were not. The underlying value is a LE
-// uint32 — see services/blockpersister/Server.go.
+// normal on a recently-resynced node — the value is left alone.
+//
+// Raising it is not a cosmetic misreport. The pruner reads this key once in
+// Init() (services/pruner/server.go:250) and afterwards only updates its cached
+// copy from BlockPersisted notifications (:163-176). Block persister's
+// corrective republish on startup is a bare SetState with no notification
+// (services/blockpersister/Server.go:329), so an inflated value can be latched
+// by the pruner and drive irreversible blob deletion for blocks that were never
+// persisted. The underlying value is a LE uint32 — see
+// services/blockpersister/Server.go.
 func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult) error {
 	existingHeight, known, err := e.readBlockPersisterHeight(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Diagnostics, not a write guard: unknown decodes to 0, which the <= check
+	// below would also skip. Returning here keeps the log from claiming the
+	// height is 0 when it is actually unreadable.
 	if !known {
 		return nil
 	}

--- a/cmd/rewindblockchain/rewindblockchain/phase4_verify.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase4_verify.go
@@ -6,7 +6,8 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 )
 
-// phase4Verify runs cheap post-rewind consistency checks.
+// phase4Verify runs cheap post-rewind consistency checks. It also asserts
+// state["BlockPersisterHeight"] never increased across the run.
 //
 // Deeper checks (BlockID membership sweep, orphan subtree scan) are left out
 // for now — they'd require iterator primitives we don't have on the UTXO
@@ -23,6 +24,19 @@ func (e *env) phase4Verify(ctx context.Context, pf *preflightResult) error {
 	}
 	if header.Hash().String() != pf.targetHash.String() {
 		return errors.NewProcessingError("verify: best block hash %s != target hash %s", header.Hash(), pf.targetHash)
+	}
+
+	if pf.persisterHeightKnown {
+		current, known, readErr := e.readBlockPersisterHeight(ctx)
+		if readErr != nil {
+			return errors.NewStorageError("verify: read state[%s]", blockPersisterHeightKey, readErr)
+		}
+
+		if known && current > pf.persisterHeight {
+			return errors.NewProcessingError("verify: state[%s] increased from %d to %d", blockPersisterHeightKey, pf.persisterHeight, current)
+		}
+
+		e.logger.Infof("verify: state[%s]=%d did not increase (was %d)", blockPersisterHeightKey, current, pf.persisterHeight)
 	}
 
 	e.logger.Infof("verify: best block at height %d matches target", pf.target)

--- a/cmd/rewindblockchain/rewindblockchain/phase4_verify.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase4_verify.go
@@ -26,19 +26,56 @@ func (e *env) phase4Verify(ctx context.Context, pf *preflightResult) error {
 		return errors.NewProcessingError("verify: best block hash %s != target hash %s", header.Hash(), pf.targetHash)
 	}
 
-	if pf.persisterHeightKnown {
-		current, known, readErr := e.readBlockPersisterHeight(ctx)
-		if readErr != nil {
-			return errors.NewStorageError("verify: read state[%s]", blockPersisterHeightKey, readErr)
-		}
-
-		if known && current > pf.persisterHeight {
-			return errors.NewProcessingError("verify: state[%s] increased from %d to %d", blockPersisterHeightKey, pf.persisterHeight, current)
-		}
-
-		e.logger.Infof("verify: state[%s]=%d did not increase (was %d)", blockPersisterHeightKey, current, pf.persisterHeight)
+	if err = e.verifyBlockPersisterHeight(ctx, pf); err != nil {
+		return err
 	}
 
 	e.logger.Infof("verify: best block at height %d matches target", pf.target)
+	return nil
+}
+
+// verifyBlockPersisterHeight asserts the run did not raise
+// state["BlockPersisterHeight"] — including the case where it had no readable
+// value going in, since this tool never creates the key.
+//
+// With --force-not-idle the node may still be running, and block persister
+// raises this key itself (services/blockpersister/Server.go:417). Failing there
+// would condemn a run that actually succeeded, after every mutation is already
+// applied, so a concurrent raise is downgraded to a warning naming the cause.
+func (e *env) verifyBlockPersisterHeight(ctx context.Context, pf *preflightResult) error {
+	current, known, err := e.readBlockPersisterHeight(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !pf.persisterHeightKnown {
+		if !known {
+			e.logger.Infof("verify: state[%s] was unreadable before the run and still is", blockPersisterHeightKey)
+			return nil
+		}
+
+		if e.opts.ForceNotIdle {
+			e.logger.Warnf("verify: state[%s] was unreadable before the run and is now %d; --force-not-idle was given, so a running block persister can have written it — re-check with the node stopped", blockPersisterHeightKey, current)
+			return nil
+		}
+
+		return errors.NewProcessingError("verify: state[%s] was unreadable before the run and is now %d", blockPersisterHeightKey, current)
+	}
+
+	if !known {
+		e.logger.Warnf("verify: state[%s] was %d before the run and is no longer readable", blockPersisterHeightKey, pf.persisterHeight)
+		return nil
+	}
+
+	if current > pf.persisterHeight {
+		if e.opts.ForceNotIdle {
+			e.logger.Warnf("verify: state[%s] increased from %d to %d; --force-not-idle was given, so a running block persister can have raised it concurrently — re-check with the node stopped", blockPersisterHeightKey, pf.persisterHeight, current)
+			return nil
+		}
+
+		return errors.NewProcessingError("verify: state[%s] increased from %d to %d", blockPersisterHeightKey, pf.persisterHeight, current)
+	}
+
+	e.logger.Infof("verify: state[%s]=%d did not increase (was %d)", blockPersisterHeightKey, current, pf.persisterHeight)
 	return nil
 }

--- a/cmd/rewindblockchain/rewindblockchain/preflight.go
+++ b/cmd/rewindblockchain/rewindblockchain/preflight.go
@@ -85,11 +85,16 @@ func (e *env) preflight(ctx context.Context) (*preflightResult, error) {
 		return nil, err
 	}
 
-	if persisterHeightKnown {
-		e.logger.Infof("state[%s]=%d (target %d)", blockPersisterHeightKey, persisterHeight, target)
-	} else {
+	switch {
+	case !persisterHeightKnown:
 		e.logger.Infof("state[%s] not set or undecodable; it will be left untouched", blockPersisterHeightKey)
+	case persisterHeight <= target:
+		e.logger.Infof("state[%s]=%d (target %d); it will be left untouched", blockPersisterHeightKey, persisterHeight, target)
+	default:
+		e.logger.Infof("state[%s]=%d (target %d); it will be rewritten down to the target", blockPersisterHeightKey, persisterHeight, target)
 	}
+
+	e.warnOnPersisterAnomalies(ctx, target, persisterHeight, persisterHeightKnown)
 
 	// 6. Enumerate blocks above target.
 	deleteList, err := e.enumerateBlocksAboveTarget(ctx, target)
@@ -123,6 +128,35 @@ func (e *env) preflight(ctx context.Context) (*preflightResult, error) {
 	}
 
 	return res, nil
+}
+
+// warnOnPersisterAnomalies cross-checks the state key against the persister's
+// real position and speaks up about the two states an operator needs to know
+// before confirming a destructive run.
+//
+// The tool cannot repair either of them: this guard only stops it from creating
+// the first, and the second is what made someone reach for a rewind in the first
+// place. Both are diagnostics — never fatal.
+func (e *env) warnOnPersisterAnomalies(ctx context.Context, target, persisterHeight uint32, persisterHeightKnown bool) {
+	realHeight, realKnown := e.blockPersisterGroundTruth(ctx)
+	if !realKnown {
+		return
+	}
+
+	// An inflated key: the blocks table says the persister is at realHeight, the
+	// key claims higher. Nothing legitimate writes a value above ground truth,
+	// so this is the fingerprint of a pre-fix run of this tool.
+	if persisterHeightKnown && persisterHeight > realHeight {
+		e.logger.Warnf("state[%s]=%d is ahead of the real block persister position %d (lowest unpersisted block is %d): the value was inflated by an earlier run of this tool (issue 1340) or another writer, and this run cannot repair it — delete the state row and let block persister republish it on next start",
+			blockPersisterHeightKey, persisterHeight, realHeight, realHeight+1)
+	}
+
+	// A large lag: the rewind will not move where the persister resumes, and the
+	// pruner stays gated there until it catches up.
+	if target > realHeight && target-realHeight > coinbaseMaturity {
+		e.logger.Warnf("block persister is %d blocks behind the target (real position %d, target %d): it will resume from %d after the rewind and the pruner stays gated there",
+			target-realHeight, realHeight, target, realHeight+1)
+	}
 }
 
 // resolveTarget picks a target height from --target-height, or failing that,

--- a/cmd/rewindblockchain/rewindblockchain/preflight.go
+++ b/cmd/rewindblockchain/rewindblockchain/preflight.go
@@ -20,6 +20,12 @@ type preflightResult struct {
 	deleteList  []blockToDelete
 	deleteByID  map[uint32]struct{}
 	deleteByHsh map[chainhash.Hash]struct{}
+
+	// persisterHeight is state["BlockPersisterHeight"] as read before any
+	// mutation, and persisterHeightKnown says whether it decoded. Phase 3
+	// refuses to raise it; Phase 4 asserts it never went up.
+	persisterHeight      uint32
+	persisterHeightKnown bool
 }
 
 // blockToDelete is one row from the enumeration query, preserving processing
@@ -72,7 +78,20 @@ func (e *env) preflight(ctx context.Context) (*preflightResult, error) {
 		return nil, errors.NewProcessingError("rewind depth %d exceeds coinbase maturity (%d); pass --force-deep to override", tip-target, coinbaseMaturity)
 	}
 
-	// 5. Enumerate blocks above target.
+	// 5. Capture the pre-run block persister height. Reading it here means a
+	// genuine storage failure aborts before Phase 0 mutates anything.
+	persisterHeight, persisterHeightKnown, err := e.readBlockPersisterHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if persisterHeightKnown {
+		e.logger.Infof("state[%s]=%d (target %d)", blockPersisterHeightKey, persisterHeight, target)
+	} else {
+		e.logger.Infof("state[%s] not set or undecodable; it will be left untouched", blockPersisterHeightKey)
+	}
+
+	// 6. Enumerate blocks above target.
 	deleteList, err := e.enumerateBlocksAboveTarget(ctx, target)
 	if err != nil {
 		return nil, err
@@ -86,15 +105,17 @@ func (e *env) preflight(ctx context.Context) (*preflightResult, error) {
 	}
 
 	res := &preflightResult{
-		target:      target,
-		tip:         tip,
-		targetHash:  targetHash,
-		deleteList:  deleteList,
-		deleteByID:  byID,
-		deleteByHsh: byHash,
+		target:               target,
+		tip:                  tip,
+		targetHash:           targetHash,
+		deleteList:           deleteList,
+		deleteByID:           byID,
+		deleteByHsh:          byHash,
+		persisterHeight:      persisterHeight,
+		persisterHeightKnown: persisterHeightKnown,
 	}
 
-	// 6. Interactive confirmation.
+	// 7. Interactive confirmation.
 	if !e.opts.AssumeYes && !e.opts.DryRun {
 		if err = e.confirmPrompt(res); err != nil {
 			return nil, err

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -942,20 +942,40 @@ func setPersisterHeight(t *testing.T, ctx context.Context, store blockchain_stor
 	require.NoError(t, store.SetState(ctx, "BlockPersisterHeight", payload))
 }
 
+// countingSetStateStore wraps a blockchain.Store and counts SetState calls per
+// key. Needed because a value assertion cannot distinguish "skipped the write"
+// from "wrote LE(target)" when the stored height already equals the target —
+// both leave the same bytes behind. The call count can.
+type countingSetStateStore struct {
+	blockchain_store.Store
+	setStateCalls map[string]int
+}
+
+func newCountingSetStateStore(inner blockchain_store.Store) *countingSetStateStore {
+	return &countingSetStateStore{Store: inner, setStateCalls: make(map[string]int)}
+}
+
+func (c *countingSetStateStore) SetState(ctx context.Context, key string, data []byte) error {
+	c.setStateCalls[key]++
+	return c.Store.SetState(ctx, key, data)
+}
+
 // TestResetBlockPersisterHeight_NeverMovesForward covers issue #1340: the tool
 // used to write LE(target) unconditionally, which raised the recorded persister
 // height on nodes whose persister was behind the target (normal after a
-// resync). Raising it tells the pruner and the p2p storage-mode check that
-// blocks were persisted when they were not.
+// resync). Raising it makes the pruner treat unpersisted blocks as persisted.
 func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("below target is left untouched", func(t *testing.T) {
 		bcStore, _, _, _ := newTestStores(t, ctx)
 		setPersisterHeight(t, ctx, bcStore, 422492)
+		spy := newCountingSetStateStore(bcStore)
 
-		e := &env{logger: logger(), blockchainStore: bcStore}
+		e := &env{logger: logger(), blockchainStore: spy}
 		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 1749334}))
+
+		require.Zero(t, spy.setStateCalls[blockPersisterHeightKey], "no write may be issued at all")
 
 		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
 		require.NoError(t, err)
@@ -967,9 +987,14 @@ func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
 	t.Run("equal to target is left untouched", func(t *testing.T) {
 		bcStore, _, _, _ := newTestStores(t, ctx)
 		setPersisterHeight(t, ctx, bcStore, 7)
+		spy := newCountingSetStateStore(bcStore)
 
-		e := &env{logger: logger(), blockchainStore: bcStore}
+		e := &env{logger: logger(), blockchainStore: spy}
 		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 7}))
+
+		// The call count is the only assertion that can fail here: skipping the
+		// write and rewriting LE(7) both leave 7 in the store.
+		require.Zero(t, spy.setStateCalls[blockPersisterHeightKey], "no write may be issued at the equality boundary")
 
 		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
 		require.NoError(t, err)
@@ -979,9 +1004,12 @@ func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
 	t.Run("above target is rewritten down", func(t *testing.T) {
 		bcStore, _, _, _ := newTestStores(t, ctx)
 		setPersisterHeight(t, ctx, bcStore, 10)
+		spy := newCountingSetStateStore(bcStore)
 
-		e := &env{logger: logger(), blockchainStore: bcStore}
+		e := &env{logger: logger(), blockchainStore: spy}
 		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}))
+
+		require.Equal(t, 1, spy.setStateCalls[blockPersisterHeightKey], "exactly one write down to the target")
 
 		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
 		require.NoError(t, err)
@@ -993,10 +1021,13 @@ func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
 	t.Run("payload shorter than 4 bytes is left untouched", func(t *testing.T) {
 		bcStore, _, _, _ := newTestStores(t, ctx)
 		require.NoError(t, bcStore.SetState(ctx, "BlockPersisterHeight", []byte{0x01, 0x02}))
+		spy := newCountingSetStateStore(bcStore)
 
-		e := &env{logger: logger(), blockchainStore: bcStore}
+		e := &env{logger: logger(), blockchainStore: spy}
 		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}),
 			"an undecodable payload must not fail the run")
+
+		require.Zero(t, spy.setStateCalls[blockPersisterHeightKey])
 
 		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
 		require.NoError(t, err)
@@ -1004,11 +1035,29 @@ func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
 			"cannot prove a write would be downward, so leave the value alone")
 	})
 
+	t.Run("empty payload is left untouched", func(t *testing.T) {
+		bcStore, _, _, _ := newTestStores(t, ctx)
+		require.NoError(t, bcStore.SetState(ctx, "BlockPersisterHeight", []byte{}))
+		spy := newCountingSetStateStore(bcStore)
+
+		e := &env{logger: logger(), blockchainStore: spy}
+		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}))
+
+		require.Zero(t, spy.setStateCalls[blockPersisterHeightKey])
+
+		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+		require.NoError(t, err)
+		require.Empty(t, got, "a present-but-empty row is as undecodable as a short one")
+	})
+
 	t.Run("absent key stays absent", func(t *testing.T) {
 		bcStore, _, _, _ := newTestStores(t, ctx)
+		spy := newCountingSetStateStore(bcStore)
 
-		e := &env{logger: logger(), blockchainStore: bcStore}
+		e := &env{logger: logger(), blockchainStore: spy}
 		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}))
+
+		require.Zero(t, spy.setStateCalls[blockPersisterHeightKey])
 
 		_, err := bcStore.GetState(ctx, "BlockPersisterHeight")
 		require.Error(t, err, "the tool must not create the key when it was never set")

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -844,10 +844,14 @@ func TestRewindBlockchain_ForceDeep(t *testing.T) {
 type errOnGetStateStore struct {
 	blockchain_store.Store
 	getStateErr error
+	// onlyKey, when non-empty, limits the injected failure to that one state
+	// key. Without it a test cannot tell "the persister read aborted preflight"
+	// from "the first read of any key aborted preflight".
+	onlyKey string
 }
 
 func (e *errOnGetStateStore) GetState(ctx context.Context, key string) ([]byte, error) {
-	if e.getStateErr != nil {
+	if e.getStateErr != nil && (e.onlyKey == "" || e.onlyKey == key) {
 		return nil, e.getStateErr
 	}
 	return e.Store.GetState(ctx, key)
@@ -1128,8 +1132,8 @@ func TestPreflight_MissingBlockPersisterHeightIsNotKnown(t *testing.T) {
 // TestPreflight_BlockPersisterHeightReadErrorFailsFast checks that a genuine
 // storage failure on the state read aborts during preflight, before Phase 0
 // touches any store — rather than surfacing in Phase 3 with phases 0-2 already
-// applied. TargetHeight is set so preflight never reads state["BlockAssembler"],
-// leaving the persister read as the only GetState call.
+// applied. The injected failure is scoped to the persister key so the test
+// cannot pass by aborting on some other state read.
 func TestPreflight_BlockPersisterHeightReadErrorFailsFast(t *testing.T) {
 	ctx := context.Background()
 	bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
@@ -1141,7 +1145,7 @@ func TestPreflight_BlockPersisterHeightReadErrorFailsFast(t *testing.T) {
 	require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
 
 	simulated := errors.NewStorageError("simulated db read failure")
-	wrapped := &errOnGetStateStore{Store: bcStore, getStateErr: simulated}
+	wrapped := &errOnGetStateStore{Store: bcStore, getStateErr: simulated, onlyKey: blockPersisterHeightKey}
 
 	e := &env{
 		logger:          logger(),
@@ -1208,7 +1212,7 @@ func TestPhase4Verify_BlockPersisterHeightIncrease(t *testing.T) {
 		require.NoError(t, e.phase4Verify(ctx, pf))
 	})
 
-	t.Run("unknown pre-run value skips the check", func(t *testing.T) {
+	t.Run("unreadable before and set after fails verify", func(t *testing.T) {
 		bcStore, _, _, tSettings := newTestStores(t, ctx)
 
 		bits, err := model.NewNBitFromString("207fffff")
@@ -1224,8 +1228,60 @@ func TestPhase4Verify_BlockPersisterHeightIncrease(t *testing.T) {
 			persisterHeightKnown: false,
 		}
 
-		require.NoError(t, e.phase4Verify(ctx, pf),
-			"with no baseline there is nothing to compare against")
+		// An unreadable baseline is still a baseline: this tool never creates the
+		// key, so a value appearing across the run is an anomaly, not a no-op.
+		err = e.phase4Verify(ctx, pf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "was unreadable before the run and is now 9999")
+	})
+
+	t.Run("force-not-idle downgrades a concurrent increase to a warning", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		setPersisterHeight(t, ctx, bcStore, 2)
+
+		log := &capturingLogger{}
+		e := &env{logger: log, blockchainStore: bcStore, opts: Options{ForceNotIdle: true}}
+		pf := &preflightResult{
+			target:               4,
+			targetHash:           blocks[3].Hash(),
+			persisterHeight:      1,
+			persisterHeightKnown: true,
+		}
+
+		// With the node left running, block persister raises this key itself. A
+		// hard failure here would condemn a run that actually succeeded, after
+		// every mutation is already applied.
+		require.NoError(t, e.phase4Verify(ctx, pf))
+		require.Contains(t, log.warnText(), "--force-not-idle")
+	})
+
+	t.Run("value lost during the run is reported as lost, not as zero", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		require.NoError(t, bcStore.SetState(ctx, "BlockPersisterHeight", []byte{0x01, 0x02}))
+
+		log := &capturingLogger{}
+		e := &env{logger: log, blockchainStore: bcStore}
+		pf := &preflightResult{
+			target:               4,
+			targetHash:           blocks[3].Hash(),
+			persisterHeight:      422492,
+			persisterHeightKnown: true,
+		}
+
+		require.NoError(t, e.phase4Verify(ctx, pf))
+		require.Contains(t, log.warnText(), "is no longer readable")
+		require.NotContains(t, log.infoText(), "=0 did not increase",
+			"an unreadable value must never be reported as a live 0")
 	})
 }
 

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -1107,3 +1107,73 @@ func TestPreflight_BlockPersisterHeightReadErrorFailsFast(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, simulated), "real read failure must abort preflight, got %v", err)
 }
+
+// TestPhase4Verify_BlockPersisterHeightIncrease asserts the --verify guard
+// catches a persister height that went up during the run. The fixture points
+// the target at the existing tip so the best-block checks pass and only the
+// persister comparison decides the outcome.
+func TestPhase4Verify_BlockPersisterHeightIncrease(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("increase fails verify", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		setPersisterHeight(t, ctx, bcStore, 2)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		pf := &preflightResult{
+			target:               4,
+			targetHash:           blocks[3].Hash(),
+			persisterHeight:      1,
+			persisterHeightKnown: true,
+		}
+
+		err = e.phase4Verify(ctx, pf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "increased from 1 to 2")
+	})
+
+	t.Run("unchanged passes verify", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		setPersisterHeight(t, ctx, bcStore, 1)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		pf := &preflightResult{
+			target:               4,
+			targetHash:           blocks[3].Hash(),
+			persisterHeight:      1,
+			persisterHeightKnown: true,
+		}
+
+		require.NoError(t, e.phase4Verify(ctx, pf))
+	})
+
+	t.Run("unknown pre-run value skips the check", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		setPersisterHeight(t, ctx, bcStore, 9999)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		pf := &preflightResult{
+			target:               4,
+			targetHash:           blocks[3].Hash(),
+			persisterHeightKnown: false,
+		}
+
+		require.NoError(t, e.phase4Verify(ctx, pf),
+			"with no baseline there is nothing to compare against")
+	})
+}

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -1177,3 +1177,40 @@ func TestPhase4Verify_BlockPersisterHeightIncrease(t *testing.T) {
 			"with no baseline there is nothing to compare against")
 	})
 }
+
+// TestRewind_PersisterHeightBelowTargetLeftAlone runs the whole pipeline with
+// --verify against a node whose persister sits far behind the target — the
+// issue #1340 shape. Target equals the tip, so no blocks are deleted and the
+// run exercises Phase 0/1/3/4 wiring end to end.
+func TestRewind_PersisterHeightBelowTargetLeftAlone(t *testing.T) {
+	ctx := context.Background()
+	bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+	bits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+	require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+	require.NoError(t, setBlockAssemblerState(ctx, bcStore, 4, blocks[3].Header))
+	setPersisterHeight(t, ctx, bcStore, 1)
+
+	stats, err := Rewind(ctx, logger(), tSettings, Options{
+		TargetHeight: 4,
+		AssumeYes:    true,
+		Verify:       true,
+		Stores: &Stores{
+			Blockchain: bcStore,
+			UTXO:       utxoStore,
+			Subtree:    subtreeStore,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.Zero(t, stats.BlocksDeleted)
+
+	got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+	require.Equal(t, uint32(1), binary.LittleEndian.Uint32(got),
+		"a lagging persister height must survive a full rewind run untouched")
+}

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -932,3 +932,85 @@ func TestConfirmPrompt(t *testing.T) {
 		require.Contains(t, err.Error(), "--assume-yes")
 	})
 }
+
+// setPersisterHeight seeds state["BlockPersisterHeight"] with an LE uint32,
+// the format services/blockpersister/Server.go writes.
+func setPersisterHeight(t *testing.T, ctx context.Context, store blockchain_store.Store, height uint32) {
+	t.Helper()
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, height)
+	require.NoError(t, store.SetState(ctx, "BlockPersisterHeight", payload))
+}
+
+// TestResetBlockPersisterHeight_NeverMovesForward covers issue #1340: the tool
+// used to write LE(target) unconditionally, which raised the recorded persister
+// height on nodes whose persister was behind the target (normal after a
+// resync). Raising it tells the pruner and the p2p storage-mode check that
+// blocks were persisted when they were not.
+func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("below target is left untouched", func(t *testing.T) {
+		bcStore, _, _, _ := newTestStores(t, ctx)
+		setPersisterHeight(t, ctx, bcStore, 422492)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 1749334}))
+
+		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+		require.Equal(t, uint32(422492), binary.LittleEndian.Uint32(got),
+			"persister height behind the target must not be moved forward")
+	})
+
+	t.Run("equal to target is left untouched", func(t *testing.T) {
+		bcStore, _, _, _ := newTestStores(t, ctx)
+		setPersisterHeight(t, ctx, bcStore, 7)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 7}))
+
+		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+		require.NoError(t, err)
+		require.Equal(t, uint32(7), binary.LittleEndian.Uint32(got))
+	})
+
+	t.Run("above target is rewritten down", func(t *testing.T) {
+		bcStore, _, _, _ := newTestStores(t, ctx)
+		setPersisterHeight(t, ctx, bcStore, 10)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}))
+
+		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+		require.Equal(t, uint32(4), binary.LittleEndian.Uint32(got),
+			"persister height ahead of the target must be rewritten down to it")
+	})
+
+	t.Run("payload shorter than 4 bytes is left untouched", func(t *testing.T) {
+		bcStore, _, _, _ := newTestStores(t, ctx)
+		require.NoError(t, bcStore.SetState(ctx, "BlockPersisterHeight", []byte{0x01, 0x02}))
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}),
+			"an undecodable payload must not fail the run")
+
+		got, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x01, 0x02}, got,
+			"cannot prove a write would be downward, so leave the value alone")
+	})
+
+	t.Run("absent key stays absent", func(t *testing.T) {
+		bcStore, _, _, _ := newTestStores(t, ctx)
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		require.NoError(t, e.resetBlockPersisterHeight(ctx, &preflightResult{target: 4}))
+
+		_, err := bcStore.GetState(ctx, "BlockPersisterHeight")
+		require.Error(t, err, "the tool must not create the key when it was never set")
+	})
+}

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -1262,4 +1264,162 @@ func TestRewind_PersisterHeightBelowTargetLeftAlone(t *testing.T) {
 	require.Len(t, got, 4)
 	require.Equal(t, uint32(1), binary.LittleEndian.Uint32(got),
 		"a lagging persister height must survive a full rewind run untouched")
+}
+
+// capturingLogger records Infof/Warnf output so tests can assert on the
+// operator-facing diagnostics. On the skip path the log IS the deliverable —
+// the tool deliberately changes nothing — so it is worth asserting on.
+type capturingLogger struct {
+	ulogger.TestLogger
+	mu    sync.Mutex
+	infos []string
+	warns []string
+}
+
+func (c *capturingLogger) Infof(format string, args ...interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.infos = append(c.infos, fmt.Sprintf(format, args...))
+}
+
+func (c *capturingLogger) Warnf(format string, args ...interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.warns = append(c.warns, fmt.Sprintf(format, args...))
+}
+
+func (c *capturingLogger) infoText() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.infos, "\n")
+}
+
+func (c *capturingLogger) warnText() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.warns, "\n")
+}
+
+// TestBlockPersisterGroundTruth derives the persister's real position from the
+// blocks table instead of trusting the state key — the same derivation block
+// persister itself uses on startup.
+func TestBlockPersisterGroundTruth(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("lowest unpersisted block minus one", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		require.NoError(t, bcStore.SetBlockPersistedAt(ctx, blocks[0].Hash()))
+		require.NoError(t, bcStore.SetBlockPersistedAt(ctx, blocks[1].Hash()))
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		height, known := e.blockPersisterGroundTruth(ctx)
+		require.True(t, known)
+		require.Equal(t, uint32(2), height, "blocks 1-2 persisted, lowest pending is 3, so the real position is 2")
+	})
+
+	t.Run("nothing pending is not a baseline", func(t *testing.T) {
+		bcStore, _, _, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 2, bits, tSettings.ChainCfgParams.GenesisHash)
+		for _, b := range blocks {
+			require.NoError(t, bcStore.SetBlockPersistedAt(ctx, b.Hash()))
+		}
+
+		e := &env{logger: logger(), blockchainStore: bcStore}
+		_, known := e.blockPersisterGroundTruth(ctx)
+		require.False(t, known, "with no pending block there is nothing to compare against")
+	})
+}
+
+// TestPreflight_WarnsOnInflatedAndLaggingPersisterHeight covers the two
+// operator-facing diagnostics: a key already inflated past the real position by
+// an earlier buggy run (issue 1340 leaves exactly this state behind, and the
+// fixed tool cannot repair it), and a persister lagging the target far enough
+// that the rewind will not change where it resumes.
+func TestPreflight_WarnsOnInflatedAndLaggingPersisterHeight(t *testing.T) {
+	ctx := context.Background()
+
+	newEnv := func(t *testing.T, bcStore blockchain_store.Store, utxoStore utxo.Store, subtreeStore *memory.Memory, tSettings *settings.Settings, log *capturingLogger, target int64) *env {
+		return &env{
+			logger:          log,
+			settings:        tSettings,
+			blockchainStore: bcStore,
+			utxoStore:       utxoStore,
+			subtreeStore:    subtreeStore,
+			opts:            Options{TargetHeight: target, AssumeYes: true},
+			stats:           &Stats{},
+			concurrency:     1,
+		}
+	}
+
+	t.Run("inflated key is called out", func(t *testing.T) {
+		bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+		require.NoError(t, bcStore.SetBlockPersistedAt(ctx, blocks[0].Hash()))
+		// Real position is 1, but the key claims 4 — the shape a pre-fix run leaves.
+		setPersisterHeight(t, ctx, bcStore, 4)
+
+		log := &capturingLogger{}
+		pf, err := newEnv(t, bcStore, utxoStore, subtreeStore, tSettings, log, 3).preflight(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint32(4), pf.persisterHeight)
+
+		require.Contains(t, log.warnText(), "is ahead of the real block persister position 1",
+			"an inflated key must be reported, not silently accepted")
+	})
+
+	t.Run("large lag is called out", func(t *testing.T) {
+		bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		buildLinearChain(t, ctx, bcStore, 150, bits, tSettings.ChainCfgParams.GenesisHash)
+		require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+		// Nothing persisted at all: real position 0, target 149 — a 149-block lag.
+		setPersisterHeight(t, ctx, bcStore, 0)
+
+		log := &capturingLogger{}
+		_, err = newEnv(t, bcStore, utxoStore, subtreeStore, tSettings, log, 149).preflight(ctx)
+		require.NoError(t, err)
+
+		require.Contains(t, log.warnText(), "blocks behind the target",
+			"a persister lagging past coinbase maturity must warn")
+	})
+
+	t.Run("healthy persister stays quiet and the decision is logged", func(t *testing.T) {
+		bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+		bits, err := model.NewNBitFromString("207fffff")
+		require.NoError(t, err)
+
+		blocks := buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+		require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+		for _, b := range blocks[:3] {
+			require.NoError(t, bcStore.SetBlockPersistedAt(ctx, b.Hash()))
+		}
+		// Real position 3, key agrees, target 2 → the write-down case.
+		setPersisterHeight(t, ctx, bcStore, 3)
+
+		log := &capturingLogger{}
+		_, err = newEnv(t, bcStore, utxoStore, subtreeStore, tSettings, log, 2).preflight(ctx)
+		require.NoError(t, err)
+
+		require.Empty(t, log.warnText(), "a healthy, slightly-ahead persister is not an anomaly")
+		require.Contains(t, log.infoText(), "it will be rewritten down to the target",
+			"the preflight log must state the decision, not just the numbers")
+	})
 }

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -1014,3 +1014,96 @@ func TestResetBlockPersisterHeight_NeverMovesForward(t *testing.T) {
 		require.Error(t, err, "the tool must not create the key when it was never set")
 	})
 }
+
+// TestPreflight_CapturesBlockPersisterHeight checks that preflight records the
+// pre-run persister height so Phase 4 has a baseline to compare against.
+func TestPreflight_CapturesBlockPersisterHeight(t *testing.T) {
+	ctx := context.Background()
+	bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+	bits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+	require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+	setPersisterHeight(t, ctx, bcStore, 1)
+
+	e := &env{
+		logger:          logger(),
+		settings:        tSettings,
+		blockchainStore: bcStore,
+		utxoStore:       utxoStore,
+		subtreeStore:    subtreeStore,
+		opts:            Options{TargetHeight: 2, AssumeYes: true},
+		stats:           &Stats{},
+		concurrency:     1,
+	}
+
+	pf, err := e.preflight(ctx)
+	require.NoError(t, err)
+	require.True(t, pf.persisterHeightKnown, "a decodable key must be reported as known")
+	require.Equal(t, uint32(1), pf.persisterHeight)
+}
+
+// TestPreflight_MissingBlockPersisterHeightIsNotKnown checks the absent-key
+// path: preflight succeeds and reports the value as unknown.
+func TestPreflight_MissingBlockPersisterHeightIsNotKnown(t *testing.T) {
+	ctx := context.Background()
+	bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+	bits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+	require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+
+	e := &env{
+		logger:          logger(),
+		settings:        tSettings,
+		blockchainStore: bcStore,
+		utxoStore:       utxoStore,
+		subtreeStore:    subtreeStore,
+		opts:            Options{TargetHeight: 2, AssumeYes: true},
+		stats:           &Stats{},
+		concurrency:     1,
+	}
+
+	pf, err := e.preflight(ctx)
+	require.NoError(t, err)
+	require.False(t, pf.persisterHeightKnown)
+	require.Zero(t, pf.persisterHeight)
+}
+
+// TestPreflight_BlockPersisterHeightReadErrorFailsFast checks that a genuine
+// storage failure on the state read aborts during preflight, before Phase 0
+// touches any store — rather than surfacing in Phase 3 with phases 0-2 already
+// applied. TargetHeight is set so preflight never reads state["BlockAssembler"],
+// leaving the persister read as the only GetState call.
+func TestPreflight_BlockPersisterHeightReadErrorFailsFast(t *testing.T) {
+	ctx := context.Background()
+	bcStore, utxoStore, subtreeStore, tSettings := newTestStores(t, ctx)
+
+	bits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	buildLinearChain(t, ctx, bcStore, 4, bits, tSettings.ChainCfgParams.GenesisHash)
+	require.NoError(t, bcStore.SetFSMState(ctx, "IDLE"))
+
+	simulated := errors.NewStorageError("simulated db read failure")
+	wrapped := &errOnGetStateStore{Store: bcStore, getStateErr: simulated}
+
+	e := &env{
+		logger:          logger(),
+		settings:        tSettings,
+		blockchainStore: wrapped,
+		utxoStore:       utxoStore,
+		subtreeStore:    subtreeStore,
+		opts:            Options{TargetHeight: 2, AssumeYes: true},
+		stats:           &Stats{},
+		concurrency:     1,
+	}
+
+	_, err = e.preflight(ctx)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, simulated), "real read failure must abort preflight, got %v", err)
+}


### PR DESCRIPTION
Fixes #1340

## Problem

`resetBlockPersisterHeight` read `state["BlockPersisterHeight"]`, checked only that it was present and non-empty, then wrote `LE(target)` unconditionally. On a node whose block persister sits *below* the rewind target — normal after a resync — that moves the recorded height **forward**. No warning, no error; the summary log reports a normal rewrite. The function's own doc comment said it writes the height "down to the target"; the code never enforced it.

testnet-eu-1 shape from the issue: `block_assembly_height=1749337`, `block_persister_height=422492`. A 3-block rewind to 1749334 would have written `BlockPersisterHeight = 1749334`.

## Severity: data-loss-capable, not transient misreporting

An earlier revision of this description called the key "derived data" that block persister republishes on startup, so nothing is permanently lost. That is true of the *stored key* and false of its consumers. The chain, all verified in-tree:

1. The pruner reads the key **once, in `Init()`** (`services/pruner/server.go:250`) into `lastPersistedHeight`.
2. Its cached copy is afterwards updated **only** from `BlockPersisted` notification metadata (`:163-176`).
3. Block persister's corrective republish on startup is a **bare `SetState` with no notification** (`services/blockpersister/Server.go:329`) — unlike the runtime path (`:401-417`), which sends the notification first.

So a pruner that has latched an inflated value never learns better, and the key being repaired in the database does not repair the process acting on it. From there: `worker.go:200` → `blob_deletion_worker.go:75-99` computes `safeHeight = blockHeight - BlobDeletionSafetyWindow` and `blobStore.Del`s at `:232` — files off disk, no soft-delete. `worker.go:249` DAH-prunes UTXO records to the same inflated height, and `:263` advances `lastProcessedHeight` past it, so every subsequent real `BlockPersisted` is dropped by the `<= lastProcessedHeight` guard and pruning stalls for the whole gap.

The safety gates do not catch it, because the buggy tool wrote exactly `LE(target)` — the largest value that still resolves in `GetBlockHeadersByHeight(target, target)`, and the same value written to `state[BlockAssembler]`, so `checkBlockAssemblySafeForPruner` passes too. A value above the tip would have been rejected. Stock config is the exposed path: `pruner_block_trigger` defaults to `OnBlockPersisted`, `pruner_skipBlobDeletion` to `false`, `pruner_force_ignore_block_persister_height` to `false`.

Whether any given node actually lost blobs depends on rows existing in the scheduled-deletion table under the inflated height at that moment — code path verified, no live database inspected.

## Change

- New `readBlockPersisterHeight` helper: one decode/tolerance policy for all call sites. Absent / empty / shorter than 4 bytes → "unknown"; real storage errors propagate.
- `resetBlockPersisterHeight` writes only when the stored height is strictly above the target. At/below target, or undecodable, it logs and leaves the value alone.
- Preflight captures the pre-run height and **cross-checks it against ground truth** — the lowest block with `persisted_at IS NULL`, minus one, which is what block persister derives on startup (genesis skipped; it is never marked persisted, and block persister skips it the same way). A key sitting above that real position is the fingerprint of a pre-fix run, and this tool cannot repair it, so it says so and names the manual repair: delete the `state` row and let block persister republish on next start. The query is backed by `idx_not_persisted_height`, so it stays cheap. Preflight also warns when the persister lags the target by more than coinbase maturity, spelling out that the rewind will not move where it resumes.
- A genuine read failure on the key now aborts before Phase 0 instead of surfacing in Phase 3 with phases 0-2 already applied.
- `--verify` (Phase 4) fails the run if the height increased, **or** if a key that was unreadable going in has a value coming out — this tool never creates the key. Under `--force-not-idle` both are downgraded to warnings naming the cause, since a running block persister legitimately raises the key and a hard failure there would condemn a run that actually succeeded after all mutation is applied.

Kept as adjust-down rather than delete-the-row (the policy the sibling `deleteUTXOPersisterLastProcessed` uses for the utxo persister's position): the row is the operator's only record of where the persister was on a node they are already debugging, and discarding it to save a warning is a bad trade. The cross-check covers the case delete would have repaired.

No new flag, nothing touched outside `cmd/rewindblockchain/rewindblockchain/`.

## Consumers of the key

Four read sites, all gating on `len(...) >= 4`: `services/pruner/server.go:250`, `services/p2p/Server.go:1409`, `services/legacy/peer_server.go:3549`, and `services/asset/httpimpl/get_service_heights.go:31` — the last exposes it as `block_persister_height` over HTTP, i.e. an inflated key lies on the very endpoint an operator would hit to check whether the persister is behind.

Three writers, and only one could produce a value not derived from ground truth: `blockpersister/Server.go:329` (startup, from `persisted_at`), `:417` (runtime, from `block.Height`), and this tool. Fixing it here closes the class in-tree.

## Tests

`rewind_test.go`: below / equal / above target, 2-byte payload, empty payload, absent key — each asserting the `SetState` **call count**, not just the stored bytes, because at the equality boundary skipping the write and rewriting `LE(target)` leave identical bytes (the value-only assertion survived deleting the guard; the counter kills it). Ground-truth derivation, inflated-key warning, large-lag warning, and the preflight decision log. Phase 4: increase fails, unchanged passes, unreadable-before-set-after fails, `--force-not-idle` downgrades, lost-value reported as lost rather than as a live `0`. Plus a full `Rewind` run with `--verify` against a lagging persister height. The existing integration test still covers the write-down path.

`go test -race ./cmd/rewindblockchain/...` 33 pass. `make test` 11982 tests, 0 failures. `go vet` clean, `make lint` 0 issues.

## Backport

`release/v0.15` **and** `release/v0.16` both carry the identical pre-fix body. Both still use `%w` in the `errors.New*` format strings that `main` stripped in #1335, so the cherry-pick will conflict on exactly those lines in `resetBlockPersisterHeight` — resolve toward the release branch's `%w` style.

Follow-up, not in this PR: `BlockPersisterHeight` has no shared accessor, unlike `blockassembly.StateKey`/`EncodeState` — the key literal and the 4-byte LE encode/decode are hand-rolled at six sites.
