### PR TITLE
feat(aerospike): add batch diagnostics helpers

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -124,6 +124,36 @@ type batcherIfc[T any] interface {
 	Close()
 }
 
+// safeBatcherPutCtx enqueues item into b, converting the "send on closed channel"
+// panic — which go-batcher v2.0.4 raises when Put is called after Close — into a
+// returned error. Store.Close closes the batchers during graceful shutdown while
+// external callers (block validation, assembly, …) may still be enqueuing; that
+// race must abort the operation, not crash the process. who labels the call site.
+func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+		}
+	}()
+
+	b.PutCtx(ctx, item)
+
+	return nil
+}
+
+// safeBatcherPut is the Put (no-context) counterpart of safeBatcherPutCtx.
+func safeBatcherPut[T any](b batcherIfc[T], item *T, who string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+		}
+	}()
+
+	b.Put(item)
+
+	return nil
+}
+
 // Store implements the UTXO store interface using Aerospike.
 // It is thread-safe for concurrent access.
 type Store struct {

--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -125,14 +125,19 @@ type batcherIfc[T any] interface {
 }
 
 // safeBatcherPutCtx enqueues item into b, converting the "send on closed channel"
-// panic — which go-batcher v2.0.4 raises when Put is called after Close — into a
+// panic — which go-batcher v2.0.6 raises when Put is called after Close — into a
 // returned error. Store.Close closes the batchers during graceful shutdown while
 // external callers (block validation, assembly, …) may still be enqueuing; that
 // race must abort the operation, not crash the process. who labels the call site.
+//
+// The recovered value is pre-formatted with fmt.Sprintf: the runtime's panic
+// value is a runtime.plainError, which implements error, and errors.New consumes
+// a trailing error argument as the wrapped error rather than formatting it —
+// orphaning the %v verb and mislabelling the result as wrapping an UNKNOWN (0).
 func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, fmt.Sprintf("%v", r))
 		}
 	}()
 
@@ -145,7 +150,7 @@ func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who
 func safeBatcherPut[T any](b batcherIfc[T], item *T, who string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, r)
+			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, fmt.Sprintf("%v", r))
 		}
 	}()
 

