### PR TITLE
fix(asset): stop serving and caching an empty subtree_data as a valid 200

### DIFF
--- a/deploy/docker/base/asset-cache-nginx.conf
+++ b/deploy/docker/base/asset-cache-nginx.conf
@@ -88,8 +88,14 @@ http {
       # signal only exists on HTTP/1.1. With 1.1, nginx logs "upstream prematurely
       # closed connection while reading upstream" and discards the cache entry.
       #
-      # Connection "" clears the hop-by-hop Connection header so keepalive is not
-      # forced closed per request.
+      # Connection "" clears the hop-by-hop Connection header, the standard idiom
+      # paired with proxy_http_version 1.1. It buys no connection reuse HERE, though:
+      # nginx's keepalive pool needs a named upstream {} block with "keepalive N;",
+      # and proxy_pass to a variable (http://$asset_backend) disables the upstream
+      # connection cache outright — nginx re-resolves DNS and opens a fresh TCP
+      # connection per request either way. The directive's only effect is that nginx
+      # stops sending an explicit "Connection: close" to the backend. Harmless and
+      # correct, but do not read a keepalive saving into it.
       proxy_http_version 1.1;
       proxy_set_header Connection "";
 

--- a/deploy/docker/base/asset-cache-nginx.conf
+++ b/deploy/docker/base/asset-cache-nginx.conf
@@ -99,6 +99,16 @@ http {
       # If cache lock times out, serve from backend anyway
       proxy_cache_lock_timeout 5s;
 
+      # Narrower than the http{}-level default (which includes http_500): a 500 from
+      # asset on these routes is a content fault — an empty or failed generation for
+      # one specific hash — not a transient backend outage, so re-invoking the backend
+      # cannot change the answer. With proxy_next_upstream_tries 3 that would cost up
+      # to three backend invocations per client request. Harmless in the default
+      # single-container topology, where proxy_pass to a variable yields one peer and
+      # the retry cannot fire, but real once asset is scaled and Docker DNS returns
+      # several A records — and worst exactly while the fleet is under catchup load.
+      proxy_next_upstream error timeout http_502 http_503 http_504;
+
       # Talk HTTP/1.1 upstream so responses are chunk-framed.
       #
       # nginx defaults to HTTP/1.0 for proxy_pass, where a body without a

--- a/deploy/docker/base/asset-cache-nginx.conf
+++ b/deploy/docker/base/asset-cache-nginx.conf
@@ -35,6 +35,29 @@ http {
   proxy_no_cache 0;      # 0 = do cache (do not disable caching)
   proxy_cache_bypass 0;  # 0 = use cache (do not bypass)
 
+  # Freshness label for the cached location, derived from the upstream status.
+  #
+  # This nginx never stores a failure (proxy_cache_valid lists 200 only), but that is
+  # a property of THIS hop, not of the response. RFC 9111 section 3 lets a shared
+  # cache store a 5xx precisely when explicit freshness information is present, so
+  # labelling a 500 "public, max-age=300" licenses any second cache in the path (an
+  # operator CDN or ingress in front of this container, a second asset-cache layer, a
+  # proxy between peers) to store and replay it for five minutes. The asset service
+  # now answers a zero-byte source with 500 rather than a cacheable empty 200
+  # (services/asset/httpimpl/stream.go streamOrAbort), which makes 5xx an expected
+  # outcome of these routes, so the failure path has to be labelled no-store — issue
+  # 1368's suggested fix 0.
+  #
+  # The "" arm is required: on a cache HIT no upstream is contacted and
+  # $upstream_status is empty, which must stay cacheable. A comma-separated
+  # $upstream_status (possible when proxy_next_upstream retried) and a revalidated
+  # 304 both fall to default, i.e. no-store — conservative, never the other way.
+  map $upstream_status $asset_cache_control {
+    default "no-store";              # 4xx/5xx: never store, never replay
+    200     "public, max-age=300";
+    ""      "public, max-age=300";   # cache HIT — no upstream was contacted
+  }
+
   # Set timeouts for upstream connections
   proxy_connect_timeout 5s;
   proxy_send_timeout 60s;  # Increased for large request bodies
@@ -107,7 +130,11 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
 
       add_header X-Cache-Status $upstream_cache_status always;
-      add_header Cache-Control "public, max-age=300" always;
+
+      # always: attach on every status, including the ones nginx generates itself.
+      # The value is conditional (see the $asset_cache_control map) so a 4xx/5xx is
+      # labelled no-store instead of inheriting the 300s freshness lifetime.
+      add_header Cache-Control $asset_cache_control always;
     }
 
     location ~ ^/api/v1/(txs|subtree/[0-9a-fA-F]+/txs)$ {

--- a/deploy/docker/base/asset-cache-nginx.conf
+++ b/deploy/docker/base/asset-cache-nginx.conf
@@ -76,6 +76,23 @@ http {
       # If cache lock times out, serve from backend anyway
       proxy_cache_lock_timeout 5s;
 
+      # Talk HTTP/1.1 upstream so responses are chunk-framed.
+      #
+      # nginx defaults to HTTP/1.0 for proxy_pass, where a body without a
+      # Content-Length ends at connection close. That makes an aborted upstream
+      # stream indistinguishable from a complete one, so nginx caches truncated and
+      # empty bodies as valid 200s — issue 1368, where a 0-byte subtree_data was
+      # cached and replayed (x-cache-status: HIT) until catchup stalled. The asset
+      # service already defends against this by closing the connection WITHOUT the
+      # chunked terminator (services/asset/httpimpl/stream.go streamOrAbort), but that
+      # signal only exists on HTTP/1.1. With 1.1, nginx logs "upstream prematurely
+      # closed connection while reading upstream" and discards the cache entry.
+      #
+      # Connection "" clears the hop-by-hop Connection header so keepalive is not
+      # forced closed per request.
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+
       proxy_pass http://$asset_backend;
 
       proxy_set_header Host $host;

--- a/deploy/docker/base/asset-cache-nginx.conf
+++ b/deploy/docker/base/asset-cache-nginx.conf
@@ -52,6 +52,14 @@ http {
   # $upstream_status is empty, which must stay cacheable. A comma-separated
   # $upstream_status (possible when proxy_next_upstream retried) and a revalidated
   # 304 both fall to default, i.e. no-store — conservative, never the other way.
+  #
+  # Accepted tradeoff: when proxy_cache_use_stale serves a stale-but-good 200
+  # because the upstream attempt failed, $upstream_status is that failed attempt's
+  # 5xx, so a valid body goes out labelled no-store and downstream caches will not
+  # store it. Only for the duration of the upstream-failure window, and it fails in
+  # the safe direction. Distinguishing it needs a composite
+  # "$upstream_cache_status|$upstream_status" key, which is more ways to get the
+  # labelling wrong than the marginal cacheability is worth.
   map $upstream_status $asset_cache_control {
     default "no-store";              # 4xx/5xx: never store, never replay
     200     "public, max-age=300";

--- a/services/asset/httpimpl/GetLegacyBlock.go
+++ b/services/asset/httpimpl/GetLegacyBlock.go
@@ -92,9 +92,17 @@ func (h *HTTP) GetLegacyBlock() func(c echo.Context) error {
 		// ever closes the read end.
 		defer r.Close()
 
+		// Outcome counted after streaming — see the note in GetSubtreeData for why, and
+		// for which cases this still labels as OK.
+		if err := streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r); err != nil {
+			prometheusAssetHTTPGetBlockLegacy.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
+			return err
+		}
+
 		prometheusAssetHTTPGetBlockLegacy.WithLabelValues("OK", "200").Inc()
 
-		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
+		return nil
 	}
 }
 
@@ -152,8 +160,15 @@ func (h *HTTP) GetRestLegacyBlock() func(c echo.Context) error {
 		// goroutine when the response write failed and streamOrAbort hijacked.
 		defer r.Close()
 
+		// Outcome counted after streaming — see the note in GetSubtreeData.
+		if err := streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r); err != nil {
+			prometheusAssetHTTPGetBlockLegacy.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
+			return err
+		}
+
 		prometheusAssetHTTPGetBlockLegacy.WithLabelValues("OK", "200").Inc()
 
-		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
+		return nil
 	}
 }

--- a/services/asset/httpimpl/GetLegacyBlock.go
+++ b/services/asset/httpimpl/GetLegacyBlock.go
@@ -84,6 +84,14 @@ func (h *HTTP) GetLegacyBlock() func(c echo.Context) error {
 			}
 		}
 
+		// The reader is a *io.PipeReader fed by a goroutine. Closing it unblocks that
+		// goroutine with io.ErrClosedPipe, which it already handles. Without this, a
+		// stream that fails because the write to the response failed (client gone) leaves
+		// the producer blocked in Write forever, holding its arena and any file-store read
+		// permit — streamOrAbort hijacks and returns nil in that case, so nothing else
+		// ever closes the read end.
+		defer r.Close()
+
 		prometheusAssetHTTPGetBlockLegacy.WithLabelValues("OK", "200").Inc()
 
 		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
@@ -139,6 +147,10 @@ func (h *HTTP) GetRestLegacyBlock() func(c echo.Context) error {
 				return echo.NewHTTPError(http.StatusInternalServerError, errors.NewProcessingError("error getting block", err).Error())
 			}
 		}
