### PR TITLE
fix(subtreevalidation): walk the conflicting descendant cone once, not once per member (#1391)

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -62,6 +62,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// conflictingConeWarnThreshold is the counter-conflicting set size above which the
+// cone is worth a log line. The set is the loser's full descendant closure, which
+// keeps growing for as long as the node cannot advance past the block that would
+// demote it (#1391), so its size is the leading indicator of that condition.
+const conflictingConeWarnThreshold = 1000
+
 // missingTx represents a transaction that needs to be retrieved and its position in the subtree.
 //
 // This structure pairs a transaction with its index in the original subtree transaction list,
@@ -470,6 +476,10 @@ func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHa
 	counterConflictingTxHashes, err := utxo.GetCounterConflictingTxHashes(ctx, u.utxoStore, txHash)
 	if err != nil {
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx hashes", txHash.String(), err)
+	}
+
+	if len(counterConflictingTxHashes) > conflictingConeWarnThreshold {
+		u.logger.Warnf("[checkCounterConflictingOnCurrentChain][%s] counter-conflicting set is %d transactions", txHash.String(), len(counterConflictingTxHashes))
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -510,20 +510,20 @@ func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHa
 	}
 
 	// One walk, not one per element. counterConflictingTxHashes is already the
-	// transitive closure of the counter-conflicting transactions' descendants
-	// (GetCounterConflictingTxHashes unions GetConflictingChildren of every spender
-	// into it at process_conflicting.go:1129), so re-walking each element only
+	// transitive closure of the counter-conflicting transactions' descendants —
+	// GetCounterConflictingTxHashes unions each spender's GetConflictingChildren
+	// result into counterConflictingMap — so re-walking each element only
 	// re-derives subsets of what is already in hand: N serial BFS walks over the set
 	// that IS the descendant set, one store round trip per level. With a linear
 	// self-spend chain for a cone that is O(N^2) reads, which wedged the mainnet
 	// fleet at height 960,827 for 26 minutes per attempt — see #1391.
 	//
-	// The frozen sentinel is already rejected on the counter side: inside the counter
-	// walk for descendants (process_conflicting.go:1125) and in the errgroup above for
-	// a directly-frozen counter. The one term no earlier walk covers is the descendant
-	// cone of the transaction under check itself, so that is the single walk that
-	// remains. It is cheap — the transaction has just arrived in a block, so it
-	// normally has no descendants in the store at all.
+	// The frozen sentinel is already rejected on the counter side: by the
+	// FrozenBytesTxHash check inside GetCounterConflictingTxHashes, and in the
+	// errgroup above for a directly-frozen counter. The one term no earlier walk
+	// covers is the descendant cone of the transaction under check itself, so that
+	// is the single walk that remains. It is cheap — the transaction has just
+	// arrived in a block, so it normally has no descendants in the store at all.
 	childTransactionHashes, err := utxo.GetConflictingChildren(ctx, u.utxoStore, txHash)
 	if err != nil {
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get child transactions", txHash.String(), err)

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -499,17 +499,29 @@ func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHa
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx meta", txHash.String(), err)
 	}
 
-	// check whether the child transactions of the counter-conflicting transactions are frozen
-	for _, counterConflictingTxHash := range counterConflictingTxHashes {
-		childTransactionHashes, err := utxo.GetConflictingChildren(ctx, u.utxoStore, counterConflictingTxHash)
-		if err != nil {
-			return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get child transactions", txHash.String(), err)
-		}
+	// One walk, not one per element. counterConflictingTxHashes is already the
+	// transitive closure of the counter-conflicting transactions' descendants
+	// (GetCounterConflictingTxHashes unions GetConflictingChildren of every spender
+	// into it at process_conflicting.go:1129), so re-walking each element only
+	// re-derives subsets of what is already in hand: N serial BFS walks over the set
+	// that IS the descendant set, one store round trip per level. With a linear
+	// self-spend chain for a cone that is O(N^2) reads, which wedged the mainnet
+	// fleet at height 960,827 for 26 minutes per attempt — see #1391.
+	//
+	// The frozen sentinel is already rejected on the counter side: inside the counter
+	// walk for descendants (process_conflicting.go:1125) and in the errgroup above for
+	// a directly-frozen counter. The one term no earlier walk covers is the descendant
+	// cone of the transaction under check itself, so that is the single walk that
+	// remains. It is cheap — the transaction has just arrived in a block, so it
+	// normally has no descendants in the store at all.
+	childTransactionHashes, err := utxo.GetConflictingChildren(ctx, u.utxoStore, txHash)
+	if err != nil {
+		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get child transactions", txHash.String(), err)
+	}
 
-		for _, childTransactionHash := range childTransactionHashes {
-			if childTransactionHash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
-				return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] child transaction is frozen", txHash.String())
-			}
+	for _, childTransactionHash := range childTransactionHashes {
+		if childTransactionHash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
+			return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] child transaction is frozen", txHash.String())
 		}
 	}
 

