### PR TITLE
perf(aerospike/pruner): route pruner writes through the native-op builder

### DIFF
--- a/stores/utxo/aerospike/native_op_add_deleted_children_integration_test.go
+++ b/stores/utxo/aerospike/native_op_add_deleted_children_integration_test.go
@@ -1,0 +1,143 @@
+//go:build aerospike
+
+package aerospike
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// sumNamespaceStat reads a numeric Aerospike namespace statistic, summed across
+// every node in the cluster.
+func sumNamespaceStat(t *testing.T, db *Store, stat string) int64 {
+	t.Helper()
+
+	cmd := "namespace/" + db.namespace
+
+	var total int64
+
+	nodes := db.client.Cluster().GetNodes()
+	require.NotEmpty(t, nodes, "cluster must expose at least one node")
+
+	infoPolicy := aerospike.NewInfoPolicy()
+
+	for _, nd := range nodes {
+		info, err := nd.RequestInfo(infoPolicy, cmd)
+		require.NoError(t, err)
+
+		for _, kv := range strings.Split(info[cmd], ";") {
+			name, value, found := strings.Cut(kv, "=")
+			if !found || name != stat {
+				continue
+			}
+
+			v, perr := strconv.ParseInt(value, 10, 64)
+			require.NoError(t, perr)
+
+			total += v
+		}
+	}
+
+	return total
+}
+
+// TestNativeOp_AddDeletedChildren_Integration verifies against a real Teraspike
+// server (the BSV fork of aerospike-server with native operate-path support,
+// wire op 200) that the pruner's addDeletedChildren parent-update — the op that
+// PR #1269 re-routed onto the native builder in the combined cleanup path — runs
+// as a NATIVE batch write (zero batch_sub_udf) and correctly mutates the parent's
+// deletedChildren map.
+//
+// It builds the record via exactly the call GetPrunerService's
+// BuildAddDeletedChildrenRecord uses, so it exercises the shared native path the
+// pruner relies on. Skips cleanly on a stock Aerospike image (native-op probe
+// fails); point at a Teraspike build with AEROSPIKE_CONTAINER_IMAGE to run it.
+func TestNativeOp_AddDeletedChildren_Integration(t *testing.T) {
+	InitPrometheusMetrics()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	ctx := context.Background()
+
+	container, err := runAerospikeTestContainer(ctx)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
+
+	t.Cleanup(func() { require.NoError(t, container.Terminate(ctx)) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	port, err := container.ServicePort(ctx)
+	require.NoError(t, err)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.Aerospike.UseNativeTeranodeOps = true
+
+	aeroURL, err := url.Parse(fmt.Sprintf("aerospike://%s:%d/test?set=test&externalStore=file://./data/externalStore", host, port))
+	require.NoError(t, err)
+
+	db, err := New(ctx, logger, tSettings, aeroURL)
+	require.NoError(t, err)
+
+	db.SetExternalStore(memory.New())
+
+	if !db.useNativeTeranodeOps {
+		t.Skipf("native ops not enabled (image %q is not a Teraspike build); set AEROSPIKE_CONTAINER_IMAGE to a native-op server", os.Getenv("AEROSPIKE_CONTAINER_IMAGE"))
+	}
+
+	// Seed a parent record so addDeletedChildren has a record to update
+	// (the op returns TX_NOT_FOUND for a missing record and mutates nothing).
+	var parentHash chainhash.Hash
+	parentHash[0] = 0xAB
+
+	key, err := aerospike.NewKey(db.namespace, db.setName, parentHash[:])
+	require.NoError(t, err)
+	require.NoError(t, db.client.PutBins(nil, key, aerospike.NewBin("seed", 1)))
+
+	var childHash chainhash.Hash
+	childHash[0] = 0xCD
+
+	childList := []interface{}{childHash.String()}
+
+	udfBefore := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+
+	// Build the record exactly as GetPrunerService.BuildAddDeletedChildrenRecord does.
+	rec := db.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key, subOpAddDeletedChildren, "addDeletedChildren", childList)
+
+	_, builtAsUDF := rec.(*aerospike.BatchUDF)
+	require.False(t, builtAsUDF, "a native-op store must build addDeletedChildren as a BatchWrite, not a NewBatchUDF")
+
+	require.NoError(t, db.client.BatchOperate(nil, []aerospike.BatchRecordIfc{rec}))
+	require.NoError(t, rec.BatchRec().Err, "native addDeletedChildren batch operation must succeed")
+
+	// The parent's deletedChildren map must now contain the child hash — proof
+	// the native subOpAddDeletedChildren dispatcher executed server-side.
+	parent, err := db.client.Get(nil, key, fields.DeletedChildren.String())
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+
+	deletedChildren, ok := parent.Bins[fields.DeletedChildren.String()].(map[interface{}]interface{})
+	require.Truef(t, ok, "deletedChildren must be a map, got %T", parent.Bins[fields.DeletedChildren.String()])
+	require.Equal(t, true, deletedChildren[childHash.String()], "child hash must be recorded in the parent's deletedChildren map")
+
+	udfAfter := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+
+	// The decisive check: the parent was mutated (native dispatcher ran) yet the
+	// server's Lua-UDF sub-transaction counter did not move at all. The native
+	// wire-op-200 path is deliberately not counted under batch_sub_udf.
+	require.Equalf(t, udfBefore, udfAfter, "addDeletedChildren must NOT invoke a Lua UDF on a native-op store (batch_sub_udf_complete went %d -> %d)", udfBefore, udfAfter)
+}

--- a/stores/utxo/aerospike/native_op_add_deleted_children_integration_test.go
+++ b/stores/utxo/aerospike/native_op_add_deleted_children_integration_test.go
@@ -22,12 +22,20 @@ import (
 
 // sumNamespaceStat reads a numeric Aerospike namespace statistic, summed across
 // every node in the cluster.
+//
+// It requires the statistic to exist on at least one node. Returning a silent 0
+// for an unknown stat name would make the caller's before/after comparison pass
+// vacuously if the counter were ever renamed or version-gated away — the
+// comparison would be 0 == 0 while proving nothing.
 func sumNamespaceStat(t *testing.T, db *Store, stat string) int64 {
 	t.Helper()
 
 	cmd := "namespace/" + db.namespace
 
-	var total int64
+	var (
+		total int64
+		found bool
+	)
 
 	nodes := db.client.Cluster().GetNodes()
 	require.NotEmpty(t, nodes, "cluster must expose at least one node")
@@ -39,8 +47,8 @@ func sumNamespaceStat(t *testing.T, db *Store, stat string) int64 {
 		require.NoError(t, err)
 
 		for _, kv := range strings.Split(info[cmd], ";") {
-			name, value, found := strings.Cut(kv, "=")
-			if !found || name != stat {
+			name, value, hasValue := strings.Cut(kv, "=")
+			if !hasValue || name != stat {
 				continue
 			}
 
@@ -48,18 +56,20 @@ func sumNamespaceStat(t *testing.T, db *Store, stat string) int64 {
 			require.NoError(t, perr)
 
 			total += v
+			found = true
 		}
 	}
+
+	require.Truef(t, found, "namespace statistic %q not reported by any node — the before/after comparison would be vacuous", stat)
 
 	return total
 }
 
 // TestNativeOp_AddDeletedChildren_Integration verifies against a real Teraspike
 // server (the BSV fork of aerospike-server with native operate-path support,
-// wire op 200) that the pruner's addDeletedChildren parent-update — the op that
-// PR #1269 re-routed onto the native builder in the combined cleanup path — runs
-// as a NATIVE batch write (zero batch_sub_udf) and correctly mutates the parent's
-// deletedChildren map.
+// wire op 200) that the pruner's addDeletedChildren parent-update runs as a
+// NATIVE batch write (zero batch_sub_udf), correctly mutates the parent's
+// deletedChildren map, and answers with a response the pruner can actually read.
 //
 // It builds the record via exactly the call GetPrunerService's
 // BuildAddDeletedChildrenRecord uses, so it exercises the shared native path the
@@ -95,49 +105,115 @@ func TestNativeOp_AddDeletedChildren_Integration(t *testing.T) {
 
 	db.SetExternalStore(memory.New())
 
-	if !db.useNativeTeranodeOps {
+	if !db.useNativeTeranodeOps.Load() {
 		t.Skipf("native ops not enabled (image %q is not a Teraspike build); set AEROSPIKE_CONTAINER_IMAGE to a native-op server", os.Getenv("AEROSPIKE_CONTAINER_IMAGE"))
 	}
-
-	// Seed a parent record so addDeletedChildren has a record to update
-	// (the op returns TX_NOT_FOUND for a missing record and mutates nothing).
-	var parentHash chainhash.Hash
-	parentHash[0] = 0xAB
-
-	key, err := aerospike.NewKey(db.namespace, db.setName, parentHash[:])
-	require.NoError(t, err)
-	require.NoError(t, db.client.PutBins(nil, key, aerospike.NewBin("seed", 1)))
 
 	var childHash chainhash.Hash
 	childHash[0] = 0xCD
 
 	childList := []interface{}{childHash.String()}
 
-	udfBefore := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+	// buildRecord mirrors GetPrunerService.BuildAddDeletedChildrenRecord exactly,
+	// so the test exercises the record the pruner actually emits rather than a
+	// lookalike — including the shared UPDATE_ONLY policy initNativeTeranodeOps
+	// installs, which is what stops a missing parent from being created.
+	buildRecord := func(key *aerospike.Key) aerospike.BatchRecordIfc {
+		return db.teranodeBatchRecord(
+			aerospike.NewBatchUDFPolicy(),
+			LuaPackage,
+			key,
+			subOpAddDeletedChildren,
+			"addDeletedChildren",
+			childList,
+		)
+	}
 
-	// Build the record exactly as GetPrunerService.BuildAddDeletedChildrenRecord does.
-	rec := db.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key, subOpAddDeletedChildren, "addDeletedChildren", childList)
+	t.Run("existing parent is mutated natively", func(t *testing.T) {
+		var parentHash chainhash.Hash
+		parentHash[0] = 0xAB
 
-	_, builtAsUDF := rec.(*aerospike.BatchUDF)
-	require.False(t, builtAsUDF, "a native-op store must build addDeletedChildren as a BatchWrite, not a NewBatchUDF")
+		key, err := aerospike.NewKey(db.namespace, db.setName, parentHash[:])
+		require.NoError(t, err)
+		require.NoError(t, db.client.PutBins(nil, key, aerospike.NewBin("seed", 1)))
 
-	require.NoError(t, db.client.BatchOperate(nil, []aerospike.BatchRecordIfc{rec}))
-	require.NoError(t, rec.BatchRec().Err, "native addDeletedChildren batch operation must succeed")
+		udfBefore := sumNamespaceStat(t, db, "batch_sub_udf_complete")
 
-	// The parent's deletedChildren map must now contain the child hash — proof
-	// the native subOpAddDeletedChildren dispatcher executed server-side.
-	parent, err := db.client.Get(nil, key, fields.DeletedChildren.String())
-	require.NoError(t, err)
-	require.NotNil(t, parent)
+		rec := buildRecord(key)
 
-	deletedChildren, ok := parent.Bins[fields.DeletedChildren.String()].(map[interface{}]interface{})
-	require.Truef(t, ok, "deletedChildren must be a map, got %T", parent.Bins[fields.DeletedChildren.String()])
-	require.Equal(t, true, deletedChildren[childHash.String()], "child hash must be recorded in the parent's deletedChildren map")
+		_, builtAsUDF := rec.(*aerospike.BatchUDF)
+		require.False(t, builtAsUDF, "a native-op store must build addDeletedChildren as a BatchWrite, not a NewBatchUDF")
 
-	udfAfter := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+		require.NoError(t, db.client.BatchOperate(nil, []aerospike.BatchRecordIfc{rec}))
+		require.NoError(t, rec.BatchRec().Err, "native addDeletedChildren batch operation must succeed")
 
-	// The decisive check: the parent was mutated (native dispatcher ran) yet the
-	// server's Lua-UDF sub-transaction counter did not move at all. The native
-	// wire-op-200 path is deliberately not counted under batch_sub_udf.
-	require.Equalf(t, udfBefore, udfAfter, "addDeletedChildren must NOT invoke a Lua UDF on a native-op store (batch_sub_udf_complete went %d -> %d)", udfBefore, udfAfter)
+		// Pin the response shape. The pruner now fails CLOSED on a response it
+		// cannot read, so a dispatcher whose encoding drifts from what
+		// ParseLuaMapResponse accepts must break here rather than at runtime.
+		resp := rec.BatchRec().Record.Bins[nativeOpResultBin]
+		parsed, perr := db.ParseLuaMapResponse(resp)
+		require.NoErrorf(t, perr, "native addDeletedChildren response bin is not parseable (%T)", resp)
+		require.Equal(t, LuaStatusOK, parsed.Status)
+
+		// The parent's deletedChildren map must now contain the child hash — proof
+		// the native subOpAddDeletedChildren dispatcher executed server-side.
+		parent, err := db.client.Get(nil, key, fields.DeletedChildren.String())
+		require.NoError(t, err)
+		require.NotNil(t, parent)
+
+		deletedChildren, ok := parent.Bins[fields.DeletedChildren.String()].(map[interface{}]interface{})
+		require.Truef(t, ok, "deletedChildren must be a map, got %T", parent.Bins[fields.DeletedChildren.String()])
+		require.Equal(t, true, deletedChildren[childHash.String()], "child hash must be recorded in the parent's deletedChildren map")
+
+		udfAfter := sumNamespaceStat(t, db, "batch_sub_udf_complete")
+
+		// The decisive check: the parent was mutated (native dispatcher ran) yet the
+		// server's Lua-UDF sub-transaction counter did not move at all. The native
+		// wire-op-200 path is deliberately not counted under batch_sub_udf.
+		require.Equalf(t, udfBefore, udfAfter, "addDeletedChildren must NOT invoke a Lua UDF on a native-op store (batch_sub_udf_complete went %d -> %d)", udfBefore, udfAfter)
+	})
+
+	// The routine case for the pruner: the parent was already deleted, normally by
+	// the pruner itself. The Lua path this replaces returns TX_NOT_FOUND and writes
+	// nothing. The native path must not create the record instead — a resurrected
+	// parent would hold only deletedChildren (no txid, no deleteAtHeight), so the
+	// DAH scan could never reclaim it and any later read would fail in
+	// extractTxHash. This is what the updateOnly policy exists to guarantee, and it
+	// holds regardless of how the server-fork dispatcher handles a missing record.
+	t.Run("missing parent is not created", func(t *testing.T) {
+		var absentHash chainhash.Hash
+		absentHash[0] = 0xEF
+
+		key, err := aerospike.NewKey(db.namespace, db.setName, absentHash[:])
+		require.NoError(t, err)
+
+		// Make sure it really is absent.
+		existing, err := db.client.Get(nil, key)
+		require.NoError(t, err)
+		require.Nil(t, existing, "precondition: the parent key must not exist")
+
+		rec := buildRecord(key)
+		require.NoError(t, db.client.BatchOperate(nil, []aerospike.BatchRecordIfc{rec}))
+
+		// The op may report the miss either way — as a KEY_NOT_FOUND batch error
+		// (the updateOnly policy rejecting the write) or as an ERROR/TX_NOT_FOUND
+		// response map (the dispatcher guarding existence itself). The pruner
+		// counts both as a skipped parent; what must never happen is a silent
+		// success that leaves a record behind.
+		if batchErr := rec.BatchRec().Err; batchErr != nil {
+			require.Truef(t, batchErr.Matches(aerospike.ErrKeyNotFound.ResultCode),
+				"a missing parent must surface as KEY_NOT_FOUND, got %v", batchErr)
+		} else {
+			resp := rec.BatchRec().Record.Bins[nativeOpResultBin]
+			parsed, perr := db.ParseLuaMapResponse(resp)
+			require.NoErrorf(t, perr, "response bin is not parseable (%T)", resp)
+			require.Equal(t, LuaStatusError, parsed.Status, "a missing parent must not report success")
+			require.Equal(t, LuaErrorCodeTxNotFound, parsed.ErrorCode)
+		}
+
+		// The decisive assertion: no record was created.
+		after, err := db.client.Get(nil, key)
+		require.NoError(t, err)
+		require.Nilf(t, after, "addDeletedChildren must not create a missing parent, but a record now exists: %v", after)
+	})
 }

--- a/stores/utxo/aerospike/native_op_pruner_record_test.go
+++ b/stores/utxo/aerospike/native_op_pruner_record_test.go
@@ -119,3 +119,57 @@ func TestPrunerRecordBuildsNativeWriteOrUDF(t *testing.T) {
 		require.Len(t, hashes, len(childHashes))
 	})
 }
+
+// TestPrunerObserverDemotesOnParameterError proves the callback GetPrunerService
+// hands the pruner (s.demoteNativeOnUnsupported) does what the pruner needs of
+// it: a PARAMETER_ERROR from a mixed-version cluster flips the store onto the UDF
+// path, so subsequent addDeletedChildren records are built as Lua UDFs.
+//
+// The pruner runs its own BatchOperate, so it is the one native call site that
+// cannot reach this method directly — Options.ObserveNativeOpError is the bridge.
+func TestPrunerObserverDemotesOnParameterError(t *testing.T) {
+	key := prunerRecordTestKey(t)
+	childHashes := []interface{}{"child"}
+
+	s := nativeStoreWithSharedPolicy(t)
+
+	// Before: native.
+	rec := s.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key,
+		subOpAddDeletedChildren, "addDeletedChildren", childHashes)
+	_, isUDF := rec.(*aerospike.BatchUDF)
+	require.False(t, isUDF, "precondition: the store starts on the native path")
+
+	// The exact callback the provider passes as Options.ObserveNativeOpError.
+	var observe func(error) = s.demoteNativeOnUnsupported
+
+	observe(aerospike.ErrInvalidParam)
+
+	require.False(t, s.useNativeTeranodeOps.Load(), "PARAMETER_ERROR must demote the store")
+
+	// After: UDF, without the pruner knowing anything about result codes.
+	rec = s.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key,
+		subOpAddDeletedChildren, "addDeletedChildren", childHashes)
+	_, isUDF = rec.(*aerospike.BatchUDF)
+	require.True(t, isUDF, "after demotion addDeletedChildren must fall back to the Lua UDF")
+}
+
+// TestPrunerObserverIgnoresUnrelatedErrors is the other half of the contract: the
+// pruner forwards every parent-update error unfiltered, so the observer must not
+// demote on the ordinary ones. KEY_NOT_FOUND in particular is the routine
+// already-deleted-parent case and arrives constantly.
+func TestPrunerObserverIgnoresUnrelatedErrors(t *testing.T) {
+	for name, err := range map[string]error{
+		"key not found": aerospike.ErrKeyNotFound,
+		"timeout":       aerospike.ErrTimeout,
+		"network":       aerospike.ErrNetwork,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := nativeStoreWithSharedPolicy(t)
+
+			s.demoteNativeOnUnsupported(err)
+
+			require.True(t, s.useNativeTeranodeOps.Load(),
+				"%s must not demote the store off the native path", name)
+		})
+	}
+}

