### PR TITLE
fix(aerospike): guard the remaining batcher enqueue sites and re-panic unrelated panics

### DIFF
--- a/stores/utxo/aerospike/aerospike.go
+++ b/stores/utxo/aerospike/aerospike.go
@@ -124,20 +124,40 @@ type batcherIfc[T any] interface {
 	Close()
 }
 
-// safeBatcherPutCtx enqueues item into b, converting the "send on closed channel"
-// panic — which go-batcher v2.0.6 raises when Put is called after Close — into a
-// returned error. Store.Close closes the batchers during graceful shutdown while
-// external callers (block validation, assembly, …) may still be enqueuing; that
-// race must abort the operation, not crash the process. who labels the call site.
+// shutdownPanicText is the runtime's message when a send targets a closed
+// channel. That is how go-batcher v2 surfaces Put-after-Close; see
+// batcher.Batcher.Close, which documents that Put must not be called after it.
+const shutdownPanicText = "send on closed channel"
+
+// recoverBatcherShutdown turns the send-on-closed-channel panic into a returned
+// error and re-panics everything else. Store.Close closes the batchers during
+// graceful shutdown while external callers (block validation, assembly, …) may
+// still be enqueuing; that race must abort the operation rather than crash the
+// process. Any other panic — a nil batcher, a future go-batcher failure mode — is
+// a genuine bug and must not be relabelled as an orderly shutdown.
 //
-// The recovered value is pre-formatted with fmt.Sprintf: the runtime's panic
-// value is a runtime.plainError, which implements error, and errors.New consumes
-// a trailing error argument as the wrapped error rather than formatting it —
-// orphaning the %v verb and mislabelling the result as wrapping an UNKNOWN (0).
+// Matching is on the rendered text, not the concrete type: the runtime panics
+// with a runtime.plainError, so a type switch would pass in tests that fake the
+// panic with a string and miss in production. Rendering also has to happen before
+// the value reaches errors.New, which consumes a trailing error argument as the
+// wrapped error instead of formatting it — orphaning the %v verb and mislabelling
+// the result as wrapping an UNKNOWN (0).
+func recoverBatcherShutdown(r any, who string, err *error) {
+	text := fmt.Sprint(r)
+
+	if !strings.Contains(text, shutdownPanicText) {
+		panic(r)
+	}
+
+	*err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, text)
+}
+
+// safeBatcherPutCtx enqueues item into b, converting a Put-after-Close panic into
+// a returned error. who labels the call site.
 func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, fmt.Sprintf("%v", r))
+			recoverBatcherShutdown(r, who, &err)
 		}
 	}()
 
@@ -150,11 +170,27 @@ func safeBatcherPutCtx[T any](b batcherIfc[T], ctx context.Context, item *T, who
 func safeBatcherPut[T any](b batcherIfc[T], item *T, who string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.NewServiceUnavailableError("[%s] aerospike batcher unavailable (store shutting down): %v", who, fmt.Sprintf("%v", r))
+			recoverBatcherShutdown(r, who, &err)
 		}
 	}()
 
 	b.Put(item)
+
+	return nil
+}
+
+// safeBatcherPutBatchCtx is the PutBatchCtx counterpart. PutBatch* enqueues the
+// whole group in a single channel send, so a rejected send rejects every item:
+// callers must complete all of them, or the shared group.Wait parks for its full
+// timeout and then reports a misleading timeout instead of the shutdown.
+func safeBatcherPutBatchCtx[T any](b batcherIfc[T], ctx context.Context, items []*T, who string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			recoverBatcherShutdown(r, who, &err)
+		}
+	}()
+
+	b.PutBatchCtx(ctx, items)
 
 	return nil
 }

