### PR TITLE
fix(p2p): randomize sync-peer tiebreak to resist peer-ID grinding

### DIFF
--- a/docs/topics/features/img/peer_selection_sequence.puml
+++ b/docs/topics/features/img/peer_selection_sequence.puml
@@ -31,8 +31,8 @@ end note
 PS -> PS: Filter for "full" storage mode
 
 alt Full nodes available
-  PS -> PS: Sort by:\n1. Reputation (desc)\n2. Ban score (asc)\n3. Height (desc)\n4. Peer ID
-  PS -> PS: Select top candidate
+  PS -> PS: Rank by:\n1. Proven full-block delivery\n2. Validated chain work (desc)\n3. Reputation (desc)\n4. Response time (asc)\n5. Ban score (asc)\n6. Validated height (desc)
+  PS -> PS: Random pick among\ntop-ranked ties\n(no peer-ID tiebreak)
   PS --> BV: Selected full node peer
 else No full nodes available
 
@@ -40,13 +40,8 @@ else No full nodes available
 
   alt Fallback enabled
     PS -> PS: Filter non-full peers
-    PS -> PS: Sort by:\n1. Reputation (desc)\n2. Ban score (asc)\n3. Height (asc)\n4. Peer ID
-    note right
-      Prefer youngest pruned
-      nodes to minimize
-      UTXO pruning risk
-    end note
-    PS -> PS: Select top candidate
+    PS -> PS: Rank with same criteria\nas full nodes
+    PS -> PS: Random pick among\ntop-ranked ties\n(no peer-ID tiebreak)
     PS --> BV: Selected pruned node peer
   else Fallback disabled
     PS --> BV: No peer available

--- a/docs/topics/features/peer_registry_reputation.md
+++ b/docs/topics/features/peer_registry_reputation.md
@@ -218,27 +218,30 @@ The peer selector uses a two-phase approach for optimal selection:
 #### Phase 1: Full Node Selection
 
 1. Filter for peers that explicitly announce as "full" storage mode
-2. Sort candidates by:
+2. Rank candidates by:
 
-   - Reputation score (highest first) - **primary**
-   - Ban score (lowest first) - **secondary**
-   - Block height (highest first) - **tertiary**
-   - Peer ID (for deterministic ordering) - **quaternary**
-3. Select the top candidate (or second if top was previous peer)
+   - Proven recent full-block delivery - **primary**
+   - Locally validated chain work (highest first) - **secondary**
+   - Reputation score (highest first) - **tertiary**
+   - Average response time (lowest first, peers with measurements first) - **quaternary**
+   - Ban score (lowest first) - **quinary**
+   - Validated block height (highest first) - **senary**
+3. Exclude the previously selected peer when any alternative exists
+4. Select uniformly at random among the top-ranked candidates that tie on
+   every criterion above
+
+There is deliberately no peer-ID tiebreak: peer IDs are attacker-grindable
+(cheap libp2p keypair generation), so a deterministic ID ordering would let a
+Sybil attacker mint an ID that always wins selection among otherwise equal
+candidates. Random selection within the top band caps a Sybil set's capture
+probability at its proportional share of that band.
 
 #### Phase 2: Pruned Node Fallback
 
 If no full nodes are available and fallback is enabled:
 
 1. Filter for peers not in "full" mode but meeting other criteria
-2. Sort by:
-
-   - Reputation score (highest first)
-   - Ban score (lowest first)
-   - Block height (lowest first) - **prefer youngest pruned nodes**
-   - Peer ID
-
-The preference for younger pruned nodes minimizes UTXO pruning risk during catchup.
+2. Rank and select using the same criteria and random tiebreak as Phase 1
 
 ### 5.3. Fallback to Pruned Nodes
 
@@ -250,7 +253,7 @@ Pruned node fallback is controlled by the `p2p_allow_pruned_node_fallback` setti
 When using pruned nodes:
 
 - Warning is logged about potential UTXO pruning risk
