### PR TITLE
fix(rewindblockchain): open the subtree store with the node's hashPrefix (#1351)

### DIFF
--- a/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
@@ -154,9 +154,23 @@ func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult
 // deleteUTXOPersisterLastProcessed removes the file the utxo persister uses
 // to track its position. On next startup it will recompute from block
 // data — which is the correct behaviour post-rewind.
+//
+// NOTE: this Del does not currently match what the persister writes, and never
+// has. services/utxopersister/Server.go:772,826 uses the BLOCK store with
+// options.WithFilename("lastProcessed") and options.WithNoHashPrefix(), which
+// resolves to <blockstore>/lastProcessed.dat. This call uses the SUBTREE store
+// with filename "lastProcessed.dat", and ConstructFilename appends "." +
+// fileType, so it targets <subtreestore>/lastProcessed.dat.dat — a different
+// store and a different name. The Del is best-effort, so the miss is swallowed
+// by the Debugf below. Fixing it needs the block store, which resolveStores
+// does not open; tracked separately rather than widened into the hashPrefix fix.
+//
+// WithNoHashPrefix is passed so that giving the subtree store the node's
+// hashPrefix (see newSubtreeStore) leaves this path exactly as it was.
 func (e *env) deleteUTXOPersisterLastProcessed(ctx context.Context) error {
 	key := []byte(utxoPersisterLastHeightFn)
-	if err := e.subtreeStore.Del(ctx, key, fileformat.FileTypeDat, options.WithFilename(utxoPersisterLastHeightFn)); err != nil {
+	if err := e.subtreeStore.Del(ctx, key, fileformat.FileTypeDat,
+		options.WithFilename(utxoPersisterLastHeightFn), options.WithNoHashPrefix()); err != nil {
 		// Best-effort. Log and continue.
 		e.logger.Debugf("delete utxo-persister lastProcessed.dat: %v", err)
 	}

--- a/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
+++ b/cmd/rewindblockchain/rewindblockchain/phase3_finalize.go
@@ -163,10 +163,14 @@ func (e *env) resetBlockPersisterHeight(ctx context.Context, pf *preflightResult
 // fileType, so it targets <subtreestore>/lastProcessed.dat.dat — a different
 // store and a different name. The Del is best-effort, so the miss is swallowed
 // by the Debugf below. Fixing it needs the block store, which resolveStores
-// does not open; tracked separately rather than widened into the hashPrefix fix.
+// does not open; tracked in #1353 rather than widened into the hashPrefix fix.
 //
-// WithNoHashPrefix is passed so that giving the subtree store the node's
-// hashPrefix (see newSubtreeStore) leaves this path exactly as it was.
+// WithNoHashPrefix does more than keep this path byte-identical now that the
+// store carries the node's hashPrefix (see newSubtreeStore). Without it
+// CalculatePrefix would derive "la" from the filename "lastProcessed.dat", and
+// ConstructFilename MkdirAlls the prefix folder on every call including Del
+// (stores/blob/options/Options.go:397-401) — so each rewind would leave a stray
+// empty <subtreestore>/la/ behind while still deleting nothing.
 func (e *env) deleteUTXOPersisterLastProcessed(ctx context.Context) error {
 	key := []byte(utxoPersisterLastHeightFn)
 	if err := e.subtreeStore.Del(ctx, key, fileformat.FileTypeDat,

--- a/cmd/rewindblockchain/rewindblockchain/rewind.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind.go
@@ -2,11 +2,13 @@ package rewindblockchain
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/blob"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	"github.com/bsv-blockchain/teranode/stores/blockchain"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	utxofactory "github.com/bsv-blockchain/teranode/stores/utxo/factory"
@@ -139,9 +141,9 @@ func resolveStores(ctx context.Context, logger ulogger.Logger, s *settings.Setti
 		return nil, false, errors.NewConfigurationError("failed to open utxo store", err)
 	}
 
-	subtreeStore, err := blob.NewStore(logger, s.SubtreeValidation.SubtreeStore)
+	subtreeStore, err := newSubtreeStore(logger, s)
 	if err != nil {
-		return nil, false, errors.NewConfigurationError("failed to open subtree blob store", err)
+		return nil, false, err
 	}
 
 	return &Stores{
@@ -149,6 +151,43 @@ func resolveStores(ctx context.Context, logger ulogger.Logger, s *settings.Setti
 		UTXO:       utxoStore,
 		Subtree:    subtreeStore,
 	}, true, nil
+}
+
+// newSubtreeStore opens the subtree blob store the same way the node does.
+//
+// blob.NewStore does NOT read hashPrefix from the URL query — stores/blob/factory.go
+// parses only batch, logger, sizeInBytes and writeKeys. hashPrefix reaches the store
+// solely as an option, which the daemon supplies (daemon/daemon_stores.go:454-479).
+// Without it Options.HashPrefix stays 0, CalculatePrefix returns "", and every key
+// resolves to a flat path while the node writes hash-sharded ones — so every read
+// misses with NOT_FOUND and Phase 2 cannot rewind a file:// deployment at all.
+//
+// Only WithHashPrefix is mirrored here: the daemon's other options drive
+// DAH-managed lifecycle, and this tool wants raw Dels.
+func newSubtreeStore(logger ulogger.Logger, s *settings.Settings) (blob.Store, error) {
+	subtreeStoreURL := s.SubtreeValidation.SubtreeStore
+	if subtreeStoreURL == nil {
+		return nil, errors.NewConfigurationError("subtreestore URL is not configured")
+	}
+
+	// Same default and query override as daemon.GetSubtreeStore.
+	hashPrefix := 2
+
+	if v := subtreeStoreURL.Query().Get("hashPrefix"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, errors.NewConfigurationError("subtreestore hashPrefix config error", err)
+		}
+
+		hashPrefix = parsed
+	}
+
+	subtreeStore, err := blob.NewStore(logger, subtreeStoreURL, options.WithHashPrefix(hashPrefix))
+	if err != nil {
+		return nil, errors.NewConfigurationError("failed to open subtree blob store", err)
+	}
+
+	return subtreeStore, nil
 }
 
 // env bundles the resolved stores and counters shared across phases.

--- a/cmd/rewindblockchain/rewindblockchain/rewind.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind.go
@@ -2,6 +2,7 @@ package rewindblockchain
 
 import (
 	"context"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -153,33 +154,59 @@ func resolveStores(ctx context.Context, logger ulogger.Logger, s *settings.Setti
 	}, true, nil
 }
 
+// defaultSubtreeHashPrefix matches daemon.GetSubtreeStore's default
+// (daemon/daemon_stores.go:454): a subtree store URL with no ?hashPrefix shards
+// two characters deep. Every shipped subtreestore setting is exactly that — a
+// bare file:// URL with no query — so this default is what real deployments run.
+const defaultSubtreeHashPrefix = 2
+
+// subtreeHashPrefix resolves the hash prefix for the subtree store, mirroring
+// daemon.GetSubtreeStore: default 2, overridden by ?hashPrefix= on the URL.
+func subtreeHashPrefix(subtreeStoreURL *url.URL) (int, error) {
+	v := subtreeStoreURL.Query().Get("hashPrefix")
+	if v == "" {
+		return defaultSubtreeHashPrefix, nil
+	}
+
+	parsed, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, errors.NewConfigurationError("subtreestore hashPrefix config error", err)
+	}
+
+	return parsed, nil
+}
+
 // newSubtreeStore opens the subtree blob store the same way the node does.
 //
-// blob.NewStore does NOT read hashPrefix from the URL query — stores/blob/factory.go
-// parses only batch, logger, sizeInBytes and writeKeys. hashPrefix reaches the store
-// solely as an option, which the daemon supplies (daemon/daemon_stores.go:454-479).
-// Without it Options.HashPrefix stays 0, CalculatePrefix returns "", and every key
-// resolves to a flat path while the node writes hash-sharded ones — so every read
-// misses with NOT_FOUND and Phase 2 cannot rewind a file:// deployment at all.
+// The prefix has to be passed as a store option rather than left to the URL.
+// stores/blob/factory.go parses only batch, logger, sizeInBytes and writeKeys.
+// The file backend does additionally read ?hashPrefix / ?hashSuffix for itself
+// (stores/blob/file/file.go:446-462) and applies them after the options, so on
+// file:// a query parameter would win — but the s3 backend does not read the
+// query at all (s3.go derives its path via CalculatePrefix from the store
+// options alone), and no shipped subtreestore URL carries a query anyway. So
+// with the default configuration the option is the only source of the prefix,
+// and it is the only route that works across backends.
 //
-// Only WithHashPrefix is mirrored here: the daemon's other options drive
+// Without it Options.HashPrefix stays 0, CalculatePrefix returns "", and every
+// key resolves to a flat path while the node writes hash-sharded ones — so every
+// read misses with NOT_FOUND and Phase 2 cannot rewind the deployment at all.
+//
+// Only WithHashPrefix is mirrored from the daemon: its other options drive
 // DAH-managed lifecycle, and this tool wants raw Dels.
+//
+// Known parity gap, inherited from daemon.GetSubtreeStore: neither reads
+// ?hashSuffix, which the file backend turns into a negative HashPrefix and
+// which would therefore override what is passed here.
 func newSubtreeStore(logger ulogger.Logger, s *settings.Settings) (blob.Store, error) {
 	subtreeStoreURL := s.SubtreeValidation.SubtreeStore
 	if subtreeStoreURL == nil {
 		return nil, errors.NewConfigurationError("subtreestore URL is not configured")
 	}
 
-	// Same default and query override as daemon.GetSubtreeStore.
-	hashPrefix := 2
-
-	if v := subtreeStoreURL.Query().Get("hashPrefix"); v != "" {
-		parsed, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, errors.NewConfigurationError("subtreestore hashPrefix config error", err)
-		}
-
-		hashPrefix = parsed
+	hashPrefix, err := subtreeHashPrefix(subtreeStoreURL)
+	if err != nil {
+		return nil, err
 	}
 
 	subtreeStore, err := blob.NewStore(logger, subtreeStoreURL, options.WithHashPrefix(hashPrefix))

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -18,7 +19,9 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/blob"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	blockchain_store "github.com/bsv-blockchain/teranode/stores/blockchain"
 	blockchainoptions "github.com/bsv-blockchain/teranode/stores/blockchain/options"
 	blockchainsql "github.com/bsv-blockchain/teranode/stores/blockchain/sql"
@@ -1478,4 +1481,147 @@ func TestPreflight_WarnsOnInflatedAndLaggingPersisterHeight(t *testing.T) {
 		require.Contains(t, log.infoText(), "it will be rewritten down to the target",
 			"the preflight log must state the decision, not just the numbers")
 	})
+}
+
+// -----------------------------------------------------------------------------
+// Production store construction (resolveStores)
+// -----------------------------------------------------------------------------
+
+// newFileStoreSettings points all three stores at throwaway backends: real
+// file:// subtree storage in a temp dir, in-memory SQL for the other two. The
+// subtree URL deliberately carries no query parameters, matching the resolved
+// config on a real deployment (subtreestore=file:///data/.../subtreestore),
+// where the node's default hashPrefix=2 applies.
+func newFileStoreSettings(t *testing.T, subtreeQuery string) (*settings.Settings, *url.URL) {
+	t.Helper()
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	bcURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	tSettings.BlockChain.StoreURL = bcURL
+
+	utxoURL, err := url.Parse("sqlitememory:///resolve-stores-utxo")
+	require.NoError(t, err)
+	tSettings.UtxoStore.UtxoStore = utxoURL
+
+	raw := "file://" + t.TempDir()
+	if subtreeQuery != "" {
+		raw += "?" + subtreeQuery
+	}
+
+	subtreeURL, err := url.Parse(raw)
+	require.NoError(t, err)
+	tSettings.SubtreeValidation.SubtreeStore = subtreeURL
+
+	return tSettings, subtreeURL
+}
+
+// TestResolveStores_SubtreeStoreReadsWhatTheNodeWrote is the regression test for
+// the bug where the tool opened the subtree store without options.WithHashPrefix.
+// blob.NewStore does not parse hashPrefix from the URL query (stores/blob/factory.go
+// reads only batch, logger, sizeInBytes, writeKeys), so without the option
+// Options.HashPrefix stayed 0, CalculatePrefix returned "", and the tool resolved
+// flat filenames while the node wrote hash-sharded ones. Every read missed with
+// NOT_FOUND and Phase 2 could not rewind any file:// deployment.
+//
+// The existing Rewind tests all inject memory.New() via Options.Stores, which
+// bypasses resolveStores entirely — so none of them could catch this.
+func TestResolveStores_SubtreeStoreReadsWhatTheNodeWrote(t *testing.T) {
+	ctx := context.Background()
+	tSettings, subtreeURL := newFileStoreSettings(t, "")
+
+	hash := chainhash.HashH([]byte("subtree-hashprefix-regression"))
+	payload := []byte("subtree bytes")
+
+	// Write through a store built the way the daemon builds it
+	// (daemon/daemon_stores.go:454-479): hashPrefix 2, so the blob lands in a
+	// two-character shard directory.
+	nodeStore, err := blob.NewStore(logger(), subtreeURL, options.WithHashPrefix(2))
+	require.NoError(t, err)
+	require.NoError(t, nodeStore.Set(ctx, hash[:], fileformat.FileTypeSubtree, payload))
+
+	// Confirm the fixture really is sharded — otherwise this test would pass
+	// against a flat layout too and prove nothing.
+	shard := filepath.Join(subtreeURL.Path, hash.String()[:2])
+	require.DirExists(t, shard, "fixture must be hash-sharded for this test to mean anything")
+
+	// The tool's own construction path must find it.
+	stores, ownedByUs, err := resolveStores(ctx, logger(), tSettings, Options{})
+	require.NoError(t, err)
+	require.True(t, ownedByUs)
+
+	exists, err := stores.Subtree.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
+	require.NoError(t, err)
+	require.True(t, exists,
+		"resolveStores must open the subtree store with the node's hashPrefix; "+
+			"without it every subtree read misses and Phase 2 cannot rewind")
+
+	got, err := stores.Subtree.Get(ctx, hash[:], fileformat.FileTypeSubtree)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+
+	// And the deletion Phase 2 performs must land on the same path.
+	require.NoError(t, stores.Subtree.Del(ctx, hash[:], fileformat.FileTypeSubtree))
+
+	exists, err = stores.Subtree.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
+	require.NoError(t, err)
+	require.False(t, exists, "Del must remove the sharded blob, not a flat path that never existed")
+}
+
+// TestNewSubtreeStore_FlatLayoutMissesShardedBlob pins the mechanism itself, so
+// the regression above cannot be "fixed" by something that merely happens to
+// work. A store opened without the option — the old behaviour — cannot see a
+// blob the node wrote.
+func TestNewSubtreeStore_FlatLayoutMissesShardedBlob(t *testing.T) {
+	ctx := context.Background()
+	_, subtreeURL := newFileStoreSettings(t, "")
+
+	hash := chainhash.HashH([]byte("flat-vs-sharded"))
+
+	nodeStore, err := blob.NewStore(logger(), subtreeURL, options.WithHashPrefix(2))
+	require.NoError(t, err)
+	require.NoError(t, nodeStore.Set(ctx, hash[:], fileformat.FileTypeSubtree, []byte("x")))
+
+	flatStore, err := blob.NewStore(logger(), subtreeURL)
+	require.NoError(t, err)
+
+	exists, err := flatStore.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
+	require.NoError(t, err)
+	require.False(t, exists,
+		"a store opened without WithHashPrefix looks at a flat path — this is the bug, "+
+			"and blob.NewStore never reads hashPrefix from the URL query")
+}
+
+// TestNewSubtreeStore_HonoursHashPrefixQuery covers the override branch: the
+// daemon reads hashPrefix from the URL query, so the tool must too, or a
+// deployment that sets it would break in the same way.
+func TestNewSubtreeStore_HonoursHashPrefixQuery(t *testing.T) {
+	ctx := context.Background()
+	tSettings, subtreeURL := newFileStoreSettings(t, "hashPrefix=4")
+
+	hash := chainhash.HashH([]byte("hashprefix-four"))
+
+	nodeStore, err := blob.NewStore(logger(), subtreeURL, options.WithHashPrefix(4))
+	require.NoError(t, err)
+	require.NoError(t, nodeStore.Set(ctx, hash[:], fileformat.FileTypeSubtree, []byte("y")))
+
+	require.DirExists(t, filepath.Join(subtreeURL.Path, hash.String()[:4]))
+
+	toolStore, err := newSubtreeStore(logger(), tSettings)
+	require.NoError(t, err)
+
+	exists, err := toolStore.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
+	require.NoError(t, err)
+	require.True(t, exists, "hashPrefix from the URL query must reach the store as an option")
+}
+
+// TestNewSubtreeStore_RejectsBadHashPrefix keeps the parse failure loud rather
+// than silently falling back to a layout that would miss every read.
+func TestNewSubtreeStore_RejectsBadHashPrefix(t *testing.T) {
+	tSettings, _ := newFileStoreSettings(t, "hashPrefix=banana")
+
+	_, err := newSubtreeStore(logger(), tSettings)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "hashPrefix")
 }

--- a/cmd/rewindblockchain/rewindblockchain/rewind_test.go
+++ b/cmd/rewindblockchain/rewindblockchain/rewind_test.go
@@ -1549,7 +1549,12 @@ func TestResolveStores_SubtreeStoreReadsWhatTheNodeWrote(t *testing.T) {
 	// The tool's own construction path must find it.
 	stores, ownedByUs, err := resolveStores(ctx, logger(), tSettings, Options{})
 	require.NoError(t, err)
-	require.True(t, ownedByUs)
+	require.True(t, ownedByUs, "resolveStores opened these, so the caller owns closing them")
+
+	// ownedByUs is the close-me signal; honour it.
+	t.Cleanup(func() {
+		require.NoError(t, stores.Subtree.Close(ctx))
+	})
 
 	exists, err := stores.Subtree.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
 	require.NoError(t, err)
@@ -1593,35 +1598,74 @@ func TestNewSubtreeStore_FlatLayoutMissesShardedBlob(t *testing.T) {
 			"and blob.NewStore never reads hashPrefix from the URL query")
 }
 
-// TestNewSubtreeStore_HonoursHashPrefixQuery covers the override branch: the
-// daemon reads hashPrefix from the URL query, so the tool must too, or a
-// deployment that sets it would break in the same way.
-func TestNewSubtreeStore_HonoursHashPrefixQuery(t *testing.T) {
-	ctx := context.Background()
-	tSettings, subtreeURL := newFileStoreSettings(t, "hashPrefix=4")
+// TestSubtreeHashPrefix covers the tool's own prefix resolution directly.
+//
+// This deliberately does NOT assert on file layout. The file backend parses
+// ?hashPrefix for itself and applies it after the store options
+// (stores/blob/file/file.go:446-453), so a layout-based test passes whether or
+// not this code resolves anything — it cannot discriminate. Asserting on the
+// resolved value pins the tool's logic for every backend, including s3, which
+// does not read the query at all.
+func TestSubtreeHashPrefix(t *testing.T) {
+	t.Run("defaults to the daemon's 2 when the URL carries no query", func(t *testing.T) {
+		// This is every shipped subtreestore setting: a bare file:// URL.
+		u, err := url.Parse("file:///data/teranode/subtreestore")
+		require.NoError(t, err)
 
-	hash := chainhash.HashH([]byte("hashprefix-four"))
+		prefix, err := subtreeHashPrefix(u)
+		require.NoError(t, err)
+		require.Equal(t, 2, prefix, "must match daemon.GetSubtreeStore's default")
+	})
 
-	nodeStore, err := blob.NewStore(logger(), subtreeURL, options.WithHashPrefix(4))
-	require.NoError(t, err)
-	require.NoError(t, nodeStore.Set(ctx, hash[:], fileformat.FileTypeSubtree, []byte("y")))
+	t.Run("honours an explicit ?hashPrefix", func(t *testing.T) {
+		for _, tc := range []struct {
+			query string
+			want  int
+		}{
+			{"hashPrefix=4", 4},
+			{"hashPrefix=0", 0},
+			{"hashPrefix=-2", -2}, // negative means suffix; parity with the daemon
+		} {
+			u, err := url.Parse("file:///data/teranode/subtreestore?" + tc.query)
+			require.NoError(t, err)
 
-	require.DirExists(t, filepath.Join(subtreeURL.Path, hash.String()[:4]))
+			prefix, err := subtreeHashPrefix(u)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, prefix, "query %q", tc.query)
+		}
+	})
 
-	toolStore, err := newSubtreeStore(logger(), tSettings)
-	require.NoError(t, err)
+	t.Run("rejects a non-numeric ?hashPrefix", func(t *testing.T) {
+		u, err := url.Parse("file:///data/teranode/subtreestore?hashPrefix=banana")
+		require.NoError(t, err)
 
-	exists, err := toolStore.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
-	require.NoError(t, err)
-	require.True(t, exists, "hashPrefix from the URL query must reach the store as an option")
+		_, err = subtreeHashPrefix(u)
+		require.Error(t, err)
+		// Assert on this tool's message, not the substring "hashPrefix": the file
+		// backend also rejects "banana" with a message containing that word, so a
+		// looser assertion would pass even with this parse deleted.
+		require.Contains(t, err.Error(), "subtreestore hashPrefix config error")
+	})
 }
 
-// TestNewSubtreeStore_RejectsBadHashPrefix keeps the parse failure loud rather
-// than silently falling back to a layout that would miss every read.
+// TestNewSubtreeStore_RejectsBadHashPrefix checks the error surfaces through the
+// constructor rather than being swallowed or replaced by the backend's own.
 func TestNewSubtreeStore_RejectsBadHashPrefix(t *testing.T) {
 	tSettings, _ := newFileStoreSettings(t, "hashPrefix=banana")
 
 	_, err := newSubtreeStore(logger(), tSettings)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "hashPrefix")
+	require.Contains(t, err.Error(), "subtreestore hashPrefix config error")
+}
+
+// TestNewSubtreeStore_RejectsNilURL covers the guard added with this fix:
+// blob.NewStore dereferences storeURL.Scheme before any nil check, so an
+// unconfigured subtreestore used to panic.
+func TestNewSubtreeStore_RejectsNilURL(t *testing.T) {
+	tSettings, _ := newFileStoreSettings(t, "")
+	tSettings.SubtreeValidation.SubtreeStore = nil
+
+	_, err := newSubtreeStore(logger(), tSettings)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not configured")
 }