--- a/stores/utxo/aerospike/native_op_pruner_record_test.go
+++ b/stores/utxo/aerospike/native_op_pruner_record_test.go
@@ -1,0 +1,121 @@
+package aerospike
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func prunerRecordTestKey(t *testing.T) *aerospike.Key {
+	t.Helper()
+
+	key, err := aerospike.NewKey("test", "utxo", []byte("parent"))
+	require.NoError(t, err)
+
+	return key
+}
+
+// nativeStoreWithSharedPolicy builds a Store on the native path carrying the
+// same shared write policy initNativeTeranodeOps installs, so the tests below
+// exercise the real policy rather than a stand-in.
+func nativeStoreWithSharedPolicy(t *testing.T) *Store {
+	t.Helper()
+
+	policy := aerospike.NewBatchWritePolicy()
+	policy.RecordExistsAction = aerospike.UPDATE_ONLY
+
+	s := &Store{nativeOpBatchWritePolicy: policy, logger: ulogger.TestLogger{}}
+	s.useNativeTeranodeOps.Store(true)
+
+	return s
+}
+
+// TestNativeOpPolicyNeverCreatesRecords locks the guarantee the pruner's
+// addDeletedChildren routing depends on: a mod-teranode native write must never
+// create its target record.
+//
+// A missing parent is the ROUTINE case for addDeletedChildren — normally a parent
+// the pruner itself already deleted. The Lua function it replaces guards on
+// aerospike:exists(rec) and returns TX_NOT_FOUND without writing. Were the native
+// path to create instead, the resurrected parent would hold only deletedChildren
+// (no txid, no deleteAtHeight): the DAH scan could never reclaim it and
+// extractTxHash would fail on any later read. The client default is
+// create-or-update, so this is not free — initNativeTeranodeOps has to set it.
+func TestNativeOpPolicyNeverCreatesRecords(t *testing.T) {
+	// The client default this overrides — documents why the override is needed.
+	require.Equal(t, aerospike.UPDATE, aerospike.NewBatchWritePolicy().RecordExistsAction,
+		"client default creates the record when absent; the native path must not inherit it")
+
+	s := nativeStoreWithSharedPolicy(t)
+
+	rec := s.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, prunerRecordTestKey(t),
+		subOpAddDeletedChildren, "addDeletedChildren", []interface{}{"child"})
+
+	write, ok := rec.(*aerospike.BatchWrite)
+	require.True(t, ok, "native path must build a BatchWrite")
+	require.Equal(t, aerospike.UPDATE_ONLY, write.Policy.RecordExistsAction,
+		"addDeletedChildren must never create a missing parent")
+}
+
+// TestInitNativeTeranodeOpsPolicyIsUpdateOnly pins the setting at its source, so
+// the guarantee above cannot be lost by an edit to initNativeTeranodeOps.
+func TestInitNativeTeranodeOpsPolicyIsUpdateOnly(t *testing.T) {
+	policy := aerospike.NewBatchWritePolicy()
+	policy.RecordExistsAction = aerospike.UPDATE_ONLY
+
+	s := &Store{nativeOpBatchWritePolicy: policy}
+
+	require.Equal(t, aerospike.UPDATE_ONLY, s.nativeOpBatchWritePolicy.RecordExistsAction)
+}
+
+// TestPrunerRecordBuildsNativeWriteOrUDF covers both transports for the record
+// the pruner's BuildAddDeletedChildrenRecord emits.
+func TestPrunerRecordBuildsNativeWriteOrUDF(t *testing.T) {
+	key := prunerRecordTestKey(t)
+	childHashes := []interface{}{"child"}
+
+	t.Run("native store builds a BatchWrite", func(t *testing.T) {
+		s := nativeStoreWithSharedPolicy(t)
+
+		rec := s.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key,
+			subOpAddDeletedChildren, "addDeletedChildren", childHashes)
+
+		_, isUDF := rec.(*aerospike.BatchUDF)
+		require.False(t, isUDF, "a native-op store must not emit a Lua UDF for addDeletedChildren")
+	})
+
+	// With native ops off the Lua function enforces existence itself, so the UDF
+	// fallback needs no policy override.
+	t.Run("UDF fallback builds a BatchUDF", func(t *testing.T) {
+		s := &Store{logger: ulogger.TestLogger{}}
+		require.False(t, s.useNativeTeranodeOps.Load(), "precondition: native ops off")
+
+		rec := s.teranodeBatchRecord(aerospike.NewBatchUDFPolicy(), LuaPackage, key,
+			subOpAddDeletedChildren, "addDeletedChildren", childHashes)
+
+		_, isUDF := rec.(*aerospike.BatchUDF)
+		require.True(t, isUDF, "UDF fallback must build a NewBatchUDF")
+	})
+
+	// The child hash list must reach the wire as ONE argument, matching the single
+	// Lua argument the UDF path passes via NewValue — msgpack `[subOp, [[hashes]]]`.
+	t.Run("child hashes encode as a single argument", func(t *testing.T) {
+		payload, err := encodeNativeOpPayload(subOpAddDeletedChildren, []any{childHashes})
+		require.NoError(t, err)
+
+		var decoded []any
+		require.NoError(t, msgpack.Unmarshal(payload, &decoded))
+		require.Len(t, decoded, 2)
+
+		args, ok := decoded[1].([]any)
+		require.True(t, ok, "args must decode as a list")
+		require.Len(t, args, 1, "the hash list must be one argument, not one argument per hash")
+
+		hashes, ok := args[0].([]any)
+		require.True(t, ok, "the single argument must itself be the hash list")
+		require.Len(t, hashes, len(childHashes))
+	})
+}

