### PR TITLE
ci: honor GITHUB_REF and prefer stable tag when multiple tags point at HEAD

### DIFF
--- a/scripts/determine-git-version.sh
+++ b/scripts/determine-git-version.sh
@@ -12,8 +12,37 @@ if [ "$1" = "--makefile" ]; then
   MAKEFILE_MODE=true
 fi
 
-# Get git values similar to Makefile
-GIT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+# Resolve the tag for HEAD.
+#
+# When the workflow was triggered by a tag push, GITHUB_REF is the exact ref
+# that fired it (e.g. refs/tags/v0.15.8). Trusting it here makes the picked
+# tag deterministic: a release-branch tip commonly carries BOTH a v0.15.8
+# and a v0.15.8-beta-2 tag (we tag the beta, promote to stable at the same
+# SHA), and `git describe --tags --exact-match` breaks ties by tagger date
+# in a way that varies across git versions and fetch orders — so a stable
+# build could stamp itself as the earlier beta.
+#
+# For local Makefile / shell use (no GITHUB_REF), fall back to git and
+# prefer a plain vX.Y.Z tag over any prerelease tag pointing at the same
+# commit; then fall back to `describe --exact-match` for anything else
+# (e.g. -rc, custom prefixes).
+GIT_TAG=""
+if [ -n "$GITHUB_REF" ] && [[ "$GITHUB_REF" == refs/tags/* ]]; then
+  GIT_TAG="${GITHUB_REF#refs/tags/}"
+else
+  # Prefer a stable release tag (vMAJOR.MINOR.PATCH) if one is present.
+  while IFS= read -r candidate; do
+    if [[ "$candidate" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      GIT_TAG="$candidate"
+      break
+    fi
+  done < <(git tag --points-at HEAD 2>/dev/null | sort -V -r)
+
+  if [ -z "$GIT_TAG" ]; then
+    GIT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+  fi
+fi
+
 GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_TIMESTAMP=$(git show -s --format=%cd --date=format:%Y%m%d%H%M%S HEAD 2>/dev/null || date +%Y%m%d%H%M%S)

--- a/scripts/determine-git-version.sh
+++ b/scripts/determine-git-version.sh
@@ -31,12 +31,13 @@ if [ -n "$GITHUB_REF" ] && [[ "$GITHUB_REF" == refs/tags/* ]]; then
   GIT_TAG="${GITHUB_REF#refs/tags/}"
 else
   # Prefer a stable release tag (vMAJOR.MINOR.PATCH) if one is present.
-  while IFS= read -r candidate; do
-    if [[ "$candidate" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      GIT_TAG="$candidate"
-      break
-    fi
-  done < <(git tag --points-at HEAD 2>/dev/null | sort -V -r)
+  # `grep -E` is POSIX and works on both GNU and BSD (macOS) — unlike
+  # `sort -V`, which is a GNU coreutils extension and errors out silently
+  # on the default macOS `sort`. Multiple stable tags on one commit is
+  # never expected, so head -n 1 is deterministic enough here.
+  GIT_TAG=$(git tag --points-at HEAD 2>/dev/null \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | head -n 1)
 
   if [ -z "$GIT_TAG" ]; then
     GIT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- `git describe --tags --exact-match` breaks ties between multiple tags on one commit by tagger date, in a way that varies across git versions and fetch orders. A release-branch tip commonly carries both a `v0.15.8` and a `v0.15.8-beta-2` tag (we tag the beta, promote to stable at the same SHA), so CI can stamp a stable build with the earlier beta version string — correct binary, wrong self-reported version. Observed on `v0.15.8`, which shipped a container reporting itself as `v0.15.8-beta-2` in logs.
- Fix `scripts/determine-git-version.sh`:
  - In GitHub Actions, honor `GITHUB_REF` when it points at a tag: that IS the ref that fired the workflow, so it is the authoritative tag for this build. No ambiguity.
  - For local Makefile / shell use (no `GITHUB_REF`), prefer a plain `vMAJOR.MINOR.PATCH` tag over any prerelease tag pointing at the same commit. Fall back to `describe --exact-match` when neither yields a `vX.Y.Z` (e.g. `-rc`, custom prefixes).

## Test plan
Verified against a worktree at `v0.15.8` (a commit carrying both `v0.15.8` and `v0.15.8-beta-2` tags):
- [x] Local run (no `GITHUB_REF`) picks `v0.15.8`
- [x] CI simulation with `GITHUB_REF=refs/tags/v0.15.8` picks `v0.15.8`
- [x] CI simulation with `GITHUB_REF=refs/tags/v0.15.8-beta-2` picks `v0.15.8-beta-2` (a real beta build should still report as beta)
- [x] Bash `-n` syntax check clean

Not covered by these tests but worth watching in the next release cycle:
- [ ] Next `-beta-N` push triggers a build stamped correctly as `-beta-N`
- [ ] Next stable tag push at a beta-tagged SHA triggers a build stamped as stable, NOT the beta