### PR DESCRIPTION
Closes #1351.

## What

`resolveStores` opened the subtree blob store with no options, so `Options.HashPrefix` stayed `0` and `CalculatePrefix` returned `""`. The tool resolved flat filenames while the node writes hash-sharded ones: every subtree read missed with `NOT_FOUND` and Phase 2 died on the first block. `rewindblockchain` could not rewind any `file://` deployment as shipped — which is every deployment.

Mirrors `daemon.GetSubtreeStore` (`daemon/daemon_stores.go:454-479`): hashPrefix defaults to 2, the `?hashPrefix=` query overrides it, and it reaches the store as `options.WithHashPrefix`. Only that option — the daemon's others drive DAH-managed lifecycle, and this tool wants raw `Del`s.

**Correction from review** (thanks @ordishs, @freemans13): the original version of this description — and the comment in the code — claimed `?hashPrefix=2` on the URL could not work around this, because `stores/blob/factory.go` parses only `batch`, `logger`, `sizeInBytes` and `writeKeys`. That is true of the factory, but the **file backend parses the query itself** (`stores/blob/file/file.go:446-462`) and applies it *after* the store options, so on `file://` the query would in fact have won.

The fix stands, for two better reasons now stated in the code instead:

- No shipped `subtreestore` setting carries a query — they are all bare `file://` URLs — so with the default configuration the option is the only source of the node's `hashPrefix=2`.
- `s3` does not read the query at all (it derives its path via `CalculatePrefix` from the store options alone), so the option is the only route that works across backends.

