### PR TITLE
investigation(#1379): unseen-tx throughput harness, level-depth instrumentation, 2PC unlock fix

### DIFF
--- a/plans/1379-unseen-tx-throughput-design.md
+++ b/plans/1379-unseen-tx-throughput-design.md
@@ -1,0 +1,191 @@
+# Reproducing the unseen-tx block validation throughput collapse
+
+Design for a local reproduction harness and bisect for
+[issue #1379](https://github.com/bsv-blockchain/teranode/issues/1379):
+block validation drops to ~30–50 tx/s on blocks whose transactions never
+arrived via propagation.
+
+## Problem
+
+On mainnet 2026-07-29, block 959984 (27,132 txs, 23.7 MB) took 12+ minutes to
+validate on all three BSVA mainnet nodes. The same day, block 959964 —
+232,673 txs, 62.6 MB — validated in 0.2–10.6 s on the same nodes.
+
+Size is not the variable. The discriminator is the pre-check in
+`processTransactionsInLevels` (`services/subtreevalidation/check_block_subtrees.go:1009-1028`):
+when every tx in the block is already in the txMeta cache or UTXO store,
+`missed == 0` and the function returns immediately. When the block contains txs
+the node never saw via propagation, each one goes through
+`blessMissingTransaction` and throughput collapses.
+
+The cost scales with the count of *unseen* txs, not block size, and behaves
+identically on v0.15 and v0.16.0-beta-1. A block carrying ~1M never-broadcast
+txs would take roughly 6–9 hours per node. Any miner can construct one.
+
+## What code reading already settled
+
+Three of the issue's own hypotheses were resolved by reading the code, before
+any measurement.
+
+**TX_LOCKED retry backoff is not the cause.** `services/validator/Validator.go:479-510`
+caps backoff at 10/20/40 ms over 3 retries, hard-clamped at 10 attempts. Maximum
+~70 ms per tx. It cannot produce the observed ~8.7 s per level.
+
+**The issue quoted the wrong batcher numbers.** It cited
+`utxostore_spendBatcherSize = 100` and `spendBatcherDurationMillis = 100`; those
+are the Go struct defaults in `settings/settings.go:445-446`, used only when the
+key is absent. `settings.conf` overrides them to 1024 and 10. The real
+constraint on that path is `utxostore_spendBatcherConcurrency = 4`
+(`settings.conf:1298`) — four concurrent Lua batch operations.
+
+**`prefetchLevelParents` is not the root cause.** It landed in `7091af082`,
+first tagged v0.16.0-beta-1. The v0.15 nodes were equally slow, so it cannot
+explain the collapse. It remains a real latent regression: `BatchDecorate`
+(`stores/utxo/aerospike/get.go:697-742`) walks batch results serially and calls
+`GetTxFromExternalStore` inline, converting external-store reads that were
+previously parallel across the level's goroutines into serial ones.
+
+Two further observations shape the harness:
+
+**The existing histogram already exists.** `prometheusSubtreeValidationBlessMissingTransaction`
+is observed at `services/subtreevalidation/SubtreeValidation.go:412`. The issue's
+ask for "a latency histogram around `blessMissingTransaction`" is already
+satisfied in code; the gap is purely that nothing scrapes it on the mainnet
+nodes.
+
+**The validator is in-process.** `useLocalValidator = true` (`settings.conf:1255`).
+A Go test wiring subtreevalidation → real `validator.Validator` → real GoBDK is
+therefore topology-faithful, not an approximation. This is what makes a local
+repro cheap.
+
+**New suspect the issue missed.** At the tip the FSM is RUNNING, so
+`addTXToBlockAssembly = true`. Every unseen tx then pays Create-with-locked →
+block-assembly insert → Kafka txmeta → `SetLocked` unlock two-phase commit
+(`services/validator/Validator.go:940-1057`). Two extra store round trips per tx
+that the catchup path does not pay, and the manufacturing source of the
+TX_LOCKED children the issue observed. Cached txs skip all of it — which is
+exactly the fast/slow discriminator.
+
+## Approach
+
+Reproduce locally against real Aerospike and a real validator, profile, then fix
+what the profile names. A replay on a live mainnet node was considered and
+rejected on correctness grounds, not just risk: the precondition is that the txs
+are unseen, and the first validation put them in the txmeta store, so a replay
+hits the `missed == 0` fast path and returns in milliseconds. The bug destroys
+its own precondition.
+
+The fix is deliberately out of scope for this design. Scoping it before the
+profile lands would be guessing, which is what this exercise exists to stop.
+
+## Harness
+
+New file `services/subtreevalidation/check_block_subtrees_unseen_perf_test.go`,
+gated `//go:build aerospike` so `make test` never tries to start a container.
+Invoked as `go test -tags aerospike -run TestUnseenTxThroughput`.
+
+Nothing is mocked below the server. The wiring extends the pattern already
+proven in `legacy_real_validator_integration_test.go:85-130`:
+
+- Aerospike from `test/utils/aerospike.InitAerospikeContainer()`.
+  `aerospikestore.New` registers the Lua UDFs itself
+  (`stores/utxo/aerospike/aerospike.go:365-383`), so `SPEND_BATCH_LUA` genuinely
+  runs.
+- Real `validator.New(...)`, real `TxValidator`, real GoBDK. No
+  `SkipScriptValidation`, so script verification cost is inside the measurement.
+- `blockchain.NewLocalClient` with the FSM pinned to **RUNNING**, not
+  `CATCHINGBLOCKS`. This is where the existing integration test differs and why
+  it cannot be reused directly: RUNNING is what sets
+  `addTXToBlockAssembly = true`, the state the slow mainnet blocks were actually
+  in, and it is what pulls in the per-tx block-assembly insert and the
+  `SetLocked` 2PC unlock.
+- Entry via `CheckBlockSubtrees(ctx, *CheckBlockSubtreesRequest)` with
+  serialized block bytes — not `processTransactionsInLevels` directly — so the
+  pre-check, subtree splitting and level machinery all run as they do on the
+  wire.
+
+## Fixture
+
+Parameterised on `txCount`, level histogram, `inputsPerTx`, and
+`parentExtendedSize`. The last straddles the 32 KB `MaxTxSizeInStoreInBytes`
+threshold (`stores/utxo/aerospike/aerospike.go:92`) that decides whether a
+parent is stored externally.
+
+Transactions are real coinbase-funded chains with real signatures, so GoBDK does
+genuine work. Generation streams through a channel and caches to a blob store,
+reusing the generator in `check_block_subtrees_large_test.go` rather than writing
+a second one.
+
+The precondition is explicit and is the whole point: **only the parents are
+seeded** into Aerospike, as mined with `BlockHeights` set. The block's own txs
+are absent from both the txMeta cache and the store. That forces `missed > 0`
+instead of the `missed == 0` early return.
+
+Baseline shape matches the measured block 959979: 6,258 txs, 25 levels,
+L0 = 2936, median 119 txs/level.
+
+### Deliberate simplifications
+
+Block height sits below mainnet CSVHeight (the 257727 fixture height the
+existing integration test documents) so the post-CSV parent-MTP path needs no
+real headers. That path is one blockchain call per block, not per tx, so it
+cannot affect throughput.
+
+The container namespace is in-memory single-node; mainnet is persistent. A
+*slow* local result is therefore strong evidence and a *fast* one is weak. This
+asymmetry is a limit of the harness, not a defect to paper over.
+
+## Measurement
+
+Per run: wall time of `CheckBlockSubtrees`, derived tx/s, and `runtime/pprof`
+CPU, block and mutex profiles written to the scratchpad.
+
+Block and mutex profiles are the primary artefacts. If this is latency-bound on
+a store round trip, CPU will look idle and only the block profile shows where
+the time went.
+
+## Bisect matrix
+
+Each axis is flipped independently from the shape-matched baseline. Whichever
+flip collapses the runtime names the bottleneck.
+
+| axis | baseline → flip | hypothesis under test |
+|---|---|---|
+| block assembly | RUNNING+2PC → Disabled | per-tx BA insert + `SetLocked` unlock |
+| parent size | <32 KB → >32 KB external | serial `GetTxFromExternalStore` in `BatchDecorate` |
+| level shape | 25 levels → 1 flat level | level serialization + per-level `prefetchLevelParents` |
+| prefetch | on → off | whether `7091af082` is a regression |
+| `spendBatcherConcurrency` | 4 → 32 | Lua batch concurrency ceiling |
+
+## Success criteria
+
+Baseline reproduces **≤100 tx/s** → the hypothesis space is local and the
+profile is authoritative. Proceed to the bisect matrix, then design the fix.
+
+Baseline runs at **>1000 tx/s** → the synthetic shape is wrong. Escalate to
+replaying real block 959979: fetch the block and its ~3k distinct parent txs
+from WhatsOnChain, seed the parents into Aerospike as mined, run the real block
+through `CheckBlockSubtrees`.
+
+## Known weakest assumption
+
+The synthetic shape matches tx count and level histogram, but if the trigger is
+some aspect of real mainnet tx composition not parameterised here — unusual
+input counts, script sizes, or parents split across `utxoBatchSize` records —
+the baseline runs fast and the real-block fallback is needed. The bisect matrix
+partially mitigates this: sweeping `inputsPerTx` and `parentExtendedSize`
+independently probes two of those three dimensions directly.
+
+## Out of scope
+
+Deferred to follow-up work, tracked on the issue:
+
+- The fix itself, pending the profile.
+- Promoting the level count, per-level duration and `missed` count from `Debugf`
+  to `Infof` (issue ask 1). Worth doing, but the profile should inform which
+  numbers are actually worth logging at INFO.
+- Shipping node metrics from the mainnet nodes to Coralogix (issue ask 2) —
+  infrastructure, not code.
+- Deduping concurrent legacy block deliveries per block hash (issue ask 3).
+  Independent of the per-tx latency question and a clear win on its own, but it
+  reduces wasted work by ~3x rather than touching the 30–50 tx/s floor.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -324,3 +324,80 @@ it is now unmeasurable retroactively on this node.
 Closing this out therefore depends on instrumentation being live *before* the next
 occurrence — which makes fixing the monitoring stack the highest-value next action,
 ahead of any code change.
+
+## Follow-up 3: live production metrics from bsva-ovh-teranode-eu-2
+
+The monitoring stack on that node was not actually running (see follow-up 2:
+Prometheus and Grafana both exited on bind-mount permission errors, filed upstream
+as bsv-blockchain/teranode-quickstart#9). With permissions fixed, all 9 scrape
+targets are up and these are the first real numbers from the #1379 hot path.
+
+The path is genuinely active: `bless_missing_transaction` accumulated 3,784
+samples, so unseen transactions are being blessed continuously in steady state.
+
+### Steady-state latency, subtreevalidation service
+
+| metric | n | p50 | p90 | p99 | mean |
+|---|---|---|---|---|---|
+| `subtreevalidation_bless_missing_transaction` | 3,784 | 16 ms | 16 ms | **64 ms** | 15.2 ms |
+| `validator_transactions_input_block_heights` | 3,784 | 16 ms | 16 ms | 16 ms | 11.4 ms |
+| `validator_transactions_spend_utxos` | 376 | 33 ms | 33 ms | 131 ms | 25.3 ms |
+| `validator_transactions_2phase_commit` | 351 | 8 ms | 8 ms | 8 ms | 6.4 ms |
+| `validator_transactions_validate` (GoBDK script) | 376 | <1 ms | <1 ms | 66 ms | 0.56 ms |
+
+Histogram buckets are coarse (16/33/64/131/262 ms), so quantiles are
+bucket-granular. Roughly 5 minutes of steady state on **v0.16.0-beta-9**, not
+incident conditions.
+
+### The incident was a transient, not the steady state
+
+`blessMissingTransaction` p99 is 64 ms here. The incident's 8.7 s per level needs
+per-operation costs in the seconds — 30–100x above what this node does normally.
+That closes off any reading of #1379 in which this code path is simply slow by
+nature. Whatever happened on 2026-07-29 was a departure from this baseline, and the
+baseline is healthy.
+
+### Production confirms the batcher-wait finding
+
+This is the most useful result. Compare the validator-level wrapper against the
+underlying Aerospike operation it drives:
+
+| layer | mean |
+|---|---|
+| `validator_transactions_spend_utxos` | 25.3 ms (p50 33 ms) |
+| `aerospike_utxo_spend_batch` | **0.54 ms** |
+| `aerospike_utxo_create_batch` | 4.07 ms |
+
+A ~60x gap between the wrapper and the store operation. That gap is batcher
+queueing plus the flush timer, which is precisely the local block-profile result
+(97.5% of blocking delay in `go-batcher completion.(*Group).Wait`, spread across
+Spend 38.7% / Create 39.1% / SetLocked 19.8%) — now reproduced on production
+hardware under real load rather than in a testcontainer.
+
+**The store itself is fast. The batching wrapper is where the time goes.** This is
+the strongest evidence so far for fix candidate 1 (collapse the per-level round
+trips), and it means that fix is justified on steady-state grounds alone,
+independent of whatever caused the incident.
+
+### Parent resolution dominates, not script verification
+
+`input_block_heights` is 11.4 ms of the 15.2 ms bless cost, about 75%. GoBDK script
+verification is 0.56 ms. So per-tx cost is dominated by parent lookups — which is
+the component that scales with parent count and with external-store behaviour, and
+the right place to aim any per-tx optimisation.
+
+### External reads are bursty, not continuous
+
+`teranode_aerospike_get_external` has **no samples at all** in this window, despite
+~4 million external transactions on disk. So the 203-fetches-in-one-call bursts
+seen in the incident logs are event-driven per block, not a standing load. This is
+consistent with follow-up 2: external reads are irrelevant in steady state and
+appear only on particular blocks.
+
+### Correction to an earlier claim
+
+The section above states "there are no `*aerospike*` metrics shipped from these
+nodes at all". That was true when written and is no longer: the metrics existed in
+the code and were exposed on `:9091` all along, but nothing scraped them. Issue
+ask 2 is therefore narrower than originally filed — it is a scrape/permissions
+problem, not missing instrumentation.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -751,3 +751,59 @@ first:
 
 The harness now dumps these op counts on every run, so either change can be checked
 against `aerospike_txmeta_get` returning to zero rather than only against tx/s.
+
+## Follow-up 9: pass attribution refutes follow-up 8's inference
+
+Snapshotting the counters at the `[CheckBlockSubtrees] Completed processing ...` Infof
+(check_block_subtrees.go:608), which sits between the level pipeline and
+`validateMissingSubtreesWithOrderedRetry`, attributes every store op to one pass.
+
+| pass | baseline (0.9 s) | conflicts=50 (78 s) |
+|---|---|---|
+| level pipeline | `txmeta_get=1` `bless=1,561` `get_multi_n=4,684` | `txmeta_get=3,380` **`bless=3,122`** `get_multi_n=14,307` |
+| per-subtree pass | `txmeta_get=0` `bless=0` `get_multi_n=1,561` | **`txmeta_get=11,745`** **`bless=0`** `get_multi_n=13,306` |
+
+Follow-up 8 inferred that the per-subtree pass re-validates every transaction when
+conflicts are present, and that its missing parent-prefetch turns those into single
+Gets. **Both halves are wrong.**
+
+### The blessing doubling is inside the level pipeline
+
+`bless_missing_transaction` goes 1,561 → 3,122 **entirely within the level pipeline**;
+the per-subtree pass records **zero** blessings in both runs. So the second pass is not
+re-validating anything. Something makes the level pipeline bless every transaction
+twice when conflicts are present — the pipeline is repeating its own work, and that is
+where the extra 3,380 single Gets on that side come from too.
+
+The baseline shows the level pipeline blessing each transaction exactly once
+(1,561 = tx count), so the doubling is conflict-induced, not structural.
+
+### The Gets are in the per-subtree pass, but it blesses nothing
+
+11,745 of the 15,125 single Gets (78%) occur in the per-subtree pass, which performs
+**zero** blessings. So that pass is not validating transactions; it is reading records
+individually for some other reason. `blessMissingTransaction` is not on that path, so
+the earlier guess that the absence of `prefetchLevelParents` degrades parent resolution
+there cannot be the explanation either — no parent resolution for validation is
+happening.
+
+Its batched reads also roughly match the level pipeline's (13,306 vs 14,307), so the
+pass is doing a full pre-check either way; the single Gets are additional to that.
+
+### Where this leaves it
+
+Two separate unexplained behaviours, both conflict-induced:
+
+1. The level pipeline blesses every transaction twice (3,122 vs 1,561) and issues
+   3,380 single Gets against the baseline's 1.
+2. The per-subtree pass issues 11,745 single Gets while blessing nothing.
+
+Between them these account for the runtime, since 15,125 Gets at the ~5.7 ms cost of a
+partially filled 10 ms get-batcher window is ~86 s.
+
+Neither is explained yet. What is now firmly established, and useful regardless: the
+harness reproduces the collapse deterministically, attributes cost per pass, and has
+refuted three successive mechanism hypotheses — the phase-3 fallback (follow-up 6),
+batcher saturation (follow-up 7), and per-subtree revalidation (follow-up 8). The
+remaining question is narrow and instrumented: what issues single-record Gets on each
+of these two paths.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -171,3 +171,89 @@ TERANODE_PERF_PROFILE_DIR=/tmp/1379 \
 go test -tags aerospike -run TestUnseenTxBisect -v -timeout 60m \
   ./services/subtreevalidation/
 ```
+
+## Follow-up: externalized transactions (production evidence)
+
+Prompted by "is it a lot of externalized transactions?". Answer: **yes, and they
+are fetched serially.**
+
+`BatchDecorate` logs its external-fetch counts at INFO
+(`stores/utxo/aerospike/get.go:949`), so this is answerable from production logs
+directly. Coralogix, `bsva-infra`, archive tier, all three mainnet nodes:
+
+| window | calls | items | external fetched | max in one call |
+|---|---|---|---|---|
+| 14:29–14:46 (slow block 959984) | 383 | 31,264 | **1,600** | **203** |
+| 12:00–12:17 (quiet, sub-11s blocks) | 176 | 33,881 | 519 | 24 |
+
+Same item volume, **3x the external fetches and 8.5x the worst single call**. The
+heaviest calls were nearly all-external and clustered at 14:44:24, seconds before
+block 959984 finally completed at 14:44:37:
+
+```
+Processed 210 items - External txs: 203 fetched, 0 skipped
+Processed 165 items - External txs: 160 fetched, 0 skipped
+Processed  87 items - External txs:  84 fetched, 0 skipped
+```
+
+203 of 210 records external, and `BatchDecorate` walks its results in a single
+serial loop calling `GetTxFromExternalStore` inline (`get.go:697-742`). That is
+203 sequential blob reads inside one call, with no concurrency at all.
+
+### A harness bug this exposed, and the corrected measurement
+
+The original external-parents axis reported −2%, i.e. no effect. That row was
+**wrong** — it fetched zero externals. Two compounding causes:
+
+1. The generated txs were *extended*. `prefetchLevelParents` only requests
+   `fields.Tx` when some tx in the level is NOT extended
+   (`check_block_subtrees.go:1293`), and without `fields.Tx` `needsFullExternalTx`
+   stays false so the external fetch is skipped entirely. The validator likewise
+   skips its parent read (`Validator.go:765`). Legacy blocks from an SV node carry
+   raw, non-extended txs — the fixture now writes non-extended subtree data.
+2. `ulogger.TestLogger.Infof` is a no-op, so the `BatchDecorate` log was silently
+   discarded and "no external log lines" was indistinguishable from "no external
+   fetches". The capturing logger now counts them.
+
+With both fixed, the axis actually exercises the path:
+
+| axis | tx/s | external fetched |
+|---|---|---|
+| baseline (small parents) | 1,646 | 0 |
+| external parents (40 KB) | 1,194 | **734 in a single serial call** |
+
+734 sequential external reads cost ~360 ms of a 1.31 s run — about **0.49 ms per
+read** against a local-file blob store on SSD.
+
+### What that implies for the mainnet nodes
+
+`utxostore.docker.m` (`settings.conf:1271`) uses
+`externalStore=file://${DATADIR}/external?hashPrefix=2` — a file store, not S3.
+So the per-read cost there is whatever `DATADIR` is backed by.
+
+For 203 serial reads to account for a level taking 8.7 s, each read has to cost
+~43 ms rather than 0.49 ms. That is entirely plausible on network-attached
+storage, and this codebase already treats NFS-backed blob stores as a real
+deployment shape — `check_block_subtrees.go:405` notes "on NFS-backed blob stores
+each `Exists` call is a network round-trip". It is not confirmed, because external
+read latency is exactly one of the quantities no metric ships from these nodes.
+
+Two related settings checked and ruled out as the constraint:
+
+- `utxostore_externalStoreConcurrency.docker.m = 4` applies only to the **write**
+  path (`create.go:1062`), so it does not throttle these reads.
+- `utxostore_useExternalTxCache = true` gives a 10-minute cache, but it is keyed by
+  hash and a block's parents are mostly distinct, so it cannot absorb 203 misses.
+
+### Revised fix ranking
+
+Parallelising the external fetch loop in `BatchDecorate` moves from "not this
+incident, but a real cliff" to a **primary** candidate. It is currently
+concurrency 1; even 8-way would cut a 203-read call by ~25x, and it composes with
+the per-level round-trip batching above. `getExternalTransaction`
+(`get.go:1628-1637`) additionally tries `FileTypeTx` first and only falls back to
+`FileTypeOutputs`, so every outputs-only parent pays a wasted lookup first —
+worth fixing in the same pass.
+
+Still needed to close this out: external-read latency from the nodes themselves,
+which is issue ask 2.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -294,16 +294,16 @@ with `DATADIR` on the NVMe RAID0.
   **Jul 30 02:02** — well after the Jul 29 14:29 incident.
 - The node now runs **v0.16.0-beta-9**; the incident was on beta-1.
 
-### The monitoring stack is not actually running
+### The monitoring stack was not actually running (since fixed)
 
-Both containers exited ~2 minutes after being started:
+Resolved — see follow-up 3. Recorded here as found. Both containers had exited ~2 minutes after being started:
 
 ```
 prometheus  Exited (2)   open /etc/prometheus/prometheus.yml: permission denied
 grafana     Exited (1)   open /etc/grafana/provisioning/dashboards/main.yaml: permission denied
 ```
 
-Cause is bind-mount permissions, not config content. `config/` and
+Cause was bind-mount permissions, not config content. `config/` and
 `config/grafana_dashboards/` are `drwxrwx--- ubuntu:ubuntu` and the mounted files
 are `-rw-rw---- ubuntu:ubuntu`, while `prom/prometheus:v2.44.0` runs as uid 65534
 and `grafana:12.2.0` as uid 472 — neither can traverse the directory or read the

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -534,3 +534,80 @@ only shows up on blocks carrying many unseen transactions.
 
 Root cause still not identified. Next untested candidate is the conflicting-tx path,
 being the only positive content correlation and wholly unmodelled by the fixture.
+
+## Follow-up 6: REPRODUCED — conflicting transactions abandon the fast path
+
+Modelling conflicting transactions in the fixture reproduces the collapse.
+
+| axis | tx/s | vs baseline | conflict warnings |
+|---|---|---|---|
+| 0 conflicts | 1,557 | — | 0 |
+| **50 conflicts (3.2% of 1,561 txs), descendant depth 0** | **18.8** | **0.012x** | 807 |
+| 50 conflicts, depth 5 | 18.6 | 0.012x | 807 |
+| 200 conflicts, depth 5 | 11.5 | 0.007x | 1,027 |
+
+Mainnet observed 27–50 tx/s. The harness now produces 11.5–18.8 tx/s. Same regime.
+
+### The mechanism
+
+`processTransactionsInLevels` treats a conflicting transaction as fatal to the whole
+batch. `errorsFound` (check_block_subtrees.go:1189) counts conflicting-tx errors
+alongside everything else, and only the *all*-missing-parent case is tolerated
+(:1244). Any conflicting transaction therefore makes the fast parallel level pass
+return an error at :1248, which throws away all the work it just completed and forces
+`CheckBlockSubtrees` into `validateMissingSubtreesWithOrderedRetry` — whose **phase 3
+is explicitly sequential, one subtree at a time**.
+
+Three measurements pin this down:
+
+- **The level pass itself is fine.** 25 levels, slowest 70 ms, ~1 s total — but the
+  run took 83 s. The time is entirely outside the level loop.
+- **Descendant depth is irrelevant** (18.8 vs 18.6 tx/s at depth 0 vs 5), so it is
+  not `MarkConflictingRecursively` or the children walk.
+- **807 conflict warnings for 50 conflicting txs** — roughly 16 revalidations each,
+  which is the fallback re-walking the same transactions.
+
+### Why conflicting transactions are not an error case
+
+Double-spend attempts are routine on mainnet. The code explicitly supports them:
+`processTransactionsInLevels` sets `WithCreateConflicting(true)` (:1075), the
+validator stores them flagged conflicting, and `blessMissingTransaction` blesses them
+after `checkCounterConflictingOnCurrentChain` confirms no counter-conflict is mined on
+our chain. The block is valid and the transactions are handled correctly.
+
+They are nonetheless counted as `errorsFound`, so their mere presence costs an ~83x
+throughput collapse for the entire block.
+
+### This resolves the puzzle that 13 conflicts cost more than 189
+
+The fallback's cost scales with the **block's transaction count**, not with the
+conflict count — because the whole block is revalidated, not just the conflicts.
+
+| block | txs | conflicts | duration | rate |
+|---|---|---|---|---|
+| 959979 | 6,258 | 189 | 218 s | 28.7 tx/s |
+| 959984 | 27,131 | 13 | 716 s | 37.9 tx/s |
+
+The *rate* is near-constant and the *duration* tracks tx count, which is exactly what
+a serial revalidation predicts and is why 13 conflicts in a 27k-tx block cost more
+than 189 in a 6k-tx block. Earlier sections treated that inversion as evidence
+against the conflict hypothesis; it is in fact a prediction of it.
+
+### Consistency with the production logs
+
+The `'sequential revalidation'` INFO line showed 0 occurrences in both Class B
+windows, which earlier looked like it ruled the fallback out. It does not: that log
+(:1245) fires only when `errorsFound == missingParentErrors`. With conflicts the
+counts differ, so :1248 returns a processing error and no such line is emitted. The
+absence of that log is what this mechanism predicts.
+
+### Fix direction
+
+Conflicting transactions should not fail the batch. The same deferral already applied
+to all-missing-parent errors should extend to conflicting-tx outcomes: they are a
+successful, expected result, not a validation failure. That keeps the block on the
+parallel level path and removes the ~83x penalty.
+
+Worth checking as part of that change: whether any conflicting tx needs the fallback
+at all, or whether the conflicting-create plus counter-conflict check already leaves
+the store in its final correct state — in which case the error return is pure waste.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -462,3 +462,75 @@ achievable.
 Which makes the harness's 5,107 tx/s the most valuable remaining clue rather than a
 dead end: the ~170x gap is not environmental, so it is something the fixture does
 not model about these specific blocks.
+
+## Follow-up 5: Class B hypothesis eliminations
+
+Focused hunt for the Class B mechanism. Each row was tested against production logs
+or measured in the harness, not reasoned about.
+
+| hypothesis | test | result |
+|---|---|---|
+| Phase-3 sequential revalidation fallback | `'sequential revalidation'` in both windows | **0** (116 in July overall) |
+| Missing / cross-subtree parents | deferral log fires whenever `errorsFound > 0` | never fired → `errorsFound == 0` |
+| `DEVICE_OVERLOAD` overload-retry | `'aerospike overloaded'` in both windows | **0** (954 in July overall) |
+| Batcher leak guard (160 s) | `'did not complete within'` in both windows | **0** (6 in July overall) |
+| `mtpMu` serialising the fan-out | code: `sync.RWMutex`, read path uses `RLock` | shared, no serialisation |
+| Pathological level count | both variants set `level = maxParentLevel+1` | tracks longest chain, ~25 |
+| External-store read latency | measured on the node | 0.33 ms p50 → 203 serial = 0.11 s |
+| **Aerospike connection pool cap** | **harness A/B** | **0.89x — no effect** |
+
+### The connection-pool result is worth keeping
+
+Production caps the client at `ConnectionQueueSize=128` with
+`LimitConnectionsToQueueSize=true` (settings.conf:1271) — a hard ceiling where
+callers block. `processTransactionsInLevels` independently fans out to
+`SpendBatcherSize*2 = 2048` (check_block_subtrees.go:1156). Those two numbers come
+from unrelated settings and nothing reconciles them, so on paper the fan-out
+oversubscribes a blocking pool ~16x. Every earlier harness run had used
+`InitAerospikeContainer`'s bare URL with no connection tuning at all, so the entire
+bisect matrix had never modelled it.
+
+Measured: 1,656 tx/s capped vs 1,467 tx/s uncapped. No effect.
+
+The reason is that the fan-out's store operations go through batchers, which
+coalesce thousands of validations into a handful of batch calls — so 2048 goroutines
+never become 2048 connections. Consistent with `connections_pool_empty = 0` in
+production and with the block profile showing all waiting on batcher completion
+rather than on connection acquisition.
+
+The harness now applies the production connection params by default anyway, so it
+stops flattering itself with an unbounded pool.
+
+### The one positive correlation found
+
+Conflicting-transaction warnings (`[blessMissingTransaction] ... is conflicting`,
+logged at Warn so present in Coralogix):
+
+| window | conflicting warnings |
+|---|---|
+| 959979 (slow) | **189** |
+| 959984 (slow) | **13** |
+| 12:00–12:17 same day (fast) | **0** |
+
+Present in both slow windows, absent from the fast one. The count does not track
+duration (13 conflicts → 12 min; 189 → 3.6 min), so it is not the conflict count
+itself — but it is the only block-content marker found so far that separates slow
+blocks from fast ones.
+
+The conflict path is expensive and entirely absent from the fixture:
+`checkCounterConflictingOnCurrentChain` (counter-conflict hash lookups plus a
+`GetMeta` per hash), `MarkConflictingRecursively` (a batched BFS over unconfirmed
+descendants — cost scales with descendant depth, not block size), and the
+`CreateConflicting` create path. A single slow conflicting tx also stalls its entire
+level, because the level's `g.Wait()` cannot return until every tx in it finishes.
+
+### Where the arithmetic points
+
+At 2048-wide fan-out over ~25 levels, 959979 is ~26 waves. 218 s / 26 ≈ **8.4 s per
+`blessMissingTransaction`**, against 15 ms mean / 64 ms p99 in production steady
+state. So per-call latency degraded ~560x under the fan-out. Steady state validates
+~12 tx/s with no concurrency, which is why it looks healthy and why the incident
+only shows up on blocks carrying many unseen transactions.
+
+Root cause still not identified. Next untested candidate is the conflicting-tx path,
+being the only positive content correlation and wholly unmodelled by the fixture.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -854,3 +854,62 @@ fraction rather than the seed count: seed conflicts in the deepest level (no
 descendants to cascade into) and sweep the total conflicting share through 3%, 10%,
 25%, 50% to find where the collapse begins. That would establish whether mainnet's
 conflict density is enough.
+
+## Follow-up 11: instrumentation shipped (issue ask 1)
+
+Done first, before touching the per-level cost, so the production level depth is known
+rather than assumed.
+
+### Logs promoted to INFO
+
+Five sites in `processTransactionsInLevels`, all at block or level grain:
+
+- pre-check `missed` counts (two variants) — once per batch
+- `Processing transactions across %d levels` — once per batch, **the level count that
+  had to be reconstructed from a third-party API for #1379**
+- per-level start, and per-level DONE now carrying its duration
+
+All six per-transaction `Debugf` sites are deliberately untouched. They are the ones
+that would flood: at ~750 blessings/minute in steady state they would add 25–40x the
+current log volume, and they sit inside the 2048-wide fan-out where writing to one
+stdout lock would contend with the work being measured. Volume added is ~52 lines per
+block (2 pre-check + 1 level count + 2 x levels), negligible against a 10-minute block
+interval.
+
+INFO matters specifically because this deployment's Coralogix pipeline **drops DEBUG**,
+so a log-level flip would have put the data only in a local file that rotates in ~5
+hours. See follow-up 2.
+
+### Metrics added
+
+| metric | purpose |
+|---|---|
+| `teranode_subtreevalidation_levels_per_block` | level depth distribution — the cost driver for item 1, previously unmeasurable |
+| `teranode_subtreevalidation_level_duration` | per-level wall time including prefetch |
+| `teranode_subtreevalidation_prefetch_level_parents` | the per-level bulk parent read, previously uninstrumented |
+
+`levels_per_block` uses power-of-two buckets to 4096 rather than latency buckets, so a
+flat block (1) and a pathologically deep one land in distinct buckets.
+
+### Verified
+
+- Untagged package tests pass.
+- Harness runs green; `level_duration` reports mean 44.87 ms against a captured
+  per-level table of 38–49 ms, an independent cross-check that the metric is correct.
+- `prefetch_level_parents` mean 2.69 ms, so the prefetch is a small part of the ~45 ms
+  level floor — useful on its own, since it means the floor is the spend/create/unlock
+  round trips rather than the parent read.
+- `golangci-lint` clean on both changed files (the 5 remaining `prealloc` findings are
+  pre-existing, in test files not touched here).
+
+One consequence worth noting: the harness's own level capture had to move from `Debugf`
+to `Infof`, because the lines it reads are now emitted at INFO. It therefore reads
+exactly what production aggregation sees, which is a better arrangement than the
+Debug-level capture it replaced.
+
+### What this unblocks
+
+Once deployed, `levels_per_block` on real mainnet traffic answers the question item 1
+currently rests on an assumption for: whether real blocks are deep enough for the
+measured 10x level-depth penalty to matter. The #1379 blocks were reconstructed at 25
+levels, but that is one third-party measurement of one block.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -37,7 +37,7 @@ Reduced scale: 1,587 txs, same 25-level depth and wide-head/thin-tail character.
 | **single flat level (same tx count)** | **16,404** | **+891%** |
 | batcher timers 10 ms → 1 ms | 2,118 | +28% |
 | block assembly disabled (no insert, no 2PC) | 1,912 | +16% |
-| external parents (40 KB, above the 32 KB threshold) | 1,621 | −2% |
+| external parents (40 KB) — **INVALID, see follow-up** | 1,621 | −2% |
 | `inputsPerTx` = 4 | 1,370 | −17% |
 | `inputsPerTx` = 16 | 1,303 | −21% |
 
@@ -101,17 +101,7 @@ repo and the issue:
 Issue ask 2 (ship node metrics) moves from "would be nice" to the thing that
 would have answered this outright.
 
-### Two suspicions from code reading, killed
-
-**External-store parents are not the local bottleneck.** `BatchDecorate`
-(`stores/utxo/aerospike/get.go:697-742`) does walk batch results serially and
-call `GetTxFromExternalStore` inline, so N external parents in a level cost N
-sequential blob reads. With a local-file external store that measured −2%, i.e.
-free. It stays a latent risk for any node whose external store is S3-backed —
-where each of those reads is a network round trip, and
-`getExternalTransaction` (`get.go:1628-1637`) tries `FileTypeTx` first and only
-falls back to `FileTypeOutputs`, so outputs-only parents pay a wasted lookup
-first — but it is not what happened here.
+### One suspicion from code reading, killed
 
 **Parent fan-out is not the driver.** Raising inputs per transaction from 1 to 4
 cost 17%, and 4 to 16 only a further 4%. Sublinear, so distinct-parent resolution
@@ -141,8 +131,8 @@ Ordered by the evidence, not by ease:
    be available in production logs.
 4. **Dedupe concurrent legacy block deliveries** (issue ask 3) — unchanged by
    these findings, still a ~3x waste reduction independent of the per-level cost.
-5. Parallelise the external fetch loop in `BatchDecorate` — not this incident,
-   but a real cliff for any S3-backed deployment.
+5. Parallelise the external fetch loop in `BatchDecorate`. **Superseded — see the
+   follow-up section, which promotes this to a primary candidate.**
 
 ## Harness caveats
 

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -807,3 +807,50 @@ refuted three successive mechanism hypotheses — the phase-3 fallback (follow-u
 batcher saturation (follow-up 7), and per-subtree revalidation (follow-up 8). The
 remaining question is narrow and instrumented: what issues single-record Gets on each
 of these two paths.
+
+## Follow-up 10: two corrections that change the severity claim
+
+### The "blessed twice" finding was an instrumentation artifact
+
+`prometheus.DefaultGatherer` is process-global, and `TestUnseenTxBisect_ConflictingTxs`
+runs its baseline first in the same test binary, so `dumpStoreOpCounts` reports
+**cumulative** totals. The conflict run's 3,122 blessings are 1,561 (baseline) + 1,561
+(conflict run).
+
+The arithmetic is exact and self-consistent:
+
+- `bless`, `validate` and `spend_utxos` are all precisely 2x the baseline.
+- `2phase_commit` is 2,315 rather than 3,122, and decomposes as 1,561 + 754 — where
+  754 non-conflicting + **807 conflicting = 1,561**, the conflict run's tx count.
+  Conflicting transactions skip the 2PC unlock because they are never locked.
+
+So each transaction is blessed **once**. Follow-up 9's claim that the level pipeline
+blesses everything twice is withdrawn.
+
+The single-Get finding survives, because the baseline contributes almost nothing to it
+(1 Get total): the conflict run really does issue ~3,379 single Gets in the level
+pipeline and 11,745 in the per-subtree pass.
+
+### The conflict rate is 52%, not 3% — the severity claim was overstated
+
+The same accounting shows **807 of 1,561 transactions conflicting**, from only 50
+seeded double-spends. Conflicts cascade: a block transaction spending a conflicting
+parent's output is itself conflicting, so the 50 seeds propagate down the dependency
+graph.
+
+Mainnet block 959979 logged 189 conflicting warnings across 6,258 transactions, ~3%.
+So the fixture runs at roughly 17x mainnet's conflict density, and every earlier
+statement of the form "3% conflicts collapse throughput 83x" is wrong. The correct
+statement is that **52% conflicting transactions collapse throughput 83x**.
+
+Whether mainnet's actual ~3% is sufficient to produce the observed 27–50 tx/s is
+therefore **not established**. The cascade property means a small number of seeded
+double-spends near the top of the dependency graph can still conflict a large fraction
+of a block, which is a plausible route from 3% seeds to a large conflicting
+population — but that is a hypothesis, not a measurement.
+
+The missing experiment is a fixture parameterised on the *resulting* conflicting
+fraction rather than the seed count: seed conflicts in the deepest level (no
+descendants to cascade into) and sweep the total conflicting share through 3%, 10%,
+25%, 50% to find where the collapse begins. That would establish whether mainnet's
+conflict density is enough.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -974,3 +974,88 @@ The waste was attempt 1's `HandleBlockDirect` being cancelled after 10m40 with i
 downstream validation still running. **Why that cancellation happened is not
 diagnosed**, and it is a different problem from delivery dedup. That is the real
 residual item from the issue's ask 3, restated.
+
+## Follow-up 13: #1391's O(N^2) cone re-walk confirmed — very likely the Class B mechanism
+
+Issue #1391 (mainnet fleet wedged at 960,827) proposes that
+`checkCounterConflictingOnCurrentChain` re-walks the counter-conflicting descendant cone
+once per node **of that same cone**. All three of its code claims verify:
+
+1. `GetConflictingChildren` recurses into `SpendingDatas`
+   (`stores/utxo/process_conflicting.go:1038-1048`), not just `ConflictingChildren` — so
+   the walk covers the whole descendant spend cone.
+2. Its per-level errgroup (`:1004`) has **no `SetLimit`**, and issues a **single-record
+   `s.Get` per node per level**.
+3. `GetCounterConflictingTxHashes` adds every descendant to `counterConflictingMap`
+   (`:1129`, after the walk at `:1119`), so the slice it returns *is* the descendant set.
+   `SubtreeValidation.go:503-514` then calls `GetConflictingChildren` again per element,
+   with a fresh `visited` map each time and the outer loop fully serial.
+
+### Measured: it is quadratic
+
+`TestUnseenTxBisect_ConflictCone` isolates it — a trivial flat single-level block with
+exactly ONE conflicting transaction, whose squatter heads a linear descendant chain of
+length `depth`. Nothing but the cone size varies.
+
+| depth | N | elapsed | single-record Gets | gets/N² |
+|---|---|---|---|---|
+| 0 | 1 | 168 ms | 13 | 13.00 |
+| 25 | 26 | 8.3 s | 788 | **1.17** |
+| 50 | 51 | 29.9 s | 2,813 | **1.08** |
+| 100 | 101 | **1 m 55 s** | 10,613 | **1.04** |
+
+`gets/N²` converges on 1.0 and elapsed grows ~4x per doubling of N. **One** conflicting
+transaction with a 100-node cone costs 115 seconds and ~105 Gets per cone node.
+
+Extrapolating: N≈350–400 gives ~26 minutes, which is what #1391 observed before context
+cancellation. Consistent.
+
+### Why this is very likely Class B's mechanism
+
+It matches every Class B observation, including the one this document could not explain:
+
+- **Conflicting transactions are the trigger** — the only positive content correlation
+  found (189 and 13 conflicting warnings in the two slow windows, 0 in a fast window the
+  same day).
+- **Single-record Gets** — the smoking gun was `aerospike_txmeta_get` at 15,125 in the
+  conflict run against 0 in the baseline. This walk is single-record `s.Get` per node.
+- **`checkCounterConflictingOnCurrentChain` was the largest teranode-attributed frame** in
+  the block profile at 173.9 s cumulative.
+- **Latency-bound and serial** — 5.67% CPU, what little there was inside the Aerospike
+  client.
+- **Deterministic and version-independent** — explains all three nodes across two
+  providers stalling on the same block.
+- **It explains 13 conflicts costing more than 189.** Cost is Σ(N² ) over conflicts, so a
+  few conflicts with large cones dominate many with small ones. Follow-up 6's
+  "whole-block revalidation" explanation for that inversion was withdrawn as an
+  instrumentation artifact; this replaces it with a measured one.
+
+### What it does not explain
+
+The 83x collapse measured in follow-up 6 used cone depths of 0 and 5, i.e. N of 1 and 6,
+where the quadratic term is negligible — 13 Gets at N=1. So **that** collapse is a
+separate, milder conflict-path cost and should not be conflated with this one. That depth
+0 vs 5 showed no difference is consistent with the quadratic only biting at large N,
+rather than evidence against it.
+
+Also still open: follow-up 9 attributed 11,745 of the 15,125 Gets to the per-subtree pass,
+which recorded zero blessings — yet `checkCounterConflictingOnCurrentChain` only runs
+under `blessMissingTransaction`. Either the split-point capture mis-attributes or
+something else issues them.
+
+### Regression test
+
+`TestConflictConeBlessesInBoundedTime` asserts one conflicting transaction with a
+101-node cone blesses within 15 s **and** issues fewer than 10 Gets per cone node. It
+currently fails at 1 m 56 s and 105.1 Gets per node, which is the point: it must be seen
+failing before the fix and passing after.
+
+The budget sits an order of magnitude above the expected post-fix O(N) figure (~101
+sequential Gets, ~1 s) and an order of magnitude below the measured O(N²) figure, so it
+is neither flaky nor able to pass while the quadratic remains. The Gets-per-node
+assertion guards against the time budget being met on faster hardware while the shape is
+unchanged.
+
+It is behind `//go:build aerospike`, which CI does not run for this package (`make test`
+passes no tag, and the one tagged job covers only `./stores/utxo/aerospike/...`), so the
+intentional failure does not turn CI red.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -247,3 +247,80 @@ worth fixing in the same pass.
 
 Still needed to close this out: external-read latency from the nodes themselves,
 which is issue ask 2.
+
+## Follow-up 2: measured on bsva-ovh-teranode-eu-2 directly
+
+SSH access to the node settled the external-read question with measurement
+instead of inference. **The external-store latency hypothesis is dead.**
+
+### The store is huge but fast
+
+| fact | value |
+|---|---|
+| external store size | **2.2 TB** (of 2.3 TB total used on /mnt/data) |
+| shard dirs (`hashPrefix=2`) | 256 |
+| entries per shard | ~31,200 (`.tx` + `.tx.sha256`) |
+| **estimated external transactions** | **~4 million** |
+| mean external tx size | ~575 KB |
+| backing store | ext4 on `md10`, RAID0 over local NVMe (`ROTA=0`), 21 TB |
+| RAM | 251 GB total, 147 GB page cache |
+
+So yes — externalized transactions are numerous, and they dominate this node's
+storage. But reading them is cheap. 160 random `.tx` reads sampled across 40
+shards (92 MB total, mostly cold given 2.2 TB against 147 GB of cache):
+
+```
+latency ms: min=0.15 p50=0.33 p90=0.82 p99=3.93 max=5.32 mean=0.55
+```
+
+203 serial reads — the worst single production `BatchDecorate` call — therefore
+costs **0.11 s at p50, 0.8 s even at p99**. Not 8.7 s. The serial fetch loop in
+`BatchDecorate` remains a genuine design wart (concurrency 1, and it would bite
+hard on an S3-backed external store), but on this hardware it cannot account for
+the collapse.
+
+`utxostore.docker.m` is confirmed in use: the container has
+`SETTINGS_CONTEXT=docker.m`, so `externalStore=file://${DATADIR}/external?hashPrefix=2`
+with `DATADIR` on the NVMe RAID0.
+
+### Why the incident itself can no longer be diagnosed from this node
+
+- Teranode's own metrics endpoints work and expose the right histograms
+  (`teranode_aerospike_get_external`, `set_external`) on `:9091` per service — but
+  every counter is 0 because all teranode containers were restarted minutes
+  before, so there is no incident-era data.
+- Aerospike was NOT restarted (up 4 weeks), but its log driver is `json-file` with
+  `max-size:100m` and console-only logging, so retained history starts at
+  **Jul 30 02:02** — well after the Jul 29 14:29 incident.
+- The node now runs **v0.16.0-beta-9**; the incident was on beta-1.
+
+### The monitoring stack is not actually running
+
+Both containers exited ~2 minutes after being started:
+
+```
+prometheus  Exited (2)   open /etc/prometheus/prometheus.yml: permission denied
+grafana     Exited (1)   open /etc/grafana/provisioning/dashboards/main.yaml: permission denied
+```
+
+Cause is bind-mount permissions, not config content. `config/` and
+`config/grafana_dashboards/` are `drwxrwx--- ubuntu:ubuntu` and the mounted files
+are `-rw-rw---- ubuntu:ubuntu`, while `prom/prometheus:v2.44.0` runs as uid 65534
+and `grafana:12.2.0` as uid 472 — neither can traverse the directory or read the
+files. Only `aerospike-exporter` (which needs no host config) came up, which is
+why the stack looked partially alive.
+
+No secrets are involved: `prometheus.yml` is scrape targets only and
+`grafana_datasource.yaml` contains no password/token, so a group/other read bit is
+not an exposure.
+
+### Where this leaves the root cause
+
+External reads: ruled out by measurement. Level depth: confirmed 10x, but a 10x on
+a ~45 ms/level floor is ~1 s for a 25-level block, not 12 minutes. The remaining
+unexplained factor is still Aerospike operation latency during the incident, and
+it is now unmeasurable retroactively on this node.
+
+Closing this out therefore depends on instrumentation being live *before* the next
+occurrence — which makes fixing the monitoring stack the highest-value next action,
+ahead of any code change.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -401,3 +401,64 @@ nodes at all". That was true when written and is no longer: the metrics existed 
 the code and were exposed on `:9091` all along, but nothing scraped them. Issue
 ask 2 is therefore narrower than originally filed — it is a scrape/permissions
 problem, not missing instrumentation.
+
+## Follow-up 4: the slow events are TWO distinct classes
+
+Grouping every minute-scale `processTransactionsInLevels` event in July by how many
+nodes logged it for the same block height splits the data cleanly, and the split
+matters: two of the conclusions above were drawn from the wrong class.
+
+| height | txs | nodes hit | hosts |
+|---|---|---|---|
+| 1730302 | 1 | 1 | `ip-10-11-164-241` |
+| 1734144 | 17,808 | 1 | `ip-10-11-164-241` |
+| 1735305 | 20,001 | 1 | `ip-10-11-164-241` |
+| 956467 | 149,738 | 1 | `ip-10-11-164-241` |
+| 956694 | 226,914 | 1 | `ip-10-11-164-241` |
+| 957561 | 506 | 1 | `ip-10-11-164-241` |
+| **959979** | 6,258 | **2** | `ip-10-11-181-104`, `ovh-eu-2` |
+| **959984** | 27,131 | **3** | `ip-10-11-181-104`, `ovh-eu-1`, `ovh-eu-2` |
+
+### Class A — one bad host, not a Teranode bug
+
+All six single-node events are on the **same** EKS worker, `ip-10-11-164-241`. It
+spans both mainnet (~956k) and teratestnet (~1.73M) heights because multiple
+namespaces schedule pods onto that one machine. Durations bear no relation to
+transaction count (1 tx → 64 s; 149,738 tx → 78 s), which is the signature of a
+host-level stall — disk, noisy neighbour, CPU throttling.
+
+Out of scope for #1379. Worth raising separately with whoever owns that node.
+
+### Class B — the actual issue
+
+Two events, and they hit a *different* EKS host plus both OVH bare-metal boxes:
+independent machines, two hardware providers, simultaneously slow on the same
+block. That cannot be node-local. It is block-content-driven.
+
+| height | txs | duration range | rate |
+|---|---|---|---|
+| 959979 | 6,258 | 3m38s – 3m53s | **~28 tx/s** |
+| 959984 | 27,131 | 2m42s – 12m17s | **~37 tx/s** |
+
+~28–40 tx/s, consistently, across unrelated hardware.
+
+### Two corrections to earlier sections
+
+**Follow-up 3's "duration is independent of tx count" is withdrawn.** That was
+derived from the 1-tx/64 s event, which is Class A. It says nothing about #1379.
+Restricted to Class B, the rate is roughly constant per transaction (~30 tx/s),
+which is the original issue framing.
+
+**The level-depth finding is therefore back in play**, not sidelined. Follow-up 3
+demoted it on the strength of a Class A datapoint; that demotion was wrong.
+
+### Why this reframes the investigation favourably
+
+Whatever the mechanism is, it is deterministic enough to produce the same ~30 tx/s
+on three different machines across two providers. That rules out intermittent
+node-local Aerospike stalls, and it means a local reproduction *should* be
+achievable.
+
+Which makes the harness's 5,107 tx/s the most valuable remaining clue rather than a
+dead end: the ~170x gap is not environmental, so it is something the fixture does
+not model about these specific blocks.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -1,0 +1,173 @@
+# Findings — unseen-tx throughput reproduction (#1379)
+
+Results from the harness described in
+[the design](./1379-unseen-tx-throughput-design.md). Run on an in-memory
+single-node Aerospike testcontainer with a local-file external store, real
+`validator.Validator`, real GoBDK, FSM pinned to RUNNING.
+
+## Headline: the collapse did not reproduce
+
+The shape-matched baseline — 6,258 txs in mainnet block 959979's measured level
+histogram (25 levels, L0 = 2936) — ran at **5,107 tx/s**. Mainnet observed
+**27–50 tx/s** on the same shape. That is a ~100x gap.
+
+The measurement is valid, not misconfigured. The harness asserts both halves of
+the precondition and both held:
+
+- `Pre-check: 6258/6258 transactions missed in cache` — every tx was genuinely
+  unseen, so nothing took the `missed == 0` fast path.
+- `blockAssemblyStores=6258` — every tx went to block assembly, confirming
+  `addTXToBlockAssembly == true` and therefore the tip path, not the catchup
+  path.
+- The production level splitter derived exactly the 25 levels the fixture was
+  built for.
+
+So no combination of the level machinery, the 25-level serialisation,
+`prefetchLevelParents`, per-tx Create + 2PC + block-assembly insert + Kafka
+enqueue, real GoBDK script verification and real Aerospike is *intrinsically*
+capable of 30–50 tx/s. Something specific to those nodes is.
+
+## Bisect matrix
+
+Reduced scale: 1,587 txs, same 25-level depth and wide-head/thin-tail character.
+
+| axis | tx/s | vs baseline |
+|---|---|---|
+| baseline (25 levels, 1 input/tx, small parents) | 1,655 | — |
+| **single flat level (same tx count)** | **16,404** | **+891%** |
+| batcher timers 10 ms → 1 ms | 2,118 | +28% |
+| block assembly disabled (no insert, no 2PC) | 1,912 | +16% |
+| external parents (40 KB, above the 32 KB threshold) | 1,621 | −2% |
+| `inputsPerTx` = 4 | 1,370 | −17% |
+| `inputsPerTx` = 16 | 1,303 | −21% |
+
+## What this establishes
+
+### Level depth is a 10x multiplier
+
+The same 1,587 transactions cost 16,404 tx/s in one dependency level and 1,655
+tx/s across 25. Nothing else on the matrix is within an order of magnitude of
+that.
+
+This contradicts the issue's own conclusion that "level serialization is not
+[the defect]". Level serialisation is not a 200x effect, but it is a 10x one, and
+it is structural rather than incidental.
+
+The mechanism, from the block profile (320.7 s of aggregate blocking delay over a
+1.225 s wall run):
+
+| phase | blocking delay | share |
+|---|---|---|
+| `Create` (via `CreateInUtxoStore`) | 125.4 s | 39.1% |
+| `Spend` (via `spendUtxos`) | 124.1 s | 38.7% |
+| `SetLocked` (via `twoPhaseCommitTransaction`) | 63.4 s | 19.8% |
+| **all three via `go-batcher completion.(*Group).Wait`** | **312.7 s** | **97.5%** |
+
+97.5% of all blocking time is goroutines waiting on batcher completion groups.
+Within a single transaction those three store phases are strictly sequential, and
+a level cannot finish until every transaction in it has completed all three. So a
+level costs roughly four serialised store round trips (the three above plus
+`prefetchLevelParents`) **regardless of how many transactions it contains** —
+which is exactly why a 27-tx tail level and a 2,936-tx head level both cost
+~45 ms.
+
+Total block cost is therefore approximately `levels × 4 store round trips`, not
+`transactions × per-tx cost`. Block *size* is nearly free; block *depth* is what
+costs.
+
+The 10 ms batcher windows are a minority of that: cutting all three to 1 ms
+bought only 28%. The rest is the round trips themselves.
+
+### This reframes the issue
+
+At ~4 round trips per level, mainnet's observed 8.7 s per level requires
+individual Aerospike batch operations to be taking roughly **2 seconds each**.
+Locally they take ~10 ms.
+
+So the thing to chase is not the per-tx validation path — the issue's original
+framing, and mine — but why store operations on those nodes are three orders of
+magnitude slower than a local container. Circumstantial support already in the
+repo and the issue:
+
+- `aerospike_batchPolicy.docker.m` (`settings.conf:171`) carries the comment
+  "guard below the 2m overload-retry budget", so Aerospike overload on the
+  mainnet stack is a known, previously-encountered condition.
+- The issue recorded 71 `TX_LOCKED [SPEND_BATCH_LUA]` events in the window,
+  which is what contention on the spend path looks like.
+- There are no `*aerospike*` metrics shipped from these nodes at all, so store
+  latency was invisible — which is why this could not be diagnosed from
+  telemetry.
+
+Issue ask 2 (ship node metrics) moves from "would be nice" to the thing that
+would have answered this outright.
+
+### Two suspicions from code reading, killed
+
+**External-store parents are not the local bottleneck.** `BatchDecorate`
+(`stores/utxo/aerospike/get.go:697-742`) does walk batch results serially and
+call `GetTxFromExternalStore` inline, so N external parents in a level cost N
+sequential blob reads. With a local-file external store that measured −2%, i.e.
+free. It stays a latent risk for any node whose external store is S3-backed —
+where each of those reads is a network round trip, and
+`getExternalTransaction` (`get.go:1628-1637`) tries `FileTypeTx` first and only
+falls back to `FileTypeOutputs`, so outputs-only parents pay a wasted lookup
+first — but it is not what happened here.
+
+**Parent fan-out is not the driver.** Raising inputs per transaction from 1 to 4
+cost 17%, and 4 to 16 only a further 4%. Sublinear, so distinct-parent resolution
+is not near a cliff.
+
+### The tip path's extra cost is real but small
+
+Disabling block assembly — removing the per-tx insert and with it
+Create-with-locked plus the `SetLocked` 2PC unlock — gained 16%, consistent with
+`SetLocked`'s 19.8% share of blocking delay. This is the cost the tip path pays
+and the catchup path does not, and it is the source of the TX_LOCKED children.
+Worth knowing, not the explanation.
+
+## Fix candidates this points at
+
+Ordered by the evidence, not by ease:
+
+1. **Collapse the per-level round trips.** A level currently serialises
+   spend → create → setLocked per transaction. Batching each phase *across* the
+   whole level, or overlapping levels that have no actual dependency, attacks the
+   10x directly. This is the only local finding with a large multiplier.
+2. **Ship Aerospike and subtreevalidation metrics from the mainnet nodes**
+   (issue ask 2). Without store-latency histograms the ~2 s-per-operation
+   hypothesis cannot be confirmed or killed on the next occurrence.
+3. **Promote the per-level and `missed` logs to INFO** (issue ask 1) — the
+   per-level table this harness had to reconstruct via a capturing logger should
+   be available in production logs.
+4. **Dedupe concurrent legacy block deliveries** (issue ask 3) — unchanged by
+   these findings, still a ~3x waste reduction independent of the per-level cost.
+5. Parallelise the external fetch loop in `BatchDecorate` — not this incident,
+   but a real cliff for any S3-backed deployment.
+
+## Harness caveats
+
+Stated in the design and still true:
+
+- The container namespace is in-memory single-node; mainnet is persistent and
+  under concurrent production load. **A slow local result would have been strong
+  evidence; this fast one is weak** — it bounds what the code path costs in
+  isolation, and cannot rule out an environmental cause. That is precisely the
+  conclusion reached.
+- The block-assembly gRPC hop and the Kafka broker round trip are not measured,
+  only the enqueue.
+- The synthetic level-histogram tail is flat rather than matching the reported
+  median of 119; level width below the 2048 concurrency cap does not change the
+  code path taken.
+
+## Reproducing
+
+```bash
+# baseline, 6,258 txs in mainnet 959979's level shape
+TERANODE_PERF_PROFILE_DIR=/tmp/1379 \
+  go test -tags aerospike -run 'TestUnseenTxThroughput$' -v -timeout 40m \
+  ./services/subtreevalidation/
+
+# full bisect matrix
+go test -tags aerospike -run TestUnseenTxBisect -v -timeout 60m \
+  ./services/subtreevalidation/
+```

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -913,3 +913,64 @@ Once deployed, `levels_per_block` on real mainnet traffic answers the question i
 currently rests on an assumption for: whether real blocks are deep enough for the
 measured 10x level-depth penalty to matter. The #1379 blocks were reconstructed at 25
 levels, but that is one third-party measurement of one block.
+
+## Follow-up 12: the 2PC robustness fix, and ask 3 is already shipped
+
+### Fixed: a failed 2PC unlock no longer fails the transaction
+
+`validateInternal` logged the two-phase-commit unlock failure as recoverable —
+"transaction will be marked as spendable on next block" — and then returned the error
+anyway. The two statements contradicted each other and the error won.
+
+By that point the tx is fully validated: inputs spent, record created, sent to block
+assembly, txmeta published. Clearing the locked flag also happens when the tx is mined
+(SetMinedMulti, the "set the record to not be locked again" branch in `teranode.lua`),
+exactly as the warning claimed. Returning the error escalated a self-healing condition
+into a transaction failure, and on the block-validation path
+`blessMissingTransaction` turns that into a processing error which increments
+`errorsFound` and can fail an entire batch of an otherwise valid block.
+
+Now logged and swallowed, kept out of the named `err` return so tracing records the tx
+as the success it is; `Locked` stays true on failure so the returned metadata still
+matches the stored record.
+`TestValidator_FailedTwoPhaseCommitDoesNotFailTransaction` injects a `SetLocked`
+failure, asserts the tx still validates and its parent output is still spent, and
+asserts `SetLocked` was actually attempted so it cannot silently prove nothing.
+Confirmed failing without the change and passing with it.
+
+### Ask 3 (dedupe concurrent legacy deliveries) needs no code — it exists
+
+`SyncManager.inFlightBlocks` (manager.go:544) already holds the hash of every block
+admitted or parked, so at most one copy of a hash is in flight at a time.
+`AcquireBlockPrefetch` (:2764) inserts before the budget acquire and returns
+`ErrDuplicateBlockInFlight` for a duplicate; it is called from the peer read loop
+(`peer_server.go:1112`), so dedup happens at receipt across peers. It is active
+whenever `legacy_blockPrefetchBufferBytes > 0`, which defaults to 256 MB and is not
+overridden — so enabled on mainnet.
+
+It landed in commit `3c400fd97` (#1190, 2026-07-14), first tagged **v0.16.0-beta-4**.
+
+At the time of the incident on 2026-07-29 none of the three nodes had it:
+
+| node | version then | dedup? |
+|---|---|---|
+| `teranode-mainnet-eu-1` | v0.15 | no |
+| `bsva-ovh-teranode-eu-1` | v0.15 | no |
+| `bsva-ovh-teranode-eu-2` | v0.16.0-beta-1 | no (beta-1 < beta-4) |
+
+`bsva-ovh-teranode-eu-2` now runs beta-9 and therefore has it. **Ask 3 is a deployment
+item, not a code item** — the other two nodes are still on v0.15.
+
+### What the incident's duplicate work actually was
+
+Worth separating, because "dedupe deliveries" does not describe it. The timeline was
+sequential, not two concurrent deliveries: attempt 1 at 14:29 from one peer ran 10m40
+and ended in `context canceled`; attempt 2 at 14:39:59 from another peer then **latched
+onto attempt 1's still-running `CheckBlockSubtrees`** and both completions logged at the
+same instant.
+
+So the subtreevalidation-layer dedup already worked — attempt 2 did not redo the work.
+The waste was attempt 1's `HandleBlockDirect` being cancelled after 10m40 with its
+downstream validation still running. **Why that cancellation happened is not
+diagnosed**, and it is a different problem from delivery dedup. That is the real
+residual item from the issue's ask 3, restated.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -611,3 +611,68 @@ parallel level path and removes the ~83x penalty.
 Worth checking as part of that change: whether any conflicting tx needs the fallback
 at all, or whether the conflicting-create plus counter-conflict check already leaves
 the store in its final correct state — in which case the error return is pure waste.
+
+## Follow-up 7: follow-up 6's mechanism was wrong, and the first fix attempt failed
+
+### Correction: the level pass never fails
+
+Follow-up 6 claimed conflicting transactions make `processTransactionsInLevels`
+return an error, forcing the phase-2/phase-3 fallback. **That is wrong.** Checked
+against the run output: there is no `Failed to process level`, no
+`Completed processing with N errors`, and only one pre-check line per run. The level
+pass completes successfully.
+
+Reading the code confirms why. For a conflicting tx whose counter-conflict is not
+mined on our chain, `blessMissingTransaction` returns `(txMeta, nil)` — the
+`ErrTxConflicting` from the validator is deliberately not propagated
+(SubtreeValidation.go:426-431), and `checkCounterConflictingOnCurrentChain` reassigns
+`err` to nil on success. So `errorsFound` is never incremented and nothing is
+deferred.
+
+Also corrected: `validateMissingSubtreesWithOrderedRetry` runs **unconditionally**
+after the level pipeline (check_block_subtrees.go:681), not as a fallback. The level
+pass is a pre-warm; the per-subtree pass is authoritative.
+
+### What is actually established
+
+The reproduction stands — it is the mechanism explanation that was wrong:
+
+- 3% conflicting transactions collapse throughput 83x (1,557 → 18.8 tx/s), which
+  brackets mainnet's observed 27–50 tx/s.
+- Descendant depth is irrelevant, so it is not `MarkConflictingRecursively`.
+- The level loop accounts for ~1 s of an 80 s run, so the cost is outside it.
+- The block profile puts **79.7% of all blocking delay on
+  `go-batcher SetMaxConcurrent.func1`** via `chanrecv2` — 5,058 s over an 80 s run,
+  i.e. ~63 batch-dispatch goroutines permanently waiting for a slot against a
+  64-slot limit. The batchers are saturated for the entire run.
+- `utxostore_batcherMaxConcurrent.docker.m = 24` (settings.conf:1338) caps mainnet at
+  24 slots; the base default is 64, which is what the harness gets. So production has
+  2.7x less headroom than the harness that already collapses.
+
+### Fix attempt 1: batch the counter-conflict reads — DID NOT WORK
+
+`checkCounterConflictingOnCurrentChain` fanned out one `GetMeta` per
+counter-conflicting hash across a 128-wide errgroup, nested inside the 2048-wide
+per-level fan-out, and fetched whole records when only `BlockIDs` is read. Replaced
+with a single `BatchDecorate` requesting just `fields.BlockIDs`.
+
+Measured: **18.8 → 20.5 tx/s. Noise.** Not the bottleneck.
+
+Kept in `git stash` — it is a genuine improvement (N round trips to 1, one field
+instead of a whole record, removes a nested fan-out) but it does not fix #1379 and
+should not be presented as doing so.
+
+### What is still unknown
+
+Which operation in the conflict path saturates the batchers. The numbers say the cost
+is roughly fixed per conflicting transaction and large: 50 conflicts → 80 s (~1.6 s
+each), 200 conflicts → 132 s (~0.66 s each). Sub-linear, so there is a shared
+component.
+
+Also unexplained: conflict warnings do not scale with conflict count — 807 for 50
+conflicts, 1,027 for 200. Roughly constant total, which suggests a fixed quantity of
+repeated work rather than per-conflict work.
+
+Next step is a CPU profile alongside the block profile for a conflict run, to
+separate "waiting on saturated batchers" from whatever is generating the batch
+volume. The block profile alone shows the queue, not its source.

--- a/plans/1379-unseen-tx-throughput-findings.md
+++ b/plans/1379-unseen-tx-throughput-findings.md
@@ -676,3 +676,78 @@ repeated work rather than per-conflict work.
 Next step is a CPU profile alongside the block profile for a conflict run, to
 separate "waiting on saturated batchers" from whatever is generating the batch
 volume. The block profile alone shows the queue, not its source.
+
+## Follow-up 8: the profiles were misleading; op counts locate it
+
+### Correction: the block profile measures idle parking, not contention
+
+Follow-up 7 read 79.7% of blocking delay on `go-batcher SetMaxConcurrent` as batcher
+saturation, and built a `batcherMaxConcurrent.docker.m = 24` story on it. **Both are
+withdrawn.**
+
+The goroutine profile shows 7 batchers each holding exactly 128 goroutines parked in
+`SetMaxConcurrent.func1` on an empty channel — idle worker pools, not queued work.
+Decisive check: the 0.89 s baseline run reports 69 s of blocking delay (78x wall) and
+the 78 s conflict run reports 6,200 s (also 78x wall). Identical ratio, so the block
+profile is measuring goroutines parked idle, proportional to pool size times wall
+time. It says nothing about contention.
+
+The CPU profile is the reliable one: **4.45 s of samples over 78.5 s wall — 5.67%**.
+The process is idle. What CPU exists is in the Aerospike client's batch command
+execute and connection read/write. So the run is latency-bound on store round trips,
+and the question is only how many.
+
+### Op counts from the in-process Prometheus registry
+
+| metric | baseline (0.9 s) | conflicts=50 (86.8 s) |
+|---|---|---|
+| `subtreevalidation_bless_missing_transaction` | 1,561 (= tx count) | **3,122 (2x)** |
+| **`aerospike_txmeta_get`** (single record) | **0** | **15,125** |
+| `aerospike_txmeta_get_multi_n` (batched) | 6,245 | 27,613 |
+| `validator_transactions_spend_utxos` | 1,561 | 3,122 |
+
+Two measured facts:
+
+1. **Every transaction is blessed twice** in the conflict run and once in the
+   baseline. So the second (per-subtree) pass skips everything in the baseline and
+   re-validates everything when conflicts are present — all 1,561, not just the 50
+   conflicting ones.
+2. **15,125 single-record Gets against zero in the baseline.** At 86 s / 15,125 ≈
+   5.7 ms each this accounts for the entire runtime, and 5.7 ms is what a partially
+   filled 10 ms get-batcher window costs (`utxostore_getBatcherDurationMillis = 10`).
+
+### Mechanism (measured parts vs inferred parts)
+
+Measured: the doubling of blessings, the 15,125 single Gets, 5.67% CPU, and the
+per-Get cost matching the batcher window.
+
+Inferred and still to be confirmed: that the second pass is
+`validateMissingSubtreesWithOrderedRetry` re-validating whole subtrees because they
+contain a conflicting transaction, and that the single Gets arise because
+`ValidateSubtreeInternal` has no equivalent of `prefetchLevelParents` — so parent
+resolution falls back to a per-parent `Get` in the validator instead of one batched
+read per level.
+
+This also accounts for the two anomalies follow-up 7 could not explain:
+
+- **Sub-linearity** (50 conflicts → 80 s, 200 → 132 s rather than 4x): in both cases
+  every subtree is already being reprocessed, so extra conflicts add little.
+- **Near-constant warning count** (807 at 50 conflicts, 1,027 at 200): the repeated
+  work is per-subtree, not per-conflict.
+
+### Fix direction
+
+The cost is not the conflict handling itself — it is that one conflicting transaction
+in a subtree forfeits the level pass's batched parent prefetch for every transaction
+in that subtree. Two candidate directions, both needing the inference above confirmed
+first:
+
+1. Stop a conflicting transaction from invalidating the whole subtree's
+   already-validated state, so the second pass skips the other transactions as it does
+   in the baseline.
+2. Give the per-subtree path the same batched parent prefetch the level path has, so
+   the fallback costs one batched read per subtree rather than ~10 single Gets per
+   transaction.
+
+The harness now dumps these op counts on every run, so either change can be checked
+against `aerospike_txmeta_get` returning to zero rather than only against tx/s.

--- a/plans/1379-unseen-tx-throughput-plan.md
+++ b/plans/1379-unseen-tx-throughput-plan.md
@@ -1,0 +1,113 @@
+# Implementation plan — unseen-tx throughput repro
+
+Executes [the design](./1379-unseen-tx-throughput-design.md) for
+[issue #1379](https://github.com/bsv-blockchain/teranode/issues/1379).
+
+Each phase ends in a runnable verification. Phases 1–3 build the harness; phase 4
+is the measurement that decides whether the rest of the plan is the bisect or the
+real-block fallback.
+
+## Phase 1 — Aerospike-backed server fixture
+
+Stand up the wiring with a single transaction, proving every real component
+connects before any generator work.
+
+New file `services/subtreevalidation/check_block_subtrees_unseen_perf_test.go`,
+build tag `aerospike`.
+
+1. `InitAerospikeContainer()` → URL, deferred cleanup.
+2. `aerospikestore.New` UTXO store against that URL. Confirms Lua UDF
+   registration succeeded.
+3. `test.CreateBaseTestSettings(t)`, mainnet chaincfg, fixture height 257727.
+4. Real `validator.New(...)` with mock Kafka producers.
+5. `blockchain.NewLocalClient` wrapped so `GetFSMCurrentState` reports **RUNNING**
+   — reuse or mirror the `fsmStateOverrideClient` already in the package.
+6. subtreevalidation `New(...)` server.
+7. Reuse the mainnet parent/child fixture pair from
+   `legacy_real_validator_integration_test.go:67-71`, seed the parent as mined,
+   drive one tx through `CheckBlockSubtrees`.
+
+**Verify:** `go test -tags aerospike -run TestUnseenTxThroughput_Smoke -v` passes,
+the child is blessed, and the parent output is spent. Assert
+`addTXToBlockAssembly` actually took effect by checking the child's meta went
+through the locked → unlocked 2PC transition, not just that it exists — otherwise
+the RUNNING pin is silently ineffective and the whole harness measures the wrong
+path.
+
+## Phase 2 — Parameterised fixture generator
+
+Generate a block of unseen txs over seeded parents.
+
+1. Config struct: `txCount`, `levelSizes []int`, `inputsPerTx`,
+   `parentExtendedSize`, `subtreeSize`.
+2. Coinbase-funded chain generation with real signatures. Reuse
+   `generateChainToChannel` / `streamTransactionsToSubtrees` from
+   `check_block_subtrees_large_test.go` where they fit; extract rather than
+   duplicate if they need to be shared.
+3. Level shaping: place txs so the in-block dependency graph produces exactly
+   `levelSizes`. Verify against `selectPrepareTxsPerLevel` rather than trusting
+   the construction — a generator that thinks it built 25 levels but built 1 is
+   the most likely way this whole exercise silently measures nothing.
+4. Seed **only parents** into Aerospike via `utxoStore.Create` with mined info so
+   `BlockHeights` is non-empty. Block txs stay absent from cache and store.
+5. Assemble subtrees + subtreeData into the blob store, build the `model.Block`,
+   serialize for the request.
+
+**Verify:** a 500-tx / 5-level fixture round-trips through `CheckBlockSubtrees`
+with no errors, and an assertion confirms `missed == txCount` on the pre-check —
+i.e. the unseen precondition genuinely holds. If `missed` comes back 0 the
+fixture is seeding too much and every subsequent number is meaningless.
+
+## Phase 3 — Instrumentation and profiling
+
+1. Wall-clock timing around `CheckBlockSubtrees`, derived tx/s.
+2. `runtime/pprof` CPU, block and mutex profiles to the scratchpad. Set
+   `runtime.SetBlockProfileRate` and `SetMutexProfileFraction` — without them the
+   block and mutex profiles come back empty, which is the failure mode that
+   wastes a whole run.
+3. Capture per-level durations. The existing per-level logs are `Debugf`
+   (`check_block_subtrees.go:1112`, `:1223`); capture them via a recording logger
+   rather than editing production log levels, so the harness needs no production
+   change to work.
+
+**Verify:** a run emits non-empty CPU, block and mutex profiles and a per-level
+duration table.
+
+## Phase 4 — Baseline measurement (decision point)
+
+Run the shape-matched baseline: 6,258 txs, 25 levels, L0 = 2936, median 119.
+
+**Verify and branch:**
+
+- **≤100 tx/s** → reproduced. Proceed to phase 5.
+- **>1000 tx/s** → not reproduced. Stop, report, escalate to the real-block-959979
+  fallback agreed in the design.
+- **Between** → report the number and the profile before choosing; a partial
+  reproduction may still localise the bottleneck, but the decision is the user's.
+
+## Phase 5 — Bisect matrix
+
+Only if phase 4 reproduced. Flip each axis independently from baseline:
+
+| run | flip |
+|---|---|
+| A | block assembly disabled |
+| B | `parentExtendedSize` > 32 KB (forces external store) |
+| C | single flat level |
+| D | `prefetchLevelParents` disabled |
+| E | `spendBatcherConcurrency` 4 → 32 |
+
+**Verify:** a table of tx/s per run against baseline, plus the profile for
+whichever flip moved the number most.
+
+## Phase 6 — Report
+
+Post findings to issue #1379: the corrected hypotheses from code reading, the
+reproduced number, the bisect table, and the named bottleneck. Fix design is a
+separate pass.
+
+## Non-goals
+
+The fix, the INFO log promotion, the Coralogix metrics shipping, and the legacy
+delivery dedup. All tracked on the issue, all deferred until the profile names
+the bottleneck.

--- a/services/subtreevalidation/check_block_subtrees.go
+++ b/services/subtreevalidation/check_block_subtrees.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -1012,7 +1013,7 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 	}
 
 	if missed > 0 {
-		u.logger.Debugf("[processTransactionsInLevels] Pre-check: %d/%d transactions missed in cache, checking UTXO store", missed, len(txHashes))
+		u.logger.Infof("[processTransactionsInLevels] Pre-check: %d/%d transactions missed in cache, checking UTXO store", missed, len(txHashes))
 
 		batched := u.settings.SubtreeValidation.BatchMissingTransactions
 		missed, err = u.processTxMetaUsingStore(ctx, txHashes, txMetaSlice, blockIds, batched, false)
@@ -1027,7 +1028,7 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 		u.logger.Debugf("[processTransactionsInLevels] All transactions already validated, skipping processing")
 		return nil
 	} else if alreadyValidated > 0 {
-		u.logger.Debugf("[processTransactionsInLevels] Pre-check: %d/%d transactions already validated, %d need validation", alreadyValidated, len(txHashes), missed)
+		u.logger.Infof("[processTransactionsInLevels] Pre-check: %d/%d transactions already validated, %d need validation", alreadyValidated, len(txHashes), missed)
 	}
 
 	// Convert transactions to missingTx format for prepareTxsPerLevel
@@ -1062,7 +1063,12 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 	allTransactions = nil //nolint:ineffassign // Intentional early GC hint
 	missingTxs = nil      //nolint:ineffassign // Intentional early GC hint
 
-	u.logger.Debugf("[processTransactionsInLevels] Processing transactions across %d levels", maxLevel+1)
+	// Level count is the primary cost driver on this path and is emitted at INFO so it
+	// reaches log aggregation: levels are processed serially with a barrier each, and a
+	// level costs a roughly fixed set of store round trips regardless of its width. In
+	// #1379 this had to be reconstructed from a third-party API because it was Debugf.
+	u.logger.Infof("[processTransactionsInLevels] Processing transactions across %d levels", maxLevel+1)
+	prometheusSubtreeValidationLevelsPerBlock.Observe(float64(maxLevel + 1))
 
 	// WithUnconfirmedParentsAtCandidateHeight must agree with the
 	// validateSubtree closure in CheckBlockSubtrees (which carries the full
@@ -1109,7 +1115,9 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 			continue
 		}
 
-		u.logger.Debugf("[processTransactionsInLevels] Processing level %d/%d with %d transactions", level+1, maxLevel+1, len(levelTxs))
+		levelStart := time.Now()
+
+		u.logger.Infof("[processTransactionsInLevels] Processing level %d/%d with %d transactions", level+1, maxLevel+1, len(levelTxs))
 
 		// PHASE 2 OPTIMIZATION: Extend transactions with in-block parent outputs
 		// This avoids Aerospike fetches for intra-block dependencies (~500MB+ savings)
@@ -1143,7 +1151,12 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 		// Get would see it (empty BlockHeights → unconfirmed sentinel). Parents the
 		// store does not resolve are omitted, so the validator falls back to a Get
 		// and the existing missing-parent handling is preserved.
+		prefetchStart := time.Now()
+
 		prefetchedParents, prefetchErr := u.prefetchLevelParents(ctx, levelTxs)
+
+		prometheusSubtreeValidationPrefetchLevelParents.Observe(time.Since(prefetchStart).Seconds())
+
 		if prefetchErr != nil {
 			return prefetchErr
 		}
@@ -1220,7 +1233,10 @@ func (u *Server) processTransactionsInLevels(ctx context.Context, allTransaction
 			return errors.NewProcessingError("[processTransactionsInLevels] Failed to process level %d", level+1, err)
 		}
 
-		u.logger.Debugf("[processTransactionsInLevels] Processing level %d/%d with %d transactions DONE", level+1, maxLevel+1, len(levelTxs))
+		levelDuration := time.Since(levelStart)
+		prometheusSubtreeValidationLevelDuration.Observe(levelDuration.Seconds())
+
+		u.logger.Infof("[processTransactionsInLevels] Processing level %d/%d with %d transactions DONE in %s", level+1, maxLevel+1, len(levelTxs), levelDuration)
 
 		// PHASE 2 OPTIMIZATION: Release grandparent level (level-2) after current level succeeds
 		// Keep current level (being processed) and parent level (level-1) for safety

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
@@ -158,3 +158,28 @@ func TestUnseenTxBisect_BlockAssemblyDisabled(t *testing.T) {
 
 	t.Logf("AXIS blockAssemblyDisabled: %.1f tx/s", float64(fx.txCount)/elapsed.Seconds())
 }
+
+// TestUnseenTxBisect_ConnectionPool A/Bs mainnet's Aerospike connection cap
+// against an unbounded pool at the same fan-out.
+//
+// Production runs ConnectionQueueSize=128 with LimitConnectionsToQueueSize=true
+// (settings.conf:1271) — a hard ceiling where the client refuses to open a 129th
+// connection and callers block waiting for one. processTransactionsInLevels
+// independently fans out to SpendBatcherSize*2 = 2048 concurrent validations
+// (check_block_subtrees.go:1156), each issuing several store operations. The two
+// numbers come from unrelated settings and nothing reconciles them, so the fan-out
+// oversubscribes the pool ~16x.
+//
+// Every earlier harness run used InitAerospikeContainer's bare URL, which carries
+// no connection tuning at all — so the whole bisect matrix ran on the client
+// default and never modelled this. That makes it the leading unmodelled difference
+// between the harness (~4,700 tx/s) and production (~30 tx/s) for a Class B block.
+func TestUnseenTxBisect_ConnectionPool(t *testing.T) {
+	capped := runBisectAxis(t, "bisect-pool-capped", defaultPerfOptions(), baseBisectConfig())
+	t.Logf("AXIS pool=128 (production): %.1f tx/s", capped)
+
+	unlimited := runBisectAxis(t, "bisect-pool-default", unlimitedPoolPerfOptions(), baseBisectConfig())
+	t.Logf("AXIS pool=client-default: %.1f tx/s", unlimited)
+
+	t.Logf("RATIO default/capped = %.2fx", unlimited/capped)
+}

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
@@ -1,0 +1,160 @@
+//go:build aerospike
+
+// Bisect matrix for the issue #1379 reproduction. Phase 5 of
+// plans/1379-unseen-tx-throughput-plan.md.
+//
+// The shape-matched baseline (TestUnseenTxThroughput) came out at ~5,100 tx/s
+// against mainnet's observed 27-50 tx/s, so it does NOT reproduce the collapse.
+// These runs flip one axis at a time off that baseline to find which dimension,
+// if any, moves the number toward mainnet — and to nail down the fixed per-level
+// cost the baseline exposed.
+package subtreevalidation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/stretchr/testify/require"
+)
+
+// bisectShape is a smaller version of the mainnet 959979 histogram: same 25-level
+// depth and same wide-head/thin-tail character, ~1/4 the transactions. The
+// baseline showed runtime is dominated by a fixed per-level cost rather than a
+// per-tx one, so level depth is what has to be preserved; shrinking the widths
+// keeps each axis cheap enough to sweep.
+func bisectShape() []int {
+	head := []int{734, 98, 65, 57, 48, 46}
+
+	sizes := append([]int(nil), head...)
+	for i := 0; i < 19; i++ {
+		sizes = append(sizes, 27)
+	}
+
+	return sizes
+}
+
+// runBisectAxis executes one axis and returns tx/s.
+func runBisectAxis(t *testing.T, label string, opts perfHarnessOptions, cfg unseenFixtureConfig) float64 {
+	t.Helper()
+
+	h, capture := newCapturingPerfHarness(t, opts)
+
+	fx := generateUnseenFixture(t, h, cfg)
+	assertUnseenPrecondition(t, h, fx)
+
+	elapsed := runUnseenBlock(t, h, capture, fx, label)
+
+	return float64(fx.txCount) / elapsed.Seconds()
+}
+
+func baseBisectConfig() unseenFixtureConfig {
+	return unseenFixtureConfig{
+		levelSizes:    bisectShape(),
+		txsPerSubtree: 1024,
+	}
+}
+
+// TestUnseenTxBisect_Baseline is the reference point every other axis is read
+// against, at the reduced bisect scale.
+func TestUnseenTxBisect_Baseline(t *testing.T) {
+	rate := runBisectAxis(t, "bisect-baseline", defaultPerfOptions(), baseBisectConfig())
+	t.Logf("AXIS baseline: %.1f tx/s", rate)
+}
+
+// TestUnseenTxBisect_BatcherTimers tests the explanation the baseline's level
+// table suggests: tail levels of 27-108 txs each cost ~45 ms regardless of width,
+// which is close to four 10 ms batcher windows (get, spend, store, setLocked —
+// settings.conf:1282, 1304, 1308). A level's transactions never fill a
+// 1024-2048-deep batch, so each store phase waits out its timer, giving a fixed
+// per-level floor that scales with level COUNT and not with transaction count.
+//
+// If that is right, dropping every batcher window to 1 ms should cut the
+// per-level floor roughly tenfold.
+func TestUnseenTxBisect_BatcherTimers(t *testing.T) {
+	opts := defaultPerfOptions()
+	opts.tune = func(s *settings.Settings) {
+		s.UtxoStore.GetBatcherDurationMillis = 1
+		s.UtxoStore.SpendBatcherDurationMillis = 1
+		s.UtxoStore.StoreBatcherDurationMillis = 1
+	}
+
+	rate := runBisectAxis(t, "bisect-batcher-1ms", opts, baseBisectConfig())
+	t.Logf("AXIS batcherTimers=1ms: %.1f tx/s", rate)
+}
+
+// TestUnseenTxBisect_FlatLevel collapses the same transaction count into a single
+// dependency level. If the per-level floor explanation holds, this should be
+// dramatically faster than the 25-level baseline at identical tx count — which
+// would also mean level depth, not block size, is what makes a block expensive.
+func TestUnseenTxBisect_FlatLevel(t *testing.T) {
+	cfg := baseBisectConfig()
+	cfg.levelSizes = []int{sumInts(bisectShape())}
+
+	rate := runBisectAxis(t, "bisect-flat-level", defaultPerfOptions(), cfg)
+	t.Logf("AXIS flatLevel: %.1f tx/s", rate)
+}
+
+// TestUnseenTxBisect_ExternalParents pushes every seeded parent past
+// MaxTxSizeInStoreInBytes (32 KB, stores/utxo/aerospike/aerospike.go:92) so
+// Aerospike stores it externally. That is the axis the baseline never exercised:
+// with small parents no external read happens at all, so the serial
+// GetTxFromExternalStore loop inside BatchDecorate
+// (stores/utxo/aerospike/get.go:697-742) was never entered.
+//
+// That loop walks batch results one at a time and fetches each external parent
+// inline, so N external parents in a level cost N sequential blob reads. Here the
+// blob store is a local file store; on a node backed by S3 each of those is a
+// network round trip, and getExternalTransaction additionally tries FileTypeTx
+// first and only falls back to FileTypeOutputs (get.go:1628-1637), so an
+// outputs-only parent pays a wasted lookup first.
+func TestUnseenTxBisect_ExternalParents(t *testing.T) {
+	cfg := baseBisectConfig()
+	cfg.parentFillerBytes = 40 * 1024
+
+	rate := runBisectAxis(t, "bisect-external-parents", defaultPerfOptions(), cfg)
+	t.Logf("AXIS externalParents: %.1f tx/s", rate)
+}
+
+// TestUnseenTxBisect_MultiInput raises the inputs per transaction. The baseline
+// gave every tx exactly one input, which is the least stressful possible setting
+// and not representative: mainnet block 959979 averages ~873 bytes/tx, implying
+// several inputs each. Every extra input is another distinct parent to resolve,
+// multiplying both the prefetchLevelParents batch and the validator's per-parent
+// work.
+func TestUnseenTxBisect_MultiInput(t *testing.T) {
+	for _, inputs := range []int{4, 16} {
+		inputs := inputs
+
+		t.Run(fmt.Sprintf("inputs%d", inputs), func(t *testing.T) {
+			cfg := baseBisectConfig()
+			cfg.inputsPerTx = inputs
+
+			rate := runBisectAxis(t, "bisect-inputs", defaultPerfOptions(), cfg)
+			t.Logf("AXIS inputsPerTx=%d: %.1f tx/s", inputs, rate)
+		})
+	}
+}
+
+// TestUnseenTxBisect_BlockAssemblyDisabled removes the per-tx block-assembly
+// insert and, with it, the Create-with-locked plus SetLocked 2PC unlock
+// (Validator.go:940-1057). This is the catchup path's cost profile. The gap
+// against baseline is what the tip path pays extra for the same transactions.
+func TestUnseenTxBisect_BlockAssemblyDisabled(t *testing.T) {
+	opts := defaultPerfOptions()
+	opts.tune = func(s *settings.Settings) {
+		s.BlockAssembly.Disabled = true
+	}
+
+	h, capture := newCapturingPerfHarness(t, opts)
+
+	fx := generateUnseenFixture(t, h, baseBisectConfig())
+	assertUnseenPrecondition(t, h, fx)
+
+	elapsed := runUnseenBlock(t, h, capture, fx, "bisect-ba-disabled")
+
+	require.Zero(t, h.blockAssembly.stores.Load(),
+		"block assembly must have received nothing on this axis")
+
+	t.Logf("AXIS blockAssemblyDisabled: %.1f tx/s", float64(fx.txCount)/elapsed.Seconds())
+}

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
@@ -183,3 +183,51 @@ func TestUnseenTxBisect_ConnectionPool(t *testing.T) {
 
 	t.Logf("RATIO default/capped = %.2fx", unlimited/capped)
 }
+
+// TestUnseenTxBisect_ConflictingTxs is the conflicting-transaction axis: the only
+// block-content marker that separated the slow mainnet blocks from fast ones (189
+// and 13 conflicting warnings in the two Class B windows, 0 in a fast window the
+// same day), and wholly unmodelled by the fixture until now.
+//
+// Each conflicting block tx double-spends an outpoint already spent by a squatter
+// that carries an unconfirmed descendant chain, so the run exercises the
+// conflicting-create path plus checkCounterConflictingOnCurrentChain and the
+// children walk.
+//
+// The subtests assert conflictingTxsSeen > 0. Without that assertion this axis could
+// silently measure nothing and report "no effect", which is precisely the false
+// negative the external-parents axis produced.
+func TestUnseenTxBisect_ConflictingTxs(t *testing.T) {
+	baseline := runBisectAxis(t, "bisect-conflict-none", defaultPerfOptions(), baseBisectConfig())
+	t.Logf("AXIS conflicts=0: %.1f tx/s", baseline)
+
+	for _, c := range []struct {
+		n, depth int
+	}{
+		{50, 0},
+		{50, 5},
+		{200, 5},
+	} {
+		c := c
+
+		t.Run(fmt.Sprintf("n%d_depth%d", c.n, c.depth), func(t *testing.T) {
+			h, capture := newCapturingPerfHarness(t, defaultPerfOptions())
+
+			cfg := baseBisectConfig()
+			cfg.conflictingTxs = c.n
+			cfg.conflictChainDepth = c.depth
+
+			fx := generateUnseenFixture(t, h, cfg)
+			assertUnseenPrecondition(t, h, fx)
+
+			elapsed := runUnseenBlock(t, h, capture, fx, fmt.Sprintf("bisect-conflict-n%d-d%d", c.n, c.depth))
+			rate := float64(fx.txCount) / elapsed.Seconds()
+
+			require.Positive(t, capture.conflictingSeen.Load(),
+				"no conflicting-tx warnings observed — the conflict path was never entered, so this axis measured nothing")
+
+			t.Logf("AXIS conflicts=%d depth=%d: %.1f tx/s (%.2fx vs baseline %.1f)",
+				c.n, c.depth, rate, rate/baseline, baseline)
+		})
+	}
+}

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_bisect_test.go
@@ -13,6 +13,7 @@ package subtreevalidation
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/stretchr/testify/require"
@@ -230,4 +231,124 @@ func TestUnseenTxBisect_ConflictingTxs(t *testing.T) {
 				c.n, c.depth, rate, rate/baseline, baseline)
 		})
 	}
