### PR TITLE
p2p: Implement p2p Client.GetPeers and surface peer decode errors

### DIFF
--- a/services/p2p/Client.go
+++ b/services/p2p/Client.go
@@ -99,15 +99,27 @@ func (c *Client) Close() error {
 //   - []*PeerInfo: Slice of peer information
 //   - error: Any error encountered during the operation
 func (c *Client) GetPeers(ctx context.Context) ([]*PeerInfo, error) {
-	_, err := c.client.GetPeers(ctx, &emptypb.Empty{})
+	resp, err := c.client.GetPeers(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert p2p_api response to native PeerInfo slice
-	// Note: The p2p_api.GetPeersResponse contains legacy SVNode format
-	// For now, return empty slice as the actual implementation uses GetPeerRegistry
-	return []*PeerInfo{}, nil
+	peers := make([]*PeerInfo, 0, len(resp.GetPeers()))
+
+	for _, apiPeer := range resp.GetPeers() {
+		peerInfo, err := convertFromAPIPeerInfo(apiPeer)
+		if err != nil {
+			c.logger.Warnf("skipping peer with invalid data: %v", err)
+			continue
+		}
+
+		// The GetPeers RPC only reports currently connected peers.
+		peerInfo.IsConnected = true
+
+		peers = append(peers, peerInfo)
+	}
+
+	return peers, nil
 }
 
 // BanPeer implements the ClientI interface method to ban a peer.
@@ -523,7 +535,12 @@ func (c *Client) GetPeersForCatchup(ctx context.Context) ([]*PeerInfo, error) {
 	// Convert p2p_api peer info to native PeerInfo
 	peers := make([]*PeerInfo, 0, len(resp.Peers))
 	for _, apiPeer := range resp.Peers {
-		peerInfo := convertFromAPIPeerInfo(apiPeer)
+		peerInfo, err := convertFromAPIPeerInfo(apiPeer)
+		if err != nil {
+			c.logger.Warnf("skipping catchup peer with invalid data: %v", err)
+			continue
+		}
+
 		peers = append(peers, peerInfo)
 	}
 
@@ -717,7 +734,13 @@ func (c *Client) GetPeerRegistry(ctx context.Context) ([]*PeerInfo, error) {
 	// Convert p2p_api peer registry info to native PeerInfo
 	peers := make([]*PeerInfo, 0, len(resp.Peers))
 	for _, apiPeer := range resp.Peers {
-		peers = append(peers, convertFromAPIPeerInfo(apiPeer))
+		peerInfo, err := convertFromAPIPeerInfo(apiPeer)
+		if err != nil {
+			c.logger.Warnf("skipping registry peer with invalid data: %v", err)
+			continue
+		}
+
+		peers = append(peers, peerInfo)
 	}
 
 	return peers, nil
@@ -765,19 +788,59 @@ func (c *Client) GetPeer(ctx context.Context, peerID string) (*PeerInfo, error) 
 	}
 
 	// Convert from protobuf to native PeerInfo
-	return convertFromAPIPeerInfo(resp.Peer), nil
+	return convertFromAPIPeerInfo(resp.Peer)
 }
 
-// convertFromAPIPeerInfo converts a p2p_api peer info (either PeerInfoForCatchup or PeerRegistryInfo) to native PeerInfo
-func convertFromAPIPeerInfo(apiPeer interface{}) *PeerInfo {
-	// Handle both PeerInfoForCatchup and PeerRegistryInfo types
-	switch p := apiPeer.(type) {
-	case *p2p_api.PeerInfoForCatchup:
-		peerID, _ := peer.Decode(p.Id)
+// decodePeerID decodes a peer ID string, wrapping any failure with context.
+func decodePeerID(id string) (peer.ID, error) {
+	peerID, err := peer.Decode(id)
+	if err != nil {
+		return "", errors.NewProcessingError("invalid peer ID %q", id, err)
+	}
 
-		var blockHash *chainhash.Hash
-		if p.BlockHash != "" {
-			blockHash, _ = chainhash.NewHashFromStr(p.BlockHash)
+	return peerID, nil
+}
+
+// parseOptionalBlockHash parses a block hash string, returning nil for an empty string.
+func parseOptionalBlockHash(hash, peerID string) (*chainhash.Hash, error) {
+	if hash == "" {
+		return nil, nil
+	}
+
+	blockHash, err := chainhash.NewHashFromStr(hash)
+	if err != nil {
+		return nil, errors.NewProcessingError("invalid block hash %q for peer %s", hash, peerID, err)
+	}
+
+	return blockHash, nil
+}
+
+// convertFromAPIPeerInfo converts a p2p_api peer message (Peer, PeerInfoForCatchup or
+// PeerRegistryInfo) to a native PeerInfo, propagating any decode failure.
+func convertFromAPIPeerInfo(apiPeer interface{}) (*PeerInfo, error) {
+	switch p := apiPeer.(type) {
+	case *p2p_api.Peer:
+		peerID, err := decodePeerID(p.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		return &PeerInfo{
+			ID:            peerID,
+			Height:        p.CurrentHeight,
+			BanScore:      int(p.Banscore),
+			BytesReceived: p.BytesReceived,
+		}, nil
+
+	case *p2p_api.PeerInfoForCatchup:
+		peerID, err := decodePeerID(p.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		blockHash, err := parseOptionalBlockHash(p.BlockHash, p.Id)
+		if err != nil {
+			return nil, err
 		}
 
 		return &PeerInfo{
@@ -789,14 +852,17 @@ func convertFromAPIPeerInfo(apiPeer interface{}) *PeerInfo {
 			CatchupAttempts:  p.CatchupAttempts,
 			CatchupSuccesses: p.CatchupSuccesses,
 			CatchupFailures:  p.CatchupFailures,
-		}
+		}, nil
 
 	case *p2p_api.PeerRegistryInfo:
-		peerID, _ := peer.Decode(p.Id)
+		peerID, err := decodePeerID(p.Id)
+		if err != nil {
+			return nil, err
+		}
 
-		var blockHash *chainhash.Hash
-		if p.BlockHash != "" {
-			blockHash, _ = chainhash.NewHashFromStr(p.BlockHash)
+		blockHash, err := parseOptionalBlockHash(p.BlockHash, p.Id)
+		if err != nil {
+			return nil, err
 		}
 
 		return &PeerInfo{
@@ -827,10 +893,9 @@ func convertFromAPIPeerInfo(apiPeer interface{}) *PeerInfo {
 			CatchupAttempts:        p.CatchupAttempts,
 			CatchupSuccesses:       p.CatchupSuccesses,
 			CatchupFailures:        p.CatchupFailures,
-		}
+		}, nil
 
 	default:
-		// Return empty PeerInfo for unknown types
-		return &PeerInfo{}
+		return nil, errors.NewProcessingError("unsupported peer info type %T", apiPeer)
 	}
 }

--- a/services/p2p/Client_test.go
+++ b/services/p2p/Client_test.go
@@ -237,28 +237,106 @@ func (m *MockPeerServiceClient) GetPeer(ctx context.Context, in *p2p_api.GetPeer
 }
 
 func TestSimpleClientGetPeers(t *testing.T) {
-	mockClient := &MockPeerServiceClient{
-		GetPeersFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*p2p_api.GetPeersResponse, error) {
-			return &p2p_api.GetPeersResponse{
-				Peers: []*p2p_api.Peer{
-					{Id: "peer1", Addr: "/ip4/127.0.0.1/tcp/9905"},
-					{Id: "peer2", Addr: "/ip4/127.0.0.2/tcp/9905"},
+	t.Run("ok", func(t *testing.T) {
+		mockClient := &MockPeerServiceClient{
+			GetPeersFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*p2p_api.GetPeersResponse, error) {
+				return &p2p_api.GetPeersResponse{
+					Peers: []*p2p_api.Peer{
+						{Id: "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz", Addr: "/ip4/127.0.0.1/tcp/9905", CurrentHeight: 101, Banscore: 7, BytesReceived: 2048},
+						{Id: "12D3KooWAfBVdmphtMFPVq3GEpcg3QMiRbrwD9mpd6D6fc4CswRw", Addr: "/ip4/127.0.0.2/tcp/9905", CurrentHeight: 99},
+					},
+				}, nil
+			},
+		}
+
+		client := &Client{
+			client: mockClient,
+			logger: ulogger.New("test"),
+		}
+
+		peers, err := client.GetPeers(context.Background())
+		require.NoError(t, err)
+		require.Len(t, peers, 2)
+		require.Equal(t, "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz", peers[0].ID.String())
+		require.Equal(t, uint32(101), peers[0].Height)
+		require.Equal(t, 7, peers[0].BanScore)
+		require.Equal(t, uint64(2048), peers[0].BytesReceived)
+		require.True(t, peers[0].IsConnected)
+		require.Equal(t, uint32(99), peers[1].Height)
+	})
+
+	t.Run("grpc_error", func(t *testing.T) {
+		client := &Client{
+			client: &MockPeerServiceClient{
+				GetPeersFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*p2p_api.GetPeersResponse, error) {
+					return nil, assert.AnError
 				},
-			}, nil
-		},
-	}
+			},
+			logger: ulogger.New("test"),
+		}
 
-	client := &Client{
-		client: mockClient,
-		logger: ulogger.New("test"),
-	}
+		_, err := client.GetPeers(context.Background())
+		require.Error(t, err)
+	})
 
-	ctx := context.Background()
-	resp, err := client.GetPeers(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	// GetPeers now returns empty slice as it uses legacy format
-	require.Len(t, resp, 0)
+	t.Run("invalid_peer_id_skipped", func(t *testing.T) {
+		client := &Client{
+			client: &MockPeerServiceClient{
+				GetPeersFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*p2p_api.GetPeersResponse, error) {
+					return &p2p_api.GetPeersResponse{
+						Peers: []*p2p_api.Peer{
+							{Id: "not-a-valid-peer-id"},
+							{Id: "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz", CurrentHeight: 55},
+						},
+					}, nil
+				},
+			},
+			logger: ulogger.New("test"),
+		}
+
+		peers, err := client.GetPeers(context.Background())
+		require.NoError(t, err)
+		require.Len(t, peers, 1, "invalid peer entry should be skipped, not fail the call")
+		require.Equal(t, uint32(55), peers[0].Height)
+	})
+}
+
+func TestConvertFromAPIPeerInfoErrors(t *testing.T) {
+	t.Run("invalid_peer_id_catchup", func(t *testing.T) {
+		_, err := convertFromAPIPeerInfo(&p2p_api.PeerInfoForCatchup{Id: "bogus"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid peer ID")
+	})
+
+	t.Run("invalid_block_hash_catchup", func(t *testing.T) {
+		_, err := convertFromAPIPeerInfo(&p2p_api.PeerInfoForCatchup{
+			Id:        "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz",
+			BlockHash: "not-a-hash",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid block hash")
+	})
+
+	t.Run("invalid_peer_id_registry", func(t *testing.T) {
+		_, err := convertFromAPIPeerInfo(&p2p_api.PeerRegistryInfo{Id: "bogus"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid peer ID")
+	})
+
+	t.Run("invalid_block_hash_registry", func(t *testing.T) {
+		_, err := convertFromAPIPeerInfo(&p2p_api.PeerRegistryInfo{
+			Id:        "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz",
+			BlockHash: "not-a-hash",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid block hash")
+	})
+
+	t.Run("unsupported_type", func(t *testing.T) {
+		_, err := convertFromAPIPeerInfo("not a peer message")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported peer info type")
+	})
 }
 
 func TestSimpleClientBanPeer(t *testing.T) {

--- a/services/p2p/Interface.go
+++ b/services/p2p/Interface.go
@@ -73,7 +73,7 @@ type PeerInfo struct {
 type ClientI interface {
 	// GetPeers retrieves a list of connected peers from the P2P network.
 	// It provides information about all active peer connections including their
-	// addresses, connection details, and network statistics.
+	// heights, ban scores, and network statistics.
 	//
 	// Parameters:
 	// - ctx: Context for the operation, allowing for cancellation and timeouts

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -1785,27 +1785,30 @@ func (s *Server) GetPeers(ctx context.Context, _ *emptypb.Empty) (*p2p_api.GetPe
 			return nil, errors.WrapGRPCPublic(errors.NewServiceError("list peers", err))
 		}
 
+		// Look up libp2p addresses once, not per registry peer.
+		addrByPeerID := make(map[string]string)
+		if s.P2PClient != nil {
+			for _, sp := range s.P2PClient.GetPeers() {
+				if len(sp.Addrs) > 0 {
+					addrByPeerID[sp.ID] = sp.Addrs[0]
+				}
+			}
+		}
+
 		resp := &p2p_api.GetPeersResponse{}
 		for _, p := range allPeers {
 			if !p.IsConnected {
 				continue
 			}
-			// Get address from libp2p if available.
-			addr := ""
-			if s.P2PClient != nil {
-				libp2pPeers := s.P2PClient.GetPeers()
-				for _, sp := range libp2pPeers {
-					if sp.ID == p.ID && len(sp.Addrs) > 0 {
-						addr = sp.Addrs[0]
-						break
-					}
-				}
-			}
+
+			addr := addrByPeerID[p.ID]
 
 			resp.Peers = append(resp.Peers, &p2p_api.Peer{
-				Id:       p.ID,
-				Addr:     addr,
-				Banscore: p.BanScore,
+				Id:            p.ID,
+				Addr:          addr,
+				Banscore:      p.BanScore,
+				CurrentHeight: p.Height,
+				BytesReceived: p.BytesReceived,
 			})
 		}
 

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func newServerWithLocalRegistry(t *testing.T) (*Server, *blockchain.CentralizedPeerRegistry) {
@@ -962,4 +963,20 @@ func TestIsBaseURLBlacklisted(t *testing.T) {
 				"baseURL %q vs blacklist entry %q", tt.baseURL, tt.entry)
 		})
 	}
+}
+
+func TestServerGetPeersReturnsConnectedPeersWithHeight(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+
+	connectedPID := mustNewPeerID(t)
+	disconnectedPID := mustNewPeerID(t)
+
+	s.addConnectedPeer(connectedPID, "client/1.0", 123, nil, "")
+	s.addPeer(disconnectedPID, "client/1.0", 99, nil, "")
+
+	resp, err := s.GetPeers(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.Len(t, resp.Peers, 1, "disconnected peers must be excluded")
+	require.Equal(t, connectedPID.String(), resp.Peers[0].Id)
+	require.Equal(t, uint32(123), resp.Peers[0].CurrentHeight)
 }


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4721.**

### Problem
`Client.GetPeers` made the gRPC call, discarded the response, and unconditionally returned an empty slice, silently violating the `ClientI` contract - callers paid for the RPC and could not distinguish "no peers" from "not implemented". Additionally, `convertFromAPIPeerInfo` swallowed `peer.Decode` and `chainhash.NewHashFromStr` errors (`peerID, _ := ...`) and returned a silent empty `PeerInfo` for unknown types, so corrupt data surfaced as zero peer IDs / nil hashes instead of errors. Both items were confirmed still present.

### Fix
- `Client.GetPeers` now converts the `GetPeersResponse` into native `[]*PeerInfo` (new `*p2p_api.Peer` case in the converter: ID, height, ban score, bytes received) and marks results `IsConnected`, since the RPC only ever reports connected peers.
- `convertFromAPIPeerInfo` returns `(*PeerInfo, error)`; decode failures are wrapped in a `ProcessingError` via small `decodePeerID` / `parseOptionalBlockHash` helpers, and the unknown-type default returns an error instead of an empty struct.
- Error handling is deliberately split by call shape: list endpoints (`GetPeers`, `GetPeersForCatchup`, `GetPeerRegistry`) log a warning and skip the bad entry so one corrupt registry record cannot blank out catchup peer selection or the asset `/peers` endpoint, while `GetPeer` (single-peer lookup) propagates the error.
- Beyond the proposed fix, `Server.GetPeers` only populated `Id`/`Addr`/`Banscore`, which would have left client-side `Height` permanently zero and kept `cmd/diagnose`'s peer-height check inert; the registry path now also fills `CurrentHeight` and `BytesReceived`. While touching that block, the libp2p address lookup was hoisted out of the per-peer loop (it was O(peers x libp2p peers) per call).
- Stale `ClientI.GetPeers` doc (peer "addresses" are not part of `PeerInfo`) corrected.

Side effect worth noting: RPC `getinfo`'s `connections` count previously always added 0 for teranode p2p peers; it now includes them. Rolling upgrade is graceful in both directions: an old server simply reports `CurrentHeight`/`BytesReceived` as 0 (the diagnose height check guards on `> 0`), and an old client ignores the new fields.

### Residual
- `cmd/monitor` renders `ReputationScore`, which the legacy `p2p_api.Peer` message cannot carry, so monitor shows `rep:0` for `GetPeers` results; carrying reputation would need a proto change (or pointing monitor at `GetPeerRegistry`), left out of scope.
- Pre-existing direct field access on gRPC responses elsewhere in `Client.go` (no nil guards) was left untouched to keep the diff minimal; the new code uses nil-safe `resp.GetPeers()`.

### Tests
- `TestSimpleClientGetPeers`: real conversion assertions (ID, height, ban score, bytes received, `IsConnected`), gRPC error propagation, and invalid-entry skip behavior.
- `TestConvertFromAPIPeerInfoErrors`: invalid peer ID and invalid block hash for both `PeerInfoForCatchup` and `PeerRegistryInfo`, plus the unsupported-type case.
- `TestServerGetPeersReturnsConnectedPeersWithHeight`: server-level test (local registry) asserting connected-only filtering and that `CurrentHeight` reaches the response.

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
ok  github.com/bsv-blockchain/teranode/services/p2p  14.006s
```