--- a/stores/utxo/aerospike/closed_batcher_group_test.go
+++ b/stores/utxo/aerospike/closed_batcher_group_test.go
@@ -1,0 +1,140 @@
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetLocked_ClosedBatcherDoesNotParkForFullTimeout is the regression test for
+// the batch-enqueue accounting. PutBatchCtx sends the whole group in one channel
+// send, so a Put-after-Close rejects every item at once. If the guard returned
+// its error without completing them, group.Wait would park for the full
+// batcherWait and then report a timeout — hiding the shutdown and stalling the
+// caller for the whole budget.
+//
+// batcherWait is set high enough that a parked wait is unmistakable.
+func TestSetLocked_ClosedBatcherDoesNotParkForFullTimeout(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.batcherWait = 30 * time.Second
+	s.lockedBatcher = sendOnClosedBatcher[batchLocked]{}
+
+	hashes := []chainhash.Hash{{0x01}, {0x02}, {0x03}}
+
+	start := time.Now()
+
+	var err error
+
+	require.NotPanics(t, func() {
+		err = s.SetLocked(context.Background(), hashes, true)
+	}, "SetLocked must not propagate the batcher's send-on-closed-channel panic")
+
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shutting down")
+	require.Less(t, elapsed, 5*time.Second,
+		"every item must be completed on a rejected batch send; parking for batcherWait means the accounting is wrong")
+}
+
+// TestCreate_ClosedBatcherSurfacesShutdown drives the guard through the real
+// Create path. Store.Close closes the store batcher FIRST, so it is dead for the
+// whole remaining drain — a Create racing shutdown is the widest window of any
+// site, and previously crashed the process.
+func TestCreate_ClosedBatcherSurfacesShutdown(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.batcherWait = 30 * time.Second
+	s.storeBatcher = sendOnClosedBatcher[BatchStoreItem]{}
+
+	tx, err := bt.NewTxFromString("010000000000000000ef011c044c4db32b3da68aa54e3f30c71300db250e0b48ea740bd3897a8ea1a2cc9a020000006b483045022100c6177fa406ecb95817d3cdd3e951696439b23f8e888ef993295aa73046504029022052e75e7bfd060541be406ec64f4fc55e708e55c3871963e95bf9bd34df747ee041210245c6e32afad67f6177b02cfc2878fce2a28e77ad9ecbc6356960c020c592d867ffffffffd4c7a70c000000001976a914296b03a4dd56b3b0fe5706c845f2edff22e84d7388ac0301000000000000001976a914a4429da7462800dedc7b03a4fc77c363b8de40f588ac000000000000000024006a4c2042535620466175636574207c20707573682d7468652d627574746f6e2e617070d2c7a70c000000001976a914296b03a4dd56b3b0fe5706c845f2edff22e84d7388ac00000000")
+	require.NoError(t, err)
+
+	start := time.Now()
+
+	var createErr error
+
+	require.NotPanics(t, func() {
+		_, createErr = s.Create(context.Background(), tx, 900000)
+	}, "Create must not propagate the batcher's send-on-closed-channel panic")
+
+	require.Error(t, createErr)
+	require.Contains(t, createErr.Error(), "shutting down")
+	require.Less(t, time.Since(start), 5*time.Second,
+		"the item must be completed on a rejected send; parking for batcherWait means the accounting is wrong")
+}
+
+// TestSetDAHForChildRecords_ClosedBatcherSurfacesShutdown covers the per-item
+// guard in the setDAH loop. Each child is its own channel send, so a shutdown
+// race rejects them individually; completing each one lets the existing
+// aggregate result read report the failure rather than waiting out batcherWait.
+func TestSetDAHForChildRecords_ClosedBatcherSurfacesShutdown(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.batcherWait = 30 * time.Second
+	s.setDAHBatcher = sendOnClosedBatcher[batchDAH]{}
+
+	txID := &chainhash.Hash{0x07}
+
+	start := time.Now()
+
+	var err error
+
+	require.NotPanics(t, func() {
+		err = s.SetDAHForChildRecords(txID, 3, 900000)
+	})
+
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 5*time.Second,
+		"each rejected child must be completed; parking for batcherWait means the accounting is wrong")
+}
+
+// TestIncrementSpentRecords_ClosedBatcherSurfacesShutdown covers the
+// single-item guard on the increment batcher. SpendWaitTimeout is left at zero
+// so the method's own 30s fallback applies — a parked wait would be obvious.
+func TestIncrementSpentRecords_ClosedBatcherSurfacesShutdown(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.incrementBatcher = sendOnClosedBatcher[batchIncrement]{}
+
+	txID := &chainhash.Hash{0x08}
+
+	start := time.Now()
+
+	var err error
+
+	require.NotPanics(t, func() {
+		_, err = s.IncrementSpentRecords(txID, 1, 900000)
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shutting down")
+	require.Less(t, time.Since(start), 5*time.Second)
+}
+
+// TestSpend_ClosedBatcherSurfacesShutdown drives the guard through the real Spend
+// path — the hottest write path and the one this guard exists for. PutBatchCtx
+// carries every input in one send, so a shutdown race rejects the whole group;
+// all items must be completed or resolveSpendCompletions never sees them and the
+// caller parks for the full SpendWaitTimeout.
+func TestSpend_ClosedBatcherSurfacesShutdown(t *testing.T) {
+	s := newTestStoreForGet(t)
+	s.settings.UtxoStore.SpendWaitTimeout = 30 * time.Second
+	s.spendBatcher = sendOnClosedBatcher[batchSpend]{}
+
+	tx, err := bt.NewTxFromString("010000000000000000ef011c044c4db32b3da68aa54e3f30c71300db250e0b48ea740bd3897a8ea1a2cc9a020000006b483045022100c6177fa406ecb95817d3cdd3e951696439b23f8e888ef993295aa73046504029022052e75e7bfd060541be406ec64f4fc55e708e55c3871963e95bf9bd34df747ee041210245c6e32afad67f6177b02cfc2878fce2a28e77ad9ecbc6356960c020c592d867ffffffffd4c7a70c000000001976a914296b03a4dd56b3b0fe5706c845f2edff22e84d7388ac0301000000000000001976a914a4429da7462800dedc7b03a4fc77c363b8de40f588ac000000000000000024006a4c2042535620466175636574207c20707573682d7468652d627574746f6e2e617070d2c7a70c000000001976a914296b03a4dd56b3b0fe5706c845f2edff22e84d7388ac00000000")
+	require.NoError(t, err)
+
+	start := time.Now()
+
+	var spendErr error
+
+	require.NotPanics(t, func() {
+		_, spendErr = s.Spend(context.Background(), tx, 900000)
+	}, "Spend must not propagate the batcher's send-on-closed-channel panic")
+
+	require.Error(t, spendErr)
+	require.Less(t, time.Since(start), 5*time.Second,
+		"every rejected input must be completed; parking for SpendWaitTimeout means the accounting is wrong")
+}

--- a/stores/utxo/aerospike/create.go
+++ b/stores/utxo/aerospike/create.go
@@ -254,7 +254,12 @@ func (s *Store) Create(ctx context.Context, tx *bt.Tx, blockHeight uint32, opts 
 		group:        group,
 	}
 
-	s.storeBatcher.PutCtx(ctx, item)
+	// Guard the enqueue: Store.Close closes the store batcher first, so a Create
+	// racing shutdown would otherwise panic. Complete the item so the shared wait
+	// below returns and the existing item.result read surfaces the error.
+	if enqueueErr := safeBatcherPutCtx(s.storeBatcher, ctx, item, "store"); enqueueErr != nil {
+		item.complete(enqueueErr)
+	}
 
 	// One shared wait for the item instead of a per-item timer + select.
 	// s.batcherWait <= 0 means unbounded (ctx-only) — Group.Wait treats a

--- a/stores/utxo/aerospike/get_closed_batcher_test.go
+++ b/stores/utxo/aerospike/get_closed_batcher_test.go
@@ -105,13 +105,10 @@ func (okBatcher[T]) SetDrainMode(bool)                         {}
 func (okBatcher[T]) SetTickInterval(time.Duration)             {}
 func (okBatcher[T]) Close()                                    {}
 
-// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard behind the two
-// enqueue paths routed through it — get (putGetBatch) and outpoint
-// (PreviousOutputsDecorate). The spend and locked paths enqueue via PutBatchCtx,
-// for which there is no guard variant; they are not covered here.
-//
-// A send-on-closed-channel panic becomes a returned shutdown error, and the
-// open-batcher path returns nil.
+// TestSafeBatcherPut_RecoversSendOnClosed locks the shared guard behind every
+// batcher enqueue in the store: get and setDAH/increment via Put/PutCtx, and
+// spend/locked via the PutBatchCtx variant. A send-on-closed-channel panic
+// becomes a returned shutdown error, and the open-batcher path returns nil.
 func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
 	closed := sendOnClosedBatcher[batchGetItem]{}
 
@@ -123,11 +120,16 @@ func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
 	require.Error(t, errPut)
 	require.Contains(t, errPut.Error(), "shutting down")
 
+	errBatch := safeBatcherPutBatchCtx[batchGetItem](closed, context.Background(),
+		[]*batchGetItem{{}, {}}, "spend")
+	require.Error(t, errBatch)
+	require.Contains(t, errBatch.Error(), "shutting down")
+
 	// The recovered value must be rendered into the message, not consumed by
 	// errors.New as a trailing wrapped error. runtime.plainError implements
 	// error, so passing it raw orphans the %v verb and mislabels the error as
 	// wrapping an UNKNOWN (0).
-	for _, err := range []error{errCtx, errPut} {
+	for _, err := range []error{errCtx, errPut, errBatch} {
 		require.Contains(t, err.Error(), "send on closed channel")
 		require.NotContains(t, err.Error(), "MISSING")
 		require.False(t, errors.Is(err, errors.ErrUnknown),
@@ -136,4 +138,41 @@ func TestSafeBatcherPut_RecoversSendOnClosed(t *testing.T) {
 
 	require.NoError(t, safeBatcherPutCtx[batchGetItem](okBatcher[batchGetItem]{}, context.Background(), &batchGetItem{}, "get"))
 	require.NoError(t, safeBatcherPut[batchGetItem](okBatcher[batchGetItem]{}, &batchGetItem{}, "get"))
+	require.NoError(t, safeBatcherPutBatchCtx[batchGetItem](okBatcher[batchGetItem]{}, context.Background(), []*batchGetItem{{}}, "spend"))
+}
+
+// panickingBatcher panics with something that is NOT the shutdown race, to prove
+// the guard re-panics instead of relabelling a genuine bug as an orderly
+// shutdown.
+type panickingBatcher[T any] struct{}
+
+func (panickingBatcher[T]) Put(*T, ...int)                     { panic("nil map write") }
+func (panickingBatcher[T]) PutCtx(context.Context, *T, ...int) { panic("nil map write") }
+func (panickingBatcher[T]) PutBatch([]*T, ...int)              { panic("nil map write") }
+func (panickingBatcher[T]) PutBatchCtx(context.Context, []*T, ...int) {
+	panic("nil map write")
+}
+func (panickingBatcher[T]) Trigger()                      {}
+func (panickingBatcher[T]) SetDrainMode(bool)             {}
+func (panickingBatcher[T]) SetTickInterval(time.Duration) {}
+func (panickingBatcher[T]) Close()                        {}
+
+// TestSafeBatcherPut_RepanicsUnrelatedPanic is the regression test for a blanket
+// recover: swallowing every panic would report a real bug (nil deref, nil map
+// write, a future go-batcher failure mode) as "store shutting down" — a
+// retryable error — on a path that only runs when something is already wrong.
+func TestSafeBatcherPut_RepanicsUnrelatedPanic(t *testing.T) {
+	bad := panickingBatcher[batchGetItem]{}
+
+	require.PanicsWithValue(t, "nil map write", func() {
+		_ = safeBatcherPutCtx[batchGetItem](bad, context.Background(), &batchGetItem{}, "get")
+	})
+
+	require.PanicsWithValue(t, "nil map write", func() {
+		_ = safeBatcherPut[batchGetItem](bad, &batchGetItem{}, "outpoint")
+	})
+
+	require.PanicsWithValue(t, "nil map write", func() {
+		_ = safeBatcherPutBatchCtx[batchGetItem](bad, context.Background(), []*batchGetItem{{}}, "spend")
+	})
 }

--- a/stores/utxo/aerospike/locked.go
+++ b/stores/utxo/aerospike/locked.go
@@ -84,7 +84,15 @@ func (s *Store) SetLocked(ctx context.Context, txHashes []chainhash.Hash, setVal
 	// Enqueue all hashes as one ordered group via a single PutBatchCtx, instead
 	// of one PutCtx per hash — cutting the per-item channel-send and collector-
 	// select overhead to a single operation for the whole set.
-	s.lockedBatcher.PutBatchCtx(ctx, items)
+	// Guard the enqueue: Store.Close closes the locked batcher last, so a
+	// SetLocked racing shutdown would otherwise panic. One send carries the whole
+	// group, so a rejected send rejects every hash — completing each item also
+	// trips its onError/failFast, which cancels waitCtx and captures firstErr.
+	if enqueueErr := safeBatcherPutBatchCtx(s.lockedBatcher, ctx, items, "locked"); enqueueErr != nil {
+		for _, item := range items {
+			item.complete(enqueueErr)
+		}
+	}
 
 	// s.batcherWait <= 0 means unbounded (ctx-only) — Group.Wait treats a
 	// non-positive timeout the same way. waitCtx cancellation (from failFast on

--- a/stores/utxo/aerospike/spend.go
+++ b/stores/utxo/aerospike/spend.go
@@ -419,7 +419,16 @@ func (s *Store) Spend(ctx context.Context, tx *bt.Tx, blockHeight uint32, ignore
 	}
 
 	// PutBatchCtx is a no-op on an empty slice (e.g. every input fast-failed).
-	s.spendBatcher.PutBatchCtx(ctx, toEnqueue)
+	// Guard the enqueue: Store.Close may close the spend batcher while an
+	// external caller is still spending. One send carries the whole group, so a
+	// rejected send rejects every item — complete all of them and let the
+	// resolveSpendCompletions path below report it, instead of parking on
+	// group.Wait for the full spendTimeout and reporting a bogus timeout.
+	if enqueueErr := safeBatcherPutBatchCtx(s.spendBatcher, ctx, toEnqueue, "spend"); enqueueErr != nil {
+		for _, item := range toEnqueue {
+			item.complete(enqueueErr)
+		}
+	}
 
 	// One shared wait for the whole batch, instead of one goroutine + timer
 	// per input. spendTimeout mirrors the previous per-item fallback.
@@ -1067,7 +1076,10 @@ func (s *Store) SetDAHForChildRecords(txID *chainhash.Hash, childCount int, dah 
 		}
 		items[i] = item
 
-		s.setDAHBatcher.Put(item)
+		// Per-item send, so only this child is rejected on a shutdown race.
+		if enqueueErr := safeBatcherPut(s.setDAHBatcher, item, "setDAH"); enqueueErr != nil {
+			item.complete(enqueueErr)
+		}
 	}
 
 	// s.batcherWait <= 0 means unbounded (ctx-only) — Group.Wait treats a
@@ -1156,7 +1168,10 @@ func (s *Store) handleExtraRecords(ctx context.Context, txID *chainhash.Hash, in
 								deleteAtHeight: 0, // clear DAH
 								group:          group,
 							}
-							s.setDAHBatcher.PutCtx(ctx, item)
+							if enqueueErr := safeBatcherPutCtx(s.setDAHBatcher, ctx, item, "setDAH"); enqueueErr != nil {
+								item.complete(enqueueErr)
+							}
+
 							if werr := group.Wait(ctx, s.batcherWait); werr != nil {
 								s.logger.Errorf("[handleExtraRecords][%s] failed to clear drifted master DAH: %v", txID.String(), werr)
 							} else if item.result != nil {
@@ -1263,7 +1278,9 @@ func (s *Store) IncrementSpentRecords(txid *chainhash.Hash, increment int, block
 	// Enqueue inline: Put is a non-blocking channel send, so the previous
 	// goroutine wrapper (needed only to avoid blocking on a per-item channel)
 	// is unnecessary under the group model.
-	s.incrementBatcher.Put(item)
+	if enqueueErr := safeBatcherPut(s.incrementBatcher, item, "increment"); enqueueErr != nil {
+		item.complete(nil, enqueueErr)
+	}
 
 	spendTimeout := s.settings.UtxoStore.SpendWaitTimeout
 	if spendTimeout <= 0 {


### PR DESCRIPTION
Follow-up to #1361. These changes were pushed to that branch after it had already been merged at an earlier commit, so they never reached `main` — reopening them here rather than leaving the gap.

## Why this is needed

#1361 landed the guard on two enqueue sites (get and outpoint). `Store.Close` closes **seven** batchers, so on current `main` a `Spend`, `Create` or `SetLocked` in flight when `Close` runs still panics `send on closed channel` and takes the process down — on the hottest write path. This was raised as a blocking item (ChiR2) in the review of #1363.

Verified against `main` as it stands:

| file | guarded | unguarded |
|---|---|---|
| spend.go | 0 | 4 |
| create.go | 0 | 1 |
| locked.go | 0 | 1 |
| get.go | 3 | 0 |

## What this changes

- Adds `safeBatcherPutBatchCtx` and routes the six remaining sites through the guards: `Spend`, `Create` and `SetLocked` (reachable from external callers during shutdown), plus `SetDAHForChildRecords`, `handleExtraRecords` and `IncrementSpentRecords` (internal today, guarded so a future external caller or a change to `Close`'s ordering cannot reintroduce the crash).
- **Completion accounting:** `PutBatch*` enqueues a whole group in one channel send, so a rejected send rejects every item. Each batch call site completes all of its items, letting the existing post-`Wait` result read surface the shutdown error. Without this the shared `group.Wait` parks for its full budget and then reports a misleading timeout — `TestSetLocked_ClosedBatcherDoesNotParkForFullTimeout` pins that, and deleting the completion loop makes it fail with `"set locked did not complete within 30s" does not contain "shutting down"` after a 30s park.
- **Narrows the recover** to the send-on-closed-channel panic and re-panics anything else. A blanket recover reported a nil batcher or any future go-batcher failure mode as an orderly shutdown *and* as a retryable error, on a path that only runs when something is already wrong. Matching is on the rendered text, not the concrete type, because the runtime panics with a `runtime.plainError`. Covered by `TestSafeBatcherPut_RepanicsUnrelatedPanic`.
- Corrects the test comment that claimed coverage of spend/locked before those paths were actually wired.

## On the error code

The guard deliberately keeps `ERR_SERVICE_UNAVAILABLE` rather than the `ERR_UNKNOWN` that `handleSpendPanic` (`spend.go:340`) chose for its own recovered panic. That looks inconsistent but is not. `ERR_SERVICE_UNAVAILABLE` places the error inside `IsTransientLocalError`, which `netsync/manager.go:1776` and `peer_server.go:1204` consume in lock-step; with `ERR_UNKNOWN` both invert, so netsync would `PushRejectMsg(..., wire.RejectInvalid, ...)` — telling a peer a valid block is invalid — and `shouldDisconnectOnBlockErr` would drop the delivering peer, both because *our* node was shutting down. `quick_validate.go:1385` would likewise route it to `hardFail` instead of the bounded retry list. `handleSpendPanic` is right to differ because its cause is unknown and possibly a code bug; this guard's cause is precisely identified. Narrowing the recover is what keeps the two conditions from overlapping.

## Verification

`go build ./...`, `go vet` clean; full package suites green on the merged result:

```
ok  	github.com/bsv-blockchain/teranode/stores/utxo/aerospike	254.401s
ok  	github.com/bsv-blockchain/teranode/stores/utxo/aerospike/pruner	39.367s
```

After this, no bare `s.*Batcher.Put*(` remains in non-test code.