--- a/services/subtreevalidation/SubtreeValidation_test.go
+++ b/services/subtreevalidation/SubtreeValidation_test.go
@@ -1015,6 +1015,7 @@ func Test_checkCounterConflictingOnCurrentChain(t *testing.T) {
 
 		// Create a mock Server struct
 		s := &Server{
+			logger:    ulogger.New("test"),
 			utxoStore: utxoStore,
 		}
 
@@ -1043,6 +1044,7 @@ func Test_checkCounterConflictingOnCurrentChain(t *testing.T) {
 
 		// Create a mock Server struct
 		s := &Server{
+			logger:    ulogger.New("test"),
 			utxoStore: utxoStore,
 		}
 

--- a/services/subtreevalidation/conflicting_walk_cost_test.go
+++ b/services/subtreevalidation/conflicting_walk_cost_test.go
@@ -1,0 +1,292 @@
+// Package subtreevalidation provides functionality for validating subtrees in a blockchain context.
+package subtreevalidation
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/nullstore"
+	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// countingStore is a map-backed utxo.Store that counts Store.Get calls. The
+// conflicting walks are real — GetConflictingChildren and GetCounterConflicting
+// delegate to the production free functions — so the Get count is the true cost
+// of the walk under test, not a stubbed approximation. NullStore is embedded only
+// to satisfy the rest of the wide utxo.Store interface.
+type countingStore struct {
+	*nullstore.NullStore
+
+	mu        sync.Mutex
+	records   map[chainhash.Hash]*meta.Data
+	getCount  atomic.Int64
+	metaCount atomic.Int64
+}
+
+func newCountingStore(t *testing.T) *countingStore {
+	t.Helper()
+
+	null, err := nullstore.NewNullStore()
+	require.NoError(t, err)
+
+	return &countingStore{NullStore: null, records: make(map[chainhash.Hash]*meta.Data)}
+}
+
+func (s *countingStore) put(hash chainhash.Hash, data *meta.Data) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.records[hash] = data
+}
+
+func (s *countingStore) gets() int64     { return s.getCount.Load() }
+func (s *countingStore) getMetas() int64 { return s.metaCount.Load() }
+
+// lookup is the uncounted read. Get and GetMeta both go through it so the two
+// counters stay independent — a GetMeta must not inflate the walk's Get count,
+// which is the number the cost assertion is about.
+func (s *countingStore) lookup(hash *chainhash.Hash) (*meta.Data, error) {
+	// The frozen / coinbase-placeholder sentinel is a record-less pseudo-hash.
+	// Aerospike returns (nil, nil) for it rather than an error
+	// (stores/utxo/aerospike/get.go:724) and the walk relies on that, so the fake
+	// must reproduce it or frozen detection behaves differently here than in
+	// production.
+	if hash.Equal(subtree.CoinbasePlaceholderHashValue) {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, ok := s.records[*hash]
+	if !ok {
+		return nil, errors.NewTxNotFoundError("%v not found", hash)
+	}
+
+	return data, nil
+}
+
+func (s *countingStore) Get(_ context.Context, hash *chainhash.Hash, _ ...fields.FieldName) (*meta.Data, error) {
+	// Not counted for the sentinel: no round trip happens for it in the real store
+	// either, so counting it would make the bound depend on frozen placement.
+	if !hash.Equal(subtree.CoinbasePlaceholderHashValue) {
+		s.getCount.Add(1)
+	}
+
+	return s.lookup(hash)
+}
+
+func (s *countingStore) GetMeta(_ context.Context, hash *chainhash.Hash, data *meta.Data) error {
+	s.metaCount.Add(1)
+
+	found, err := s.lookup(hash)
+	if err != nil {
+		return err
+	}
+
+	if found != nil {
+		*data = *found
+	}
+
+	return nil
+}
+
+func (s *countingStore) GetConflictingChildren(ctx context.Context, hash chainhash.Hash) ([]chainhash.Hash, error) {
+	return utxo.GetConflictingChildren(ctx, s, hash)
+}
+
+func (s *countingStore) GetCounterConflicting(ctx context.Context, hash chainhash.Hash) ([]chainhash.Hash, error) {
+	return utxo.GetCounterConflictingTxHashes(ctx, s, hash)
+}
+
+// txSpending builds a transaction spending vout 0 of parentTxHash. Only the input
+// list matters — GetCounterConflictingTxHashes reads Tx.Inputs to find the parents
+// whose spender slots identify the counter-conflicting transactions.
+func txSpending(t *testing.T, parentTxHash chainhash.Hash) *bt.Tx {
+	t.Helper()
+
+	tx := bt.NewTx()
+
+	input := &bt.Input{PreviousTxOutIndex: 0}
+	require.NoError(t, input.PreviousTxIDAdd(&parentTxHash))
+	tx.Inputs = append(tx.Inputs, input)
+	tx.Outputs = append(tx.Outputs, &bt.Output{Satoshis: 1000, LockingScript: &bscript.Script{bscript.OpTRUE}})
+
+	return tx
+}
+
+func spentBy(txHash chainhash.Hash) []*spendpkg.SpendingData {
+	return []*spendpkg.SpendingData{spendpkg.NewSpendingData(&txHash, 0)}
+}
+
+// coneChainLength is the length of the planted linear self-spend chain. It mirrors the
+// production shape from #1391: the counter-conflicting transaction heads a chain
+// that extends by roughly a hundred transactions per block, one transaction per
+// BFS level, so each walk costs N serial store round trips.
+const coneChainLength = 1000
+
+// plantLinearChain builds the #1391 shape and returns (parent, txUnderCheck, counter).
+//
+//	parent P  — vout 0 recorded as spent by the counter Y0
+//	txUnderCheck X — spends P:0 as well (the conflicting transaction), no descendants
+//	counter Y0 → Y1 → ... → Y{coneChainLength-1}, a linear chain of ordinary spenders
+func plantLinearChain(t *testing.T, store *countingStore) (chainhash.Hash, chainhash.Hash, chainhash.Hash) {
+	t.Helper()
+
+	parentHash := chainhash.HashH([]byte("cone-parent"))
+	txUnderCheck := chainhash.HashH([]byte("cone-tx-under-check"))
+
+	chain := make([]chainhash.Hash, coneChainLength)
+	for i := range chain {
+		chain[i] = chainhash.HashH([]byte("cone-chain-" + strconv.Itoa(i)))
+	}
+
+	store.put(parentHash, &meta.Data{
+		Tx:            txSpending(t, chainhash.HashH([]byte("cone-grandparent"))),
+		SpendingDatas: spentBy(chain[0]),
+	})
+
+	// X spends the same parent output and has no descendants of its own.
+	store.put(txUnderCheck, &meta.Data{Tx: txSpending(t, parentHash)})
+
+	for i := 0; i < coneChainLength-1; i++ {
+		store.put(chain[i], &meta.Data{SpendingDatas: spentBy(chain[i+1])})
+	}
+
+	// tip of the chain: unspent
+	store.put(chain[coneChainLength-1], &meta.Data{})
+
+	return parentHash, txUnderCheck, chain[0]
+}
+
+// The counter-conflicting check must cost O(N) store reads, not O(N^2). Before the
+// fix it walked the full descendant cone once per element of a slice that already
+// IS the cone: 1002 reads for the first walk plus sum(1..1000) = 500500 for the
+// re-walks, which is the 26-minute mainnet stall at 960,827.
+func TestCheckCounterConflictingOnCurrentChain_CostIsLinear(t *testing.T) {
+	ctx := context.Background()
+	store := newCountingStore(t)
+
+	_, txUnderCheck, _ := plantLinearChain(t, store)
+
+	u := &Server{utxoStore: store, logger: ulogger.New("test")}
+
+	require.NoError(t, u.checkCounterConflictingOnCurrentChain(ctx, txUnderCheck, map[uint32]bool{}))
+
+	// Post-fix: 1 (X.Tx) + 1 (parent utxos) + coneChainLength (the single cone walk)
+	// + 1 (the one walk rooted at X) = coneChainLength + 3.
+	require.Less(t, store.gets(), int64(3*coneChainLength),
+		"descendant walk cost is not linear in the chain length — the per-element re-walk is back")
+
+	// The mined-on-our-chain check still reads every counter's meta exactly once.
+	require.Equal(t, int64(coneChainLength+1), store.getMetas())
+}
+
+// Equivalence guard: a frozen output directly on the counter-conflicting slot must
+// still be rejected. Passes both before and after the fix — that is the point.
+func TestCheckCounterConflictingOnCurrentChain_RejectsFrozenCounter(t *testing.T) {
+	ctx := context.Background()
+	store := newCountingStore(t)
+
+	parentHash := chainhash.HashH([]byte("frozen-counter-parent"))
+	txUnderCheck := chainhash.HashH([]byte("frozen-counter-tx"))
+
+	store.put(parentHash, &meta.Data{SpendingDatas: spentBy(subtree.CoinbasePlaceholderHashValue)})
+	store.put(txUnderCheck, &meta.Data{Tx: txSpending(t, parentHash)})
+
+	u := &Server{utxoStore: store, logger: ulogger.New("test")}
+
+	err := u.checkCounterConflictingOnCurrentChain(ctx, txUnderCheck, map[uint32]bool{})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "frozen")
+}
+
+// Equivalence guard: a frozen output deep inside the counter's descendant cone must
+// still be rejected. This one is caught inside GetCounterConflictingTxHashes, which
+// is why the per-element re-walk was redundant for it.
+func TestCheckCounterConflictingOnCurrentChain_RejectsFrozenDeepInCounterCone(t *testing.T) {
+	ctx := context.Background()
+	store := newCountingStore(t)
+
+	parentHash := chainhash.HashH([]byte("frozen-deep-parent"))
+	txUnderCheck := chainhash.HashH([]byte("frozen-deep-tx"))
+	counterHash := chainhash.HashH([]byte("frozen-deep-counter"))
+	midHash := chainhash.HashH([]byte("frozen-deep-mid"))
+
+	store.put(parentHash, &meta.Data{SpendingDatas: spentBy(counterHash)})
+	store.put(txUnderCheck, &meta.Data{Tx: txSpending(t, parentHash)})
+	store.put(counterHash, &meta.Data{SpendingDatas: spentBy(midHash)})
+	store.put(midHash, &meta.Data{SpendingDatas: spentBy(subtree.CoinbasePlaceholderHashValue)})
+
+	u := &Server{utxoStore: store, logger: ulogger.New("test")}
+
+	err := u.checkCounterConflictingOnCurrentChain(ctx, txUnderCheck, map[uint32]bool{})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "frozen")
+}
+
+// Equivalence guard for the one term the deleted loop uniquely covered: a frozen
+// output inside the descendant cone of the transaction under CHECK, which no
+// earlier walk visits. This is why the fix keeps one walk instead of zero — delete
+// the remaining GetConflictingChildren call and this test fails.
+func TestCheckCounterConflictingOnCurrentChain_RejectsFrozenInOwnCone(t *testing.T) {
+	ctx := context.Background()
+	store := newCountingStore(t)
+
+	parentHash := chainhash.HashH([]byte("frozen-own-parent"))
+	txUnderCheck := chainhash.HashH([]byte("frozen-own-tx"))
+	counterHash := chainhash.HashH([]byte("frozen-own-counter"))
+	childHash := chainhash.HashH([]byte("frozen-own-child"))
+
+	store.put(parentHash, &meta.Data{SpendingDatas: spentBy(counterHash)})
+	store.put(txUnderCheck, &meta.Data{
+		Tx:            txSpending(t, parentHash),
+		SpendingDatas: spentBy(childHash),
+	})
+	store.put(counterHash, &meta.Data{})
+	store.put(childHash, &meta.Data{SpendingDatas: spentBy(subtree.CoinbasePlaceholderHashValue)})
+
+	u := &Server{utxoStore: store, logger: ulogger.New("test")}
+
+	err := u.checkCounterConflictingOnCurrentChain(ctx, txUnderCheck, map[uint32]bool{})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "frozen")
+}
+
+// Equivalence guard: a counter mined in a block on our current chain is still an
+// invalid-transaction rejection, not a processing error.
+func TestCheckCounterConflictingOnCurrentChain_StillRejectsMinedCounter(t *testing.T) {
+	ctx := context.Background()
+	store := newCountingStore(t)
+
+	parentHash := chainhash.HashH([]byte("mined-parent"))
+	txUnderCheck := chainhash.HashH([]byte("mined-tx"))
+	counterHash := chainhash.HashH([]byte("mined-counter"))
+
+	store.put(parentHash, &meta.Data{SpendingDatas: spentBy(counterHash)})
+	store.put(txUnderCheck, &meta.Data{Tx: txSpending(t, parentHash)})
+	store.put(counterHash, &meta.Data{BlockIDs: []uint32{7}})
+
+	u := &Server{utxoStore: store, logger: ulogger.New("test")}
+
+	err := u.checkCounterConflictingOnCurrentChain(ctx, txUnderCheck, map[uint32]bool{7: true})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxInvalid))
+}

