### PR TITLE
fix(blockvalidation): enforce checkpoint hash-match on the direct validate path

### DIFF
--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -35,6 +35,7 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -1636,14 +1637,30 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		// difficulty checks must run first. It also means a peer cannot make us do
 		// full tx validation for a garbage header at zero cost.
 		//
+		// Checkpoint enforcement (defense-in-depth on the direct, non-catchup path):
+		// a block whose height matches a hardcoded checkpoint MUST match the
+		// checkpoint hash, mirroring the catchup header pipeline. Without this the
+		// difficulty-skip below would let a fabricated block AT a checkpoint height
+		// reach subtree validation with the expected-nBits check skipped and no
+		// checkpoint assertion. See gap-analysis #&NoBreak;4697. (Rejecting sub-checkpoint
+		// forks at non-checkpoint heights — the fork-depth rule — is a separate,
+		// broader change and is not done here.)
+		if err = catchup.ValidateHeaderAgainstCheckpoints(block.Header, block.Height, u.settings.ChainCfgParams.Checkpoints); err != nil {
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, err.Error())
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] block conflicts with hardcoded checkpoint", block.Hash().String(), err)
+		}
+
 		// Skip difficulty validation for blocks at or below the highest checkpoint:
 		// these blocks are already verified by checkpoints. NOTE: on this direct
-		// (non-catchup) path the checkpoint linkage itself is not verified here, so
-		// for heights at or below the checkpoint the zero-cost claim above does not
-		// hold — a fabricated low-height header reaches subtree validation without
-		// paying PoW. block.Valid still rejects such a block unconditionally
-		// (HasMetTargetDifficulty + checkParentsExistOnChain) before acceptance;
-		// the exposure is transient blessing only, same as the pre-option design.
+		// path only the checkpoint-height hash-match above is enforced; a fabricated
+		// header at a non-checkpoint height at or below the checkpoint still reaches
+		// subtree validation without paying PoW. block.Valid rejects such a block
+		// (HasMetTargetDifficulty + checkParentsExistOnChain) before acceptance and
+		// its trivial cumulative work cannot reorg the chain; the residual exposure
+		// is wasted validation work on a transient fork, same as the pre-option design.
 		highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
 		skipDifficultyCheck := block.Height <= highestCheckpointHeight
 

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1562,6 +1562,11 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 
 		// Use cached headers if available (during catchup), otherwise fetch from blockchain
 		var blockHeaders []*model.BlockHeader
+		// parentMeta holds the parent's locally-stored metadata. It is populated in
+		// both branches below and reused further down to derive a trusted block height
+		// (block.Height itself is peer-supplied and must not be trusted for checkpoint
+		// or difficulty decisions).
+		var parentMeta *model.BlockHeaderMeta
 		if opts.CachedHeaders != nil && len(opts.CachedHeaders) > 0 {
 			// Use provided cached headers
 			blockHeaders = opts.CachedHeaders
@@ -1574,7 +1579,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			// Check if parent block is invalid - if so, child is automatically invalid
 			// This optimization skips expensive validation when parent is already invalid
 			// For catchup mode with cached headers, we need to query parent metadata
-			_, parentMeta, err := u.blockchainClient.GetBlockHeader(ctx, block.Header.HashPrevBlock)
+			_, parentMeta, err = u.blockchainClient.GetBlockHeader(ctx, block.Header.HashPrevBlock)
 			if err != nil {
 				ctxLogger.Warnf("[ValidateBlock][%s] failed to get parent block metadata: %v, continuing with validation", block.Hash().String(), err)
 				// Continue with validation - this is defensive programming
@@ -1606,7 +1611,6 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}
 
 			// Check if parent block is invalid using the metadata we just got
-			var parentMeta *model.BlockHeaderMeta
 			if len(parentBlockHeadersMeta) > 0 {
 				parentMeta = parentBlockHeadersMeta[0]
 			}
@@ -1637,16 +1641,34 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		// difficulty checks must run first. It also means a peer cannot make us do
 		// full tx validation for a garbage header at zero cost.
 		//
-		// Checkpoint enforcement (defense-in-depth on the direct, non-catchup path):
-		// a block whose height matches a hardcoded checkpoint MUST match the
-		// checkpoint hash, mirroring the catchup header pipeline. Without this the
-		// difficulty-skip below would let a fabricated block AT a checkpoint height
-		// reach subtree validation with the expected-nBits check skipped and no
-		// checkpoint assertion. See gap-analysis #&NoBreak;4697. (Rejecting sub-checkpoint
-		// forks at non-checkpoint heights — the fork-depth rule — is a separate,
-		// broader change and is not done here.)
-		if err = catchup.ValidateHeaderAgainstCheckpoints(block.Header, block.Height, u.settings.ChainCfgParams.Checkpoints); err != nil {
-			if !opts.IsRevalidation {
+		// Checkpoint enforcement (defense-in-depth): a block whose height matches a
+		// hardcoded checkpoint MUST match the checkpoint hash, mirroring the catchup
+		// header pipeline. Without this the difficulty-skip below would let a fabricated
+		// block AT a checkpoint height reach subtree validation with the expected-nBits
+		// check skipped and no checkpoint assertion. See gap-analysis 4697.
+		//
+		// The height used here is derived from the parent's locally-stored metadata,
+		// NOT block.Height: the latter is a peer-supplied varint in the block body that
+		// is not covered by the header hash, so a peer could relabel the honest tip with
+		// a checkpoint height and, since storeInvalidBlock keys on the header hash,
+		// persistently poison the real block. We fall back to block.Height only when the
+		// parent is not locally known (the block cannot be accepted then anyway) and
+		// never persist it invalid in that uncorroborated case.
+		//
+		// The check is unconditional rather than direct-path-only; on the catchup path
+		// the header was already checked, so this is a cheap, harmless re-assertion.
+		// (Rejecting sub-checkpoint forks at non-checkpoint heights — the fork-depth
+		// rule — is a separate, broader change and is not done here.)
+		blockHeight := block.Height
+		heightCorroborated := false
+
+		if parentMeta != nil {
+			blockHeight = parentMeta.Height + 1
+			heightCorroborated = true
+		}
+
+		if err = catchup.ValidateHeaderAgainstCheckpoints(block.Header, blockHeight, u.settings.ChainCfgParams.Checkpoints); err != nil {
+			if heightCorroborated && !opts.IsRevalidation {
 				u.storeInvalidBlock(ctx, block, opts.PeerID, err.Error())
 			}
 
@@ -1654,13 +1676,14 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		}
 
 		// Skip difficulty validation for blocks at or below the highest checkpoint:
-		// these blocks are already verified by checkpoints. NOTE: on this direct
-		// path only the checkpoint-height hash-match above is enforced; a fabricated
-		// header at a non-checkpoint height at or below the checkpoint still reaches
-		// subtree validation without paying PoW. block.Valid rejects such a block
-		// (HasMetTargetDifficulty + checkParentsExistOnChain) before acceptance and
-		// its trivial cumulative work cannot reorg the chain; the residual exposure
-		// is wasted validation work on a transient fork, same as the pre-option design.
+		// these blocks are already verified by checkpoints. NOTE: a fabricated header
+		// at a non-checkpoint height at or below the checkpoint still reaches subtree
+		// validation without paying PoW. block.Valid rejects such a block
+		// (HasMetTargetDifficulty + checkParentsExistOnChain) before acceptance and its
+		// trivial cumulative work cannot reorg the chain; the residual exposure is wasted
+		// validation work on a transient fork, same as the pre-option design. Deriving
+		// this skip from the parent-corroborated height instead of block.Height is part
+		// of the deferred fork-depth change, not done here.
 		highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
 		skipDifficultyCheck := block.Height <= highestCheckpointHeight
 

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1560,13 +1560,27 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			return errors.NewBlockInvalidError("[ValidateBlock][%s] bad coinbase length", block.Header.Hash().String())
 		}
 
+		// Checkpoint enforcement (defense-in-depth): a block whose height matches a hardcoded
+		// checkpoint MUST match the checkpoint hash, mirroring the catchup header pipeline.
+		// Without this the difficulty-skip below would let a fabricated block AT a checkpoint
+		// height reach subtree validation with the expected-nBits check skipped and no
+		// checkpoint assertion. See gap-analysis 4697. block.Height is settled against the
+		// parent before this function runs (Server.deriveBlockHeight on the peer route; catchup
+		// and the operator revalidation endpoint carry authoritative heights), so this reads a
+		// trusted height. Run before the (expensive) header/subtree work so a checkpoint-
+		// conflicting block costs nothing. On the catchup path the header was already checked,
+		// so this is a cheap, harmless re-assertion. (Rejecting sub-checkpoint forks at
+		// non-checkpoint heights — the fork-depth rule — is a separate, broader change.)
+		if err = catchup.ValidateHeaderAgainstCheckpoints(block.Header, block.Height, u.settings.ChainCfgParams.Checkpoints); err != nil {
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, err.Error())
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] block conflicts with hardcoded checkpoint", block.Hash().String(), err)
+		}
+
 		// Use cached headers if available (during catchup), otherwise fetch from blockchain
 		var blockHeaders []*model.BlockHeader
