### PR TITLE
fix(blockvalidation): survive a peer serving cached empty subtree_data, attribute catchup failures correctly

### DIFF
--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1811,10 +1811,17 @@ func (u *Server) processCatchupChItem(ctx context.Context, c processBlockCatchup
 			u.logger.Warnf("[catchup] All peers failed for block %s (attempt %d/%d), clearing markers and reporting peer failure to allow retry from a different peer: %v", c.block.Hash().String(), attempts, u.settings.BlockValidation.CatchupMaxAttemptsPerBlock, err)
 			u.processBlockNotify.Delete(*c.block.Hash())
 			u.catchupAlternatives.Delete(*c.block.Hash())
-			u.reportCatchupFailure(ctx, c.peerID)
 
-			if reportErr := u.blockchainClient.ReportPeerFailure(ctx, c.block.Hash(), c.peerID, "catchup", err.Error()); reportErr != nil {
-				u.logger.Errorf("[catchup] failed to report peer failure for block %s peer %s: %v", c.block.Hash().String(), c.peerID, reportErr)
+			// Peers that actually failed were charged individually at the point of
+			// failure (recordCatchupPeerFailure / markCatchupFailureReported). Charging
+			// c.peerID here would blame the catchup primary for another peer's failure,
+			// which is what drove healthy peers to 0% success in issue 1368.
+			u.reportCatchupFailureForError(ctx, c.peerID, err)
+
+			if !catchupFailureAlreadyReported(err) {
+				if reportErr := u.blockchainClient.ReportPeerFailure(ctx, c.block.Hash(), c.peerID, "catchup", err.Error()); reportErr != nil {
+					u.logger.Errorf("[catchup] failed to report peer failure for block %s peer %s: %v", c.block.Hash().String(), c.peerID, reportErr)
+				}
 			}
 
 			return

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1815,13 +1815,40 @@ func (u *Server) processCatchupChItem(ctx context.Context, c processBlockCatchup
 			// Peers that actually failed were charged individually at the point of
 			// failure (recordCatchupPeerFailure / markCatchupFailureReported). Charging
 			// c.peerID here would blame the catchup primary for another peer's failure,
-			// which is what drove healthy peers to 0% success in issue 1368.
+			// which is what drove healthy peers to 0% success in issue 1368. The
+			// already-reported marker check inside reportCatchupFailureForError
+			// suppresses exactly that duplicate *reputation* charge.
 			u.reportCatchupFailureForError(ctx, c.peerID, err)
 
-			if !catchupFailureAlreadyReported(err) {
-				if reportErr := u.blockchainClient.ReportPeerFailure(ctx, c.block.Hash(), c.peerID, "catchup", err.Error()); reportErr != nil {
-					u.logger.Errorf("[catchup] failed to report peer failure for block %s peer %s: %v", c.block.Hash().String(), c.peerID, reportErr)
-				}
+			// ReportPeerFailure is deliberately NOT gated on catchupFailureAlreadyReported.
+			// It is not a reputation call — it is the sync-peer ROTATION signal, and it has
+			// to fire on every all-peers-failed cycle:
+			//
+			//   blockchain.Server.ReportPeerFailure broadcasts NotificationType_PeerFailure
+			//   -> p2p.Server routes failure_type "catchup" to
+			//      syncCoordinator.HandleCatchupFailure (and its subscription listener
+			//      deliberately bypasses the "skip notifications while syncing" filter for
+			//      this type — "needed to switch peers on catchup failure")
+			//   -> SyncCoordinator clears currentSyncPeer and calls triggerSyncLocked, i.e.
+			//      immediate re-selection of a different sync peer.
+			//
+			// A marker gate here is dead code in production: fetchAndStoreSubtreeAndSubtreeData
+			// applies markCatchupFailureReported unconditionally to every all-peers-failed
+			// error and is the only producer of this ErrExternal in the package, so the gate
+			// is always false and rotation never happens. A stuck node would then depend on
+			// the sync coordinator's 30s periodicEvaluation, which only rotates on reputation
+			// below 20 or the 5-minute SyncPeerNoProgressTimeout — a peer with history (say
+			// 100 successes and 1 failure) trips neither, so recovery costs the full five
+			// minutes per stuck cycle.
+			//
+			// The price is one extra interaction-failure charge against the primary. That is
+			// accepted, and consistent with the round-2 adjudication documented in
+			// catchup.go's failedPeers drain: an over-charge is directionally accurate while
+			// an under-charge hides a real failure, and the duplicate increment is a
+			// telemetry-precision cost rather than a reputation-math break. Losing peer
+			// rotation to save one charge is the worse trade — do not re-add the gate.
+			if reportErr := u.blockchainClient.ReportPeerFailure(ctx, c.block.Hash(), c.peerID, "catchup", err.Error()); reportErr != nil {
+				u.logger.Errorf("[catchup] failed to report peer failure for block %s peer %s: %v", c.block.Hash().String(), c.peerID, reportErr)
 			}
 
 			return

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -251,6 +251,10 @@ type Server struct {
 	blocksFetched   atomic.Int64
 	blocksValidated atomic.Int64
 
+	// cacheBustCounter produces the unique token appended to a peer request URL when
+	// a previous response from that peer looked poisoned. See peer_cache_bypass.go.
+	cacheBustCounter atomic.Uint64
+
 	// previousCatchupAttempt stores details about the last failed catchup attempt.
 	// This is used to display in the dashboard why we switched from one peer to another.
 	// Protected by activeCatchupCtxMu for thread-safe access.

--- a/services/blockvalidation/block_processing_retry_test.go
+++ b/services/blockvalidation/block_processing_retry_test.go
@@ -351,6 +351,37 @@ func TestProcessCatchupChItem(t *testing.T) {
 		mockBC.AssertCalled(t, "ReportPeerFailure", mock.Anything, mock.Anything, mock.Anything, "catchup", mock.Anything)
 	})
 
+	// The two cases above build ErrExternal chains WITHOUT the already-reported
+	// marker. Production never emits that shape: fetchAndStoreSubtreeAndSubtreeData
+	// applies markCatchupFailureReported to every all-peers-failed error, and it is
+	// the only producer of this ErrExternal in the package. This case pins the real
+	// shape — ReportPeerFailure is the sync-peer ROTATION signal (blockchain
+	// PeerFailure notification -> p2p HandleCatchupFailure -> currentSyncPeer cleared
+	// + triggerSyncLocked), so it must still fire even though the marker suppresses
+	// the duplicate reputation charge in reportCatchupFailureForError. Gating it on
+	// the marker silently disabled rotation and left recovery to the 5-minute
+	// SyncPeerNoProgressTimeout.
+	t.Run("marked external error (production shape) still reports peer failure for rotation", func(t *testing.T) {
+		// Exactly what get_blocks.go returns, then the wraps it picks up on the way up.
+		marked := markCatchupFailureReported(errors.NewExternalError("all 3 peer attempts failed to fetch subtree aa"))
+		svcWrap := errors.NewServiceError("failed to fetch subtree data for block bb", marked)
+		chain := errors.NewProcessingError("worker failed for block bb", svcWrap)
+
+		require.True(t, catchupFailureAlreadyReported(chain), "precondition: production marks every all-peers-failed error")
+		require.True(t, errors.Is(chain, errors.ErrExternal))
+
+		u, _ := newServer(3, chain)
+		b := testBlock()
+		u.processBlockNotify.Set(*b.Hash(), true, ttlcache.DefaultTTL)
+
+		u.processCatchupChItem(ctx, item(b))
+
+		require.Nil(t, u.processBlockNotify.Get(*b.Hash()))
+
+		mockBC := u.blockchainClient.(*blockchain.Mock)
+		mockBC.AssertCalled(t, "ReportPeerFailure", mock.Anything, mock.Anything, mock.Anything, "catchup", mock.Anything)
+	})
+
 	t.Run("invalid block clears notify without counting toward cap", func(t *testing.T) {
 		u, _ := newServer(3, errors.NewBlockInvalidError("bad block"))
 		b := testBlock()

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -486,13 +486,15 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 		// Accounting note: this charges a CatchupFailure without a paired
 		// CatchupAttempt for the failing peer (only the primary gets a
 		// reportCatchupAttempt call, at the start of catchup — see catchup.go's
-		// call site). CatchupAttempts/CatchupFailures are display/telemetry
-		// counters, not reputation inputs (reputation is computed from the
-		// separate Interaction* counters, which RecordCatchupFailureWithKind keeps
-		// internally consistent), and this matches existing precedent for
-		// reporting failures against alternative peers elsewhere in this package.
-		// The tradeoff: the displayed attempts/failures ratio for a fallback-only
-		// peer is not a rate.
+		// call site). That is new to this change, and there is no precedent for it
+		// in this package: the other sites that charge non-primary peers reach them
+		// through catchup()/catchupFunc(), which calls reportCatchupAttempt
+		// unconditionally, so those charges do have a paired attempt. Accepted
+		// regardless, because CatchupAttempts/CatchupFailures are display/telemetry
+		// counters, not reputation inputs (reputation is computed from the separate
+		// Interaction* counters, which RecordCatchupFailureWithKind keeps internally
+		// consistent). The tradeoff: the displayed attempts/failures ratio for a
+		// fallback-only peer is not a rate.
 		//
 		// This loop is authoritative for every peer in failedPeers, including the
 		// primary — deliberately, even though that means a peer which both failed

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -493,17 +493,40 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 		// reporting failures against alternative peers elsewhere in this package.
 		// The tradeoff: the displayed attempts/failures ratio for a fallback-only
 		// peer is not a rate.
+		//
+		// This loop is authoritative for every peer in failedPeers, including the
+		// primary — deliberately, even though that means a peer which both failed
+		// a subtree fetch mid-cycle AND caused the cycle's terminal error gets
+		// charged twice for one attempt. An earlier version tried to skip the
+		// primary here whenever the terminal error was a generic peer error, on
+		// the assumption that Server.go's processCatchupChItem would charge it
+		// once instead, using the terminal error. That assumption does not hold
+		// for every terminal error shape: a genuinely local failure produced by
+		// fetchAndStoreSubtreeAndSubtreeData (e.g. its "Local error fetching
+		// subtree ... not retrying with other peers" wrap) is coded
+		// ErrServiceError, which this switch has no specific case for (it falls
+		// to the unknown_error default with isPeerError left true), and
+		// Server.go's ErrServiceError branch returns early WITHOUT ever calling
+		// reportCatchupFailureForError. Skipping the primary here in that case
+		// charged it zero times for a real subtree failure it caused — an
+		// under-charge that hides a genuine failure entirely, which is worse
+		// than an over-charge that is at least directionally accurate. Both
+		// increments feed InteractionAttempts/InteractionFailures consistently
+		// (see the peer registry), so the occasional double-charge is a
+		// telemetry precision cost, not a reputation-math break. The one
+		// exception is reportIncompleteBlock, guarded below, where both charges
+		// live in this same function and the skip carries no such cross-file risk.
 		for failedPeerID, failedMsg := range failedPeers {
-			if reportPeerErr && failedPeerID == peerID {
-				// reportPeerErr=true (isPeerError, e.g. validation_failure or a
-				// generic/network error — never set alongside ErrExternal, whose
-				// case above always sets isPeerError=false) means the caller in
-				// Server.go's processCatchupChItem will report this catchup
-				// failure itself, once, using the terminal error for the whole
-				// cycle (reportCatchupFailureForError, called after catchup()
-				// returns). Also charging the primary here, from an earlier
-				// subtree-level failure recorded mid-cycle, would double the
-				// CatchupFailures increment for a single catchup attempt.
+			if reportIncompleteBlock && failedPeerID == peerID {
+				// reportIncompleteBlock already charges the primary below via
+				// reportCatchupFailureWithKind, with the more specific
+				// catchupFailureKindBlockIncomplete (which drives a documented
+				// incomplete-block penalty window a generic charge would not).
+				// Both calls are local to this function, so — unlike the
+				// cross-file assumption described above — this skip is safe.
+				// Still store the subtree-level error text so it isn't lost;
+				// only the generic failure counter is skipped.
+				u.reportCatchupError(rpcCtx, failedPeerID, failedMsg)
 				continue
 			}
 

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -55,6 +56,15 @@ type CatchupContext struct {
 	highestCheckpointHeight uint32 // Highest checkpoint height for validation checks
 	catchupError            error  // Any error encountered during catchup
 	incompleteBlockHash     string // Block hash reported when a peer serves an incomplete block
+
+	// failedPeers records the peers that actually failed to serve data during this
+	// catchup cycle, deduplicated by peer ID (last error message wins). Written from
+	// concurrent per-subtree fetch goroutines via recordCatchupPeerFailure and drained
+	// by releaseCatchupLock, which charges each of them once. Deduplication keeps
+	// CatchupFailures from exceeding CatchupAttempts when several concurrent subtree
+	// fetches fail against the same peer.
+	failedPeersMu sync.Mutex
+	failedPeers   map[string]string
 
 	// Performance monitoring and dynamic peer switching
 	performanceMonitor   *CatchupPerformanceMonitor
@@ -366,6 +376,7 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 		peerID                string
 		errorMsg              string
 		incompleteBlockHash   string
+		failedPeers           map[string]string
 	)
 
 	// Capture failure details for dashboard before clearing context
@@ -383,6 +394,16 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 			errorType = "validation_failure"
 			// Mark peer as malicious for validation failure (reported after unlock)
 			reportMalicious = true
+		case errors.Is(*err, errors.ErrExternal):
+			// Every peer attempt failed to fetch subtree data. The individual failures
+			// were already attributed to the peers that produced them
+			// (recordCatchupPeerFailure), so charging the catchup primary here as well
+			// would penalize a healthy peer for another peer's failure — the 0%-success
+			// symptom in issue 1368. Must precede the IsNetworkError case: one peer's
+			// connection error inside the chain would otherwise classify the whole
+			// all-peers-failed error as a network error against the primary.
+			errorType = "peer_data_unavailable"
+			isPeerError = false
 		case errors.IsNetworkError(*err):
 			errorType = "network_error"
 		case strings.Contains(errorMsg, "secret mining") || strings.Contains(errorMsg, "secretly mined"):
@@ -418,6 +439,15 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 			incompleteBlockHash = ctx.incompleteBlockHash
 		}
 
+		ctx.failedPeersMu.Lock()
+		if len(ctx.failedPeers) > 0 {
+			failedPeers = make(map[string]string, len(ctx.failedPeers))
+			for id, msg := range ctx.failedPeers {
+				failedPeers[id] = msg
+			}
+		}
+		ctx.failedPeersMu.Unlock()
+
 		u.previousCatchupAttempt = &PreviousAttempt{
 			PeerID:            ctx.peerID,
 			PeerURL:           ctx.baseURL,
@@ -446,9 +476,16 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 	// Make the fire-and-forget reputation gRPC calls outside the lock with a bounded
 	// context, so a stalled P2P service can neither hold activeCatchupCtxMu nor outlive
 	// shutdown. These are best-effort; failures are logged inside the helpers.
-	if reportMalicious || reportPeerErr || reportIncompleteBlock {
+	if reportMalicious || reportPeerErr || reportIncompleteBlock || len(failedPeers) > 0 {
 		rpcCtx, cancel := context.WithTimeout(context.Background(), catchupReputationReportTimeout)
 		defer cancel()
+
+		// Charge each peer that actually failed to serve data, once, with its own
+		// error text (issue 1368: a healthy peer used to carry another peer's 404).
+		for failedPeerID, failedMsg := range failedPeers {
+			u.reportCatchupFailure(rpcCtx, failedPeerID)
+			u.reportCatchupError(rpcCtx, failedPeerID, failedMsg)
+		}
 
 		if reportMalicious {
 			u.reportCatchupMalicious(rpcCtx, peerID, "validation_failure")
@@ -480,6 +517,32 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 	if prometheusCatchupDuration != nil {
 		prometheusCatchupDuration.WithLabelValues(ctx.baseURL, success).Observe(time.Since(ctx.startTime).Seconds())
 	}
+}
+
+// recordCatchupPeerFailure attributes a data-serving failure to the peer that caused
+// it, for the current catchup cycle. Best-effort: with no active catchup context
+// (e.g. a direct block fetch outside catchup) the call is a no-op.
+func (u *Server) recordCatchupPeerFailure(peerID string, err error) {
+	if peerID == "" || err == nil {
+		return
+	}
+
+	u.activeCatchupCtxMu.RLock()
+	catchupCtx := u.activeCatchupCtx
+	u.activeCatchupCtxMu.RUnlock()
+
+	if catchupCtx == nil {
+		return
+	}
+
+	catchupCtx.failedPeersMu.Lock()
+	defer catchupCtx.failedPeersMu.Unlock()
+
+	if catchupCtx.failedPeers == nil {
+		catchupCtx.failedPeers = make(map[string]string)
+	}
+
+	catchupCtx.failedPeers[peerID] = err.Error()
 }
 
 // fetchHeaders retrieves block headers from the peer using block locator pattern.

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -482,7 +482,31 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 
 		// Charge each peer that actually failed to serve data, once, with its own
 		// error text (issue 1368: a healthy peer used to carry another peer's 404).
+		//
+		// Accounting note: this charges a CatchupFailure without a paired
+		// CatchupAttempt for the failing peer (only the primary gets a
+		// reportCatchupAttempt call, at the start of catchup — see catchup.go's
+		// call site). CatchupAttempts/CatchupFailures are display/telemetry
+		// counters, not reputation inputs (reputation is computed from the
+		// separate Interaction* counters, which RecordCatchupFailureWithKind keeps
+		// internally consistent), and this matches existing precedent for
+		// reporting failures against alternative peers elsewhere in this package.
+		// The tradeoff: the displayed attempts/failures ratio for a fallback-only
+		// peer is not a rate.
 		for failedPeerID, failedMsg := range failedPeers {
+			if reportPeerErr && failedPeerID == peerID {
+				// reportPeerErr=true (isPeerError, e.g. validation_failure or a
+				// generic/network error — never set alongside ErrExternal, whose
+				// case above always sets isPeerError=false) means the caller in
+				// Server.go's processCatchupChItem will report this catchup
+				// failure itself, once, using the terminal error for the whole
+				// cycle (reportCatchupFailureForError, called after catchup()
+				// returns). Also charging the primary here, from an earlier
+				// subtree-level failure recorded mid-cycle, would double the
+				// CatchupFailures increment for a single catchup attempt.
+				continue
+			}
+
 			u.reportCatchupFailure(rpcCtx, failedPeerID)
 			u.reportCatchupError(rpcCtx, failedPeerID, failedMsg)
 		}
@@ -522,8 +546,13 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 // recordCatchupPeerFailure attributes a data-serving failure to the peer that caused
 // it, for the current catchup cycle. Best-effort: with no active catchup context
 // (e.g. a direct block fetch outside catchup) the call is a no-op.
+//
+// errors.IsLocalError is checked here — not at each call site — so every caller
+// gets the guard for free: a context cancellation (catchup abort / peer switch /
+// shutdown landing mid-retry) or a local storage failure (subtreeStore.Set) is ours,
+// not the peer's, and must never land an innocent peer in failedPeers.
 func (u *Server) recordCatchupPeerFailure(peerID string, err error) {
-	if peerID == "" || err == nil {
+	if peerID == "" || err == nil || errors.IsLocalError(err) {
 		return
 	}
 

--- a/services/blockvalidation/catchup_release_lock_test.go
+++ b/services/blockvalidation/catchup_release_lock_test.go
@@ -251,3 +251,79 @@ func TestReleaseCatchupLock_IncompleteBlockPenaltyAttribution(t *testing.T) {
 		require.Equal(t, "block_incomplete", server.previousCatchupAttempt.ErrorType)
 	})
 }
+
+// peerFailureRecordingP2PClient records the reputation calls releaseCatchupLock makes, so a
+// test can assert WHICH peer was charged for a failure.
+type peerFailureRecordingP2PClient struct {
+	P2PClientI
+
+	mu              sync.Mutex
+	failuresByPeer  map[string]int
+	errorMsgsByPeer map[string]string
+}
+
+func newPeerFailureRecordingP2PClient() *peerFailureRecordingP2PClient {
+	return &peerFailureRecordingP2PClient{
+		failuresByPeer:  make(map[string]int),
+		errorMsgsByPeer: make(map[string]string),
+	}
+}
+
+func (r *peerFailureRecordingP2PClient) RecordCatchupFailureWithKind(_ context.Context, peerID, _, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failuresByPeer[peerID]++
+
+	return nil
+}
+
+func (r *peerFailureRecordingP2PClient) UpdateCatchupError(_ context.Context, peerID string, errorMsg string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errorMsgsByPeer[peerID] = errorMsg
+
+	return nil
+}
+
+// TestReleaseCatchupLock_ExternalErrorChargesOnlyTheFailingPeers covers issue-1368
+// Defect B: an all-peers-failed subtree error used to fall through to
+// "unknown_error" with isPeerError=true, charging the catchup primary for another
+// peer's failure. The primary must be charged only if it actually failed, each
+// failing peer must get its own error text, and the classification must be explicit.
+func TestReleaseCatchupLock_ExternalErrorChargesOnlyTheFailingPeers(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	recorder := newPeerFailureRecordingP2PClient()
+	server.p2pClient = recorder
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo: &model.Block{Header: header, Height: 1000},
+		baseURL:   "http://healthy-primary:8000",
+		peerID:    "healthy-primary",
+		startTime: time.Now(),
+	}
+
+	require.NoError(t, server.acquireCatchupLock(ctx))
+
+	// Only this peer actually failed — twice, from two concurrent subtree fetches.
+	server.recordCatchupPeerFailure("broken-peer", errors.NewNotFoundError("status code [404] subtree not found"))
+	server.recordCatchupPeerFailure("broken-peer", errors.NewNotFoundError("status code [404] subtree not found"))
+
+	relErr := error(errors.NewExternalError("all 2 peer attempts failed to fetch subtree abc [primary healthy-primary (http://healthy-primary:8000)=empty body; alternative broken-peer (http://broken:8000)=404]"))
+	server.releaseCatchupLock(ctx, &relErr)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	require.Equal(t, 0, recorder.failuresByPeer["healthy-primary"], "the primary must not be charged for another peer's failure")
+	require.Equal(t, 1, recorder.failuresByPeer["broken-peer"], "each failing peer is charged exactly once per cycle")
+	require.Contains(t, recorder.errorMsgsByPeer["broken-peer"], "404", "each peer stores its own error, not another peer's")
+	require.Empty(t, recorder.errorMsgsByPeer["healthy-primary"])
+
+	status := server.getCatchupStatusInternal()
+	require.NotNil(t, status.PreviousAttempt)
+	require.Equal(t, "peer_data_unavailable", status.PreviousAttempt.ErrorType)
+	require.Contains(t, status.PreviousAttempt.ErrorMessage, "broken-peer", "the dashboard keeps the full per-peer summary")
+}

--- a/services/blockvalidation/catchup_release_lock_test.go
+++ b/services/blockvalidation/catchup_release_lock_test.go
@@ -327,3 +327,91 @@ func TestReleaseCatchupLock_ExternalErrorChargesOnlyTheFailingPeers(t *testing.T
 	require.Equal(t, "peer_data_unavailable", status.PreviousAttempt.ErrorType)
 	require.Contains(t, status.PreviousAttempt.ErrorMessage, "broken-peer", "the dashboard keeps the full per-peer summary")
 }
+
+// TestReleaseCatchupLock_PrimaryNotDoubleChargedOnMixedCycle covers issue-1368
+// review finding 2a: the primary itself failed one subtree fetch earlier in the
+// cycle (recorded via recordCatchupPeerFailure), but the cycle's overall terminal
+// error is a different, generic peer error (isPeerError=true, reportPeerErr=true —
+// never true together with the ErrExternal case, which always sets
+// isPeerError=false). In that mixed cycle, Server.go's processCatchupChItem
+// reports this catchup failure itself, once, using the terminal error — so the
+// failedPeers drain loop inside releaseCatchupLock must not also charge the
+// primary for the earlier, now-stale subtree failure.
+func TestReleaseCatchupLock_PrimaryNotDoubleChargedOnMixedCycle(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	recorder := newPeerFailureRecordingP2PClient()
+	server.p2pClient = recorder
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo: &model.Block{Header: header, Height: 1000},
+		baseURL:   "http://primary:8000",
+		peerID:    "primary-peer",
+		startTime: time.Now(),
+	}
+	require.NoError(t, server.acquireCatchupLock(ctx))
+
+	// The primary itself failed one subtree fetch earlier in this cycle...
+	server.recordCatchupPeerFailure("primary-peer", errors.NewNotFoundError("status code [404] subtree not found"))
+
+	// ...but the cycle's terminal error is unrelated: a generic peer error, not
+	// ErrExternal/ErrBlockInvalid/ErrBlockIncomplete/local.
+	relErr := error(errors.NewProcessingError("terminal generic peer error"))
+	server.releaseCatchupLock(ctx, &relErr)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	require.Equal(t, 0, recorder.failuresByPeer["primary-peer"],
+		"the primary must not be charged from the failedPeers drain when the generic peer-error path charges it separately")
+	require.Contains(t, recorder.errorMsgsByPeer["primary-peer"], "terminal generic peer error",
+		"the stored error text must be the terminal error, not the stale subtree-failure message")
+}
+
+// TestRecordCatchupPeerFailure_SkipsLocalErrors covers review finding 1 on
+// issue-1368 Defect B: a local failure — a context cancellation (catchup abort /
+// peer switch / shutdown landing mid-retry) or a local storage error — is ours, not
+// the peer's, and must never land an innocent peer in failedPeers. The guard lives
+// in recordCatchupPeerFailure itself so both call sites in tryPeerForSubtree
+// (the non-retryable branch and the cache-bypass-retry tail) get it for free.
+func TestRecordCatchupPeerFailure_SkipsLocalErrors(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo: &model.Block{Header: header, Height: 1000},
+		baseURL:   "http://peer1",
+		peerID:    "peer-123",
+		startTime: time.Now(),
+	}
+	require.NoError(t, server.acquireCatchupLock(ctx))
+	defer func() {
+		var relErr error
+		server.releaseCatchupLock(ctx, &relErr)
+	}()
+
+	recorded := func(peerID string) bool {
+		ctx.failedPeersMu.Lock()
+		defer ctx.failedPeersMu.Unlock()
+		_, ok := ctx.failedPeers[peerID]
+		return ok
+	}
+
+	t.Run("context-cancelled error is not recorded", func(t *testing.T) {
+		server.recordCatchupPeerFailure("innocent-peer-ctx", context.Canceled)
+		require.False(t, recorded("innocent-peer-ctx"), "a context cancellation is our failure, not the peer's")
+	})
+
+	t.Run("storage error is not recorded", func(t *testing.T) {
+		server.recordCatchupPeerFailure("innocent-peer-storage", errors.NewStorageError("disk full"))
+		require.False(t, recorded("innocent-peer-storage"), "a local storage failure is ours, not the peer's")
+	})
+
+	t.Run("genuine peer error is still recorded", func(t *testing.T) {
+		server.recordCatchupPeerFailure("broken-peer-genuine", errors.NewNotFoundError("status code [404]"))
+		require.True(t, recorded("broken-peer-genuine"), "a genuine peer failure must still be recorded")
+	})
+}

--- a/services/blockvalidation/catchup_release_lock_test.go
+++ b/services/blockvalidation/catchup_release_lock_test.go
@@ -259,20 +259,23 @@ type peerFailureRecordingP2PClient struct {
 
 	mu              sync.Mutex
 	failuresByPeer  map[string]int
+	kindsByPeer     map[string][]string // every failureKind recorded per peer, in call order
 	errorMsgsByPeer map[string]string
 }
 
 func newPeerFailureRecordingP2PClient() *peerFailureRecordingP2PClient {
 	return &peerFailureRecordingP2PClient{
 		failuresByPeer:  make(map[string]int),
+		kindsByPeer:     make(map[string][]string),
 		errorMsgsByPeer: make(map[string]string),
 	}
 }
 
-func (r *peerFailureRecordingP2PClient) RecordCatchupFailureWithKind(_ context.Context, peerID, _, _ string) error {
+func (r *peerFailureRecordingP2PClient) RecordCatchupFailureWithKind(_ context.Context, peerID, failureKind, _ string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.failuresByPeer[peerID]++
+	r.kindsByPeer[peerID] = append(r.kindsByPeer[peerID], failureKind)
 
 	return nil
 }
@@ -328,16 +331,26 @@ func TestReleaseCatchupLock_ExternalErrorChargesOnlyTheFailingPeers(t *testing.T
 	require.Contains(t, status.PreviousAttempt.ErrorMessage, "broken-peer", "the dashboard keeps the full per-peer summary")
 }
 
-// TestReleaseCatchupLock_PrimaryNotDoubleChargedOnMixedCycle covers issue-1368
-// review finding 2a: the primary itself failed one subtree fetch earlier in the
-// cycle (recorded via recordCatchupPeerFailure), but the cycle's overall terminal
-// error is a different, generic peer error (isPeerError=true, reportPeerErr=true —
-// never true together with the ErrExternal case, which always sets
-// isPeerError=false). In that mixed cycle, Server.go's processCatchupChItem
-// reports this catchup failure itself, once, using the terminal error — so the
-// failedPeers drain loop inside releaseCatchupLock must not also charge the
-// primary for the earlier, now-stale subtree failure.
-func TestReleaseCatchupLock_PrimaryNotDoubleChargedOnMixedCycle(t *testing.T) {
+// TestReleaseCatchupLock_DrainChargesPrimaryEvenOnMixedCycle covers issue-1368
+// review round 2, change 1: the drain loop is authoritative for every peer in
+// failedPeers, including the primary, with no assumption about which branch
+// Server.go's processCatchupChItem will take for the cycle's terminal error.
+//
+// An earlier version tried to skip the primary in the drain whenever the
+// terminal error was a generic peer error (reportPeerErr), on the theory that
+// Server.go would charge it once instead. That assumption does not hold for
+// every terminal-error shape: a genuinely local failure surfacing as
+// ErrServiceError falls to this switch's unknown_error default (isPeerError
+// stays true, so reportPeerErr is true) while Server.go's ErrServiceError
+// branch returns early WITHOUT ever reporting a failure — so the skip could
+// leave a real, already-recorded subtree failure charged zero times. Charging
+// the primary here unconditionally means a peer that both failed a subtree
+// fetch mid-cycle AND caused the cycle's generic terminal error is charged
+// twice for one attempt — an accepted tradeoff: both increments feed
+// InteractionAttempts/InteractionFailures consistently (reputation math is
+// unaffected), so this is telemetry precision, not a correctness break, and
+// far preferable to silently dropping a genuine failure.
+func TestReleaseCatchupLock_DrainChargesPrimaryEvenOnMixedCycle(t *testing.T) {
 	server, _, _, cleanup := setupTestCatchupServer(t)
 	defer cleanup()
 
@@ -356,7 +369,7 @@ func TestReleaseCatchupLock_PrimaryNotDoubleChargedOnMixedCycle(t *testing.T) {
 	// The primary itself failed one subtree fetch earlier in this cycle...
 	server.recordCatchupPeerFailure("primary-peer", errors.NewNotFoundError("status code [404] subtree not found"))
 
-	// ...but the cycle's terminal error is unrelated: a generic peer error, not
+	// ...and the cycle's terminal error is unrelated: a generic peer error, not
 	// ErrExternal/ErrBlockInvalid/ErrBlockIncomplete/local.
 	relErr := error(errors.NewProcessingError("terminal generic peer error"))
 	server.releaseCatchupLock(ctx, &relErr)
@@ -364,10 +377,106 @@ func TestReleaseCatchupLock_PrimaryNotDoubleChargedOnMixedCycle(t *testing.T) {
 	recorder.mu.Lock()
 	defer recorder.mu.Unlock()
 
-	require.Equal(t, 0, recorder.failuresByPeer["primary-peer"],
-		"the primary must not be charged from the failedPeers drain when the generic peer-error path charges it separately")
+	require.Equal(t, 1, recorder.failuresByPeer["primary-peer"],
+		"the drain charges the primary for its genuine subtree failure regardless of the cycle's terminal error")
 	require.Contains(t, recorder.errorMsgsByPeer["primary-peer"], "terminal generic peer error",
-		"the stored error text must be the terminal error, not the stale subtree-failure message")
+		"the reportPeerErr branch overwrites the stored message with the terminal error after the drain runs")
+}
+
+// TestReleaseCatchupLock_LocalTerminalErrorStillChargesFailedPrimary covers
+// issue-1368 review round 2, change 1's under-charge regression: the primary
+// genuinely failed a subtree fetch mid-cycle (recorded in failedPeers), and the
+// cycle's terminal error is the exact ErrServiceError-coded shape
+// fetchAndStoreSubtreeAndSubtreeData/fetchSubtreeDataForBlock produce for a
+// genuinely LOCAL failure (get_blocks.go's "Local error fetching subtree ...
+// not retrying with other peers", re-wrapped by fetchSubtreeDataForBlock).
+// releaseCatchupLock's switch has no specific case for generic ErrServiceError
+// (only the narrower ErrServiceUnavailable), so this falls to the
+// unknown_error default with isPeerError left true — and Server.go's
+// ErrServiceError branch returns early WITHOUT ever calling
+// reportCatchupFailureForError. The drain loop is therefore the ONLY place
+// this cycle's genuine primary failure can be recorded; it must not be
+// skipped down to zero.
+func TestReleaseCatchupLock_LocalTerminalErrorStillChargesFailedPrimary(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	recorder := newPeerFailureRecordingP2PClient()
+	server.p2pClient = recorder
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo: &model.Block{Header: header, Height: 1000},
+		baseURL:   "http://primary:8000",
+		peerID:    "primary-peer",
+		startTime: time.Now(),
+	}
+	require.NoError(t, server.acquireCatchupLock(ctx))
+
+	// The primary genuinely failed a subtree fetch earlier in this cycle.
+	server.recordCatchupPeerFailure("primary-peer", errors.NewNotFoundError("status code [404] subtree not found"))
+
+	// The cycle's terminal error mirrors the production local-error wrap chain:
+	// fetchAndStoreSubtreeAndSubtreeData's local-error ServiceError, re-wrapped by
+	// fetchSubtreeDataForBlock's ServiceError.
+	localErr := errors.NewStorageError("disk full")
+	innerErr := errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtree abc (not retrying with other peers)", localErr)
+	relErr := error(errors.NewServiceError("[catchup:fetchSubtreeDataForBlock] Failed to fetch subtree data for block bb", innerErr))
+
+	require.True(t, errors.Is(relErr, errors.ErrServiceError), "precondition: this must be the ErrServiceError-coded shape Server.go treats as local infra")
+
+	server.releaseCatchupLock(ctx, &relErr)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	require.Equal(t, 1, recorder.failuresByPeer["primary-peer"],
+		"the primary must be charged exactly once for its genuine subtree failure, even though the terminal error is local-infra-coded and Server.go's ErrServiceError branch never reports it")
+}
+
+// TestReleaseCatchupLock_IncompleteBlockDoesNotDoubleChargeFailedPrimary covers
+// issue-1368 review round 2, change 2: the primary genuinely failed a subtree
+// fetch mid-cycle (recorded in failedPeers), and the cycle's terminal error is a
+// peer-attributable incomplete block from that SAME primary. Unlike the
+// reportPeerErr case, this guard is safe: both the generic drain charge and the
+// kind-specific incomplete-block charge live in this same function, so there is
+// no cross-file assumption about what Server.go will do. The primary must be
+// charged exactly once, with the specific catchupFailureKindBlockIncomplete
+// kind (which drives the documented incomplete-block penalty window), not
+// twice; its subtree-level error message must still be stored even though the
+// generic counter call is skipped.
+func TestReleaseCatchupLock_IncompleteBlockDoesNotDoubleChargeFailedPrimary(t *testing.T) {
+	server, _, _, cleanup := setupTestCatchupServer(t)
+	defer cleanup()
+
+	recorder := newPeerFailureRecordingP2PClient()
+	server.p2pClient = recorder
+
+	header := testhelpers.CreateTestHeaders(t, 1)[0]
+	ctx := &CatchupContext{
+		blockUpTo:           &model.Block{Header: header, Height: 1000},
+		baseURL:             "http://primary:8000",
+		peerID:              "primary-peer",
+		startTime:           time.Now(),
+		incompleteBlockHash: "0000000000000000000000000000000000000000000000000000000000000001",
+	}
+	require.NoError(t, server.acquireCatchupLock(ctx))
+
+	// The primary genuinely failed a subtree fetch earlier in this cycle.
+	server.recordCatchupPeerFailure("primary-peer", errors.NewNotFoundError("status code [404] subtree not found"))
+
+	relErr := error(errors.NewBlockIncompleteError("no coinbase from seeded peer"))
+	server.releaseCatchupLock(ctx, &relErr)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+
+	require.Equal(t, 1, recorder.failuresByPeer["primary-peer"],
+		"the primary must be charged exactly once, not twice, for the same cycle")
+	require.Equal(t, []string{catchupFailureKindBlockIncomplete}, recorder.kindsByPeer["primary-peer"],
+		"the one charge must be the kind-specific incomplete-block penalty, not the drain's generic kind")
+	require.Contains(t, recorder.errorMsgsByPeer["primary-peer"], "404",
+		"the primary's subtree-level error message must still be stored even though its generic counter charge is skipped")
 }
 
 // TestRecordCatchupPeerFailure_SkipsLocalErrors covers review finding 1 on

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -657,10 +657,9 @@ func (u *Server) tryPeerForSubtree(ctx context.Context, block *model.Block, subt
 	}
 
 	if !isCacheBypassRetryable(err) {
-		// A local failure is ours, not the peer's — do not charge the peer for it.
-		if !errors.IsLocalError(err) {
-			u.recordCatchupPeerFailure(peerID, err)
-		}
+		// recordCatchupPeerFailure itself skips errors.IsLocalError — a local failure
+		// (context cancellation, storage) is ours, not the peer's.
+		u.recordCatchupPeerFailure(peerID, err)
 
 		return err
 	}

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -652,13 +652,27 @@ func (u *Server) fetchSubtreeAndDataFromPeer(ctx context.Context, block *model.B
 func (u *Server) tryPeerForSubtree(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash,
 	peerID, baseURL string) error {
 	err := u.fetchSubtreeAndDataFromPeer(ctx, block, subtreeHash, peerID, baseURL, false)
-	if err == nil || !isCacheBypassRetryable(err) {
+	if err == nil {
+		return nil
+	}
+
+	if !isCacheBypassRetryable(err) {
+		// A local failure is ours, not the peer's — do not charge the peer for it.
+		if !errors.IsLocalError(err) {
+			u.recordCatchupPeerFailure(peerID, err)
+		}
+
 		return err
 	}
 
 	u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Peer %s served an unusable response for subtree %s, retrying with cache bypass: %v", peerID, subtreeHash.String(), err)
 
-	return u.fetchSubtreeAndDataFromPeer(ctx, block, subtreeHash, peerID, baseURL, true)
+	bypassErr := u.fetchSubtreeAndDataFromPeer(ctx, block, subtreeHash, peerID, baseURL, true)
+	if bypassErr != nil {
+		u.recordCatchupPeerFailure(peerID, bypassErr)
+	}
+
+	return bypassErr
 }
 
 // fetchAndStoreSubtreeAndSubtreeData fetches both subtree and subtreeData for a single subtree hash
@@ -747,7 +761,7 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	// so no attempt is lost (issue 1368, Defect A — a single lastErr variable used to
 	// be overwritten by each alternative, so the reported cause was whichever
 	// alternative failed last, unrelated to the primary).
-	return "", errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] all %d peer attempts failed to fetch subtree %s [%s]", len(attempts), subtreeHash.String(), formatSubtreeFetchAttempts(attempts), primaryErr)
+	return "", markCatchupFailureReported(errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] all %d peer attempts failed to fetch subtree %s [%s]", len(attempts), subtreeHash.String(), formatSubtreeFetchAttempts(attempts), primaryErr))
 }
 
 // fetchSubtreeFromPeer fetches subtree (for subtreeToCheck) from a peer via HTTP

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -664,13 +664,18 @@ func (u *Server) fetchSubtreeAndDataFromPeer(ctx context.Context, block *model.B
 }
 
 // tryPeerForSubtree fetches subtree + subtreeData from one peer, retrying that same
-// peer exactly once with a cache-busting URL when its response looked poisoned (a
-// 200 with an empty or short body). A peer whose proxy cache is replaying a failed
-// generation is the issue-1368 stall: without the bypass no peer behind that cache
-// can serve the subtree for the whole TTL, and the node cannot pass the checkpoint.
-// The bypass only fires after a detected poisoning, so a healthy fleet never pays
-// for it. The already-stored subtree file makes the retry's /subtree fetch a local
-// load, so only subtree_data is re-requested.
+// peer exactly once with a cache-busting URL when its response looked poisoned.
+// "Poisoned" is what carries the cache-bypass marker, and that is narrower than "any
+// 200 with a short body": a subtree_data body that is empty or cannot satisfy the
+// subtree, or a strictly empty /subtree body. A truncated-but-nonzero /subtree body
+// is not covered — it fails in the subtree parser on a different, unmarked path.
+//
+// A peer whose proxy cache is replaying a failed generation is the issue-1368 stall:
+// without the bypass no peer behind that cache can serve the subtree for the whole
+// TTL, and the node cannot pass the checkpoint. The bypass only fires after a
+// detected poisoning, so a healthy fleet never pays for it. The already-stored
+// subtree file makes the retry's /subtree fetch a local load, so only subtree_data
+// is re-requested.
 func (u *Server) tryPeerForSubtree(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash,
 	peerID, baseURL string) error {
 	err := u.fetchSubtreeAndDataFromPeer(ctx, block, subtreeHash, peerID, baseURL, false)
@@ -779,9 +784,10 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	//
 	// The wrapped cause is the PRIMARY's error: it is the peer catchup selected and
 	// the most relevant single reason. The full per-peer summary rides in the message
-	// so no attempt is lost (issue 1368, Defect A — a single lastErr variable used to
-	// be overwritten by each alternative, so the reported cause was whichever
-	// alternative failed last, unrelated to the primary).
+	// so no attempt is lost (issue 1368, Defect A — this function used to keep a single
+	// error variable that each alternative overwrote, so the reported cause was
+	// whichever alternative failed last, unrelated to the primary; primaryErr replaced
+	// it precisely so the primary's error survives).
 	return "", markCatchupFailureReported(errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] all %d peer attempts failed to fetch subtree %s [%s]", len(attempts), subtreeHash.String(), formatSubtreeFetchAttempts(attempts), primaryErr))
 }
 
@@ -859,8 +865,8 @@ func (u *Server) fetchSubtreeDataFromPeer(ctx context.Context, subtreeHash *chai
 	)
 	defer deferFn()
 
-	// Construct URL for subtree data endpoint
-	// Based on user clarification, subtree data is fetched from /subtree_data/:hash
+	// peerResourceURL builds <baseURL>/subtree_data/<hash>, appending the cachebust
+	// query parameter when bypassCache is set.
 	url := u.peerResourceURL(baseURL, "subtree_data", subtreeHash, bypassCache)
 
 	u.logger.Debugf("[catchup:fetchSubtreeDataFromPeer] fetching subtree data from %s", url)

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -530,7 +530,7 @@ func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, s
 
 // fetchAndStoreSubtreeData fetches and stores only the subtreeData
 func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash,
-	subtree *subtreepkg.Subtree, peerID, baseURL string) error {
+	subtree *subtreepkg.Subtree, peerID, baseURL string, bypassCache bool) error {
 	ctx, _, deferFn := tracing.Tracer("blockvalidation").Start(ctx, "fetchAndStoreSubtreeData",
 		tracing.WithParentStat(u.stats),
 		tracing.WithDebugLogMessage(u.logger, "[catchup:fetchAndStoreSubtreeData][%s] Fetching subtree data from peer %s (%s) for subtree %s", block.Hash().String(), peerID, baseURL, subtreeHash.String()),
@@ -563,7 +563,7 @@ func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Bloc
 	// See companion fix in services/subtreevalidation/check_block_subtrees.go.
 	ctx = context.WithoutCancel(ctx)
 
-	subtreeDataReader, err := u.fetchSubtreeDataFromPeer(ctx, subtreeHash, peerID, baseURL)
+	subtreeDataReader, err := u.fetchSubtreeDataFromPeer(ctx, subtreeHash, peerID, baseURL, bypassCache)
 	if err != nil {
 		return errors.NewProcessingError("[catchup:fetchAndStoreSubtreeData] Failed to fetch subtreeData for %s", subtreeHash.String(), err)
 	}
@@ -585,15 +585,28 @@ func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Bloc
 		return errors.NewProcessingError("[catchup:fetchAndStoreSubtreeData] Failed to create subtreeData for %s", subtreeHash.String(), err)
 	}
 
-	// Debug: Log how many transactions we actually got
-	nonNilCount := 0
-	for _, tx := range subtreeData.Txs {
-		if tx != nil {
-			nonNilCount++
+	// Reject a response the subtree cannot be satisfied by, before Serialize turns it
+	// into a generic ErrSubtreeLengthMismatch that names no peer. An empty body is the
+	// issue-1368 signature: a peer's proxy cache replaying a failed or aborted
+	// on-demand generation as "200 + 0 bytes". The predicate matches
+	// subtreepkg.Data.Serialize (index 0 is exempt — it may be the coinbase
+	// placeholder), so nothing that used to succeed starts failing here.
+	missing := 0
+
+	for i, tx := range subtreeData.Txs {
+		if tx == nil && i != 0 {
+			missing++
 		}
 	}
-	u.logger.Debugf("[catchup:fetchAndStoreSubtreeData] Subtree %s from %s has %d/%d non-nil transactions",
-		subtreeHash.String(), baseURL, nonNilCount, len(subtreeData.Txs))
+
+	bytesRead := subtreeDataReader.BytesRead()
+
+	u.logger.Debugf("[catchup:fetchAndStoreSubtreeData] Subtree %s from %s has %d/%d txs (%d bytes, %d missing)",
+		subtreeHash.String(), baseURL, len(subtreeData.Txs)-missing, len(subtreeData.Txs), bytesRead, missing)
+
+	if missing > 0 {
+		return newPoisonedSubtreeDataError(peerID, baseURL, subtreeHash, missing, subtree.Length(), bytesRead)
+	}
 
 	// Try to serialize the subtreeData to validate it's complete
 	subtreeDataBytes, err := subtreeData.Serialize()
@@ -631,7 +644,7 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	subtree, err := u.fetchAndStoreSubtree(ctx, block, subtreeHash, peerID, baseURL)
 	if err == nil {
 		// Primary peer succeeded for subtree, now try subtreeData
-		if err = u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, peerID, baseURL); err == nil {
+		if err = u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, peerID, baseURL, false); err == nil {
 			return peerID, nil // Success
 		}
 		// Check if error is local (not peer-related) - don't retry with other peers
@@ -679,7 +692,7 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 				}
 
 				// Subtree succeeded, try subtreeData
-				if err = u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, altPeerID, altBaseURL); err != nil {
+				if err = u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, altPeerID, altBaseURL, false); err != nil {
 					u.logger.Debugf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Alternative peer %s failed for subtreeData %s: %v", altPeerID, subtreeHash.String(), err)
 					lastErr = err
 					// Don't continue trying other peers if it's a local error
@@ -776,8 +789,15 @@ func (c *countingReadCloser) Close() error {
 	return c.reader.Close()
 }
 
+// BytesRead returns the number of bytes pulled from the underlying reader so far.
+// Callers read it after the stream has been consumed, from the same goroutine that
+// consumed it, so no synchronisation is needed.
+func (c *countingReadCloser) BytesRead() uint64 {
+	return c.bytesRead
+}
+
 // fetchSubtreeDataFromPeer fetches subtree data from a peer via HTTP
-func (u *Server) fetchSubtreeDataFromPeer(ctx context.Context, subtreeHash *chainhash.Hash, peerID string, baseURL string) (io.ReadCloser, error) {
+func (u *Server) fetchSubtreeDataFromPeer(ctx context.Context, subtreeHash *chainhash.Hash, peerID string, baseURL string, bypassCache bool) (*countingReadCloser, error) {
 	ctx, _, deferFn := tracing.Tracer("blockvalidation").Start(ctx, "fetchSubtreeDataFromPeer",
 		tracing.WithParentStat(u.stats),
 	)
@@ -785,7 +805,7 @@ func (u *Server) fetchSubtreeDataFromPeer(ctx context.Context, subtreeHash *chai
 
 	// Construct URL for subtree data endpoint
 	// Based on user clarification, subtree data is fetched from /subtree_data/:hash
-	url := fmt.Sprintf("%s/subtree_data/%s", baseURL, subtreeHash.String())
+	url := u.peerResourceURL(baseURL, "subtree_data", subtreeHash, bypassCache)
 
 	u.logger.Debugf("[catchup:fetchSubtreeDataFromPeer] fetching subtree data from %s", url)
 

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -433,7 +433,7 @@ func (u *Server) fetchSubtreeDataForBlock(gCtx context.Context, block *model.Blo
 }
 
 // fetchAndStoreSubtree fetches and stores only the subtree (for subtreeToCheck)
-func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash, peerID, baseURL string) (*subtreepkg.Subtree, error) {
+func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash, peerID, baseURL string, bypassCache bool) (*subtreepkg.Subtree, error) {
 	ctx, _, deferFn := tracing.Tracer("blockvalidation").Start(ctx, "fetchAndStoreSubtree",
 		tracing.WithParentStat(u.stats),
 		// tracing.WithDebugLogMessage(u.logger, "[catchup:fetchAndStoreSubtree] fetching subtree for %s", subtreeHash.String()),
@@ -468,7 +468,7 @@ func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, s
 	}
 
 	// Fetch subtree from peer
-	subtreeNodeBytes, subtreeErr := u.fetchSubtreeFromPeer(ctx, subtreeHash, peerID, baseURL)
+	subtreeNodeBytes, subtreeErr := u.fetchSubtreeFromPeer(ctx, subtreeHash, peerID, baseURL, bypassCache)
 	if subtreeErr != nil {
 		return nil, errors.NewServiceError("[catchup:fetchAndStoreSubtree] Failed to fetch subtree for %s", subtreeHash.String(), subtreeErr)
 	}
@@ -628,6 +628,39 @@ func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Bloc
 	return nil
 }
 
+// fetchSubtreeAndDataFromPeer fetches the subtree and then its subtreeData from a
+// single peer. With bypassCache set, both requests carry a cache-busting query
+// parameter.
+func (u *Server) fetchSubtreeAndDataFromPeer(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash,
+	peerID, baseURL string, bypassCache bool) error {
+	subtree, err := u.fetchAndStoreSubtree(ctx, block, subtreeHash, peerID, baseURL, bypassCache)
+	if err != nil {
+		return err
+	}
+
+	return u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, peerID, baseURL, bypassCache)
+}
+
+// tryPeerForSubtree fetches subtree + subtreeData from one peer, retrying that same
+// peer exactly once with a cache-busting URL when its response looked poisoned (a
+// 200 with an empty or short body). A peer whose proxy cache is replaying a failed
+// generation is the issue-1368 stall: without the bypass no peer behind that cache
+// can serve the subtree for the whole TTL, and the node cannot pass the checkpoint.
+// The bypass only fires after a detected poisoning, so a healthy fleet never pays
+// for it. The already-stored subtree file makes the retry's /subtree fetch a local
+// load, so only subtree_data is re-requested.
+func (u *Server) tryPeerForSubtree(ctx context.Context, block *model.Block, subtreeHash *chainhash.Hash,
+	peerID, baseURL string) error {
+	err := u.fetchSubtreeAndDataFromPeer(ctx, block, subtreeHash, peerID, baseURL, false)
+	if err == nil || !isCacheBypassRetryable(err) {
+		return err
+	}
+
+	u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Peer %s served an unusable response for subtree %s, retrying with cache bypass: %v", peerID, subtreeHash.String(), err)
+
+	return u.fetchSubtreeAndDataFromPeer(ctx, block, subtreeHash, peerID, baseURL, true)
+}
+
 // fetchAndStoreSubtreeAndSubtreeData fetches both subtree and subtreeData for a single subtree hash
 // and stores them in the subtreeStore. If the primary peer fails, it will try alternative peers
 // at max height before giving up.
@@ -640,28 +673,22 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	)
 	defer deferFn()
 
-	// Try primary peer first
-	subtree, err := u.fetchAndStoreSubtree(ctx, block, subtreeHash, peerID, baseURL)
+	// Try the primary peer first.
+	err := u.tryPeerForSubtree(ctx, block, subtreeHash, peerID, baseURL)
 	if err == nil {
-		// Primary peer succeeded for subtree, now try subtreeData
-		if err = u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, peerID, baseURL, false); err == nil {
-			return peerID, nil // Success
-		}
-		// Check if error is local (not peer-related) - don't retry with other peers
-		if errors.IsLocalError(err) {
-			return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtreeData for %s (not retrying with other peers)", subtreeHash.String(), err)
-		}
-		u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Primary peer %s failed to fetch subtreeData for %s: %v, trying alternatives", peerID, subtreeHash.String(), err)
-	} else {
-		// Check if error is local (not peer-related) - don't retry with other peers
-		if errors.IsLocalError(err) {
-			return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtree for %s (not retrying with other peers)", subtreeHash.String(), err)
-		}
-		u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Primary peer %s failed to fetch subtree for %s: %v, trying alternatives", peerID, subtreeHash.String(), err)
+		return peerID, nil
 	}
 
-	// Primary peer failed, try alternative peers
-	var lastErr error = err
+	// A local error means our own storage or context failed — another peer cannot fix
+	// that, so do not spend attempts on the rest of the fleet.
+	if errors.IsLocalError(err) {
+		return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtree %s (not retrying with other peers)", subtreeHash.String(), err)
+	}
+
+	u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Primary peer %s failed for subtree %s: %v, trying alternatives", peerID, subtreeHash.String(), err)
+
+	primaryErr := err
+
 	if u.p2pClient != nil {
 		alternativePeers, getPeersErr := GetPeersAtMaxHeight(ctx, u.logger, u.p2pClient, peerID)
 		if getPeersErr != nil {
@@ -677,34 +704,17 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 					continue
 				}
 
-				u.logger.Debugf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Trying alternative peer %s for subtree %s", altPeerID, subtreeHash.String())
-
-				// Try to fetch subtree from alternative peer
-				subtree, err = u.fetchAndStoreSubtree(ctx, block, subtreeHash, altPeerID, altBaseURL)
-				if err != nil {
-					u.logger.Debugf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Alternative peer %s failed for subtree %s: %v", altPeerID, subtreeHash.String(), err)
-					lastErr = err
-					// Don't continue trying other peers if it's a local error
-					if errors.IsLocalError(err) {
-						return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtree %s (aborting peer retry)", subtreeHash.String(), err)
-					}
-					continue
+				altErr := u.tryPeerForSubtree(ctx, block, subtreeHash, altPeerID, altBaseURL)
+				if altErr == nil {
+					u.logger.Infof("[catchup:fetchAndStoreSubtreeAndSubtreeData] Successfully fetched subtree %s from alternative peer %s", subtreeHash.String(), altPeerID)
+					return altPeerID, nil
 				}
 
-				// Subtree succeeded, try subtreeData
-				if err = u.fetchAndStoreSubtreeData(ctx, block, subtreeHash, subtree, altPeerID, altBaseURL, false); err != nil {
-					u.logger.Debugf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Alternative peer %s failed for subtreeData %s: %v", altPeerID, subtreeHash.String(), err)
-					lastErr = err
-					// Don't continue trying other peers if it's a local error
-					if errors.IsLocalError(err) {
-						return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtreeData %s (aborting peer retry)", subtreeHash.String(), err)
-					}
-					continue
-				}
+				u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Alternative peer %s failed for subtree %s: %v", altPeerID, subtreeHash.String(), altErr)
 
-				// Success with alternative peer
-				u.logger.Infof("[catchup:fetchAndStoreSubtreeAndSubtreeData] Successfully fetched subtree %s from alternative peer %s", subtreeHash.String(), altPeerID)
-				return altPeerID, nil
+				if errors.IsLocalError(altErr) {
+					return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtree %s (aborting peer retry)", subtreeHash.String(), altErr)
+				}
 			}
 		}
 	}
@@ -726,18 +736,18 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	// errors.NewExternalError extracts the trailing error param as the wrapped error,
 	// so a "%v" placeholder for lastErr would render as %!v(MISSING). The wrapped error
 	// is preserved in the chain.
-	return "", errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s", subtreeHash.String(), lastErr)
+	return "", errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s", subtreeHash.String(), primaryErr)
 }
 
 // fetchSubtreeFromPeer fetches subtree (for subtreeToCheck) from a peer via HTTP
-func (u *Server) fetchSubtreeFromPeer(ctx context.Context, subtreeHash *chainhash.Hash, peerID string, baseURL string) ([]byte, error) {
+func (u *Server) fetchSubtreeFromPeer(ctx context.Context, subtreeHash *chainhash.Hash, peerID string, baseURL string, bypassCache bool) ([]byte, error) {
 	ctx, _, deferFn := tracing.Tracer("blockvalidation").Start(ctx, "fetchSubtreeFromPeer",
 		tracing.WithParentStat(u.stats),
 	)
 	defer deferFn()
 
 	// Construct URL for subtree endpoint (for subtreeToCheck)
-	url := fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String())
+	url := u.peerResourceURL(baseURL, "subtree", subtreeHash, bypassCache)
 
 	u.logger.Debugf("[catchup:fetchSubtreeFromPeer] fetching subtree from %s", url)
 
@@ -761,7 +771,7 @@ func (u *Server) fetchSubtreeFromPeer(ctx context.Context, subtreeHash *chainhas
 	}
 
 	if len(subtreeBytes) == 0 {
-		return nil, errors.NewNotFoundError("[catchup:fetchSubtreeFromPeer] empty subtree received from %s", url)
+		return nil, markCacheBypassRetryable(errors.NewNotFoundError("[catchup:fetchSubtreeFromPeer] empty subtree received from %s", url))
 	}
 
 	u.logger.Debugf("[catchup:fetchSubtreeFromPeer] successfully fetched %d bytes of subtree from %s", len(subtreeBytes), url)

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -689,6 +689,9 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 
 	primaryErr := err
 
+	attempts := make([]subtreeFetchAttempt, 0, 4)
+	attempts = append(attempts, subtreeFetchAttempt{peerID: peerID, baseURL: baseURL, role: "primary", err: err})
+
 	if u.p2pClient != nil {
 		alternativePeers, getPeersErr := GetPeersAtMaxHeight(ctx, u.logger, u.p2pClient, peerID)
 		if getPeersErr != nil {
@@ -712,6 +715,8 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 
 				u.logger.Warnf("[catchup:fetchAndStoreSubtreeAndSubtreeData] Alternative peer %s failed for subtree %s: %v", altPeerID, subtreeHash.String(), altErr)
 
+				attempts = append(attempts, subtreeFetchAttempt{peerID: altPeerID, baseURL: altBaseURL, role: "alternative", err: altErr})
+
 				if errors.IsLocalError(altErr) {
 					return "", errors.NewServiceError("[catchup:fetchAndStoreSubtreeAndSubtreeData] Local error fetching subtree %s (aborting peer retry)", subtreeHash.String(), altErr)
 				}
@@ -726,7 +731,7 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	// into a silent "clear markers, retry" loop that hides peer-data-quality issues.
 	// With ErrExternal the handler reports peer failure and lets P2P switch peers instead.
 	//
-	// Note on detection: lastErr usually carries ERR_SERVICE_ERROR (the per-peer HTTP
+	// Note on detection: primaryErr usually carries ERR_SERVICE_ERROR (the per-peer HTTP
 	// fetch wrappers), and callers wrap this error further (fetchSubtreeDataForBlock
 	// adds a ServiceError, orderedDelivery a ProcessingError), so by the time it
 	// reaches processCatchupChItem the ERR_EXTERNAL code sits mid-chain and
@@ -734,9 +739,15 @@ func (u *Server) fetchAndStoreSubtreeAndSubtreeData(ctx context.Context, block *
 	// ErrExternal before ErrServiceError — see processCatchupChItem.
 	//
 	// errors.NewExternalError extracts the trailing error param as the wrapped error,
-	// so a "%v" placeholder for lastErr would render as %!v(MISSING). The wrapped error
-	// is preserved in the chain.
-	return "", errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] All peers failed to fetch subtree %s", subtreeHash.String(), primaryErr)
+	// so a "%v" placeholder for primaryErr would render as %!v(MISSING). The wrapped
+	// error is preserved in the chain.
+	//
+	// The wrapped cause is the PRIMARY's error: it is the peer catchup selected and
+	// the most relevant single reason. The full per-peer summary rides in the message
+	// so no attempt is lost (issue 1368, Defect A — a single lastErr variable used to
+	// be overwritten by each alternative, so the reported cause was whichever
+	// alternative failed last, unrelated to the primary).
+	return "", errors.NewExternalError("[catchup:fetchAndStoreSubtreeAndSubtreeData] all %d peer attempts failed to fetch subtree %s [%s]", len(attempts), subtreeHash.String(), formatSubtreeFetchAttempts(attempts), primaryErr)
 }
 
 // fetchSubtreeFromPeer fetches subtree (for subtreeToCheck) from a peer via HTTP

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -588,15 +588,37 @@ func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Bloc
 	// Reject a response the subtree cannot be satisfied by, before Serialize turns it
 	// into a generic ErrSubtreeLengthMismatch that names no peer. An empty body is the
 	// issue-1368 signature: a peer's proxy cache replaying a failed or aborted
-	// on-demand generation as "200 + 0 bytes". The predicate matches
-	// subtreepkg.Data.Serialize (index 0 is exempt — it may be the coinbase
-	// placeholder), so nothing that used to succeed starts failing here.
+	// on-demand generation as "200 + 0 bytes".
+	//
+	// The predicate mirrors what subtreepkg.Data.Serialize *safely* tolerates, which is
+	// not the same as its literal `i != 0` nil exemption. Serialize skips index 0 only
+	// when Nodes[0] is the coinbase placeholder: it then sets txStartIndex = 1 and never
+	// touches Txs[0]. For any other Nodes[0] it sets txStartIndex = 0 while still
+	// guarding its own nil check with `i != 0`, so it walks straight into
+	// Txs[0].SerializeBytes() on a nil *bt.Tx and panics (IsExtended is nil-safe, so it
+	// falls through to Bytes -> toBytesHelper -> Size). Copying the unconditional
+	// exemption here would let such a response through with missing == 0, and the panic
+	// lands in a per-subtree errgroup goroutine that no recover() in this package
+	// covers. That is reachable without malice: a non-first subtree has no coinbase
+	// placeholder, so any block whose tx count is congruent to 1 modulo the subtree size
+	// ends with a one-node subtree holding a real tx hash at index 0.
+	//
+	// So index 0 counts as missing unless it genuinely is the coinbase placeholder —
+	// the only case Serialize actually tolerates — and nothing that used to succeed
+	// starts failing here.
 	missing := 0
+	coinbaseAtZero := len(subtree.Nodes) > 0 && subtree.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue)
 
 	for i, tx := range subtreeData.Txs {
-		if tx == nil && i != 0 {
-			missing++
+		if tx != nil {
+			continue
 		}
+
+		if i == 0 && coinbaseAtZero {
+			continue
+		}
+
+		missing++
 	}
 
 	bytesRead := subtreeDataReader.BytesRead()

--- a/services/blockvalidation/get_blocks_test.go
+++ b/services/blockvalidation/get_blocks_test.go
@@ -3716,3 +3716,51 @@ func TestFetchAndStoreSubtreeAndSubtreeData_CacheBypassRetry(t *testing.T) {
 	require.Equal(t, 1, counts["GET "+poisonedURL], "the poisoned URL must be requested exactly once")
 	require.Equal(t, 1, counts["GET "+bustedURL], "the bypass retry must fire exactly once")
 }
+
+// TestFetchAndStoreSubtreeAndSubtreeData_AllPeersFailedErrorNamesEveryPeer covers
+// issue-1368 Defect A: the reported cause used to be whichever alternative failed
+// last, so an operator saw an unrelated peer's error. Every attempt must appear, and
+// the wrapped cause must be the primary's error.
+func TestFetchAndStoreSubtreeAndSubtreeData_AllPeersFailedErrorNamesEveryPeer(t *testing.T) {
+	baseURL := "http://primary-peer:8000"
+	peerID := "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ"
+	ctx := context.Background()
+
+	subtreeHash := chainhash.HashH([]byte("subtree-1368-defect-a"))
+
+	server := &Server{
+		logger:       ulogger.TestLogger{},
+		subtreeStore: memory.New(),
+		settings:     test.CreateBaseTestSettings(t),
+	}
+
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	// No p2pClient, so there are no alternatives: the primary's error must survive.
+	httpmock.RegisterResponder("GET",
+		fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String()),
+		httpmock.NewStringResponder(404, `{"message":"NOT_FOUND (3): subtree not found"}`))
+
+	_, err := server.fetchAndStoreSubtreeAndSubtreeData(ctx, &model.Block{Height: 100}, &subtreeHash, peerID, baseURL)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrExternal))
+	require.Contains(t, err.Error(), "primary "+peerID, "the primary attempt must be named in the summary")
+	require.Contains(t, err.Error(), baseURL)
+	require.Contains(t, err.Error(), "404")
+}
+
+func TestFormatSubtreeFetchAttempts(t *testing.T) {
+	attempts := []subtreeFetchAttempt{
+		{peerID: "peer-a", baseURL: "http://a:8000", role: "primary", err: errors.NewNotFoundError("404 from a")},
+		{peerID: "peer-b", baseURL: "http://b:8000", role: "alternative", err: errors.NewExternalError("empty body from b")},
+	}
+
+	got := formatSubtreeFetchAttempts(attempts)
+	require.Contains(t, got, "primary peer-a (http://a:8000)=")
+	require.Contains(t, got, "404 from a")
+	require.Contains(t, got, "alternative peer-b (http://b:8000)=")
+	require.Contains(t, got, "empty body from b")
+	require.Contains(t, got, "; ", "attempts must be separated so each is readable in one log line")
+	require.Empty(t, formatSubtreeFetchAttempts(nil))
+}

--- a/services/blockvalidation/get_blocks_test.go
+++ b/services/blockvalidation/get_blocks_test.go
@@ -1523,7 +1523,7 @@ func TestSubtreeFunctions(t *testing.T) {
 			fmt.Sprintf("http://test-peer/subtree_data/%s", subtreeHash.String()),
 			httpmock.NewBytesResponder(200, expectedData))
 
-		reader, err := suite.Server.fetchSubtreeDataFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer")
+		reader, err := suite.Server.fetchSubtreeDataFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer", false)
 		assert.NoError(t, err)
 		assert.NotNil(t, reader)
 		defer reader.Close()
@@ -1547,7 +1547,7 @@ func TestSubtreeFunctions(t *testing.T) {
 			fmt.Sprintf("http://test-peer/subtree_data/%s", subtreeHash.String()),
 			httpmock.NewStringResponder(404, "Not Found"))
 
-		result, err := suite.Server.fetchSubtreeDataFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer")
+		result, err := suite.Server.fetchSubtreeDataFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer", false)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "failed to fetch subtree data from")
@@ -1566,7 +1566,7 @@ func TestSubtreeFunctions(t *testing.T) {
 			fmt.Sprintf("http://test-peer/subtree_data/%s", subtreeHash.String()),
 			httpmock.NewBytesResponder(200, []byte{}))
 
-		reader, err := suite.Server.fetchSubtreeDataFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer")
+		reader, err := suite.Server.fetchSubtreeDataFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer", false)
 		// Empty response is not an error for the fetcher - it just returns an empty reader
 		assert.NoError(t, err)
 		assert.NotNil(t, reader)
@@ -2614,7 +2614,7 @@ func TestFetchSubtreeDataFromPeer(t *testing.T) {
 		httpmock.RegisterResponder("GET", subtreeDataURL,
 			httpmock.NewBytesResponder(200, expectedData))
 
-		reader, err := server.fetchSubtreeDataFromPeer(ctx, subtreeHash, "test-peer-id", baseURL)
+		reader, err := server.fetchSubtreeDataFromPeer(ctx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, reader)
 		defer reader.Close()
@@ -2632,7 +2632,7 @@ func TestFetchSubtreeDataFromPeer(t *testing.T) {
 		httpmock.RegisterResponder("GET", subtreeDataURL,
 			httpmock.NewErrorResponder(errors.NewNetworkError("HTTP request failed")))
 
-		data, err := server.fetchSubtreeDataFromPeer(ctx, subtreeHash, "test-peer-id", baseURL)
+		data, err := server.fetchSubtreeDataFromPeer(ctx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.Error(t, err)
 		assert.Nil(t, data)
 		assert.Contains(t, err.Error(), "failed to fetch subtree data from")
@@ -2645,7 +2645,7 @@ func TestFetchSubtreeDataFromPeer(t *testing.T) {
 		httpmock.RegisterResponder("GET", subtreeDataURL,
 			httpmock.NewBytesResponder(200, []byte{})) // Empty response
 
-		reader, err := server.fetchSubtreeDataFromPeer(ctx, subtreeHash, "test-peer-id", baseURL)
+		reader, err := server.fetchSubtreeDataFromPeer(ctx, subtreeHash, "test-peer-id", baseURL, false)
 		// Empty response is not an error for the fetcher - it just returns an empty reader
 		assert.NoError(t, err)
 		assert.NotNil(t, reader)
@@ -2677,7 +2677,7 @@ func TestFetchSubtreeDataFromPeer(t *testing.T) {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel() // Cancel immediately
 
-		data, err := server.fetchSubtreeDataFromPeer(cancelCtx, subtreeHash, "test-peer-id", baseURL)
+		data, err := server.fetchSubtreeDataFromPeer(cancelCtx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.Error(t, err)
 		assert.Nil(t, data)
 		// Check for either context canceled or the wrapped error containing context cancellation
@@ -3392,7 +3392,7 @@ func TestFetchAndStoreSubtreeDataEdgeCases(t *testing.T) {
 		}
 
 		// This should skip fetching since data already exists
-		err = suite.Server.fetchAndStoreSubtreeData(suite.Ctx, testBlock, &subtreeHash, subtree, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		err = suite.Server.fetchAndStoreSubtreeData(suite.Ctx, testBlock, &subtreeHash, subtree, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 		assert.NoError(t, err)
 	})
 }
@@ -3567,4 +3567,90 @@ func TestBlockvalidation_AdaptiveFetch_PessToOptToPess(t *testing.T) {
 	})
 	require.Equal(t, adaptivefetch.ModePessimistic, af.Mode(),
 		"single 500-miss optimistic block must trip back to pessimistic")
+}
+
+// TestFetchAndStoreSubtreeData_PoisonedResponses covers issue 1368: a peer that
+// answers subtree_data with 200 and an empty (or truncated) body must produce a
+// distinct, peer-attributed error rather than a generic parse failure.
+func TestFetchAndStoreSubtreeData_PoisonedResponses(t *testing.T) {
+	baseURL := "http://poisoned-peer:8000"
+	peerID := "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ"
+	ctx := context.Background()
+
+	txs := transactions.CreateTestTransactionChainWithCount(t, 5)
+
+	subtree, err := subtreepkg.NewIncompleteTreeByLeafCount(4)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	require.NoError(t, subtree.AddNode(*txs[1].TxIDChainHash(), 1, 11))
+	require.NoError(t, subtree.AddNode(*txs[2].TxIDChainHash(), 2, 12))
+	require.NoError(t, subtree.AddNode(*txs[3].TxIDChainHash(), 3, 13))
+
+	subtreeHash := subtree.RootHash()
+	subtreeDataURL := fmt.Sprintf("%s/subtree_data/%s", baseURL, subtreeHash.String())
+	testBlock := &model.Block{Height: 100}
+
+	newServer := func() *Server {
+		return &Server{
+			logger:       ulogger.TestLogger{},
+			subtreeStore: memory.New(),
+			settings:     test.CreateBaseTestSettings(t),
+		}
+	}
+
+	t.Run("EmptyBodyIsAPeerFailure", func(t *testing.T) {
+		server := newServer()
+		httpmock.ActivateNonDefault(util.HTTPClient())
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", subtreeDataURL, httpmock.NewBytesResponder(200, []byte{}))
+
+		err := server.fetchAndStoreSubtreeData(ctx, testBlock, subtreeHash, subtree, peerID, baseURL, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "served empty subtree_data")
+		require.Contains(t, err.Error(), peerID)
+		require.Contains(t, err.Error(), baseURL)
+		require.True(t, errors.Is(err, errors.ErrExternal))
+		require.False(t, errors.IsLocalError(err), "must not short-circuit the alternative-peer loop")
+		require.True(t, isCacheBypassRetryable(err))
+	})
+
+	t.Run("TruncatedBodyIsAPeerFailure", func(t *testing.T) {
+		server := newServer()
+		httpmock.ActivateNonDefault(util.HTTPClient())
+		defer httpmock.DeactivateAndReset()
+
+		// Only the coinbase and the first tx — the subtree needs four. txs[0] is the
+		// coinbase (the pre-existing TestFetchAndStoreSubtreeData relies on that, since
+		// AddTx(txs[0], 0) only succeeds for a coinbase at the placeholder node).
+		truncated := append(txs[0].SerializeBytes(), txs[1].SerializeBytes()...)
+
+		httpmock.RegisterResponder("GET", subtreeDataURL, httpmock.NewBytesResponder(200, truncated))
+
+		err := server.fetchAndStoreSubtreeData(ctx, testBlock, subtreeHash, subtree, peerID, baseURL, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "served incomplete subtree_data")
+		require.True(t, isCacheBypassRetryable(err))
+	})
+
+	t.Run("CoinbaseOnlySubtreeWithNoDataIsNotFlagged", func(t *testing.T) {
+		// A subtree whose only node is the coinbase placeholder has no required tx
+		// data (go-subtree's Serialize exempts index 0), so an empty body here must
+		// NOT be treated as poisoned.
+		server := newServer()
+		httpmock.ActivateNonDefault(util.HTTPClient())
+		defer httpmock.DeactivateAndReset()
+
+		coinbaseOnly, err := subtreepkg.NewIncompleteTreeByLeafCount(1)
+		require.NoError(t, err)
+		require.NoError(t, coinbaseOnly.AddCoinbaseNode())
+
+		coinbaseHash := coinbaseOnly.RootHash()
+		httpmock.RegisterResponder("GET",
+			fmt.Sprintf("%s/subtree_data/%s", baseURL, coinbaseHash.String()),
+			httpmock.NewBytesResponder(200, []byte{}))
+
+		err = server.fetchAndStoreSubtreeData(ctx, testBlock, coinbaseHash, coinbaseOnly, peerID, baseURL, false)
+		require.NoError(t, err)
+	})
 }

--- a/services/blockvalidation/get_blocks_test.go
+++ b/services/blockvalidation/get_blocks_test.go
@@ -1466,7 +1466,7 @@ func TestSubtreeFunctions(t *testing.T) {
 			fmt.Sprintf("http://test-peer/subtree/%s", subtreeHash.String()),
 			httpmock.NewBytesResponder(200, expectedData))
 
-		result, err := suite.Server.fetchSubtreeFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer")
+		result, err := suite.Server.fetchSubtreeFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer", false)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedData, result)
 	})
@@ -1484,7 +1484,7 @@ func TestSubtreeFunctions(t *testing.T) {
 			fmt.Sprintf("http://test-peer/subtree/%s", subtreeHash.String()),
 			httpmock.NewStringResponder(500, "Internal Server Error"))
 
-		result, err := suite.Server.fetchSubtreeFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer")
+		result, err := suite.Server.fetchSubtreeFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer", false)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "failed to fetch subtree")
@@ -1503,7 +1503,7 @@ func TestSubtreeFunctions(t *testing.T) {
 			fmt.Sprintf("http://test-peer/subtree/%s", subtreeHash.String()),
 			httpmock.NewBytesResponder(200, []byte{}))
 
-		result, err := suite.Server.fetchSubtreeFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer")
+		result, err := suite.Server.fetchSubtreeFromPeer(suite.Ctx, subtreeHash, "test-peer-id", "http://test-peer", false)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "empty subtree received")
@@ -2462,7 +2462,7 @@ func TestFetchSubtreeFromPeer(t *testing.T) {
 		httpmock.RegisterResponder("GET", subtreeURL,
 			httpmock.NewBytesResponder(200, expectedData))
 
-		data, err := server.fetchSubtreeFromPeer(ctx, subtreeHash, "test-peer-id", baseURL)
+		data, err := server.fetchSubtreeFromPeer(ctx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedData, data)
 	})
@@ -2474,7 +2474,7 @@ func TestFetchSubtreeFromPeer(t *testing.T) {
 		httpmock.RegisterResponder("GET", subtreeURL,
 			httpmock.NewErrorResponder(errors.NewNetworkError("HTTP request failed")))
 
-		data, err := server.fetchSubtreeFromPeer(ctx, subtreeHash, "test-peer-id", baseURL)
+		data, err := server.fetchSubtreeFromPeer(ctx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.Error(t, err)
 		assert.Nil(t, data)
 		assert.Contains(t, err.Error(), "failed to fetch subtree")
@@ -2487,7 +2487,7 @@ func TestFetchSubtreeFromPeer(t *testing.T) {
 		httpmock.RegisterResponder("GET", subtreeURL,
 			httpmock.NewBytesResponder(200, []byte{})) // Empty response
 
-		data, err := server.fetchSubtreeFromPeer(ctx, subtreeHash, "test-peer-id", baseURL)
+		data, err := server.fetchSubtreeFromPeer(ctx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.Error(t, err)
 		assert.Nil(t, data)
 		assert.Contains(t, err.Error(), "empty subtree received")
@@ -2513,7 +2513,7 @@ func TestFetchSubtreeFromPeer(t *testing.T) {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel() // Cancel immediately
 
-		data, err := server.fetchSubtreeFromPeer(cancelCtx, subtreeHash, "test-peer-id", baseURL)
+		data, err := server.fetchSubtreeFromPeer(cancelCtx, subtreeHash, "test-peer-id", baseURL, false)
 		assert.Error(t, err)
 		assert.Nil(t, data)
 		// Check for either context canceled or the wrapped error containing context cancellation
@@ -2548,7 +2548,7 @@ func TestFetchSubtreeFromPeer_OversizedBody(t *testing.T) {
 	httpmock.RegisterResponder("GET", subtreeURL,
 		httpmock.NewBytesResponder(http.StatusOK, oversized))
 
-	data, err := server.fetchSubtreeFromPeer(context.Background(), &subtreeHash, "test-peer-id", baseURL)
+	data, err := server.fetchSubtreeFromPeer(context.Background(), &subtreeHash, "test-peer-id", baseURL, false)
 
 	require.Error(t, err)
 	require.Nil(t, data)
@@ -2585,7 +2585,7 @@ func TestFetchSubtreeFromPeer_LocalAssemblyPolicyIgnored(t *testing.T) {
 	httpmock.RegisterResponder("GET", subtreeURL,
 		httpmock.NewBytesResponder(http.StatusOK, largeBody))
 
-	data, err := server.fetchSubtreeFromPeer(context.Background(), &subtreeHash, "test-peer-id", baseURL)
+	data, err := server.fetchSubtreeFromPeer(context.Background(), &subtreeHash, "test-peer-id", baseURL, false)
 
 	require.NoError(t, err)
 	require.Len(t, data, len(largeBody))
@@ -3161,7 +3161,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 		}
 
 		// Fetch the subtree (should load from store, not network)
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, &subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, &subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3200,7 +3200,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 		testBlock := &model.Block{Height: 100}
 
 		// Should succeed with no HTTP mock registered: load from store, not network.
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, &subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, &subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3238,7 +3238,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 			Height: 100,
 		}
 
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3280,7 +3280,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 			Height: 100,
 		}
 
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3305,7 +3305,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 			Height: 100,
 		}
 
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -3332,7 +3332,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 			Height: 100,
 		}
 
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -3354,7 +3354,7 @@ func TestFetchAndStoreSubtree(t *testing.T) {
 			Height: 100,
 		}
 
-		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+		result, err := suite.Server.fetchAndStoreSubtree(suite.Ctx, testBlock, subtreeHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer", false)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -3653,4 +3653,66 @@ func TestFetchAndStoreSubtreeData_PoisonedResponses(t *testing.T) {
 		err = server.fetchAndStoreSubtreeData(ctx, testBlock, coinbaseHash, coinbaseOnly, peerID, baseURL, false)
 		require.NoError(t, err)
 	})
+}
+
+// TestFetchAndStoreSubtreeAndSubtreeData_CacheBypassRetry covers the issue-1368
+// recovery lever: when a peer serves a poisoned (empty) subtree_data body, the same
+// peer is retried once with a cache-busting query parameter, which forces its proxy
+// cache to miss and regenerate. No peer-side change is required.
+func TestFetchAndStoreSubtreeAndSubtreeData_CacheBypassRetry(t *testing.T) {
+	baseURL := "http://poisoned-peer:8000"
+	peerID := "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ"
+	ctx := context.Background()
+
+	txs := transactions.CreateTestTransactionChainWithCount(t, 5)
+
+	subtree, err := subtreepkg.NewIncompleteTreeByLeafCount(4)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	require.NoError(t, subtree.AddNode(*txs[1].TxIDChainHash(), 1, 11))
+	require.NoError(t, subtree.AddNode(*txs[2].TxIDChainHash(), 2, 12))
+	require.NoError(t, subtree.AddNode(*txs[3].TxIDChainHash(), 3, 13))
+
+	subtreeHash := subtree.RootHash()
+
+	subtreeData := subtreepkg.NewSubtreeData(subtree)
+	require.NoError(t, subtreeData.AddTx(txs[0], 0))
+	require.NoError(t, subtreeData.AddTx(txs[1], 1))
+	require.NoError(t, subtreeData.AddTx(txs[2], 2))
+	require.NoError(t, subtreeData.AddTx(txs[3], 3))
+
+	subtreeDataBytes, err := subtreeData.Serialize()
+	require.NoError(t, err)
+
+	var nodeHashes []byte
+	nodeHashes = append(nodeHashes, subtreepkg.CoinbasePlaceholderHashValue[:]...)
+	nodeHashes = append(nodeHashes, txs[1].TxIDChainHash()[:]...)
+	nodeHashes = append(nodeHashes, txs[2].TxIDChainHash()[:]...)
+	nodeHashes = append(nodeHashes, txs[3].TxIDChainHash()[:]...)
+
+	server := &Server{
+		logger:       ulogger.TestLogger{},
+		subtreeStore: memory.New(),
+		settings:     test.CreateBaseTestSettings(t),
+	}
+
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	subtreeURL := fmt.Sprintf("%s/subtree/%s", baseURL, subtreeHash.String())
+	poisonedURL := fmt.Sprintf("%s/subtree_data/%s", baseURL, subtreeHash.String())
+	// cacheBustCounter starts at zero on a fresh Server, so the first bypass is 1.
+	bustedURL := poisonedURL + "?cachebust=1"
+
+	httpmock.RegisterResponder("GET", subtreeURL, httpmock.NewBytesResponder(200, nodeHashes))
+	httpmock.RegisterResponder("GET", poisonedURL, httpmock.NewBytesResponder(200, []byte{}))
+	httpmock.RegisterResponder("GET", bustedURL, httpmock.NewBytesResponder(200, subtreeDataBytes))
+
+	servingPeer, err := server.fetchAndStoreSubtreeAndSubtreeData(ctx, &model.Block{Height: 100}, subtreeHash, peerID, baseURL)
+	require.NoError(t, err, "the cache-busted retry must recover without any alternative peer")
+	require.Equal(t, peerID, servingPeer)
+
+	counts := httpmock.GetCallCountInfo()
+	require.Equal(t, 1, counts["GET "+poisonedURL], "the poisoned URL must be requested exactly once")
+	require.Equal(t, 1, counts["GET "+bustedURL], "the bypass retry must fire exactly once")
 }

--- a/services/blockvalidation/get_blocks_test.go
+++ b/services/blockvalidation/get_blocks_test.go
@@ -3653,6 +3653,40 @@ func TestFetchAndStoreSubtreeData_PoisonedResponses(t *testing.T) {
 		err = server.fetchAndStoreSubtreeData(ctx, testBlock, coinbaseHash, coinbaseOnly, peerID, baseURL, false)
 		require.NoError(t, err)
 	})
+
+	// The mirror image of the case above, and the reason index 0 cannot be exempted
+	// unconditionally. A non-first subtree of a block has no coinbase placeholder, so a
+	// subtree with exactly one node (any block whose tx count is congruent to 1 modulo
+	// the subtree size) has a real tx hash at index 0. go-subtree's Data.Serialize sets
+	// txStartIndex = 0 in that case and guards its own nil check with i != 0, so it
+	// dereferences a nil Txs[0] -- a remotely triggerable panic inside the per-subtree
+	// errgroup goroutine, which no recover() in this package covers. The predicate must
+	// therefore count a nil index 0 as missing unless the node really is the coinbase
+	// placeholder.
+	t.Run("SingleNonCoinbaseNodeWithEmptyBodyIsRejectedNotPanicking", func(t *testing.T) {
+		server := newServer()
+		httpmock.ActivateNonDefault(util.HTTPClient())
+		defer httpmock.DeactivateAndReset()
+
+		oneNode, err := subtreepkg.NewIncompleteTreeByLeafCount(1)
+		require.NoError(t, err)
+		require.NoError(t, oneNode.AddNode(*txs[1].TxIDChainHash(), 1, 11))
+		require.NotEqual(t, subtreepkg.CoinbasePlaceholderHashValue, oneNode.Nodes[0].Hash,
+			"precondition: index 0 must NOT be the coinbase placeholder")
+
+		oneNodeHash := oneNode.RootHash()
+		httpmock.RegisterResponder("GET",
+			fmt.Sprintf("%s/subtree_data/%s", baseURL, oneNodeHash.String()),
+			httpmock.NewBytesResponder(200, []byte{}))
+
+		require.NotPanics(t, func() {
+			err = server.fetchAndStoreSubtreeData(ctx, testBlock, oneNodeHash, oneNode, peerID, baseURL, false)
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "served empty subtree_data")
+		require.True(t, errors.Is(err, errors.ErrExternal))
+		require.True(t, isCacheBypassRetryable(err))
+	})
 }
 
 // TestFetchAndStoreSubtreeAndSubtreeData_CacheBypassRetry covers the issue-1368

--- a/services/blockvalidation/peer_cache_bypass.go
+++ b/services/blockvalidation/peer_cache_bypass.go
@@ -1,0 +1,104 @@
+package blockvalidation
+
+import (
+	"fmt"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+)
+
+// cacheBypassRetryableKey marks an error whose cause is a peer response that a
+// caching layer in front of that peer may have poisoned — specifically a 200 whose
+// body is empty or shorter than the subtree it belongs to requires.
+//
+// Peers front the asset service with an nginx proxy_cache that caches any 200 for
+// the configured TTL. An aborted or failed on-demand subtree_data generation that
+// still reached the client as "200 + empty body" is stored as a valid response and
+// replayed to every requester, which is what stalled catchup in issue 1368. An
+// error carrying this marker tells the fetch loop that one retry with a
+// cache-busting URL is worth attempting before moving on to another peer.
+const cacheBypassRetryableKey = "cache_bypass_retryable"
+
+// markCacheBypassRetryable tags err with the cache-bypass marker in place and
+// returns it. The error code and wrapped chain are unchanged, so callers matching
+// on the code still behave identically. Nil-safe. A non-native error is returned
+// untouched (nothing downstream can carry the marker for it).
+func markCacheBypassRetryable(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var e *errors.Error
+	if errors.As(err, &e) {
+		e.SetData(cacheBypassRetryableKey, true)
+	}
+
+	return err
+}
+
+// isCacheBypassRetryable reports whether any link in err's chain carries the
+// cache-bypass marker. The walk mirrors catchupFailureAlreadyReported: the marker
+// must be found mid-chain because every layer above the fetch wraps the error.
+func isCacheBypassRetryable(err error) bool {
+	var e *errors.Error
+	if !errors.As(err, &e) {
+		return false
+	}
+
+	for depth := 0; e != nil && depth < 32; depth++ {
+		if v, ok := e.GetData(cacheBypassRetryableKey).(bool); ok && v {
+			return true
+		}
+
+		next := e.WrappedErr()
+		if next == nil {
+			return false
+		}
+
+		var wrapped *errors.Error
+		if !errors.As(next, &wrapped) {
+			return false
+		}
+
+		e = wrapped
+	}
+
+	return false
+}
+
+// peerResourceURL builds the URL for a peer asset endpoint.
+//
+// With bypassCache set, a unique cachebust query parameter is appended. A peer's
+// nginx cache key includes $request_uri (deploy/docker/base/asset-cache-nginx.conf),
+// while nginx location matching ignores the query string — so the busted URL reaches
+// the same handler but misses the cache, forcing a fresh on-demand generation. This
+// needs no change on the peer, which is the only lever available against a fleet we
+// cannot update.
+func (u *Server) peerResourceURL(baseURL, resource string, hash *chainhash.Hash, bypassCache bool) string {
+	url := fmt.Sprintf("%s/%s/%s", baseURL, resource, hash.String())
+	if !bypassCache {
+		return url
+	}
+
+	return fmt.Sprintf("%s?cachebust=%d", url, u.cacheBustCounter.Add(1))
+}
+
+// newPoisonedSubtreeDataError builds the error returned when a peer answers a
+// subtree_data request with 200 but a body that cannot satisfy the subtree.
+//
+// Classified ErrExternal: no local component failed, so errors.IsLocalError is false
+// and the caller still tries alternative peers. Carries the cache-bypass marker so
+// the same peer is retried once with a cache-busting URL.
+func newPoisonedSubtreeDataError(peerID, baseURL string, subtreeHash *chainhash.Hash, missing, expected int, bytesRead uint64) error {
+	var e *errors.Error
+
+	if bytesRead == 0 {
+		e = errors.NewExternalError("[catchup:fetchAndStoreSubtreeData] peer %s (%s) served empty subtree_data for %s (HTTP 200, 0 bytes, expected %d txs) - poisoned cache entry or aborted on-demand generation", peerID, baseURL, subtreeHash.String(), expected)
+	} else {
+		e = errors.NewExternalError("[catchup:fetchAndStoreSubtreeData] peer %s (%s) served incomplete subtree_data for %s (%d bytes, %d of %d txs missing)", peerID, baseURL, subtreeHash.String(), bytesRead, missing, expected)
+	}
+
+	e.SetData(cacheBypassRetryableKey, true)
+
+	return e
+}

--- a/services/blockvalidation/peer_cache_bypass.go
+++ b/services/blockvalidation/peer_cache_bypass.go
@@ -19,10 +19,17 @@ import (
 // cache-busting URL is worth attempting before moving on to another peer.
 const cacheBypassRetryableKey = "cache_bypass_retryable"
 
-// markCacheBypassRetryable tags err with the cache-bypass marker in place and
-// returns it. The error code and wrapped chain are unchanged, so callers matching
-// on the code still behave identically. Nil-safe. A non-native error is returned
-// untouched (nothing downstream can carry the marker for it).
+// markCacheBypassRetryable tags err with the cache-bypass marker and returns
+// the result. Nil-safe.
+//
+// If err's chain already contains a native *errors.Error, the marker is set
+// in place via SetData: the error's code and wrapped chain are left exactly
+// as they were, so callers matching on the code still behave identically.
+// Otherwise err is a foreign error type (e.g. a bare stdlib error or an HTTP
+// client error) with nothing to call SetData on, so it is wrapped in a new
+// native *errors.Error the way markCatchupFailureReported does
+// (peer_metrics_helpers.go:121) — guaranteeing the marker survives regardless
+// of err's type, at the cost of an extra link in the chain.
 func markCacheBypassRetryable(err error) error {
 	if err == nil {
 		return nil
@@ -31,9 +38,13 @@ func markCacheBypassRetryable(err error) error {
 	var e *errors.Error
 	if errors.As(err, &e) {
 		e.SetData(cacheBypassRetryableKey, true)
+		return err
 	}
 
-	return err
+	wrapped := errors.NewProcessingError("cache bypass retryable", err)
+	wrapped.SetData(cacheBypassRetryableKey, true)
+
+	return wrapped
 }
 
 // isCacheBypassRetryable reports whether any link in err's chain carries the

--- a/services/blockvalidation/peer_cache_bypass.go
+++ b/services/blockvalidation/peer_cache_bypass.go
@@ -2,6 +2,7 @@ package blockvalidation
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
@@ -112,4 +113,30 @@ func newPoisonedSubtreeDataError(peerID, baseURL string, subtreeHash *chainhash.
 	e.SetData(cacheBypassRetryableKey, true)
 
 	return e
+}
+
+// subtreeFetchAttempt records one peer's attempt at serving a subtree, so an
+// all-peers-failed error can name every peer and its own failure instead of only the
+// last one tried.
+type subtreeFetchAttempt struct {
+	peerID  string
+	baseURL string
+	role    string // "primary" or "alternative"
+	err     error
+}
+
+// formatSubtreeFetchAttempts renders attempts as a single-line, semicolon-separated
+// summary for inclusion in an error message and the dashboard's catchup details.
+func formatSubtreeFetchAttempts(attempts []subtreeFetchAttempt) string {
+	if len(attempts) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(attempts))
+
+	for _, attempt := range attempts {
+		parts = append(parts, fmt.Sprintf("%s %s (%s)=%v", attempt.role, attempt.peerID, attempt.baseURL, attempt.err))
+	}
+
+	return strings.Join(parts, "; ")
 }

--- a/services/blockvalidation/peer_cache_bypass_test.go
+++ b/services/blockvalidation/peer_cache_bypass_test.go
@@ -1,6 +1,7 @@
 package blockvalidation
 
 import (
+	stderrors "errors"
 	"fmt"
 	"testing"
 
@@ -58,4 +59,16 @@ func TestMarkCacheBypassRetryable(t *testing.T) {
 	require.True(t, isCacheBypassRetryable(marked))
 	require.True(t, errors.Is(marked, errors.ErrNotFound), "marking must not change the error code")
 	require.Nil(t, markCacheBypassRetryable(nil))
+}
+
+// TestMarkCacheBypassRetryableForeignError pins the guarantee that the marker
+// survives even when err has no native *errors.Error anywhere in its chain
+// (e.g. a raw stdlib error returned by an HTTP client). markCacheBypassRetryable
+// must wrap such an error rather than silently drop the marker.
+func TestMarkCacheBypassRetryableForeignError(t *testing.T) {
+	foreign := stderrors.New("raw stdlib error")
+
+	marked := markCacheBypassRetryable(foreign)
+	require.True(t, isCacheBypassRetryable(marked), "the marker must survive a foreign error type")
+	require.True(t, errors.Is(marked, foreign), "the original error must still be reachable")
 }

--- a/services/blockvalidation/peer_cache_bypass_test.go
+++ b/services/blockvalidation/peer_cache_bypass_test.go
@@ -1,0 +1,61 @@
+package blockvalidation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerResourceURL(t *testing.T) {
+	server := &Server{}
+	hash := chainhash.HashH([]byte("subtree-1368"))
+	base := "http://peer:8000/api/v1"
+
+	plain := server.peerResourceURL(base, "subtree_data", &hash, false)
+	require.Equal(t, fmt.Sprintf("%s/subtree_data/%s", base, hash.String()), plain)
+
+	// Each bypass gets a distinct query string so a proxy_cache keyed on
+	// $request_uri cannot serve the same (possibly poisoned) entry twice.
+	first := server.peerResourceURL(base, "subtree_data", &hash, true)
+	second := server.peerResourceURL(base, "subtree", &hash, true)
+	require.Equal(t, fmt.Sprintf("%s/subtree_data/%s?cachebust=1", base, hash.String()), first)
+	require.Equal(t, fmt.Sprintf("%s/subtree/%s?cachebust=2", base, hash.String()), second)
+}
+
+func TestPoisonedSubtreeDataError(t *testing.T) {
+	hash := chainhash.HashH([]byte("subtree-1368"))
+
+	empty := newPoisonedSubtreeDataError("peer-a", "http://peer-a:8000", &hash, 1023, 1024, 0)
+	require.True(t, errors.Is(empty, errors.ErrExternal), "must be a peer-side error so alternatives are still tried")
+	require.False(t, errors.IsLocalError(empty), "a local error would skip the alternative-peer loop")
+	require.Contains(t, empty.Error(), "peer-a")
+	require.Contains(t, empty.Error(), "http://peer-a:8000")
+	require.Contains(t, empty.Error(), "0 bytes")
+	require.True(t, isCacheBypassRetryable(empty))
+
+	short := newPoisonedSubtreeDataError("peer-a", "http://peer-a:8000", &hash, 7, 1024, 4096)
+	require.Contains(t, short.Error(), "7 of 1024")
+	require.Contains(t, short.Error(), "4096 bytes")
+	require.True(t, isCacheBypassRetryable(short))
+}
+
+func TestIsCacheBypassRetryableWalksWrappedChain(t *testing.T) {
+	hash := chainhash.HashH([]byte("subtree-1368"))
+	poisoned := newPoisonedSubtreeDataError("peer-a", "http://peer-a:8000", &hash, 1, 2, 0)
+
+	wrapped := errors.NewServiceError("outer layer", errors.NewProcessingError("middle layer", poisoned))
+	require.True(t, isCacheBypassRetryable(wrapped))
+
+	require.False(t, isCacheBypassRetryable(errors.NewNetworkError("connection refused")))
+	require.False(t, isCacheBypassRetryable(nil))
+}
+
+func TestMarkCacheBypassRetryable(t *testing.T) {
+	marked := markCacheBypassRetryable(errors.NewNotFoundError("empty subtree received"))
+	require.True(t, isCacheBypassRetryable(marked))
+	require.True(t, errors.Is(marked, errors.ErrNotFound), "marking must not change the error code")
+	require.Nil(t, markCacheBypassRetryable(nil))
+}

--- a/services/blockvalidation/peer_cache_bypass_test.go
+++ b/services/blockvalidation/peer_cache_bypass_test.go
@@ -1,8 +1,8 @@
 package blockvalidation
 
 import (
-	stderrors "errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -63,12 +63,16 @@ func TestMarkCacheBypassRetryable(t *testing.T) {
 
 // TestMarkCacheBypassRetryableForeignError pins the guarantee that the marker
 // survives even when err has no native *errors.Error anywhere in its chain
-// (e.g. a raw stdlib error returned by an HTTP client). markCacheBypassRetryable
-// must wrap such an error rather than silently drop the marker.
+// (e.g. a raw error returned by an HTTP client). markCacheBypassRetryable must
+// wrap such an error rather than silently drop the marker. io.EOF stands in
+// for that foreign error: a plain stdlib sentinel reached through the io
+// package rather than importing "errors" directly (forbidden by depguard) or
+// using fmt.Errorf (forbidden by forbidigo in this package).
 func TestMarkCacheBypassRetryableForeignError(t *testing.T) {
-	foreign := stderrors.New("raw stdlib error")
+	foreign := io.EOF
 
 	marked := markCacheBypassRetryable(foreign)
 	require.True(t, isCacheBypassRetryable(marked), "the marker must survive a foreign error type")
 	require.True(t, errors.Is(marked, foreign), "the original error must still be reachable")
+	require.Contains(t, marked.Error(), "EOF", "the original error's message must still be reachable")
 }

--- a/services/blockvalidation/peer_metrics_helpers_test.go
+++ b/services/blockvalidation/peer_metrics_helpers_test.go
@@ -89,3 +89,21 @@ func TestMarkCatchupFailureReported_TransparentToErrorCodes(t *testing.T) {
 	// An unmarked error must not read as already-reported.
 	require.False(t, catchupFailureAlreadyReported(errors.NewServiceError("http 429")))
 }
+
+// TestMarkedExternalError_SurvivesProductionWrapChain guards issue-1368 review
+// finding 3: catchupFailureAlreadyReported bails at the first non-native link, so
+// this pins that the exact production wrap chain — ErrExternal marked at the
+// source (fetchAndStoreSubtreeAndSubtreeData), then re-wrapped as ServiceError
+// (fetchSubtreeDataForBlock) and ProcessingError (orderedDelivery), both native
+// *errors.Error links — still carries the marker AND still matches ErrExternal by
+// the time it reaches releaseCatchupLock's switch and Server.go's dispatch. A
+// future refactor swapping in a foreign (non-native) wrapper anywhere in this
+// chain would silently break both and restore the primary-charging bug.
+func TestMarkedExternalError_SurvivesProductionWrapChain(t *testing.T) {
+	marked := markCatchupFailureReported(errors.NewExternalError("all peer attempts failed to fetch subtree abc"))
+	svcWrap := errors.NewServiceError("failed to fetch subtree data for block bb", marked)
+	chain := errors.NewProcessingError("worker failed for block bb", svcWrap)
+
+	require.True(t, errors.Is(chain, errors.ErrExternal), "ErrExternal classification must survive the production wrap chain")
+	require.True(t, catchupFailureAlreadyReported(chain), "the already-reported marker must survive the production wrap chain")
+}


### PR DESCRIPTION
Part of #1368 — the client-side half. Asset/nginx serving fixes and the log-storm fix follow in separate PRs.

## Why

A single peer serving `subtree_data` as `HTTP 200` with an **empty body**, replayed from its nginx `proxy_cache` (`x-cache-status: HIT`, `content-length: 0`), permanently stalled post-checkpoint catchup on a teratestnet node — height pinned at 18635 against a tip of 27431. Every catchup against every peer failed, and the diagnostics pointed at the wrong peer: two healthy peers accumulated 20/20 and 18/18 failure records carrying a *third* peer's 404.

The serving fleet can't be updated on our schedule, so the client has to make progress against peers that will keep replaying a poisoned cache entry indefinitely. That constraint shaped this PR: it's the deliverable, not the serving-side fix.

## What was actually broken

**An empty body parsed clean.** go-subtree's `serializeFromReader` hits `io.EOF` on its first read and returns `nil` with every tx nil, so the failure only surfaced later inside `Serialize()` as a generic `ErrSubtreeLengthMismatch` naming no peer, no URL, no byte count.

**The surfaced error belonged to the wrong peer.** `fetchAndStoreSubtreeAndSubtreeData` kept one `lastErr`, overwritten by each alternative, so the persisted and displayed cause was whichever alternative failed *last* — unrelated to the primary. The primary's real reason was `Warnf`'d and each alternative's was `Debugf`'d, i.e. invisible at INFO.

**Failures were charged to the catchup primary.** Two sites: `releaseCatchupLock` had no `ErrExternal` case, so all-peers-failed fell through to `unknown_error` with `isPeerError = true`; and `processCatchupChItem`'s `ErrExternal` branch charged `c.peerID` unconditionally. Reputation-based selection was being steered *away* from the peers that worked.

## What this changes

- **Detect the poison explicitly** (`get_blocks.go`). An empty or short `subtree_data` body becomes a distinct `ErrExternal` naming the peer, the URL, the bytes read and how many txs are missing. The predicate mirrors what go-subtree's `Serialize` safely tolerates, so nothing that succeeds today starts failing.
- **Retry that peer once with `?cachebust=<n>`.** A peer's cache key includes `$request_uri` while nginx location matching ignores the query string, so a busted URL reaches the same handler and misses the cache, forcing regeneration — no peer-side change. `proxy_cache_bypass` is pinned to `0` in the asset cache conf, so a request header can't do this; the query parameter is the only lever available against an unpatched peer. Fires only after a detected poisoning.
- **Keep every peer's error.** The all-peers-failed error carries `primary <id> (<url>)=…; alternative <id> (<url>)=…` for every attempt and wraps the *primary's* error as the cause. Alternative failures moved `Debugf` → `Warnf`.
- **Charge each peer for its own failure, once per cycle.** A deduplicated `failedPeers` set on `CatchupContext`, drained in `releaseCatchupLock`, plus an `ErrExternal` case in that switch. `recordCatchupPeerFailure` skips local errors, so our own cancellations and storage failures can't land on a peer.

## Behaviour changes worth a reviewer's attention

1. The two "Local error fetching subtree" / "…subtreeData" messages collapse into one — the wrapped cause still identifies the stage.
2. Alternative-peer failures are now `Warnf`, and the pre-attempt `Debugf` is gone. Every alternative attempt still terminates in either a `Warnf` or the success `Infof`.
3. `ReportPeerFailure` on the all-peers-failed path charges the sync peer one extra interaction failure. That's deliberate: the call is the peer-*rotation* signal (`blockchain` → `NotificationType_PeerFailure` → `HandleCatchupFailure` → clears `currentSyncPeer`), not just blame. Gating it to avoid the charge silently degraded rotation to the 5-minute `SyncPeerNoProgressTimeout` — in this issue's own failure mode. For a peer with history the charge moves reputation ~0.6 points, nowhere near the `< 20` rotation gate. Do not re-add the gate; there's a comment saying so.
4. Subtree-fallback peers now receive a `CatchupFailure` with no paired `CatchupAttempt`, so the displayed attempts/failures pairing for a fallback-only peer isn't a rate. Reputation is computed from the separate `Interaction*` counters, which `RecordCatchupFailure` keeps consistent, so selection math is unaffected.

## Ordering / load

The bypass ceiling is `FetchNumWorkers` × `SubtreeFetchConcurrency` = up to 128 concurrent forced regenerations against a fleet-wide poisoned cache — exactly one per subtree per peer, no retry loop. The backstop is the serving peer's own non-blocking admission control returning 503, which the client honours with `Retry-After` backoff.

## Also fixed here

A remotely-triggerable panic, found by review and verified by execution: a 1-node subtree whose `Nodes[0]` is not the coinbase placeholder, plus an empty `subtree_data` body, made go-subtree's `Serialize` dereference a nil `*bt.Tx` inside a `g.Go` goroutine with no `recover()` on that stack. Reachable for any block whose tx count is ≡ 1 (mod subtree size). Pre-existing, but on the exact path this PR hardens.

## Testing

Full `services/blockvalidation` package green; regression tests for the empty body, the short body, the coinbase-only subtree that must *not* be flagged, the cache-bypass retry (asserting the busted URL was requested exactly once), the one-node non-coinbase panic shape, and `releaseCatchupLock` cases covering `ErrExternal` classification, the local-error skip, the mixed-cycle charge, and the incomplete-block double-charge guard. `go vet` and `make lint` clean.

## Not in this PR

- Serving side: asset must not emit a cacheable empty 200, and `asset-cache-nginx.conf` needs `proxy_http_version 1.1` — nginx defaults to HTTP/1.0 upstream, where a body ends at connection close, which makes `streamOrAbort`'s hijack-without-chunked-terminator defense inert in production. Separate PR.
- The `context canceled` log storm (6k–47k lines per cycle). Separate PR.
- Deferred to follow-up issues: re-queuing the affected block instead of cancelling the shared errgroup; per-resource-class peer deprioritization on 404; root-hash verification in `fetchAndStoreSubtree`; the pre-existing cross-site charge duplication across `releaseCatchupLock` / `processCatchupChItem` / `peer_selection.go`.