Also now recorded in the code: neither this nor `daemon.GetSubtreeStore` reads `?hashSuffix`, which the file backend turns into a negative `HashPrefix` and which would therefore override what is passed. Inherited parity gap, not introduced here.

## Why nothing caught it

Every existing test injects `memory.New()` via `Options.Stores`, which returns before `resolveStores` constructs anything. The production store-construction path had no coverage at all.

Five tests now cover it, against a real `file://` store in a temp dir plus direct coverage of the prefix resolution:

- **`TestResolveStores_SubtreeStoreReadsWhatTheNodeWrote`** — writes a blob through a store built the daemon's way (`WithHashPrefix(2)`), asserts the fixture really is sharded, then drives `resolveStores` itself and requires `Exists`/`Get`/`Del` all land on it.
- **`TestNewSubtreeStore_FlatLayoutMissesShardedBlob`** — pins the mechanism, so the fix can't be "fixed" by something that merely happens to work.
- **`TestSubtreeHashPrefix`** — the prefix resolution itself: the default of 2 on a bare URL, the `?hashPrefix=` override, and a non-numeric value rejected.
- **`TestNewSubtreeStore_RejectsBadHashPrefix`** / **`TestNewSubtreeStore_RejectsNilURL`** — the error surfaces through the constructor, and the nil-URL guard (`blob.NewStore` dereferences `storeURL.Scheme` before any nil check, so a missing setting used to panic).