-		// parentMeta holds the parent's locally-stored metadata. It is populated in
-		// both branches below and reused further down to derive a trusted block height
-		// (block.Height itself is peer-supplied and must not be trusted for checkpoint
-		// or difficulty decisions).
-		var parentMeta *model.BlockHeaderMeta
 		if opts.CachedHeaders != nil && len(opts.CachedHeaders) > 0 {
 			// Use provided cached headers
 			blockHeaders = opts.CachedHeaders
@@ -1579,7 +1593,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			// Check if parent block is invalid - if so, child is automatically invalid
 			// This optimization skips expensive validation when parent is already invalid
 			// For catchup mode with cached headers, we need to query parent metadata
-			_, parentMeta, err = u.blockchainClient.GetBlockHeader(ctx, block.Header.HashPrevBlock)
+			_, parentMeta, err := u.blockchainClient.GetBlockHeader(ctx, block.Header.HashPrevBlock)
 			if err != nil {
 				ctxLogger.Warnf("[ValidateBlock][%s] failed to get parent block metadata: %v, continuing with validation", block.Hash().String(), err)
 				// Continue with validation - this is defensive programming
@@ -1611,6 +1625,7 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}
 
 			// Check if parent block is invalid using the metadata we just got
+			var parentMeta *model.BlockHeaderMeta
 			if len(parentBlockHeadersMeta) > 0 {
 				parentMeta = parentBlockHeadersMeta[0]
 			}
@@ -1641,55 +1656,18 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		// difficulty checks must run first. It also means a peer cannot make us do
 		// full tx validation for a garbage header at zero cost.
 		//
-		// Checkpoint enforcement (defense-in-depth): a block whose height matches a
-		// hardcoded checkpoint MUST match the checkpoint hash, mirroring the catchup
-		// header pipeline. Without this the difficulty-skip below would let a fabricated
-		// block AT a checkpoint height reach subtree validation with the expected-nBits
-		// check skipped and no checkpoint assertion. See gap-analysis 4697.
-		//
-		// The height used here is derived from the parent's locally-stored metadata,
-		// NOT block.Height: the latter is a peer-supplied varint in the block body that
-		// is not covered by the header hash, so a peer could relabel the honest tip with
-		// a checkpoint height and, since storeInvalidBlock keys on the header hash,
-		// persistently poison the real block. We fall back to block.Height only when the
-		// parent is not locally known (the block cannot be accepted then anyway) and
-		// never persist it invalid in that uncorroborated case.
-		//
-		// The check is unconditional rather than direct-path-only; on the catchup path
-		// the header was already checked, so this is a cheap, harmless re-assertion.
-		// (Rejecting sub-checkpoint forks at non-checkpoint heights — the fork-depth
-		// rule — is a separate, broader change and is not done here.)
-		blockHeight := block.Height
-		heightCorroborated := false
-
-		if parentMeta != nil {
-			blockHeight = parentMeta.Height + 1
-			heightCorroborated = true
-		}
-
-		if err = catchup.ValidateHeaderAgainstCheckpoints(block.Header, blockHeight, u.settings.ChainCfgParams.Checkpoints); err != nil {
-			if heightCorroborated && !opts.IsRevalidation {
-				u.storeInvalidBlock(ctx, block, opts.PeerID, err.Error())
-			}
-
-			return errors.NewBlockInvalidError("[ValidateBlock][%s] block conflicts with hardcoded checkpoint", block.Hash().String(), err)
-		}
-
 		// Skip difficulty validation for blocks at or below the highest checkpoint:
-		// these blocks are already verified by checkpoints. NOTE: a fabricated header
-		// at a non-checkpoint height at or below the checkpoint still reaches subtree
-		// validation without paying PoW. block.Valid rejects such a block
-		// (HasMetTargetDifficulty + checkParentsExistOnChain) before acceptance and its
-		// trivial cumulative work cannot reorg the chain; the residual exposure is wasted
-		// validation work on a transient fork, same as the pre-option design. Deriving
-		// this skip from the parent-corroborated height instead of block.Height is part
-		// of the deferred fork-depth change, not done here.
-		highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
-		skipDifficultyCheck := block.Height <= highestCheckpointHeight
+		// these blocks are already verified by checkpoints. block.Height is settled
+		// against the parent before this function runs (Server.deriveBlockHeight on the
+		// peer route; catchup and the operator revalidation endpoint carry authoritative
+		// heights), and BelowCheckpoint applies the mandatory height > 0 guard, so a peer
+		// cannot obtain the skip by declaring height 0 or a fabricated sub-checkpoint
+		// height. The checkpoint hash-match itself was asserted above.
+		skipDifficultyCheck := model.BelowCheckpoint(u.settings.ChainCfgParams.Checkpoints, block.Height)
 
 		if skipDifficultyCheck {
-			ctxLogger.Debugf("[ValidateBlock][%s] skipping difficulty validation for block at height %d (at or below checkpoint height %d)",
-				block.Header.Hash().String(), block.Height, highestCheckpointHeight)
+			ctxLogger.Debugf("[ValidateBlock][%s] skipping difficulty validation for block at height %d (at or below highest checkpoint height %d)",
+				block.Header.Hash().String(), block.Height, blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints))
 		} else {
 			// First check that the nBits (difficulty target) is correct for this block
 			expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, block.Header.HashPrevBlock, int64(block.Header.Timestamp))