--- a/services/subtreevalidation/conflicting_walk_cost_test.go
+++ b/services/subtreevalidation/conflicting_walk_cost_test.go
@@ -60,10 +60,11 @@ func (s *countingStore) getMetas() int64 { return s.metaCount.Load() }
 // which is the number the cost assertion is about.
 func (s *countingStore) lookup(hash *chainhash.Hash) (*meta.Data, error) {
 	// The frozen / coinbase-placeholder sentinel is a record-less pseudo-hash.
-	// Aerospike returns (nil, nil) for it rather than an error
-	// (stores/utxo/aerospike/get.go:724) and the walk relies on that, so the fake
-	// must reproduce it or frozen detection behaves differently here than in
-	// production.
+	// Aerospike returns (nil, nil) for it rather than an error — BatchDecorate's
+	// per-record error handling special-cases CoinbasePlaceholderHashValue so no
+	// Err is set for it even when the batch record itself errored — and the walk
+	// relies on that, so the fake must reproduce it or frozen detection behaves
+	// differently here than in production.
 	if hash.Equal(subtree.CoinbasePlaceholderHashValue) {
 		return nil, nil
 	}
@@ -174,8 +175,10 @@ func plantLinearChain(t *testing.T, store *countingStore) (chainhash.Hash, chain
 
 // The counter-conflicting check must cost O(N) store reads, not O(N^2). Before the
 // fix it walked the full descendant cone once per element of a slice that already
-// IS the cone: 1002 reads for the first walk plus sum(1..1000) = 500500 for the
-// re-walks, which is the 26-minute mainnet stall at 960,827.
+// IS the cone: 1002 reads to build the set (see GetCounterConflictingTxHashes) plus
+// sum(1..1000) = 500500 for re-walking the chain elements plus 1 more for re-walking
+// the tx-under-check itself, which is also a member of that slice — 501503 reads
+// total, the 26-minute mainnet stall at 960,827.
 func TestCheckCounterConflictingOnCurrentChain_CostIsLinear(t *testing.T) {
 	ctx := context.Background()
 	store := newCountingStore(t)
@@ -188,7 +191,7 @@ func TestCheckCounterConflictingOnCurrentChain_CostIsLinear(t *testing.T) {
 
 	// Post-fix: 1 (X.Tx) + 1 (parent utxos) + coneChainLength (the single cone walk)
 	// + 1 (the one walk rooted at X) = coneChainLength + 3.
-	require.Less(t, store.gets(), int64(3*coneChainLength),
+	require.Equal(t, int64(coneChainLength+3), store.gets(),
 		"descendant walk cost is not linear in the chain length — the per-element re-walk is back")
 
 	// The mined-on-our-chain check still reads every counter's meta exactly once.

--- a/stores/utxo/conflicting_walk_metrics_test.go
+++ b/stores/utxo/conflicting_walk_metrics_test.go
@@ -1,0 +1,65 @@
+package utxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func histogramSample(t *testing.T, h interface{ Write(*dto.Metric) error }) (count uint64, sum float64) {
+	t.Helper()
+
+	var m dto.Metric
+	require.NoError(t, h.Write(&m))
+
+	return m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum()
+}
+
+// A completed walk records exactly one node-count and one depth observation. The
+// stores/utxo free functions have no logger, so these histograms are the only
+// observability surface on a cone that grows with every block the node stays
+// wedged — a silent 26-minute walk is what #1391 presented as.
+func TestGetConflictingChildren_ObservesWalkSizeAndDepth(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	rootHash := chainhash.HashH([]byte("metrics-root"))
+	midHash := chainhash.HashH([]byte("metrics-mid"))
+	tipHash := chainhash.HashH([]byte("metrics-tip"))
+
+	// One .On per hash with a static return — the style the existing walk tests in
+	// process_conflicting_test.go use. The two trailing mock.Anything match the
+	// variadic fields the walk passes (fields.Utxos, fields.ConflictingChildren).
+	mockStore.On("Get", mock.Anything, &rootHash, mock.Anything, mock.Anything).
+		Return(&meta.Data{SpendingDatas: []*spendpkg.SpendingData{{TxID: &midHash}}}, nil)
+	mockStore.On("Get", mock.Anything, &midHash, mock.Anything, mock.Anything).
+		Return(&meta.Data{SpendingDatas: []*spendpkg.SpendingData{{TxID: &tipHash}}}, nil)
+	mockStore.On("Get", mock.Anything, &tipHash, mock.Anything, mock.Anything).
+		Return(&meta.Data{}, nil)
+
+	nodesBefore, nodesSumBefore := histogramSample(t, prometheusUtxoConflictingWalkNodes)
+	depthBefore, depthSumBefore := histogramSample(t, prometheusUtxoConflictingWalkDepth)
+
+	children, err := GetConflictingChildren(ctx, mockStore, rootHash)
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+
+	nodesAfter, nodesSumAfter := histogramSample(t, prometheusUtxoConflictingWalkNodes)
+	depthAfter, depthSumAfter := histogramSample(t, prometheusUtxoConflictingWalkDepth)
+
+	require.Equal(t, nodesBefore+1, nodesAfter)
+	require.Equal(t, depthBefore+1, depthAfter)
+
+	// three nodes visited: root, mid, tip
+	require.InDelta(t, nodesSumBefore+3, nodesSumAfter, 0.001)
+	// three levels walked: [root], [mid], [tip]
+	require.InDelta(t, depthSumBefore+3, depthSumAfter, 0.001)
+
+	mockStore.AssertExpectations(t)
+}

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -958,8 +958,10 @@ func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]ch
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
-		// Same unbounded per-level width as GetConflictingChildren; same ceiling.
-		g.SetLimit(128)
+		// Same unbounded per-level width as GetConflictingChildren, same ceiling, same
+		// reason: 4096 matches the aerospike Get batcher's getBatcherSize so a level
+		// still fills a batch in one wave rather than waiting out getBatcherDurationMillis.
+		g.SetLimit(4096)
 
 		for i, current := range currentLevel {
 			i := i
@@ -1038,11 +1040,12 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
 		// A single level is unbounded in width: one Get per member, no ceiling. A wide
-		// cone would open tens of thousands of concurrent store reads. 128 matches the
-		// limit the caller uses for its own per-hash fan-out
-		// (services/subtreevalidation/SubtreeValidation.go:476). Note this does not
-		// bind on the linear-chain shape from #1391, where every level holds one node.
-		g.SetLimit(128)
+		// cone would otherwise open one concurrent store read per level member. 4096
+		// matches the aerospike Get batcher's getBatcherSize, so a level still fills a
+		// batch in a single wave instead of waiting out the batcher's
+		// getBatcherDurationMillis flush timer on an otherwise-quiet node — the state a
+		// wedged node is in, which is the condition this walk exists to make visible.
+		g.SetLimit(4096)
 
 		depth++
 

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -21,7 +21,39 @@ import (
 	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/bsv-blockchain/teranode/util/tracing"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/errgroup"
+)
+
+// prometheusUtxoConflictingWalkNodes and prometheusUtxoConflictingWalkDepth record the
+// shape of each completed GetConflictingChildren walk. The cone is unbounded by
+// construction — it is every spender of every output of a transaction's descendants —
+// and in the #1391 incident it was a linear self-spend chain growing by roughly a
+// hundred transactions per block, so the walk degenerated to one store round trip per
+// node with no fan-out at all. These free functions have no logger, so the histograms
+// are the surface that makes a growing cone visible before it becomes a stall.
+// Only completed walks are observed; an aborted walk returns before the observation.
+var (
+	prometheusUtxoConflictingWalkNodes = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "teranode",
+			Subsystem: "utxo",
+			Name:      "conflicting_walk_nodes",
+			Help:      "Number of transactions visited by a completed conflicting-descendant walk",
+			Buckets:   prometheus.ExponentialBuckets(1, 4, 10),
+		},
+	)
+
+	prometheusUtxoConflictingWalkDepth = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "teranode",
+			Subsystem: "utxo",
+			Name:      "conflicting_walk_depth",
+			Help:      "Number of BFS levels walked by a completed conflicting-descendant walk",
+			Buckets:   prometheus.ExponentialBuckets(1, 4, 8),
+		},
+	)
 )
 
 // step5RetryDelays controls the bounded back-off when SetLocked(false) fails at the very
@@ -926,6 +958,8 @@ func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]ch
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
+		// Same unbounded per-level width as GetConflictingChildren; same ceiling.
+		g.SetLimit(128)
 
 		for i, current := range currentLevel {
 			i := i
@@ -998,10 +1032,19 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	visited := make(map[chainhash.Hash]struct{})
 	visited[hash] = struct{}{}
 	currentLevel := []chainhash.Hash{hash}
+	depth := 0
 
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
+		// A single level is unbounded in width: one Get per member, no ceiling. A wide
+		// cone would open tens of thousands of concurrent store reads. 128 matches the
+		// limit the caller uses for its own per-hash fan-out
+		// (services/subtreevalidation/SubtreeValidation.go:476). Note this does not
+		// bind on the linear-chain shape from #1391, where every level holds one node.
+		g.SetLimit(128)
+
+		depth++
 
 		for i, current := range currentLevel {
 			i := i
@@ -1057,6 +1100,9 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	for child := range visited {
 		conflictingChildren = append(conflictingChildren, child)
 	}
+
+	prometheusUtxoConflictingWalkNodes.Observe(float64(len(visited) + 1)) // + the root, deleted above
+	prometheusUtxoConflictingWalkDepth.Observe(float64(depth))
 
 	return conflictingChildren, nil
 }

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -56,6 +56,31 @@ var (
 	)
 )
 