--- a/stores/utxo/aerospike/batch_diagnostics.go
+++ b/stores/utxo/aerospike/batch_diagnostics.go
@@ -1,0 +1,187 @@
+package aerospike
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+)
+
+func describeAerospikeBatchRecord(batchRecord aerospike.BatchRecordIfc) string {
+	if batchRecord == nil {
+		return "batchRecord=<nil>"
+	}
+
+	rec := batchRecord.BatchRec()
+	if rec == nil {
+		return "batchRecord.BatchRec=<nil>"
+	}
+
+	parts := []string{
+		fmt.Sprintf("resultCode=%s", rec.ResultCode.String()),
+		fmt.Sprintf("inDoubt=%t", rec.InDoubt),
+	}
+
+	if rec.Key != nil {
+		parts = append(parts, fmt.Sprintf("key=%s", rec.Key.String()))
+	}
+
+	if rec.Err != nil {
+		parts = append(parts, fmt.Sprintf("recordErr=%s", rec.Err.Error()))
+	}
+
+	if rec.Record == nil {
+		parts = append(parts, "record=<nil>")
+		return strings.Join(parts, ", ")
+	}
+
+	parts = append(parts, describeAerospikeRecord(rec.Record))
+	return strings.Join(parts, ", ")
+}
+
+func describeAerospikeRecord(record *aerospike.Record) string {
+	if record == nil {
+		return "record=<nil>"
+	}
+
+	// Generation distinguishes a stale-read failure from a missing record, and
+	// the originating node identifies which cluster member served the result —
+	// the signature of a partially-upgraded cluster, where writes fail only on
+	// the nodes that have not been upgraded yet. Both are worth the few
+	// characters even when Bins is absent.
+	parts := []string{fmt.Sprintf("generation=%d", record.Generation)}
+
+	if record.Node != nil {
+		parts = append(parts, fmt.Sprintf("node=%s", record.Node.String()))
+	}
+
+	if record.Bins == nil {
+		parts = append(parts, "bins=<nil>")
+	} else {
+		parts = append(parts, fmt.Sprintf("bins=%s", describeAerospikeBins(record.Bins)))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// binDiagnosticPriority ranks the bins that actually explain a failed
+// BatchOperate — the UTXO accounting counters and the state flags a spend or
+// setMined decision turns on. Bins listed here are rendered before any others.
+//
+// Without this, plain alphabetical ordering plus truncation is actively
+// misleading: fields.go defines 33 bin names, so an alphabetical cut always
+// renders blockHeights…deletedChildren and always discards spentUtxos,
+// totalUtxos, recordUtxos, utxos, utxoSpendableIn and spendingHeight.
+var binDiagnosticPriority = map[string]int{
+	fields.SpentUtxos.String():      0,
+	fields.TotalUtxos.String():      1,
+	fields.RecordUtxos.String():     2,
+	fields.Utxos.String():           3,
+	fields.UtxoSpendableIn.String(): 4,
+	fields.SpendingHeight.String():  5,
+	fields.SpentExtraRecs.String():  6,
+	fields.TotalExtraRecs.String():  7,
+	fields.Conflicting.String():     8,
+	fields.Locked.String():          9,
+	fields.External.String():        10,
+	fields.DeleteAtHeight.String():  11,
+	fields.PreserveUntil.String():   12,
+}
+
+func describeAerospikeBins(bins aerospike.BinMap) string {
+	if len(bins) == 0 {
+		return "{}"
+	}
+
+	keys := make([]string, 0, len(bins))
+	for key := range bins {
+		keys = append(keys, key)
+	}
+
+	// Priority bins first, then alphabetical for everything else so the output
+	// stays stable across calls.
+	sort.Slice(keys, func(i, j int) bool {
+		pi, iPrioritised := binDiagnosticPriority[keys[i]]
+		pj, jPrioritised := binDiagnosticPriority[keys[j]]
+
+		if iPrioritised != jPrioritised {
+			return iPrioritised
+		}
+
+		if iPrioritised && pi != pj {
+			return pi < pj
+		}
+
+		return keys[i] < keys[j]
+	})
+
+	// Sized to cover every prioritised bin plus a few of the alphabetical tail,
+	// keeping the line bounded without cutting into the bins that matter.
+	const maxBins = 16
+
+	parts := make([]string, 0, min(len(keys), maxBins)+1)
+
+	for idx, key := range keys {
+		if idx == maxBins {
+			parts = append(parts, fmt.Sprintf("...+%d more", len(keys)-idx))
+			break
+		}
+
+		parts = append(parts, fmt.Sprintf("%s:%s", key, describeAerospikeValue(bins[key])))
+	}
+
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// maxStringValueLen bounds a rendered string bin so one oversized value cannot
+// dominate the log line.
+const maxStringValueLen = 64
+
+func describeAerospikeValue(value interface{}) string {
+	switch v := value.(type) {
+	case nil:
+		return "<nil>"
+	case []byte:
+		return fmt.Sprintf("%T(len=%d)", value, len(v))
+	case []interface{}:
+		return fmt.Sprintf("%T(len=%d)", value, len(v))
+	case map[interface{}]interface{}:
+		return fmt.Sprintf("%T(len=%d)", value, len(v))
+	case map[string]interface{}:
+		return fmt.Sprintf("%T(len=%d)", value, len(v))
+	case aerospike.OpResults:
+		return fmt.Sprintf("%T(len=%d)", value, len(v))
+	case string:
+		if len(v) > maxStringValueLen {
+			return fmt.Sprintf("%q...(len=%d)", v[:maxStringValueLen], len(v))
+		}
+
+		return fmt.Sprintf("%q", v)
+	case bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, float32, float64:
+		// The counters and flags that explain a batch failure (spentUtxos,
+		// totalUtxos, conflicting, locked, …) land here. Rendering %T would print
+		// "int" / "bool" and tell the reader nothing.
+		return fmt.Sprintf("%v", v)
+	default:
+		return fmt.Sprintf("%T", value)
+	}
+}
+
+func describeChainHash(hash *chainhash.Hash) string {
+	if hash == nil {
+		return "<nil>"
+	}
+	return hash.String()
+}
+
+func describeUTXOSpend(spend *utxo.Spend) string {
+	if spend == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%s:%d", describeChainHash(spend.TxID), spend.Vout)
+}

--- a/stores/utxo/aerospike/batch_diagnostics_test.go
+++ b/stores/utxo/aerospike/batch_diagnostics_test.go
@@ -1,0 +1,186 @@
+package aerospike
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/aerospike-client-go/v8/types"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeAerospikeBatchRecordIncludesResponseShape(t *testing.T) {
+	batchRecord := &aerospike.BatchWrite{}
+	batchRecord.ResultCode = types.OK
+	batchRecord.Record = &aerospike.Record{
+		Generation: 7,
+		Bins: aerospike.BinMap{
+			LuaSuccess.String(): nil,
+			"other":             []byte{1, 2, 3},
+		},
+	}
+
+	got := describeAerospikeBatchRecord(batchRecord)
+
+	for _, want := range []string{
+		"resultCode=OK",
+		"inDoubt=false",
+		"generation=7",
+		"SUCCESS:<nil>",
+		"other:[]uint8(len=3)",
+	} {
+		require.Contains(t, got, want)
+	}
+}
+
+func TestDescribeAerospikeBatchRecordIncludesBatchError(t *testing.T) {
+	batchRecord := &aerospike.BatchWrite{}
+	batchRecord.ResultCode = types.PARAMETER_ERROR
+	batchRecord.Err = aerospike.ErrInvalidParam
+
+	got := describeAerospikeBatchRecord(batchRecord)
+
+	for _, want := range []string{
+		"resultCode=PARAMETER_ERROR",
+		"recordErr=ResultCode: PARAMETER_ERROR",
+		"record=<nil>",
+	} {
+		require.Contains(t, got, want)
+	}
+}
+
+func TestDiagnosticHelpersHandleNilInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "nil batch record", got: describeAerospikeBatchRecord(nil), want: "batchRecord=<nil>"},
+		{name: "nil record", got: describeAerospikeRecord(nil), want: "record=<nil>"},
+		{name: "nil hash", got: describeChainHash(nil), want: "<nil>"},
+		{name: "nil spend", got: describeUTXOSpend(nil), want: "<nil>"},
+		{name: "nil txid spend", got: describeUTXOSpend(&utxo.Spend{}), want: "<nil>:0"},
+		{name: "nil bins", got: describeAerospikeRecord(&aerospike.Record{}), want: "generation=0, bins=<nil>"},
+		{name: "empty bins", got: describeAerospikeBins(aerospike.BinMap{}), want: "{}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+// TestDescribeAerospikeValueRendersScalarsNotTypes covers the arms that decide
+// whether a log line is useful: the counters and flags that explain a batch
+// failure must render their value, while bulk containers stay summarised by
+// length so one record cannot flood the line.
+func TestDescribeAerospikeValueRendersScalarsNotTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{name: "nil", value: nil, want: "<nil>"},
+		{name: "int counter", value: 42, want: "42"},
+		{name: "int64 counter", value: int64(-7), want: "-7"},
+		{name: "uint32 height", value: uint32(910000), want: "910000"},
+		{name: "float", value: 1.5, want: "1.5"},
+		{name: "bool true", value: true, want: "true"},
+		{name: "bool false", value: false, want: "false"},
+		{name: "short string", value: "abc", want: `"abc"`},
+		{name: "byte slice", value: []byte{1, 2, 3, 4}, want: "[]uint8(len=4)"},
+		{name: "interface slice", value: []interface{}{1, 2}, want: "[]interface {}(len=2)"},
+		{name: "iface map", value: map[interface{}]interface{}{1: 2}, want: "map[interface {}]interface {}(len=1)"},
+		{name: "string map", value: map[string]interface{}{"a": 1}, want: "map[string]interface {}(len=1)"},
+		{name: "op results", value: aerospike.OpResults{1, 2, 3}, want: "aerospike.OpResults(len=3)"},
+		{name: "unhandled type falls back to type", value: struct{ A int }{A: 1}, want: "struct { A int }"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, describeAerospikeValue(tt.value))
+		})
+	}
+}
+
+func TestDescribeAerospikeValueCapsLongStrings(t *testing.T) {
+	long := strings.Repeat("x", maxStringValueLen+50)
+
+	got := describeAerospikeValue(long)
+
+	require.Equal(t,
+		fmt.Sprintf("%q...(len=%d)", strings.Repeat("x", maxStringValueLen), len(long)),
+		got)
+	require.Less(t, len(got), len(long),
+		"rendered value must be shorter than the raw string")
+}
+
+// TestDescribeAerospikeBinsPrioritisesDiagnosticBins is the regression test for
+// the truncation defect: with plain alphabetical ordering and a cap of 8, a full
+// 33-bin record always rendered blockHeights…deletedChildren and always dropped
+// the UTXO accounting counters that explain the failure.
+func TestDescribeAerospikeBinsPrioritisesDiagnosticBins(t *testing.T) {
+	bins := aerospike.BinMap{}
+
+	// Every bin the store defines, so the truncation path is exercised for real.
+	for _, name := range []fields.FieldName{
+		fields.Tx, fields.TxID, fields.Inputs, fields.Outputs, fields.External,
+		fields.LockTime, fields.Version, fields.Fee, fields.SizeInBytes,
+		fields.ExtendedSize, fields.TxInpoints, fields.IsCoinbase,
+		fields.Conflicting, fields.ConflictingChildren, fields.Locked,
+		fields.Creating, fields.UtxoSpendableIn, fields.SpendingHeight,
+		fields.Utxos, fields.TotalUtxos, fields.RecordUtxos, fields.SpentUtxos,
+		fields.TotalExtraRecs, fields.SpentExtraRecs, fields.BlockIDs,
+		fields.BlockHeights, fields.SubtreeIdxs, fields.Reassignments,
+		fields.DeleteAtHeight, fields.CreatedAt, fields.UnminedSince,
+		fields.PreserveUntil, fields.DeletedChildren,
+	} {
+		bins[name.String()] = 1
+	}
+
+	require.Len(t, bins, 33, "guard against fields.go drifting from this fixture")
+
+	got := describeAerospikeBins(bins)
+
+	// The bins that explain a BatchOperate failure must survive truncation.
+	for _, name := range []fields.FieldName{
+		fields.SpentUtxos, fields.TotalUtxos, fields.RecordUtxos, fields.Utxos,
+		fields.UtxoSpendableIn, fields.SpendingHeight, fields.Conflicting,
+		fields.Locked, fields.DeleteAtHeight,
+	} {
+		require.Contains(t, got, name.String()+":1",
+			"diagnostic bin %s must survive truncation", name)
+	}
+
+	require.Contains(t, got, "more", "truncation marker expected for a 33-bin record")
+
+	// spentUtxos is the highest-priority bin, so it must lead the rendering —
+	// ahead of the alphabetically-first bin that previously crowded it out.
+	require.Less(t, strings.Index(got, fields.SpentUtxos.String()),
+		strings.Index(got, fields.BlockHeights.String()),
+		"priority bins must precede the alphabetical tail")
+}
+
+func TestDescribeAerospikeBinsIsDeterministic(t *testing.T) {
+	bins := aerospike.BinMap{
+		"zeta":                      1,
+		"alpha":                     2,
+		fields.SpentUtxos.String():  3,
+		fields.TotalUtxos.String():  4,
+		fields.Conflicting.String(): true,
+	}
+
+	first := describeAerospikeBins(bins)
+
+	for i := 0; i < 20; i++ {
+		require.Equal(t, first, describeAerospikeBins(bins),
+			"bin rendering must not depend on map iteration order")
+	}
+
+	// Priority order, then alphabetical tail.
+	require.Equal(t, "{spentUtxos:3, totalUtxos:4, conflicting:true, alpha:2, zeta:1}", first)
+}

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -468,7 +468,7 @@ func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.Fie
 }
 
 // putGetBatch enqueues item into the get batcher, converting the