@@ -2316,14 +2294,23 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 	)
 	defer deferFn()
 
+	// Checkpoint enforcement, mirroring ValidateBlockWithOptions: this path is reachable
+	// before that guard runs (the GetBlockHeaders-failure branch enqueues here) and carries
+	// the same difficulty skip, so assert the checkpoint hash-match here too. block.Height is
+	// already settled against the parent by the time a block reaches this worker (every
+	// ReValidateBlock call site sits inside ValidateBlockWithOptions, downstream of
+	// Server.deriveBlockHeight). No storeInvalidBlock: this is a revalidation path.
+	if err := catchup.ValidateHeaderAgainstCheckpoints(blockData.block.Header, blockData.block.Height, u.settings.ChainCfgParams.Checkpoints); err != nil {
+		return errors.NewBlockInvalidError("[reValidateBlock][%s] block conflicts with hardcoded checkpoint", blockData.block.Hash().String(), err)
+	}
+
 	// Skip difficulty validation for blocks at or below the highest checkpoint
 	// These blocks are already verified by checkpoints, so we don't need to validate difficulty
-	highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
-	skipDifficultyCheck := blockData.block.Height <= highestCheckpointHeight
+	skipDifficultyCheck := model.BelowCheckpoint(u.settings.ChainCfgParams.Checkpoints, blockData.block.Height)
 
 	if skipDifficultyCheck {
-		u.logger.Debugf("[reValidateBlock][%s] skipping difficulty validation for block at height %d (at or below checkpoint height %d)",
-			blockData.block.Header.Hash().String(), blockData.block.Height, highestCheckpointHeight)
+		u.logger.Debugf("[reValidateBlock][%s] skipping difficulty validation for block at height %d (at or below highest checkpoint height %d)",
+			blockData.block.Header.Hash().String(), blockData.block.Height, blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints))
 	} else {
 		// First check that the nBits (difficulty target) is correct for this block
 		expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, blockData.block.Header.HashPrevBlock, int64(blockData.block.Header.Timestamp))

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -3936,7 +3936,9 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 
 	mockBlockchain := &blockchain.Mock{}
 	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil).Maybe()
-	// storeInvalidBlock persists the rejected block; the accept-path AddBlock must never fire.
+	// storeInvalidBlock persists the rejected block via AddBlock(WithInvalid(true)); we assert
+	// below that it fired. The accept-path AddBlock shares this mock, so we additionally assert
+	// the optimistic background path (GetBlockHeaderIDs) never ran to distinguish the two.
 	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, mock.Anything).Return(nil)
 	// GetBlockHeaderIDs is only reached inside the optimistic background goroutine, which must
 	// not start when the header is rejected synchronously.
@@ -3947,7 +3949,10 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 	subChan := make(chan *blockchain_api.Notification, 1)
 	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
 	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
-	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil)
+	// Corroborate the block height from the parent's stored metadata (parent at checkpointHeight-1)
+	// so the gate uses a trusted height and reaches storeInvalidBlock.
+	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).
+		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{{Height: checkpointHeight - 1}}, nil)
 	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100}, nil)
 	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil)
@@ -3966,6 +3971,112 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 	// Rejection must happen before the optimistic AddBlock, so the background goroutine
 	// (which alone calls GetBlockHeaderIDs) never starts.
 	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
+
+	// The block was persisted invalid (storeInvalidBlock -> AddBlock with WithInvalid(true)),
+	// not accepted: AddBlock fired while the accept-path GetBlockHeaderIDs above did not.
+	mockBlockchain.AssertCalled(t, "AddBlock", mock.Anything, block, mock.Anything, mock.Anything)
+}
+
+// TestBlockValidation_DirectPath_SpoofedHeightDoesNotPoisonHonestTip is a regression test
+// for the height-corroboration guard. block.Height is a peer-supplied varint that is NOT
+// covered by the header hash, so a peer could relabel an honest block with a checkpoint
+// height; because storeInvalidBlock keys on the header hash, trusting that value would let
+// the peer persistently poison the honest block. The gate must derive the height from the
+// parent's metadata (parent.Height+1) instead, so a spoofed checkpoint height on a block
+// whose true height is not a checkpoint must NOT trigger the checkpoint rejection.
+func TestBlockValidation_DirectPath_SpoofedHeightDoesNotPoisonHonestTip(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.OptimisticMining = true
+
+	privateKey, _ := bec.NewPrivateKey()
+	address, _ := bscript.NewAddressFromPublicKey(privateKey.PubKey(), true)
+	coinbaseTx := bt.NewTx()
+	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
+	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
+	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
+
+	subtree, _ := subtreepkg.NewTreeByLeafCount(2)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	subtreeHashes := []*chainhash.Hash{subtree.RootHash()}
+	nodeBytes, err := subtree.SerializeNodes()
+	require.NoError(t, err)
+
+	httpmock.RegisterResponder("GET", `=~^/subtree/[a-z0-9]+\z`, httpmock.NewBytesResponder(200, nodeBytes))
+
+	nBits, _ := model.NewNBitFromString("207fffff")
+	// A timestamp past the two-hour bound gives a deterministic rejection in block.Valid,
+	// after the checkpoint gate. It is independent of the difficulty-skip (which still keys
+	// off block.Height), so it works whether or not difficulty is skipped.
+	blockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  tSettings.ChainCfgParams.GenesisHash,
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Add(3 * time.Hour).Unix()), //nolint:gosec
+		Bits:           *nBits,
+		Nonce:          0,
+	}
+	for {
+		if ok, _, _ := blockHeader.HasMetTargetDifficulty(); ok {
+			break
+		}
+		blockHeader.Nonce++
+	}
+
+	// Peer-supplied (spoofed) height equals the checkpoint height...
+	const spoofedCheckpointHeight = 100
+	block, _ := model.NewBlock(
+		blockHeader,
+		coinbaseTx,
+		subtreeHashes,
+		uint64(subtree.Length()),  //nolint:gosec
+		uint64(coinbaseTx.Size()), //nolint:gosec
+		spoofedCheckpointHeight, 0,
+	)
+
+	// ...but the parent's corroborated height puts the real height well above any checkpoint.
+	const parentHeight = 500
+	otherHash, err := chainhash.NewHashFromStr("00000000000000000000000000000000000000000000000000000000deadbeef")
+	require.NoError(t, err)
+	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: spoofedCheckpointHeight, Hash: otherHash}}
+
+	mockBlockchain := &blockchain.Mock{}
+	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil).Maybe()
+	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, mock.Anything).Return(nil)
+	mockBlockchain.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{1}, nil).Maybe()
+	mockBlockchain.On("InvalidateBlock", mock.Anything, mock.Anything).Return([]chainhash.Hash{}, nil).Maybe()
+	mockBlockchain.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	mockBlockchain.On("GetBlocksSubtreesNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	subChan := make(chan *blockchain_api.Notification, 1)
+	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
+	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
+	// Parent metadata corroborates the real height (parentHeight -> real height parentHeight+1).
+	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).
+		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{{Height: parentHeight}}, nil)
+	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: parentHeight}, nil)
+	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil)
+
+	txMetaStore, subtreeValidationClient, _, txStore, subtreeStore, deferFunc := setup(t)
+	defer deferFunc()
+
+	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, txMetaStore, nil, subtreeValidationClient)
+
+	subtreeBytes, err := subtree.Serialize()
+	require.NoError(t, err)
+	err = subtreeStore.Set(context.Background(), subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes)
+	require.NoError(t, err)
+
+	err = bv.ValidateBlock(ctx, block, "test", false)
+	// The block is still rejected (for the future timestamp), but crucially NOT for a
+	// checkpoint conflict: the spoofed checkpoint height was ignored in favour of the
+	// parent-corroborated height. Pre-fix this returned the checkpoint-conflict error.
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "conflicts with hardcoded checkpoint")
+	require.Contains(t, err.Error(), "two hours in the future")
 }
 
 // TestBlockValidation_SetMined_UpdatesTxMeta ensures that after block validation, calling setTxMined marks all block transactions as mined in the txMetaStore.

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -3876,6 +3876,98 @@ func TestBlockValidation_OptimisticMining_RejectsFutureTimestampSynchronously(t 
 	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
 }
 
+// TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch verifies checkpoint
+// enforcement on the direct (non-catchup) ValidateBlock path (gap-analysis #4697):
+// a block whose height matches a hardcoded checkpoint but whose hash differs must be
+// rejected synchronously, before subtree validation and the optimistic AddBlock —
+// otherwise the difficulty-skip for sub-checkpoint heights would let a fabricated
+// block at a checkpoint height through with no checkpoint assertion.
+func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.OptimisticMining = true
+
+	privateKey, _ := bec.NewPrivateKey()
+	address, _ := bscript.NewAddressFromPublicKey(privateKey.PubKey(), true)
+	coinbaseTx := bt.NewTx()
+	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
+	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
+	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
+
+	subtree, _ := subtreepkg.NewTreeByLeafCount(2)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	subtreeHashes := []*chainhash.Hash{subtree.RootHash()}
+
+	nBits, _ := model.NewNBitFromString("207fffff")
+	blockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  tSettings.ChainCfgParams.GenesisHash,
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()), //nolint:gosec
+		Bits:           *nBits,
+		Nonce:          0,
+	}
+	for {
+		if ok, _, _ := blockHeader.HasMetTargetDifficulty(); ok {
+			break
+		}
+		blockHeader.Nonce++
+	}
+
+	const checkpointHeight = 100
+	block, _ := model.NewBlock(
+		blockHeader,
+		coinbaseTx,
+		subtreeHashes,
+		uint64(subtree.Length()),  //nolint:gosec
+		uint64(coinbaseTx.Size()), //nolint:gosec
+		checkpointHeight, 0,
+	)
+
+	// Configure a checkpoint at the block's height whose hash differs from the block.
+	// (The block hash is deterministic from the mined header; any other hash mismatches.)
+	otherHash, err := chainhash.NewHashFromStr("00000000000000000000000000000000000000000000000000000000deadbeef")
+	require.NoError(t, err)
+	require.False(t, block.Hash().IsEqual(otherHash))
+	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: checkpointHeight, Hash: otherHash}}
+
+	mockBlockchain := &blockchain.Mock{}
+	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil).Maybe()
+	// storeInvalidBlock persists the rejected block; the accept-path AddBlock must never fire.
+	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, mock.Anything).Return(nil)
+	// GetBlockHeaderIDs is only reached inside the optimistic background goroutine, which must
+	// not start when the header is rejected synchronously.
+	mockBlockchain.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{1}, nil).Maybe()
+	mockBlockchain.On("InvalidateBlock", mock.Anything, mock.Anything).Return([]chainhash.Hash{}, nil).Maybe()
+	mockBlockchain.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	mockBlockchain.On("GetBlocksSubtreesNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	subChan := make(chan *blockchain_api.Notification, 1)
+	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
+	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
+	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil)
+	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100}, nil)
+	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil)
+
+	txMetaStore, subtreeValidationClient, _, txStore, subtreeStore, deferFunc := setup(t)
+	defer deferFunc()
+
+	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, txMetaStore, nil, subtreeValidationClient)
+
+	// The block must be rejected synchronously with the checkpoint-conflict reason.
+	err = bv.ValidateBlock(ctx, block, "test", false)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+	require.Contains(t, err.Error(), "conflicts with hardcoded checkpoint")
+
+	// Rejection must happen before the optimistic AddBlock, so the background goroutine
+	// (which alone calls GetBlockHeaderIDs) never starts.
+	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
+}
+
 // TestBlockValidation_SetMined_UpdatesTxMeta ensures that after block validation, calling setTxMined marks all block transactions as mined in the txMetaStore.
 func TestBlockValidation_SetMined_UpdatesTxMeta(t *testing.T) {
 	initPrometheusMetrics()

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -3988,6 +3988,92 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
 }
 
