### PR TITLE
fix(p2p): key gossip peer maps by canonical hash, parse subtree hash before use

### DIFF
--- a/docs/references/services/p2p_reference.md
+++ b/docs/references/services/p2p_reference.md
@@ -38,8 +38,8 @@ type Server struct {
     invalidSubtreeTopicName           string             // Kafka topic for invalid subtrees
     nodeStatusTopicName               string             // pubsub topic for node status messages
     topicPrefix                       string             // Chain identifier prefix for topic validation
-    blockPeerMap                      sync.Map           // Map to track which peer sent each block (hash -> peerMapEntry)
-    subtreePeerMap                    sync.Map           // Map to track which peer sent each subtree (hash -> peerMapEntry)
+    blockPeerMap                      sync.Map           // Map to track which peer sent each block (canonical chainhash.Hash.String() -> peerMapEntry)
+    subtreePeerMap                    sync.Map           // Map to track which peer sent each subtree (canonical chainhash.Hash.String() -> peerMapEntry)
     startTime                         time.Time          // Server start time for uptime calculation
     peerRegistry                      *PeerRegistry      // Central registry for all peer information
     peerSelector                      *PeerSelector      // Stateless peer selection logic

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -134,8 +134,8 @@ type Server struct {
 	invalidSubtreeTopicName           string                         // Kafka topic for invalid subtrees
 	nodeStatusTopicName               string                         // pubsub topic for node status messages
 	topicPrefix                       string                         // Chain identifier prefix for topic validation
-	blockPeerMap                      sync.Map                       // Map to track which peer sent each block (hash -> peerMapEntry)
-	subtreePeerMap                    sync.Map                       // Map to track which peer sent each subtree (hash -> peerMapEntry)
+	blockPeerMap                      sync.Map                       // Map to track which peer sent each block (canonical chainhash.Hash.String() -> peerMapEntry)
+	subtreePeerMap                    sync.Map                       // Map to track which peer sent each subtree (canonical chainhash.Hash.String() -> peerMapEntry)
 	startTime                         time.Time                      // Server start time for uptime calculation
 	peerRegistry                      blockchain.PeerRegistryClientI // gRPC client for the centralized peer registry hosted by the blockchain service
 	peerSelector                      *PeerSelector                  // Stateless peer selection logic

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -203,13 +203,20 @@ func (s *Server) handleSubtreeTopic(_ context.Context, m []byte, fromID string) 
 
 	s.logger.Debugf("[handleSubtreeTopic] received subtree %s from %s", subtreeMessage.Hash, subtreeMessage.PeerID)
 
+	// Parse the hash before any use, mirroring handleBlockTopic: a malformed
+	// hash must not reach WebSocket subscribers or count as peer activity.
+	hash, err = s.parseHash(subtreeMessage.Hash, "handleSubtreeTopic")
+	if err != nil {
+		return
+	}
+
 	now := time.Now().UTC()
 
 	select {
 	case s.notificationCh <- &notificationMsg{
 		Timestamp:  now.Format(isoFormat),
 		Type:       "subtree",
-		Hash:       subtreeMessage.Hash,
+		Hash:       hash.String(),
 		BaseURL:    subtreeMessage.DataHubURL,
 		PeerID:     subtreeMessage.PeerID,
 		ClientName: subtreeMessage.ClientName,
@@ -232,12 +239,6 @@ func (s *Server) handleSubtreeTopic(_ context.Context, m []byte, fromID string) 
 
 	// Skip notifications from unhealthy peers
 	if s.shouldSkipUnhealthyPeer(fromID, "handleSubtreeTopic") {
-		return
-	}
-
-	hash, err = s.parseHash(subtreeMessage.Hash, "handleSubtreeTopic")
-	if err != nil {
-		s.logger.Errorf("[handleSubtreeTopic] error parsing hash: %v", err)
 		return
 	}
 

--- a/services/p2p/server_helpers.go
+++ b/services/p2p/server_helpers.go
@@ -108,8 +108,12 @@ func (s *Server) handleBlockTopic(_ context.Context, m []byte, fromID string) {
 
 	now := time.Now().UTC()
 
-	// Store the peer ID that sent this block
-	s.storePeerMapEntry(&s.blockPeerMap, blockMessage.Hash, fromID, now)
+	// Store the peer ID that sent this block, keyed by the canonical hash
+	// string. Ban lookups (ReportInvalidBlock, processInvalidBlockMessage) use
+	// hash.String() from block validation, so keying by the raw message string
+	// would let a peer evade the invalid-block ban by announcing a
+	// non-canonical hex form (uppercase, truncated).
+	s.storePeerMapEntry(&s.blockPeerMap, hash.String(), fromID, now)
 
 	s.logger.Debugf("[handleBlockTopic] storing peer %s for block %s", fromID, blockMessage.Hash)
 
@@ -237,8 +241,11 @@ func (s *Server) handleSubtreeTopic(_ context.Context, m []byte, fromID string) 
 		return
 	}
 
-	// Store the peer ID that sent this subtree
-	s.storePeerMapEntry(&s.subtreePeerMap, subtreeMessage.Hash, fromID, now)
+	// Store the peer ID that sent this subtree, keyed by the canonical hash
+	// string so the ReportInvalidSubtree lookup (which uses hash.String() from
+	// subtree validation) matches even when the announcer sent a non-canonical
+	// hex form.
+	s.storePeerMapEntry(&s.subtreePeerMap, hash.String(), fromID, now)
 	s.logger.Debugf("[handleSubtreeTopic] storing peer %s for subtree %s", fromID, subtreeMessage.Hash)
 
 	if s.subtreeKafkaProducerClient != nil { // tests may not set this

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -468,6 +468,91 @@ func TestHandleSubtreeTopic_PeerMapKeyedByCanonicalHash(t *testing.T) {
 	peerID, err := s.getPeerFromMap(&s.subtreePeerMap, canonical, "subtree")
 	require.NoError(t, err, "subtreePeerMap must be keyed by the canonical hash string")
 	require.Equal(t, remote.String(), peerID)
+
+	_, err = s.getPeerFromMap(&s.subtreePeerMap, strings.ToUpper(canonical), "subtree")
+	require.Error(t, err, "raw non-canonical announce string must not be a map key")
+
+	select {
+	case notification := <-s.notificationCh:
+		require.Equal(t, canonical, notification.Hash,
+			"subtree notification must carry the canonical hash")
+	default:
+		t.Fatal("expected subtree notification")
+	}
+}
+
+// A malformed subtree hash must be rejected before any use: no WebSocket
+// notification, no peerMapEntry, and no peer-activity credit.
+func TestHandleSubtreeTopic_RejectsMalformedHash(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	remote := mustNewPeerID(t)
+	msgBytes, err := json.Marshal(SubtreeMessage{
+		PeerID:     remote.String(),
+		ClientName: "client/1.0",
+		DataHubURL: "http://peer.example",
+		Hash:       "not-a-subtree-hash",
+	})
+	require.NoError(t, err)
+
+	s.handleSubtreeTopic(context.Background(), msgBytes, remote.String())
+
+	select {
+	case notification := <-s.notificationCh:
+		t.Fatalf("unexpected subtree notification for malformed hash: %+v", notification)
+	default:
+	}
+
+	entries := 0
+	s.subtreePeerMap.Range(func(_, _ any) bool { entries++; return true })
+	require.Zero(t, entries, "malformed hash must not create a subtreePeerMap entry")
+
+	_, ok := reg.Get(remote.String())
+	require.False(t, ok, "malformed hash must not count as peer activity")
+}
+
+// End-to-end guard for the canonical-key fix: a peer that announces an
+// invalid block using a non-canonical hex form (uppercase) must still be
+// banned when block validation reports the block by its canonical hash.
+func TestHandleBlockTopic_NonCanonicalAnnouncerStillBanned(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+	setServerLocalHeight(t, s, 100)
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	remote := mustNewPeerID(t)
+	canonical := chainhash.HashH([]byte("invalid block announced uppercase")).String()
+	msgBytes, err := json.Marshal(BlockMessage{
+		PeerID:     remote.String(),
+		ClientName: "client/1.0",
+		DataHubURL: "http://peer.example",
+		Hash:       strings.ToUpper(canonical),
+		Height:     101,
+	})
+	require.NoError(t, err)
+
+	s.handleBlockTopic(context.Background(), msgBytes, remote.String())
+
+	// Block validation reports the invalid block by its canonical hash.
+	invalidMsg := mustMarshalInvalidBlockMsg(t, canonical, "invalid block")
+	require.NoError(t, s.processInvalidBlockMessage(&kafka.KafkaMessage{Value: invalidMsg}))
+
+	info, ok := reg.Get(remote.String())
+	require.True(t, ok)
+	require.Positive(t, info.BanScore, "announcer of the invalid block must be banned")
+
+	_, stillThere := s.blockPeerMap.Load(canonical)
+	require.False(t, stillThere, "entry must be removed after the ban")
 }
 
 func TestHandleNodeStatusTopic_RejectsMalformedAdvertisedHash(t *testing.T) {

--- a/services/p2p/server_helpers_test.go
+++ b/services/p2p/server_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -398,6 +399,75 @@ func TestHandleBlockTopic_RejectsMalformedAdvertisedHash(t *testing.T) {
 		t.Fatalf("unexpected Kafka publish for malformed hash: %+v", published)
 	default:
 	}
+
+	entries := 0
+	s.blockPeerMap.Range(func(_, _ any) bool { entries++; return true })
+	require.Zero(t, entries, "malformed hash must not create a blockPeerMap entry")
+}
+
+// chainhash.NewHashFromStr accepts non-canonical hex forms (uppercase,
+// truncated), while the ban lookups in ReportInvalidBlock and
+// processInvalidBlockMessage use the canonical hash.String() from block
+// validation. The blockPeerMap must therefore be keyed by the canonical form,
+// or a peer could evade the invalid-block ban by announcing the block with a
+// non-canonical hash string.
+func TestHandleBlockTopic_PeerMapKeyedByCanonicalHash(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+	setServerLocalHeight(t, s, 100)
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	remote := mustNewPeerID(t)
+	canonical := chainhash.HashH([]byte("canonical block key")).String()
+	msgBytes, err := json.Marshal(BlockMessage{
+		PeerID:     remote.String(),
+		ClientName: "client/1.0",
+		DataHubURL: "http://peer.example",
+		Hash:       strings.ToUpper(canonical),
+		Height:     101,
+	})
+	require.NoError(t, err)
+
+	s.handleBlockTopic(context.Background(), msgBytes, remote.String())
+
+	peerID, err := s.getPeerFromMap(&s.blockPeerMap, canonical, "block")
+	require.NoError(t, err, "blockPeerMap must be keyed by the canonical hash string")
+	require.Equal(t, remote.String(), peerID)
+
+	_, err = s.getPeerFromMap(&s.blockPeerMap, strings.ToUpper(canonical), "block")
+	require.Error(t, err, "raw non-canonical announce string must not be a map key")
+}
+
+// Same canonical-key requirement as the block map: ReportInvalidSubtree looks
+// up subtreePeerMap with the canonical hash.String() from subtree validation.
+func TestHandleSubtreeTopic_PeerMapKeyedByCanonicalHash(t *testing.T) {
+	s, _ := newServerWithLocalRegistry(t)
+
+	self := mustNewPeerID(t)
+	mockP2P := new(MockServerP2PClient)
+	mockP2P.peerID = self
+	s.P2PClient = mockP2P
+	s.notificationCh = make(chan *notificationMsg, 1)
+
+	remote := mustNewPeerID(t)
+	canonical := chainhash.HashH([]byte("canonical subtree key")).String()
+	msgBytes, err := json.Marshal(SubtreeMessage{
+		PeerID:     remote.String(),
+		ClientName: "client/1.0",
+		DataHubURL: "http://peer.example",
+		Hash:       strings.ToUpper(canonical),
+	})
+	require.NoError(t, err)
+
+	s.handleSubtreeTopic(context.Background(), msgBytes, remote.String())
+
+	peerID, err := s.getPeerFromMap(&s.subtreePeerMap, canonical, "subtree")
+	require.NoError(t, err, "subtreePeerMap must be keyed by the canonical hash string")
+	require.Equal(t, remote.String(), peerID)
 }
 
 func TestHandleNodeStatusTopic_RejectsMalformedAdvertisedHash(t *testing.T) {


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4726.**

### Problem

The issue reported two defects in `handleBlockTopic`: the announcing peer was registered with a nil block hash, and the raw (unvalidated, up-to-32KB) message hash string was stored as a `blockPeerMap` key before any validation.

Since the issue was filed, PR bsv-blockchain/teranode#1201 added `sanitizeAdvertisedTip`, which parses and validates the hash before `addPeer` and `storePeerMapEntry` run - so the nil-hash registration and the unbounded-garbage-key vectors are already closed on main, and those items are skipped.

What remained of the issue: the peer maps were still keyed by the **raw** message string rather than the canonical form. `chainhash.NewHashFromStr` accepts non-canonical hex (uppercase, truncated, odd length), while the ban lookups - `ReportInvalidBlock`, `processInvalidBlockMessage`, `ReportInvalidSubtree` - use the canonical `hash.String()` produced by the validation services. A peer announcing an invalid block or subtree with e.g. an uppercase hash string therefore created a map entry that never matched the lookup, evading the invalid-block/invalid-subtree ban.

The fresh-eyes review also found that `handleSubtreeTopic` still had the exact use-before-parse pattern the issue describes: the raw, unvalidated hash string was forwarded to WebSocket subscribers and credited as peer activity before `parseHash` ran.

### Fix

- `handleBlockTopic` and `handleSubtreeTopic` now key `blockPeerMap` / `subtreePeerMap` by the canonical `hash.String()` (the issue's proposed fix; the hash is already parsed at that point on all paths).
- `handleSubtreeTopic` now parses the hash before any use, mirroring `handleBlockTopic`: a malformed hash is rejected before the WebSocket notification, `updatePeerLastMessageTime`, and `updateBytesReceived`, and the notification carries the canonical hash.
- Updated the map-key comments in `Server.go` and `docs/references/services/p2p_reference.md` to state the canonical-key contract.

### Residual

Pre-existing behavior deliberately left unchanged (flagged by review, out of scope for this issue):

- Degenerate-but-hex strings (`""`, `"abc"`) are normalized by `chainhash.NewHashFromStr` (zero-padded) rather than rejected at ingress; an empty announce hash still normalizes to the zero hash, as it did before.
- Readers (`getPeerFromMap` and the `Delete` call sites) do not re-normalize their input; all producers were verified to pass canonical `hash.String()` values.
- `storePeerMapEntry` is last-writer-wins, so the most recent announcer of a hash absorbs the ban.

### Tests

Added in `services/p2p/server_helpers_test.go`:

- `TestHandleBlockTopic_PeerMapKeyedByCanonicalHash` - uppercase announce is stored under the canonical key, not the raw string.
- `TestHandleSubtreeTopic_PeerMapKeyedByCanonicalHash` - same for the subtree map, plus the notification carries the canonical hash.
- `TestHandleBlockTopic_NonCanonicalAnnouncerStillBanned` - end-to-end: uppercase announce, then `processInvalidBlockMessage` with the canonical hash bans the announcer and removes the entry.
- `TestHandleSubtreeTopic_RejectsMalformedHash` - malformed hash produces no notification, no map entry, no peer-activity credit.
- Strengthened `TestHandleBlockTopic_RejectsMalformedAdvertisedHash` to assert the map stays empty.

Run (affected package only):

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
go vet ./services/p2p/
```

Both green.