+}
+
+// TestUnseenTxBisect_ConflictCone tests the mechanism described in issue #1391:
+// checkCounterConflictingOnCurrentChain's loop at SubtreeValidation.go:503-514 calls
+// utxo.GetConflictingChildren once per element of counterConflictingTxHashes — but
+// GetCounterConflictingTxHashes already put every descendant into that slice
+// (process_conflicting.go:1129, after the walk at :1119). So it re-walks the whole
+// descendant cone once per node of that same cone, with a fresh visited map each time
+// and the outer loop fully serial. That is O(N^2) single-record Gets in the cone size.
+//
+// GetConflictingChildren also recurses into SpendingDatas (:1038-1048), not just
+// ConflictingChildren, so the cone is the entire descendant spend cone rather than the
+// conflicting sub-DAG; and its per-level errgroup (:1004) has no SetLimit.
+//
+// The fixture is deliberately minimal so nothing but the cone varies: a trivial flat
+// single-level block with exactly ONE conflicting transaction, whose squatter heads a
+// linear descendant chain of conflictChainDepth. Linear is the production shape — #1391
+// found an automated self-spend chain growing ~100 txs per block.
+//
+// If #1391 is right, both elapsed time and the single-record Get count grow roughly
+// quadratically in depth. A linear growth would refute it.
+//
+// Note the earlier conflict axis (TestUnseenTxBisect_ConflictingTxs) used depth 0 and 5,
+// where N is 1 and 6 — far too small for the quadratic term to show, which is why that
+// axis saw no difference between them.
+func TestUnseenTxBisect_ConflictCone(t *testing.T) {
+	for _, depth := range []int{0, 25, 50, 100, 200} {
+		depth := depth
+
+		t.Run(fmt.Sprintf("depth%d", depth), func(t *testing.T) {
+			h, capture := newCapturingPerfHarness(t, defaultPerfOptions())
+
+			cfg := unseenFixtureConfig{
+				// Flat single level: no in-block children, so the conflict cannot cascade
+				// to other block transactions and the cone is the only variable.
+				levelSizes:         []int{20},
+				txsPerSubtree:      1024,
+				conflictingTxs:     1,
+				conflictChainDepth: depth,
+			}
+
+			fx := generateUnseenFixture(t, h, cfg)
+			assertUnseenPrecondition(t, h, fx)
+
+			getsBefore := readCounterSum("teranode_aerospike_txmeta_get")
+
+			elapsed := runUnseenBlock(t, h, capture, fx, fmt.Sprintf("bisect-cone-d%d", depth))
+
+			gets := readCounterSum("teranode_aerospike_txmeta_get") - getsBefore
+
+			require.Positive(t, capture.conflictingSeen.Load(),
+				"no conflicting-tx warning — the conflict path was never entered, so this run measured nothing")
+
+			// N is the cone size: the squatter plus its linear descendant chain.
+			n := depth + 1
+
+			t.Logf("CONE depth=%-4d N=%-4d elapsed=%-12s singleGets=%-8d gets/N^2=%.2f",
+				depth, n, elapsed.Round(time.Millisecond), gets, float64(gets)/float64(n*n))
+		})
+	}
+}
+
+// coneRegressionDepth and coneRegressionBudget define the #1391 regression bound.
+//
+// Measured on the O(N^2) code: N=101 takes ~115s and issues ~10,600 single-record Gets
+// (gets/N^2 = 1.04). Once checkCounterConflictingOnCurrentChain stops re-walking the
+// cone once per cone node, the work is O(N) — on the order of 101 sequential Gets, ~1s.
+//
+// The budget sits an order of magnitude above that expected O(N) figure and an order of
+// magnitude below the measured O(N^2) figure, so it is neither flaky nor able to pass
+// while the quadratic remains.
+const (
+	coneRegressionDepth  = 100
+	coneRegressionBudget = 15 * time.Second
+)
+
+// TestConflictConeBlessesInBoundedTime is the #1391 regression test: a conflicting
+// transaction whose counter-conflicting transaction heads a long linear descendant chain
+// must bless in time proportional to the chain, not to its square.
+//
+// FAILS on the current code by design — that is the point. It is the check that the
+// O(N^2) re-walk at SubtreeValidation.go:503-514 has actually been removed, and it must
+// be seen to fail before the fix and pass after, or it proves nothing.
+func TestConflictConeBlessesInBoundedTime(t *testing.T) {
+	h, capture := newCapturingPerfHarness(t, defaultPerfOptions())
+
+	fx := generateUnseenFixture(t, h, unseenFixtureConfig{
+		levelSizes:         []int{20},
+		txsPerSubtree:      1024,
+		conflictingTxs:     1,
+		conflictChainDepth: coneRegressionDepth,
+	})
+
+	assertUnseenPrecondition(t, h, fx)
+
+	getsBefore := readCounterSum("teranode_aerospike_txmeta_get")
+
+	elapsed := runUnseenBlock(t, h, capture, fx, "cone-regression")
+
+	gets := readCounterSum("teranode_aerospike_txmeta_get") - getsBefore
+	n := coneRegressionDepth + 1
+
+	require.Positive(t, capture.conflictingSeen.Load(),
+		"no conflicting-tx warning — the conflict path was never entered, so this test proves nothing")
+
+	t.Logf("cone N=%d elapsed=%s singleGets=%d gets/N=%.1f gets/N^2=%.2f",
+		n, elapsed.Round(time.Millisecond), gets, float64(gets)/float64(n), float64(gets)/float64(n*n))
+
+	require.Less(t, elapsed, coneRegressionBudget,
+		"blessing one conflicting tx with a %d-node descendant cone took %s (budget %s). "+
+			"checkCounterConflictingOnCurrentChain re-walks the whole cone once per cone node "+
+			"(SubtreeValidation.go:503-514 over the set GetCounterConflictingTxHashes already "+
+			"populated), which is O(N^2) single-record Gets — see issue #1391",
+		n, elapsed.Round(time.Millisecond), coneRegressionBudget)
+
+	// Independent of wall time, pin the shape: O(N) work, not O(N^2). Guards against the
+	// budget being met on faster hardware while the quadratic is still there.
+	require.Less(t, gets, uint64(10*n),
+		"issued %d single-record Gets for a %d-node cone (%.1f per node) — expected O(N), so the cone is still being re-walked per node",
+		gets, n, float64(gets)/float64(n))
 }

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
@@ -76,6 +76,25 @@ type unseenFixtureConfig struct {
 	// silently measures the cheap path.
 	extendedInSubtreeData bool
 
+	// conflictingTxs is how many level-0 block transactions are genuine
+	// double-spends: before the block tx is built, a different "squatter" tx is
+	// created in the store and already spends the same outpoint. The block tx's
+	// spend then fails with ErrSpent, and because processTransactionsInLevels sets
+	// WithCreateConflicting(true) the validator takes the conflicting-create path
+	// and blessMissingTransaction follows up with
+	// checkCounterConflictingOnCurrentChain (SubtreeValidation.go:447-451).
+	//
+	// This is the only block-content marker that separated the slow mainnet blocks
+	// from fast ones (189 and 13 conflicting warnings vs 0), and it was entirely
+	// absent from the fixture.
+	conflictingTxs int
+
+	// conflictChainDepth is how many unconfirmed descendants each squatter has.
+	// The squatter's chain is what GetConflictingChildren walks and what
+	// MarkConflictingRecursively would BFS over, so this is the cost knob that
+	// scales with descendant depth rather than with block size.
+	conflictChainDepth int
+
 	// txsPerSubtree splits the block across subtrees. The default TxBatchSize is
 	// 1048576 (settings/settings.go:616), so for fixtures of this size all
 	// subtrees land in a single batch — same as mainnet.
@@ -235,6 +254,15 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 				return err
 			}
 