+// TestBlockValidation_DirectPath_AcceptsMatchingCheckpoint is the positive control for the
+// guard above: a block sitting AT a configured checkpoint height whose hash IS the checkpoint
+// hash must pass the gate untouched. This is what backs the "can never reject a legitimate
+// block" claim — the mismatch test alone would still pass if the guard rejected everything at
+// a checkpoint height.
+//
+// Reaching GetBlockHeaders is the proof: it is the first blockchain call after the gate, and
+// the mismatch test asserts the converse (the gate returns before it).
+func TestBlockValidation_DirectPath_AcceptsMatchingCheckpoint(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tSettings := test.CreateBaseTestSettings(t)
+
+	privateKey, _ := bec.NewPrivateKey()
+	address, _ := bscript.NewAddressFromPublicKey(privateKey.PubKey(), true)
+	coinbaseTx := bt.NewTx()
+	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
+	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
+	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
+
+	subtree, _ := subtreepkg.NewTreeByLeafCount(2)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	subtreeHashes := []*chainhash.Hash{subtree.RootHash()}
+
+	nBits, _ := model.NewNBitFromString("207fffff")
+	blockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  tSettings.ChainCfgParams.GenesisHash,
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()), //nolint:gosec
+		Bits:           *nBits,
+		Nonce:          0,
+	}
+	for {
+		if ok, _, _ := blockHeader.HasMetTargetDifficulty(); ok {
+			break
+		}
+		blockHeader.Nonce++
+	}
+
+	const checkpointHeight = 100
+	block, _ := model.NewBlock(
+		blockHeader,
+		coinbaseTx,
+		subtreeHashes,
+		uint64(subtree.Length()),  //nolint:gosec
+		uint64(coinbaseTx.Size()), //nolint:gosec
+		checkpointHeight, 0,
+	)
+
+	// The checkpoint at this height IS this block — the legitimate case.
+	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: checkpointHeight, Hash: block.Hash()}}
+
+	mockBlockchain := &blockchain.Mock{}
+	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil).Maybe()
+	mockBlockchain.On("AddBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBlockchain.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{1}, nil).Maybe()
+	mockBlockchain.On("InvalidateBlock", mock.Anything, mock.Anything).Return([]chainhash.Hash{}, nil).Maybe()
+	mockBlockchain.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	mockBlockchain.On("GetBlocksSubtreesNotSet", mock.Anything).Return([]*model.Block{}, nil)
+	subChan := make(chan *blockchain_api.Notification, 1)
+	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
+	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
+	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).
+		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil).Maybe()
+	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100}, nil).Maybe()
+	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil).Maybe()
+
+	txMetaStore, subtreeValidationClient, _, txStore, subtreeStore, deferFunc := setup(t)
+	defer deferFunc()
+
+	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, txMetaStore, nil, subtreeValidationClient)
+
+	// The block fails later on in this harness (no real parent chain or subtree data), which is
+	// fine — what matters is that it was NOT stopped by the checkpoint gate.
+	err := bv.ValidateBlock(ctx, block, "test", false)
+	if err != nil {
+		require.NotContains(t, err.Error(), "conflicts with hardcoded checkpoint")
+	}
+
+	mockBlockchain.AssertCalled(t, "GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything)
+}
+
 // TestDeriveBlockHeight covers the height-corroboration that closes the poisoning vector.
 // block.Height is a peer-supplied varint NOT covered by the header hash, so on the
 // peer-fetched route processBlockFound settles it against the on-chain parent before any

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -48,6 +48,7 @@ import (
 	blobmemory "github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/blob/options"
 	blockchain_store "github.com/bsv-blockchain/teranode/stores/blockchain"
+	blockchainoptions "github.com/bsv-blockchain/teranode/stores/blockchain/options"
 	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/test/utils/transactions"
@@ -451,7 +452,10 @@ func TestBlockValidationValidateBlockSmall(t *testing.T) {
 	require.NoError(t, err)
 
 	coinbase.Outputs = nil
-	_ = coinbase.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 5000000000+300)
+	// Pay just the block subsidy (no fees claimed). At height 100 the coinbase-reward check runs
+	// (it is skipped for height 0), and under-claiming is always valid, so this stays robust
+	// regardless of the exact fees the subtree txs carry.
+	_ = coinbase.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 5000000000)
 
 	subtreeHashes := make([]*chainhash.Hash, 0)
 	subtreeHashes = append(subtreeHashes, subtree.RootHash())
@@ -484,13 +488,17 @@ func TestBlockValidationValidateBlockSmall(t *testing.T) {
 		blockHeader.Nonce++
 	}
 
+	// Height 100 is below mainnet's lowest checkpoint (11111), so difficulty is legitimately
+	// skipped by model.BelowCheckpoint (the block cannot meet real mainnet genesis difficulty).
+	// The previous height 0 relied on the raw 0 <= highestCheckpoint skip that BelowCheckpoint's
+	// height > 0 guard removes. Subsidy is unchanged (50 BTC below the first halving).
 	block, err := model.NewBlock(
 		blockHeader,
 		coinbase,
 		subtreeHashes,            // should be the subtree with placeholder
 		uint64(subtree.Length()), // nolint:gosec
 		123123,
-		0, 0)
+		100, 0)
 	require.NoError(t, err)
 
 	blockChainStore, err := blockchain_store.NewStore(ulogger.TestLogger{}, &url.URL{Scheme: "sqlitememory"}, tSettings)
@@ -1310,8 +1318,11 @@ func TestBlockValidationRequestMissingTransaction(t *testing.T) {
 		fees += tx.TotalInputSatoshis() - tx.TotalOutputSatoshis()
 	}
 
-	// Create block header
-	nBits, _ := model.NewNBitFromString("2000ffff")
+	// Create block header. Use the regtest expected nBits (207fffff) so the difficulty-
+	// correctness check passes: block.Height here is 0, which no longer skips difficulty
+	// now that the skip uses model.BelowCheckpoint (height > 0 guard) rather than a raw
+	// height <= highestCheckpoint(0) comparison.
+	nBits, _ := model.NewNBitFromString("207fffff")
 	hashPrevBlock := chaincfg.RegressionNetParams.GenesisBlock.BlockHash()
 
 	// Calculate merkle root using coinbase and subtree
@@ -3934,12 +3945,16 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 	require.False(t, block.Hash().IsEqual(otherHash))
 	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: checkpointHeight, Hash: otherHash}}
 
+	// Matches only the storeInvalidBlock write (AddBlock with WithInvalid(true)), so it cannot
+	// be satisfied by an accept-path write. The mock hands the variadic options to testify as a
+	// single []StoreBlockOption arg, which ProcessStoreBlockOptions resolves.
+	invalidStore := mock.MatchedBy(func(opts []blockchainoptions.StoreBlockOption) bool {
+		return blockchainoptions.ProcessStoreBlockOptions(opts...).Invalid
+	})
+
 	mockBlockchain := &blockchain.Mock{}
 	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil).Maybe()
-	// storeInvalidBlock persists the rejected block via AddBlock(WithInvalid(true)); we assert
-	// below that it fired. The accept-path AddBlock shares this mock, so we additionally assert
-	// the optimistic background path (GetBlockHeaderIDs) never ran to distinguish the two.
-	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, mock.Anything).Return(nil)
+	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, invalidStore).Return(nil).Once()
 	// GetBlockHeaderIDs is only reached inside the optimistic background goroutine, which must
 	// not start when the header is rejected synchronously.
 	mockBlockchain.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{1}, nil).Maybe()
@@ -3949,13 +3964,12 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 	subChan := make(chan *blockchain_api.Notification, 1)
 	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
 	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
-	// Corroborate the block height from the parent's stored metadata (parent at checkpointHeight-1)
-	// so the gate uses a trusted height and reaches storeInvalidBlock.
+	// Not reached: the guard now runs before GetBlockHeaders, but registered defensively.
 	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).
-		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{{Height: checkpointHeight - 1}}, nil)
+		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil).Maybe()
 	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
-	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100}, nil)
-	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil)
+	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: 100}, nil).Maybe()
+	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil).Maybe()
 
 	txMetaStore, subtreeValidationClient, _, txStore, subtreeStore, deferFunc := setup(t)
 	defer deferFunc()
@@ -3968,115 +3982,51 @@ func TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch(t *testing.T) 
 	require.True(t, errors.Is(err, errors.ErrBlockInvalid))
 	require.Contains(t, err.Error(), "conflicts with hardcoded checkpoint")
 
-	// Rejection must happen before the optimistic AddBlock, so the background goroutine
-	// (which alone calls GetBlockHeaderIDs) never starts.
-	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
-
 	// The block was persisted invalid (storeInvalidBlock -> AddBlock with WithInvalid(true)),