**Also from review:** the first two of those were originally written as layout assertions and *could not fail* — because the file backend honours `?hashPrefix` itself, they passed with the entire parse block deleted, and `RejectsBadHashPrefix` passed because `file.newStore` rejects `banana` with a message that also contains the substring `hashPrefix`. They now assert on the resolved value and on this tool's own `subtreestore hashPrefix config error` text. Verified by deleting the parse: both fail.

Verified the regression test actually bites: reintroducing the bug as `WithHashPrefix(0)` fails it with

```
Error:    Should be true
Messages: resolveStores must open the subtree store with the node's hashPrefix;
          without it every subtree read misses and Phase 2 cannot rewind
```

## Separate bug found by the audit

The issue asks to audit `resolveStores` against `daemon_stores.go` as a whole. The subtree store is the only blob store it opens, so that's the only `WithHashPrefix` gap — but the audit turned up something else.

`deleteUTXOPersisterLastProcessed` (`phase3_finalize.go`) has never worked:

| | Persister writes (`services/utxopersister/Server.go:772,826`) | Tool deletes |
|---|---|---|
| Store | **block** store | **subtree** store — different directory |
| Filename | `"lastProcessed"` → `lastProcessed.dat` | `"lastProcessed.dat"` → `lastProcessed.dat.dat` (`ConstructFilename` appends `"." + fileType`) |
| Prefix | `WithNoHashPrefix()` | none |