+			// Make this tx a double-spend: plant a different tx that already spends
+			// the same outpoint, plus its unconfirmed descendant chain.
+			if i < cfg.conflictingTxs {
+				if err = seedConflictingSquatter(seedCtx, h, primary, lockingScript,
+					unlockerGetter, cfg.conflictChainDepth); err != nil {
+					return err
+				}
+			}
+
 			extras, err := seedExtraParents(seedCtx, seedParent, inputsPerTx-1)
 			if err != nil {
 				return err
@@ -353,6 +381,81 @@ func buildSeededParent(idx int, lockingScript *bscript.Script, ug *unlocker.Gett
 	}
 
 	return tx, nil
+}
+
+// seedConflictingSquatter creates a transaction that already spends parent's
+// output 0 and records that spend in the store, so a later block transaction
+// spending the same outpoint conflicts.
+//
+// The squatter is given TWO outputs while the block transaction has one, so the two
+// differ and therefore have different txids while spending the identical outpoint —
+// without that they would be the same transaction and there would be no conflict at
+// all.
+//
+// The squatter and its descendants are created WITHOUT mined info, i.e. unconfirmed.
+// That matters: checkCounterConflictingOnCurrentChain only rejects the block
+// transaction when a counter-conflicting tx is mined on the current chain
+// (process_conflicting.go, BlockIDs check), so leaving them unconfirmed keeps the
+// block valid and exercises the conflict-handling cost rather than a rejection.
+func seedConflictingSquatter(ctx context.Context, h *perfHarness, parent *bt.Tx,
+	lockingScript *bscript.Script, ug *unlocker.Getter, chainDepth int) error {
+	half := parent.Outputs[0].Satoshis / 2
+
+	squatter := bt.NewTx()
+
+	if err := squatter.FromUTXOs(&bt.UTXO{
+		TxIDHash:      parent.TxIDChainHash(),
+		Vout:          0,
+		LockingScript: parent.Outputs[0].LockingScript,
+		Satoshis:      parent.Outputs[0].Satoshis,
+	}); err != nil {
+		return err
+	}
+
+	// Two outputs — this is what makes the squatter a different tx from the block's
+	// spend of the same outpoint.
+	if err := squatter.AddP2PKHOutputFromScript(lockingScript, half); err != nil {
+		return err
+	}
+
+	if err := squatter.AddP2PKHOutputFromScript(lockingScript, parent.Outputs[0].Satoshis-half); err != nil {
+		return err
+	}
+
+	if err := squatter.FillAllInputs(context.Background(), ug); err != nil {
+		return err
+	}
+
+	// Unconfirmed in the store, and holding the spend on parent:0.
+	if _, err := h.utxoStore.Create(ctx, squatter, h.blockHeight-1); err != nil {
+		return err
+	}
+
+	if _, err := h.utxoStore.Spend(ctx, squatter, h.blockHeight-1); err != nil {
+		return err
+	}
+
+	// Unconfirmed descendant chain, so the conflict has children to walk.
+	current := squatter
+
+	for d := 0; d < chainDepth; d++ {
+		child, err := spendOutputs([]*bt.Tx{current}, lockingScript, ug)
+		if err != nil {
+			return err
+		}
+
+		if _, err = h.utxoStore.Create(ctx, child, h.blockHeight-1); err != nil {
+			return err
+		}
+
+		if _, err = h.utxoStore.Spend(ctx, child, h.blockHeight-1); err != nil {
+			return err
+		}
+
+		current = child
+	}
+
+	return nil
 }
 
 // seedExtraParents seeds n additional mined parents for a tx's non-primary

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
@@ -1,0 +1,399 @@
+//go:build aerospike
+
+// Fixture generator for the issue #1379 reproduction harness. Builds a block of
+// transactions that the node has never seen, over parents that are already in
+// the UTXO store as mined.
+//
+// The generator gives exact control over the in-block dependency level
+// histogram, which the chain generator in check_block_subtrees_large_test.go
+// cannot: that one builds long chains per worker, so its max dependency depth
+// equals its chain length. The measured mainnet shape is the opposite — one wide
+// level plus a long thin tail — and level count is one of the bisect axes, so it
+// has to be a parameter rather than a side effect.
+package subtreevalidation
+
+import (
+	"context"
+	"encoding/binary"
+	"runtime"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/unlocker"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// seedSatoshis funds every chain. Outputs carry the full input value (zero fee),
+// matching the existing generator in check_block_subtrees_large_test.go:566 —
+// processTransactionsInLevels sets WithSkipPolicyChecks(true), so no min-fee
+// policy applies and a zero fee keeps the satoshi arithmetic constant down a
+// 25-level chain.
+const seedSatoshis = uint64(100_000)
+
+// unseenFixtureConfig parameterises the fixture. Each field is a bisect axis
+// from plans/1379-unseen-tx-throughput-design.md.
+type unseenFixtureConfig struct {
+	// levelSizes[k] is the number of txs whose deepest in-block ancestor chain is
+	// k long. levelSizes[0] txs spend seeded (already-stored, mined) parents;
+	// levelSizes[k] txs spend an output of a level k-1 tx.
+	levelSizes []int
+
+	// parentFillerBytes adds an OP_RETURN of this size to each seeded parent. Set
+	// above ~32 KB to push the parent past MaxTxSizeInStoreInBytes
+	// (stores/utxo/aerospike/aerospike.go:92) so it is stored externally, which is
+	// what exercises the serial GetTxFromExternalStore loop in BatchDecorate
+	// (stores/utxo/aerospike/get.go:697-742).
+	parentFillerBytes int
+
+	// txsPerSubtree splits the block across subtrees. The default TxBatchSize is
+	// 1048576 (settings/settings.go:616), so for fixtures of this size all
+	// subtrees land in a single batch — same as mainnet.
+	txsPerSubtree int
+}
+
+// mainnet959979Shape is the measured dependency-level histogram of mainnet block
+// 959979, the smaller of the two slow blocks in issue #1379: 6,258 txs across 25
+// levels, 3,323 of them with an in-block parent.
+//
+// Levels 0-5 (2936, 394, 262, 228, 194, 186) are measured values from the issue.
+// The 19-level tail is SYNTHESISED to make the total come to 6,258 — the issue
+// reports only the head of the histogram plus a median of 119 txs/level. The
+// synthesised tail is flat, which puts the histogram median at 108 rather than
+// the reported 119. That is a known, deliberate approximation: level *width*
+// below ~2048 does not change the per-level concurrency (the cap is
+// SpendBatcherSize*2 = 2048, check_block_subtrees.go:1156), so a flat tail and a
+// jittered one exercise the same code path.
+func mainnet959979Shape() []int {
+	head := []int{2936, 394, 262, 228, 194, 186}
+
+	const total = 6258
+	const tailLevels = 19
+
+	used := 0
+	for _, n := range head {
+		used += n
+	}
+
+	remaining := total - used
+	sizes := append([]int(nil), head...)
+
+	base := remaining / tailLevels
+	extra := remaining % tailLevels
+
+	for i := 0; i < tailLevels; i++ {
+		n := base
+		if i < extra {
+			n++
+		}
+
+		sizes = append(sizes, n)
+	}
+
+	return sizes
+}
+
+// unseenFixture is the generated block plus the facts a test needs to assert the
+// fixture is actually what it claims to be.
+type unseenFixture struct {
+	blockBytes    []byte
+	subtreeHashes []*chainhash.Hash
+	txs           []*bt.Tx
+	txCount       int
+	seededParents int
+}
+
+// generateUnseenFixture builds the fixture and seeds ONLY the parents into the
+// UTXO store.
+//
+// The seeded parents are created with mined block info so their BlockHeights is
+// non-empty — the state a parent confirmed in an earlier block is in. Without
+// that, the validator stamps the unconfirmedParentHeight sentinel and the run
+// exercises the legacy unconfirmed-parent path instead of the steady-state one.
+//
+// The block's own transactions are never written to the store or the txMeta
+// cache. That is the unseen precondition the whole reproduction depends on, and
+// TestUnseenTxThroughput asserts it held rather than trusting this function.
+func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig) *unseenFixture {
+	t.Helper()
+
+	require.NotEmpty(t, cfg.levelSizes, "levelSizes must describe at least one level")
+
+	// A level cannot be wider than its parent level: each tx spends a distinct
+	// output of a distinct parent-level tx, so a wider child level would have to
+	// double-spend. Those would be admitted as conflicting rather than failing
+	// loudly, silently changing what is being measured — so reject the shape here.
+	for k := 1; k < len(cfg.levelSizes); k++ {
+		require.LessOrEqual(t, cfg.levelSizes[k], cfg.levelSizes[k-1],
+			"level %d (%d txs) is wider than level %d (%d txs); each tx needs a distinct parent-level output, so this shape would double-spend",
+			k, cfg.levelSizes[k], k-1, cfg.levelSizes[k-1])
+	}
+
+	ctx := context.Background()
+
+	privKey, err := bec.NewPrivateKey()
+	require.NoError(t, err)
+
+	lockingScript, err := bscript.NewP2PKHFromPubKeyBytes(privKey.PubKey().Compressed())
+	require.NoError(t, err)
+
+	unlockerGetter := &unlocker.Getter{PrivateKey: privKey}
+
+	// Level 0: one distinct seeded parent per tx. One parent per tx rather than a
+	// few fan-out parents is the faithful choice — on mainnet these txs spend
+	// thousands of distinct earlier outputs, and prefetchLevelParents dedups
+	// distinct parents per level, so funding a whole level from a handful of
+	// parents would collapse exactly the fan-out the prefetch axis is testing.
+	levelTxs := make([][]*bt.Tx, len(cfg.levelSizes))
+	allTxs := make([]*bt.Tx, 0, sumInts(cfg.levelSizes))
+
+	// Level 0 is built and seeded in parallel. Sequentially it is the dominant
+	// setup cost: every Create waits out the store batcher's 10 ms timer
+	// (utxostore_storeBatcherDurationMillis, settings.conf:1308) because a lone
+	// Create never fills the 2048-deep batch, so 2,936 parents would cost ~30 s of
+	// setup. This is fixture construction, outside the measured window, but there
+	// is no reason to pay it.
+	levelTxs[0] = make([]*bt.Tx, cfg.levelSizes[0])
+
+	seedGroup, seedCtx := errgroup.WithContext(ctx)
+	seedGroup.SetLimit(runtime.NumCPU() * 4)
+
+	for i := 0; i < cfg.levelSizes[0]; i++ {
+		i := i
+
+		seedGroup.Go(func() error {
+			parentTx, buildErr := buildSeededParent(i, lockingScript, unlockerGetter, cfg.parentFillerBytes)
+			if buildErr != nil {
+				return buildErr
+			}
+
+			// Mined info makes BlockHeights non-empty: a parent confirmed in an earlier
+			// block, which is the steady-state case. Block ID 1 is inside the set
+			// perfBlockchainClient.GetBlockHeaderIDs reports, so
+			// blessMissingTransaction's already-mined-on-our-chain check
+			// (SubtreeValidation.go:439) sees a consistent view.
+			if _, createErr := h.utxoStore.Create(seedCtx, parentTx, h.blockHeight-1,
+				utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+					BlockID:        1,
+					BlockHeight:    h.blockHeight - 1,
+					SubtreeIdx:     0,
+					OnLongestChain: true,
+				})); createErr != nil {
+				return createErr
+			}
+
+			tx, spendErr := spendOutput(parentTx, 0, lockingScript, unlockerGetter)
+			if spendErr != nil {
+				return spendErr
+			}
+
+			levelTxs[0][i] = tx
+
+			return nil
+		})
+	}
+
+	require.NoError(t, seedGroup.Wait(), "failed to build and seed level 0")
+
+	allTxs = append(allTxs, levelTxs[0]...)
+
+	// Levels are sequential relative to each other (level k spends level k-1's
+	// outputs) but the txs within a level are independent, so signing fans out.
+	for k := 1; k < len(cfg.levelSizes); k++ {
+		levelTxs[k] = make([]*bt.Tx, cfg.levelSizes[k])
+
+		levelGroup := new(errgroup.Group)
+		levelGroup.SetLimit(runtime.NumCPU() * 4)
+
+		for i := 0; i < cfg.levelSizes[k]; i++ {
+			i, k := i, k
+
+			levelGroup.Go(func() error {
+				// Index i into the parent level, not i modulo its width: the width check
+				// above guarantees i is in range, and a modulo would silently produce
+				// double spends the moment that invariant broke.
+				tx, spendErr := spendOutput(levelTxs[k-1][i], 0, lockingScript, unlockerGetter)
+				if spendErr != nil {
+					return spendErr
+				}
+
+				levelTxs[k][i] = tx
+
+				return nil
+			})
+		}
+
+		require.NoError(t, levelGroup.Wait(), "failed to build level %d", k)
+
+		allTxs = append(allTxs, levelTxs[k]...)
+	}
+
+	seeded := cfg.levelSizes[0]
+
+	// allTxs is in level order, which is a topological order — the same order a
+	// miner would have to place them in for the block to be valid.
+	blockBytes, subtreeHashes := buildUnseenBlockFromTxs(t, h, allTxs, cfg.txsPerSubtree)
+
+	return &unseenFixture{
+		blockBytes:    blockBytes,
+		subtreeHashes: subtreeHashes,
+		txs:           allTxs,
+		txCount:       len(allTxs),
+		seededParents: seeded,
+	}
+}
+
+// buildSeededParent constructs a parent transaction to pre-store. Its own input
+// points at a synthetic outpoint that does not exist: nothing ever validates
+// this tx (it is written straight to the store, not through the validator), and
+// its grandparent is never consulted because the parent resolves with
+// BlockHeights set. The input is still built through FromUTXOs so the tx is
+// extended, which utxoStore.Create requires in order to compute fees.
+//
+// Returns an error rather than calling require: it runs on errgroup worker
+// goroutines, and testify's FailNow is only safe on the test goroutine.
+func buildSeededParent(idx int, lockingScript *bscript.Script, ug *unlocker.Getter, fillerBytes int) (*bt.Tx, error) {
+	var fakePrevTxID chainhash.Hash
+
+	binary.LittleEndian.PutUint64(fakePrevTxID[:8], uint64(idx)+1)
+	// Tag the high bytes so a synthetic outpoint can never collide with a real
+	// generated txid if this fixture is ever mixed with real fixtures.
+	copy(fakePrevTxID[24:], []byte("1379seed"))
+
+	tx := bt.NewTx()
+
+	if err := tx.FromUTXOs(&bt.UTXO{
+		TxIDHash:      &fakePrevTxID,
+		Vout:          0,
+		LockingScript: lockingScript,
+		Satoshis:      seedSatoshis,
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := tx.AddP2PKHOutputFromScript(lockingScript, seedSatoshis); err != nil {
+		return nil, err
+	}
+
+	if fillerBytes > 0 {
+		// Pushes extendedTxSize past MaxTxSizeInStoreInBytes so Aerospike stores
+		// this parent externally. Unspendable, and never spent — only output 0 is.
+		if err := tx.AddOpReturnOutput(make([]byte, fillerBytes)); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.FillAllInputs(context.Background(), ug); err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+// spendOutput builds a tx spending one output of parent, signed for real so
+// GoBDK script verification does genuine work. Zero fee: the output carries the
+// full input value.
+//
+// Returns an error rather than calling require, for the same goroutine-safety
+// reason as buildSeededParent.
+func spendOutput(parent *bt.Tx, vout uint32, lockingScript *bscript.Script, ug *unlocker.Getter) (*bt.Tx, error) {
+	tx := bt.NewTx()
+
+	if err := tx.FromUTXOs(&bt.UTXO{
+		TxIDHash:      parent.TxIDChainHash(),
+		Vout:          vout,
+		LockingScript: parent.Outputs[vout].LockingScript,
+		Satoshis:      parent.Outputs[vout].Satoshis,
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := tx.AddP2PKHOutputFromScript(lockingScript, parent.Outputs[vout].Satoshis); err != nil {
+		return nil, err
+	}
+
+	if err := tx.FillAllInputs(context.Background(), ug); err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+// buildUnseenBlockFromTxs writes txs into subtrees as legacy files and returns
+// the serialized block referencing them.
+//
+// Subtrees are written as FileTypeSubtreeToCheck and FileTypeSubtreeData but
+// deliberately NOT as FileTypeSubtree: CheckBlockSubtrees early-returns Blessed
+// for subtrees that already exist under that type
+// (check_block_subtrees.go:438-465), which would skip everything being measured.
+func buildUnseenBlockFromTxs(t *testing.T, h *perfHarness, txs []*bt.Tx, txsPerSubtree int) ([]byte, []*chainhash.Hash) {
+	t.Helper()
+
+	require.Positive(t, txsPerSubtree, "txsPerSubtree must be positive")
+
+	ctx := context.Background()
+	subtreeHashes := make([]*chainhash.Hash, 0, (len(txs)/txsPerSubtree)+1)
+
+	for start := 0; start < len(txs); start += txsPerSubtree {
+		end := subtreepkg.Min(start+txsPerSubtree, len(txs))
+		chunk := txs[start:end]
+
+		subtree, err := subtreepkg.NewTreeByLeafCount(subtreepkg.CeilPowerOfTwo(len(chunk)))
+		require.NoError(t, err)
+
+		subtreeData := subtreepkg.NewSubtreeData(subtree)
+
+		for idx, tx := range chunk {
+			require.NoError(t, subtree.AddNode(*tx.TxIDChainHash(), 1, 0))
+			require.NoError(t, subtreeData.AddTx(tx, idx))
+		}
+
+		subtreeBytes, err := subtree.Serialize()
+		require.NoError(t, err)
+
+		subtreeDataBytes, err := subtreeData.Serialize()
+		require.NoError(t, err)
+
+		root := subtree.RootHash()
+
+		require.NoError(t, h.subtreeStore.Set(ctx, root[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes))
+		require.NoError(t, h.subtreeStore.Set(ctx, root[:], fileformat.FileTypeSubtreeData, subtreeDataBytes))
+
+		subtreeHashes = append(subtreeHashes, root)
+	}
+
+	header := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      1,
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}
+
+	coinbaseTx := &bt.Tx{Version: 1}
+
+	block, err := model.NewBlock(header, coinbaseTx, subtreeHashes, uint64(len(txs)+1), 0, h.blockHeight, 0)
+	require.NoError(t, err)
+
+	blockBytes, err := block.Bytes()
+	require.NoError(t, err)
+
+	return blockBytes, subtreeHashes
+}
+
+func sumInts(xs []int) int {
+	total := 0
+	for _, x := range xs {
+		total += x
+	}
+
+	return total
+}

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/binary"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -52,6 +53,14 @@ type unseenFixtureConfig struct {
 	// what exercises the serial GetTxFromExternalStore loop in BatchDecorate
 	// (stores/utxo/aerospike/get.go:697-742).
 	parentFillerBytes int
+
+	// inputsPerTx is how many outputs each generated tx spends. Input 0 always
+	// comes from the tx's 1:1 parent-level transaction, which is what fixes the
+	// level histogram; any additional inputs come from extra freshly-seeded mined
+	// parents. So raising this multiplies the distinct-parent fan-out per level —
+	// the work prefetchLevelParents does and the per-parent reads the validator
+	// makes — without perturbing the level shape. Defaults to 1.
+	inputsPerTx int
 
 	// txsPerSubtree splits the block across subtrees. The default TxBatchSize is
 	// 1048576 (settings/settings.go:616), so for fixtures of this size all
@@ -151,15 +160,53 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 	// thousands of distinct earlier outputs, and prefetchLevelParents dedups
 	// distinct parents per level, so funding a whole level from a handful of
 	// parents would collapse exactly the fan-out the prefetch axis is testing.
+	inputsPerTx := cfg.inputsPerTx
+	if inputsPerTx < 1 {
+		inputsPerTx = 1
+	}
+
 	levelTxs := make([][]*bt.Tx, len(cfg.levelSizes))
 	allTxs := make([]*bt.Tx, 0, sumInts(cfg.levelSizes))
+
+	// parentIdx hands out unique synthetic outpoints across all goroutines so no
+	// two seeded parents can collide (a collision would be a double spend admitted
+	// as conflicting, silently changing what is measured).
+	var parentIdx atomic.Int64
+
+	// seedParent builds a mined parent and writes it to the store, returning it for
+	// a child to spend.
+	seedParent := func(ctx context.Context) (*bt.Tx, error) {
+		idx := int(parentIdx.Add(1))
+
+		parentTx, err := buildSeededParent(idx, lockingScript, unlockerGetter, cfg.parentFillerBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		// Mined info makes BlockHeights non-empty: a parent confirmed in an earlier
+		// block, the steady-state case. Block ID 1 is inside the set
+		// perfBlockchainClient.GetBlockHeaderIDs reports, so
+		// blessMissingTransaction's already-mined-on-our-chain check
+		// (SubtreeValidation.go:439) sees a consistent view.
+		if _, err = h.utxoStore.Create(ctx, parentTx, h.blockHeight-1,
+			utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
+				BlockID:        1,
+				BlockHeight:    h.blockHeight - 1,
+				SubtreeIdx:     0,
+				OnLongestChain: true,
+			})); err != nil {
+			return nil, err
+		}
+
+		return parentTx, nil
+	}
 
 	// Level 0 is built and seeded in parallel. Sequentially it is the dominant
 	// setup cost: every Create waits out the store batcher's 10 ms timer
 	// (utxostore_storeBatcherDurationMillis, settings.conf:1308) because a lone
-	// Create never fills the 2048-deep batch, so 2,936 parents would cost ~30 s of
-	// setup. This is fixture construction, outside the measured window, but there
-	// is no reason to pay it.
+	// Create never fills the 2048-deep batch, so thousands of parents would cost
+	// tens of seconds. This is fixture construction, outside the measured window,
+	// but there is no reason to pay it.
 	levelTxs[0] = make([]*bt.Tx, cfg.levelSizes[0])
 
 	seedGroup, seedCtx := errgroup.WithContext(ctx)
@@ -169,29 +216,19 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 		i := i
 
 		seedGroup.Go(func() error {
-			parentTx, buildErr := buildSeededParent(i, lockingScript, unlockerGetter, cfg.parentFillerBytes)
-			if buildErr != nil {
-				return buildErr
+			primary, err := seedParent(seedCtx)
+			if err != nil {
+				return err
 			}
 
-			// Mined info makes BlockHeights non-empty: a parent confirmed in an earlier
-			// block, which is the steady-state case. Block ID 1 is inside the set
-			// perfBlockchainClient.GetBlockHeaderIDs reports, so
-			// blessMissingTransaction's already-mined-on-our-chain check
-			// (SubtreeValidation.go:439) sees a consistent view.
-			if _, createErr := h.utxoStore.Create(seedCtx, parentTx, h.blockHeight-1,
-				utxo.WithMinedBlockInfo(utxo.MinedBlockInfo{
-					BlockID:        1,
-					BlockHeight:    h.blockHeight - 1,
-					SubtreeIdx:     0,
-					OnLongestChain: true,
-				})); createErr != nil {
-				return createErr
+			extras, err := seedExtraParents(seedCtx, seedParent, inputsPerTx-1)
+			if err != nil {
+				return err
 			}
 
-			tx, spendErr := spendOutput(parentTx, 0, lockingScript, unlockerGetter)
-			if spendErr != nil {
-				return spendErr
+			tx, err := spendOutputs(append([]*bt.Tx{primary}, extras...), lockingScript, unlockerGetter)
+			if err != nil {
+				return err
 			}
 
 			levelTxs[0][i] = tx
@@ -209,7 +246,7 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 	for k := 1; k < len(cfg.levelSizes); k++ {
 		levelTxs[k] = make([]*bt.Tx, cfg.levelSizes[k])
 
-		levelGroup := new(errgroup.Group)
+		levelGroup, levelCtx := errgroup.WithContext(ctx)
 		levelGroup.SetLimit(runtime.NumCPU() * 4)
 
 		for i := 0; i < cfg.levelSizes[k]; i++ {
@@ -219,9 +256,16 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 				// Index i into the parent level, not i modulo its width: the width check
 				// above guarantees i is in range, and a modulo would silently produce
 				// double spends the moment that invariant broke.
-				tx, spendErr := spendOutput(levelTxs[k-1][i], 0, lockingScript, unlockerGetter)
-				if spendErr != nil {
-					return spendErr
+				primary := levelTxs[k-1][i]
+
+				extras, err := seedExtraParents(levelCtx, seedParent, inputsPerTx-1)
+				if err != nil {
+					return err
+				}
+
+				tx, err := spendOutputs(append([]*bt.Tx{primary}, extras...), lockingScript, unlockerGetter)
+				if err != nil {
+					return err
 				}
 
 				levelTxs[k][i] = tx
@@ -235,7 +279,7 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 		allTxs = append(allTxs, levelTxs[k]...)
 	}
 
-	seeded := cfg.levelSizes[0]
+	seeded := int(parentIdx.Load())
 
 	// allTxs is in level order, which is a topological order — the same order a
 	// miner would have to place them in for the block to be valid.
@@ -297,25 +341,52 @@ func buildSeededParent(idx int, lockingScript *bscript.Script, ug *unlocker.Gett
 	return tx, nil
 }
 
-// spendOutput builds a tx spending one output of parent, signed for real so
-// GoBDK script verification does genuine work. Zero fee: the output carries the
-// full input value.
+// seedExtraParents seeds n additional mined parents for a tx's non-primary
+// inputs.
+func seedExtraParents(ctx context.Context, seed func(context.Context) (*bt.Tx, error), n int) ([]*bt.Tx, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+
+	out := make([]*bt.Tx, 0, n)
+
+	for i := 0; i < n; i++ {
+		parent, err := seed(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, parent)
+	}
+
+	return out, nil
+}
+
+// spendOutputs builds a tx spending output 0 of every given parent, signed for
+// real so GoBDK script verification does genuine work. Zero fee: the single
+// output carries the summed input value.
 //
 // Returns an error rather than calling require, for the same goroutine-safety
 // reason as buildSeededParent.
-func spendOutput(parent *bt.Tx, vout uint32, lockingScript *bscript.Script, ug *unlocker.Getter) (*bt.Tx, error) {
+func spendOutputs(parents []*bt.Tx, lockingScript *bscript.Script, ug *unlocker.Getter) (*bt.Tx, error) {
 	tx := bt.NewTx()
 
-	if err := tx.FromUTXOs(&bt.UTXO{
-		TxIDHash:      parent.TxIDChainHash(),
-		Vout:          vout,
-		LockingScript: parent.Outputs[vout].LockingScript,
-		Satoshis:      parent.Outputs[vout].Satoshis,
-	}); err != nil {
-		return nil, err
+	total := uint64(0)
+
+	for _, parent := range parents {
+		if err := tx.FromUTXOs(&bt.UTXO{
+			TxIDHash:      parent.TxIDChainHash(),
+			Vout:          0,
+			LockingScript: parent.Outputs[0].LockingScript,
+			Satoshis:      parent.Outputs[0].Satoshis,
+		}); err != nil {
+			return nil, err
+		}
+
+		total += parent.Outputs[0].Satoshis
 	}
 
-	if err := tx.AddP2PKHOutputFromScript(lockingScript, parent.Outputs[vout].Satoshis); err != nil {
+	if err := tx.AddP2PKHOutputFromScript(lockingScript, total); err != nil {
 		return nil, err
 	}
 

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_fixture_test.go
@@ -62,6 +62,20 @@ type unseenFixtureConfig struct {
 	// makes — without perturbing the level shape. Defaults to 1.
 	inputsPerTx int
 
+	// extendedInSubtreeData controls the serialization form of the txs written
+	// into FileTypeSubtreeData. Default (false) writes NON-extended txs, which is
+	// what the legacy path actually carries: a block from an SV node contains raw
+	// transactions with no parent satoshis or scripts.
+	//
+	// This is not cosmetic, it selects an entirely different code path. An extended
+	// tx makes prefetchLevelParents skip fields.Tx (check_block_subtrees.go:1293
+	// only sets needTx when some tx is NOT extended), which makes
+	// needsFullExternalTx false in BatchDecorate (get.go:722-742), which means
+	// externally-stored parents are never fetched at all — and the validator
+	// likewise skips its parent read (Validator.go:765). Writing extended txs here
+	// silently measures the cheap path.
+	extendedInSubtreeData bool
+
 	// txsPerSubtree splits the block across subtrees. The default TxBatchSize is
 	// 1048576 (settings/settings.go:616), so for fixtures of this size all
 	// subtrees land in a single batch — same as mainnet.
@@ -283,7 +297,7 @@ func generateUnseenFixture(t *testing.T, h *perfHarness, cfg unseenFixtureConfig
 
 	// allTxs is in level order, which is a topological order — the same order a
 	// miner would have to place them in for the block to be valid.
-	blockBytes, subtreeHashes := buildUnseenBlockFromTxs(t, h, allTxs, cfg.txsPerSubtree)
+	blockBytes, subtreeHashes := buildUnseenBlockFromTxs(t, h, allTxs, cfg.txsPerSubtree, cfg.extendedInSubtreeData)
 
 	return &unseenFixture{
 		blockBytes:    blockBytes,
@@ -404,7 +418,7 @@ func spendOutputs(parents []*bt.Tx, lockingScript *bscript.Script, ug *unlocker.
 // deliberately NOT as FileTypeSubtree: CheckBlockSubtrees early-returns Blessed
 // for subtrees that already exist under that type
 // (check_block_subtrees.go:438-465), which would skip everything being measured.
-func buildUnseenBlockFromTxs(t *testing.T, h *perfHarness, txs []*bt.Tx, txsPerSubtree int) ([]byte, []*chainhash.Hash) {
+func buildUnseenBlockFromTxs(t *testing.T, h *perfHarness, txs []*bt.Tx, txsPerSubtree int, extendedInSubtreeData bool) ([]byte, []*chainhash.Hash) {
 	t.Helper()
 
 	require.Positive(t, txsPerSubtree, "txsPerSubtree must be positive")
@@ -423,7 +437,22 @@ func buildUnseenBlockFromTxs(t *testing.T, h *perfHarness, txs []*bt.Tx, txsPerS
 
 		for idx, tx := range chunk {
 			require.NoError(t, subtree.AddNode(*tx.TxIDChainHash(), 1, 0))
-			require.NoError(t, subtreeData.AddTx(tx, idx))
+
+			stored := tx
+
+			if !extendedInSubtreeData {
+				// Round-trip through standard serialization to drop the extended
+				// fields. SerializeBytes emits extended form whenever IsExtended is
+				// true, and the re-parsed tx carries no PreviousTxScript so it cannot
+				// be. The txid is unchanged, so AddTx's hash check still passes.
+				plain, err := bt.NewTxFromBytes(tx.Bytes())
+				require.NoError(t, err)
+				require.False(t, plain.IsExtended(), "tx written to subtree data must not be extended")
+
+				stored = plain
+			}
+
+			require.NoError(t, subtreeData.AddTx(stored, idx))
 		}
 
 		subtreeBytes, err := subtree.Serialize()

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime/pprof"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -49,6 +50,36 @@ type levelCaptureLogger struct {
 	mu       sync.Mutex
 	events   []levelEvent
 	preCheck []string
+
+	// External-store fetch accounting, lifted from the BatchDecorate Infof at
+	// stores/utxo/aerospike/get.go:949. ulogger.TestLogger.Infof is a no-op, so
+	// without this override that log is silently discarded and an absence of
+	// external fetches is indistinguishable from an absence of logging.
+	batchDecorateCalls atomic.Uint64
+	batchDecorateItems atomic.Uint64
+	externalFetched    atomic.Uint64
+	externalSkipped    atomic.Uint64
+}
+
+// Infof captures the BatchDecorate external-fetch counters. The counts arrive as
+// int args, so no string parsing is needed.
+func (l *levelCaptureLogger) Infof(format string, args ...interface{}) {
+	if !strings.HasPrefix(format, "[BatchDecorate] Processed") || len(args) < 3 {
+		return
+	}
+
+	items, ok1 := args[0].(int)
+	fetched, ok2 := args[1].(int)
+	skipped, ok3 := args[2].(int)
+
+	if !ok1 || !ok2 || !ok3 {
+		return
+	}
+
+	l.batchDecorateCalls.Add(1)
+	l.batchDecorateItems.Add(uint64(items))
+	l.externalFetched.Add(uint64(fetched))
+	l.externalSkipped.Add(uint64(skipped))
 }
 
 func (l *levelCaptureLogger) Debugf(format string, args ...interface{}) {
@@ -229,6 +260,9 @@ func runUnseenBlock(t *testing.T, h *perfHarness, capture *levelCaptureLogger, f
 	t.Logf("txs=%d seededParents=%d subtrees=%d", fx.txCount, fx.seededParents, len(fx.subtreeHashes))
 	t.Logf("elapsed=%s throughput=%.1f tx/s", elapsed.Round(time.Millisecond), txPerSec)
 	t.Logf("blockAssemblyStores=%d txMetaPublished=%d", h.blockAssembly.stores.Load(), h.txMetaPublished.Load())
+	t.Logf("batchDecorate: calls=%d items=%d externalFetched=%d externalSkipped=%d",
+		capture.batchDecorateCalls.Load(), capture.batchDecorateItems.Load(),
+		capture.externalFetched.Load(), capture.externalSkipped.Load())
 	t.Logf("profiles written to %s", dir)
 
 	for _, line := range capture.preCheck {

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -23,6 +24,7 @@ import (
 	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -205,6 +207,74 @@ func assertUnseenPrecondition(t *testing.T, h *perfHarness, fx *unseenFixture) {
 		"seeded parent must be mined — empty BlockHeights sends the validator down the unconfirmed-parent path instead of steady state")
 }
 
+// dumpStoreOpCounts reports Aerospike and validator operation counts from the
+// in-process Prometheus registry.
+//
+// This is the instrument the profiles could not provide. The CPU profile shows the
+// conflict run is only ~6% busy, and the block profile turned out to be dominated by
+// idle batcher worker pools parked on empty channels (the same ~78x-wall ratio
+// appears in a 0.89s baseline run, so it measures parking, not contention). What
+// remains unanswered is how many store round trips each run makes and of which kind —
+// which these counters answer directly.
+func dumpStoreOpCounts(t *testing.T, label string) {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Logf("could not gather metrics: %v", err)
+		return
+	}
+
+	type row struct {
+		name  string
+		count uint64
+		sum   float64
+	}
+
+	rows := make([]row, 0, 32)
+
+	for _, fam := range families {
+		n := fam.GetName()
+		if !strings.Contains(n, "aerospike") && !strings.Contains(n, "validator_transactions") &&
+			!strings.Contains(n, "subtreevalidation_bless") {
+			continue
+		}
+
+		var c uint64
+		var sum float64
+
+		for _, m := range fam.GetMetric() {
+			if h := m.GetHistogram(); h != nil {
+				c += h.GetSampleCount()
+				sum += h.GetSampleSum()
+			} else if cnt := m.GetCounter(); cnt != nil {
+				c += uint64(cnt.GetValue())
+			}
+		}
+
+		if c > 0 {
+			rows = append(rows, row{n, c, sum})
+		}
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].count > rows[j].count })
+
+	t.Logf("--- store op counts [%s] ---", label)
+
+	for i, r := range rows {
+		if i >= 14 {
+			break
+		}
+
+		mean := 0.0
+		if r.count > 0 {
+			mean = r.sum / float64(r.count) * 1000
+		}
+
+		t.Logf("  %-58s n=%-8d mean=%.2fms", strings.TrimPrefix(r.name, "teranode_"), r.count, mean)
+	}
+}
+
 // profileDir resolves where profiles are written. TERANODE_PERF_PROFILE_DIR keeps
 // them after the test process exits; otherwise they land in the test temp dir and
 // the path is logged.
@@ -267,6 +337,8 @@ func runUnseenBlock(t *testing.T, h *perfHarness, capture *levelCaptureLogger, f
 		require.NoError(t, pprof.Lookup(name).WriteTo(f, 0))
 		require.NoError(t, f.Close())
 	}
+
+	dumpStoreOpCounts(t, label)
 
 	txPerSec := float64(fx.txCount) / elapsed.Seconds()
 

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
@@ -1,0 +1,363 @@
+//go:build aerospike
+
+// Measurement and profiling for the issue #1379 reproduction. Phases 2-4 of
+// plans/1379-unseen-tx-throughput-plan.md.
+package subtreevalidation
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation/subtreevalidation_api"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// levelEvent is one captured per-level boundary from processTransactionsInLevels.
+type levelEvent struct {
+	level int
+	txs   int
+	done  bool
+	at    time.Time
+}
+
+// levelCaptureLogger records the per-level and pre-check progress that
+// processTransactionsInLevels only emits at Debugf (check_block_subtrees.go:1015,
+// :1030, :1112, :1223). Capturing them here means the harness needs no change to
+// production log levels to produce a per-level breakdown.
+//
+// The prefix checks matter for correctness of the measurement, not just speed:
+// the same function also Debugf's once per transaction (:1180, :1211), so a
+// logger that took its mutex on every call would serialise 6,258 debug lines
+// across the 2048-wide fan-out and show up in the profile as contention the
+// production path does not have. Only the ~50 level-boundary lines take the lock.
+type levelCaptureLogger struct {
+	ulogger.TestLogger
+
+	mu       sync.Mutex
+	events   []levelEvent
+	preCheck []string
+}
+
+func (l *levelCaptureLogger) Debugf(format string, args ...interface{}) {
+	switch {
+	case strings.HasPrefix(format, "[processTransactionsInLevels] Processing level "):
+		if len(args) < 3 {
+			return
+		}
+
+		level, ok1 := args[0].(uint32)
+		count, ok2 := args[2].(int)
+
+		if !ok1 || !ok2 {
+			return
+		}
+
+		l.mu.Lock()
+		l.events = append(l.events, levelEvent{
+			level: int(level),
+			txs:   count,
+			done:  strings.HasSuffix(format, "DONE"),
+			at:    time.Now(),
+		})
+		l.mu.Unlock()
+
+	case strings.HasPrefix(format, "[processTransactionsInLevels] Pre-check:"):
+		l.mu.Lock()
+		l.preCheck = append(l.preCheck, fmt.Sprintf(format, args...))
+		l.mu.Unlock()
+	}
+}
+
+// The server replaces its logger via these in places; returning the same
+// instance keeps the capture attached.
+func (l *levelCaptureLogger) New(_ string, _ ...ulogger.Option) ulogger.Logger { return l }
+func (l *levelCaptureLogger) Duplicate(_ ...ulogger.Option) ulogger.Logger     { return l }
+func (l *levelCaptureLogger) WithTraceContext(_ context.Context) ulogger.Logger {
+	return l
+}
+
+// levelDurations pairs start and DONE events into per-level wall times.
+func (l *levelCaptureLogger) levelDurations() map[int]time.Duration {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	starts := make(map[int]time.Time)
+	out := make(map[int]time.Duration)
+
+	for _, e := range l.events {
+		if e.done {
+			if start, ok := starts[e.level]; ok {
+				out[e.level] = e.at.Sub(start)
+			}
+
+			continue
+		}
+
+		starts[e.level] = e.at
+	}
+
+	return out
+}
+
+// assertUnseenPrecondition proves both halves of the fixture contract before any
+// timing is taken: the block's own txs are absent from the UTXO store, and the
+// seeded parents are present and mined.
+//
+// This is the assertion the whole reproduction rests on. If the block txs were
+// present, processTransactionsInLevels would take the missed == 0 early return
+// (check_block_subtrees.go:1026) and the measured number would be the fast path
+// — the exact thing being investigated, silently inverted.
+func assertUnseenPrecondition(t *testing.T, h *perfHarness, fx *unseenFixture) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	items := make([]*utxostore.UnresolvedMetaData, 0, len(fx.txs))
+	for _, tx := range fx.txs {
+		items = append(items, &utxostore.UnresolvedMetaData{Hash: *tx.TxIDChainHash()})
+	}
+
+	require.NoError(t, h.utxoStore.BatchDecorate(ctx, items, fields.BlockIDs))
+
+	present := 0
+
+	for _, item := range items {
+		if item.Err == nil {
+			present++
+			continue
+		}
+
+		require.True(t, errors.Is(item.Err, errors.ErrTxNotFound),
+			"unexpected error probing block tx %s: %v", item.Hash, item.Err)
+	}
+
+	require.Zero(t, present,
+		"%d/%d block transactions were already in the UTXO store — the unseen precondition does not hold and this run would measure the missed==0 fast path",
+		present, len(fx.txs))
+
+	// Spot-check the parent side. A parent that is missing, or present but
+	// unmined, sends the run down the missing-parent or unconfirmed-parent path
+	// instead of the steady-state one.
+	firstLevelTx := fx.txs[0]
+	parentHash := firstLevelTx.Inputs[0].PreviousTxIDChainHash()
+
+	parentMeta, err := h.utxoStore.Get(ctx, parentHash, fields.BlockHeights, fields.BlockIDs)
+	require.NoError(t, err, "seeded parent %s must be in the store", parentHash)
+	require.NotEmpty(t, parentMeta.BlockHeights,
+		"seeded parent must be mined — empty BlockHeights sends the validator down the unconfirmed-parent path instead of steady state")
+}
+
+// profileDir resolves where profiles are written. TERANODE_PERF_PROFILE_DIR keeps
+// them after the test process exits; otherwise they land in the test temp dir and
+// the path is logged.
+func profileDir(t *testing.T) string {
+	t.Helper()
+
+	if dir := os.Getenv("TERANODE_PERF_PROFILE_DIR"); dir != "" {
+		require.NoError(t, os.MkdirAll(dir, 0o750))
+		return dir
+	}
+
+	return t.TempDir()
+}
+
+// runUnseenBlock drives one measured CheckBlockSubtrees pass and reports
+// throughput, the per-level breakdown, and profile paths.
+func runUnseenBlock(t *testing.T, h *perfHarness, capture *levelCaptureLogger, fx *unseenFixture, label string) time.Duration {
+	t.Helper()
+
+	dir := profileDir(t)
+
+	// Block and mutex profiling must be armed explicitly. Without these two calls
+	// both profiles come back empty — and for a latency-bound path they are the
+	// primary artefacts, because CPU will look idle while goroutines park on store
+	// round trips.
+	runtime.SetBlockProfileRate(1)
+	runtime.SetMutexProfileFraction(1)
+
+	defer func() {
+		runtime.SetBlockProfileRate(0)
+		runtime.SetMutexProfileFraction(0)
+	}()
+
+	cpuPath := filepath.Join(dir, label+"-cpu.pprof")
+	cpuFile, err := os.Create(cpuPath) // nolint:gosec // test-controlled path
+	require.NoError(t, err)
+
+	require.NoError(t, pprof.StartCPUProfile(cpuFile))
+
+	start := time.Now()
+
+	response, err := h.server.CheckBlockSubtrees(context.Background(), &subtreevalidation_api.CheckBlockSubtreesRequest{
+		Block:   fx.blockBytes,
+		BaseUrl: "legacy",
+	})
+
+	elapsed := time.Since(start)
+
+	pprof.StopCPUProfile()
+	require.NoError(t, cpuFile.Close())
+
+	require.NoError(t, err)
+	require.True(t, response.Blessed)
+
+	for _, name := range []string{"block", "mutex", "goroutine", "heap"} {
+		path := filepath.Join(dir, label+"-"+name+".pprof")
+
+		f, ferr := os.Create(path) // nolint:gosec // test-controlled path
+		require.NoError(t, ferr)
+		require.NoError(t, pprof.Lookup(name).WriteTo(f, 0))
+		require.NoError(t, f.Close())
+	}
+
+	txPerSec := float64(fx.txCount) / elapsed.Seconds()
+
+	t.Logf("=== %s ===", label)
+	t.Logf("txs=%d seededParents=%d subtrees=%d", fx.txCount, fx.seededParents, len(fx.subtreeHashes))
+	t.Logf("elapsed=%s throughput=%.1f tx/s", elapsed.Round(time.Millisecond), txPerSec)
+	t.Logf("blockAssemblyStores=%d txMetaPublished=%d", h.blockAssembly.stores.Load(), h.txMetaPublished.Load())
+	t.Logf("profiles written to %s", dir)
+
+	for _, line := range capture.preCheck {
+		t.Logf("precheck: %s", line)
+	}
+
+	durations := capture.levelDurations()
+	if len(durations) > 0 {
+		levels := make([]int, 0, len(durations))
+		for level := range durations {
+			levels = append(levels, level)
+		}
+
+		// Report slowest levels first: with 25 levels the interesting signal is
+		// which few dominate, not the full ordered list.
+		sortIntsByDurationDesc(levels, durations)
+
+		t.Logf("--- slowest levels (of %d) ---", len(durations))
+
+		for i, level := range levels {
+			if i >= 10 {
+				break
+			}
+
+			t.Logf("level %d: %s", level, durations[level].Round(time.Millisecond))
+		}
+	}
+
+	return elapsed
+}
+
+func sortIntsByDurationDesc(levels []int, durations map[int]time.Duration) {
+	for i := 1; i < len(levels); i++ {
+		for j := i; j > 0 && durations[levels[j]] > durations[levels[j-1]]; j-- {
+			levels[j], levels[j-1] = levels[j-1], levels[j]
+		}
+	}
+}
+
+// newCapturingPerfHarness is newPerfHarness with the level-capturing logger
+// installed.
+func newCapturingPerfHarness(t *testing.T, opts perfHarnessOptions) (*perfHarness, *levelCaptureLogger) {
+	t.Helper()
+
+	capture := &levelCaptureLogger{}
+	h := newPerfHarnessWithLogger(t, capture, opts)
+
+	return h, capture
+}
+
+// TestUnseenTxThroughput_FixtureRoundTrip is phase 2's verification: a small
+// fixture must round-trip and, critically, the unseen precondition must actually
+// hold and the generator must produce the level count it claims. A generator that
+// believes it built 5 levels but built 1 would make every later number
+// meaningless.
+func TestUnseenTxThroughput_FixtureRoundTrip(t *testing.T) {
+	h, capture := newCapturingPerfHarness(t, defaultPerfOptions())
+
+	cfg := unseenFixtureConfig{
+		levelSizes:    []int{200, 120, 80, 60, 40},
+		txsPerSubtree: 1024,
+	}
+
+	fx := generateUnseenFixture(t, h, cfg)
+	require.Equal(t, 500, fx.txCount)
+
+	assertUnseenPrecondition(t, h, fx)
+
+	runUnseenBlock(t, h, capture, fx, "fixture-roundtrip")
+
+	// The generator's claimed shape must match what the production level splitter
+	// actually derived.
+	durations := capture.levelDurations()
+	require.Len(t, durations, len(cfg.levelSizes),
+		"production level splitter derived %d levels but the fixture was built for %d — the dependency graph is not the shape the generator thinks it is",
+		len(durations), len(cfg.levelSizes))
+
+	// Every block tx should now be in the store, unlocked.
+	assertAllValidatedAndUnlocked(t, h, fx)
+}
+
+// TestUnseenTxThroughput is phase 4: the shape-matched baseline against mainnet
+// block 959979's measured dependency histogram. This is the decision point —
+// <=100 tx/s reproduces the issue, >1000 tx/s means the synthetic shape is wrong
+// and the real-block fallback is needed.
+func TestUnseenTxThroughput(t *testing.T) {
+	h, capture := newCapturingPerfHarness(t, defaultPerfOptions())
+
+	cfg := unseenFixtureConfig{
+		levelSizes:    mainnet959979Shape(),
+		txsPerSubtree: 1024,
+	}
+
+	fx := generateUnseenFixture(t, h, cfg)
+	require.Equal(t, 6258, fx.txCount, "baseline must match the measured tx count of mainnet block 959979")
+
+	assertUnseenPrecondition(t, h, fx)
+
+	elapsed := runUnseenBlock(t, h, capture, fx, "baseline-959979-shape")
+
+	txPerSec := float64(fx.txCount) / elapsed.Seconds()
+	t.Logf("BASELINE RESULT: %.1f tx/s (mainnet observed 27-50 tx/s)", txPerSec)
+}
+
+func assertAllValidatedAndUnlocked(t *testing.T, h *perfHarness, fx *unseenFixture) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	hashes := make([]chainhash.Hash, 0, len(fx.txs))
+	for _, tx := range fx.txs {
+		hashes = append(hashes, *tx.TxIDChainHash())
+	}
+
+	locked := 0
+	missing := 0
+
+	for i := range hashes {
+		md, err := h.utxoStore.Get(ctx, &hashes[i], fields.Locked)
+		if err != nil {
+			missing++
+			continue
+		}
+
+		if md.Locked {
+			locked++
+		}
+	}
+
+	require.Zero(t, missing, "%d/%d validated txs are absent from the store", missing, len(hashes))
+	require.Zero(t, locked, "%d/%d validated txs are still locked — the SetLocked 2PC did not complete for them", locked, len(hashes))
+}

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
@@ -128,6 +128,43 @@ func (l *levelCaptureLogger) Infof(format string, args ...interface{}) {
 		return
 	}
 
+	// The per-level and pre-check lines are emitted at INFO as of the #1379
+	// instrumentation change, so they are captured here rather than in Debugf. The
+	// harness therefore reads exactly what production log aggregation now sees.
+	switch {
+	case strings.HasPrefix(format, "[processTransactionsInLevels] Processing level "):
+		if len(args) < 3 {
+			return
+		}
+
+		level, ok1 := args[0].(uint32)
+		count, ok2 := args[2].(int)
+
+		if !ok1 || !ok2 {
+			return
+		}
+
+		l.mu.Lock()
+		l.events = append(l.events, levelEvent{
+			level: int(level),
+			txs:   count,
+			// The DONE variant now carries a duration ("... DONE in %s"), so match on
+			// the substring rather than a suffix.
+			done: strings.Contains(format, "DONE in"),
+			at:   time.Now(),
+		})
+		l.mu.Unlock()
+
+		return
+
+	case strings.HasPrefix(format, "[processTransactionsInLevels] Pre-check:"):
+		l.mu.Lock()
+		l.preCheck = append(l.preCheck, fmt.Sprintf(format, args...))
+		l.mu.Unlock()
+
+		return
+	}
+
 	if !strings.HasPrefix(format, "[BatchDecorate] Processed") || len(args) < 3 {
 		return
 	}
@@ -146,35 +183,11 @@ func (l *levelCaptureLogger) Infof(format string, args ...interface{}) {
 	l.externalSkipped.Add(uint64(skipped))
 }
 
-func (l *levelCaptureLogger) Debugf(format string, args ...interface{}) {
-	switch {
-	case strings.HasPrefix(format, "[processTransactionsInLevels] Processing level "):
-		if len(args) < 3 {
-			return
-		}
-
-		level, ok1 := args[0].(uint32)
-		count, ok2 := args[2].(int)
-
-		if !ok1 || !ok2 {
-			return
-		}
-
-		l.mu.Lock()
-		l.events = append(l.events, levelEvent{
-			level: int(level),
-			txs:   count,
-			done:  strings.HasSuffix(format, "DONE"),
-			at:    time.Now(),
-		})
-		l.mu.Unlock()
-
-	case strings.HasPrefix(format, "[processTransactionsInLevels] Pre-check:"):
-		l.mu.Lock()
-		l.preCheck = append(l.preCheck, fmt.Sprintf(format, args...))
-		l.mu.Unlock()
-	}
-}
+// Debugf is deliberately a no-op. The level and pre-check lines this harness needs
+// are emitted at INFO now, and the remaining Debugf sites in
+// processTransactionsInLevels are per-transaction — capturing those under a mutex
+// would serialise the fan-out being measured.
+func (l *levelCaptureLogger) Debugf(_ string, _ ...interface{}) {}
 
 // The server replaces its logger via these in places; returning the same
 // instance keeps the capture attached.
@@ -284,7 +297,8 @@ func dumpStoreOpCounts(t *testing.T, label string) {
 	for _, fam := range families {
 		n := fam.GetName()
 		if !strings.Contains(n, "aerospike") && !strings.Contains(n, "validator_transactions") &&
-			!strings.Contains(n, "subtreevalidation_bless") {
+			!strings.Contains(n, "subtreevalidation_bless") && !strings.Contains(n, "subtreevalidation_level") &&
+			!strings.Contains(n, "prefetch_level_parents") {
 			continue
 		}
 
@@ -310,7 +324,7 @@ func dumpStoreOpCounts(t *testing.T, label string) {
 	t.Logf("--- store op counts [%s] ---", label)
 
 	for i, r := range rows {
-		if i >= 14 {
+		if i >= 26 {
 			break
 		}
 

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
@@ -59,6 +59,20 @@ type levelCaptureLogger struct {
 	batchDecorateItems atomic.Uint64
 	externalFetched    atomic.Uint64
 	externalSkipped    atomic.Uint64
+
+	// conflictingSeen counts the blessMissingTransaction conflicting warnings
+	// (SubtreeValidation.go:430). Without this the conflict axis could measure
+	// nothing and report it as "no effect" — exactly how the external-parents axis
+	// produced a false negative.
+	conflictingSeen atomic.Uint64
+}
+
+// Warnf captures the conflicting-transaction warning so a run can prove the
+// conflict path was actually entered.
+func (l *levelCaptureLogger) Warnf(format string, _ ...interface{}) {
+	if strings.Contains(format, "transaction is conflicting") {
+		l.conflictingSeen.Add(1)
+	}
 }
 
 // Infof captures the BatchDecorate external-fetch counters. The counts arrive as
@@ -263,6 +277,7 @@ func runUnseenBlock(t *testing.T, h *perfHarness, capture *levelCaptureLogger, f
 	t.Logf("batchDecorate: calls=%d items=%d externalFetched=%d externalSkipped=%d",
 		capture.batchDecorateCalls.Load(), capture.batchDecorateItems.Load(),
 		capture.externalFetched.Load(), capture.externalSkipped.Load())
+	t.Logf("conflictingTxsSeen=%d", capture.conflictingSeen.Load())
 	t.Logf("profiles written to %s", dir)
 
 	for _, line := range capture.preCheck {

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_measure_test.go
@@ -67,6 +67,43 @@ type levelCaptureLogger struct {
 	// nothing and report it as "no effect" — exactly how the external-parents axis
 	// produced a false negative.
 	conflictingSeen atomic.Uint64
+
+	// Counter snapshots taken at the boundary between the two passes.
+	// CheckBlockSubtrees logs "Completed processing N transactions across M subtree
+	// batches" at Infof (check_block_subtrees.go:608) after the level pipeline and
+	// immediately before validateMissingSubtreesWithOrderedRetry, so capturing there
+	// attributes every store op to one pass or the other.
+	splitSeen     atomic.Bool
+	getsAtSplit   atomic.Uint64
+	blessAtSplit  atomic.Uint64
+	multiNAtSplit atomic.Uint64
+}
+
+// readCounterSum sums a metric family from the in-process registry. Histograms
+// contribute their sample count, counters their value.
+func readCounterSum(name string) uint64 {
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return 0
+	}
+
+	var total uint64
+
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+
+		for _, m := range fam.GetMetric() {
+			if h := m.GetHistogram(); h != nil {
+				total += h.GetSampleCount()
+			} else if c := m.GetCounter(); c != nil {
+				total += uint64(c.GetValue())
+			}
+		}
+	}
+
+	return total
 }
 
 // Warnf captures the conflicting-transaction warning so a run can prove the
@@ -80,6 +117,17 @@ func (l *levelCaptureLogger) Warnf(format string, _ ...interface{}) {
 // Infof captures the BatchDecorate external-fetch counters. The counts arrive as
 // int args, so no string parsing is needed.
 func (l *levelCaptureLogger) Infof(format string, args ...interface{}) {
+	// The boundary between the level pipeline and the per-subtree pass.
+	if strings.HasPrefix(format, "[CheckBlockSubtrees] Completed processing") {
+		if l.splitSeen.CompareAndSwap(false, true) {
+			l.getsAtSplit.Store(readCounterSum("teranode_aerospike_txmeta_get"))
+			l.blessAtSplit.Store(readCounterSum("teranode_subtreevalidation_bless_missing_transaction"))
+			l.multiNAtSplit.Store(readCounterSum("teranode_aerospike_txmeta_get_multi_n"))
+		}
+
+		return
+	}
+
 	if !strings.HasPrefix(format, "[BatchDecorate] Processed") || len(args) < 3 {
 		return
 	}
@@ -336,6 +384,22 @@ func runUnseenBlock(t *testing.T, h *perfHarness, capture *levelCaptureLogger, f
 		require.NoError(t, ferr)
 		require.NoError(t, pprof.Lookup(name).WriteTo(f, 0))
 		require.NoError(t, f.Close())
+	}
+
+	// Attribute store ops to the level pipeline vs the per-subtree pass.
+	if capture.splitSeen.Load() {
+		getsEnd := readCounterSum("teranode_aerospike_txmeta_get")
+		blessEnd := readCounterSum("teranode_subtreevalidation_bless_missing_transaction")
+		multiEnd := readCounterSum("teranode_aerospike_txmeta_get_multi_n")
+
+		t.Logf("--- pass attribution [%s] ---", label)
+		t.Logf("  level pipeline:   txmeta_get=%d bless=%d get_multi_n=%d",
+			capture.getsAtSplit.Load(), capture.blessAtSplit.Load(), capture.multiNAtSplit.Load())
+		t.Logf("  per-subtree pass: txmeta_get=%d bless=%d get_multi_n=%d",
+			getsEnd-capture.getsAtSplit.Load(), blessEnd-capture.blessAtSplit.Load(),
+			multiEnd-capture.multiNAtSplit.Load())
+	} else {
+		t.Logf("WARNING: never saw the CheckBlockSubtrees split log — attribution unavailable")
 	}
 
 	dumpStoreOpCounts(t, label)

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
@@ -31,6 +31,7 @@ package subtreevalidation
 import (
 	"context"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -78,11 +79,37 @@ type perfHarnessOptions struct {
 	chainParams *chaincfg.Params
 	blockHeight uint32
 	tune        func(*settings.Settings)
+
+	// aerospikeURLParams are appended to the testcontainer's Aerospike URL. The
+	// InitAerospikeContainer helper builds a bare URL with no connection tuning, so
+	// without this the harness silently runs on the client's default pool while
+	// production runs a hard cap — see productionAerospikeParams.
+	aerospikeURLParams string
 }
 
+// productionAerospikeParams are the connection settings mainnet actually runs
+// (utxostore.docker.m, settings.conf:1271).
+//
+// ConnectionQueueSize=128 with LimitConnectionsToQueueSize=true is a HARD ceiling:
+// the client will not open a 129th connection, and callers block waiting for one to
+// free. Meanwhile processTransactionsInLevels fans out to SpendBatcherSize*2 = 2048
+// concurrent validations (check_block_subtrees.go:1156), each of which issues
+// several store operations. That is a ~16x oversubscription of a blocking,
+// hard-capped pool, and the fan-out width is derived from a batcher setting with no
+// relationship to the pool size.
+const productionAerospikeParams = "WarmUp=0&ConnectionQueueSize=128&LimitConnectionsToQueueSize=true&MinConnectionsPerNode=16&IdleTimeout=60s"
+
 // defaultPerfOptions is the context for generated fixtures: regtest at height
-// 100, post-UAHF and pre-CSV.
+// 100, post-UAHF and pre-CSV, with mainnet's Aerospike connection caps applied so
+// the harness does not flatter itself with an unbounded pool.
+
 func defaultPerfOptions() perfHarnessOptions {
+	return perfHarnessOptions{blockHeight: 100, aerospikeURLParams: productionAerospikeParams}
+}
+
+// unlimitedPoolPerfOptions is defaultPerfOptions with no connection cap, for A/B
+// against the production caps.
+func unlimitedPoolPerfOptions() perfHarnessOptions {
 	return perfHarnessOptions{blockHeight: 100}
 }
 
@@ -221,8 +248,18 @@ func newPerfHarnessWithLogger(t *testing.T, logger ulogger.Logger, opts perfHarn
 		opts.tune(tSettings)
 	}
 
+	if opts.aerospikeURLParams != "" {
+		sep := "&"
+		if !strings.Contains(aeroURL, "?") {
+			sep = "?"
+		}
+
+		aeroURL += sep + opts.aerospikeURLParams
+	}
+
 	parsedURL, err := url.Parse(aeroURL)
 	require.NoError(t, err)
+	t.Logf("aerospike URL: %s", parsedURL.String())
 
 	utxoStore, err := aerospikestore.New(ctx, logger, tSettings, parsedURL)
 	require.NoError(t, err, "aerospike store must construct — this also proves Lua UDF registration succeeded")

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
@@ -1,0 +1,315 @@
+//go:build aerospike
+
+// Reproduction harness for issue #1379: block validation collapses to ~30-50
+// tx/s on blocks whose transactions were never seen via propagation.
+//
+// The discriminator is the pre-check in processTransactionsInLevels
+// (check_block_subtrees.go:1009-1028): when every tx in the block is already in
+// the txMeta cache or UTXO store, missed == 0 and the function returns
+// immediately. This harness deliberately establishes the opposite state — only
+// the PARENTS are seeded into the UTXO store, the block's own txs are absent
+// from both cache and store — so every tx goes through blessMissingTransaction.
+//
+// Nothing is mocked below the server: real Aerospike (testcontainer, with the
+// Lua UDFs registered by aerospike.New), real validator.Validator, real
+// TxValidator, real GoBDK. The mainnet nodes run useLocalValidator = true
+// (settings.conf:1255), so an in-process validator is topology-faithful rather
+// than an approximation.
+//
+// Two boundaries are deliberate and must be remembered when reading numbers
+// out of this harness:
+//
+//   - The block-assembly gRPC hop is NOT measured. blockAssemblyStub records
+//     calls and returns immediately. What IS measured on that axis is the part
+//     that touches the store: Create-with-locked plus the SetLocked two-phase
+//     commit unlock (Validator.go:940-1057), which is a real Aerospike round
+//     trip per tx.
+//   - The container namespace is in-memory single-node; mainnet is persistent.
+//     A SLOW result here is therefore strong evidence and a FAST one is weak.
+package subtreevalidation
+
+import (
+	"context"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockassembly"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation/subtreevalidation_api"
+	"github.com/bsv-blockchain/teranode/services/validator"
+	"github.com/bsv-blockchain/teranode/settings"
+	blobmemory "github.com/bsv-blockchain/teranode/stores/blob/memory"
+	aerospikestore "github.com/bsv-blockchain/teranode/stores/utxo/aerospike"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	aerospiketest "github.com/bsv-blockchain/teranode/test/utils/aerospike"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/kafka"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// perfFixtureHeight sits below mainnet CSVHeight (419328) so the post-CSV
+// candidate-parent MTP fetch and the validator's EnsureMTPLoaded both no-op
+// (Validator.go:1654 returns nil below csvHeight) and the harness needs no real
+// headers. Both are one call per block, not per tx, so excluding them cannot
+// affect the throughput being measured.
+const perfFixtureHeight = uint32(257727)
+
+// blockAssemblyStub implements the blockassembly client surface the validator
+// uses, with an atomic counter instead of a testify mock. A testify mock takes a
+// mutex and runs reflection on every call; at the 2048-wide per-level fan-out
+// (SpendBatcherSize * 2, check_block_subtrees.go:1156) that contention would
+// show up in the profile as a bottleneck the production path does not have.
+type blockAssemblyStub struct {
+	blockassembly.ClientI
+	stores atomic.Uint64
+}
+
+func (s *blockAssemblyStub) Store(_ context.Context, _ *chainhash.Hash, _, _ uint64, _ subtreepkg.TxInpoints) (bool, error) {
+	s.stores.Add(1)
+	return true, nil
+}
+
+// perfBlockchainClient overrides only the blockchain methods this path is
+// expected to call. The embedded nil ClientI is intentional: any method that
+// turns out to be in the hot path and is not overridden here will nil-panic and
+// name itself, rather than being silently absorbed by a permissive mock.
+type perfBlockchainClient struct {
+	blockchain.ClientI
+	state          blockchain.FSMStateType
+	blockHeaderIDs []uint32
+	fsmCalls       atomic.Uint64
+	headerIDsCalls atomic.Uint64
+}
+
+func (c *perfBlockchainClient) GetFSMCurrentState(_ context.Context) (*blockchain.FSMStateType, error) {
+	c.fsmCalls.Add(1)
+	state := c.state
+	return &state, nil
+}
+
+func (c *perfBlockchainClient) GetBlockHeaderIDs(_ context.Context, _ *chainhash.Hash, _ uint64) ([]uint32, error) {
+	c.headerIDsCalls.Add(1)
+	return c.blockHeaderIDs, nil
+}
+
+// Subscribe feeds Server.blockchainSubscriptionListener, a background goroutine
+// started by New (Server.go:309). It is handed a channel that never receives, so
+// the listener parks on it for the life of the test and never competes with the
+// measurement.
+func (c *perfBlockchainClient) Subscribe(_ context.Context, _ string) (chan *blockchain_api.Notification, error) {
+	return make(chan *blockchain_api.Notification), nil
+}
+
+// GetBestBlockHeader is called once from Server.updateBestBlock during New
+// (Server.go:387), not per tx, so a static header costs the measurement nothing.
+// The reported height must match perfFixtureHeight: updateBestBlock pushes it
+// into subtreeStore.SetCurrentBlockHeight, and a mismatch would put the DAH
+// arithmetic in CheckBlockSubtrees on a different height than the fixture.
+func (c *perfBlockchainClient) GetBestBlockHeader(_ context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+	return &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      1,
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}, &model.BlockHeaderMeta{ID: 1, Height: perfFixtureHeight}, nil
+}
+
+// perfHarness bundles the wired-up server and the collaborators a test needs to
+// seed state and read counters back.
+type perfHarness struct {
+	server        *Server
+	utxoStore     *aerospikestore.Store
+	subtreeStore  *blobmemory.Memory
+	blockAssembly *blockAssemblyStub
+	blockchain    *perfBlockchainClient
+	settings      *settings.Settings
+	logger        ulogger.Logger
+}
+
+// newPerfHarness stands up real Aerospike + real validator + subtreevalidation
+// server. tune runs after the base settings are built so a test can flip a
+// single bisect axis without forking the whole setup.
+func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
+	t.Helper()
+
+	InitPrometheusMetrics()
+
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+
+	aeroURL, cleanup, err := aerospiketest.InitAerospikeContainer()
+	require.NoError(t, err, "aerospike testcontainer must start — this harness has no in-memory fallback by design")
+	t.Cleanup(func() {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+	})
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	// Mainnet params to match the environment the issue was observed in;
+	// perfFixtureHeight stays below mainnet CSVHeight so the MTP paths no-op.
+	mainnetParams := chaincfg.MainNetParams
+	tSettings.ChainCfgParams = &mainnetParams
+
+	// Block assembly ENABLED is the baseline: at the tip the FSM is RUNNING, so
+	// addTXToBlockAssembly is true (check_block_subtrees.go:504) and every unseen
+	// tx pays Create-with-locked plus the SetLocked 2PC unlock. That is the state
+	// the slow mainnet blocks were actually in, and cached txs skip all of it —
+	// which is exactly the fast/slow discriminator.
+	tSettings.BlockAssembly.Disabled = false
+
+	if tune != nil {
+		tune(tSettings)
+	}
+
+	parsedURL, err := url.Parse(aeroURL)
+	require.NoError(t, err)
+
+	utxoStore, err := aerospikestore.New(ctx, logger, tSettings, parsedURL)
+	require.NoError(t, err, "aerospike store must construct — this also proves Lua UDF registration succeeded")
+
+	require.NoError(t, utxoStore.SetBlockHeight(perfFixtureHeight))
+
+	subtreeStore := blobmemory.New()
+	txStore := blobmemory.New()
+
+	blockchainClient := &perfBlockchainClient{
+		state:          blockchain.FSMStateRUNNING,
+		blockHeaderIDs: []uint32{1, 2, 3},
+	}
+
+	baStub := &blockAssemblyStub{}
+
+	realValidator, err := validator.New(ctx, logger, tSettings, utxoStore,
+		kafka.NewKafkaAsyncProducerMock(), kafka.NewKafkaAsyncProducerMock(), nil,
+		baStub, blockchainClient)
+	require.NoError(t, err)
+
+	nilConsumer := &kafka.KafkaConsumerGroup{}
+
+	server, err := New(ctx, logger, tSettings, subtreeStore, txStore, utxoStore,
+		realValidator, blockchainClient, nilConsumer, nilConsumer, nil, nil)
+	require.NoError(t, err)
+
+	return &perfHarness{
+		server:        server,
+		utxoStore:     utxoStore,
+		subtreeStore:  subtreeStore,
+		blockAssembly: baStub,
+		blockchain:    blockchainClient,
+		settings:      tSettings,
+		logger:        logger,
+	}
+}
+
+// TestUnseenTxThroughput_Smoke is phase 1: prove every real component connects
+// and, critically, that the RUNNING FSM pin actually took effect. A harness that
+// silently ran with addTXToBlockAssembly == false would measure the catchup path
+// instead of the tip path and every later number would be wrong.
+func TestUnseenTxThroughput_Smoke(t *testing.T) {
+	h := newPerfHarness(t, nil)
+	ctx := context.Background()
+
+	// Same real-mainnet parent/child pair the validator-level consensus tests and
+	// legacy_real_validator_integration_test.go use: the child spends parent
+	// output 1 with a valid signature, so GoBDK script validation genuinely runs.
+	childTx, err := bt.NewTxFromString("010000000000000000ef01febe0cbd7d87d44cbd4b5adac0a5bfcdbd2b672c9113f5d74a6459a2b85569db010000008b48304502207ec38d0a4ef79c3a4286ba3e5a5b6ede1fa678af9242465140d78a901af9e4e0022100c26c377d44b761469cf0bdcdbf4931418f2c5a02ce6b72bbb7af52facd7228c1014104bc9eb4fe4cb53e35df7e7734c4c3cd91c6af7840be80f4a1fff283e2cd6ae8f7713cb263a4590263240e3c01ec36bc603c32281ac08773484dc69b8152e48cecffffffff60b74700000000001976a9148ac9bdc626352d16e18c26f431e834f9aae30e2888ac0230424700000000001976a9148ac9bdc626352d16e18c26f431e834f9aae30e2888ac1027000000000000166a148ac9bdc626352d16e18c26f431e834f9aae30e2800000000")
+	require.NoError(t, err)
+
+	parentTx, err := bt.NewTxFromString("010000000000000000ef01154d5d31268f7ea94c80a7bf6de54e47812712feec25c17b8feceb570dfd9daf000000008b4830450220612b3ec065ec2b2a1757d97b7f57fba3c363645355cf6e1a5a1834411e6ab425022100bd071b90d391eb75dc9e2eea8b6774f36bf9c55439a971f0d1f4470b6448aef601410426e4e0654f72721b97a03c8170417c9ddabadcef97fe8ea626176ea62665b55ca2ff485f84df12ddec171e01ee8f9c7472c6c8467b0cf74ae8b3b614ed16cbdbffffffff008a6600000000001976a91429be45311cc66a5a6cc4a42516dbb7c9b126a3c188ac0280841e00000000001976a914996ed5e55d68aef653c85339f83873fac1321f0788ac60b74700000000001976a9148ac9bdc626352d16e18c26f431e834f9aae30e2888ac00000000")
+	require.NoError(t, err)
+
+	// Seed ONLY the parent. The child stays absent from cache and store — that is
+	// the unseen precondition the whole reproduction depends on.
+	_, err = h.utxoStore.Create(ctx, parentTx, perfFixtureHeight-1)
+	require.NoError(t, err)
+
+	blockBytes, subtreeHash := buildUnseenBlock(t, h, []*bt.Tx{childTx})
+
+	response, err := h.server.CheckBlockSubtrees(ctx, &subtreevalidation_api.CheckBlockSubtreesRequest{
+		Block:   blockBytes,
+		BaseUrl: "legacy",
+	})
+	require.NoError(t, err)
+	require.True(t, response.Blessed)
+	_ = subtreeHash
+
+	// The child must exist and be spendable: Create marked it locked because it
+	// went to block assembly, then twoPhaseCommitTransaction unlocked it. Locked
+	// still true here would mean the 2PC never ran.
+	childMeta, err := h.utxoStore.Get(ctx, childTx.TxIDChainHash(), fields.Locked, fields.BlockIDs)
+	require.NoError(t, err)
+	require.False(t, childMeta.Locked, "child must be unlocked — a still-locked record means the SetLocked 2PC never ran, so the harness is measuring the wrong path")
+
+	// The RUNNING pin must have produced a real block-assembly insert. Zero here
+	// means addTXToBlockAssembly was false and this harness is measuring the
+	// catchup path, not the tip path.
+	require.Equal(t, uint64(1), h.blockAssembly.stores.Load(),
+		"block assembly must have received the tx — zero means the RUNNING FSM pin did not take effect")
+}
+
+// buildUnseenBlock writes the given txs into a single subtree as legacy files and
+// returns the serialized block referencing it.
+//
+// The subtree is written as FileTypeSubtreeToCheck and FileTypeSubtreeData but
+// deliberately NOT as FileTypeSubtree: CheckBlockSubtrees early-returns Blessed
+// for subtrees that already exist as FileTypeSubtree
+// (check_block_subtrees.go:438-465), which would skip all the work being
+// measured.
+func buildUnseenBlock(t *testing.T, h *perfHarness, txs []*bt.Tx) ([]byte, *chainhash.Hash) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	subtree, err := subtreepkg.NewTreeByLeafCount(subtreepkg.CeilPowerOfTwo(len(txs)))
+	require.NoError(t, err)
+
+	subtreeData := subtreepkg.NewSubtreeData(subtree)
+
+	for idx, tx := range txs {
+		require.NoError(t, subtree.AddNode(*tx.TxIDChainHash(), 1, 0))
+		require.NoError(t, subtreeData.AddTx(tx, idx))
+	}
+
+	subtreeBytes, err := subtree.Serialize()
+	require.NoError(t, err)
+
+	subtreeDataBytes, err := subtreeData.Serialize()
+	require.NoError(t, err)
+
+	root := subtree.RootHash()
+
+	require.NoError(t, h.subtreeStore.Set(ctx, root[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes))
+	require.NoError(t, h.subtreeStore.Set(ctx, root[:], fileformat.FileTypeSubtreeData, subtreeDataBytes))
+
+	header := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      1,
+		Bits:           model.NBit{},
+		Nonce:          0,
+	}
+
+	coinbaseTx := &bt.Tx{Version: 1}
+
+	block, err := model.NewBlock(header, coinbaseTx, []*chainhash.Hash{root}, uint64(len(txs)+1), 0, perfFixtureHeight, 0)
+	require.NoError(t, err)
+
+	blockBytes, err := block.Bytes()
+	require.NoError(t, err)
+
+	return blockBytes, root
+}

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
@@ -336,7 +336,7 @@ func TestUnseenTxThroughput_Smoke(t *testing.T) {
 	_, err = h.utxoStore.Create(ctx, parentTx, h.blockHeight-1)
 	require.NoError(t, err)
 
-	blockBytes, _ := buildUnseenBlockFromTxs(t, h, []*bt.Tx{childTx}, 1)
+	blockBytes, _ := buildUnseenBlockFromTxs(t, h, []*bt.Tx{childTx}, 1, false)
 
 	response, err := h.server.CheckBlockSubtrees(ctx, &subtreevalidation_api.CheckBlockSubtreesRequest{
 		Block:   blockBytes,

--- a/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
+++ b/services/subtreevalidation/check_block_subtrees_unseen_perf_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/bsv-blockchain/go-chaincfg"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/model"
-	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockassembly"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
@@ -56,12 +55,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// perfFixtureHeight sits below mainnet CSVHeight (419328) so the post-CSV
-// candidate-parent MTP fetch and the validator's EnsureMTPLoaded both no-op
-// (Validator.go:1654 returns nil below csvHeight) and the harness needs no real
-// headers. Both are one call per block, not per tx, so excluding them cannot
-// affect the throughput being measured.
-const perfFixtureHeight = uint32(257727)
+// perfHarnessOptions selects the consensus context a run executes in. It exists
+// because the two kinds of fixture need different eras.
+//
+// Generated fixtures (the throughput runs) sign through go-bt's unlocker, which
+// uses SIGHASH_FORKID. That is only valid at or above the UAHF fork, so they
+// cannot run at a pre-2018 mainnet height — GoBDK computes the pre-fork sighash
+// and the signature fails with "false/empty top stack element". Regtest has
+// UahfForkHeight: 0 ("UAHF is always enabled on regtest") and CSVHeight 576, so
+// regtest at height 100 gives valid FORKID signatures AND stays below CSV, which
+// keeps the candidate-parent MTP fetch and the validator's EnsureMTPLoaded
+// no-ops (Validator.go:1654) so the harness needs no real headers. This is the
+// same height/params pairing the other tests in this package use.
+//
+// The smoke test instead replays real 2013-era mainnet transactions, whose
+// signatures are pre-fork, so it needs mainnet params at a pre-fork height.
+//
+// Chain params change which consensus rules apply, not how many store round
+// trips a tx costs, so this choice does not affect the throughput being
+// measured.
+type perfHarnessOptions struct {
+	chainParams *chaincfg.Params
+	blockHeight uint32
+	tune        func(*settings.Settings)
+}
+
+// defaultPerfOptions is the context for generated fixtures: regtest at height
+// 100, post-UAHF and pre-CSV.
+func defaultPerfOptions() perfHarnessOptions {
+	return perfHarnessOptions{blockHeight: 100}
+}
 
 // blockAssemblyStub implements the blockassembly client surface the validator
 // uses, with an atomic counter instead of a testify mock. A testify mock takes a
@@ -86,6 +109,7 @@ type perfBlockchainClient struct {
 	blockchain.ClientI
 	state          blockchain.FSMStateType
 	blockHeaderIDs []uint32
+	height         uint32
 	fsmCalls       atomic.Uint64
 	headerIDsCalls atomic.Uint64
 }
@@ -111,7 +135,7 @@ func (c *perfBlockchainClient) Subscribe(_ context.Context, _ string) (chan *blo
 
 // GetBestBlockHeader is called once from Server.updateBestBlock during New
 // (Server.go:387), not per tx, so a static header costs the measurement nothing.
-// The reported height must match perfFixtureHeight: updateBestBlock pushes it
+// The reported height must match the fixture height: updateBestBlock pushes it
 // into subtreeStore.SetCurrentBlockHeight, and a mismatch would put the DAH
 // arithmetic in CheckBlockSubtrees on a different height than the fixture.
 func (c *perfBlockchainClient) GetBestBlockHeader(_ context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
@@ -122,31 +146,42 @@ func (c *perfBlockchainClient) GetBestBlockHeader(_ context.Context) (*model.Blo
 		Timestamp:      1,
 		Bits:           model.NBit{},
 		Nonce:          0,
-	}, &model.BlockHeaderMeta{ID: 1, Height: perfFixtureHeight}, nil
+	}, &model.BlockHeaderMeta{ID: 1, Height: c.height}, nil
 }
 
 // perfHarness bundles the wired-up server and the collaborators a test needs to
 // seed state and read counters back.
 type perfHarness struct {
-	server        *Server
-	utxoStore     *aerospikestore.Store
-	subtreeStore  *blobmemory.Memory
-	blockAssembly *blockAssemblyStub
-	blockchain    *perfBlockchainClient
-	settings      *settings.Settings
-	logger        ulogger.Logger
+	server          *Server
+	utxoStore       *aerospikestore.Store
+	subtreeStore    *blobmemory.Memory
+	blockAssembly   *blockAssemblyStub
+	blockchain      *perfBlockchainClient
+	settings        *settings.Settings
+	logger          ulogger.Logger
+	txMetaPublished *atomic.Uint64
+	blockHeight     uint32
 }
 
-// newPerfHarness stands up real Aerospike + real validator + subtreevalidation
-// server. tune runs after the base settings are built so a test can flip a
-// single bisect axis without forking the whole setup.
-func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
+// newPerfHarness stands up the harness with a quiet logger. Tests that need the
+// per-level breakdown use newPerfHarnessWithLogger instead.
+func newPerfHarness(t *testing.T, opts perfHarnessOptions) *perfHarness {
 	t.Helper()
+
+	return newPerfHarnessWithLogger(t, ulogger.TestLogger{}, opts)
+}
+
+// newPerfHarnessWithLogger stands up real Aerospike + real validator +
+// subtreevalidation server. opts.tune runs after the base settings are built so a
+// test can flip a single bisect axis without forking the whole setup.
+func newPerfHarnessWithLogger(t *testing.T, logger ulogger.Logger, opts perfHarnessOptions) *perfHarness {
+	t.Helper()
+
+	require.Positive(t, opts.blockHeight, "blockHeight must be set")
 
 	InitPrometheusMetrics()
 
 	ctx := context.Background()
-	logger := ulogger.TestLogger{}
 
 	aeroURL, cleanup, err := aerospiketest.InitAerospikeContainer()
 	require.NoError(t, err, "aerospike testcontainer must start — this harness has no in-memory fallback by design")
@@ -158,10 +193,22 @@ func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
 
 	tSettings := test.CreateBaseTestSettings(t)
 
-	// Mainnet params to match the environment the issue was observed in;
-	// perfFixtureHeight stays below mainnet CSVHeight so the MTP paths no-op.
-	mainnetParams := chaincfg.MainNetParams
-	tSettings.ChainCfgParams = &mainnetParams
+	// CreateBaseTestSettings defaults to regtest, which is what generated fixtures
+	// need (see perfHarnessOptions). Only the smoke test overrides it.
+	if opts.chainParams != nil {
+		tSettings.ChainCfgParams = opts.chainParams
+	}
+
+	// CreateBaseTestSettings installs a test-only Aerospike write policy
+	// (util/test/helpers.go:38-41: MaxRetries=30, SleepBetweenRetries=50ms,
+	// SleepMultiplier=2, TotalTimeout=30s) to paper over hot-key errors in
+	// ordinary tests. Left in place it would add up to ~25s of exponential backoff
+	// to a single contended write and this harness would report production code as
+	// slow when the cost was a test setting. Restore the production policy from
+	// settings.conf (:172-173) so the numbers mean something.
+	prodSettings := settings.NewSettings()
+	tSettings.Aerospike.WritePolicyURL = prodSettings.Aerospike.WritePolicyURL
+	tSettings.Aerospike.ReadPolicyURL = prodSettings.Aerospike.ReadPolicyURL
 
 	// Block assembly ENABLED is the baseline: at the tip the FSM is RUNNING, so
 	// addTXToBlockAssembly is true (check_block_subtrees.go:504) and every unseen
@@ -170,8 +217,8 @@ func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
 	// which is exactly the fast/slow discriminator.
 	tSettings.BlockAssembly.Disabled = false
 
-	if tune != nil {
-		tune(tSettings)
+	if opts.tune != nil {
+		opts.tune(tSettings)
 	}
 
 	parsedURL, err := url.Parse(aeroURL)
@@ -180,7 +227,7 @@ func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
 	utxoStore, err := aerospikestore.New(ctx, logger, tSettings, parsedURL)
 	require.NoError(t, err, "aerospike store must construct — this also proves Lua UDF registration succeeded")
 
-	require.NoError(t, utxoStore.SetBlockHeight(perfFixtureHeight))
+	require.NoError(t, utxoStore.SetBlockHeight(opts.blockHeight))
 
 	subtreeStore := blobmemory.New()
 	txStore := blobmemory.New()
@@ -188,12 +235,28 @@ func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
 	blockchainClient := &perfBlockchainClient{
 		state:          blockchain.FSMStateRUNNING,
 		blockHeaderIDs: []uint32{1, 2, 3},
+		height:         opts.blockHeight,
 	}
 
 	baStub := &blockAssemblyStub{}
 
+	// KafkaAsyncProducerMock.Publish is a blocking send into a 100-deep buffer
+	// (util/kafka/kafka_producer_async_mock.go:19,47) that nothing drains. The
+	// validator publishes one txmeta per validated tx
+	// (Validator.go:1005-1016), so past 100 txs every remaining
+	// blessMissingTransaction goroutine parks in Publish forever. Draining keeps
+	// the real per-tx enqueue cost in the measurement without the deadlock.
+	//
+	// Boundary, same class as the block-assembly hop: the Kafka broker round trip
+	// itself is not measured, only the enqueue.
+	txMetaProducer := kafka.NewKafkaAsyncProducerMock()
+	rejectedProducer := kafka.NewKafkaAsyncProducerMock()
+
+	drained := drainProducer(t, txMetaProducer)
+	drainProducer(t, rejectedProducer)
+
 	realValidator, err := validator.New(ctx, logger, tSettings, utxoStore,
-		kafka.NewKafkaAsyncProducerMock(), kafka.NewKafkaAsyncProducerMock(), nil,
+		txMetaProducer, rejectedProducer, nil,
 		baStub, blockchainClient)
 	require.NoError(t, err)
 
@@ -204,14 +267,41 @@ func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
 	require.NoError(t, err)
 
 	return &perfHarness{
-		server:        server,
-		utxoStore:     utxoStore,
-		subtreeStore:  subtreeStore,
-		blockAssembly: baStub,
-		blockchain:    blockchainClient,
-		settings:      tSettings,
-		logger:        logger,
+		server:          server,
+		utxoStore:       utxoStore,
+		subtreeStore:    subtreeStore,
+		blockAssembly:   baStub,
+		blockchain:      blockchainClient,
+		settings:        tSettings,
+		logger:          logger,
+		txMetaPublished: drained,
+		blockHeight:     opts.blockHeight,
 	}
+}
+
+// drainProducer consumes a mock producer's publish channel for the life of the
+// test and counts the messages, so Publish never blocks. Returns the counter.
+func drainProducer(t *testing.T, producer *kafka.KafkaAsyncProducerMock) *atomic.Uint64 {
+	t.Helper()
+
+	counter := &atomic.Uint64{}
+	done := make(chan struct{})
+	ch := producer.PublishChannel()
+
+	go func() {
+		for {
+			select {
+			case <-ch:
+				counter.Add(1)
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	t.Cleanup(func() { close(done) })
+
+	return counter
 }
 
 // TestUnseenTxThroughput_Smoke is phase 1: prove every real component connects
@@ -219,7 +309,17 @@ func newPerfHarness(t *testing.T, tune func(*settings.Settings)) *perfHarness {
 // silently ran with addTXToBlockAssembly == false would measure the catchup path
 // instead of the tip path and every later number would be wrong.
 func TestUnseenTxThroughput_Smoke(t *testing.T) {
-	h := newPerfHarness(t, nil)
+	// Mainnet params at a pre-fork height: the fixtures below are real 2013-era
+	// mainnet transactions whose signatures predate SIGHASH_FORKID, so they only
+	// verify under the pre-UAHF sighash algorithm. 257727 is also below mainnet
+	// CSVHeight (419328), keeping the MTP paths no-ops.
+	mainnetParams := chaincfg.MainNetParams
+
+	h := newPerfHarness(t, perfHarnessOptions{
+		chainParams: &mainnetParams,
+		blockHeight: 257727,
+	})
+
 	ctx := context.Background()
 
 	// Same real-mainnet parent/child pair the validator-level consensus tests and
@@ -233,10 +333,10 @@ func TestUnseenTxThroughput_Smoke(t *testing.T) {
 
 	// Seed ONLY the parent. The child stays absent from cache and store — that is
 	// the unseen precondition the whole reproduction depends on.
-	_, err = h.utxoStore.Create(ctx, parentTx, perfFixtureHeight-1)
+	_, err = h.utxoStore.Create(ctx, parentTx, h.blockHeight-1)
 	require.NoError(t, err)
 
-	blockBytes, subtreeHash := buildUnseenBlock(t, h, []*bt.Tx{childTx})
+	blockBytes, _ := buildUnseenBlockFromTxs(t, h, []*bt.Tx{childTx}, 1)
 
 	response, err := h.server.CheckBlockSubtrees(ctx, &subtreevalidation_api.CheckBlockSubtreesRequest{
 		Block:   blockBytes,
@@ -244,7 +344,6 @@ func TestUnseenTxThroughput_Smoke(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, response.Blessed)
-	_ = subtreeHash
 
 	// The child must exist and be spendable: Create marked it locked because it
 	// went to block assembly, then twoPhaseCommitTransaction unlocked it. Locked
@@ -258,58 +357,4 @@ func TestUnseenTxThroughput_Smoke(t *testing.T) {
 	// catchup path, not the tip path.
 	require.Equal(t, uint64(1), h.blockAssembly.stores.Load(),
 		"block assembly must have received the tx — zero means the RUNNING FSM pin did not take effect")
-}
-
-// buildUnseenBlock writes the given txs into a single subtree as legacy files and
-// returns the serialized block referencing it.
-//
-// The subtree is written as FileTypeSubtreeToCheck and FileTypeSubtreeData but
-// deliberately NOT as FileTypeSubtree: CheckBlockSubtrees early-returns Blessed
-// for subtrees that already exist as FileTypeSubtree
-// (check_block_subtrees.go:438-465), which would skip all the work being
-// measured.
-func buildUnseenBlock(t *testing.T, h *perfHarness, txs []*bt.Tx) ([]byte, *chainhash.Hash) {
-	t.Helper()
-
-	ctx := context.Background()
-
-	subtree, err := subtreepkg.NewTreeByLeafCount(subtreepkg.CeilPowerOfTwo(len(txs)))
-	require.NoError(t, err)
-
-	subtreeData := subtreepkg.NewSubtreeData(subtree)
-
-	for idx, tx := range txs {
-		require.NoError(t, subtree.AddNode(*tx.TxIDChainHash(), 1, 0))
-		require.NoError(t, subtreeData.AddTx(tx, idx))
-	}
-
-	subtreeBytes, err := subtree.Serialize()
-	require.NoError(t, err)
-
-	subtreeDataBytes, err := subtreeData.Serialize()
-	require.NoError(t, err)
-
-	root := subtree.RootHash()
-
-	require.NoError(t, h.subtreeStore.Set(ctx, root[:], fileformat.FileTypeSubtreeToCheck, subtreeBytes))
-	require.NoError(t, h.subtreeStore.Set(ctx, root[:], fileformat.FileTypeSubtreeData, subtreeDataBytes))
-
-	header := &model.BlockHeader{
-		Version:        1,
-		HashPrevBlock:  &chainhash.Hash{},
-		HashMerkleRoot: &chainhash.Hash{},
-		Timestamp:      1,
-		Bits:           model.NBit{},
-		Nonce:          0,
-	}
-
-	coinbaseTx := &bt.Tx{Version: 1}
-
-	block, err := model.NewBlock(header, coinbaseTx, []*chainhash.Hash{root}, uint64(len(txs)+1), 0, perfFixtureHeight, 0)
-	require.NoError(t, err)
-
-	blockBytes, err := block.Bytes()
-	require.NoError(t, err)
-
-	return blockBytes, root
 }

--- a/services/subtreevalidation/metrics.go
+++ b/services/subtreevalidation/metrics.go
@@ -58,6 +58,30 @@ var (
 	// validation logic, separate from handler overhead.
 	prometheusSubtreeValidationValidateSubtreeDuration prometheus.Histogram
 
+	// prometheusSubtreeValidationLevelsPerBlock records how many dependency levels a
+	// block's unseen transactions were organised into by selectPrepareTxsPerLevel.
+	//
+	// This is the number that decides the cost of a block on this path. Levels are
+	// processed serially with a barrier each (check_block_subtrees.go), and a level
+	// costs roughly a fixed set of store round trips regardless of how many
+	// transactions it holds — so total cost tracks level COUNT, not transaction count.
+	// It was previously available only at Debugf, which meant the depth of the two
+	// slow mainnet blocks in #1379 had to be reconstructed from a third-party API.
+	prometheusSubtreeValidationLevelsPerBlock prometheus.Histogram
+
+	// prometheusSubtreeValidationLevelDuration tracks the wall time of a single
+	// dependency level: parent prefetch, then the bounded-parallel validation of every
+	// transaction at that level, up to the barrier.
+	//
+	// Per-level timing was Debugf-only, so diagnosing #1379 required deriving a
+	// per-level average by dividing a total by a level count obtained elsewhere.
+	prometheusSubtreeValidationLevelDuration prometheus.Histogram
+
+	// prometheusSubtreeValidationPrefetchLevelParents tracks the duration of the
+	// per-level bulk parent read. It is one of the serialised round trips on a level's
+	// critical path and had no instrumentation at all.
+	prometheusSubtreeValidationPrefetchLevelParents prometheus.Histogram
+
 	// prometheusSubtreeValidationBlessMissingTransaction tracks the duration of bless missing transaction operations.
 	// This histogram measures the time taken to handle missing transactions,
 	// which is an important aspect of subtree validation.
@@ -161,6 +185,38 @@ func _initPrometheusMetrics() {
 			Name:      "validate_subtree_duration",
 			Help:      "Duration of validate subtree",
 			Buckets:   util.MetricsBucketsMilliLongSeconds,
+		},
+	)
+
+	prometheusSubtreeValidationLevelsPerBlock = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "teranode",
+			Subsystem: "subtreevalidation",
+			Name:      "levels_per_block",
+			Help:      "Number of dependency levels the unseen transactions of a block were organised into",
+			// Level depth, not a duration: powers of two up to 4096 so both a flat
+			// block (1) and a pathologically deep one land in distinct buckets.
+			Buckets: []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096},
+		},
+	)
+
+	prometheusSubtreeValidationLevelDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "teranode",
+			Subsystem: "subtreevalidation",
+			Name:      "level_duration",
+			Help:      "Duration of processing a single dependency level, including parent prefetch",
+			Buckets:   util.MetricsBucketsMilliSeconds,
+		},
+	)
+
+	prometheusSubtreeValidationPrefetchLevelParents = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "teranode",
+			Subsystem: "subtreevalidation",
+			Name:      "prefetch_level_parents",
+			Help:      "Duration of the per-level bulk parent read",
+			Buckets:   util.MetricsBucketsMilliSeconds,
 		},
 	)
 

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -1002,13 +1002,28 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 	}
 
 	if txMetaData.Locked {
-		if err = v.twoPhaseCommitTransaction(decoupledCtx, tx, txID); err != nil {
-			v.logger.Warnf("[Validate][%s] error during two phase commit, transaction will be marked as spendable on next block: %v", txID, err)
-
-			return txMetaData, err
+		// A failed unlock is recoverable and must NOT fail the transaction.
+		//
+		// By this point the tx is fully validated: inputs spent, record created, sent
+		// to block assembly, txmeta published. The only outstanding work is clearing
+		// the locked flag, and that happens anyway when the tx is mined
+		// (SetMinedMulti clears it — see the "set the record to not be locked again"
+		// branch in stores/utxo/aerospike/teranode.lua), which is exactly what the
+		// warning below has always claimed.
+		//
+		// Returning the error here contradicted that: it escalated a self-healing
+		// condition into a transaction failure. On the block-validation path that
+		// increments errorsFound in processTransactionsInLevels, which can fail an
+		// entire batch of an otherwise valid block (#1379).
+		//
+		// The error is deliberately kept out of the named `err` return so the
+		// tracing/metrics deferral records this tx as the success it is. Locked stays
+		// true on failure so the in-memory metadata still reflects the stored state.
+		if commitErr := v.twoPhaseCommitTransaction(decoupledCtx, tx, txID); commitErr != nil {
+			v.logger.Warnf("[Validate][%s] error during two phase commit, transaction will be marked as spendable on next block: %v", txID, commitErr)
+		} else {
+			txMetaData.Locked = false
 		}
-
-		txMetaData.Locked = false
 	}
 
 	return txMetaData, nil

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1356,6 +1357,98 @@ func TestValidator_TwoPhaseCommitTransaction_SetLockedFails(t *testing.T) {
 	err = utxoStore.GetMeta(ctx, tx.TxIDChainHash(), metaData)
 	require.NoError(t, err)
 	require.True(t, metaData.Locked)
+}
+
+// failSetLockedStore fails only SetLocked, so the two-phase-commit unlock at the end
+// of validateInternal is the single operation that errors.
+type failSetLockedStore struct {
+	utxostore.Store
+
+	calls atomic.Uint64
+}
+
+func (s *failSetLockedStore) SetLocked(_ context.Context, _ []chainhash.Hash, _ bool) error {
+	s.calls.Add(1)
+	return errors.NewStorageError("injected SetLocked failure")
+}
+
+// TestValidator_FailedTwoPhaseCommitDoesNotFailTransaction pins that a failed unlock
+// is reported but does not fail the transaction.
+//
+// The unlock is the last step of validateInternal: by then the inputs are spent, the
+// record is created, the tx has gone to block assembly and the txmeta is published.
+// Clearing the locked flag also happens anyway when the tx is mined (SetMinedMulti),
+// which is what the warning on that path has always stated.
+//
+// It previously returned the error regardless, which on the block-validation path
+// increments errorsFound in processTransactionsInLevels and can fail an entire batch
+// of an otherwise valid block (#1379). Locked must stay true so the returned metadata
+// still matches what is stored.
+func TestValidator_FailedTwoPhaseCommitDoesNotFailTransaction(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test_2pc_failure")
+	require.NoError(t, err)
+
+	baseStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	utxoStore := &failSetLockedStore{Store: baseStore}
+
+	txs := transactions.CreateTestTransactionChainWithCount(t, 3)
+
+	_, err = baseStore.Create(ctx, txs[0], 1, utxostore.WithLocked(false))
+	require.NoError(t, err)
+
+	blockAsmMock := blockassembly.NewMock()
+	blockAsmMock.On("Store", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(true, nil).Times(1)
+
+	settings := test.CreateBaseTestSettings(t)
+	settings.BlockAssembly.Disabled = false
+
+	v := &Validator{
+		logger:         logger,
+		utxoStore:      utxoStore,
+		blockAssembler: blockAsmMock,
+		settings:       settings,
+		txValidator:    NewTxValidator(logger, test.CreateBaseTestSettings(t)),
+		stats:          gocore.NewStat("validator"),
+	}
+
+	require.NoError(t, baseStore.SetBlockHeight(2))
+	require.NoError(t, baseStore.SetMedianBlockTime(1700000000))
+
+	txMeta, err := v.ValidateWithOptions(ctx, txs[1], 2, &Options{AddTXToBlockAssembly: true})
+
+	require.NoError(t, err, "a failed two-phase-commit unlock must not fail the transaction — it is recoverable when the tx is mined")
+	require.NotNil(t, txMeta)
+	require.Positive(t, utxoStore.calls.Load(), "SetLocked must actually have been attempted, otherwise this test proves nothing")
+
+	// The unlock failed, so the flag is still set both in the returned metadata and in
+	// the store. Reporting it as cleared would misrepresent the stored state.
+	require.True(t, txMeta.Locked, "returned metadata must still report Locked after a failed unlock")
+
+	stored := &meta.Data{}
+	require.NoError(t, baseStore.GetMeta(ctx, txs[1].TxIDChainHash(), stored))
+	require.True(t, stored.Locked, "stored record must still be locked after a failed unlock")
+
+	// The transaction is nonetheless fully validated: its parent's output is spent.
+	spentUtxoHash, err := util.UTXOHashFromOutput(txs[0].TxIDChainHash(), txs[0].Outputs[0], 0)
+	require.NoError(t, err)
+
+	spendStatus, err := baseStore.GetSpend(ctx, &utxostore.Spend{
+		TxID:     txs[0].TxIDChainHash(),
+		Vout:     0,
+		UTXOHash: spentUtxoHash,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, spendStatus.SpendingData, "parent output must be spent — the tx was validated despite the unlock failing")
 }
 
 func TestValidator_LockedFlagChangedIfBlockAssemblyStoreSucceeds(t *testing.T) {


### PR DESCRIPTION
Investigation of #1379 (block validation collapsing to ~30–50 tx/s on blocks whose
transactions were never seen via propagation), plus the two code changes it produced
and the reproduction harness.

**The root cause is not found.** The harness reproduces a collapse in the same range as
mainnet, but the mechanism is still open. Details and the current state of the
hypothesis space are in `plans/1379-unseen-tx-throughput-findings.md`. Read that before
building on any of this.

## Code changes

### `fix(validator)`: a failed 2PC unlock no longer fails the transaction

`validateInternal` logged the two-phase-commit unlock failure as recoverable —
"transaction will be marked as spendable on next block" — and then returned the error
anyway. The two statements contradicted each other and the error won.

By the time the unlock runs the transaction is fully validated: inputs spent, record
created, sent to block assembly, txmeta published. Clearing the locked flag also happens
when the transaction is mined (`SetMinedMulti`, the "set the record to not be locked
again" branch in `teranode.lua`), exactly as the warning claimed. So the condition is
self-healing.

Returning it escalated that into a transaction failure. On the block-validation path
`blessMissingTransaction` turns a non-conflicting error into a processing error, which
increments `errorsFound` in `processTransactionsInLevels` and can fail an entire batch
of an otherwise valid block.

The error is now logged and swallowed, kept out of the named `err` return so the tracing
deferral records the transaction as the success it is. `Locked` stays true on failure so
the returned metadata still matches the stored record.

`TestValidator_FailedTwoPhaseCommitDoesNotFailTransaction` injects a `SetLocked` failure
via a store wrapper and asserts the transaction still validates, the parent output is
still spent, and `Locked` remains true in both the returned metadata and the store. It
also asserts `SetLocked` was actually attempted, so it cannot silently pass without
exercising the path. Confirmed failing without the change and passing with it.

### `feat(subtreevalidation)`: instrument level depth and per-level duration

Issue ask 1. Five block/level-grain logs in `processTransactionsInLevels` move from
`Debugf` to `Infof`: the two pre-check `missed` variants, the level count, and the
per-level start/DONE (DONE now carries its duration).

The level count is the one that mattered — analysing #1379 required reconstructing it
from a third-party API because it was Debug-only.

All six per-transaction `Debugf` sites are deliberately left alone. Those are what would
flood: at roughly 750 blessings/minute in steady state they add 25–40x the current log
volume, and they sit inside the 2048-wide per-level fan-out where writing to a single
stdout lock would contend with the work being measured. This change adds ~52 lines per
block (2 pre-check + 1 level count + 2 × levels) against a 10-minute block interval.

INFO rather than a log-level flip because the deployment's log pipeline drops DEBUG, so
DEBUG would land only in a container log that rotates in hours at that volume.

Three histograms added:

| metric | purpose |
|---|---|
| `teranode_subtreevalidation_levels_per_block` | level depth distribution — the cost driver, previously unmeasurable |
| `teranode_subtreevalidation_level_duration` | per-level wall time including prefetch |
| `teranode_subtreevalidation_prefetch_level_parents` | the per-level bulk parent read, previously uninstrumented |

`levels_per_block` uses power-of-two buckets to 4096 rather than latency buckets, since
it is a depth.

## Reproduction harness

`services/subtreevalidation/check_block_subtrees_unseen_perf_*_test.go`, all behind
`//go:build aerospike` so `make test` never starts a container.

Real Aerospike (testcontainer, Lua UDFs registered), real `validator.Validator`, real
GoBDK, FSM pinned to RUNNING so `addTXToBlockAssembly` is true and the tip path is what
gets measured. The mainnet nodes run `useLocalValidator = true`, so an in-process
validator is topology-faithful rather than an approximation.

The fixture seeds only the parents, as mined; the block's own transactions stay absent
from cache and store, which is the unseen precondition. `assertUnseenPrecondition`
proves both halves before any timing is taken rather than trusting the generator.

Parameterised on level histogram, inputs per transaction, parent size relative to the
32 KB external-store threshold, and conflicting-transaction count. Reports throughput,
per-level durations, per-pass store-operation attribution, and CPU/block/mutex profiles.

```bash
# baseline in mainnet block 959979's level shape
go test -tags aerospike -run 'TestUnseenTxThroughput$' -v -timeout 40m ./services/subtreevalidation/

# bisect matrix
go test -tags aerospike -run TestUnseenTxBisect -v -timeout 60m ./services/subtreevalidation/
```

## What the investigation established

Measured, and independent of the unresolved root cause:

- **Level depth is a ~10x multiplier.** The same 1,587 transactions run at 16,404 tx/s
  in one dependency level and 1,655 tx/s across 25. A level costs roughly a fixed set of
  serialised store round trips regardless of its width, so cost tracks level count, not
  transaction count.
- **Production confirms the wrapper/store gap.** `validator_transactions_spend_utxos`
  averages 25.3 ms while the `aerospike_utxo_spend_batch` it drives averages 0.54 ms.
  The store is fast; the wait is batcher queueing plus flush window.
- **Conflicting transactions collapse throughput.** 807 of 1,561 transactions conflicting
  takes the harness from 1,557 to 18.8 tx/s. Descendant depth is irrelevant, so it is not
  the recursive conflict marking.
- **Ruled out by measurement**, each tested rather than reasoned about: the phase-3
  sequential fallback, missing/cross-subtree parents, `DEVICE_OVERLOAD` retry, the batcher
  leak guard, `mtpMu` serialisation, pathological level counts, external-store read
  latency (0.33 ms p50 measured on the node itself), and the Aerospike connection-pool cap
  (A/B measured, no effect).

## What is explicitly not claimed

- No root cause for the collapse.
- The harness runs at ~52% conflicting transactions where mainnet 959979 was ~3%, so
  **whether mainnet's conflict density alone is sufficient is not established.** The
  findings doc names the experiment that would settle it.
- The 10x level-depth figure is measured locally at 25 levels. Real mainnet block depth
  is unknown, which is why the instrumentation is in this PR — it should inform any work
  on the per-level cost rather than the reverse.
- The findings doc records several hypotheses that were raised and then refuted, marked in
  place rather than deleted, so the reasoning is auditable. Four are retractions of my own
  earlier conclusions.

Issue ask 3 (dedupe concurrent legacy deliveries) needs no code: `SyncManager.inFlightBlocks`
already does it, shipped in v0.16.0-beta-4, and none of the three nodes ran it on
2026-07-29. That is a deployment item, covered in the findings doc.

## Testing

- `go build ./...` clean.
- `go test ./services/validator/ ./services/subtreevalidation/` pass.
- `go vet` clean with and without the `aerospike` tag.
- `golangci-lint run` clean on both packages (5 remaining `prealloc` findings are
  pre-existing, in test files not touched here).
- Harness smoke and fixture round-trip pass against Aerospike after rebasing onto current
  main, including the `SpendAndCreate` refactor.