-- Youngest (lowest height) pruned node is preferred
+- Candidates are ranked with the same criteria as full nodes
 - Reputation still prioritized over height
 
 ## 6. Integration with Other Services

--- a/services/p2p/peer_selector.go
+++ b/services/p2p/peer_selector.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"math/rand/v2"
 	"net/http"
 	"sort"
 	"time"
@@ -25,11 +26,14 @@ type SelectionCriteria struct {
 	SyncAttemptCooldown          time.Duration // Cooldown period before retrying a peer
 }
 
-// PeerSelector handles peer selection logic
-// This is a stateless, pure function component
+// PeerSelector handles peer selection logic.
+// It is stateless; selection among candidates that are equal on every merit
+// criterion is randomized so a Sybil attacker cannot capture selection by
+// grinding peer IDs.
 type PeerSelector struct {
 	logger   ulogger.Logger
 	settings *settings.Settings
+	randIntN func(n int) int // injectable for tests; must return a uniform value in [0, n)
 }
 
 // NewPeerSelector creates a new peer selector
@@ -37,13 +41,15 @@ func NewPeerSelector(logger ulogger.Logger, settings *settings.Settings) *PeerSe
 	return &PeerSelector{
 		logger:   logger,
 		settings: settings,
+		randIntN: rand.IntN,
 	}
 }
 
 // SelectSyncPeer selects the best peer for syncing using two-phase selection:
 // Phase 1: Try to select from full nodes (nodes with complete block data)
 // Phase 2: If no full nodes and fallback enabled, select from non-full nodes