+
+		// See GetLegacyBlock: closing the pipe read end is what unblocks the producer
+		// goroutine when the response write failed and streamOrAbort hijacked.
+		defer r.Close()
 
 		prometheusAssetHTTPGetBlockLegacy.WithLabelValues("OK", "200").Inc()
 

--- a/services/asset/httpimpl/GetSubtree.go
+++ b/services/asset/httpimpl/GetSubtree.go
@@ -124,7 +124,11 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("invalid hash string", err).Error())
 		}
 
-		prometheusAssetHTTPGetSubtree.WithLabelValues("OK", "200").Inc()
+		// The outcome is counted per return path below rather than once up front. Counting
+		// OK/200 here filed every later failure — including the empty-source 500 the
+		// streaming modes can now return — in the success bucket. Every path that used to
+		// be counted by this single increment still increments exactly once; the two hash
+		// validation errors above return before it and were never counted, unchanged.
 
 		// sign the response, if the private key is set, ignore error
 		// do this before any output is sent to the client, this adds a signature to the response header
@@ -135,14 +139,20 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 		if mode == JSON {
 			offset, limit, err := h.getLimitOffset(c)
 			if err != nil {
+				prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusBadRequest)).Inc()
+
 				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 			}
 
 			subtree, offset, totalNodes, err := h.repository.GetSubtreePage(ctx, hash, offset, limit)
 			if err != nil {
 				if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+					prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusNotFound)).Inc()
+
 					return echo.NewHTTPError(http.StatusNotFound, err.Error())
 				} else {
+					prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
 					return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 				}
 			}
@@ -163,10 +173,14 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 				},
 			}
 
+			prometheusAssetHTTPGetSubtree.WithLabelValues("OK", "200").Inc()
+
 			return c.JSONPretty(200, response, "  ")
 		}
 
 		if mode != BINARY_STREAM && mode != HEX {
+			prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusBadRequest)).Inc()
+
 			return echo.NewHTTPError(http.StatusBadRequest, errors.NewInvalidArgumentError("bad read mode").Error())
 		}
 
@@ -175,21 +189,45 @@ func (h *HTTP) GetSubtree(mode ReadMode) func(c echo.Context) error {
 		subtreeReader, err := h.repository.GetSubtreeNodeHashesReader(ctx, hash)
 		if err != nil {
 			if errors.Is(err, errors.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+				prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusNotFound)).Inc()
+
 				return echo.NewHTTPError(http.StatusNotFound, err.Error())
 			} else {
+				prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
 				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 			}
 		}
 		defer subtreeReader.Close()
 
 		if mode == BINARY_STREAM {
-			return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, subtreeReader)
+			// Outcome counted after streaming — see the note in GetSubtreeData for why, and
+			// for which cases this still labels as OK.
+			if err = streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, subtreeReader); err != nil {
+				prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
+				return err
+			}
+
+			prometheusAssetHTTPGetSubtree.WithLabelValues("OK", "200").Inc()
+
+			return nil
 		}
 
-		// mode == HEX (validated above)
+		// mode == HEX (validated above). This route commits the status line before its
+		// first byte, so it cannot report an empty source as anything but a 200 — see the
+		// scope note on streamOrAbort. It is outside the cached nginx location.
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
 		c.Response().WriteHeader(http.StatusOK)
-		_, err = io.Copy(hex.NewEncoder(c.Response()), subtreeReader)
-		return err
+
+		if _, err = io.Copy(hex.NewEncoder(c.Response()), subtreeReader); err != nil {
+			prometheusAssetHTTPGetSubtree.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
+			return err
+		}
+
+		prometheusAssetHTTPGetSubtree.WithLabelValues("OK", "200").Inc()
+
+		return nil
 	}
 }

--- a/services/asset/httpimpl/GetSubtreeData.go
+++ b/services/asset/httpimpl/GetSubtreeData.go
@@ -78,8 +78,23 @@ func (h *HTTP) GetSubtreeData() func(c echo.Context) error {
 		}
 		defer r.Close()
 