-	// not accepted: AddBlock fired while the accept-path GetBlockHeaderIDs above did not.
-	mockBlockchain.AssertCalled(t, "AddBlock", mock.Anything, block, mock.Anything, mock.Anything)
+	// proven by the invalidStore matcher; the accept path never ran (GetBlockHeaderIDs unused).
+	mockBlockchain.AssertCalled(t, "AddBlock", mock.Anything, block, mock.Anything, invalidStore)
+	mockBlockchain.AssertNotCalled(t, "GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything)
 }
 
-// TestBlockValidation_DirectPath_SpoofedHeightDoesNotPoisonHonestTip is a regression test
-// for the height-corroboration guard. block.Height is a peer-supplied varint that is NOT
-// covered by the header hash, so a peer could relabel an honest block with a checkpoint
-// height; because storeInvalidBlock keys on the header hash, trusting that value would let
-// the peer persistently poison the honest block. The gate must derive the height from the
-// parent's metadata (parent.Height+1) instead, so a spoofed checkpoint height on a block
-// whose true height is not a checkpoint must NOT trigger the checkpoint rejection.
-func TestBlockValidation_DirectPath_SpoofedHeightDoesNotPoisonHonestTip(t *testing.T) {
-	initPrometheusMetrics()
+// TestDeriveBlockHeight covers the height-corroboration that closes the poisoning vector.
+// block.Height is a peer-supplied varint NOT covered by the header hash, so on the
+// peer-fetched route processBlockFound settles it against the on-chain parent before any
+// consumer (checkpoint guard, difficulty skip, block-assembly gating, coinbase subsidy)
+// reads it. An honest peer sends the correct height or 0; a lying non-zero height that would
+// relabel the honest tip with a checkpoint height is rejected here, before validation, so it
+// can never reach storeInvalidBlock and poison the real block.
+func TestDeriveBlockHeight(t *testing.T) {
+	const cp = 100 // a checkpoint height, for the poisoning case
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	tSettings := test.CreateBaseTestSettings(t)
-	tSettings.BlockValidation.OptimisticMining = true
-
-	privateKey, _ := bec.NewPrivateKey()
-	address, _ := bscript.NewAddressFromPublicKey(privateKey.PubKey(), true)
-	coinbaseTx := bt.NewTx()
-	_ = coinbaseTx.From("0000000000000000000000000000000000000000000000000000000000000000", 0xffffffff, "", 0)
-	coinbaseTx.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{0x03, 0x64, 0x00, 0x00, 0x00, '/', 'T', 'e', 's', 't'})
-	_ = coinbaseTx.AddP2PKHOutputFromAddress(address.AddressString, 50*100000000)
-
-	subtree, _ := subtreepkg.NewTreeByLeafCount(2)
-	require.NoError(t, subtree.AddCoinbaseNode())
-	subtreeHashes := []*chainhash.Hash{subtree.RootHash()}
-	nodeBytes, err := subtree.SerializeNodes()
-	require.NoError(t, err)
-
-	httpmock.RegisterResponder("GET", `=~^/subtree/[a-z0-9]+\z`, httpmock.NewBytesResponder(200, nodeBytes))
-
-	nBits, _ := model.NewNBitFromString("207fffff")
-	// A timestamp past the two-hour bound gives a deterministic rejection in block.Valid,
-	// after the checkpoint gate. It is independent of the difficulty-skip (which still keys
-	// off block.Height), so it works whether or not difficulty is skipped.
-	blockHeader := &model.BlockHeader{
-		Version:        1,
-		HashPrevBlock:  tSettings.ChainCfgParams.GenesisHash,
-		HashMerkleRoot: &chainhash.Hash{},
-		Timestamp:      uint32(time.Now().Add(3 * time.Hour).Unix()), //nolint:gosec
-		Bits:           *nBits,
-		Nonce:          0,
-	}
-	for {
-		if ok, _, _ := blockHeader.HasMetTargetDifficulty(); ok {
-			break
-		}
-		blockHeader.Nonce++
+	tests := []struct {
+		name       string
+		claimed    uint32
+		parent     uint32
+		want       uint32
+		wantReject bool
+	}{
+		{name: "honest height passes", claimed: 501, parent: 500, want: 501},
+		{name: "genesis child derived", claimed: 1, parent: 0, want: 1},
+		{name: "wire height zeroed is derived", claimed: 0, parent: cp - 1, want: cp},
+		{name: "honest height at a checkpoint", claimed: cp, parent: cp - 1, want: cp},
+		// The poisoning attempt: relabel the honest tip (real height 501) as checkpoint height 100.
+		{name: "spoofed checkpoint height rejected", claimed: cp, parent: 500, wantReject: true},
+		{name: "wire height one past rejected", claimed: cp + 1, parent: cp - 1, wantReject: true},
 	}
 
-	// Peer-supplied (spoofed) height equals the checkpoint height...
-	const spoofedCheckpointHeight = 100
-	block, _ := model.NewBlock(
-		blockHeader,
-		coinbaseTx,
-		subtreeHashes,
-		uint64(subtree.Length()),  //nolint:gosec
-		uint64(coinbaseTx.Size()), //nolint:gosec
-		spoofedCheckpointHeight, 0,
-	)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deriveBlockHeight(tc.claimed, tc.parent)
+			if tc.wantReject {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+				return
+			}
 
-	// ...but the parent's corroborated height puts the real height well above any checkpoint.
-	const parentHeight = 500
-	otherHash, err := chainhash.NewHashFromStr("00000000000000000000000000000000000000000000000000000000deadbeef")
-	require.NoError(t, err)
-	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: spoofedCheckpointHeight, Hash: otherHash}}
-
-	mockBlockchain := &blockchain.Mock{}
-	mockBlockchain.On("GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything).Return(nBits, nil).Maybe()
-	mockBlockchain.On("AddBlock", mock.Anything, block, mock.Anything, mock.Anything).Return(nil)
-	mockBlockchain.On("GetBlockHeaderIDs", mock.Anything, mock.Anything, mock.Anything).Return([]uint32{1}, nil).Maybe()
-	mockBlockchain.On("InvalidateBlock", mock.Anything, mock.Anything).Return([]chainhash.Hash{}, nil).Maybe()
-	mockBlockchain.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil)
-	mockBlockchain.On("GetBlocksSubtreesNotSet", mock.Anything).Return([]*model.Block{}, nil)
-	subChan := make(chan *blockchain_api.Notification, 1)
-	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(subChan, nil)
-	mockBlockchain.On("GetBlockExists", mock.Anything, mock.Anything).Return(false, nil)
-	// Parent metadata corroborates the real height (parentHeight -> real height parentHeight+1).
-	mockBlockchain.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).
-		Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{{Height: parentHeight}}, nil)
-	mockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
-	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(&model.BlockHeader{}, &model.BlockHeaderMeta{Height: parentHeight}, nil)
-	mockBlockchain.On("GetBlockIsMined", mock.Anything, mock.Anything).Return(true, nil)
-
-	txMetaStore, subtreeValidationClient, _, txStore, subtreeStore, deferFunc := setup(t)
-	defer deferFunc()
-
-	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, txMetaStore, nil, subtreeValidationClient)
-
-	subtreeBytes, err := subtree.Serialize()
-	require.NoError(t, err)
-	err = subtreeStore.Set(context.Background(), subtree.RootHash()[:], fileformat.FileTypeSubtree, subtreeBytes)
-	require.NoError(t, err)
-
-	err = bv.ValidateBlock(ctx, block, "test", false)
-	// The block is still rejected (for the future timestamp), but crucially NOT for a
-	// checkpoint conflict: the spoofed checkpoint height was ignored in favour of the
-	// parent-corroborated height. Pre-fix this returned the checkpoint-conflict error.
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "conflicts with hardcoded checkpoint")
-	require.Contains(t, err.Error(), "two hours in the future")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestBlockValidation_SetMined_UpdatesTxMeta ensures that after block validation, calling setTxMined marks all block transactions as mined in the txMetaStore.

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1511,6 +1511,13 @@ func (u *Server) processBlockFound(ctx context.Context, hash *chainhash.Hash, pe
 		return errors.NewServiceError("[processBlockFound][%s] failed to get parent header %s", hash.String(), block.Header.HashPrevBlock.String(), err)
 	}
 