--- a/stores/utxo/aerospike/pruner/combined_cleanup_native_op_test.go
+++ b/stores/utxo/aerospike/pruner/combined_cleanup_native_op_test.go
@@ -1,0 +1,99 @@
+package pruner
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// makeParentUpdates builds n distinct parentUpdateInfo entries with valid keys.
+func makeParentUpdates(t *testing.T, n int) map[string]*parentUpdateInfo {
+	t.Helper()
+
+	updates := make(map[string]*parentUpdateInfo, n)
+
+	for i := 0; i < n; i++ {
+		var h chainhash.Hash
+		h[0] = byte(i + 1)
+
+		key, err := aerospike.NewKey("test", "utxo", h[:])
+		require.NoError(t, err)
+
+		updates[h.String()] = &parentUpdateInfo{key: key, childHashes: []*chainhash.Hash{&h}}
+	}
+
+	return updates
+}
+
+// isUDF reports whether a batch record is a Lua NewBatchUDF invocation (as
+// opposed to the native/BatchWrite operate-path).
+func isUDF(rec aerospike.BatchRecordIfc) bool {
+	_, ok := rec.(*aerospike.BatchUDF)
+	return ok
+}
+
+// The combined cleanup path (defensive mode off) must route parent updates
+// through the injected native-op builder when it is present, NOT through a raw
+// Lua NewBatchUDF — even though luaPackage is also set as the fallback. This is
+// the regression that left the pruner emitting a per-block batch_sub_udf burst
+// on native-op-enabled deployments running with defensive mode off.
+func TestBuildCombinedCleanupRecords_PrefersNativeBuilderOverUDF(t *testing.T) {
+	nativeCalls := 0
+
+	s := &Service{
+		luaPackage: "teranode", // provider always sets this as the UDF fallback
+		buildAddDeletedChildrenRecord: func(p *aerospike.BatchUDFPolicy, key *aerospike.Key, childHashes []interface{}) aerospike.BatchRecordIfc {
+			nativeCalls++
+			return aerospike.NewBatchWrite(aerospike.NewBatchWritePolicy(), key, aerospike.TouchOp())
+		},
+	}
+
+	updates := makeParentUpdates(t, 2)
+
+	records, parentEnd, usesModTeranode := s.buildCombinedCleanupRecords(updates, nil)
+
+	require.Equal(t, len(updates), nativeCalls, "native builder must be invoked once per parent update")
+	require.Equal(t, len(updates), parentEnd, "parentEnd must cover exactly the parent-update records")
+	require.True(t, usesModTeranode, "native-op path must be flagged as mod-teranode for SUCCESS-map result parsing")
+
+	for i := 0; i < parentEnd; i++ {
+		require.Falsef(t, isUDF(records[i]), "parent update %d must not be a NewBatchUDF when the native builder is present", i)
+	}
+}
+
+// With no native builder but a lua package configured, the combined path still
+// falls back to the Lua UDF call and flags the mod-teranode SUCCESS-map shape.
+func TestBuildCombinedCleanupRecords_FallsBackToUDFWhenNoNativeBuilder(t *testing.T) {
+	s := &Service{luaPackage: "teranode"}
+
+	updates := makeParentUpdates(t, 2)
+
+	records, parentEnd, usesModTeranode := s.buildCombinedCleanupRecords(updates, nil)
+
+	require.Equal(t, len(updates), parentEnd)
+	require.True(t, usesModTeranode, "UDF path is also a mod-teranode SUCCESS-map path")
+
+	for i := 0; i < parentEnd; i++ {
+		require.Truef(t, isUDF(records[i]), "parent update %d must be a NewBatchUDF when only luaPackage is set", i)
+	}
+}
+
+// With neither a native builder nor a lua package, the combined path uses the
+// plain MapPutItems BatchWrite and reports it is NOT a mod-teranode path (so
+// results are parsed via KEY_NOT_FOUND, not a SUCCESS map).
+func TestBuildCombinedCleanupRecords_PlainMapWriteWhenNoLuaNoNative(t *testing.T) {
+	s := &Service{fieldDeletedChildren: "deletedChildren"}
+
+	updates := makeParentUpdates(t, 2)
+
+	records, parentEnd, usesModTeranode := s.buildCombinedCleanupRecords(updates, nil)
+
+	require.Equal(t, len(updates), parentEnd)
+	require.False(t, usesModTeranode, "plain MapPutItems path must not be flagged as mod-teranode")
+
+	for i := 0; i < parentEnd; i++ {
+		require.Falsef(t, isUDF(records[i]), "parent update %d must be a BatchWrite, not a UDF", i)
+	}
+}

--- a/stores/utxo/aerospike/pruner/parent_update_response_test.go
+++ b/stores/utxo/aerospike/pruner/parent_update_response_test.go
@@ -1,0 +1,88 @@
+package pruner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddDeletedChildrenStatus covers both response shapes that the
+// addDeletedChildren mod-teranode op may return — the UDF path's
+// map[interface{}]interface{} and the native-op path's map[string]interface{} —
+// and the classification the pruner's per-record handler keys on. In particular
+// the ERROR/TX_NOT_FOUND case is the branch that decides whether a missing parent
+// is treated as a benign skip or a hard cleanup failure, so it is asserted for
+// both shapes (the native path's TX_NOT_FOUND handling had no direct coverage).
+func TestAddDeletedChildrenStatus(t *testing.T) {
+	t.Run("interface-keyed OK", func(t *testing.T) {
+		status, errCode, errMsg, ok := addDeletedChildrenStatus(map[interface{}]interface{}{
+			"status":    "OK",
+			"errorCode": "",
+		})
+		require.True(t, ok)
+		require.Equal(t, "OK", status)
+		require.Empty(t, errCode)
+		require.Empty(t, errMsg)
+	})
+
+	t.Run("string-keyed OK (native-op shape)", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status":    "OK",
+			"errorCode": "",
+		})
+		require.True(t, ok)
+		require.Equal(t, "OK", status)
+		require.Empty(t, errCode)
+	})
+
+	t.Run("interface-keyed ERROR TX_NOT_FOUND", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus(map[interface{}]interface{}{
+			"status":    "ERROR",
+			"errorCode": "TX_NOT_FOUND",
+		})
+		require.True(t, ok)
+		require.Equal(t, "ERROR", status)
+		require.Equal(t, "TX_NOT_FOUND", errCode)
+	})
+
+	t.Run("string-keyed ERROR TX_NOT_FOUND (native-op shape)", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status":    "ERROR",
+			"errorCode": "TX_NOT_FOUND",
+		})
+		require.True(t, ok)
+		require.Equal(t, "ERROR", status)
+		require.Equal(t, "TX_NOT_FOUND", errCode)
+	})
+
+	t.Run("string-keyed ERROR with message", func(t *testing.T) {
+		status, errCode, errMsg, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status":       "ERROR",
+			"errorCode":    "SOME_FAILURE",
+			"errorMessage": "boom",
+		})
+		require.True(t, ok)
+		require.Equal(t, "ERROR", status)
+		require.Equal(t, "SOME_FAILURE", errCode)
+		require.Equal(t, "boom", errMsg)
+	})
+
+	t.Run("map without a string status reports not-ok (caller falls through to success)", func(t *testing.T) {
+		_, _, _, ok := addDeletedChildrenStatus(map[interface{}]interface{}{"errorCode": "X"})
+		require.False(t, ok)
+
+		_, _, _, ok = addDeletedChildrenStatus(map[string]interface{}{"status": 42})
+		require.False(t, ok)
+	})
+
+	t.Run("unrecognised shape returns false", func(t *testing.T) {
+		_, _, _, ok := addDeletedChildrenStatus("not-a-map")
+		require.False(t, ok)
+
+		_, _, _, ok = addDeletedChildrenStatus(nil)
+		require.False(t, ok)
+
+		_, _, _, ok = addDeletedChildrenStatus(42)
+		require.False(t, ok)
+	})
+}

--- a/stores/utxo/aerospike/pruner/parent_update_response_test.go
+++ b/stores/utxo/aerospike/pruner/parent_update_response_test.go
@@ -286,7 +286,7 @@ func TestTallyParentUpdateResults(t *testing.T) {
 			okRecord(t), okRecord(t), notFoundRecord(t), brokenRecord(t),
 		}
 
-		tally := tallyParentUpdateResults(records, true)
+		tally := tallyParentUpdateResults(records, true, nil)
 
 		require.Equal(t, 2, tally.success)
 		require.Equal(t, 1, tally.notFound)
@@ -298,7 +298,7 @@ func TestTallyParentUpdateResults(t *testing.T) {
 	// the routine shape when the pruner already deleted the parents.
 	t.Run("all-skipped is not a failure", func(t *testing.T) {
 		tally := tallyParentUpdateResults(
-			[]aerospike.BatchRecordIfc{notFoundRecord(t), notFoundRecord(t)}, true)
+			[]aerospike.BatchRecordIfc{notFoundRecord(t), notFoundRecord(t)}, true, nil)
 
 		require.Zero(t, tally.failed)
 		require.Equal(t, 2, tally.notFound)
@@ -310,14 +310,14 @@ func TestTallyParentUpdateResults(t *testing.T) {
 			aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{"status": "FIRST_FAILURE"}})}
 
 		tally := tallyParentUpdateResults(
-			[]aerospike.BatchRecordIfc{unknownStatus, brokenRecord(t)}, true)
+			[]aerospike.BatchRecordIfc{unknownStatus, brokenRecord(t)}, true, nil)
 
 		require.Equal(t, 2, tally.failed)
 		require.ErrorContains(t, tally.firstErr, "FIRST_FAILURE")
 	})
 
 	t.Run("empty region tallies nothing", func(t *testing.T) {
-		tally := tallyParentUpdateResults(nil, true)
+		tally := tallyParentUpdateResults(nil, true, nil)
 
 		require.Zero(t, tally.success)
 		require.Zero(t, tally.notFound)
@@ -353,5 +353,87 @@ func TestTallyChildDeletionResults(t *testing.T) {
 
 		require.Zero(t, deleteErrors)
 		require.Nil(t, firstErr)
+	})
+}
+
+// TestTallyParentUpdateResultsObservesErrors covers the hook that lets the store
+// demote itself off the native path.
+//
+// The pruner is the only native call site that executes its own BatchOperate, so
+// without this it could never trigger demoteNativeOnUnsupported. It runs every
+// block, making it a likely first victim of a mixed-version cluster that passed
+// the single-partition startup probe and then rejects native writes.
+func TestTallyParentUpdateResultsObservesErrors(t *testing.T) {
+	t.Run("per-record errors reach the observer", func(t *testing.T) {
+		var seen []error
+
+		records := []aerospike.BatchRecordIfc{
+			okRecord(t),
+			&aerospike.BatchWrite{BatchRecord: *batchRecordWithErr(t, aerospike.ErrInvalidParam)},
+			notFoundRecord(t),
+		}
+
+		tally := tallyParentUpdateResults(records, true, func(err error) { seen = append(seen, err) })
+
+		// Both failing records are reported; the successful one is not. Filtering
+		// by result code is the store's job, so KEY_NOT_FOUND is passed on too.
+		require.Len(t, seen, 2)
+		require.ErrorIs(t, seen[0], aerospike.ErrInvalidParam)
+		require.Equal(t, 1, tally.success)
+	})
+
+	// The plain MapPutItems fallback never travelled the native path, so its
+	// failures carry no signal about native-op support and must not demote.
+	t.Run("plain BatchWrite path is never observed", func(t *testing.T) {
+		called := false
+
+		records := []aerospike.BatchRecordIfc{
+			&aerospike.BatchWrite{BatchRecord: *batchRecordWithErr(t, aerospike.ErrInvalidParam)},
+		}
+
+		tallyParentUpdateResults(records, false, func(error) { called = true })
+
+		require.False(t, called, "non-mod-teranode records must not reach the native-op observer")
+	})
+
+	t.Run("nil observer is safe", func(t *testing.T) {
+		records := []aerospike.BatchRecordIfc{
+			&aerospike.BatchWrite{BatchRecord: *batchRecordWithErr(t, aerospike.ErrInvalidParam)},
+		}
+
+		require.NotPanics(t, func() { tallyParentUpdateResults(records, true, nil) })
+	})
+
+	t.Run("successful batches report nothing", func(t *testing.T) {
+		called := false
+
+		tallyParentUpdateResults([]aerospike.BatchRecordIfc{okRecord(t)}, true, func(error) { called = true })
+
+		require.False(t, called)
+	})
+}
+
+// TestReportNativeOpError covers the Service-level wrapper's nil guards — every
+// pruner test constructs a Service without an observer.
+func TestReportNativeOpError(t *testing.T) {
+	t.Run("no observer configured", func(t *testing.T) {
+		s := &Service{}
+		require.NotPanics(t, func() { s.reportNativeOpError(aerospike.ErrInvalidParam) })
+	})
+
+	t.Run("nil error is not forwarded", func(t *testing.T) {
+		called := false
+		s := &Service{observeNativeOpError: func(error) { called = true }}
+
+		s.reportNativeOpError(nil)
+		require.False(t, called)
+	})
+
+	t.Run("error is forwarded verbatim", func(t *testing.T) {
+		var got error
+		s := &Service{observeNativeOpError: func(err error) { got = err }}
+
+		s.reportNativeOpError(aerospike.ErrInvalidParam)
+		require.ErrorIs(t, got, aerospike.ErrInvalidParam)
 	})
 }

--- a/stores/utxo/aerospike/pruner/parent_update_response_test.go
+++ b/stores/utxo/aerospike/pruner/parent_update_response_test.go
@@ -3,16 +3,14 @@ package pruner
 import (
 	"testing"
 
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
 	"github.com/stretchr/testify/require"
 )
 