The `Del` is best-effort and its miss is swallowed by a `Debugf`, which is why it went unnoticed. Fixing it needs the block store, which `resolveStores` does not open — so it's documented in place and left for its own change rather than widened into this one.

Filed as #1353.

What this PR does do is pass `WithNoHashPrefix()` on that `Del`. That keeps the path byte-identical now the store carries a prefix — and, as review pointed out, avoids a second effect: without it `CalculatePrefix` would derive `"la"` from `"lastProcessed.dat"`, and `ConstructFilename` `MkdirAll`s the prefix folder on every call including `Del` (`Options.go:397-401`), so each rewind would leave a stray empty `<subtreestore>/la/` behind while still deleting nothing.

## Testing

`go test ./cmd/rewindblockchain/... ./cmd/teranodecli/...` 57/57, same with `-race`. `go vet` clean. `make lint` 0 issues.

## Scope

`main` only. Backports are handled separately.


## Follow-ups from review

- `newSubtreeStore` is now near-verbatim `daemon_stores.go:454-462`. A shared settings-level helper would stop the two drifting apart the next time the default moves — which is exactly the class of bug being fixed here. Worth its own change.
- Now that subtree deletes actually land, scheduled deletions in `stores/blockchain/sql/blob_deletion.go` deserve a look across a rewind: a row scheduled for subtree X survives, and if the node re-syncs and rewrites X the pruner could delete a live blob when the chain re-crosses that height. Independent of this diff — the tool never schedules deletions — but the runbook (#1346) should cover it.