+	// No implementation returns a nil meta with a nil error, but the settled height is
+	// security-relevant, so fail closed rather than derive it from a nil dereference.
+	// Mirrors the guard on the sibling GetBlockHeader call in ProcessBlock.
+	if parentMeta == nil {
+		return errors.NewServiceError("[processBlockFound][%s] nil metadata for parent header %s", hash.String(), block.Header.HashPrevBlock.String())
+	}
+
 	settledHeight, err := deriveBlockHeight(block.Height, parentMeta.Height)
 	if err != nil {
 		return errors.NewBlockInvalidError("[processBlockFound][%s] rejecting block with peer-inconsistent height", hash.String(), err)

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1410,6 +1410,25 @@ func (u *Server) ValidateBlock(ctx context.Context, request *blockvalidation_api
 	}, nil
 }
 
+// deriveBlockHeight settles a peer-supplied block height against the on-chain parent.
+//
+// block.Height is a varint in the block body (model.NewBlockFromBytes) and is not covered
+// by the header hash, so on the peer-fetched path it cannot be trusted. An honest peer sends
+// either the correct height or 0 (the field "can be left empty"); any other value is a lie
+// and the block is rejected. The returned height (parentHeight + 1) is authoritative and must
+// be written back onto the block before anything downstream reads block.Height — the
+// checkpoint guard, the difficulty skip, block-assembly gating and the coinbase subsidy all
+// key off it. Catchup (get_blocks.go) and the operator revalidation endpoint already carry
+// authoritative heights, so this settlement is only needed on the peer-fetched route.
+func deriveBlockHeight(claimed, parentHeight uint32) (uint32, error) {
+	derived := parentHeight + 1
+	if claimed != 0 && claimed != derived {
+		return 0, errors.NewBlockInvalidError("claimed height %d does not match parent height %d + 1", claimed, parentHeight)
+	}
+
+	return derived, nil
+}
+
 // processBlockFound processes a newly discovered block by validating it and managing
 // parent block dependencies. It handles block retrieval, validation sequencing,
 // and ensures proper processing order for blockchain consistency.
@@ -1482,6 +1501,22 @@ func (u *Server) processBlockFound(ctx context.Context, hash *chainhash.Hash, pe
 
 		return nil
 	}