+		// Count the outcome AFTER streaming, not before. Incrementing OK/200 up front
+		// filed every empty-source 500 in the success bucket, leaving no signal for
+		// "this node is serving 500s for subtree_data" — the first thing an operator
+		// would look at when validating the issue 1368 fix in production.
+		//
+		// Still not exact: streamOrAbort also returns nil on the mid-stream hijack path
+		// and on the client-gone-before-first-byte path, so those are counted as OK.
+		// Labelling them needs the helper to report which path it took, which is a
+		// bigger change than this metric fix warrants.
+		if err := streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r); err != nil {
+			prometheusAssetHTTPGetSubtreeData.WithLabelValues("ERROR", http.StatusText(http.StatusInternalServerError)).Inc()
+
+			return err
+		}
+
 		prometheusAssetHTTPGetSubtreeData.WithLabelValues("OK", "200").Inc()
 
-		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
+		return nil
 	}
 }

--- a/services/asset/httpimpl/GetSubtreeData_test.go
+++ b/services/asset/httpimpl/GetSubtreeData_test.go
@@ -123,4 +123,28 @@ func TestGetSubtreeData(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, echoErr.Code)
 		assert.Equal(t, "PROCESSING (4): error getting subtree", echoErr.Message)
 	})
+
+	t.Run("empty body is a server error, never a cacheable 200", func(t *testing.T) {
+		httpServer, mockRepo, echoContext, responseRecorder := GetMockHTTP(t, nil)
+
+		reader, writer := io.Pipe()
+
+		go func() {
+			// An on-demand generation that produced nothing: closed with no bytes.
+			_ = writer.Close()
+		}()
+
+		mockRepo.On("GetSubtreeDataReader", mock.Anything, mock.Anything, mock.Anything).Return(reader, nil)
+
+		echoContext.SetPath("/subtree_data/:hash")
+		echoContext.SetParamNames("hash")
+		echoContext.SetParamValues("9d45ad79ad3c6baecae872c0e35022d60c3bbbd024ccce06690321ece15ea995")
+
+		err := httpServer.GetSubtreeData()(echoContext)
+
+		echoErr := &echo.HTTPError{}
+		require.True(t, errors.As(err, &echoErr))
+		require.Equal(t, http.StatusInternalServerError, echoErr.Code)
+		require.Empty(t, responseRecorder.Body.String())
+	})
 }

--- a/services/asset/httpimpl/mining_candidate_legacy_block.go
+++ b/services/asset/httpimpl/mining_candidate_legacy_block.go
@@ -63,5 +63,9 @@ func (h *HTTP) handleMiningCandidateLegacyBlock(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
+	// See GetLegacyBlock: closing the pipe read end is what unblocks the producer
+	// goroutine when the response write failed and streamOrAbort hijacked.
+	defer r.Close()
+
 	return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, r)
 }

--- a/services/asset/httpimpl/stream.go
+++ b/services/asset/httpimpl/stream.go
@@ -50,7 +50,10 @@ import (
 // truncation as io.ErrUnexpectedEOF in its body parse). A source that
 // yields zero bytes now returns an *echo.HTTPError with status 500 and
 // never commits a status line, so callers must not have written headers
-// before calling.
+// before calling. A client that disconnects before the first byte returns
+// nil through the same hijack-and-close, again without committing a status
+// line — that is a client fault, not a server one, and surfacing it as a
+// 500 would only log an error twice for a peer that is already gone.
 //
 // # HTTP/2 limitation
 //
@@ -75,9 +78,29 @@ func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) er
 	// 500, which the cache configuration (proxy_cache_valid 200 5m) never stores.
 	var first [1]byte
 
+	// With a one-byte buffer io.ReadFull returns a nil error only when n == 1, and
+	// io.ErrUnexpectedEOF only for 0 < n < 1 — impossible. So inside n == 0, readErr is
+	// always non-nil and the condition is simply "which failure": a client that went
+	// away, or an exhausted source. Grow the buffer and both assumptions break.
 	n, readErr := io.ReadFull(r, first[:])
 	if n == 0 {
-		if readErr == nil || errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+		// Client (or proxy) went away before the source produced anything. Not a server
+		// fault: the request context is cancelled, the producer returns ctx.Err() or the
+		// pipe is closed, and the blocked read above surfaces that. Answering 500 would
+		// make customHTTPErrorHandler log an ERROR and then fail to write JSON to a peer
+		// that is already gone — a second ERROR — for every cancelled in-flight stream,
+		// and catchup cancels in batches. Mirror the debug-level "client gone"
+		// segregation in dualStreamWithFileCreation instead: hijack and close, which
+		// leaves the response uncommitted so nothing cacheable is finalised.
+		if errors.IsContextError(readErr) || errors.Is(readErr, io.ErrClosedPipe) {
+			if conn, _, hjErr := c.Response().Hijack(); hjErr == nil {
+				_ = conn.Close()
+				return nil
+			}
+			// h2: no hijack available, fall through to the 500.
+		}
+
+		if errors.Is(readErr, io.EOF) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "empty response body")
 		}
 

--- a/services/asset/httpimpl/stream.go
+++ b/services/asset/httpimpl/stream.go
@@ -2,7 +2,9 @@ package httpimpl
 
 import (
 	"io"
+	"net/http"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/labstack/echo/v4"
 )
 
@@ -45,7 +47,10 @@ import (
 // echo signals "response already finalised, don't touch it." The error
 // from io.Copy is consumed inside this helper (an abrupt hijack + close
 // is sufficient signalling to the client, which will surface the
-// truncation as io.ErrUnexpectedEOF in its body parse).
+// truncation as io.ErrUnexpectedEOF in its body parse). A source that
+// yields zero bytes now returns an *echo.HTTPError with status 500 and
+// never commits a status line, so callers must not have written headers
+// before calling.
 //
 // # HTTP/2 limitation
 //
@@ -59,11 +64,31 @@ import (
 // hijack path is the one that runs; only a client (or caching proxy)
 // speaking h2 directly to the asset service hits the fallback.
 func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) error {
+	// Peek one byte BEFORE committing the status line. A source that yields zero bytes
+	// — an empty subtreeData file, or an on-demand generation that failed before its
+	// first write — would otherwise be sent as "200 OK + empty body", which a caching
+	// reverse proxy stores as a valid response and replays for the whole TTL. That is
+	// the poisoning in issue 1368: a 32768-byte subtree (1024 tx hashes) whose
+	// subtree_data came back 200 with content-length 0, cached, stalling every
+	// requester's catchup. None of the endpoints using this helper can legitimately
+	// return an empty body, so an empty source is a server-side fault: report it as
+	// 500, which the cache configuration (proxy_cache_valid 200 5m) never stores.
+	var first [1]byte
+
+	n, readErr := io.ReadFull(r, first[:])
+	if n == 0 {
+		if readErr == nil || errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+			return echo.NewHTTPError(http.StatusInternalServerError, "empty response body")
+		}
+
+		return echo.NewHTTPError(http.StatusInternalServerError, readErr.Error())
+	}
+
 	h := c.Response().Header()
 	h.Set(echo.HeaderContentType, contentType)
 	c.Response().WriteHeader(code)
 
-	_, copyErr := io.Copy(c.Response(), r)
+	copyErr := writeStreamRemainder(c, first[:n], r)
 	if copyErr == nil {
 		// Happy path — let echo / Go finalise the chunked stream normally.
 		return nil
@@ -78,8 +103,20 @@ func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) er
 	}
 
 	// Hijack unsupported (HTTP/2 — see the doc comment) — fall back to