+// conflictingWalkFanOut caps the per-level width of the conflicting-descendant
+// walks (GetAndLockChildren and GetConflictingChildren). 4096 matches
+// settings.conf's utxostore_getBatcherSize so a level fills one aerospike batch
+// in a single wave rather than waiting out getBatcherDurationMillis per wave.
+// These free functions cannot read settings, so the match is by convention:
+// settings.go's own default for GetBatcherSize is 1, which disables batching
+// entirely and makes the ceiling moot rather than wrong on that path.
+//
+// Two caveats, not reasons to change the number, but reasons not to raise it
+// further without checking both:
+//   - On the SQL backend (postgres/sqlite), Store.get falls back to
+//     getUnbatched whenever the requested bins include ConflictingChildren or
+//     Utxos (stores/utxo/sql/sql.go) — exactly the fields these walks request.
+//     So a wide level here opens up to conflictingWalkFanOut concurrent
+//     unbatched Gets, each issuing several queries, against postgres_maxOpenConns
+//     (50 by default). That is database/sql queueing rather than a new error
+//     path, and still strictly better than the pre-fix unbounded errgroup, but
+//     it is materially worse than a smaller ceiling on that one backend.
+//   - The ceiling is per-walk, not global: checkCounterConflictingOnCurrentChain
+//     runs inside an errgroup bounded by
+//     blockvalidation_processTxMetaUsingStore_Concurrency (default
+//     max(4, NumCPU/2)), so the aggregate worst case on an N-core node is
+//     roughly (N/2) * conflictingWalkFanOut concurrent store reads.
+const conflictingWalkFanOut = 4096
+
 // step5RetryDelays controls the bounded back-off when SetLocked(false) fails at the very
 // last step of ProcessConflicting. The slice length is the number of attempts; the value
 // at index i is the delay BEFORE attempt i (so index 0 is always zero — the first attempt