-// This is a pure function - no side effects, no network calls.
+// Selection has no side effects; ties among equally ranked candidates are
+// broken randomly, never by peer ID.
 // Peer IDs are canonical libp2p ID strings.
 func (ps *PeerSelector) SelectSyncPeer(peers []*blockchain.PeerInfo, criteria SelectionCriteria) string {
 	// Handle forced peer - always select it if it exists, regardless of eligibility
@@ -123,47 +129,99 @@ func (ps *PeerSelector) getPrunedNodeCandidates(peers []*blockchain.PeerInfo, cr
 	return candidates
 }
 
+// comparePeerCandidates orders two candidates by merit: proven recent full-block
+// delivery, validated chain work, reputation, response time, ban score, then
+// validated height. Returns a negative value when a ranks before b, positive
+// when b ranks before a, and 0 when they are equal on every criterion. There is
+// deliberately no peer-ID tiebreak: peer IDs are attacker-grindable, so ties
+// are resolved by random selection in selectFromCandidates instead.
+func (ps *PeerSelector) comparePeerCandidates(a, b *blockchain.PeerInfo, now time.Time, freshnessWindow time.Duration) int {
+	aProven := peerHasRecentFullBlockDelivery(a, now, freshnessWindow)
+	bProven := peerHasRecentFullBlockDelivery(b, now, freshnessWindow)
+	if aProven != bProven {
+		if aProven {
+			return -1
+		}
+		return 1
+	}
+	if cmp := compareChainWork(a.ValidatedChainWork, b.ValidatedChainWork); cmp != 0 {
+		return -cmp
+	}
+	if a.ReputationScore != b.ReputationScore {
+		if a.ReputationScore > b.ReputationScore {
+			return -1
+		}
+		return 1
+	}
+	aHasTime := a.AvgResponseTimeMs > 0
+	bHasTime := b.AvgResponseTimeMs > 0
+	if aHasTime != bHasTime {
+		if aHasTime {
+			return -1
+		}
+		return 1
+	}
+	if aHasTime && bHasTime && a.AvgResponseTimeMs != b.AvgResponseTimeMs {
+		if a.AvgResponseTimeMs < b.AvgResponseTimeMs {
+			return -1
+		}
+		return 1
+	}
+	if a.BanScore != b.BanScore {
+		if a.BanScore < b.BanScore {
+			return -1
+		}
+		return 1
+	}
+	if a.ValidatedHeight != b.ValidatedHeight {
+		if a.ValidatedHeight > b.ValidatedHeight {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
 // selectFromCandidates selects the best peer from a list of candidates
 // using validation-gated delivery evidence and locally validated work.
+// Candidates that tie on every merit criterion form the top band, and the
+// winner is drawn uniformly at random from that band so an attacker cannot
+// deterministically capture selection by grinding peer IDs.
 func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, criteria SelectionCriteria, isFullNode bool) string {
 	if len(candidates) == 0 {
 		return ""
 	}
 
+	// Rotate off the previously selected peer whenever an alternative exists,
+	// so a tied previous peer cannot be re-drawn from the top band.
+	if len(candidates) > 1 && criteria.PreviousPeer != "" {
+		filtered := candidates[:0]
+		for _, c := range candidates {
+			if c.ID != criteria.PreviousPeer {
+				filtered = append(filtered, c)
+			}
+		}
+		if len(filtered) > 0 && len(filtered) < len(candidates) {
+			ps.logger.Debugf("[PeerSelector] Excluding previous peer %s from selection", criteria.PreviousPeer)
+			candidates = filtered
+		}
+	}
+
 	now := time.Now()
 	sort.Slice(candidates, func(i, j int) bool {
-		iProven := peerHasRecentFullBlockDelivery(candidates[i], now, criteria.FullDeliveryFreshnessWindow)
-		jProven := peerHasRecentFullBlockDelivery(candidates[j], now, criteria.FullDeliveryFreshnessWindow)
-		if iProven != jProven {
-			return iProven
-		}
-		if cmp := compareChainWork(candidates[i].ValidatedChainWork, candidates[j].ValidatedChainWork); cmp != 0 {
-			return cmp > 0
-		}
-		if candidates[i].ReputationScore != candidates[j].ReputationScore {
-			return candidates[i].ReputationScore > candidates[j].ReputationScore
-		}
-		iHasTime := candidates[i].AvgResponseTimeMs > 0
-		jHasTime := candidates[j].AvgResponseTimeMs > 0
-		if iHasTime != jHasTime {
-			return iHasTime
-		}
-		if iHasTime && jHasTime && candidates[i].AvgResponseTimeMs != candidates[j].AvgResponseTimeMs {
-			return candidates[i].AvgResponseTimeMs < candidates[j].AvgResponseTimeMs
-		}
-		if candidates[i].BanScore != candidates[j].BanScore {
-			return candidates[i].BanScore < candidates[j].BanScore
-		}
-		if candidates[i].ValidatedHeight != candidates[j].ValidatedHeight {
-			return candidates[i].ValidatedHeight > candidates[j].ValidatedHeight
-		}
-		return candidates[i].ID < candidates[j].ID
+		return ps.comparePeerCandidates(candidates[i], candidates[j], now, criteria.FullDeliveryFreshnessWindow) < 0
 	})
 
+	topBandSize := 1
+	for topBandSize < len(candidates) &&
+		ps.comparePeerCandidates(candidates[0], candidates[topBandSize], now, criteria.FullDeliveryFreshnessWindow) == 0 {
+		topBandSize++
+	}
+
 	selectedIndex := 0
-	if len(candidates) > 1 && criteria.PreviousPeer != "" && candidates[0].ID == criteria.PreviousPeer {
-		selectedIndex = 1
-		ps.logger.Debugf("[PeerSelector] Previous peer %s was top candidate, selecting second", criteria.PreviousPeer)
+	if topBandSize > 1 {
+		selectedIndex = ps.randIntN(topBandSize)
+		ps.logger.Debugf("[PeerSelector] Randomly selected index %d among %d equally ranked top candidates", selectedIndex, topBandSize)
 	}
 
 	selected := candidates[selectedIndex]

--- a/services/p2p/peer_selector.go
+++ b/services/p2p/peer_selector.go
@@ -41,15 +41,27 @@ func NewPeerSelector(logger ulogger.Logger, settings *settings.Settings) *PeerSe
 	return &PeerSelector{
 		logger:   logger,
 		settings: settings,
+		// math/rand/v2 uses a per-thread ChaCha8 generator seeded from OS
+		// entropy; a remote attacker cannot observe or predict the stream, so
+		// crypto/rand is unnecessary for this tiebreak.
 		randIntN: rand.IntN,
 	}
+}
+
+// randomIndex returns a uniform value in [0, n), falling back to the package
+// default source if the selector was constructed without one.
+func (ps *PeerSelector) randomIndex(n int) int {
+	if ps.randIntN == nil {
+		return rand.IntN(n)
+	}
+	return ps.randIntN(n)
 }
 
 // SelectSyncPeer selects the best peer for syncing using two-phase selection:
 // Phase 1: Try to select from full nodes (nodes with complete block data)
 // Phase 2: If no full nodes and fallback enabled, select from non-full nodes
-// Selection has no side effects; ties among equally ranked candidates are
-// broken randomly, never by peer ID.
+// Ties among equally ranked candidates are broken randomly, never by peer ID.
+// May perform HTTP health checks when P2P.HealthCheckEnabled is set.
 // Peer IDs are canonical libp2p ID strings.
 func (ps *PeerSelector) SelectSyncPeer(peers []*blockchain.PeerInfo, criteria SelectionCriteria) string {
 	// Handle forced peer - always select it if it exists, regardless of eligibility
@@ -187,6 +199,8 @@ func (ps *PeerSelector) comparePeerCandidates(a, b *blockchain.PeerInfo, now tim
 // Candidates that tie on every merit criterion form the top band, and the
 // winner is drawn uniformly at random from that band so an attacker cannot
 // deterministically capture selection by grinding peer IDs.
+// The candidates slice is consumed: it is reordered and may be filtered in
+// place, so callers must not reuse it afterwards.
 func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, criteria SelectionCriteria, isFullNode bool) string {
 	if len(candidates) == 0 {
 		return ""
@@ -220,8 +234,7 @@ func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, 
 
 	selectedIndex := 0
 	if topBandSize > 1 {
-		selectedIndex = ps.randIntN(topBandSize)
-		ps.logger.Debugf("[PeerSelector] Randomly selected index %d among %d equally ranked top candidates", selectedIndex, topBandSize)
+		selectedIndex = ps.randomIndex(topBandSize)
 	}
 
 	selected := candidates[selectedIndex]
@@ -229,8 +242,8 @@ func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, 
 	if !isFullNode {
 		nodeType = "PRUNED"
 	}
-	ps.logger.Infof("[PeerSelector] Selected %s node peer %s (validated_height=%d, advertised_height=%d, banScore=%d, avgResponseTimeMs=%d) from %d candidates (index=%d)",
-		nodeType, selected.ID, selected.ValidatedHeight, selected.Height, selected.BanScore, selected.AvgResponseTimeMs, len(candidates), selectedIndex)
+	ps.logger.Infof("[PeerSelector] Selected %s node peer %s (validated_height=%d, advertised_height=%d, banScore=%d, avgResponseTimeMs=%d) from %d candidates (topBandSize=%d, index=%d)",
+		nodeType, selected.ID, selected.ValidatedHeight, selected.Height, selected.BanScore, selected.AvgResponseTimeMs, len(candidates), topBandSize, selectedIndex)
 
 	for i := 0; i < len(candidates) && i < 3; i++ {
 		ps.logger.Debugf("[PeerSelector] Candidate %d: %s (validated_height=%d, advertised_height=%d, banScore=%d, avgResponseTimeMs=%d, mode=%s, url=%s)",

--- a/services/p2p/peer_selector_test.go
+++ b/services/p2p/peer_selector_test.go
@@ -272,6 +272,7 @@ func TestPeerSelector_SelectFromCandidates_RandomTiebreakCoversWholeTopBand(t *t
 	// Stubbing the random source proves each band member is reachable and the
 	// worse peer never is.
 	tied := []string{"tied-1", "tied-2", "tied-3"}
+	seen := map[string]bool{}
 	for want := range len(tied) {
 		peers := []*blockchain.PeerInfo{
 			newPeer("tied-2", 100, "full", 80, 0),
@@ -288,44 +289,83 @@ func TestPeerSelector_SelectFromCandidates_RandomTiebreakCoversWholeTopBand(t *t
 		got := ps.SelectSyncPeer(peers, advertisedProbeCriteria(50))
 		require.Contains(t, tied, got)
 		require.NotEqual(t, "worse", got)
+		seen[got] = true
 	}
+	require.Len(t, seen, len(tied), "every band member must be reachable via the random index")
 }
 
 func TestPeerSelector_SelectSyncPeer_GrindableIDCannotCaptureSelection(t *testing.T) {
 	ps := newSelectorForTest()
 
 	// The attacker ID sorts lexicographically before every honest ID. With the
-	// old ID tiebreak it would win 100% of the time; with random tiebreaks it
-	// must lose at least once over many rounds. P(all 200 rounds pick the
-	// attacker among 4 tied peers) = 0.25^200, so this cannot flake.
-	attackerWins := 0
+	// old ID tiebreak it would win 100% of the time; with a uniform random
+	// tiebreak every one of the 4 tied peers must win at least once over 200
+	// rounds. P(some peer never wins) <= 4 * 0.75^200 ~ 1e-24, so this cannot
+	// flake, and it also catches any fixed-index selection, not just index 0.
+	ids := []string{"000000-ground-attacker-id", "honest-a", "honest-b", "honest-c"}
+	wins := map[string]int{}
 	const rounds = 200
 	for range rounds {
 		peers := []*blockchain.PeerInfo{
-			newPeer("000000-ground-attacker-id", 100, "full", 80, 0),
-			newPeer("honest-a", 100, "full", 80, 0),
-			newPeer("honest-b", 100, "full", 80, 0),
-			newPeer("honest-c", 100, "full", 80, 0),
+			newPeer(ids[0], 100, "full", 80, 0),
+			newPeer(ids[1], 100, "full", 80, 0),
+			newPeer(ids[2], 100, "full", 80, 0),
+			newPeer(ids[3], 100, "full", 80, 0),
 		}
-		if ps.SelectSyncPeer(peers, advertisedProbeCriteria(50)) == "000000-ground-attacker-id" {
-			attackerWins++
-		}
+		wins[ps.SelectSyncPeer(peers, advertisedProbeCriteria(50))]++
 	}
-	require.Less(t, attackerWins, rounds, "attacker with lexicographically smallest ID must not win every selection")
+	for _, id := range ids {
+		require.Positive(t, wins[id], "every tied peer must win at least once, got %v", wins)
+	}
+	require.Less(t, wins[ids[0]], rounds, "attacker with lexicographically smallest ID must not win every selection")
 }
 
 func TestPeerSelector_SelectSyncPeer_PreviousPeerExcludedFromTiedTopBand(t *testing.T) {
 	ps := newSelectorForTest()
 
-	// Previous peer ties with one other candidate; it must never be re-drawn.
+	// Previous peer ties with two other candidates, so after it is excluded
+	// the random draw still runs over a band of two; it must never be re-drawn.
 	for range 50 {
 		peers := []*blockchain.PeerInfo{
 			newPeer("prev", 100, "full", 80, 0),
-			newPeer("other", 100, "full", 80, 0),
+			newPeer("other-a", 100, "full", 80, 0),
+			newPeer("other-b", 100, "full", 80, 0),
 		}
 		criteria := advertisedProbeCriteria(50)
 		criteria.PreviousPeer = "prev"
-		require.Equal(t, "other", ps.SelectSyncPeer(peers, criteria))
+		got := ps.SelectSyncPeer(peers, criteria)
+		require.Contains(t, []string{"other-a", "other-b"}, got)
+	}
+}
+
+func TestPeerSelector_ComparePeerCandidates_Antisymmetric(t *testing.T) {
+	ps := newSelectorForTest()
+	now := time.Now()
+	window := 24 * time.Hour
+
+	// Peers varying one criterion at a time plus mixed combinations; the
+	// hand-written three-way comparator must satisfy compare(a,b) == -compare(b,a)
+	// and compare(a,a) == 0 for sort.Slice and the band scan to be sound.
+	peers := []*blockchain.PeerInfo{
+		newPeer("base", 100, "full", 80, 0),
+		withRecentFullBlockDelivery(newPeer("proven", 100, "full", 80, 0)),
+		withValidatedWork(newPeer("more-work", 100, "full", 80, 0), 100, []byte{0x05}),
+		withValidatedWork(newPeer("less-work", 100, "full", 80, 0), 100, []byte{0x03}),
+		newPeer("high-rep", 100, "full", 95, 0),
+		newPeer("banned-ish", 100, "full", 80, 30),
+		withValidatedWork(newPeer("tall", 100, "full", 80, 0), 500, []byte{0x03}),
+		withRecentFullBlockDelivery(withValidatedWork(newPeer("mixed", 100, "full", 60, 10), 200, []byte{0x04})),
+	}
+	peers[4].AvgResponseTimeMs = 50
+	peers[5].AvgResponseTimeMs = 500
+
+	for _, a := range peers {
+		for _, b := range peers {
+			ab := ps.comparePeerCandidates(a, b, now, window)
+			ba := ps.comparePeerCandidates(b, a, now, window)
+			require.Equal(t, -ba, ab, "compare(%s,%s) must be antisymmetric", a.ID, b.ID)
+		}
+		require.Zero(t, ps.comparePeerCandidates(a, a, now, window), "compare(%s,%s) must be 0", a.ID, a.ID)
 	}
 }
 

--- a/services/p2p/peer_selector_test.go
+++ b/services/p2p/peer_selector_test.go
@@ -265,6 +265,79 @@ func TestPeerSelector_SelectSyncPeer_StoragePenaltyDemotesFullClaim(t *testing.T
 	require.Equal(t, "full", got)
 }
 
+func TestPeerSelector_SelectFromCandidates_RandomTiebreakCoversWholeTopBand(t *testing.T) {
+	ps := newSelectorForTest()
+
+	// Three peers tied on every merit criterion, plus one strictly worse peer.
+	// Stubbing the random source proves each band member is reachable and the
+	// worse peer never is.
+	tied := []string{"tied-1", "tied-2", "tied-3"}
+	for want := range len(tied) {
+		peers := []*blockchain.PeerInfo{
+			newPeer("tied-2", 100, "full", 80, 0),
+			newPeer("tied-3", 100, "full", 80, 0),
+			newPeer("tied-1", 100, "full", 80, 0),
+			newPeer("worse", 100, "full", 50, 0),
+		}
+
+		ps.randIntN = func(n int) int {
+			require.Equal(t, 3, n, "top band must contain exactly the three tied peers")
+			return want
+		}
+
+		got := ps.SelectSyncPeer(peers, advertisedProbeCriteria(50))
+		require.Contains(t, tied, got)
+		require.NotEqual(t, "worse", got)
+	}
+}
+
+func TestPeerSelector_SelectSyncPeer_GrindableIDCannotCaptureSelection(t *testing.T) {
+	ps := newSelectorForTest()
+
+	// The attacker ID sorts lexicographically before every honest ID. With the
+	// old ID tiebreak it would win 100% of the time; with random tiebreaks it
+	// must lose at least once over many rounds. P(all 200 rounds pick the
+	// attacker among 4 tied peers) = 0.25^200, so this cannot flake.
+	attackerWins := 0
+	const rounds = 200
+	for range rounds {
+		peers := []*blockchain.PeerInfo{
+			newPeer("000000-ground-attacker-id", 100, "full", 80, 0),
+			newPeer("honest-a", 100, "full", 80, 0),
+			newPeer("honest-b", 100, "full", 80, 0),
+			newPeer("honest-c", 100, "full", 80, 0),
+		}
+		if ps.SelectSyncPeer(peers, advertisedProbeCriteria(50)) == "000000-ground-attacker-id" {
+			attackerWins++
+		}
+	}
+	require.Less(t, attackerWins, rounds, "attacker with lexicographically smallest ID must not win every selection")
+}
+
+func TestPeerSelector_SelectSyncPeer_PreviousPeerExcludedFromTiedTopBand(t *testing.T) {
+	ps := newSelectorForTest()
+
+	// Previous peer ties with one other candidate; it must never be re-drawn.
+	for range 50 {
+		peers := []*blockchain.PeerInfo{
+			newPeer("prev", 100, "full", 80, 0),
+			newPeer("other", 100, "full", 80, 0),
+		}
+		criteria := advertisedProbeCriteria(50)
+		criteria.PreviousPeer = "prev"
+		require.Equal(t, "other", ps.SelectSyncPeer(peers, criteria))
+	}
+}
+
+func TestPeerSelector_SelectSyncPeer_PreviousPeerKeptWhenOnlyCandidate(t *testing.T) {
+	ps := newSelectorForTest()
+
+	peers := []*blockchain.PeerInfo{newPeer("prev", 100, "full", 80, 0)}
+	criteria := advertisedProbeCriteria(50)
+	criteria.PreviousPeer = "prev"
+	require.Equal(t, "prev", ps.SelectSyncPeer(peers, criteria), "sole candidate is selected even if it was the previous peer")
+}
+
 func TestPeerSelector_SelectSyncPeer_UnprovenProbeBudgetBoundsHeaderOnlyPeers(t *testing.T) {
 	ps := newSelectorForTest()
 	peers := []*blockchain.PeerInfo{

--- a/services/p2p/sync_coordinator_test.go
+++ b/services/p2p/sync_coordinator_test.go
@@ -322,6 +322,43 @@ func TestSyncCoordinator_SelectNewSyncPeer_PrefersFullNode(t *testing.T) {
 	require.Equal(t, "full", sc.selectNewSyncPeer())
 }
 
+func TestSyncCoordinator_SelectNewSyncPeer_MeritTiedSybilCannotCapture(t *testing.T) {
+	sc, reg := newTestSyncCoordinator(t)
+	setSyncCoordinatorLocalTip(t, sc, 10, []byte{0x02})
+
+	// One attacker ID that sorts lexicographically first among four peers tied
+	// on every merit criterion. Through the real coordinator selection path it
+	// must not win every round; the removed peer-ID tiebreak gave it 100%
+	// capture. P(some tied peer never wins in 100 rounds) <= 4 * 0.75^100,
+	// so this cannot flake.
+	ids := []string{"000000-attacker", "honest-a", "honest-b", "honest-c"}
+	for _, id := range ids {
+		reg.Register(&blockchain.PeerInfo{
+			ID:                 id,
+			DataHubURL:         "http://" + id,
+			Height:             100,
+			BlockHash:          syncCoordinatorTestHash(t),
+			Storage:            "full",
+			ValidatedHeight:    100,
+			ValidatedBlockHash: syncCoordinatorTestHash(t),
+			ValidatedChainWork: []byte{0x03},
+		})
+		for i := 0; i < 5; i++ {
+			reg.UpdateMetrics(id, 0, 0, 0, true, false, false, 100)
+		}
+	}
+
+	wins := map[string]int{}
+	for range 100 {
+		got := sc.selectNewSyncPeer()
+		require.Contains(t, ids, got)
+		wins[got]++
+	}
+	for _, id := range ids {
+		require.Positive(t, wins[id], "every merit-tied peer must win at least once, got %v", wins)
+	}
+}
+
 func TestSyncCoordinator_FilterEligiblePeers_DropsLowAndOldPeer(t *testing.T) {
 	sc, _ := newTestSyncCoordinator(t)
 


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4723.**

### Problem

`selectFromCandidates` in `services/p2p/peer_selector.go` sorted candidates with a fully deterministic comparator whose final tiebreak was `candidates[i].ID < candidates[j].ID`, then always picked index 0. libp2p peer IDs are cheap to grind, so a Sybil attacker who matches the higher-priority criteria (reputation starts high for new peers; advertised height is peer-controlled) could mint an ID that sorts first and deterministically win sync-peer selection, biasing the node toward attacker-controlled catchup sources.

The issue was confirmed still valid on current `main`. Since it was filed the comparator gained two stronger leading criteria (proven recent full-block delivery and locally validated chain work), which already implement the issue's "weight by proven successful-interaction history" suggestion, but the grindable ID tiebreak at the bottom remained.

### Fix

- Extracted the sort comparator into a three-way `comparePeerCandidates` (proven delivery, validated chain work, reputation, response time, ban score, validated height) and removed the peer-ID tiebreak entirely.
- Candidates that tie on every merit criterion form the top band, and the winner is drawn uniformly at random from that band. Randomness comes from `math/rand/v2.IntN` (per-thread ChaCha8 seeded from OS entropy, not observable or predictable by a remote attacker, so crypto/rand is unnecessary); the source is injectable on `PeerSelector` for deterministic tests, with a nil-guard fallback so a future struct-literal construction cannot panic.
- The previous peer is excluded from selection whenever an alternative candidate exists, so a tied previous peer cannot be re-drawn from the top band. Production callers already strip the previous peer in `filterEligiblePeersWithTip`, so this is defence-in-depth at the selector layer, not a behavior change.
- Selection log now includes `topBandSize` so operators can tell "randomised among N equals" from "single clear winner".
- Updated stale docs that specified the removed ID tiebreak as design: `docs/topics/features/peer_registry_reputation.md` (selection criteria list was also stale in other ways) and the diagram source `docs/topics/features/img/peer_selection_sequence.puml`.

### Residual

- `docs/topics/features/img/peer_selection_sequence.svg` still shows the old "Peer ID" tiebreak; the `.puml` source is updated but plantuml is not available locally to regenerate the SVG.
- Randomisation engages only on exact ties across all six criteria. With N merit-tied Sybils against H merit-tied honest peers, capture probability per selection drops from 100% to N/(N+H) - proportional, not eliminated. The stronger bound remains the unproven-probe budget and the proven-delivery/validated-work criteria an attacker must genuinely satisfy to reach the top band.

### Tests

Added:

- `TestPeerSelector_SelectFromCandidates_RandomTiebreakCoversWholeTopBand` - stubs the random source; asserts the top band contains exactly the merit-tied peers, every band member is reachable (distinct results across indices), and a strictly worse peer never is.
- `TestPeerSelector_SelectSyncPeer_GrindableIDCannotCaptureSelection` - among 4 tied peers including an attacker ID that sorts lexicographically first, every peer must win at least once over 200 rounds (flake probability ~1e-24); catches any fixed-index selection.
- `TestPeerSelector_ComparePeerCandidates_Antisymmetric` - property check that the hand-written three-way comparator satisfies compare(a,b) == -compare(b,a) and compare(a,a) == 0, keeping `sort.Slice` and the band scan sound.
- `TestPeerSelector_SelectSyncPeer_PreviousPeerExcludedFromTiedTopBand` and `TestPeerSelector_SelectSyncPeer_PreviousPeerKeptWhenOnlyCandidate` - previous-peer exclusion semantics.
- `TestSyncCoordinator_SelectNewSyncPeer_MeritTiedSybilCannotCapture` - end-to-end through the real coordinator selection path (`selectNewSyncPeer` with registry, eligibility filtering, and criteria construction): a merit-tied Sybil ID that sorts first must not capture selection; every tied peer wins at least once over 100 rounds.

Ran (green):

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
go vet ./services/p2p/
```