+
+	// Settle the peer-supplied height against the on-chain parent before anything reads
+	// block.Height (block-assembly gating and the unified-route decision below, and downstream
+	// the checkpoint guard, difficulty skip and coinbase subsidy in ValidateBlockWithOptions).
+	// See deriveBlockHeight.
+	_, parentMeta, err := u.blockchainClient.GetBlockHeader(ctx, block.Header.HashPrevBlock)
+	if err != nil {
+		return errors.NewServiceError("[processBlockFound][%s] failed to get parent header %s", hash.String(), block.Header.HashPrevBlock.String(), err)
+	}
+
+	settledHeight, err := deriveBlockHeight(block.Height, parentMeta.Height)
+	if err != nil {
+		return errors.NewBlockInvalidError("[processBlockFound][%s] rejecting block with peer-inconsistent height", hash.String(), err)
+	}
+
+	block.Height = settledHeight
 
 	// Wait for block assembly to be ready before processing the block
 	if err = blockassemblyutil.WaitForBlockAssemblyReady(ctx, u.logger, u.blockAssemblyClient, block.Height, u.settings.BlockValidation.MaxBlocksBehindBlockAssembly); err != nil {

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -375,17 +375,22 @@ func TestBlockHeadersN(t *testing.T) {
 	*/
 }
 
-func Test_Server_processBlockFound(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+// processBlockFoundBlockHex is a mainnet-shaped block at height 309 whose coinbase pays
+// exactly the subsidy. Its parent is placed on-chain by newProcessBlockFoundHarness.
+const processBlockFoundBlockHex = "010000000edfb8ccf30a17b7deae9c1f1a3dbbaeb1741ff5906192b921cbe7ece5ab380081caee50ec9ca9b5686bb6f71693a1c4284a269ab5f90d8662343a18e1a7200f52a83b66ffff00202601000001fdb1010001000000010000000000000000000000000000000000000000000000000000000000000000ffffffff17033501002f6d322d75732fc1eaad86485d9cc712818b47ffffffff03ac505763000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88acaa505763000000001976a9143c22b6d9ba7b50b6d6e615c69d11ecb2ba3db14588acaa505763000000001976a9141e7ee30c5c564b78533a44aae23bec1be188281d88ac00000000fd3501"
+
+// newProcessBlockFoundHarness builds a Server whose only on-chain entry is the parent of
+// the returned block, sitting at the honest position (block height - 1). The store is
+// returned so callers can assert what was, or was not, persisted.
+func newProcessBlockFoundHarness(ctx context.Context, t *testing.T) (*Server, *blockchain_store.MockStore, *model.Block) {
+	t.Helper()
 
 	tSettings := test.CreateBaseTestSettings(t)
 	// regtest SubsidyReductionInterval is 150
 	// so use mainnet params
 	tSettings.ChainCfgParams = &chaincfg.MainNetParams
 
-	blockHex := "010000000edfb8ccf30a17b7deae9c1f1a3dbbaeb1741ff5906192b921cbe7ece5ab380081caee50ec9ca9b5686bb6f71693a1c4284a269ab5f90d8662343a18e1a7200f52a83b66ffff00202601000001fdb1010001000000010000000000000000000000000000000000000000000000000000000000000000ffffffff17033501002f6d322d75732fc1eaad86485d9cc712818b47ffffffff03ac505763000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88acaa505763000000001976a9143c22b6d9ba7b50b6d6e615c69d11ecb2ba3db14588acaa505763000000001976a9141e7ee30c5c564b78533a44aae23bec1be188281d88ac00000000fd3501"
-	blockBytes, err := hex.DecodeString(blockHex)
+	blockBytes, err := hex.DecodeString(processBlockFoundBlockHex)
 	require.NoError(t, err)
 
 	block, err := model.NewBlockFromBytes(blockBytes)
@@ -409,14 +414,10 @@ func Test_Server_processBlockFound(t *testing.T) {
 	logger := ulogger.NewErrorTestLogger(t)
 
 	utxoStoreURL, err := url.Parse("sqlitememory:///test")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	txStore := memory.New()
 
@@ -431,8 +432,66 @@ func Test_Server_processBlockFound(t *testing.T) {
 	s := New(ulogger.TestLogger{}, tSettings, nil, txStore, utxoStore, nil, blockchainClient, kafkaConsumerClient, nil, nil)
 	s.blockValidation = NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, blockchainClient, subtreeStore, txStore, utxoStore, nil, nil)
 
-	err = s.processBlockFound(context.Background(), block.Hash(), "", "legacy", block)
+	return s, blockchainStore, block
+}
+
+func Test_Server_processBlockFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s, _, block := newProcessBlockFoundHarness(ctx, t)
+
+	err := s.processBlockFound(context.Background(), block.Hash(), "", "legacy", block)
 	require.NoError(t, err)
+}
+
+// Test_Server_processBlockFound_SettlesPeerSuppliedHeight pins the height settlement at the
+// funnel itself, not just the deriveBlockHeight helper in isolation. block.Height is a varint
+// in the block body and is not covered by the header hash, so on the peer-fetched route it is
+// whatever the peer wrote. processBlockFound must overwrite it from the on-chain parent before
+// any consumer reads it — the checkpoint guard, the difficulty skip, block-assembly gating and
+// the coinbase subsidy all key off that field.
+//
+// Without these cases, dropping the `block.Height = settledHeight` write-back leaves every
+// other test in the package passing.
+func Test_Server_processBlockFound_SettlesPeerSuppliedHeight(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("zeroed wire height is settled from the parent", func(t *testing.T) {
+		s, _, block := newProcessBlockFoundHarness(ctx, t)
+		honestHeight := block.Height
+
+		// An honest peer may leave the field empty; the block must still arrive downstream
+		// carrying the derived height, otherwise the checkpoint guard reads 0 and no
+		// checkpoint ever matches.
+		block.Height = 0
+
+		err := s.processBlockFound(context.Background(), block.Hash(), "", "legacy", block)
+		require.NoError(t, err)
+		require.Equal(t, honestHeight, block.Height, "settled height must be written back onto the block")
+	})
+
+	t.Run("spoofed checkpoint height is rejected without being persisted", func(t *testing.T) {
+		s, blockchainStore, block := newProcessBlockFoundHarness(ctx, t)
+
+		// The attack the guard exists for: declare the height of a real mainnet checkpoint
+		// while the parent sits at 308, so the block would reach the checkpoint guard and the
+		// difficulty skip claiming a height it does not hold.
+		block.Height = 11111
+
+		err := s.processBlockFound(context.Background(), block.Hash(), "", "legacy", block)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+		require.Contains(t, err.Error(), "peer-inconsistent height")
+
+		// Rejected at the funnel, ahead of storeInvalidBlock. This is the converse hazard: a
+		// peer must not be able to get a block persisted invalid by lying about its height,
+		// because checkParentInvalid would then cascade that verdict to every descendant.
+		persisted, err := blockchainStore.GetBlockExists(ctx, block.Hash())
+		require.NoError(t, err)
+		require.False(t, persisted, "a height-spoofed block must not be persisted at all")
+	})
 }
 
 // TestServer_processBlockNotifyHasTTL guards against regressing to a TTL-less

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -393,6 +393,18 @@ func Test_Server_processBlockFound(t *testing.T) {
 
 	blockchainStore := blockchain_store.NewMockStore()
 	blockchainStore.BlockExists[*block.Header.HashPrevBlock] = true
+	// processBlockFound now settles block.Height against the parent header, so the parent must
+	// be resolvable at parent height = block.Height - 1 (deriveBlockHeight). Give it a header
+	// with non-nil hashes so the MockStore's GetBlockHeaders walk terminates cleanly (it chases
+	// HashPrevBlock until a hash is absent from the Blocks map).
+	blockchainStore.Blocks[*block.Header.HashPrevBlock] = &model.Block{
+		Header: &model.BlockHeader{
+			Version:        1,
+			HashPrevBlock:  &chainhash.Hash{},
+			HashMerkleRoot: &chainhash.Hash{},
+		},
+		Height: block.Height - 1,
+	}
 
 	logger := ulogger.NewErrorTestLogger(t)
 


### PR DESCRIPTION
Closes the confirmed half of the gap-analysis audit item bitcoin-sv/teranode#4697 (verdict: **partial**).

## Problem

The direct (non-catchup) `ValidateBlock` path skips difficulty validation for blocks at or below the highest hardcoded checkpoint (`BlockValidation.go`, `skipDifficultyCheck := block.Height <= highestCheckpointHeight`), but performs **no checkpoint hash comparison**. The in-code comment conceded it: *"on this direct path the checkpoint linkage itself is not verified here."* Checkpoint hash-match lived only in the catchup header pipeline (`ValidateHeaderAgainstCheckpoints`), which has no caller on the direct path.

Consequence: a fabricated block whose height matches a hardcoded checkpoint could reach subtree validation with the expected-nBits check skipped and no checkpoint assertion. It is only caught later by `block.Valid` (which checks the block's *own* nBits — cheap for an attacker to satisfy with an easy target) and by cumulative-work chain selection. The Java reference node rejects any such block outright (REJECT_CHECKPOINT, DoS 100).

## Fix

Enforce the checkpoint hash-match on the direct path too, reusing the existing, tested catchup helper `catchup.ValidateHeaderAgainstCheckpoints`. A block whose height matches a configured checkpoint but whose hash differs is rejected — stored invalid, peer flagged — **before** subtree validation and the optimistic `AddBlock`.

This is pure defense-in-depth: a valid block at a checkpoint height must carry the checkpoint hash, so the check can never reject a legitimate block. It runs for all blocks and is a no-op except at exact checkpoint heights.

**Scope note:** rejecting sub-checkpoint forks at *non-checkpoint* heights (the fork-depth rule, the broader half of #&NoBreak;4697) needs the node's best height and interacts with legitimate sub-checkpoint flows (revalidation, catchup); it's left as a separate follow-up. This PR lands the unambiguous, zero-false-positive piece.

## Tests

`TestBlockValidation_DirectPath_RejectsCheckpointHashMismatch`: a block at a configured checkpoint height with a mismatched hash is rejected synchronously with `ErrBlockInvalid` + "conflicts with hardcoded checkpoint", and the optimistic background goroutine never starts. Proven load-bearing — without the guard the block is not rejected.

## Verification

- `go build ./services/blockvalidation/...` and `go vet` — clean
- `gofmt` — clean
- New test passes; targeted `ValidateBlock` / `OptimisticMining` / `Catchup` suites pass
- Confirmed the always-on check is a no-op for existing tests: regtest has no checkpoints, and mainnet's lowest checkpoint is height 11111 (above all test block heights)