-	// surfacing the io.Copy error so echo logs it. The response is already
+	// surfacing the copy error so echo logs it. The response is already
 	// committed, so echo's error handler won't write to it; the cache-bypass
 	// guarantee does not hold on this path.
 	return copyErr
+}
+
+// writeStreamRemainder writes the peeked prefix and then copies the rest of the
+// source to the response.
+func writeStreamRemainder(c echo.Context, prefix []byte, r io.Reader) error {
+	if _, err := c.Response().Write(prefix); err != nil {
+		return err
+	}
+
+	_, err := io.Copy(c.Response(), r)
+
+	return err
 }

--- a/services/asset/httpimpl/stream.go
+++ b/services/asset/httpimpl/stream.go
@@ -76,6 +76,16 @@ func streamOrAbort(c echo.Context, code int, contentType string, r io.Reader) er
 	// requester's catchup. None of the endpoints using this helper can legitimately
 	// return an empty body, so an empty source is a server-side fault: report it as
 	// 500, which the cache configuration (proxy_cache_valid 200 5m) never stores.
+	//
+	// Scope: the routes going through here are subtree_data, subtree in BINARY_STREAM
+	// mode, block_legacy (both URL shapes) and the mining-candidate legacy block. The
+	// subtree HEX route does NOT — it commits 200 and then copies into a hex encoder, so
+	// a zero-byte source there is still a committed empty 200. It is out of the cache's
+	// reach: asset-cache-nginx.conf's cached location regex is $-anchored on the hash, so
+	// /api/v1/subtree/<hash>/hex never matches it and is never stored. The endpoint
+	// families that regex does match besides these (header, headers, block, blocks,
+	// headers_{to,from}_common_ancestor) answer with c.Blob on a fully materialised
+	// slice, so they always carry a Content-Length and none of this applies to them.
 	var first [1]byte
 
 	// With a one-byte buffer io.ReadFull returns a nil error only when n == 1, and

--- a/services/asset/httpimpl/stream_test.go
+++ b/services/asset/httpimpl/stream_test.go
@@ -168,3 +168,44 @@ func TestStreamOrAbort_FailureConnIsActuallyClosed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "still alive", string(body2))
 }
+
+// TestStreamOrAbort_EmptyBodyIsNotACommitted200 covers issue 1368: a source that
+// yields zero bytes must not be sent as "200 + empty body". A caching reverse proxy
+// stores that as a valid response and replays it for the whole TTL, which is what
+// stalled catchup on teratestnet.
+func TestStreamOrAbort_EmptyBodyIsNotACommitted200(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, bytes.NewReader(nil))
+
+	echoErr := &echo.HTTPError{}
+	require.True(t, errors.As(err, &echoErr), "an empty body must surface as an HTTP error, not a 200")
+	require.Equal(t, http.StatusInternalServerError, echoErr.Code)
+	require.False(t, c.Response().Committed, "the status line must not be committed for an empty body")
+	require.Empty(t, rec.Body.String())
+}
+
+// TestStreamOrAbort_SingleByteBodyStillSucceeds guards the boundary: the peeked byte
+// must be written, not swallowed.
+func TestStreamOrAbort_SingleByteBodyStillSucceeds(t *testing.T) {
+	e := echo.New()
+	e.GET("/x", func(c echo.Context) error {
+		return streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, strings.NewReader("A"))
+	})
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/x")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "A", string(got))
+}

--- a/services/asset/httpimpl/stream_test.go
+++ b/services/asset/httpimpl/stream_test.go
@@ -2,6 +2,7 @@ package httpimpl
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -186,6 +187,80 @@ func TestStreamOrAbort_EmptyBodyIsNotACommitted200(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, echoErr.Code)
 	require.False(t, c.Response().Committed, "the status line must not be committed for an empty body")
 	require.Empty(t, rec.Body.String())
+}
+
+// failFirstReader fails on the very first Read with the supplied error, emulating a
+// source whose producer aborted before writing a single byte — what a *io.PipeReader
+// returns once dualStreamWithFileCreation has called CloseWithError on the write end.
+type failFirstReader struct {
+	err error
+}
+
+func (f failFirstReader) Read([]byte) (int, error) {
+	return 0, f.err
+}
+
+// TestStreamOrAbort_ClientGoneBeforeFirstByte covers the peek's blast radius: a client
+// that disconnects before the source produced anything must not be reported as a server
+// fault. On the on-demand subtree_data path the cancelled request context surfaces as a
+// context error (or io.ErrClosedPipe) out of the peek, and returning a 500 there makes
+// customHTTPErrorHandler log an ERROR and then fail to write JSON to a peer that is
+// already gone — a second ERROR. Catchup cancels in batches, so that is two log lines
+// per cancelled in-flight stream on exactly the nodes an operator is diagnosing. The
+// repository does the opposite deliberately (dualStreamWithFileCreation classifies this
+// as "client gone" at debug level), so mirror it: hijack and close, no error surfaced,
+// and crucially no committed status line — an uncommitted response would otherwise be
+// finalised as the empty 200 this PR exists to prevent.
+func TestStreamOrAbort_ClientGoneBeforeFirstByte(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "closed pipe", err: io.ErrClosedPipe},
+		{name: "bare context cancellation", err: context.Canceled},
+		{name: "wrapped context cancellation", err: errors.NewProcessingError("write chunk", context.Canceled)},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				handlerErr error
+				committed  bool
+				done       = make(chan struct{})
+			)
+
+			e := echo.New()
+			e.GET("/x", func(c echo.Context) error {
+				defer close(done)
+
+				handlerErr = streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, failFirstReader{err: tc.err})
+				committed = c.Response().Committed
+
+				return handlerErr
+			})
+
+			srv := httptest.NewServer(e)
+			defer srv.Close()
+
+			resp, err := http.Get(srv.URL + "/x") //nolint:bodyclose // closed below when non-nil
+			if err == nil {
+				defer resp.Body.Close()
+
+				require.NotEqual(t, http.StatusInternalServerError, resp.StatusCode,
+					"a client disconnect must not be answered with a server-fault status")
+				require.NotEqual(t, http.StatusOK, resp.StatusCode,
+					"an uncommitted response finalised as 200 with Content-Length: 0 is the bug being fixed")
+			}
+
+			<-done
+
+			require.NoError(t, handlerErr,
+				"a client disconnect must not reach echo's error handler, which logs it at ERROR twice")
+			require.False(t, committed,
+				"the status line must stay uncommitted so no cacheable empty 200 can be finalised")
+		})
+	}
 }
 
 // TestStreamOrAbort_SingleByteBodyStillSucceeds guards the boundary: the peeked byte