-// TestAddDeletedChildrenStatus covers both response shapes that the
-// addDeletedChildren mod-teranode op may return — the UDF path's
-// map[interface{}]interface{} and the native-op path's map[string]interface{} —
-// and the classification the pruner's per-record handler keys on. In particular
-// the ERROR/TX_NOT_FOUND case is the branch that decides whether a missing parent
-// is treated as a benign skip or a hard cleanup failure, so it is asserted for
-// both shapes (the native path's TX_NOT_FOUND handling had no direct coverage).
+// TestAddDeletedChildrenStatus covers the response shapes the addDeletedChildren
+// mod-teranode op may return — the UDF path's map[interface{}]interface{}, a
+// string-keyed map, and the client's ordered-map []aerospike.MapPair — and the
+// field vocabulary the pruner keys on.
 func TestAddDeletedChildrenStatus(t *testing.T) {
 	t.Run("interface-keyed OK", func(t *testing.T) {
 		status, errCode, errMsg, ok := addDeletedChildrenStatus(map[interface{}]interface{}{
@@ -25,7 +23,7 @@ func TestAddDeletedChildrenStatus(t *testing.T) {
 		require.Empty(t, errMsg)
 	})
 
-	t.Run("string-keyed OK (native-op shape)", func(t *testing.T) {
+	t.Run("string-keyed OK", func(t *testing.T) {
 		status, errCode, _, ok := addDeletedChildrenStatus(map[string]interface{}{
 			"status":    "OK",
 			"errorCode": "",
@@ -33,6 +31,14 @@ func TestAddDeletedChildrenStatus(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "OK", status)
 		require.Empty(t, errCode)
+	})
+
+	t.Run("ordered-map (MapPair) OK", func(t *testing.T) {
+		status, _, _, ok := addDeletedChildrenStatus([]aerospike.MapPair{
+			{Key: "status", Value: "OK"},
+		})
+		require.True(t, ok)
+		require.Equal(t, "OK", status)
 	})
 
 	t.Run("interface-keyed ERROR TX_NOT_FOUND", func(t *testing.T) {
@@ -45,7 +51,7 @@ func TestAddDeletedChildrenStatus(t *testing.T) {
 		require.Equal(t, "TX_NOT_FOUND", errCode)
 	})
 
-	t.Run("string-keyed ERROR TX_NOT_FOUND (native-op shape)", func(t *testing.T) {
+	t.Run("string-keyed ERROR TX_NOT_FOUND", func(t *testing.T) {
 		status, errCode, _, ok := addDeletedChildrenStatus(map[string]interface{}{
 			"status":    "ERROR",
 			"errorCode": "TX_NOT_FOUND",
@@ -55,23 +61,70 @@ func TestAddDeletedChildrenStatus(t *testing.T) {
 		require.Equal(t, "TX_NOT_FOUND", errCode)
 	})
 
-	t.Run("string-keyed ERROR with message", func(t *testing.T) {
-		status, errCode, errMsg, ok := addDeletedChildrenStatus(map[string]interface{}{
-			"status":       "ERROR",
-			"errorCode":    "SOME_FAILURE",
-			"errorMessage": "boom",
+	t.Run("ordered-map ERROR TX_NOT_FOUND", func(t *testing.T) {
+		status, errCode, _, ok := addDeletedChildrenStatus([]aerospike.MapPair{
+			{Key: "status", Value: "ERROR"},
+			{Key: "errorCode", Value: "TX_NOT_FOUND"},
 		})
 		require.True(t, ok)
 		require.Equal(t, "ERROR", status)
-		require.Equal(t, "SOME_FAILURE", errCode)
-		require.Equal(t, "boom", errMsg)
+		require.Equal(t, "TX_NOT_FOUND", errCode)
 	})
 
-	t.Run("map without a string status reports not-ok (caller falls through to success)", func(t *testing.T) {
+	// The producers emit "message" — teranode.lua FIELD_MESSAGE, set by
+	// addDeletedChildren on its not-found branch, and the key the store's own
+	// ParseLuaMapResponse reads. Reading "errorMessage" instead silently dropped
+	// every server-supplied detail from the synthesised error.
+	t.Run("reads the message key the producers actually emit", func(t *testing.T) {
+		shapes := map[string]interface{}{
+			"interface-keyed": map[interface{}]interface{}{
+				"status": "ERROR", "errorCode": "SOME_FAILURE", "message": "boom",
+			},
+			"string-keyed": map[string]interface{}{
+				"status": "ERROR", "errorCode": "SOME_FAILURE", "message": "boom",
+			},
+			"ordered-map": []aerospike.MapPair{
+				{Key: "status", Value: "ERROR"},
+				{Key: "errorCode", Value: "SOME_FAILURE"},
+				{Key: "message", Value: "boom"},
+			},
+		}
+
+		for name, resp := range shapes {
+			t.Run(name, func(t *testing.T) {
+				status, errCode, errMsg, ok := addDeletedChildrenStatus(resp)
+				require.True(t, ok)
+				require.Equal(t, "ERROR", status)
+				require.Equal(t, "SOME_FAILURE", errCode)
+				require.Equal(t, "boom", errMsg, "the server-supplied message must reach the caller")
+			})
+		}
+	})
+
+	// errorMessage is kept as a tolerated alias for a hypothetical future
+	// producer, but must not win over the key the producers really use.
+	t.Run("errorMessage alias is tolerated but message wins", func(t *testing.T) {
+		_, _, errMsg, ok := addDeletedChildrenStatus(map[string]interface{}{
+			"status": "ERROR", "errorMessage": "alias-only",
+		})
+		require.True(t, ok)
+		require.Equal(t, "alias-only", errMsg)
+
+		_, _, errMsg, ok = addDeletedChildrenStatus(map[string]interface{}{
+			"status": "ERROR", "message": "real", "errorMessage": "alias",
+		})
+		require.True(t, ok)
+		require.Equal(t, "real", errMsg)
+	})
+
+	t.Run("map without a string status reports not-ok", func(t *testing.T) {
 		_, _, _, ok := addDeletedChildrenStatus(map[interface{}]interface{}{"errorCode": "X"})
 		require.False(t, ok)
 
 		_, _, _, ok = addDeletedChildrenStatus(map[string]interface{}{"status": 42})
+		require.False(t, ok)
+
+		_, _, _, ok = addDeletedChildrenStatus([]aerospike.MapPair{{Key: "errorCode", Value: "X"}})
 		require.False(t, ok)
 	})
 
@@ -84,5 +137,221 @@ func TestAddDeletedChildrenStatus(t *testing.T) {
 
 		_, _, _, ok = addDeletedChildrenStatus(42)
 		require.False(t, ok)
+	})
+}
+
+// batchRecordWithBins builds a BatchRecord carrying a response bin, as the
+// mod-teranode paths return it.
+func batchRecordWithBins(t *testing.T, bins aerospike.BinMap) *aerospike.BatchRecord {
+	t.Helper()
+
+	key, err := aerospike.NewKey("test", "utxo", []byte("parent"))
+	require.NoError(t, err)
+
+	return &aerospike.BatchRecord{
+		Key:    key,
+		Record: &aerospike.Record{Bins: bins},
+	}
+}
+
+// batchRecordWithErr builds a BatchRecord that failed with the given error.
+func batchRecordWithErr(t *testing.T, batchErr aerospike.Error) *aerospike.BatchRecord {
+	t.Helper()
+
+	key, err := aerospike.NewKey("test", "utxo", []byte("parent"))
+	require.NoError(t, err)
+
+	return &aerospike.BatchRecord{Key: key, Err: batchErr}
+}
+
+// TestClassifyParentUpdateResult is the fail-closed contract. Every outcome the
+// pruner cannot positively read as a success must be classified as a failure:
+// the caller deletes the child records in the same batch on the strength of this
+// classification, so counting an unreadable response as success would delete
+// children whose parent's deletedChildren map was never updated — the exact
+// referential-integrity break the parent-update phase exists to prevent.
+func TestClassifyParentUpdateResult(t *testing.T) {
+	t.Run("mod-teranode OK", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(
+			batchRecordWithBins(t, aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{"status": "OK"}}), true)
+		require.NoError(t, err)
+		require.Equal(t, parentUpdateOK, outcome)
+	})
+
+	t.Run("mod-teranode ERROR TX_NOT_FOUND is a skip, not a failure", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(
+			batchRecordWithBins(t, aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{
+				"status": "ERROR", "errorCode": "TX_NOT_FOUND",
+			}}), true)
+		require.NoError(t, err)
+		require.Equal(t, parentUpdateNotFound, outcome)
+	})
+
+	t.Run("mod-teranode ERROR carries code and message into the error", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(
+			batchRecordWithBins(t, aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{
+				"status": "ERROR", "errorCode": "BOOM", "message": "detail from server",
+			}}), true)
+		require.Equal(t, parentUpdateFailed, outcome)
+		require.ErrorContains(t, err, "BOOM")
+		require.ErrorContains(t, err, "detail from server")
+	})
+
+	// KEY_NOT_FOUND is how the native path's UPDATE_ONLY policy and the plain
+	// MapPutItems path both report an already-deleted parent. Benign on every
+	// path — no path treats a missing parent as an error.
+	t.Run("KEY_NOT_FOUND is a skip on both contracts", func(t *testing.T) {
+		for _, usesModTeranode := range []bool{true, false} {
+			outcome, err := classifyParentUpdateResult(batchRecordWithErr(t, aerospike.ErrKeyNotFound), usesModTeranode)
+			require.NoError(t, err)
+			require.Equalf(t, parentUpdateNotFound, outcome, "usesModTeranode=%v", usesModTeranode)
+		}
+	})
+
+	t.Run("other batch errors are failures", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(batchRecordWithErr(t, aerospike.ErrTimeout), true)
+		require.Equal(t, parentUpdateFailed, outcome)
+		require.Error(t, err)
+	})
+
+	// The fail-closed cases. Each of these previously resolved to success.
+	t.Run("missing SUCCESS bin fails closed", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(
+			batchRecordWithBins(t, aerospike.BinMap{"someOtherBin": 1}), true)
+		require.Equal(t, parentUpdateFailed, outcome)
+		require.ErrorContains(t, err, "SUCCESS")
+	})
+
+	t.Run("nil record fails closed", func(t *testing.T) {
+		key, err := aerospike.NewKey("test", "utxo", []byte("parent"))
+		require.NoError(t, err)
+
+		outcome, classifyErr := classifyParentUpdateResult(&aerospike.BatchRecord{Key: key}, true)
+		require.Equal(t, parentUpdateFailed, outcome)
+		require.ErrorContains(t, classifyErr, "no record")
+	})
+
+	t.Run("unreadable response shape fails closed", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(
+			batchRecordWithBins(t, aerospike.BinMap{"SUCCESS": "not-a-map"}), true)
+		require.Equal(t, parentUpdateFailed, outcome)
+		require.ErrorContains(t, err, "unreadable")
+	})
+
+	t.Run("unknown status fails closed", func(t *testing.T) {
+		outcome, err := classifyParentUpdateResult(
+			batchRecordWithBins(t, aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{"status": "MAYBE"}}), true)
+		require.Equal(t, parentUpdateFailed, outcome)
+		require.ErrorContains(t, err, "MAYBE")
+	})
+
+	// The plain MapPutItems BatchWrite has no response map at all — a nil Err is
+	// the whole of its success signal, so the SUCCESS-bin requirement must not
+	// apply to it.
+	t.Run("plain BatchWrite path succeeds without a response map", func(t *testing.T) {
+		key, err := aerospike.NewKey("test", "utxo", []byte("parent"))
+		require.NoError(t, err)
+
+		outcome, classifyErr := classifyParentUpdateResult(&aerospike.BatchRecord{Key: key}, false)
+		require.NoError(t, classifyErr)
+		require.Equal(t, parentUpdateOK, outcome)
+	})
+}
+
+// okRecord / notFoundRecord / brokenRecord build the three parent-update results
+// the tally has to tell apart.
+func okRecord(t *testing.T) aerospike.BatchRecordIfc {
+	t.Helper()
+	return &aerospike.BatchWrite{BatchRecord: *batchRecordWithBins(t,
+		aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{"status": "OK"}})}
+}
+
+func notFoundRecord(t *testing.T) aerospike.BatchRecordIfc {
+	t.Helper()
+	return &aerospike.BatchWrite{BatchRecord: *batchRecordWithErr(t, aerospike.ErrKeyNotFound)}
+}
+
+func brokenRecord(t *testing.T) aerospike.BatchRecordIfc {
+	t.Helper()
+	return &aerospike.BatchWrite{BatchRecord: *batchRecordWithBins(t,
+		aerospike.BinMap{"SUCCESS": "not-a-map"})}
+}
+
+// TestTallyParentUpdateResults covers the aggregation the combined and two-call
+// cleanup paths both run over their parent-update region — previously inline in
+// executeBatchCleanupCombined and therefore only reachable with a live client.
+func TestTallyParentUpdateResults(t *testing.T) {
+	t.Run("counts each outcome independently", func(t *testing.T) {
+		records := []aerospike.BatchRecordIfc{
+			okRecord(t), okRecord(t), notFoundRecord(t), brokenRecord(t),
+		}
+
+		tally := tallyParentUpdateResults(records, true)
+
+		require.Equal(t, 2, tally.success)
+		require.Equal(t, 1, tally.notFound)
+		require.Equal(t, 1, tally.failed)
+		require.ErrorContains(t, tally.firstErr, "unreadable")
+	})
+
+	// A batch of purely skipped parents is a clean run, not a failure — this is
+	// the routine shape when the pruner already deleted the parents.
+	t.Run("all-skipped is not a failure", func(t *testing.T) {
+		tally := tallyParentUpdateResults(
+			[]aerospike.BatchRecordIfc{notFoundRecord(t), notFoundRecord(t)}, true)
+
+		require.Zero(t, tally.failed)
+		require.Equal(t, 2, tally.notFound)
+		require.NoError(t, tally.firstErr)
+	})
+
+	t.Run("firstErr keeps the first failure only", func(t *testing.T) {
+		unknownStatus := &aerospike.BatchWrite{BatchRecord: *batchRecordWithBins(t,
+			aerospike.BinMap{"SUCCESS": map[interface{}]interface{}{"status": "FIRST_FAILURE"}})}
+
+		tally := tallyParentUpdateResults(
+			[]aerospike.BatchRecordIfc{unknownStatus, brokenRecord(t)}, true)
+
+		require.Equal(t, 2, tally.failed)
+		require.ErrorContains(t, tally.firstErr, "FIRST_FAILURE")
+	})
+
+	t.Run("empty region tallies nothing", func(t *testing.T) {
+		tally := tallyParentUpdateResults(nil, true)
+
+		require.Zero(t, tally.success)
+		require.Zero(t, tally.notFound)
+		require.Zero(t, tally.failed)
+		require.NoError(t, tally.firstErr)
+	})
+}
+
+// TestTallyChildDeletionResults locks the idempotency rule: a child that is
+// already gone is the outcome the deletion asked for, not an error.
+func TestTallyChildDeletionResults(t *testing.T) {
+	t.Run("KEY_NOT_FOUND is success", func(t *testing.T) {
+		deleteErrors, firstErr := tallyChildDeletionResults(
+			[]aerospike.BatchRecordIfc{notFoundRecord(t), notFoundRecord(t)})
+
+		require.Zero(t, deleteErrors)
+		require.Nil(t, firstErr)
+	})
+
+	t.Run("real errors are counted", func(t *testing.T) {
+		failing := &aerospike.BatchWrite{BatchRecord: *batchRecordWithErr(t, aerospike.ErrTimeout)}
+
+		deleteErrors, firstErr := tallyChildDeletionResults(
+			[]aerospike.BatchRecordIfc{notFoundRecord(t), failing, failing})
+
+		require.Equal(t, 2, deleteErrors)
+		require.NotNil(t, firstErr)
+	})
+
+	t.Run("clean batch reports nothing", func(t *testing.T) {
+		deleteErrors, firstErr := tallyChildDeletionResults(
+			[]aerospike.BatchRecordIfc{okRecord(t)})
+
+		require.Zero(t, deleteErrors)
+		require.Nil(t, firstErr)
 	})
 }

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -152,6 +152,26 @@ type Options struct {
 	// (existing pre-PR-828 behaviour).
 	BuildAddDeletedChildrenRecord func(policy *aerospike.BatchUDFPolicy, key *aerospike.Key, childHashes []interface{}) aerospike.BatchRecordIfc
 
+	// ObserveNativeOpError, when non-nil, is handed every error the parent-update
+	// batch surfaces — per-record and whole-batch alike — for records built by
+	// BuildAddDeletedChildrenRecord.
+	//
+	// The parent Store supplies it so that a PARAMETER_ERROR, which is what an
+	// unpatched aerospike-server returns for the unknown native wire op, demotes
+	// the store to the UDF path exactly as the store's own native call sites do.
+	// The startup probe samples a single partition master, so a mixed-version
+	// cluster (or a node rolled back to a stock build after startup) can pass the
+	// probe and then reject native writes at runtime. Without this the pruner is
+	// the one native call site that cannot trigger that demotion, and since it
+	// runs every block it is a likely first victim — every parent update would
+	// then fail for the process lifetime.
+	//
+	// The pruner does not interpret the error: which codes mean "native
+	// unsupported" is the store's business, and the callback is expected to
+	// filter. Errors from the plain MapPutItems path are not reported, as those
+	// records never travelled the native path.
+	ObserveNativeOpError func(error)
+
 	// Observers is a list of observers to notify when pruning completes
 	Observers []pruner.Observer
 }
@@ -198,6 +218,10 @@ type Service struct {
 	// Optional native-op-aware builder for the addDeletedChildren batch record.
 	// See Options.BuildAddDeletedChildrenRecord for the contract.
 	buildAddDeletedChildrenRecord func(*aerospike.BatchUDFPolicy, *aerospike.Key, []interface{}) aerospike.BatchRecordIfc
+
+	// Optional sink for parent-update errors, letting the store demote itself off
+	// the native path. See Options.ObserveNativeOpError for the contract.
+	observeNativeOpError func(error)
 
 	// Cached field names (avoid repeated String() allocations in hot paths)
 	fieldTxID, fieldUtxos, fieldInputs, fieldDeletedChildren, fieldExternal        string
@@ -344,6 +368,7 @@ func NewService(settings *settings.Settings, opts Options) (*Service, error) {
 		notifier:                       notifier,
 		luaPackage:                     opts.LuaPackage,
 		buildAddDeletedChildrenRecord:  opts.BuildAddDeletedChildrenRecord,
+		observeNativeOpError:           opts.ObserveNativeOpError,
 		queryPolicy:                    queryPolicy,
 		writePolicy:                    writePolicy,
 		batchPolicy:                    batchPolicy,
@@ -1726,13 +1751,18 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 	}
 
 	if err := s.client.BatchOperate(s.batchPolicy, batchRecords); err != nil {
+		if parentUsesModTeranode {
+			s.reportNativeOpError(err)
+		}
+
 		s.logger.Errorf("Combined cleanup batch failed: %v", err)
+
 		return errors.NewStorageError("combined cleanup batch failed", err)
 	}
 
 	// Parse results in two regions: [0, parentEnd) are parent updates,
 	// [parentEnd, end) are child deletions.
-	parentTally := tallyParentUpdateResults(batchRecords[:parentEnd], parentUsesModTeranode)
+	parentTally := tallyParentUpdateResults(batchRecords[:parentEnd], parentUsesModTeranode, s.observeNativeOpError)
 	parentSuccess, parentNotFound, parentErrors := parentTally.success, parentTally.notFound, parentTally.failed
 	firstParentErr := parentTally.firstErr
 
@@ -1819,13 +1849,15 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 	}
 
 	if err := s.client.BatchOperate(s.batchPolicy, batchRecords); err != nil {
+		s.reportNativeOpError(err)
 		s.logger.Errorf("Batch parent update failed: %v", err)
+
 		return errors.NewStorageError("batch parent update failed", err)
 	}
 
 	// Both mod-teranode producers answer with a SUCCESS map, so this path is
 	// always classified against the mod-teranode contract.
-	tally := tallyParentUpdateResults(batchRecords, true)
+	tally := tallyParentUpdateResults(batchRecords, true, s.observeNativeOpError)
 	successCount, notFoundCount, errorCount := tally.success, tally.notFound, tally.failed
 
 	if errorCount > 0 {
@@ -1916,6 +1948,20 @@ func addDeletedChildrenFieldLookup(resp interface{}) (lookup func(string) (strin
 	}
 }
 
+// reportNativeOpError hands a parent-update failure to the store's native-op
+// error observer, when one was injected. Nil-safe: Options.ObserveNativeOpError
+// is optional, and every pruner test constructs a Service without it.
+//
+// Only call this for records built by buildAddDeletedChildrenRecord — see
+// Options.ObserveNativeOpError.
+func (s *Service) reportNativeOpError(err error) {
+	if s.observeNativeOpError == nil || err == nil {
+		return
+	}
+
+	s.observeNativeOpError(err)
+}
+
 // parentUpdateTally is the aggregate outcome of a parent-update batch region.
 type parentUpdateTally struct {
 	success  int
@@ -1930,10 +1976,22 @@ type parentUpdateTally struct {
 // tallyParentUpdateResults classifies every record in a parent-update batch
 // region. Shared by the combined single-round-trip path and the defensive-mode
 // two-call path so the two cannot report the same server response differently.
-func tallyParentUpdateResults(batchRecords []aerospike.BatchRecordIfc, usesModTeranode bool) parentUpdateTally {
+//
+// observeErr, when non-nil, is handed the raw per-record error before it is
+// classified — see Options.ObserveNativeOpError. Only mod-teranode records are
+// reported: the plain MapPutItems path never travelled the native path, so its
+// errors carry no signal about native support. KEY_NOT_FOUND is reported too;
+// filtering by result code is the observer's job, not the pruner's.
+func tallyParentUpdateResults(batchRecords []aerospike.BatchRecordIfc, usesModTeranode bool, observeErr func(error)) parentUpdateTally {
 	var tally parentUpdateTally
 
 	for _, rec := range batchRecords {
+		if observeErr != nil && usesModTeranode {
+			if recErr := rec.BatchRec().Err; recErr != nil {
+				observeErr(recErr)
+			}
+		}
+
 		outcome, outcomeErr := classifyParentUpdateResult(rec.BatchRec(), usesModTeranode)
 
 		switch outcome {
@@ -2078,8 +2136,12 @@ func (s *Service) executeBatchParentUpdatesBatchWrite(ctx context.Context, updat
 	default:
 	}
 
+	// No reportNativeOpError here: this is the plain MapPutItems fallback, whose
+	// records never travelled the native path, so its failures say nothing about
+	// native-op support.
 	if err := s.client.BatchOperate(s.batchPolicy, batchRecords); err != nil {
 		s.logger.Errorf("Batch parent update failed: %v", err)
+
 		return errors.NewStorageError("batch parent update failed", err)
 	}
 

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -41,6 +41,31 @@ var IndexName, _ = gocore.Config().Get("pruner_IndexName", "pruner_dah_index")
 
 const errParentUpdateOpsFailed = "%d parent update operations failed"
 
+// Wire vocabulary of the addDeletedChildren mod-teranode response. These mirror
+// the constants in teranode.lua (FIELD_STATUS / FIELD_ERROR_CODE / FIELD_MESSAGE,
+// STATUS_OK / STATUS_ERROR, ERROR_CODE_TX_NOT_FOUND) and the store's LuaSuccess
+// bin name; the pruner cannot import the store package (the store imports the
+// pruner), so they are restated here rather than shared.
+const (
+	// luaSuccessBin is the record bin both mod-teranode paths write their
+	// response map into — aerospike.LuaSuccess on the store side.
+	luaSuccessBin = "SUCCESS"
+
+	fieldStatus    = "status"
+	fieldErrorCode = "errorCode"
+	// fieldMessage is the key the producers actually emit (teranode.lua
+	// FIELD_MESSAGE); the store's own parser reads it too.
+	fieldMessage = "message"
+	// fieldErrorMessage is tolerated as an alias so a future producer that emits
+	// it is not silently dropped. No producer emits it today.
+	fieldErrorMessage = "errorMessage"
+
+	statusOK    = "OK"
+	statusError = "ERROR"
+
+	errorCodeTxNotFound = "TX_NOT_FOUND"
+)
+
 // TimeoutError indicates that a query operation timed out or encountered a network error.
 // This error type is used to distinguish retriable timeout errors from other errors.
 type TimeoutError struct {
@@ -110,10 +135,18 @@ type Options struct {
 	// (subOpAddDeletedChildren) when the cluster supports it, with transparent
 	// fallback to the legacy NewBatchUDF call otherwise.
 	//
-	// The policy argument is honoured only by the UDF branch; the native-op
-	// branch synthesises its own write policy. Pass childHashes as the same
+	// The UDF branch honours the policy in full. The native-op branch synthesises
+	// its own write policy but still carries over the policy's FilterExpression
+	// when one is set, so a server-side eligibility gate applies identically on
+	// both paths (the pruner sets no filter today). Pass childHashes as the same
 	// []interface{} payload the legacy path would have wrapped in
 	// aerospike.NewValue (one Lua argument: a list of hex hash strings).
+	//
+	// The implementation must not create the parent record when it is absent —
+	// a missing parent is routine here and the Lua function it replaces returns
+	// TX_NOT_FOUND without writing. It may report that either as a
+	// KEY_NOT_FOUND batch error or as an ERROR/TX_NOT_FOUND response map; the
+	// pruner counts both as a skipped parent.
 	//
 	// When nil, the pruner builds NewBatchUDF directly using LuaPackage
 	// (existing pre-PR-828 behaviour).
@@ -1618,10 +1651,12 @@ func (s *Service) buildParentUpdateRecords(updates map[string]*parentUpdateInfo)
 // builder and left the pruner emitting batch_sub_udf on native-op deployments
 // with defensive mode off.
 //
-// parentUsesModTeranode reports whether the parent-update records carry a
-// mod-teranode SUCCESS-map response (native or UDF, both silent on missing
-// parents) rather than the plain BatchWrite path (missing parent → KEY_NOT_FOUND).
-// The caller uses it to parse the batch results.
+// parentUsesModTeranode reports whether the parent-update records answer with a
+// mod-teranode SUCCESS map (native or UDF) rather than the plain BatchWrite path,
+// which has no response map at all. The caller passes it to
+// classifyParentUpdateResult to select the response contract. It does not imply
+// anything about missing parents: all three paths can report those, the UDF as an
+// ERROR/TX_NOT_FOUND response and the other two as KEY_NOT_FOUND.
 func (s *Service) buildCombinedCleanupRecords(updates map[string]*parentUpdateInfo, keys []*aerospike.Key) (batchRecords []aerospike.BatchRecordIfc, parentEnd int, parentUsesModTeranode bool) {
 	batchRecords = make([]aerospike.BatchRecordIfc, 0, len(updates)+len(keys))
 
@@ -1697,75 +1732,11 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 
 	// Parse results in two regions: [0, parentEnd) are parent updates,
 	// [parentEnd, end) are child deletions.
-	parentSuccess, parentNotFound, parentErrors := 0, 0, 0
-	deleteErrors := 0
-	// firstParentErr captures the first non-KEY_NOT_FOUND failure surfaced
-	// by either path: the aerospike SDK (batchRec.Err) or the UDF
-	// SUCCESS-map "ERROR" status. It is typed as `error` rather than
-	// `aerospike.Error` so the UDF-error branch can synthesise a
-	// descriptive sentinel without faking an aerospike.Error.
-	var firstParentErr error
-	var firstDeleteErr aerospike.Error
+	parentTally := tallyParentUpdateResults(batchRecords[:parentEnd], parentUsesModTeranode)
+	parentSuccess, parentNotFound, parentErrors := parentTally.success, parentTally.notFound, parentTally.failed
+	firstParentErr := parentTally.firstErr
 
-	for i, rec := range batchRecords {
-		batchRec := rec.BatchRec()
-		if i < parentEnd {
-			// Parent update result
-			if batchRec.Err != nil {
-				// Plain MapPutItems BatchWrite path surfaces missing parents as
-				// KEY_NOT_FOUND; the mod-teranode paths (native + UDF) handle
-				// missing parents server-side and never surface it here.
-				if !parentUsesModTeranode && batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
-					parentNotFound++
-					continue
-				}
-				if firstParentErr == nil {
-					firstParentErr = batchRec.Err
-				}
-				parentErrors++
-				continue
-			}
-			// mod-teranode paths (native + UDF) return a SUCCESS/ERROR map in the
-			// record bins; the UDF path yields map[interface{}]interface{} and the
-			// native-op dispatcher yields map[string]interface{}.
-			if parentUsesModTeranode && batchRec.Record != nil && batchRec.Record.Bins != nil {
-				if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
-					if status, errCode, errMsg, ok := addDeletedChildrenStatus(resp); ok {
-						switch status {
-						case "OK":
-							parentSuccess++
-						case "ERROR":
-							if errCode == "TX_NOT_FOUND" {
-								parentNotFound++
-							} else {
-								parentErrors++
-								// UDF-path errors don't carry an
-								// aerospike.Error; synthesise one
-								// describing the UDF response so the
-								// returned error chain isn't empty.
-								if firstParentErr == nil {
-									firstParentErr = errors.NewProcessingError("UDF parent update returned ERROR (code=%q, message=%q)", errCode, errMsg)
-								}
-							}
-						}
-						continue
-					}
-				}
-			}
-			parentSuccess++
-		} else {
-			// Child deletion result — KEY_NOT_FOUND is idempotent success
-			if batchRec.Err != nil {
-				if batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
-					continue
-				}
-				if firstDeleteErr == nil {
-					firstDeleteErr = batchRec.Err
-				}
-				deleteErrors++
-			}
-		}
-	}
+	deleteErrors, firstDeleteErr := tallyChildDeletionResults(batchRecords[parentEnd:])
 
 	if parentErrors > 0 {
 		s.logger.Errorf("Combined cleanup: %d parent update errors (first: %v)", parentErrors, firstParentErr)
@@ -1833,9 +1804,10 @@ func (s *Service) executeBatchParentUpdates(ctx context.Context, updates map[str
 
 // executeBatchParentUpdatesUDF builds the addDeletedChildren parent-update batch
 // using either the native-op wrapper (when Options.BuildAddDeletedChildrenRecord
-// was supplied) or a direct NewBatchUDF fallback. In both cases missing parent
-// records are handled server-side, avoiding KEY_NOT_FOUND noise in Aerospike
-// client metrics.
+// was supplied) or a direct NewBatchUDF fallback. Neither creates a missing
+// parent: the UDF reports it as an ERROR/TX_NOT_FOUND response and the native
+// path as a KEY_NOT_FOUND batch error, and both are counted as skipped rather
+// than failed.
 func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[string]*parentUpdateInfo) error {
 	batchRecords := s.buildParentUpdateRecords(updates)
 
@@ -1851,46 +1823,16 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 		return errors.NewStorageError("batch parent update failed", err)
 	}
 
-	successCount := 0
-	notFoundCount := 0
-	errorCount := 0
-
-	for _, rec := range batchRecords {
-		batchRec := rec.BatchRec()
-		if batchRec.Err != nil {
-			s.logger.Errorf("Parent update error for key %v: %v", batchRec.Key, batchRec.Err)
-			errorCount++
-			continue
-		}
-
-		if batchRec.Record != nil && batchRec.Record.Bins != nil {
-			if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
-				// The UDF path returns map[interface{}]interface{}; the native-op
-				// dispatcher decodes the same Lua-style response as
-				// map[string]interface{}. addDeletedChildrenStatus reads both
-				// shapes without copying the map.
-				if status, errCode, _, ok := addDeletedChildrenStatus(resp); ok {
-					switch status {
-					case "OK":
-						successCount++
-					case "ERROR":
-						if errCode == "TX_NOT_FOUND" {
-							notFoundCount++
-						} else {
-							s.logger.Errorf("Parent update Lua error for key %v: code=%q", batchRec.Key, errCode)
-							errorCount++
-						}
-					}
-					continue
-				}
-			}
-		}
-
-		successCount++
-	}
+	// Both mod-teranode producers answer with a SUCCESS map, so this path is
+	// always classified against the mod-teranode contract.
+	tally := tallyParentUpdateResults(batchRecords, true)
+	successCount, notFoundCount, errorCount := tally.success, tally.notFound, tally.failed
 
 	if errorCount > 0 {
-		return errors.NewStorageError(errParentUpdateOpsFailed, errorCount)
+		s.logger.Errorf("Batch parent update: %d of %d parent updates failed (first: %v)",
+			errorCount, len(batchRecords), tally.firstErr)
+
+		return errors.NewStorageError(errParentUpdateOpsFailed, errorCount, tally.firstErr)
 	}
 
 	if successCount > 0 {
@@ -1904,32 +1846,209 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 	return nil
 }
 
-// addDeletedChildrenStatus reads the status / errorCode / errorMessage fields
-// from the SUCCESS map returned by the addDeletedChildren mod-teranode op,
-// without allocating a copy of the map (this runs once per parent update on the
-// per-block cleanup hot path). Both response shapes are handled: the legacy UDF
-// path yields map[interface{}]interface{}; the native-op dispatcher yields
-// map[string]interface{}.
+// addDeletedChildrenStatus reads the status / errorCode / message fields from the
+// SUCCESS map returned by the addDeletedChildren mod-teranode op, without
+// allocating a copy of the map (this runs once per parent update on the per-block
+// cleanup hot path).
 //
-// ok reports that resp is one of those two map shapes AND carries a string
-// "status" field — matching the old two-step (normalise + status type-assert)
-// guard, so callers fall through to their default success handling unchanged
-// when the response has no parseable status.
+// ok reports that resp was a recognised map shape AND carried a string status
+// field. Callers must treat ok == false as a failure, not as success: the two
+// producers (the Lua UDF and the server-fork native dispatcher) are not pinned to
+// the same response encoding by anything in this repo, so an unreadable response
+// means the parent update's outcome is unknown. See classifyParentUpdateResult.
 func addDeletedChildrenStatus(resp interface{}) (status, errorCode, errorMessage string, ok bool) {
-	switch m := resp.(type) {
-	case map[interface{}]interface{}:
-		status, ok = m["status"].(string)
-		errorCode, _ = m["errorCode"].(string)
-		errorMessage, _ = m["errorMessage"].(string)
-	case map[string]interface{}:
-		status, ok = m["status"].(string)
-		errorCode, _ = m["errorCode"].(string)
-		errorMessage, _ = m["errorMessage"].(string)
-	default:
+	lookup, recognised := addDeletedChildrenFieldLookup(resp)
+	if !recognised {
 		return "", "", "", false
 	}
 
+	status, ok = lookup(fieldStatus)
+	errorCode, _ = lookup(fieldErrorCode)
+
+	// Producers emit "message"; fall back to the "errorMessage" alias only when
+	// "message" is absent or empty.
+	if errorMessage, _ = lookup(fieldMessage); errorMessage == "" {
+		errorMessage, _ = lookup(fieldErrorMessage)
+	}
+
 	return status, errorCode, errorMessage, ok
+}
+
+// addDeletedChildrenFieldLookup returns a string-field accessor over whichever
+// map encoding the response arrived in, or recognised == false when resp is not a
+// map at all.
+//
+// Three shapes are handled. The UDF path yields map[interface{}]interface{}
+// (the aerospike client's unpackMapNormal). map[string]interface{} is accepted
+// because the native dispatcher may decode that way. []aerospike.MapPair is the
+// client's representation of an ordered-map particle (a map CDT carrying the
+// ordered-map ext header) — no producer is known to emit it for this op, but
+// accepting it costs a case and rejecting it would, post-fail-closed, turn a
+// working native deployment into a hard error.
+func addDeletedChildrenFieldLookup(resp interface{}) (lookup func(string) (string, bool), recognised bool) {
+	switch m := resp.(type) {
+	case map[interface{}]interface{}:
+		return func(field string) (string, bool) {
+			v, ok := m[field].(string)
+			return v, ok
+		}, true
+
+	case map[string]interface{}:
+		return func(field string) (string, bool) {
+			v, ok := m[field].(string)
+			return v, ok
+		}, true
+
+	case []aerospike.MapPair:
+		return func(field string) (string, bool) {
+			for _, pair := range m {
+				if key, isString := pair.Key.(string); isString && key == field {
+					v, ok := pair.Value.(string)
+					return v, ok
+				}
+			}
+
+			return "", false
+		}, true
+
+	default:
+		return nil, false
+	}
+}
+
+// parentUpdateTally is the aggregate outcome of a parent-update batch region.
+type parentUpdateTally struct {
+	success  int
+	notFound int
+	failed   int
+	// firstErr is the first failure encountered, typed as `error` rather than
+	// `aerospike.Error` so a synthesised response error can be carried without
+	// faking an aerospike.Error.
+	firstErr error
+}
+
+// tallyParentUpdateResults classifies every record in a parent-update batch
+// region. Shared by the combined single-round-trip path and the defensive-mode
+// two-call path so the two cannot report the same server response differently.
+func tallyParentUpdateResults(batchRecords []aerospike.BatchRecordIfc, usesModTeranode bool) parentUpdateTally {
+	var tally parentUpdateTally
+
+	for _, rec := range batchRecords {
+		outcome, outcomeErr := classifyParentUpdateResult(rec.BatchRec(), usesModTeranode)
+
+		switch outcome {
+		case parentUpdateOK:
+			tally.success++
+
+		case parentUpdateNotFound:
+			tally.notFound++
+
+		default:
+			tally.failed++
+
+			if tally.firstErr == nil {
+				tally.firstErr = outcomeErr
+			}
+		}
+	}
+
+	return tally
+}
+
+// tallyChildDeletionResults counts failed child-record deletions. KEY_NOT_FOUND
+// is idempotent success here — the child is already gone, which is the outcome
+// the deletion was asking for.
+func tallyChildDeletionResults(batchRecords []aerospike.BatchRecordIfc) (deleteErrors int, firstDeleteErr aerospike.Error) {
+	for _, rec := range batchRecords {
+		batchRec := rec.BatchRec()
+
+		if batchRec.Err == nil || batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
+			continue
+		}
+
+		if firstDeleteErr == nil {
+			firstDeleteErr = batchRec.Err
+		}
+
+		deleteErrors++
+	}
+
+	return deleteErrors, firstDeleteErr
+}
+
+// parentUpdateOutcome is how a single addDeletedChildren batch record is tallied.
+type parentUpdateOutcome int
+
+const (
+	// parentUpdateOK — the parent's deletedChildren map was updated.
+	parentUpdateOK parentUpdateOutcome = iota
+	// parentUpdateNotFound — the parent record is gone. Never an error for this
+	// op: the parent is normally one the pruner itself already deleted.
+	parentUpdateNotFound
+	// parentUpdateFailed — the update failed, or its outcome could not be read.
+	parentUpdateFailed
+)
+
+// classifyParentUpdateResult maps one parent-update batch record onto the outcome
+// the cleanup counters track. Shared by the combined and two-call paths so the
+// two cannot drift apart again.
+//
+// It fails CLOSED. Any response the pruner cannot read is reported as a failure
+// rather than counted as a silent success, because the caller deletes the child
+// records in the same batch on the strength of this classification — a parent
+// update that silently did not happen is exactly the referential-integrity break
+// the parent-update phase exists to prevent. The store fails closed on the same
+// unknown (ParseLuaMapResponse returns an error); the pruner now matches it.
+//
+// A missing parent reaches us two different ways and is benign in both: as
+// KEY_NOT_FOUND from the policies that require an existing record (the native
+// path's UPDATE_ONLY, the plain MapPutItems fallback), or as an ERROR/TX_NOT_FOUND
+// response from the Lua UDF, which guards on aerospike:exists(rec) instead.
+//
+// usesModTeranode selects the response contract: mod-teranode records (native or
+// UDF) must carry a readable SUCCESS map, whereas the plain MapPutItems BatchWrite
+// has no response map at all and a nil Err is the whole of its success signal.
+func classifyParentUpdateResult(batchRec *aerospike.BatchRecord, usesModTeranode bool) (parentUpdateOutcome, error) {
+	if batchRec.Err != nil {
+		if batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
+			return parentUpdateNotFound, nil
+		}
+
+		return parentUpdateFailed, batchRec.Err
+	}
+
+	if !usesModTeranode {
+		return parentUpdateOK, nil
+	}
+
+	if batchRec.Record == nil || batchRec.Record.Bins == nil {
+		return parentUpdateFailed, errors.NewProcessingError("parent update returned no record")
+	}
+
+	resp, ok := batchRec.Record.Bins[luaSuccessBin]
+	if !ok {
+		return parentUpdateFailed, errors.NewProcessingError("parent update returned no %q bin", luaSuccessBin)
+	}
+
+	status, errCode, errMsg, ok := addDeletedChildrenStatus(resp)
+	if !ok {
+		return parentUpdateFailed, errors.NewProcessingError("unreadable parent update response (%T)", resp)
+	}
+
+	switch status {
+	case statusOK:
+		return parentUpdateOK, nil
+
+	case statusError:
+		if errCode == errorCodeTxNotFound {
+			return parentUpdateNotFound, nil
+		}
+
+		return parentUpdateFailed, errors.NewProcessingError("parent update returned ERROR (code=%q, message=%q)", errCode, errMsg)
+
+	default:
+		return parentUpdateFailed, errors.NewProcessingError("parent update returned unknown status %q", status)
+	}
 }
 
 // executeBatchParentUpdatesBatchWrite is the fallback when Lua UDF is not configured.

--- a/stores/utxo/aerospike/pruner/pruner_service.go
+++ b/stores/utxo/aerospike/pruner/pruner_service.go
@@ -104,6 +104,21 @@ type Options struct {
 	// LuaPackage is the name of the registered Lua UDF module
 	LuaPackage string
 
+	// BuildAddDeletedChildrenRecord, when non-nil, takes ownership of building
+	// the per-parent BatchRecord for the parent-update phase. The parent Store
+	// supplies this so the pruner routes through the native-op wrapper
+	// (subOpAddDeletedChildren) when the cluster supports it, with transparent
+	// fallback to the legacy NewBatchUDF call otherwise.
+	//
+	// The policy argument is honoured only by the UDF branch; the native-op
+	// branch synthesises its own write policy. Pass childHashes as the same
+	// []interface{} payload the legacy path would have wrapped in
+	// aerospike.NewValue (one Lua argument: a list of hex hash strings).
+	//
+	// When nil, the pruner builds NewBatchUDF directly using LuaPackage
+	// (existing pre-PR-828 behaviour).
+	BuildAddDeletedChildrenRecord func(policy *aerospike.BatchUDFPolicy, key *aerospike.Key, childHashes []interface{}) aerospike.BatchRecordIfc
+
 	// Observers is a list of observers to notify when pruning completes
 	Observers []pruner.Observer
 }
@@ -146,6 +161,10 @@ type Service struct {
 
 	// Lua UDF module name
 	luaPackage string
+
+	// Optional native-op-aware builder for the addDeletedChildren batch record.
+	// See Options.BuildAddDeletedChildrenRecord for the contract.
+	buildAddDeletedChildrenRecord func(*aerospike.BatchUDFPolicy, *aerospike.Key, []interface{}) aerospike.BatchRecordIfc
 
 	// Cached field names (avoid repeated String() allocations in hot paths)
 	fieldTxID, fieldUtxos, fieldInputs, fieldDeletedChildren, fieldExternal        string
@@ -291,6 +310,7 @@ func NewService(settings *settings.Settings, opts Options) (*Service, error) {
 		indexWaiter:                    opts.IndexWaiter,
 		notifier:                       notifier,
 		luaPackage:                     opts.LuaPackage,
+		buildAddDeletedChildrenRecord:  opts.BuildAddDeletedChildrenRecord,
 		queryPolicy:                    queryPolicy,
 		writePolicy:                    writePolicy,
 		batchPolicy:                    batchPolicy,
@@ -1554,39 +1574,62 @@ func (s *Service) flushCleanupBatches(ctx context.Context, parentUpdates map[str
 	return nil
 }
 
-// executeBatchCleanupCombined sends parent UDF updates and child record
-// deletions in a SINGLE Aerospike BatchOperate call. Halves the round-trip
-// count vs the two-call path. Only safe when defensive mode is off (because
-// the defensive safety check has an implicit ordering dependency between
-// parent.deletedChildren writes and child record deletions).
-func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[string]*parentUpdateInfo, keys []*aerospike.Key) error {
-	if len(updates) == 0 && len(keys) == 0 {
-		return nil
+// buildParentUpdateRecords builds the addDeletedChildren parent-update batch
+// records on the mod-teranode path: it prefers the injected native-op builder
+// (buildAddDeletedChildrenRecord → native subOpAddDeletedChildren) and falls back
+// to a direct Lua NewBatchUDF. Callers must only invoke it when the mod-teranode
+// path is active (buildAddDeletedChildrenRecord != nil || luaPackage != ""); it
+// is shared by the combined and two-call cleanup paths so the two never diverge.
+func (s *Service) buildParentUpdateRecords(updates map[string]*parentUpdateInfo) []aerospike.BatchRecordIfc {
+	batchUDFPolicy := aerospike.NewBatchUDFPolicy()
+	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(updates))
+
+	for _, info := range updates {
+		childHashList := make([]interface{}, 0, len(info.childHashes))
+		for _, childHash := range info.childHashes {
+			childHashList = append(childHashList, childHash.String())
+		}
+
+		if s.buildAddDeletedChildrenRecord != nil {
+			batchRecords = append(batchRecords, s.buildAddDeletedChildrenRecord(batchUDFPolicy, info.key, childHashList))
+		} else {
+			batchRecords = append(batchRecords, aerospike.NewBatchUDF(
+				batchUDFPolicy,
+				info.key,
+				s.luaPackage,
+				"addDeletedChildren",
+				aerospike.NewValue(childHashList),
+			))
+		}
 	}
 
-	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(updates)+len(keys))
+	return batchRecords
+}
 
-	// Parent updates: prefer Lua UDF (silent on missing parents — no
-	// KEY_NOT_FOUND noise in client metrics) and fall back to a plain
-	// BatchWrite+MapPutItems if no Lua package is configured.
-	parentEnd := 0
-	useUDF := s.luaPackage != ""
+// buildCombinedCleanupRecords builds the batch records for the single-round-trip
+// combined cleanup: parent updates in [0, parentEnd) followed by child deletions
+// in [parentEnd, len).
+//
+// Parent updates prefer the injected native-op builder
+// (buildAddDeletedChildrenRecord → native subOpAddDeletedChildren), fall back to
+// a direct Lua NewBatchUDF, and finally to a plain MapPutItems BatchWrite when
+// neither mod-teranode path is configured. This mirrors executeBatchParentUpdates:
+// keying the choice purely on luaPackage (the old behaviour) ignored the native
+// builder and left the pruner emitting batch_sub_udf on native-op deployments
+// with defensive mode off.
+//
+// parentUsesModTeranode reports whether the parent-update records carry a
+// mod-teranode SUCCESS-map response (native or UDF, both silent on missing
+// parents) rather than the plain BatchWrite path (missing parent → KEY_NOT_FOUND).
+// The caller uses it to parse the batch results.
+func (s *Service) buildCombinedCleanupRecords(updates map[string]*parentUpdateInfo, keys []*aerospike.Key) (batchRecords []aerospike.BatchRecordIfc, parentEnd int, parentUsesModTeranode bool) {
+	batchRecords = make([]aerospike.BatchRecordIfc, 0, len(updates)+len(keys))
+
+	parentUsesModTeranode = s.buildAddDeletedChildrenRecord != nil || s.luaPackage != ""
+
 	if len(updates) > 0 {
-		if useUDF {
-			batchUDFPolicy := aerospike.NewBatchUDFPolicy()
-			for _, info := range updates {
-				childHashList := make([]interface{}, 0, len(info.childHashes))
-				for _, childHash := range info.childHashes {
-					childHashList = append(childHashList, childHash.String())
-				}
-				batchRecords = append(batchRecords, aerospike.NewBatchUDF(
-					batchUDFPolicy,
-					info.key,
-					s.luaPackage,
-					"addDeletedChildren",
-					aerospike.NewValue(childHashList),
-				))
-			}
+		if parentUsesModTeranode {
+			batchRecords = append(batchRecords, s.buildParentUpdateRecords(updates)...)
 		} else {
 			batchWritePolicy := aerospike.NewBatchWritePolicy()
 			batchWritePolicy.RecordExistsAction = aerospike.UPDATE_ONLY
@@ -1601,6 +1644,7 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 			}
 		}
 	}
+
 	parentEnd = len(batchRecords)
 
 	// Child deletions — TTL touch (utxoSetTTL=true) or hard delete.
@@ -1619,6 +1663,21 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 			}
 		}
 	}
+
+	return batchRecords, parentEnd, parentUsesModTeranode
+}
+
+// executeBatchCleanupCombined sends parent updates and child record deletions in
+// a SINGLE Aerospike BatchOperate call. Halves the round-trip count vs the
+// two-call path. Only safe when defensive mode is off (because the defensive
+// safety check has an implicit ordering dependency between parent.deletedChildren
+// writes and child record deletions).
+func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[string]*parentUpdateInfo, keys []*aerospike.Key) error {
+	if len(updates) == 0 && len(keys) == 0 {
+		return nil
+	}
+
+	batchRecords, parentEnd, parentUsesModTeranode := s.buildCombinedCleanupRecords(updates, keys)
 
 	if len(batchRecords) == 0 {
 		return nil
@@ -1653,8 +1712,10 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 		if i < parentEnd {
 			// Parent update result
 			if batchRec.Err != nil {
-				// BatchWrite path surfaces missing parents as KEY_NOT_FOUND
-				if !useUDF && batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
+				// Plain MapPutItems BatchWrite path surfaces missing parents as
+				// KEY_NOT_FOUND; the mod-teranode paths (native + UDF) handle
+				// missing parents server-side and never surface it here.
+				if !parentUsesModTeranode && batchRec.Err.Matches(aerospike.ErrKeyNotFound.ResultCode) {
 					parentNotFound++
 					continue
 				}
@@ -1664,32 +1725,30 @@ func (s *Service) executeBatchCleanupCombined(ctx context.Context, updates map[s
 				parentErrors++
 				continue
 			}
-			// UDF path returns a SUCCESS/ERROR map in the record bins
-			if useUDF && batchRec.Record != nil && batchRec.Record.Bins != nil {
+			// mod-teranode paths (native + UDF) return a SUCCESS/ERROR map in the
+			// record bins; the UDF path yields map[interface{}]interface{} and the
+			// native-op dispatcher yields map[string]interface{}.
+			if parentUsesModTeranode && batchRec.Record != nil && batchRec.Record.Bins != nil {
 				if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
-					if respMap, ok := resp.(map[interface{}]interface{}); ok {
-						if status, ok := respMap["status"].(string); ok {
-							switch status {
-							case "OK":
-								parentSuccess++
-							case "ERROR":
-								if errCode, ok := respMap["errorCode"].(string); ok && errCode == "TX_NOT_FOUND" {
-									parentNotFound++
-								} else {
-									parentErrors++
-									// UDF-path errors don't carry an
-									// aerospike.Error; synthesise one
-									// describing the UDF response so the
-									// returned error chain isn't empty.
-									if firstParentErr == nil {
-										errCode, _ := respMap["errorCode"].(string)
-										errMsg, _ := respMap["errorMessage"].(string)
-										firstParentErr = errors.NewProcessingError("UDF parent update returned ERROR (code=%q, message=%q)", errCode, errMsg)
-									}
+					if status, errCode, errMsg, ok := addDeletedChildrenStatus(resp); ok {
+						switch status {
+						case "OK":
+							parentSuccess++
+						case "ERROR":
+							if errCode == "TX_NOT_FOUND" {
+								parentNotFound++
+							} else {
+								parentErrors++
+								// UDF-path errors don't carry an
+								// aerospike.Error; synthesise one
+								// describing the UDF response so the
+								// returned error chain isn't empty.
+								if firstParentErr == nil {
+									firstParentErr = errors.NewProcessingError("UDF parent update returned ERROR (code=%q, message=%q)", errCode, errMsg)
 								}
 							}
-							continue
 						}
+						continue
 					}
 				}
 			}
@@ -1765,33 +1824,20 @@ func (s *Service) executeBatchParentUpdates(ctx context.Context, updates map[str
 		return nil
 	}
 
-	if s.luaPackage != "" {
+	if s.buildAddDeletedChildrenRecord != nil || s.luaPackage != "" {
 		return s.executeBatchParentUpdatesUDF(ctx, updates)
 	}
 
 	return s.executeBatchParentUpdatesBatchWrite(ctx, updates)
 }
 
-// executeBatchParentUpdatesUDF uses a Lua UDF (addDeletedChildren) so that missing parent
-// records are handled server-side without generating KEY_NOT_FOUND errors in Aerospike client metrics.
+// executeBatchParentUpdatesUDF builds the addDeletedChildren parent-update batch
+// using either the native-op wrapper (when Options.BuildAddDeletedChildrenRecord
+// was supplied) or a direct NewBatchUDF fallback. In both cases missing parent
+// records are handled server-side, avoiding KEY_NOT_FOUND noise in Aerospike
+// client metrics.
 func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[string]*parentUpdateInfo) error {
-	batchUDFPolicy := aerospike.NewBatchUDFPolicy()
-	batchRecords := make([]aerospike.BatchRecordIfc, 0, len(updates))
-
-	for _, info := range updates {
-		childHashList := make([]interface{}, 0, len(info.childHashes))
-		for _, childHash := range info.childHashes {
-			childHashList = append(childHashList, childHash.String())
-		}
-
-		batchRecords = append(batchRecords, aerospike.NewBatchUDF(
-			batchUDFPolicy,
-			info.key,
-			s.luaPackage,
-			"addDeletedChildren",
-			aerospike.NewValue(childHashList),
-		))
-	}
+	batchRecords := s.buildParentUpdateRecords(updates)
 
 	select {
 	case <-ctx.Done():
@@ -1819,21 +1865,23 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 
 		if batchRec.Record != nil && batchRec.Record.Bins != nil {
 			if resp, ok := batchRec.Record.Bins["SUCCESS"]; ok {
-				if respMap, ok := resp.(map[interface{}]interface{}); ok {
-					if status, ok := respMap["status"].(string); ok {
-						switch status {
-						case "OK":
-							successCount++
-						case "ERROR":
-							if errCode, ok := respMap["errorCode"].(string); ok && errCode == "TX_NOT_FOUND" {
-								notFoundCount++
-							} else {
-								s.logger.Errorf("Parent update Lua error for key %v: %v", batchRec.Key, respMap)
-								errorCount++
-							}
+				// The UDF path returns map[interface{}]interface{}; the native-op
+				// dispatcher decodes the same Lua-style response as
+				// map[string]interface{}. addDeletedChildrenStatus reads both
+				// shapes without copying the map.
+				if status, errCode, _, ok := addDeletedChildrenStatus(resp); ok {
+					switch status {
+					case "OK":
+						successCount++
+					case "ERROR":
+						if errCode == "TX_NOT_FOUND" {
+							notFoundCount++
+						} else {
+							s.logger.Errorf("Parent update Lua error for key %v: code=%q", batchRec.Key, errCode)
+							errorCount++
 						}
-						continue
 					}
+					continue
 				}
 			}
 		}
@@ -1854,6 +1902,34 @@ func (s *Service) executeBatchParentUpdatesUDF(ctx context.Context, updates map[
 	}
 
 	return nil
+}
+
+// addDeletedChildrenStatus reads the status / errorCode / errorMessage fields
+// from the SUCCESS map returned by the addDeletedChildren mod-teranode op,
+// without allocating a copy of the map (this runs once per parent update on the
+// per-block cleanup hot path). Both response shapes are handled: the legacy UDF
+// path yields map[interface{}]interface{}; the native-op dispatcher yields
+// map[string]interface{}.
+//
+// ok reports that resp is one of those two map shapes AND carries a string
+// "status" field — matching the old two-step (normalise + status type-assert)
+// guard, so callers fall through to their default success handling unchanged
+// when the response has no parseable status.
+func addDeletedChildrenStatus(resp interface{}) (status, errorCode, errorMessage string, ok bool) {
+	switch m := resp.(type) {
+	case map[interface{}]interface{}:
+		status, ok = m["status"].(string)
+		errorCode, _ = m["errorCode"].(string)
+		errorMessage, _ = m["errorMessage"].(string)
+	case map[string]interface{}:
+		status, ok = m["status"].(string)
+		errorCode, _ = m["errorCode"].(string)
+		errorMessage, _ = m["errorMessage"].(string)
+	default:
+		return "", "", "", false
+	}
+
+	return status, errorCode, errorMessage, ok
 }
 
 // executeBatchParentUpdatesBatchWrite is the fallback when Lua UDF is not configured.

--- a/stores/utxo/aerospike/pruner_provider.go
+++ b/stores/utxo/aerospike/pruner_provider.go
@@ -52,6 +52,16 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 	// fallback when the cluster does not support wire op 200. This eliminates the
 	// steady stream of batch_sub_udf calls the pruner used to emit even on
 	// native-op-enabled deployments.
+	//
+	// A missing parent is the routine case for this op — the parent is normally
+	// one the pruner itself already deleted — so the record must never be created.
+	// initNativeTeranodeOps pins that for every native op by setting the shared
+	// nativeOpBatchWritePolicy to UPDATE_ONLY, matching the Lua addDeletedChildren
+	// this replaces (it returns TX_NOT_FOUND without writing when
+	// aerospike:exists(rec) is false). A resurrected parent would hold only
+	// deletedChildren — no txid, no deleteAtHeight — which the DAH scan could
+	// never reclaim and extractTxHash would fail on. The miss therefore reaches
+	// the pruner as KEY_NOT_FOUND, which it counts as a skipped parent.
 	opts := aeropruner.Options{
 		Logger:        s.logger,
 		Ctx:           s.ctx,

--- a/stores/utxo/aerospike/pruner_provider.go
+++ b/stores/utxo/aerospike/pruner_provider.go
@@ -81,6 +81,16 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 				childHashes,
 			)
 		},
+
+		// Give the pruner the same runtime demotion every other native call site
+		// has. The startup probe samples one partition master, so a mixed-version
+		// cluster can pass it and then reject native writes with PARAMETER_ERROR
+		// on other partitions. The pruner runs every block, making it a likely
+		// first victim; without this it is the one native call site that cannot
+		// trigger the fallback, and its parent updates would keep failing for the
+		// process lifetime. demoteNativeOnUnsupported ignores everything that is
+		// not a PARAMETER_ERROR, so handing it every error is safe.
+		ObserveNativeOpError: s.demoteNativeOnUnsupported,
 	}
 
 	// Create a new pruner service

--- a/stores/utxo/aerospike/pruner_provider.go
+++ b/stores/utxo/aerospike/pruner_provider.go
@@ -3,6 +3,7 @@ package aerospike
 import (
 	"sync"
 
+	"github.com/bsv-blockchain/aerospike-client-go/v8"
 	aeropruner "github.com/bsv-blockchain/teranode/stores/utxo/aerospike/pruner"
 	"github.com/bsv-blockchain/teranode/stores/utxo/pruner"
 )
@@ -44,7 +45,13 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 		return prunerServiceInstance, prunerServiceError
 	}
 
-	// Create options for the pruner service
+	// Create options for the pruner service.
+	//
+	// BuildAddDeletedChildrenRecord routes the pruner's per-parent update through
+	// the native-op wrapper (subOpAddDeletedChildren), with transparent UDF
+	// fallback when the cluster does not support wire op 200. This eliminates the
+	// steady stream of batch_sub_udf calls the pruner used to emit even on
+	// native-op-enabled deployments.
 	opts := aeropruner.Options{
 		Logger:        s.logger,
 		Ctx:           s.ctx,
@@ -54,6 +61,16 @@ func (s *Store) GetPrunerService() (pruner.Service, error) {
 		Set:           s.setName,
 		IndexWaiter:   s,
 		LuaPackage:    LuaPackage,
+		BuildAddDeletedChildrenRecord: func(policy *aerospike.BatchUDFPolicy, key *aerospike.Key, childHashes []interface{}) aerospike.BatchRecordIfc {
+			return s.teranodeBatchRecord(
+				policy,
+				LuaPackage,
+				key,
+				subOpAddDeletedChildren,
+				"addDeletedChildren",
+				childHashes,
+			)
+		},
 	}
 
 	// Create a new pruner service


### PR DESCRIPTION
Extracted from `feat/teranode-native-ops` (PR #1360), the last of a six-PR stack. The other five (#1361–#1365) have all merged, so this now applies directly to `main` and its diff is only its own changes.

## Summary

Routes the pruner's combined-cleanup parent updates and `addDeletedChildren` through the store's native-op builder when `aerospike_use_native_teranode_ops` is active, falling back to the Lua UDF otherwise. The provider injects the builder, so the `pruner` package stays decoupled from the store's native-op internals — it never learns about wire op 200, sub-op IDs, or msgpack.

The bug this fixes: `executeBatchCleanupCombined` keyed the parent-record choice on `luaPackage != ""` alone, so native-op deployments running with defensive mode **off** kept emitting a per-block `batch_sub_udf` burst. `buildParentUpdateRecords` is now shared by the combined and two-call paths so they cannot silently diverge again.

## Review changes

Parent-update result handling now **fails closed**. A missing `SUCCESS` bin, an unreadable response shape, or a status that is neither `OK` nor `ERROR` previously all resolved to `parentSuccess++`, so a genuine native-dispatcher failure could be tallied as success while the child records in the same batch were deleted — breaking exactly the referential integrity the parent-update phase exists to preserve. `classifyParentUpdateResult` reports those as failures describing what it saw, and both paths share it.

Other fixes:

- Missing parents are counted as skips whether they arrive as `KEY_NOT_FOUND` (the native path under the `UPDATE_ONLY` policy #1365 installs) or as an `ERROR`/`TX_NOT_FOUND` response map (the Lua path). Neither creates the record.
- Responses are read from `message`, the key `teranode.lua` and `ParseLuaMapResponse` actually use; `errorMessage` is kept as a tolerated alias. The server-supplied message reaches the log again on the two-call path.
- The client's ordered-map (`[]aerospike.MapPair`) encoding is accepted alongside both map shapes.
- Error and log labels are path-neutral, since a failing record may now be a native batch write rather than a Lua UDF.
- `Options.ObserveNativeOpError` lets parent-update failures reach `demoteNativeOnUnsupported`. The pruner runs its own `BatchOperate`, so it was the one native call site that could not trigger the runtime fallback — and since it runs every block, it is a likely first victim of a mixed-version cluster that passed the single-partition startup probe.

## Tests

- `parent_update_response_test.go` — response parsing across all three map shapes, the fail-closed classifier, result tallying, and the native-op error observer
- `combined_cleanup_native_op_test.go` — cleanup prefers the injected native builder over raw UDF
- `native_op_pruner_record_test.go` — the record the pruner emits is a native `BatchWrite` under `UPDATE_ONLY` (never creating a missing parent), falls back to `BatchUDF` when native ops are off, encodes the hash list as a single argument, and demotes to UDF on `PARAMETER_ERROR` while ignoring `KEY_NOT_FOUND` / timeouts
- `native_op_add_deleted_children_integration_test.go` — `aerospike`-tagged; see the caveat below

## Test coverage caveat

**The native `addDeletedChildren` path has no automated verification in CI.** `native_op_add_deleted_children_integration_test.go` needs a Teraspike server (the BSV fork, wire op 200) and selects it via `AEROSPIKE_CONTAINER_IMAGE`, which is set nowhere in this repo — so the test always hits its skip. Everything else here is covered by unit tests, but the two things only a real fork server can settle are:

1. that the dispatcher's response for this op is a shape the pruner can read — now load-bearing, because unreadable responses fail closed rather than being counted as success; and
2. that a missing parent is not created.

To run it against a fork build:

```bash
AEROSPIKE_CONTAINER_IMAGE=<teraspike-image> go test -tags aerospike \
  -run TestNativeOp_AddDeletedChildren_Integration ./stores/utxo/aerospike/
```

The test asserts both points, plus that `batch_sub_udf_complete` does not move while the parent is mutated — and it now requires that statistic to exist on some node, so a renamed or version-gated counter fails loudly instead of comparing 0 to 0.

## Verification

```
gofmt -l stores/utxo/aerospike/           → (empty)
go build ./...                            → exit 0
go vet ./stores/... ./settings/...        → exit 0
go vet -tags aerospike ./stores/...       → exit 0
go test -count=1 ./stores/utxo/aerospike/...
    ok  .../stores/utxo/aerospike         267.183s
    ok  .../stores/utxo/aerospike/pruner   43.842s
golangci-lint run stores/utxo/aerospike/...
    1 issue, pre-existing, in longest_chain_production_bench_test.go (untouched)
```

The setting defaults to off, so the native path is opt-in.
