### PR TITLE
fix(aerospike): guard batcher enqueue against Store.Close race

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -124,6 +124,36 @@ type batcherIfc[T any] interface {
 	Close()
 }
 
+// safeBatcherPutCtx enqueues item into b, converting the "send on closed channel"
+// panic — which go-batcher v2.0.4 raises when Put is called after Close — into a
+// returned error. Store.Close closes the batchers during graceful shutdown while
+// external callers (block validation, assembly, …) may still be enqueuing; that
+// race must abort the operation, not crash the process. who labels the call site.
+func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+		}
+	}()
+
+	b.PutCtx(ctx, item)
+
+	return nil
+}
+
+// safeBatcherPut is the Put (no-context) counterpart of safeBatcherPutCtx.
+func safeBatcherPut[T any](b batcherIfc[T], item *T, who string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+		}
+	}()
+
+	b.Put(item)
+
+	return nil
+}
+
 // Store implements the UTXO store interface using Aerospike.
 // It is thread-safe for concurrent access.
 type Store struct {

--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -125,14 +125,19 @@ type batcherIfc[T any] interface {
 }
 
 // safeBatcherPutCtx enqueues item into b, converting the "send on closed channel"
-// panic — which go-batcher v2.0.4 raises when Put is called after Close — into a
+// panic — which go-batcher v2.0.6 raises when Put is called after Close — into a
 // returned error. Store.Close closes the batchers during graceful shutdown while
 // external callers (block validation, assembly, …) may still be enqueuing; that
 // race must abort the operation, not crash the process. who labels the call site.
+//
+// The recovered value is pre-formatted with fmt.Sprintf: the runtime's panic
+// value is a runtime.plainError, which implements error, and errors.New consumes
+// a trailing error argument as the wrapped error rather than formatting it —
+// orphaning the %v verb and mislabelling the result as wrapping an UNKNOWN (0).
 func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, fmt.Sprintf("%v", r))
 		}
 	}()
 
@@ -145,7 +150,7 @@ func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who
 func safeBatcherPut[T any](b batcherIfc[T], item *T, who string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, fmt.Sprintf("%v", r))
 		}
 	}()
 

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -468,7 +468,7 @@ func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.Fie
 }
 
 // putGetBatch enqueues item into the get batcher, converting the
-// "send on closed channel" panic — which go-batcher v2.0.4 raises when Put is
+// "send on closed channel" panic — which go-batcher v2.0.6 raises when Put is
 // called after Close — into a returned error. Store.Close closes the get batcher
 // during shutdown while external callers (e.g. an in-flight block-validation
 // goroutine in checkParentsExistOnChain) may still be calling Get. That race

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -409,13 +409,24 @@ func (s *Store) GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Da
 // getBatcher for processing. It then waits on a shared completion.Group and reads
 // the result from the item's result slot once the wait returns.
 func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.FieldName) (*meta.Data, error) {
+	// Abort early on a cancelled context (e.g. graceful shutdown) before touching
+	// the batcher. Store.Close may have already closed the get batcher's input
+	// channel, and enqueuing into it then panics "send on closed channel". The
+	// putGetBatch guard below converts that panic into a returned error for the
+	// residual race where the store closes while this caller's context is live.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	var res batchGetItemData
 
 	group := completion.NewGroup(1)
 	item := &batchGetItem{hash: *hash, fields: bins, group: group, result: &res}
 
 	if s.getBatcher != nil {
-		s.getBatcher.PutCtx(ctx, item)
+		if err := s.putGetBatch(ctx, item); err != nil {
+			return nil, err
+		}
 	} else {
 		// if the batcher is disabled, we still want to process the request in a go routine
 		go func() {
@@ -454,6 +465,16 @@ func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.Fie
 	}
 
 	return res.Data, res.Err
+}
+
+// putGetBatch enqueues item into the get batcher, converting the
+// "send on closed channel" panic — which go-batcher v2.0.4 raises when Put is
+// called after Close — into a returned error. Store.Close closes the get batcher
+// during shutdown while external callers (e.g. an in-flight block-validation
+// goroutine in checkParentsExistOnChain) may still be calling Get. That race
+// must abort the read, not crash the process.
+func (s *Store) putGetBatch(ctx context.Context, item *batchGetItem) error {
+	return safeBatcherPutCtx(s.getBatcher, ctx, item, "get")
 }
 
 // getTxFromBins reconstructs a Bitcoin transaction from Aerospike bin data.
@@ -688,7 +709,6 @@ func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaD
 
 	err = s.batchOperate(batchPolicy, batchRecords)
 	if err != nil {
-		s.logger.Errorf("error in aerospike map store batch records:\n%v\n%v", batchRecords, err)
 		return errors.NewStorageError("error in aerospike map store batch records", err)
 	}
 
@@ -1293,8 +1313,13 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 
 	for _, item := range items {
 		item.group = group
-		// Wrap the outpoint in OutpointRequest and put it in the batcher
-		s.outpointBatcher.Put(item)
+		// Guard the enqueue: Store.Close may have closed the outpoint batcher while
+		// this caller is still decorating during shutdown. safeBatcherPut converts a
+		// send-on-closed-channel panic into an error instead of crashing the process;
+		// complete the item so the shared group wait below does not hang on it.
+		if err := safeBatcherPut(s.outpointBatcher, item, "outpoint"); err != nil {
+			item.complete(err)
+		}
 	}
 
 	// One shared wait for the whole group, bounded so a wedged outpoint batcher

--- a/stores/utxo/aerospike/get_closed_batcher_test.go
+++ b/stores/utxo/aerospike/get_closed_batcher_test.go
@@ -6,21 +6,32 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/stretchr/testify/require"
 )
 