--- a/services/asset/httpimpl/stream_test.go
+++ b/services/asset/httpimpl/stream_test.go
@@ -16,19 +16,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// errReader returns the supplied prefix bytes once, then fails with the
-// supplied error on the next Read. Used to drive streamOrAbort's
+// errReader serves the supplied prefix bytes, across as many Reads as the caller's
+// buffers take, then fails with the supplied error. Used to drive streamOrAbort's
 // failure path with a deterministic mid-stream error.
+//
+// The prefix must survive a short read: streamOrAbort peeks with a one-byte buffer
+// before io.Copy takes over, so a reader that dropped its tail on the first short read
+// would silently degrade these tests to a one-byte body — a degenerate single-chunk
+// stream, leaving the multi-chunk truncation case they exist for uncovered.
 type errReader struct {
-	prefix   []byte
-	err      error
-	consumed bool
+	prefix []byte
+	err    error
 }
 
 func (e *errReader) Read(p []byte) (int, error) {
-	if !e.consumed {
+	if len(e.prefix) > 0 {
 		n := copy(p, e.prefix)
-		e.consumed = true
+		e.prefix = e.prefix[n:]
+
 		return n, nil
 	}
 
@@ -101,6 +106,34 @@ func TestStreamOrAbort_MidStreamFailure_ClientSeesUnexpectedEOF(t *testing.T) {
 	require.Error(t, readErr, "client must see a non-clean termination so caches refuse to store the truncated body")
 	assert.NotErrorIs(t, readErr, io.EOF,
 		"clean io.EOF would imply Go wrote the chunked terminator — this would let caching proxies store the truncated body")
+}
+
+// TestStreamOrAbort_MidStreamFailureWritesWholePrefix pins the multi-chunk shape of
+// the failure path where it can be asserted deterministically: server-side. How much
+// of the body reaches the client before the hijack-and-close is up to the kernel — an
+// abrupt close can discard the socket buffer — so the sibling test above cannot make
+// this claim without flaking. Here the response recorder keeps everything the helper
+// wrote, which catches both a peek that swallows its byte and a source reader that
+// drops its tail on the one-byte peek (which would degrade the mid-stream tests to a
+// degenerate single-chunk body).
+func TestStreamOrAbort_MidStreamFailureWritesWholePrefix(t *testing.T) {
+	prefix := bytes.Repeat([]byte{0xAB}, 256)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := streamOrAbort(c, http.StatusOK, echo.MIMEOctetStream, &errReader{
+		prefix: prefix,
+		err:    errors.NewProcessingError("simulated mid-stream failure"),
+	})
+
+	// httptest.ResponseRecorder is not an http.Hijacker, so the helper takes the
+	// documented h2 fallback and surfaces the copy error instead of hijacking.
+	require.Error(t, err)
+	require.True(t, c.Response().Committed, "the status line is committed once a byte has been read")
+	require.Equal(t, prefix, rec.Body.Bytes(), "the peeked byte and the rest of the source must both be written")
 }
 
 // TestStreamOrAbort_NoHeaderOverwriteAfterCommit guards against a regression

--- a/services/asset/httpimpl/stream_test.go
+++ b/services/asset/httpimpl/stream_test.go
@@ -136,6 +136,50 @@ func TestStreamOrAbort_MidStreamFailureWritesWholePrefix(t *testing.T) {
 	require.Equal(t, prefix, rec.Body.Bytes(), "the peeked byte and the rest of the source must both be written")
 }
 
+// TestStreamOrAbort_CompleteStreamDependsOnHowTheProducerCloses documents the coupling
+// that made every successful block_legacy response take the abort path: the helper's
+// happy/failure decision is exactly how the producer closed its pipe, and a producer that
+// signals completion with CloseWithError(io.ErrClosedPipe) is indistinguishable from one
+// that failed mid-stream. That is why GetLegacyBlockReader's success paths must use
+// w.Close() — see TestGetLegacyBlockReader_SuccessEndsWithCleanEOF in the repository
+// package. A complete body plus an abort meant nginx saw "upstream prematurely closed
+// connection", never cached the block, and could turn a buffered 200 into a 502.
+func TestStreamOrAbort_CompleteStreamDependsOnHowTheProducerCloses(t *testing.T) {
+	body := bytes.Repeat([]byte{0xEE}, 512)
+
+	run := func(closeWriter func(w *io.PipeWriter)) (error, *httptest.ResponseRecorder) {
+		r, w := io.Pipe()
+
+		go func() {
+			_, _ = w.Write(body)
+			closeWriter(w)
+		}()
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		rec := httptest.NewRecorder()
+
+		return streamOrAbort(e.NewContext(req, rec), http.StatusOK, echo.MIMEOctetStream, r), rec
+	}
+
+	t.Run("clean close takes the happy path", func(t *testing.T) {
+		err, rec := run(func(w *io.PipeWriter) { _ = w.Close() })
+
+		require.NoError(t, err, "a completed stream must not be treated as a failure")
+		require.Equal(t, body, rec.Body.Bytes())
+	})
+
+	t.Run("success signalled as ErrClosedPipe is taken for a failure", func(t *testing.T) {
+		err, rec := run(func(w *io.PipeWriter) { _ = w.CloseWithError(io.ErrClosedPipe) })
+
+		// The whole body still arrives, which is what kept this invisible — but the helper
+		// aborts, and on a real connection that drops the chunked terminator.
+		// httptest.ResponseRecorder cannot hijack, so the error surfaces here instead.
+		require.Error(t, err)
+		require.Equal(t, body, rec.Body.Bytes())
+	})
+}
+
 // TestStreamOrAbort_NoHeaderOverwriteAfterCommit guards against a regression
 // where the helper might try to mutate headers after WriteHeader was
 // called — which Go silently drops and would mask other bugs. We assert

--- a/services/asset/repository/GetLegacyBlock.go
+++ b/services/asset/repository/GetLegacyBlock.go
@@ -84,8 +84,10 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 				return err
 			}
 
-			// close the writer after the coinbase tx has been streamed
-			_ = w.CloseWithError(io.ErrClosedPipe)
+			// Close cleanly so the consumer's read ends in io.EOF. CloseWithError(io.ErrClosedPipe)
+			// here reported a complete body as a failure, which made streamOrAbort hijack the
+			// connection and drop the chunked terminator on every successful block.
+			_ = w.Close()
 
 			return nil
 		}
