### PR TITLE
chore: SonarQube shell test operator (S7688) + remaining S1192 constants

### DIFF
--- a/daemon/daemon_stores.go
+++ b/daemon/daemon_stores.go
@@ -24,6 +24,8 @@ import (
 	"github.com/bsv-blockchain/teranode/util/kafka"
 )
 
+const msgCreateBlockHeightTrackerCh = "could not create block height tracker channel"
+
 type Stores struct {
 	mainBlockPersisterStore     blob.Store
 	mainBlockStore              blob.Store
@@ -466,7 +468,7 @@ func (d *Stores) GetSubtreeStore(ctx context.Context, logger ulogger.Logger, app
 
 	ch, err := getBlockHeightTrackerCh(ctx, logger, blockchainClient)
 	if err != nil {
-		return nil, errors.NewServiceError("could not create block height tracker channel", err)
+		return nil, errors.NewServiceError(msgCreateBlockHeightTrackerCh, err)
 	}
 
 	// Get blob deletion scheduler (blockchain client)
@@ -538,7 +540,7 @@ func (d *Stores) GetTempStore(ctx context.Context, logger ulogger.Logger, appSet
 
 	ch, err := getBlockHeightTrackerCh(ctx, logger, blockchainClient)
 	if err != nil {
-		return nil, errors.NewServiceError("could not create block height tracker channel", err)
+		return nil, errors.NewServiceError(msgCreateBlockHeightTrackerCh, err)
 	}
 
 	// Get blob deletion scheduler (blockchain client)
@@ -591,7 +593,7 @@ func (d *Stores) GetBlockStore(ctx context.Context, logger ulogger.Logger, appSe
 
 	ch, err := getBlockHeightTrackerCh(ctx, logger, blockchainClient)
 	if err != nil {
-		return nil, errors.NewServiceError("could not create block height tracker channel", err)
+		return nil, errors.NewServiceError(msgCreateBlockHeightTrackerCh, err)
 	}
 
 	// Get blob deletion scheduler (blockchain client)
@@ -643,7 +645,7 @@ func (d *Stores) GetBlockPersisterStore(ctx context.Context, logger ulogger.Logg
 
 	ch, err := getBlockHeightTrackerCh(ctx, logger, blockchainClient)
 	if err != nil {
-		return nil, errors.NewServiceError("could not create block height tracker channel", err)
+		return nil, errors.NewServiceError(msgCreateBlockHeightTrackerCh, err)
 	}
 
 	// Get blob deletion scheduler (blockchain client)

--- a/scripts/check_error_wrap_verbs.sh
+++ b/scripts/check_error_wrap_verbs.sh
@@ -34,7 +34,7 @@ matches=$(grep -rnE 'errors\.New[A-Za-z]*\(.*%w' \
   --include='*.go' --exclude-dir=vendor . \
   | grep -vE '^\./errors/[^/]*_test\.go:' || true)
 
-if [ -n "$matches" ]; then
+if [[ -n "$matches" ]]; then
   echo "ERROR: %w found inside errors.New* format string(s)."
   echo "The trailing error argument is extracted as the wrapped error before"
   echo "formatting, so %w renders as %!w(MISSING) or survives literally."

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -47,6 +47,11 @@ const (
 	// inheriting the tip's version: at an activation boundary the tip can validly carry the old
 	// floor while the next block requires the new one, so an inherited version could be rejected.
 	miningCandidateVersion uint32 = 0x20000000
+
+	logTxInvalidParent          = "[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s"
+	errGettingBestBlockHeaders  = "error getting best block headers"
+	errMarkingTxsMined          = "error marking transactions as mined on longest chain"
+	errGettingUnminedTxIterator = "error getting unmined tx iterator"
 )
 
 // create state strings for the processor
@@ -2103,7 +2108,7 @@ func (b *BlockAssembler) validateParentChain(
 				if _, isConflictingCascade := conflictingDescendants[parentTxID]; isConflictingCascade {
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s is conflicting (cascade)", parentTxID.String())
-					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 					if filteringEnabled {
 						conflictingDescendants[tx.Hash] = struct{}{}
 					}
@@ -2115,7 +2120,7 @@ func (b *BlockAssembler) validateParentChain(
 				if _, isRejectedCascade := rejectedHashes[parentTxID]; isRejectedCascade {
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s was filtered earlier in this run (cascade)", parentTxID.String())
-					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 					break
 				}
 
@@ -2126,14 +2131,14 @@ func (b *BlockAssembler) validateParentChain(
 					// This means BatchDecorate couldn't find it - it doesn't exist
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s not found in UTXO store", parentTxID.String())
-					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 					break
 				}
 
 				if parentMeta.Conflicting {
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s is conflicting", parentTxID.String())
-					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 					if filteringEnabled {
 						conflictingDescendants[tx.Hash] = struct{}{}
 					}
@@ -2160,7 +2165,7 @@ func (b *BlockAssembler) validateParentChain(
 						// Unmined but not in our list - this is a problem
 						allParentsValid = false
 						invalidReason = fmt.Sprintf("parent tx %s is unmined but not in processing list", parentTxID.String())
-						b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+						b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 						break
 					}
 				} else if len(parentMeta.BlockIDs) > 0 {
@@ -2181,7 +2186,7 @@ func (b *BlockAssembler) validateParentChain(
 						allParentsValid = false
 						invalidReason = fmt.Sprintf("parent tx %s is on wrong chain (blocks: %v) and not in unmined list - data integrity issue from fork handling",
 							parentTxID.String(), parentMeta.BlockIDs)
-						b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+						b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 						break
 					}
 					// else: parent is mined on best chain - all good, continue
@@ -2190,7 +2195,7 @@ func (b *BlockAssembler) validateParentChain(
 					// This should never happen - a tx with unmined_since=0 should have BlockIDs
 					allParentsValid = false
 					invalidReason = fmt.Sprintf("parent tx %s has data inconsistency (unmined_since=0 but no block_ids)", parentTxID.String())
-					b.logger.Warnf("[BlockAssembler][validateParentChain] Transaction %s has invalid parent: %s", tx.Hash.String(), invalidReason)
+					b.logger.Warnf(logTxInvalidParent, tx.Hash.String(), invalidReason)
 					break
 				}
 			}
@@ -2445,7 +2450,7 @@ func (b *BlockAssembler) fixUnminedSinceInconsistencies(ctx context.Context) err
 	bestBlockHeader, _ := b.CurrentBlock()
 	bestBlockHeaderIDs, err := b.blockchainClient.GetBlockHeaderIDs(ctx, bestBlockHeader.Hash(), scanHeaders)
 	if err != nil {
-		return errors.NewProcessingError("error getting best block headers", err)
+		return errors.NewProcessingError(errGettingBestBlockHeaders, err)
 	}
 
 	bestBlockHeaderIDsMap := make(map[uint32]bool, len(bestBlockHeaderIDs))
@@ -2524,7 +2529,7 @@ func (b *BlockAssembler) fixUnminedSinceInconsistencies(ctx context.Context) err
 	if len(markAsMinedOnLongestChain) > 0 {
 		markStart := time.Now()
 		if err = b.utxoStore.MarkTransactionsOnLongestChain(ctx, markAsMinedOnLongestChain, true); err != nil {
-			return errors.NewProcessingError("error marking transactions as mined on longest chain", err)
+			return errors.NewProcessingError(errMarkingTxsMined, err)
 		}
 		b.logger.Infof("[fixUnminedSinceInconsistencies] fixed %d inconsistent transactions in %s",
 			len(markAsMinedOnLongestChain), time.Since(markStart).Truncate(time.Millisecond))
@@ -2616,7 +2621,7 @@ func (b *BlockAssembler) loadUnminedTransactions(ctx context.Context, validateIn
 
 	bestBlockHeaderIDs, err := b.blockchainClient.GetBlockHeaderIDs(ctx, bestBlockHeader.Hash(), scanHeaders)
 	if err != nil {
-		return errors.NewProcessingError("error getting best block headers", err)
+		return errors.NewProcessingError(errGettingBestBlockHeaders, err)
 	}
 
 	bestBlockHeaderIDsMap := make(map[uint32]bool, len(bestBlockHeaderIDs))
@@ -2630,7 +2635,7 @@ func (b *BlockAssembler) loadUnminedTransactions(ctx context.Context, validateIn
 	duration := time.Since(start).Seconds()
 	if err != nil {
 		prometheusBlockAssemblerGetUnminedTxIteratorTime.WithLabelValues("false", "error").Observe(duration)
-		return errors.NewProcessingError("error getting unmined tx iterator", err)
+		return errors.NewProcessingError(errGettingUnminedTxIterator, err)
 	}
 	prometheusBlockAssemblerGetUnminedTxIteratorTime.WithLabelValues("false", "success").Observe(duration)
 	b.logger.Infof("[loadUnminedTransactions] successfully created unmined tx iterator, starting to process transactions")
@@ -2800,7 +2805,7 @@ func (b *BlockAssembler) loadUnminedTransactions(ctx context.Context, validateIn
 	if len(markAsMinedOnLongestChain) > 0 {
 		markStart := time.Now()
 		if err = b.utxoStore.MarkTransactionsOnLongestChain(ctx, markAsMinedOnLongestChain, true); err != nil {
-			return errors.NewProcessingError("error marking transactions as mined on longest chain", err)
+			return errors.NewProcessingError(errMarkingTxsMined, err)
 		}
 		prometheusBlockAssemblerMarkTransactionsTime.Observe(time.Since(markStart).Seconds())
 		prometheusBlockAssemblerMarkTransactionsCount.Add(float64(len(markAsMinedOnLongestChain)))
@@ -3060,7 +3065,7 @@ func (b *BlockAssembler) CheckInputValidation(ctx context.Context) (int, error) 
 	}
 	bestBlockHeaderIDs, err := b.blockchainClient.GetBlockHeaderIDs(ctx, bestBlockHeader.Hash(), 1000)
 	if err != nil {
-		return 0, errors.NewProcessingError("error getting best block headers", err)
+		return 0, errors.NewProcessingError(errGettingBestBlockHeaders, err)
 	}
 
 	bestBlockHeaderIDsMap := make(map[uint32]bool, len(bestBlockHeaderIDs))
@@ -3070,7 +3075,7 @@ func (b *BlockAssembler) CheckInputValidation(ctx context.Context) (int, error) 
 
 	it, err := b.utxoStore.GetUnminedTxIterator()
 	if err != nil {
-		return 0, errors.NewProcessingError("error getting unmined tx iterator", err)
+		return 0, errors.NewProcessingError(errGettingUnminedTxIterator, err)
 	}
 	defer it.Close()
 
@@ -3141,7 +3146,7 @@ func (b *BlockAssembler) loadUnminedTransactionsWithDiskSort(ctx context.Context
 	bestBlockHeader, _ := b.CurrentBlock()
 	bestBlockHeaderIDs, err := b.blockchainClient.GetBlockHeaderIDs(ctx, bestBlockHeader.Hash(), scanHeaders)
 	if err != nil {
-		return errors.NewProcessingError("error getting best block headers", err)
+		return errors.NewProcessingError(errGettingBestBlockHeaders, err)
 	}
 
 	bestBlockHeaderIDsMap := make(map[uint32]bool, len(bestBlockHeaderIDs))
@@ -3155,7 +3160,7 @@ func (b *BlockAssembler) loadUnminedTransactionsWithDiskSort(ctx context.Context
 	duration := time.Since(start).Seconds()
 	if err != nil {
 		prometheusBlockAssemblerGetUnminedTxIteratorTime.WithLabelValues("false", "error").Observe(duration)
-		return errors.NewProcessingError("error getting unmined tx iterator", err)
+		return errors.NewProcessingError(errGettingUnminedTxIterator, err)
 	}
 	prometheusBlockAssemblerGetUnminedTxIteratorTime.WithLabelValues("false", "success").Observe(duration)
 	b.logger.Infof("[loadUnminedTransactionsWithDiskSort] successfully created unmined tx iterator")
@@ -3288,7 +3293,7 @@ func (b *BlockAssembler) loadUnminedTransactionsWithDiskSort(ctx context.Context
 	if len(markAsMinedOnLongestChain) > 0 {
 		markStart := time.Now()
 		if err = b.utxoStore.MarkTransactionsOnLongestChain(ctx, markAsMinedOnLongestChain, true); err != nil {
-			return errors.NewProcessingError("error marking transactions as mined on longest chain", err)
+			return errors.NewProcessingError(errMarkingTxsMined, err)
 		}
 		prometheusBlockAssemblerMarkTransactionsTime.Observe(time.Since(markStart).Seconds())
 		prometheusBlockAssemblerMarkTransactionsCount.Add(float64(len(markAsMinedOnLongestChain)))

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -57,9 +57,9 @@ import (
 // workers; 16K buckets at roughly the same total footprint reduces collision
 // probability ~4×. Exported to package-internal callers (tests) so they can
 // construct fresh maps without re-deriving the value.
-const errAddingNodeToSubtree = "error adding node to subtree"
-
 const splitMapBuckets = 16 * 1024
+
+const errAddingNodeToSubtree = "error adding node to subtree"
 
 // splitMapBucketsMax is the inclusive upper bound for
 // BlockAssembly.SplitMapBuckets — driven by the uint16 internal

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -57,6 +57,8 @@ import (
 // workers; 16K buckets at roughly the same total footprint reduces collision
 // probability ~4×. Exported to package-internal callers (tests) so they can
 // construct fresh maps without re-deriving the value.
+const errAddingNodeToSubtree = "error adding node to subtree"
+
 const splitMapBuckets = 16 * 1024
 
 // splitMapBucketsMax is the inclusive upper bound for
@@ -2110,7 +2112,7 @@ func (stp *SubtreeProcessor) addNode(node subtreepkg.Node, parents *subtreepkg.T
 	}
 
 	if err = stp.currentSubtree.Load().AddSubtreeNode(node); err != nil {
-		return errors.NewProcessingError("error adding node to subtree", err)
+		return errors.NewProcessingError(errAddingNodeToSubtree, err)
 	}
 
 	if stp.currentSubtree.Load().IsComplete() {
@@ -2151,7 +2153,7 @@ func (stp *SubtreeProcessor) addNodePreValidated(node subtreepkg.Node, skipNotif
 	}
 
 	if err = stp.currentSubtree.Load().AddSubtreeNode(node); err != nil {
-		return errors.NewProcessingError("error adding node to subtree", err)
+		return errors.NewProcessingError(errAddingNodeToSubtree, err)
 	}
 
 	if stp.currentSubtree.Load().IsComplete() {
@@ -2868,7 +2870,7 @@ func (stp *SubtreeProcessor) reChainSubtrees(fromIndex int) error {
 				// Restore to currentTxMap to avoid inconsistent state
 				stp.currentTxMap.Set(node.Hash, parents)
 				stp.deletedTxs.Delete(node.Hash)
-				return errors.NewProcessingError("error adding node to subtree", err)
+				return errors.NewProcessingError(errAddingNodeToSubtree, err)
 			}
 
 			// Clear from deletedTxs (transaction successfully re-added, no longer deleted)

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -42,6 +42,8 @@ import (
 	"github.com/ordishs/gocore"
 )
 
+const logErrParsingBufferSize = "error parsing utxoPersister_buffer_size %q, using default of 4KB"
+
 // This type is responsible for reading and writing UTXO additions, deletions and sets to and from files.
 
 // The file format is as follows:
@@ -418,7 +420,7 @@ func (us *UTXOSet) GetUTXOAdditionsReader(ctx context.Context) (io.ReadCloser, e
 
 	bufferSize, err := bytesize.Parse(utxopersisterBufferSize)
 	if err != nil {
-		us.logger.Warnf("error parsing utxoPersister_buffer_size %q, using default of 4KB", utxopersisterBufferSize)
+		us.logger.Warnf(logErrParsingBufferSize, utxopersisterBufferSize)
 
 		bufferSize = 4096
 	}
@@ -458,7 +460,7 @@ func (us *UTXOSet) GetUTXODeletionsReader(ctx context.Context) (io.ReadCloser, e
 
 	bufferSize, err := bytesize.Parse(utxopersisterBufferSize)
 	if err != nil {
-		us.logger.Warnf("error parsing utxoPersister_buffer_size %q, using default of 4KB", utxopersisterBufferSize)
+		us.logger.Warnf(logErrParsingBufferSize, utxopersisterBufferSize)
 
 		bufferSize = 4096
 	}
@@ -606,7 +608,7 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 
 		bufferSize, err := bytesize.Parse(utxopersisterBufferSize)
 		if err != nil {
-			us.logger.Warnf("error parsing utxoPersister_buffer_size %q, using default of 4KB", utxopersisterBufferSize)
+			us.logger.Warnf(logErrParsingBufferSize, utxopersisterBufferSize)
 
 			bufferSize = 4096
 		}

--- a/stores/blockchain/sql/blob_deletion.go
+++ b/stores/blockchain/sql/blob_deletion.go
@@ -9,6 +9,8 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 )
 
+const errFailedScanDeletionRow = "failed to scan deletion row"
+
 // ScheduledDeletion represents a blob deletion scheduled for a specific height.
 type ScheduledDeletion struct {
 	ID             int64
@@ -114,7 +116,7 @@ func (s *SQL) GetPendingBlobDeletions(ctx context.Context, height uint32, limit 
 		err := rows.Scan(&d.ID, &d.BlobKey, &d.FileType, &d.StoreType,
 			&d.DeleteAtHeight, &d.RetryCount)
 		if err != nil {
-			return nil, errors.NewStorageError("failed to scan deletion row", err)
+			return nil, errors.NewStorageError(errFailedScanDeletionRow, err)
 		}
 		deletions = append(deletions, &d)
 	}
@@ -206,7 +208,7 @@ func (s *SQL) ListScheduledBlobDeletions(ctx context.Context, filters *ListFilte
 		err := rows.Scan(&d.ID, &d.BlobKey, &d.FileType, &d.StoreType,
 			&d.DeleteAtHeight, &d.RetryCount)
 		if err != nil {
-			return nil, 0, errors.NewStorageError("failed to scan deletion row", err)
+			return nil, 0, errors.NewStorageError(errFailedScanDeletionRow, err)
 		}
 		deletions = append(deletions, &d)
 	}
@@ -323,7 +325,7 @@ func (s *SQL) AcquireBlobDeletionBatch(ctx context.Context, height uint32, limit
 		err := rows.Scan(&d.ID, &d.BlobKey, &d.FileType, &d.StoreType,
 			&d.DeleteAtHeight, &d.RetryCount)
 		if err != nil {
-			return nil, errors.NewStorageError("failed to scan deletion row", err)
+			return nil, errors.NewStorageError(errFailedScanDeletionRow, err)
 		}
 		deletions = append(deletions, &d)
 	}

--- a/stores/txmetacache/improved_cache.go
+++ b/stores/txmetacache/improved_cache.go
@@ -18,6 +18,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	errMaxBytesCannotBeZero      = "maxBytes cannot be zero"
+	errTooBigMaxBytes            = "too big maxBytes=%d; should be smaller than %d"
+	errFailedConvertingMaxChunks = "failed converting maxChunks"
+	errKVDoesNotFitChunk         = "key, value, and k-v length %d bytes doesn't fit to a chunk %d bytes"
+	errCannotAllocateChunk       = "cannot allocate chunk"
+	msgChunks                    = "chunks: "
+)
+
 // ImprovedCache Design Calculations and Memory Model:
 //
 // The cache is designed to efficiently handle billions of transaction entries with
@@ -906,17 +915,17 @@ type bucketNative struct {
 
 func (b *bucketNative) Init(maxBytes uint64, _ int) error {
 	if maxBytes == 0 {
-		return errors.NewProcessingError("maxBytes cannot be zero")
+		return errors.NewProcessingError(errMaxBytesCannotBeZero)
 	}
 
 	if maxBytes >= maxBucketSize {
-		return errors.NewProcessingError("too big maxBytes=%d; should be smaller than %d", maxBytes, maxBucketSize)
+		return errors.NewProcessingError(errTooBigMaxBytes, maxBytes, maxBucketSize)
 	}
 
 	maxChunks := (maxBytes + ChunkSize - 1) / ChunkSize
 	maxChunksInt, errConv := safeconversion.Uint64ToInt(maxChunks)
 	if errConv != nil {
-		return errors.NewProcessingError("failed converting maxChunks", errConv)
+		return errors.NewProcessingError(errFailedConvertingMaxChunks, errConv)
 	}
 
 	b.chunks = make([][]byte, maxChunksInt)
@@ -1044,7 +1053,7 @@ func (b *bucketNative) Set(k, v []byte, h uint64, skipLocking ...bool) error {
 	if kvLen >= ChunkSize {
 		// Do not store too big keys and values, since they do not
 		// fit a chunk.
-		return errors.NewProcessingError("key, value, and k-v length %d bytes doesn't fit to a chunk %d bytes", kvLen, ChunkSize)
+		return errors.NewProcessingError(errKVDoesNotFitChunk, kvLen, ChunkSize)
 	}
 
 	chunks := b.chunks
@@ -1099,7 +1108,7 @@ func (b *bucketNative) Set(k, v []byte, h uint64, skipLocking ...bool) error {
 		chunk, err = b.getChunk()
 
 		if err != nil {
-			return errors.NewProcessingError("cannot allocate chunk", err)
+			return errors.NewProcessingError(errCannotAllocateChunk, err)
 		}
 
 		chunk = chunk[:0]
@@ -1345,11 +1354,11 @@ type bucketTrimmed struct {
 
 func (b *bucketTrimmed) Init(maxBytes uint64, _ int) error {
 	if maxBytes == 0 {
-		return errors.NewInvalidArgumentError("maxBytes cannot be zero")
+		return errors.NewInvalidArgumentError(errMaxBytesCannotBeZero)
 	}
 
 	if maxBytes >= maxBucketSize {
-		return errors.NewProcessingError("too big maxBytes=%d; should be smaller than %d", maxBytes, maxBucketSize)
+		return errors.NewProcessingError(errTooBigMaxBytes, maxBytes, maxBucketSize)
 	}
 
 	// IMPORTANT: Use floor division so this bucket can never mmap more than maxBytes
@@ -1361,7 +1370,7 @@ func (b *bucketTrimmed) Init(maxBytes uint64, _ int) error {
 	b.maxSlabChunks = calcMaxSlabChunks(maxBytes, maxChunks)
 	maxChunksInt, err := safeconversion.Uint64ToInt(maxChunks)
 	if err != nil {
-		return errors.NewProcessingError("failed converting maxChunks", err)
+		return errors.NewProcessingError(errFailedConvertingMaxChunks, err)
 	}
 	b.chunks = make([][]byte, maxChunksInt)
 	// Inner shard count of 1 — see bucketNative.Init for the rationale. The
@@ -1470,7 +1479,7 @@ func (b *bucketTrimmed) UpdateStats(s *Stats) {
 }
 
 func (b *bucketTrimmed) listChunks() {
-	fmt.Println("chunks: ", b.chunks)
+	fmt.Println(msgChunks, b.chunks)
 }
 
 func (b *bucketTrimmed) SetMulti(keys [][]byte, values [][]byte) {
@@ -1505,7 +1514,7 @@ func (b *bucketTrimmed) Set(k, v []byte, h uint64, skipLocking ...bool) error {
 	if kvLen >= ChunkSize {
 		// Do not store too big keys and values, since they do not
 		// fit a chunk.
-		return errors.NewProcessingError("key, value, and k-v length %d bytes doesn't fit to a chunk %d bytes", kvLen, ChunkSize)
+		return errors.NewProcessingError(errKVDoesNotFitChunk, kvLen, ChunkSize)
 	}
 
 	chunks := b.chunks
@@ -1562,7 +1571,7 @@ func (b *bucketTrimmed) Set(k, v []byte, h uint64, skipLocking ...bool) error {
 		chunk, err = b.getChunk()
 
 		if err != nil {
-			return errors.NewProcessingError("cannot allocate chunk", err)
+			return errors.NewProcessingError(errCannotAllocateChunk, err)
 		}
 
 		chunk = chunk[:0]
@@ -1829,11 +1838,11 @@ type bucketPreallocated struct {
 
 func (b *bucketPreallocated) Init(maxBytes uint64, trimRatio int) error {
 	if maxBytes == 0 {
-		return errors.NewProcessingError("maxBytes cannot be zero")
+		return errors.NewProcessingError(errMaxBytesCannotBeZero)
 	}
 
 	if maxBytes >= maxBucketSize {
-		return errors.NewProcessingError("too big maxBytes=%d; should be smaller than %d", maxBytes, maxBucketSize)
+		return errors.NewProcessingError(errTooBigMaxBytes, maxBytes, maxBucketSize)
 	}
 
 	// allocate memory for all chunks of the bucket
@@ -1917,7 +1926,7 @@ func (b *bucketPreallocated) UpdateStats(s *Stats) {
 }
 
 func (b *bucketPreallocated) listChunks() {
-	fmt.Println("chunks: ", b.chunks)
+	fmt.Println(msgChunks, b.chunks)
 }
 
 // SetMulti stores multiple (k, v) entries with 1-1 mapping for the same bucket. OWERWRITES.
@@ -1967,7 +1976,7 @@ func (b *bucketPreallocated) Set(k, v []byte, h uint64, skipLocking ...bool) err
 	if kvLen >= ChunkSize {
 		// Do not store too big keys and values, since they do not
 		// fit a chunk.
-		return errors.NewProcessingError("key, value, and k-v length %d bytes doesn't fit to a chunk %d bytes", kvLen, ChunkSize)
+		return errors.NewProcessingError(errKVDoesNotFitChunk, kvLen, ChunkSize)
 	}
 
 	chunks := b.chunks
@@ -2154,11 +2163,11 @@ type bucketUnallocated struct {
 
 func (b *bucketUnallocated) Init(maxBytes uint64, _ int) error {
 	if maxBytes == 0 {
-		return errors.NewProcessingError("maxBytes cannot be zero")
+		return errors.NewProcessingError(errMaxBytesCannotBeZero)
 	}
 
 	if maxBytes >= maxBucketSize {
-		return errors.NewProcessingError("too big maxBytes=%d; should be smaller than %d", maxBytes, maxBucketSize)
+		return errors.NewProcessingError(errTooBigMaxBytes, maxBytes, maxBucketSize)
 	}
 
 	// IMPORTANT: Use floor division so this bucket can never mmap more than maxBytes
@@ -2172,7 +2181,7 @@ func (b *bucketUnallocated) Init(maxBytes uint64, _ int) error {
 	b.maxSlabChunks = calcMaxSlabChunks(maxBytes, maxChunks)
 	maxChunksInt, err := safeconversion.Uint64ToInt(maxChunks)
 	if err != nil {
-		return errors.NewProcessingError("failed converting maxChunks", err)
+		return errors.NewProcessingError(errFailedConvertingMaxChunks, err)
 	}
 
 	b.chunks = make([][]byte, maxChunksInt)
@@ -2265,7 +2274,7 @@ func (b *bucketUnallocated) UpdateStats(s *Stats) {
 }
 
 func (b *bucketUnallocated) listChunks() {
-	fmt.Println("chunks: ", b.chunks)
+	fmt.Println(msgChunks, b.chunks)
 }
 
 func (b *bucketUnallocated) SetMulti(keys [][]byte, values [][]byte) {
@@ -2300,7 +2309,7 @@ func (b *bucketUnallocated) Set(k, v []byte, h uint64, skipLocking ...bool) erro
 	if kvLen >= ChunkSize {
 		// Do not store too big keys and values, since they do not
 		// fit a chunk.
-		return errors.NewProcessingError("key, value, and k-v length %d bytes doesn't fit to a chunk %d bytes", kvLen, ChunkSize)
+		return errors.NewProcessingError(errKVDoesNotFitChunk, kvLen, ChunkSize)
 	}
 
 	chunks := b.chunks
@@ -2355,7 +2364,7 @@ func (b *bucketUnallocated) Set(k, v []byte, h uint64, skipLocking ...bool) erro
 		chunk, err = b.getChunk()
 
 		if err != nil {
-			return errors.NewProcessingError("cannot allocate chunk", err)
+			return errors.NewProcessingError(errCannotAllocateChunk, err)
 		}
 
 		chunk = chunk[:0]

--- a/util/grpc_helper.go
+++ b/util/grpc_helper.go
@@ -35,6 +35,9 @@ const (
 
 	// Default retry configuration
 	defaultRetryBackoff = 100 * time.Millisecond
+
+	errMsgReadKeyPair    = "failed to read key pair"
+	errMsgReadCaCertFile = "failed to read ca cert file"
 )
 
 // contextKey is a custom type for context keys to avoid collisions.
@@ -409,7 +412,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 		if isServer {
 			cert, err := tls.LoadX509KeyPair(connectionData.CertFile, connectionData.KeyFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read key pair", err)
+				return nil, errors.NewConfigurationError(errMsgReadKeyPair, err)
 			}
 
 			return credentials.NewTLS(&tls.Config{
@@ -431,7 +434,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 		if isServer {
 			cert, err := tls.LoadX509KeyPair(connectionData.CertFile, connectionData.KeyFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read key pair", err)
+				return nil, errors.NewConfigurationError(errMsgReadKeyPair, err)
 			}
 
 			return credentials.NewTLS(&tls.Config{
@@ -443,7 +446,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 			// Load the server's CA certificate from disk
 			caCert, err := os.ReadFile(connectionData.CaCertFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read ca cert file", err)
+				return nil, errors.NewConfigurationError(errMsgReadCaCertFile, err)
 			}
 
 			caCertPool := x509.NewCertPool()
@@ -451,7 +454,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 
 			cert, err := tls.LoadX509KeyPair(connectionData.CertFile, connectionData.KeyFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read key pair", err)
+				return nil, errors.NewConfigurationError(errMsgReadKeyPair, err)
 			}
 
 			return credentials.NewTLS(&tls.Config{
@@ -466,7 +469,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 			// Load the server's CA certificate from disk
 			caCert, err := os.ReadFile(connectionData.CaCertFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read ca cert file", err)
+				return nil, errors.NewConfigurationError(errMsgReadCaCertFile, err)
 			}
 
 			caCertPool := x509.NewCertPool()
@@ -474,7 +477,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 
 			cert, err := tls.LoadX509KeyPair(connectionData.CertFile, connectionData.KeyFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read key pair", err)
+				return nil, errors.NewConfigurationError(errMsgReadKeyPair, err)
 			}
 
 			return credentials.NewTLS(&tls.Config{
@@ -487,7 +490,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 			// Load the server's CA certificate from disk
 			caCert, err := os.ReadFile(connectionData.CaCertFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read ca cert file", err)
+				return nil, errors.NewConfigurationError(errMsgReadCaCertFile, err)
 			}
 
 			caCertPool := x509.NewCertPool()
@@ -495,7 +498,7 @@ func loadTLSCredentials(connectionData *ConnectionOptions, isServer bool) (crede
 
 			cert, err := tls.LoadX509KeyPair(connectionData.CertFile, connectionData.KeyFile)
 			if err != nil {
-				return nil, errors.NewConfigurationError("failed to read key pair", err)
+				return nil, errors.NewConfigurationError(errMsgReadKeyPair, err)
 			}
 
 			return credentials.NewTLS(&tls.Config{


### PR DESCRIPTION
Two small SonarQube cleanups in one PR.

## 1. `shelldre:S7688` (reliability, HIGH) - shell test operator

`scripts/check_error_wrap_verbs.sh:37` used `[ -n "$matches" ]`. Switched to `[[ -n "$matches" ]]` - the safer, more feature-rich construct. The script is `#!/usr/bin/env bash`, so `[[` is available; `bash -n` passes.

## 2. `go:S1192` - the 7 files held back from #1331

The main S1192 sweep (#1331) deliberately excluded 7 files whose literal-substitutions fall *inside pre-existing duplicated blocks*, because touching those lines inflates the `new_duplicated_lines_density` metric. Since that metric is **not a required gate**, those files are included here:

- `stores/txmetacache/improved_cache.go`
- `util/grpc_helper.go`
- `services/blockassembly/BlockAssembler.go`
- `daemon/daemon_stores.go`
- `stores/blockchain/sql/blob_deletion.go`
- `services/utxopersister/UTXOSet.go`
- `services/blockassembly/subtreeprocessor/SubtreeProcessor.go`

Each duplicated literal is now an unexported package-level constant, byte-identical to the literal it replaces. Only exact standalone tokens were replaced (prefixed/suffixed variants left untouched). Purely mechanical, no logic, no `_test.go`, no generated code.

**Note:** SonarQube's `new_duplicated_lines_density` condition will likely go red on this PR (the 7 files' edits sit in pre-existing duplicated blocks - this is not new duplication introduced by the change). That condition is not a required check.

## Verification

- `bash -n` on the shell script - clean
- `go build` across all 7 affected trees + `go vet` - clean
- `gofmt -l` on all changed files - clean
- Test files in affected packages compile; dedup spot-checked (each literal now appears once)