+// sendOnClosed reproduces the runtime's send-on-closed-channel panic rather than
+// faking it with a string. The real panic value is runtime.plainError, which
+// implements error — a distinction that matters, because errors.New consumes a
+// trailing error argument as the wrapped error instead of formatting it.
+func sendOnClosed() {
+	ch := make(chan struct{}, 1)
+	close(ch)
+	ch <- struct{}{}
+}
+
 // closedGetBatcher is a batcherIfc whose PutCtx panics exactly like go-batcher
-// v2.0.4 does when Put is called after Close ("send on closed channel").
+// v2.0.6 does when Put is called after Close ("send on closed channel").
 type closedGetBatcher struct{}
 
 func (closedGetBatcher) Put(*batchGetItem, ...int) {}
 func (closedGetBatcher) PutCtx(context.Context, *batchGetItem, ...int) {
-	panic("send on closed channel")
+	sendOnClosed()
 }
 func (closedGetBatcher) PutBatch([]*batchGetItem, ...int) {}
 func (closedGetBatcher) PutBatchCtx(context.Context, []*batchGetItem, ...int) {
-	panic("send on closed channel")
+	sendOnClosed()
 }
 func (closedGetBatcher) Trigger()                      {}
 func (closedGetBatcher) SetDrainMode(bool)             {}
@@ -69,14 +80,14 @@ func TestGet_CancelledContextSkipsBatcher(t *testing.T) {
 }
 
 // sendOnClosedBatcher is a generic batcherIfc whose Put/PutCtx panic exactly as
-// go-batcher v2.0.4 does after Close. okBatcher is a no-op (open) batcher.
+// go-batcher v2.0.6 does after Close. okBatcher is a no-op (open) batcher.
 type sendOnClosedBatcher[T any] struct{}
 