@@ -182,8 +184,10 @@ func (repo *Repository) GetLegacyBlockReader(ctx context.Context, hash *chainhas
 			}
 		}
 
-		// close the writer after all subtrees have been streamed
-		_ = w.CloseWithError(io.ErrClosedPipe)
+		// Close cleanly after all subtrees have been streamed, so the consumer's read ends
+		// in io.EOF and streamOrAbort takes the happy path. See the note on the
+		// no-subtrees close above; io.ErrClosedPipe stays reserved for genuine failures.
+		_ = w.Close()
 
 		return nil
 	})

--- a/services/asset/repository/GetLegacyBlock_test.go
+++ b/services/asset/repository/GetLegacyBlock_test.go
@@ -230,8 +230,11 @@ func assertBlockFromReader(t *testing.T, r *io.PipeReader, bytes []byte, block *
 	transactionCount, _ := bt.NewVarIntFromBytes(bytes[:n])
 	assert.Equal(t, block.TransactionCount, uint64(transactionCount))
 
+	// A complete block must end cleanly. This used to require io.ErrClosedPipe, which
+	// encoded the producer's success-as-failure close: streamOrAbort read that as a
+	// mid-stream fault and aborted the connection on every successful legacy block.
 	bytes, err = io.ReadAll(r)
-	require.ErrorIs(t, err, io.ErrClosedPipe)
+	require.NoError(t, err)
 
 	// check the coinbase transaction
 	coinbaseTx, coinbaseSize, err := bt.NewTxFromStream(bytes)
@@ -253,8 +256,98 @@ func assertBlockFromReader(t *testing.T, r *io.PipeReader, bytes []byte, block *
 
 	// check the end of the stream
 	n, err = r.Read(bytes)
-	assert.Equal(t, io.ErrClosedPipe, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, 0, n)
+}
+
+// TestGetLegacyBlockReader_SuccessEndsWithCleanEOF pins the producer's success signal.
+//
+// Both success paths used to end with w.CloseWithError(io.ErrClosedPipe), so a complete
+// body was delivered and then reported as a failure. io.Copy in streamOrAbort's
+// writeStreamRemainder therefore returned non-nil on a perfectly good response, and the
+// helper hijacked the connection and closed it WITHOUT the chunked terminator on every
+// successful legacy block. That was invisible while nginx spoke HTTP/1.0 upstream (a body
+// ends at connection close there, so a missing terminator means nothing); with
+// proxy_http_version 1.1 it becomes "upstream prematurely closed connection while reading
+// upstream" on every block_legacy fetch — never cached, and a 502 for responses still
+// sitting in proxy_buffers. It also breaks the SV-peer push in services/legacy, which
+// io.ReadAll's this body and surfaces the unclean end as an error.
+//
+// A completed stream must therefore end in io.EOF. io.ErrClosedPipe stays reserved for
+// genuine failures.
+func TestGetLegacyBlockReader_SuccessEndsWithCleanEOF(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	// drainAndAssertCleanEOF reads the rest of the body and requires that the stream
+	// terminated cleanly. io.ReadAll swallows io.EOF, so a non-nil error here means the
+	// producer signalled a failure; a follow-up Read pins the sentinel itself.
+	drainAndAssertCleanEOF := func(t *testing.T, r io.Reader) []byte {
+		body, err := io.ReadAll(r)
+		require.NoError(t, err, "a complete legacy block must not report a failure: streamOrAbort would hijack the connection and drop the chunked terminator")
+
+		n, err := r.Read(make([]byte, 1))
+		require.Equal(t, 0, n)
+		require.Equal(t, io.EOF, err, "the stream must end in io.EOF; io.ErrClosedPipe is reserved for genuine failures")
+
+		return body
+	}
+
+	t.Run("block with no subtrees", func(t *testing.T) {
+		ctx := setup(t)
+
+		block, _ := newBlock(ctx, t, params)
+
+		// Take the len(block.Subtrees) == 0 branch: only the coinbase is streamed.
+		block.Subtrees = nil
+		block.TransactionCount = 1
+
+		blockchainClientMock := ctx.repo.BlockchainClient.(*blockchain.Mock)
+		blockchainClientMock.On("GetBlock", mock.Anything, mock.Anything).Return(block, nil).Once()
+
+		r, err := ctx.repo.GetLegacyBlockReader(t.Context(), &chainhash.Hash{})
+		require.NoError(t, err)
+
+		defer func() {
+			_ = r.Close()
+		}()
+
+		body := drainAndAssertCleanEOF(t, r)
+
+		// magic(4) + size(4) + header(80) + tx count varint(1), then the coinbase.
+		require.Len(t, body, 4+4+model.BlockHeaderSize+1+coinbase.Size())
+	})
+
+	t.Run("block with subtrees streamed from the subtree store", func(t *testing.T) {
+		ctx := setup(t)
+
+		block, subtree := newBlock(ctx, t, params)
+
+		blockchainClientMock := ctx.repo.BlockchainClient.(*blockchain.Mock)
+		blockchainClientMock.On("GetBlock", mock.Anything, mock.Anything).Return(block, nil).Once()
+
+		for i, tx := range params.txs {
+			if i != 0 {
+				_, _, err := ctx.repo.UtxoStore.SpendAndCreate(t.Context(), tx, params.height, utxo.WithCreateOnly())
+				require.NoError(t, err)
+			}
+		}
+
+		subtreeBytes, err := subtree.Serialize()
+		require.NoError(t, err)
+		require.NoError(t, ctx.repo.SubtreeStore.Set(t.Context(), subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes))
+
+		r, err := ctx.repo.GetLegacyBlockReader(t.Context(), &chainhash.Hash{})
+		require.NoError(t, err)
+
+		defer func() {
+			_ = r.Close()
+		}()
+
+		body := drainAndAssertCleanEOF(t, r)
+
+		// Every transaction must still be there — the clean close must not cost bytes.
+		require.Len(t, body, 4+4+model.BlockHeaderSize+1+coinbase.Size()+tx1.Size())
+	})
 }
 
 type blockInfo struct {
@@ -420,9 +513,10 @@ func TestWriteTransactionsViaSubtreeStoreStreaming(t *testing.T) {
 		txCount, _ := bt.NewVarIntFromBytes(buf[:10])
 		assert.Equal(t, uint64(len(txs)), uint64(txCount))
 
-		// Read all transaction data
+		// Read all transaction data. The producer closes the pipe cleanly once every
+		// subtree has been streamed, so a complete stream ends in io.EOF.
 		allTxData, err := io.ReadAll(r)
-		require.ErrorIs(t, err, io.ErrClosedPipe) // Pipe closes after all data
+		require.NoError(t, err)
 
 		// Parse transactions from the stream and verify order
 		offset := 0
@@ -509,7 +603,7 @@ func TestWriteTransactionsViaSubtreeStoreStreaming(t *testing.T) {
 		require.NoError(t, err)
 
 		allTxData, err := io.ReadAll(r)
-		require.ErrorIs(t, err, io.ErrClosedPipe)
+		require.NoError(t, err)
 
 		// Verify all transactions are present and in order
 		offset := 0
@@ -585,7 +679,7 @@ func TestWriteTransactionsViaSubtreeStoreStreaming(t *testing.T) {
 		require.NoError(t, err)
 
 		allTxData, err := io.ReadAll(r)
-		require.ErrorIs(t, err, io.ErrClosedPipe)
+		require.NoError(t, err)
 
 		offset := 0
 		for i := 0; i < len(txs); i++ {

--- a/services/asset/repository/GetSubtreeData.go
+++ b/services/asset/repository/GetSubtreeData.go
@@ -34,6 +34,21 @@ func resetQuorumForTests() {
 	assetQuorum = nil
 }
 
+// countingWriter counts the bytes that pass through it. Used by
+// dualStreamWithFileCreation to tell "generated nothing" apart from "generated
+// something", which the writer chain itself cannot report.
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+
+	return n, err
+}
+
 // semaphoreReadCloser wraps an io.ReadCloser and releases a semaphore permit when closed.
 type semaphoreReadCloser struct {
 	io.ReadCloser
@@ -237,8 +252,9 @@ func (repo *Repository) dualStreamWithFileCreation(ctx context.Context, subtreeH
 	// Create pipe for HTTP response
 	httpReader, httpWriter := io.Pipe()
 
-	// Use MultiWriter to write to both file storage and HTTP pipe simultaneously
-	multiWriter := io.MultiWriter(storer, httpWriter)
+	// Use MultiWriter to write to both file storage and HTTP pipe simultaneously.
+	// Counted so an empty generation can be rejected before the blob is finalised.
+	counted := &countingWriter{w: io.MultiWriter(storer, httpWriter)}
 
 	// Background goroutine: generate data and write to both destinations
 	g, gCtx := errgroup.WithContext(ctx)
@@ -250,8 +266,23 @@ func (repo *Repository) dualStreamWithFileCreation(ctx context.Context, subtreeH
 		}
 
 		// Write all transactions to both destinations
-		err := repo.writeTransactionsViaSubtreeStoreStreaming(gCtx, multiWriter, nil, subtreeHash)
+		err := repo.writeTransactionsViaSubtreeStoreStreaming(gCtx, counted, nil, subtreeHash)
+
+		// A successful pass that wrote nothing must not be committed. It happens when the
+		// subtree stream header reports numLeaves == 0 — a corrupt or truncated subtree
+		// file — where writeTransactionsViaSubtreeStoreStreaming short-circuits with nil,
+		// and FileStorer.Close then finalises a zero-byte blob. Exists would return true
+		// for that hash from then on, so every later request would take the stored-file
+		// branch and never retry generation: a transient generation fault would become a
+		// hard 500 for this hash until DAH pruning (~288 blocks). No endpoint can serve
+		// an empty subtreeData, so fail here instead and leave nothing behind — the
+		// handler's 500 then stays retryable.
+		if err == nil && counted.n == 0 {
+			err = errors.NewProcessingError("[GetSubtreeDataReader] generated subtreeData for %s is empty", subtreeHash.String())
+		}
+
 		if err != nil {
+			// Abort discards the temp file rather than finalising it.
 			storer.Abort(err)
 			_ = httpWriter.CloseWithError(err)
 			// "Client gone" — the HTTP client (or proxy) disconnected mid-stream, which

--- a/services/asset/repository/GetSubtreeData_test.go
+++ b/services/asset/repository/GetSubtreeData_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
@@ -151,6 +152,51 @@ func TestGetSubtreeDataWithReader(t *testing.T) {
 			clientGoneBefore,
 			testutil.ToFloat64(prometheusAssetSubtreeDataCreated.WithLabelValues("error", "client_gone")),
 			0, "client_gone must not increment for a server-side fault")
+	})
+
+	t.Run("a zero-leaf subtree must not commit an empty subtreeData blob", func(t *testing.T) {
+		// Regression for issue 1368's write side. writeTransactionsViaSubtreeStoreStreaming
+		// returns nil after writing nothing when the subtree stream header reports
+		// numLeaves == 0 (a corrupt or truncated subtree file). FileStorer.Close finalises
+		// the blob unconditionally, so the old code persisted a zero-byte subtreeData.
+		// Exists then returns true for that hash forever after, so every later request
+		// takes the stored-file branch, never retries generation, and — now that an empty
+		// source is a 500 rather than a cacheable empty 200 — serves a hard 500 for that
+		// hash until DAH pruning. Refuse to commit instead: nothing is stored, so the
+		// handler's 500 stays retryable.
+		resetQuorumForTests()
+		ctx := setup(t)
+
+		hash := chainhash.HashH([]byte("zero-leaf-subtree"))
+
+		// A subtree stream header with numLeaves == 0 and no node records after it:
+		// 32-byte root hash + fees + sizeInBytes + numLeaves, all little-endian uint64s.
+		header := make([]byte, subtreeStreamHeaderSize)
+		copy(header, hash[:])
+		require.NoError(t, ctx.repo.SubtreeStore.Set(t.Context(), hash[:], fileformat.FileTypeSubtree, header))
+
+		initPrometheusMetrics()
+		writeFailedBefore := testutil.ToFloat64(prometheusAssetSubtreeDataCreated.WithLabelValues("error", "write_failed"))
+
+		r, err := ctx.repo.GetSubtreeDataReader(t.Context(), &hash)
+		require.NoError(t, err, "the on-demand path must start; the emptiness is only detectable after generation")
+
+		// The reader must surface the generation failure rather than a clean EOF —
+		// a clean EOF is what the HTTP layer would turn into an empty 200.
+		body, readErr := io.ReadAll(r)
+		require.Empty(t, body)
+		require.Error(t, readErr, "an empty generation must fail the stream, not end it cleanly")
+		require.NoError(t, r.Close())
+
+		require.Eventually(t, func() bool {
+			return testutil.ToFloat64(prometheusAssetSubtreeDataCreated.WithLabelValues("error", "write_failed")) > writeFailedBefore
+		}, 2*time.Second, 10*time.Millisecond, "an empty generation must be recorded as a server-side write failure")
+
+		// The blob must not exist: if it did, Exists would short-circuit every later
+		// request to the stored-file branch and the 500 would stick for the DAH window.
+		exists, err := ctx.repo.SubtreeStore.Exists(t.Context(), hash[:], fileformat.FileTypeSubtreeData)
+		require.NoError(t, err)
+		require.False(t, exists, "a zero-byte subtreeData must never be committed")
 	})
 
 	t.Run("get subtree from utxo store and verify file creation", func(t *testing.T) {

--- a/services/asset/repository/subtree_stream_backpressure_test.go
+++ b/services/asset/repository/subtree_stream_backpressure_test.go
@@ -152,9 +152,11 @@ func TestSubtreeStreamingHeadOfLineBackpressure(t *testing.T) {
 	txCount, _ := bt.NewVarIntFromBytes(buf[:10])
 	require.Equal(t, uint64(len(txs)), uint64(txCount))
 
-	// The stream must deliver every transaction — no mid-stream abort/truncation.
+	// The stream must deliver every transaction — no mid-stream abort/truncation. The
+	// assertion now says what it always claimed: a clean end, not io.ErrClosedPipe, which
+	// was the producer reporting its own success as a failure.
 	allTxData, err := io.ReadAll(r)
-	require.ErrorIs(t, err, io.ErrClosedPipe, "stream did not complete cleanly (truncated/aborted)")
+	require.NoError(t, err, "stream did not complete cleanly (truncated/aborted)")
 
 	offset := 0
 	for i := 0; i < len(txs); i++ {


### PR DESCRIPTION
Part of #1368 — the serving side. The client-side half merged in #1371; the log-storm fix follows separately.

## Why

A peer answered `subtree_data` with `HTTP 200` and an **empty body**, its nginx `proxy_cache` stored that as a valid response, and it replayed it (`x-cache-status: HIT`, `content-length: 0`, `cache-control: public, max-age=300`) to every requester for the whole TTL. A 32768-byte subtree is 1024 tx hashes, so its `subtree_data` cannot legitimately be empty.

`streamOrAbort` already defends against *truncated* streams: on a mid-stream failure it hijacks the connection and closes it **without** the chunked terminator, so nginx sees an incomplete chunked response and refuses to commit it to cache. Two holes let the empty case through anyway.

## Hole 1 — the status line was committed before the first byte was read

`streamOrAbort` called `WriteHeader(200)` up front, so a source that yielded zero bytes — an on-demand generation that failed before its first write, or an empty stored file — went out as a perfectly cacheable `200` with an empty body. The truncation defense never engaged because there was nothing to truncate.

Now the helper peeks one byte with `io.ReadFull` *before* committing, and an empty source returns `500` instead. `proxy_cache_valid` covers only `200`, so a 500 is never stored. The peeked byte is written, not swallowed.

This applies to `subtree`, `subtree_data`, `block_legacy` and the legacy mining candidate — none of which can legitimately return an empty body. The mid-stream hijack path is untouched.

## Hole 2 — nginx was talking HTTP/1.0 upstream, so the truncation defense was inert in production

`asset-cache-nginx.conf` never set `proxy_http_version`, and nginx defaults to **HTTP/1.0** for `proxy_pass`. On HTTP/1.0 a body without a Content-Length ends at connection close — which makes a deliberately aborted stream **indistinguishable from a complete one**. nginx cached truncated and empty bodies as valid 200s regardless of the hijack.

With `proxy_http_version 1.1` the response is chunk-framed, so closing without the terminator produces `upstream prematurely closed connection while reading upstream` and nginx discards the cache entry — the behaviour `streamOrAbort` was written for. Scoped to the cached location block so the blast radius stays on the endpoints that actually cache.

`proxy_set_header Connection ""` comes along per the usual 1.1 pairing. Note this conf has no `upstream {}` block with `keepalive`, and `proxy_pass http://$asset_backend` uses a variable, which disables the upstream connection cache anyway — so the directive is harmless here but buys no reuse. The comment says so, to save the next reader the same dig.

## What this does not fix

**This PR alone cannot unstick an already-poisoned peer, and that is structural, not a deployment-timing artefact.** `proxy_cache_use_stale ... http_500` means a peer holding a poisoned entry serves the **stale empty 200** rather than the new 500 once the TTL lapses, `proxy_cache_background_update on` keeps refreshes in the background, and each access refreshes the `inactive=10m` timer. Escaping it needs either the client-side cache-bust from #1371 — a busted key has no stale entry — or an operator flushing `/tmp/nginx/cache` on the affected peer.

Related: if a zero-byte `subtreeData` file was ever committed to a peer's store, that peer now returns 500 for that hash permanently instead of an empty 200. Better for clients (explicit failure, peer charged, alternatives tried) but it turns a silently-wrong condition into one that needs cleanup.

## Testing

`services/asset/...` green under `-race`; `streamOrAbort` unit tests cover the empty body (asserting the status line stays uncommitted and the recorder body is empty), the single-byte boundary, and a handler-level empty-pipe case; the four pre-existing `streamOrAbort` tests are unmodified and still pass. `nginx -t` reports the conf syntactically valid. `go build`, `go vet`, `make lint` clean.

**Outstanding manual verification:** live cache-behaviour against a running stack was not performed — it needs real chain data. The check that matters is `upstream prematurely closed connection while reading upstream` appearing in nginx's error log on an aborted stream, with no cached empty entry afterwards; also worth capturing `uht=` in the `cache_log` before and after, since the deferred header commit shifts first-byte latency into upstream header time. If someone has a stack with chain data, that is the one thing left to confirm.

## Known limitation, not addressed here

`GetSubtreeData` and `GetSubtree` both increment their `OK`/`200` Prometheus label before streaming, so an empty-body 500 is still counted as OK. That mislabelling already existed for mid-stream failures; fixing it is a separate change.