@@ -958,10 +983,9 @@ func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]ch
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
-		// Same unbounded per-level width as GetConflictingChildren, same ceiling, same
-		// reason: 4096 matches the aerospike Get batcher's getBatcherSize so a level
-		// still fills a batch in one wave rather than waiting out getBatcherDurationMillis.
-		g.SetLimit(4096)
+		// Same per-level ceiling as GetConflictingChildren, same rationale — see
+		// conflictingWalkFanOut.
+		g.SetLimit(conflictingWalkFanOut)
 
 		for i, current := range currentLevel {
 			i := i
@@ -1039,13 +1063,9 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
-		// A single level is unbounded in width: one Get per member, no ceiling. A wide
-		// cone would otherwise open one concurrent store read per level member. 4096
-		// matches the aerospike Get batcher's getBatcherSize, so a level still fills a
-		// batch in a single wave instead of waiting out the batcher's
-		// getBatcherDurationMillis flush timer on an otherwise-quiet node — the state a
-		// wedged node is in, which is the condition this walk exists to make visible.
-		g.SetLimit(4096)
+		// Without this, a level would open one concurrent store read per level member
+		// with no ceiling — see conflictingWalkFanOut for why 4096 and its caveats.
+		g.SetLimit(conflictingWalkFanOut)
 
 		depth++
 


### PR DESCRIPTION
Closes #1391.

## Problem

Every mainnet Teranode is wedged at 960,827 — still wedged as of writing. Block 960,828 contains `005a1b58…85d7`, which the local UTXO store flags conflicting. Blessing it enters `checkCounterConflictingOnCurrentChain`, which ran 26m21s and ended only when its context was cancelled. The block never reaches block validation, the legacy peer message handler is held until `legacy_peerProcessingTimeout` fires — 10m in the committed `settings.conf:725`, which is the `waited 10m0s` in the incident log, not the separate 5m `stallResponseTimeoutBlocks` — the peer is dropped, the block is re-fetched, and the cycle repeats. Fleet-wide across v0.15.6, v0.15.8 and v0.16.0 — the code is identical on all of them and on `main`.

## Root cause

The loop at `services/subtreevalidation/SubtreeValidation.go:503-514` walked the full descendant cone once per element of `counterConflictingTxHashes`:

```go
for _, counterConflictingTxHash := range counterConflictingTxHashes {
    childTransactionHashes, err := utxo.GetConflictingChildren(ctx, u.utxoStore, counterConflictingTxHash)
    ...
}
```

That slice already *is* the transitive closure of those descendants. `GetCounterConflictingTxHashes` calls `GetConflictingChildren` on each recorded spender and unions every member of the returned closure into the same `counterConflictingMap`. So the loop ran one full descendant BFS per element of the set that is the descendant set, with `visited` scoped per call, no sharing between iterations, and the outer loop fully serial.

(Citations here are by symbol rather than by line. The metrics var block this PR adds shifts `process_conflicting.go` by ~49 lines, so any file:line written against the pre-fix file is wrong at HEAD — the commit that writes the coordinates is the commit that invalidates them.)

The production shape makes it worse than O(N²) alone suggests. The counter-conflicting transaction is `62e564c8…7a6a`: 1 input, 2 outputs, vout 1 paying back to the same P2PK script with an incrementing OP_RETURN counter — an automated self-spend chain, never mined, absent from public mempools. Verified live against `mainnet-eu-1`: `blockIDs: []`, and each hop spends exactly the previous transaction's vout 1. The chain is strictly linear, so every BFS level holds exactly one node and a walk degenerates to N serial store round trips with no fan-out at all.

The production error text pins which phase burned the time — `failed to get child transactions` is `:506`, inside the deleted loop, not the first walk. The first walk completed; the 26 minutes went into re-walking.

Two consequences worth stating, because they shape the fix:

- The chain grows by roughly a hundred transactions per block for as long as the node cannot advance past the block that would demote it, so N is still increasing.
- The conflicting flag is correct. All six parents of `005a1b58…85d7` were mined in 960,827 and all six `vout 1` are spent on chain by it. This is a genuine double-spend that the block resolved in favour of the sweep, and the node correctly flagged the mined transaction as conflicting against the continuation it had already accepted.

## Fix

One walk instead of N. The detection set is unchanged, and the argument for that is:

- The cone is transitively closed, so `cone(m) ⊆ cone(Yᵢ)` for every member `m` — re-walking a member only re-derives a subset of what is already in hand.
- A frozen *descendant* of a counter already errors on the `FrozenBytesTxHash` check inside `GetCounterConflictingTxHashes`, which is applied to the full BFS closure rather than one level.
- A *directly*-frozen counter `Yᵢ` is covered only by the sentinel check in the errgroup above the deleted loop, and that check is load-bearing: `GetCounterConflictingTxHashes` inserts each `Yᵢ` into the map unconditionally with no frozen check of its own, and if `Yᵢ` is itself the sentinel then its walk early-returns `(nil, nil)`, so the closure check never sees it. Neither of these two covers depended on the deleted loop.
- The one term no earlier walk covers is the descendant cone of the transaction under check. `counterConflictingMap` is seeded with that transaction itself, which is why the deleted loop walked its cone — and why the fix keeps one walk rather than deleting the check outright.

Since the transaction under check was always a member of `counterConflictingTxHashes`, the surviving call is one the old loop already made — the new rejection set is a strict subset of the old, so no block that current code blesses can now be rejected.

Note for anyone reading the issue's original write-up: `FrozenBytesTxHash` and `CoinbasePlaceholderHashValue` are byte-identical (both 32 × `0xFF`, `go-subtree/coinbase_placeholder.go`). There is no sentinel discrepancy between `:510` and `:1125` to reconcile.

## Telemetry

`GetConflictingChildren` and `GetAndLockChildren` had no ceiling on per-level width — one concurrent store read per level member. Both now `SetLimit(4096)`, matching the aerospike get batcher's `getBatcherSize` so a level still fills a batch in a single wave instead of waiting out `getBatcherDurationMillis`. A lower ceiling starves that batcher: at 128, a 10,000-node level goes from ~3 fill-triggered round trips to ~78 timer-triggered waves.

Two histograms on completed walks, `teranode_utxo_conflicting_walk_nodes` and `teranode_utxo_conflicting_walk_depth`, plus a caller-side warn when the counter-conflicting set crosses 1000. The cone is unbounded by construction and its size is the leading indicator of this condition; the `stores/utxo` free functions have no logger, which is why the metric sits in the walk and the log in the caller.

## What this deliberately does not do

- **No fail-closed node or depth budget.** A cap trips on exactly this linear-chain shape and converts a 26-minute stall into a permanent fast rejection. The node still never advances — strictly worse than slow.
- **No narrowing of the walk to conflicting children only.** `ProcessConflicting` uses the counter set as its demotion input, and demoting a conflicting loser requires its full descendant set.

## Tests

`services/subtreevalidation/conflicting_walk_cost_test.go` — a map-backed `utxo.Store` counting `Get` calls, with the real walk delegated to the production free functions rather than stubbed. Plants the incident's shape: a linear self-spend chain of 1000.

- The cost test failed pre-fix at 501,503 `Get` calls (1002 to build the counter-conflicting set + Σ(1..1000) for the re-walks + 1 for re-walking the transaction under check, which is itself a member of the set) and passes post-fix at exactly 1003, pinned with `require.Equal` — the defect being guarded is a complexity regression, so the bound is the deterministic value rather than a multiple of it.
- Four equivalence guards pass on both sides of the fix, which is the point: the frozen sentinel at each of three placements (the counter itself, deep in the loser cone, and in the tx-under-check's own cone — that last one fails if the surviving walk is deleted), and the counter-mined-on-our-chain rejection.

`stores/utxo/conflicting_walk_metrics_test.go` — one observation per completed walk, with the right node count and depth, read as deltas since the histograms are process-global.

`go test -race ./services/subtreevalidation/... ./stores/utxo/...` green (1442 passed in 14 packages for `stores/utxo` alone), `go vet` clean.

## Residual risk

- One walk still costs N serial round trips on a linear cone, roughly 10 ms per level from the batcher's flush timer. At the estimated current N that is seconds, and it grows about 1 s per further 100 blocks of wedge. Bounded, but it argues for deploying sooner rather than later.
- The production logs cannot split the 26m21s between the first walk and the re-walks — there is no log line between them. So the hard upper bound on the surviving walk is only "completed within 26 minutes". The linear-chain arithmetic puts it at seconds and reproduces the observed magnitude, but that is a model, not a measurement. The `conflicting_walk_nodes` histogram is what replaces the estimate once this is deployed.
- Real-store latency is unverified: the cost test pins the complexity class, not aerospike round-trip behaviour.
- The deleted loop re-read every cone member as a walk root, which on the v0.15 line fails closed on root absence. A member whose record disappears between the first walk and the loop no longer fails closed. Race-window only — the first walk read it successfully microseconds earlier.

## Backports

`release/v0.15` lands separately; its `stores/utxo/process_conflicting.go` has diverged (ghost-spender tolerance from #1325) and the metrics var block conflicts. `release/v0.16` tracks `main`, so no separate backport.