-func (sendOnClosedBatcher[T]) Put(*T, ...int)                     { panic("send on closed channel") }
-func (sendOnClosedBatcher[T]) PutCtx(context.Context, *T, ...int) { panic("send on closed channel") }
-func (sendOnClosedBatcher[T]) PutBatch([]*T, ...int)              { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) Put(*T, ...int)                     { sendOnClosed() }
+func (sendOnClosedBatcher[T]) PutCtx(context.Context, *T, ...int) { sendOnClosed() }
+func (sendOnClosedBatcher[T]) PutBatch([]*T, ...int)              { sendOnClosed() }
 func (sendOnClosedBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {
-	panic("send on closed channel")
+	sendOnClosed()
 }
 func (sendOnClosedBatcher[T]) Trigger()                      {}
 func (sendOnClosedBatcher[T]) SetDrainMode(bool)             {}
@@ -94,19 +105,34 @@ func (okBatcher[T]) SetDrainMode(bool)                         {}
 func (okBatcher[T]) SetTickInterval(time.Duration)             {}
 func (okBatcher[T]) Close()                                    {}
 
-// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard used by the
-// spend / locked / outpoint / get enqueue paths: a send-on-closed-channel panic
-// becomes a returned shutdown error, and the open-batcher path returns nil.
+// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard behind the two
+// enqueue paths routed through it — get (putGetBatch) and outpoint
+// (PreviousOutputsDecorate). The spend and locked paths enqueue via PutBatchCtx,
+// for which there is no guard variant; they are not covered here.
+//
+// A send-on-closed-channel panic becomes a returned shutdown error, and the
+// open-batcher path returns nil.
 func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
 	closed := sendOnClosedBatcher[batchGetItem]{}
 
-	errCtx := safeBatcherPutCtx[batchGetItem](closed, context.Background(), &batchGetItem{}, "spend")
+	errCtx := safeBatcherPutCtx[batchGetItem](closed, context.Background(), &batchGetItem{}, "get")
 	require.Error(t, errCtx)
 	require.Contains(t, errCtx.Error(), "shutting down")
 
 	errPut := safeBatcherPut[batchGetItem](closed, &batchGetItem{}, "outpoint")
 	require.Error(t, errPut)
 	require.Contains(t, errPut.Error(), "shutting down")
+
+	// The recovered value must be rendered into the message, not consumed by
+	// errors.New as a trailing wrapped error. runtime.plainError implements
+	// error, so passing it raw orphans the %v verb and mislabels the error as
+	// wrapping an UNKNOWN (0).
+	for _, err := range []error{errCtx, errPut} {
+		require.Contains(t, err.Error(), "send on closed channel")
+		require.NotContains(t, err.Error(), "MISSING")
+		require.False(t, errors.Is(err, errors.ErrUnknown),
+			"guard must not report a spurious ErrUnknown: %s", err.Error())
+	}
 
 	require.NoError(t, safeBatcherPutCtx[batchGetItem](okBatcher[batchGetItem]{}, context.Background(), &batchGetItem{}, "get"))
 	require.NoError(t, safeBatcherPut[batchGetItem](okBatcher[batchGetItem]{}, &batchGetItem{}, "get"))

--- a/stores/utxo/aerospike/get_closed_batcher_test.go
+++ b/stores/utxo/aerospike/get_closed_batcher_test.go
@@ -1,0 +1,113 @@
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/stretchr/testify/require"
+)
+
+// closedGetBatcher is a batcherIfc whose PutCtx panics exactly like go-batcher
+// v2.0.4 does when Put is called after Close ("send on closed channel").
+type closedGetBatcher struct{}
+
+func (closedGetBatcher) Put(*batchGetItem, ...int) {}
+func (closedGetBatcher) PutCtx(context.Context, *batchGetItem, ...int) {
+	panic("send on closed channel")
+}
+func (closedGetBatcher) PutBatch([]*batchGetItem, ...int) {}
+func (closedGetBatcher) PutBatchCtx(context.Context, []*batchGetItem, ...int) {
+	panic("send on closed channel")
+}
+func (closedGetBatcher) Trigger()                      {}
+func (closedGetBatcher) SetDrainMode(bool)             {}
+func (closedGetBatcher) SetTickInterval(time.Duration) {}
+func (closedGetBatcher) Close()                        {}
+
+// TestGet_ClosedBatcherReturnsErrorNotPanic is the regression test for the
+// production crash: during graceful shutdown Store.Close closes the get
+// batcher while an in-flight block-validation goroutine
+// (checkParentsExistOnChain -> Get) is still calling Get. Enqueuing into the
+// closed batcher panics "send on closed channel" and crashes the process. The
+// store must surface this as an error, not panic.
+func TestGet_ClosedBatcherReturnsErrorNotPanic(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.getBatcher = closedGetBatcher{}
+
+	var (
+		err error
+	)
+
+	require.NotPanics(t, func() {
+		_, err = s.get(context.Background(), &chainhash.Hash{0x01}, []fields.FieldName{fields.Fee})
+	}, "get() must not propagate the batcher's send-on-closed-channel panic")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shutting down")
+}
+
+// TestGet_CancelledContextSkipsBatcher verifies the cheap fast-path: a cancelled
+// context (graceful shutdown) returns before the batcher is touched at all, so
+// the read aborts without risking the enqueue panic.
+func TestGet_CancelledContextSkipsBatcher(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.getBatcher = closedGetBatcher{} // would panic if reached
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var err error
+
+	require.NotPanics(t, func() {
+		_, err = s.get(ctx, &chainhash.Hash{0x01}, []fields.FieldName{fields.Fee})
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// sendOnClosedBatcher is a generic batcherIfc whose Put/PutCtx panic exactly as
+// go-batcher v2.0.4 does after Close. okBatcher is a no-op (open) batcher.
+type sendOnClosedBatcher[T any] struct{}
+
+func (sendOnClosedBatcher[T]) Put(*T, ...int)                     { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) PutCtx(context.Context, *T, ...int) { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) PutBatch([]*T, ...int)              { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {
+	panic("send on closed channel")
+}
+func (sendOnClosedBatcher[T]) Trigger()                      {}
+func (sendOnClosedBatcher[T]) SetDrainMode(bool)             {}
+func (sendOnClosedBatcher[T]) SetTickInterval(time.Duration) {}
+func (sendOnClosedBatcher[T]) Close()                        {}
+
+type okBatcher[T any] struct{}
+
+func (okBatcher[T]) Put(*T, ...int)                            {}
+func (okBatcher[T]) PutCtx(context.Context, *T, ...int)        {}
+func (okBatcher[T]) PutBatch([]*T, ...int)                     {}
+func (okBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {}
+func (okBatcher[T]) Trigger()                                  {}
+func (okBatcher[T]) SetDrainMode(bool)                         {}
+func (okBatcher[T]) SetTickInterval(time.Duration)             {}
+func (okBatcher[T]) Close()                                    {}
+
+// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard used by the
+// spend / locked / outpoint / get enqueue paths: a send-on-closed-channel panic
+// becomes a returned shutdown error, and the open-batcher path returns nil.
+func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
+	closed := sendOnClosedBatcher[batchGetItem]{}
+
+	errCtx := safeBatcherPutCtx[batchGetItem](closed, context.Background(), &batchGetItem{}, "spend")
+	require.Error(t, errCtx)
+	require.Contains(t, errCtx.Error(), "shutting down")
+
+	errPut := safeBatcherPut[batchGetItem](closed, &batchGetItem{}, "outpoint")
+	require.Error(t, errPut)
+	require.Contains(t, errPut.Error(), "shutting down")
+
+	require.NoError(t, safeBatcherPutCtx[batchGetItem](okBatcher[batchGetItem]{}, context.Background(), &batchGetItem{}, "get"))
+	require.NoError(t, safeBatcherPut[batchGetItem](okBatcher[batchGetItem]{}, &batchGetItem{}, "get"))
+}


### PR DESCRIPTION
Extracted from `feat/teranode-native-ops` (PR #1360) as the first of a 6-PR stack. Independent of the rest — merge first.

## Summary

go-batcher v2.0.4 panics with "send on closed channel" when `Put` is called after `Close`. `Store.Close` closes the get/outpoint batchers during graceful shutdown while block validation and assembly may still be enqueuing — that race currently crashes the process.

- Add generic `safeBatcherPut` / `safeBatcherPutCtx` wrappers that recover the panic and return a `ServiceUnavailable` error instead
- Route the get and outpoint batcher enqueues through them
- `get_closed_batcher_test.go` covers the closed-batcher path, the cancelled-context path, and the panic conversion

## Stack order

1. **this PR** — batcher shutdown-race guards
2. batch diagnostics helpers
3. `aerospike_enable_client_metrics` setting
4. test fixture fixes
5. native operate-path core
6. pruner native-op routing

Later PRs in the stack are branched off this one, so their diffs include this change until it merges.