-// "send on closed channel" panic — which go-batcher v2.0.4 raises when Put is
+// "send on closed channel" panic — which go-batcher v2.0.6 raises when Put is
 // called after Close — into a returned error. Store.Close closes the get batcher
 // during shutdown while external callers (e.g. an in-flight block-validation
 // goroutine in checkParentsExistOnChain) may still be calling Get. That race

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -409,13 +409,24 @@ func (s *Store) GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Da
 // getBatcher for processing. It then waits on a shared completion.Group and reads
 // the result from the item's result slot once the wait returns.
 func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.FieldName) (*meta.Data, error) {
+	// Abort early on a cancelled context (e.g. graceful shutdown) before touching
+	// the batcher. Store.Close may have already closed the get batcher's input
+	// channel, and enqueuing into it then panics "send on closed channel". The
+	// putGetBatch guard below converts that panic into a returned error for the
+	// residual race where the store closes while this caller's context is live.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	var res batchGetItemData
 
 	group := completion.NewGroup(1)
 	item := &batchGetItem{hash: *hash, fields: bins, group: group, result: &res}
 
 	if s.getBatcher != nil {
-		s.getBatcher.PutCtx(ctx, item)
+		if err := s.putGetBatch(ctx, item); err != nil {
+			return nil, err
+		}
 	} else {
 		// if the batcher is disabled, we still want to process the request in a go routine
 		go func() {
@@ -454,6 +465,16 @@ func (s *Store) get(ctx context.Context, hash *chainhash.Hash, bins []fields.Fie
 	}
 
 	return res.Data, res.Err
+}
+
+// putGetBatch enqueues item into the get batcher, converting the
+// "send on closed channel" panic — which go-batcher v2.0.4 raises when Put is
+// called after Close — into a returned error. Store.Close closes the get batcher
+// during shutdown while external callers (e.g. an in-flight block-validation
+// goroutine in checkParentsExistOnChain) may still be calling Get. That race
+// must abort the read, not crash the process.
+func (s *Store) putGetBatch(ctx context.Context, item *batchGetItem) error {
+	return safeBatcherPutCtx(s.getBatcher, ctx, item, "get")
 }
 
 // getTxFromBins reconstructs a Bitcoin transaction from Aerospike bin data.
@@ -688,7 +709,6 @@ func (s *Store) BatchDecorate(ctx context.Context, items []*utxo.UnresolvedMetaD
 
 	err = s.batchOperate(batchPolicy, batchRecords)
 	if err != nil {
-		s.logger.Errorf("error in aerospike map store batch records:\n%v\n%v", batchRecords, err)
 		return errors.NewStorageError("error in aerospike map store batch records", err)
 	}
 
@@ -1293,8 +1313,13 @@ func (s *Store) PreviousOutputsDecorate(_ context.Context, tx *bt.Tx) error {
 
 	for _, item := range items {
 		item.group = group
-		// Wrap the outpoint in OutpointRequest and put it in the batcher
-		s.outpointBatcher.Put(item)
+		// Guard the enqueue: Store.Close may have closed the outpoint batcher while
+		// this caller is still decorating during shutdown. safeBatcherPut converts a
+		// send-on-closed-channel panic into an error instead of crashing the process;
+		// complete the item so the shared group wait below does not hang on it.
+		if err := safeBatcherPut(s.outpointBatcher, item, "outpoint"); err != nil {
+			item.complete(err)
+		}
 	}
 
 	// One shared wait for the whole group, bounded so a wedged outpoint batcher

--- a/stores/utxo/aerospike/get_closed_batcher_test.go
+++ b/stores/utxo/aerospike/get_closed_batcher_test.go
@@ -6,21 +6,32 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/stretchr/testify/require"
 )
 
+// sendOnClosed reproduces the runtime's send-on-closed-channel panic rather than
+// faking it with a string. The real panic value is runtime.plainError, which
+// implements error — a distinction that matters, because errors.New consumes a
+// trailing error argument as the wrapped error instead of formatting it.
+func sendOnClosed() {
+	ch := make(chan struct{}, 1)
+	close(ch)
+	ch <- struct{}{}
+}
+
 // closedGetBatcher is a batcherIfc whose PutCtx panics exactly like go-batcher
-// v2.0.4 does when Put is called after Close ("send on closed channel").
+// v2.0.6 does when Put is called after Close ("send on closed channel").
 type closedGetBatcher struct{}
 
 func (closedGetBatcher) Put(*batchGetItem, ...int) {}
 func (closedGetBatcher) PutCtx(context.Context, *batchGetItem, ...int) {
-	panic("send on closed channel")
+	sendOnClosed()
 }
 func (closedGetBatcher) PutBatch([]*batchGetItem, ...int) {}
 func (closedGetBatcher) PutBatchCtx(context.Context, []*batchGetItem, ...int) {
-	panic("send on closed channel")
+	sendOnClosed()
 }
 func (closedGetBatcher) Trigger()                      {}
 func (closedGetBatcher) SetDrainMode(bool)             {}
@@ -69,14 +80,14 @@ func TestGet_CancelledContextSkipsBatcher(t *testing.T) {
 }
 
 // sendOnClosedBatcher is a generic batcherIfc whose Put/PutCtx panic exactly as
-// go-batcher v2.0.4 does after Close. okBatcher is a no-op (open) batcher.
+// go-batcher v2.0.6 does after Close. okBatcher is a no-op (open) batcher.
 type sendOnClosedBatcher[T any] struct{}
 
-func (sendOnClosedBatcher[T]) Put(*T, ...int)                     { panic("send on closed channel") }
-func (sendOnClosedBatcher[T]) PutCtx(context.Context, *T, ...int) { panic("send on closed channel") }
-func (sendOnClosedBatcher[T]) PutBatch([]*T, ...int)              { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) Put(*T, ...int)                     { sendOnClosed() }
+func (sendOnClosedBatcher[T]) PutCtx(context.Context, *T, ...int) { sendOnClosed() }
+func (sendOnClosedBatcher[T]) PutBatch([]*T, ...int)              { sendOnClosed() }
 func (sendOnClosedBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {
-	panic("send on closed channel")
+	sendOnClosed()
 }
 func (sendOnClosedBatcher[T]) Trigger()                      {}
 func (sendOnClosedBatcher[T]) SetDrainMode(bool)             {}
@@ -94,19 +105,34 @@ func (okBatcher[T]) SetDrainMode(bool)                         {}
 func (okBatcher[T]) SetTickInterval(time.Duration)             {}
 func (okBatcher[T]) Close()                                    {}
 
-// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard used by the
-// spend / locked / outpoint / get enqueue paths: a send-on-closed-channel panic
-// becomes a returned shutdown error, and the open-batcher path returns nil.
+// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard behind the two
+// enqueue paths routed through it — get (putGetBatch) and outpoint
+// (PreviousOutputsDecorate). The spend and locked paths enqueue via PutBatchCtx,
+// for which there is no guard variant; they are not covered here.
+//
+// A send-on-closed-channel panic becomes a returned shutdown error, and the
+// open-batcher path returns nil.
 func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
 	closed := sendOnClosedBatcher[batchGetItem]{}
 
-	errCtx := safeBatcherPutCtx[batchGetItem](closed, context.Background(), &batchGetItem{}, "spend")
+	errCtx := safeBatcherPutCtx[batchGetItem](closed, context.Background(), &batchGetItem{}, "get")
 	require.Error(t, errCtx)
 	require.Contains(t, errCtx.Error(), "shutting down")
 
 	errPut := safeBatcherPut[batchGetItem](closed, &batchGetItem{}, "outpoint")
 	require.Error(t, errPut)
 	require.Contains(t, errPut.Error(), "shutting down")
+
+	// The recovered value must be rendered into the message, not consumed by
+	// errors.New as a trailing wrapped error. runtime.plainError implements
+	// error, so passing it raw orphans the %v verb and mislabels the error as
+	// wrapping an UNKNOWN (0).
+	for _, err := range []error{errCtx, errPut} {
+		require.Contains(t, err.Error(), "send on closed channel")
+		require.NotContains(t, err.Error(), "MISSING")
+		require.False(t, errors.Is(err, errors.ErrUnknown),
+			"guard must not report a spurious ErrUnknown: %s", err.Error())
+	}
 
 	require.NoError(t, safeBatcherPutCtx[batchGetItem](okBatcher[batchGetItem]{}, context.Background(), &batchGetItem{}, "get"))
 	require.NoError(t, safeBatcherPut[batchGetItem](okBatcher[batchGetItem]{}, &batchGetItem{}, "get"))

--- a/stores/utxo/aerospike/get_closed_batcher_test.go
+++ b/stores/utxo/aerospike/get_closed_batcher_test.go
@@ -1,0 +1,113 @@
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/stretchr/testify/require"
+)
+
+// closedGetBatcher is a batcherIfc whose PutCtx panics exactly like go-batcher
+// v2.0.4 does when Put is called after Close ("send on closed channel").
+type closedGetBatcher struct{}
+
+func (closedGetBatcher) Put(*batchGetItem, ...int) {}
+func (closedGetBatcher) PutCtx(context.Context, *batchGetItem, ...int) {
+	panic("send on closed channel")
+}
+func (closedGetBatcher) PutBatch([]*batchGetItem, ...int) {}
+func (closedGetBatcher) PutBatchCtx(context.Context, []*batchGetItem, ...int) {
+	panic("send on closed channel")
+}
+func (closedGetBatcher) Trigger()                      {}
+func (closedGetBatcher) SetDrainMode(bool)             {}
+func (closedGetBatcher) SetTickInterval(time.Duration) {}
+func (closedGetBatcher) Close()                        {}
+
+// TestGet_ClosedBatcherReturnsErrorNotPanic is the regression test for the
+// production crash: during graceful shutdown Store.Close closes the get
+// batcher while an in-flight block-validation goroutine
+// (checkParentsExistOnChain -> Get) is still calling Get. Enqueuing into the
+// closed batcher panics "send on closed channel" and crashes the process. The
+// store must surface this as an error, not panic.
+func TestGet_ClosedBatcherReturnsErrorNotPanic(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.getBatcher = closedGetBatcher{}
+
+	var (
+		err error
+	)
+
+	require.NotPanics(t, func() {
+		_, err = s.get(context.Background(), &chainhash.Hash{0x01}, []fields.FieldName{fields.Fee})
+	}, "get() must not propagate the batcher's send-on-closed-channel panic")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shutting down")
+}
+
+// TestGet_CancelledContextSkipsBatcher verifies the cheap fast-path: a cancelled
+// context (graceful shutdown) returns before the batcher is touched at all, so
+// the read aborts without risking the enqueue panic.
+func TestGet_CancelledContextSkipsBatcher(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.getBatcher = closedGetBatcher{} // would panic if reached
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var err error
+
+	require.NotPanics(t, func() {
+		_, err = s.get(ctx, &chainhash.Hash{0x01}, []fields.FieldName{fields.Fee})
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// sendOnClosedBatcher is a generic batcherIfc whose Put/PutCtx panic exactly as
+// go-batcher v2.0.4 does after Close. okBatcher is a no-op (open) batcher.
+type sendOnClosedBatcher[T any] struct{}
+
+func (sendOnClosedBatcher[T]) Put(*T, ...int)                     { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) PutCtx(context.Context, *T, ...int) { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) PutBatch([]*T, ...int)              { panic("send on closed channel") }
+func (sendOnClosedBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {
+	panic("send on closed channel")
+}
+func (sendOnClosedBatcher[T]) Trigger()                      {}
+func (sendOnClosedBatcher[T]) SetDrainMode(bool)             {}
+func (sendOnClosedBatcher[T]) SetTickInterval(time.Duration) {}
+func (sendOnClosedBatcher[T]) Close()                        {}
+
+type okBatcher[T any] struct{}
+
+func (okBatcher[T]) Put(*T, ...int)                            {}
+func (okBatcher[T]) PutCtx(context.Context, *T, ...int)        {}
+func (okBatcher[T]) PutBatch([]*T, ...int)                     {}
+func (okBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {}
+func (okBatcher[T]) Trigger()                                  {}
+func (okBatcher[T]) SetDrainMode(bool)                         {}
+func (okBatcher[T]) SetTickInterval(time.Duration)             {}
+func (okBatcher[T]) Close()                                    {}
+
+// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard used by the
+// spend / locked / outpoint / get enqueue paths: a send-on-closed-channel panic
+// becomes a returned shutdown error, and the open-batcher path returns nil.
+func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
+	closed := sendOnClosedBatcher[batchGetItem]{}
+
+	errCtx := safeBatcherPutCtx[batchGetItem](closed, context.Background(), &batchGetItem{}, "spend")
+	require.Error(t, errCtx)
+	require.Contains(t, errCtx.Error(), "shutting down")
+
+	errPut := safeBatcherPut[batchGetItem](closed, &batchGetItem{}, "outpoint")
+	require.Error(t, errPut)
+	require.Contains(t, errPut.Error(), "shutting down")
+
+	require.NoError(t, safeBatcherPutCtx[batchGetItem](okBatcher[batchGetItem]{}, context.Background(), &batchGetItem{}, "get"))
+	require.NoError(t, safeBatcherPut[batchGetItem](okBatcher[batchGetItem]{}, &batchGetItem{}, "get"))
+}


### PR DESCRIPTION
Extracted from `feat/teranode-native-ops` (PR #1360). Stacked on #1361 (PR 2 of 6) — its diff includes #1361 until that merges.

## Summary

New `batch_diagnostics.go` with `describeAerospikeBatchRecord`, `describeAerospikeRecord`, `describeAerospikeBins`, `describeAerospikeValue`, `describeChainHash` and `describeUTXOSpend` — compact single-line renderings of Aerospike batch state for error logs. Today batch failures log only a result code, which is not enough to diagnose per-record failures inside large `BatchOperate` calls.

This PR adds the helpers and their unit tests only. Call-site adoption arrives with the native operate-path PR (5 of 6), which rewrites the affected error paths anyway.

## Stack order

1. #1361 — batcher shutdown-race guards
2. **this PR** — batch diagnostics helpers
3. `aerospike_enable_client_metrics` setting
4. test fixture fixes
5. native operate-path core
6. pruner native-op routing