### PR TITLE
fix(utxo): drop O(N^2) conflicting-descendant re-walk wedging block validation (backport #1393 to release/v0.15)

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -62,6 +62,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// conflictingConeWarnThreshold is the counter-conflicting set size above which the
+// cone is worth a log line. The set is the loser's full descendant closure, which
+// keeps growing for as long as the node cannot advance past the block that would
+// demote it (#1391), so its size is the leading indicator of that condition.
+const conflictingConeWarnThreshold = 1000
+
 // missingTx represents a transaction that needs to be retrieved and its position in the subtree.
 //
 // This structure pairs a transaction with its index in the original subtree transaction list,
@@ -470,6 +476,10 @@ func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHa
 	counterConflictingTxHashes, err := utxo.GetCounterConflictingTxHashes(ctx, u.utxoStore, txHash)
 	if err != nil {
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx hashes", txHash.String(), err)
+	}
+
+	if len(counterConflictingTxHashes) > conflictingConeWarnThreshold {
+		u.logger.Warnf("[checkCounterConflictingOnCurrentChain][%s] counter-conflicting set is %d transactions", txHash.String(), len(counterConflictingTxHashes))
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -499,17 +499,22 @@ func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHa
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx meta", txHash.String(), err)
 	}
 
-	// check whether the child transactions of the counter-conflicting transactions are frozen
-	for _, counterConflictingTxHash := range counterConflictingTxHashes {
-		childTransactionHashes, err := utxo.GetConflictingChildren(ctx, u.utxoStore, counterConflictingTxHash)
-		if err != nil {
-			return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get child transactions", txHash.String(), err)
-		}
+	// check whether any child transaction of txHash itself is frozen. This is the
+	// only walk the counter-conflicting set does not already cover: every
+	// counter-spender's descendant cone was walked (and frozen-checked against the
+	// same 32x0xFF sentinel) inside GetCounterConflictingTxHashes above, and any
+	// sentinel found there already failed the call. Re-walking each member of the
+	// set re-derived subsets of those same cones — O(N^2) store reads that wedged
+	// the mainnet fleet at height 960,827 (issue 1391) — so only the single
+	// txHash-cone walk remains.
+	childTransactionHashes, err := utxo.GetConflictingChildren(ctx, u.utxoStore, txHash)
+	if err != nil {
+		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get child transactions", txHash.String(), err)
+	}
 
-		for _, childTransactionHash := range childTransactionHashes {
-			if childTransactionHash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
-				return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] child transaction is frozen", txHash.String())
-			}
+	for _, childTransactionHash := range childTransactionHashes {
+		if childTransactionHash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
+			return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] child transaction is frozen", txHash.String())
 		}
 	}
 

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -68,10 +68,11 @@ import (
 // demote it (#1391), so its size is the leading indicator of that condition.
 const conflictingConeWarnThreshold = 1000
 
-// conflictingWalkWarnDuration is the wall-clock spent in the counter-conflicting
-// walk above which it is worth a log line regardless of outcome. The cone-size
-// check above cannot fire once the walk is slow enough to be cancelled, which is
-// exactly the #1391 regime, so duration is the signal that survives it.
+// conflictingWalkWarnDuration is the wall-clock spent in the whole
+// counter-conflicting check above which it is worth a log line, whatever the
+// outcome. The cone-size check above cannot fire once the work is slow enough to
+// be cancelled, which is exactly the #1391 regime, so duration is the signal
+// that survives it.
 const conflictingWalkWarnDuration = 10 * time.Second
 
 // missingTx represents a transaction that needs to be retrieved and its position in the subtree.
@@ -479,19 +480,22 @@ func (u *Server) blessMissingTransaction(ctx context.Context, blockHash chainhas
 func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHash chainhash.Hash, blockIds map[uint32]bool) error {
 	// the tx is conflicting, check whether the counter-conflicting transactions have already been mined on our chain
 	// first get the parent transactions and check if they were spent
-	walkStart := time.Now()
+	// Warn on elapsed time across the whole check, on every return path. A
+	// set-size check alone is unreachable in the regime it exists for: in the
+	// wedge the work is cancelled rather than returning, so an error path fires
+	// and the size is never known (#1391). Duration is the signal that survives
+	// cancellation, and it has to span all three phases — the counter walk, the
+	// GetMeta fan-out over the counter set, and the descendant walk below — since
+	// a deadline can fire in any of them.
+	checkStart := time.Now()
+
+	defer func() {
+		if elapsed := time.Since(checkStart); elapsed > conflictingWalkWarnDuration {
+			u.logger.Warnf("[checkCounterConflictingOnCurrentChain][%s] counter-conflicting check took %s", txHash.String(), elapsed)
+		}
+	}()
+
 	counterConflictingTxHashes, err := utxo.GetCounterConflictingTxHashes(ctx, u.utxoStore, txHash)
-	walkElapsed := time.Since(walkStart)
-
-	// Warn on elapsed time before inspecting the result, and on both outcomes.
-	// A set-size check alone is unreachable in the regime it exists for: in the
-	// wedge the walk is cancelled rather than returning, so the error branch
-	// below fires and the size is never known (#1391). Duration is the signal
-	// that survives cancellation.
-	if walkElapsed > conflictingWalkWarnDuration {
-		u.logger.Warnf("[checkCounterConflictingOnCurrentChain][%s] counter-conflicting walk took %s (err=%v)", txHash.String(), walkElapsed, err)
-	}
-
 	if err != nil {
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx hashes", txHash.String(), err)
 	}
@@ -501,7 +505,7 @@ func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHa
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(128)
+	util.SafeSetLimit(g, utxo.ConflictingWalkFanOut)
 
 	counterConflictingTxMetas := make([]*meta.Data, len(counterConflictingTxHashes))
 

--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -68,6 +68,12 @@ import (
 // demote it (#1391), so its size is the leading indicator of that condition.
 const conflictingConeWarnThreshold = 1000
 
+// conflictingWalkWarnDuration is the wall-clock spent in the counter-conflicting
+// walk above which it is worth a log line regardless of outcome. The cone-size
+// check above cannot fire once the walk is slow enough to be cancelled, which is
+// exactly the #1391 regime, so duration is the signal that survives it.
+const conflictingWalkWarnDuration = 10 * time.Second
+
 // missingTx represents a transaction that needs to be retrieved and its position in the subtree.
 //
 // This structure pairs a transaction with its index in the original subtree transaction list,
@@ -473,7 +479,19 @@ func (u *Server) blessMissingTransaction(ctx context.Context, blockHash chainhas
 func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHash chainhash.Hash, blockIds map[uint32]bool) error {
 	// the tx is conflicting, check whether the counter-conflicting transactions have already been mined on our chain
 	// first get the parent transactions and check if they were spent
+	walkStart := time.Now()
 	counterConflictingTxHashes, err := utxo.GetCounterConflictingTxHashes(ctx, u.utxoStore, txHash)
+	walkElapsed := time.Since(walkStart)
+
+	// Warn on elapsed time before inspecting the result, and on both outcomes.
+	// A set-size check alone is unreachable in the regime it exists for: in the
+	// wedge the walk is cancelled rather than returning, so the error branch
+	// below fires and the size is never known (#1391). Duration is the signal
+	// that survives cancellation.
+	if walkElapsed > conflictingWalkWarnDuration {
+		u.logger.Warnf("[checkCounterConflictingOnCurrentChain][%s] counter-conflicting walk took %s (err=%v)", txHash.String(), walkElapsed, err)
+	}
+
 	if err != nil {
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx hashes", txHash.String(), err)
 	}

--- a/services/subtreevalidation/SubtreeValidation_test.go
+++ b/services/subtreevalidation/SubtreeValidation_test.go
@@ -1015,6 +1015,7 @@ func Test_checkCounterConflictingOnCurrentChain(t *testing.T) {
 
 		// Create a mock Server struct
 		s := &Server{
+			logger:    logger,
 			utxoStore: utxoStore,
 		}
 
@@ -1043,6 +1044,7 @@ func Test_checkCounterConflictingOnCurrentChain(t *testing.T) {
 
 		// Create a mock Server struct
 		s := &Server{
+			logger:    logger,
 			utxoStore: utxoStore,
 		}
 

--- a/services/subtreevalidation/check_counter_conflicting_scaling_test.go
+++ b/services/subtreevalidation/check_counter_conflicting_scaling_test.go
@@ -119,6 +119,7 @@ func Test_checkCounterConflictingOnCurrentChain_scaling(t *testing.T) {
 
 	countingStore := &countingUtxoStore{Store: utxoStore}
 	s := &Server{
+		logger:    logger,
 		utxoStore: countingStore,
 		settings:  tSettings,
 	}
@@ -166,6 +167,7 @@ func Test_checkCounterConflictingOnCurrentChain_frozen(t *testing.T) {
 		require.NoError(t, err)
 
 		s := &Server{
+			logger:    logger,
 			utxoStore: utxoStore,
 			settings:  tSettings,
 		}

--- a/services/subtreevalidation/check_counter_conflicting_scaling_test.go
+++ b/services/subtreevalidation/check_counter_conflicting_scaling_test.go
@@ -20,10 +20,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// countingUtxoStore wraps a real utxo.Store and counts Get calls. It overrides
-// GetConflictingChildren to run the package-level walk against itself, so the
-// walk's per-node Get reads are observed by the counter instead of going to the
-// underlying store directly.
+// countingUtxoStore wraps a real utxo.Store and counts per-transaction reads. It
+// overrides GetConflictingChildren to run the package-level walk against itself,
+// so the walk's per-node reads are observed by the counter instead of going to
+// the underlying store directly.
+//
+// Both Get and GetMeta are counted: blessing issues one GetMeta per member of
+// the counter-conflicting set, so a counter watching Get alone would be blind to
+// a regression that reintroduced the O(N^2) blow-up on that side.
 type countingUtxoStore struct {
 	utxo.Store
 	gets atomic.Int64
@@ -33,6 +37,12 @@ func (c *countingUtxoStore) Get(ctx context.Context, hash *chainhash.Hash, f ...
 	c.gets.Add(1)
 
 	return c.Store.Get(ctx, hash, f...)
+}
+
+func (c *countingUtxoStore) GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Data) error {
+	c.gets.Add(1)
+
+	return c.Store.GetMeta(ctx, hash, data)
 }
 
 func (c *countingUtxoStore) GetConflictingChildren(ctx context.Context, txHash chainhash.Hash) ([]chainhash.Hash, error) {

--- a/services/subtreevalidation/check_counter_conflicting_scaling_test.go
+++ b/services/subtreevalidation/check_counter_conflicting_scaling_test.go
@@ -1,0 +1,256 @@
+package subtreevalidation
+
+import (
+	"context"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// countingUtxoStore wraps a real utxo.Store and counts Get calls. It overrides
+// GetConflictingChildren to run the package-level walk against itself, so the
+// walk's per-node Get reads are observed by the counter instead of going to the
+// underlying store directly.
+type countingUtxoStore struct {
+	utxo.Store
+	gets atomic.Int64
+}
+
+func (c *countingUtxoStore) Get(ctx context.Context, hash *chainhash.Hash, f ...fields.FieldName) (*meta.Data, error) {
+	c.gets.Add(1)
+
+	return c.Store.Get(ctx, hash, f...)
+}
+
+func (c *countingUtxoStore) GetConflictingChildren(ctx context.Context, txHash chainhash.Hash) ([]chainhash.Hash, error) {
+	return utxo.GetConflictingChildren(ctx, c, txHash)
+}
+
+// spendingChild builds a minimal extended child tx spending parent:vout, with the
+// empty unlocking script the SQL store's NOT NULL constraint requires.
+func spendingChild(t *testing.T, parent *bt.Tx, vout uint32) *bt.Tx {
+	t.Helper()
+
+	child := bt.NewTx()
+	require.NoError(t, child.From(parent.TxIDChainHash().String(), vout, parent.Outputs[vout].LockingScript.String(), parent.Outputs[vout].Satoshis))
+	child.Inputs[0].UnlockingScript = bscript.NewFromBytes([]byte{})
+	require.NoError(t, child.AddP2PKHOutputFromScript(parent.Outputs[vout].LockingScript, parent.Outputs[vout].Satoshis))
+
+	return child
+}
+
+// buildLoserChain seeds the store with the shape of the mainnet 960,828 wedge: a
+// conflicting (mined-winner) tx1 whose counter-conflicting loser heads a linear
+// self-spend chain of the given length.
+func buildLoserChain(t *testing.T, ctx context.Context, utxoStore utxo.Store, chainLength int) {
+	t.Helper()
+
+	_, err := utxoStore.Create(ctx, parentTx1, 122)
+	require.NoError(t, err)
+
+	// The loser: spends the same parent output as tx1 (the winner) but is a
+	// distinct tx, accepted into the store first.
+	loser := tx1.Clone()
+	loser.Version = 2
+
+	_, err = utxoStore.Spend(ctx, loser, 122)
+	require.NoError(t, err)
+
+	_, err = utxoStore.Create(ctx, loser, 122)
+	require.NoError(t, err)
+
+	// Extend the loser with a linear chain of descendants, each spending the
+	// previous tx's output 0 — the store records every spend in SpendingDatas.
+	prev := loser
+
+	for i := 0; i < chainLength; i++ {
+		child := spendingChild(t, prev, 0)
+
+		_, err = utxoStore.Spend(ctx, child, 122)
+		require.NoError(t, err)
+
+		_, err = utxoStore.Create(ctx, child, 122)
+		require.NoError(t, err)
+
+		prev = child
+	}
+
+	// The winner: mined double-spend of the loser, flagged conflicting locally.
+	_, err = utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
+	require.NoError(t, err)
+}
+
+// Test_checkCounterConflictingOnCurrentChain_scaling reproduces the shape of the
+// mainnet 960,828 wedge (issue 1391): a conflicting (mined-winner) tx whose
+// counter-conflicting (loser) tx heads a long linear self-spend chain. Blessing
+// the winner must read each chain member O(1) times; the pre-fix code re-walked
+// the full descendant cone once per descendant, i.e. O(K^2) store reads, which
+// never converged in production while the chain kept growing.
+func Test_checkCounterConflictingOnCurrentChain_scaling(t *testing.T) {
+	InitPrometheusMetrics()
+
+	const chainLength = 300
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	buildLoserChain(t, ctx, utxoStore, chainLength)
+
+	countingStore := &countingUtxoStore{Store: utxoStore}
+	s := &Server{
+		utxoStore: countingStore,
+		settings:  tSettings,
+	}
+
+	err = s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
+	require.NoError(t, err)
+
+	gets := countingStore.gets.Load()
+	require.LessOrEqualf(t, gets, int64(4*chainLength),
+		"blessing a conflicting tx must read the counter-conflicting descendant chain O(K) times, got %d Get calls for K=%d (O(K^2) indicates the per-element re-walk of issue 1391)",
+		gets, chainLength)
+}
+
+// freezeOutput marks the given output of tx as frozen in the store, so its
+// spending data carries the frozen sentinel hash.
+func freezeOutput(t *testing.T, ctx context.Context, store utxo.Store, tx *bt.Tx, vout uint32, tSettings *settings.Settings) {
+	t.Helper()
+
+	utxoHash, err := util.UTXOHashFromOutput(tx.TxIDChainHash(), tx.Outputs[vout], vout)
+	require.NoError(t, err)
+
+	err = store.FreezeUTXOs(ctx, []*utxo.Spend{{
+		TxID:     tx.TxIDChainHash(),
+		Vout:     vout,
+		UTXOHash: utxoHash,
+	}}, tSettings)
+	require.NoError(t, err)
+}
+
+// Test_checkCounterConflictingOnCurrentChain_frozen pins the frozen-sentinel
+// rejection semantics across all three detection paths. Dropping the per-member
+// re-walk (issue 1391) must not weaken any of them.
+func Test_checkCounterConflictingOnCurrentChain_frozen(t *testing.T) {
+	InitPrometheusMetrics()
+
+	newStore := func(t *testing.T) (context.Context, utxo.Store, *Server, *settings.Settings) {
+		ctx := context.Background()
+		logger := ulogger.NewErrorTestLogger(t)
+		tSettings := test.CreateBaseTestSettings(t)
+
+		utxoStoreURL, err := url.Parse("sqlitememory:///test")
+		require.NoError(t, err)
+
+		utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+		require.NoError(t, err)
+
+		s := &Server{
+			utxoStore: utxoStore,
+			settings:  tSettings,
+		}
+
+		return ctx, utxoStore, s, tSettings
+	}
+
+	t.Run("frozen direct counter", func(t *testing.T) {
+		ctx, utxoStore, s, tSettings := newStore(t)
+
+		_, err := utxoStore.Create(ctx, parentTx1, 122)
+		require.NoError(t, err)
+
+		// freeze the parent output the conflicting tx spends: its spending data
+		// becomes the frozen sentinel, i.e. the counter-conflicting "tx" is frozen
+		freezeOutput(t, ctx, utxoStore, parentTx1, tx1.Inputs[0].PreviousTxOutIndex, tSettings)
+
+		_, err = utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
+		require.NoError(t, err)
+
+		err = s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "counter conflicting tx is frozen")
+	})
+
+	t.Run("frozen deep in loser cone", func(t *testing.T) {
+		ctx, utxoStore, s, tSettings := newStore(t)
+
+		_, err := utxoStore.Create(ctx, parentTx1, 122)
+		require.NoError(t, err)
+
+		loser := tx1.Clone()
+		loser.Version = 2
+
+		_, err = utxoStore.Spend(ctx, loser, 122)
+		require.NoError(t, err)
+
+		_, err = utxoStore.Create(ctx, loser, 122)
+		require.NoError(t, err)
+
+		child := spendingChild(t, loser, 0)
+
+		_, err = utxoStore.Spend(ctx, child, 122)
+		require.NoError(t, err)
+
+		_, err = utxoStore.Create(ctx, child, 122)
+		require.NoError(t, err)
+
+		// freeze the chain tip's output: the frozen sentinel appears deep inside
+		// the loser's descendant cone
+		freezeOutput(t, ctx, utxoStore, child, 0, tSettings)
+
+		_, err = utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
+		require.NoError(t, err)
+
+		err = s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tx has frozen child")
+	})
+
+	t.Run("frozen output on the winner itself", func(t *testing.T) {
+		ctx, utxoStore, s, tSettings := newStore(t)
+
+		_, err := utxoStore.Create(ctx, parentTx1, 122)
+		require.NoError(t, err)
+
+		loser := tx1.Clone()
+		loser.Version = 2
+
+		_, err = utxoStore.Spend(ctx, loser, 122)
+		require.NoError(t, err)
+
+		_, err = utxoStore.Create(ctx, loser, 122)
+		require.NoError(t, err)
+
+		_, err = utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
+		require.NoError(t, err)
+
+		// freeze one of the winner's own outputs: the sentinel appears in the
+		// winner's own descendant cone, which the single remaining walk must still
+		// reject
+		freezeOutput(t, ctx, utxoStore, tx1, 0, tSettings)
+
+		err = s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "child transaction is frozen")
+	})
+}

--- a/services/subtreevalidation/check_counter_conflicting_scaling_test.go
+++ b/services/subtreevalidation/check_counter_conflicting_scaling_test.go
@@ -55,7 +55,7 @@ func spendingChild(t *testing.T, parent *bt.Tx, vout uint32) *bt.Tx {
 // buildLoserChain seeds the store with the shape of the mainnet 960,828 wedge: a
 // conflicting (mined-winner) tx1 whose counter-conflicting loser heads a linear
 // self-spend chain of the given length.
-func buildLoserChain(t *testing.T, ctx context.Context, utxoStore utxo.Store, chainLength int) {
+func buildLoserChain(ctx context.Context, t *testing.T, utxoStore utxo.Store, chainLength int) {
 	t.Helper()
 
 	_, err := utxoStore.Create(ctx, parentTx1, 122)
@@ -115,7 +115,7 @@ func Test_checkCounterConflictingOnCurrentChain_scaling(t *testing.T) {
 	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
 	require.NoError(t, err)
 
-	buildLoserChain(t, ctx, utxoStore, chainLength)
+	buildLoserChain(ctx, t, utxoStore, chainLength)
 
 	countingStore := &countingUtxoStore{Store: utxoStore}
 	s := &Server{
@@ -128,6 +128,14 @@ func Test_checkCounterConflictingOnCurrentChain_scaling(t *testing.T) {
 	require.NoError(t, err)
 
 	gets := countingStore.gets.Load()
+
+	// Lower bound first: without it a regression that skips the descendant walk
+	// entirely (GetConflictingChildren returning early) would satisfy the upper
+	// bound and pass. The walk has to actually visit the chain.
+	require.GreaterOrEqualf(t, gets, int64(chainLength),
+		"the walk must actually cover the counter-conflicting chain, got only %d Get calls for K=%d",
+		gets, chainLength)
+
 	require.LessOrEqualf(t, gets, int64(4*chainLength),
 		"blessing a conflicting tx must read the counter-conflicting descendant chain O(K) times, got %d Get calls for K=%d (O(K^2) indicates the per-element re-walk of issue 1391)",
 		gets, chainLength)
@@ -135,7 +143,7 @@ func Test_checkCounterConflictingOnCurrentChain_scaling(t *testing.T) {
 
 // freezeOutput marks the given output of tx as frozen in the store, so its
 // spending data carries the frozen sentinel hash.
-func freezeOutput(t *testing.T, ctx context.Context, store utxo.Store, tx *bt.Tx, vout uint32, tSettings *settings.Settings) {
+func freezeOutput(ctx context.Context, t *testing.T, store utxo.Store, tx *bt.Tx, vout uint32, tSettings *settings.Settings) {
 	t.Helper()
 
 	utxoHash, err := util.UTXOHashFromOutput(tx.TxIDChainHash(), tx.Outputs[vout], vout)
@@ -183,7 +191,7 @@ func Test_checkCounterConflictingOnCurrentChain_frozen(t *testing.T) {
 
 		// freeze the parent output the conflicting tx spends: its spending data
 		// becomes the frozen sentinel, i.e. the counter-conflicting "tx" is frozen
-		freezeOutput(t, ctx, utxoStore, parentTx1, tx1.Inputs[0].PreviousTxOutIndex, tSettings)
+		freezeOutput(ctx, t, utxoStore, parentTx1, tx1.Inputs[0].PreviousTxOutIndex, tSettings)
 
 		_, err = utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
 		require.NoError(t, err)
@@ -218,7 +226,7 @@ func Test_checkCounterConflictingOnCurrentChain_frozen(t *testing.T) {
 
 		// freeze the chain tip's output: the frozen sentinel appears deep inside
 		// the loser's descendant cone
-		freezeOutput(t, ctx, utxoStore, child, 0, tSettings)
+		freezeOutput(ctx, t, utxoStore, child, 0, tSettings)
 
 		_, err = utxoStore.Create(ctx, tx1, 123, utxo.WithConflicting(true))
 		require.NoError(t, err)
@@ -249,7 +257,7 @@ func Test_checkCounterConflictingOnCurrentChain_frozen(t *testing.T) {
 		// freeze one of the winner's own outputs: the sentinel appears in the
 		// winner's own descendant cone, which the single remaining walk must still
 		// reject
-		freezeOutput(t, ctx, utxoStore, tx1, 0, tSettings)
+		freezeOutput(ctx, t, utxoStore, tx1, 0, tSettings)
 
 		err = s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
 		require.Error(t, err)

--- a/services/subtreevalidation/counter_conflicting_ghost_test.go
+++ b/services/subtreevalidation/counter_conflicting_ghost_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
 	"github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -66,7 +67,7 @@ func TestCheckCounterConflictingOnCurrentChain_ToleratesGhostSpender(t *testing.
 	mockStore.On("Get", mock.Anything, hashMatcher(winningTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
 		Return(&meta.Data{}, nil)
 
-	u := &Server{utxoStore: mockStore}
+	u := &Server{logger: ulogger.NewErrorTestLogger(t), utxoStore: mockStore}
 
 	err := u.checkCounterConflictingOnCurrentChain(ctx, winningTxHash, map[uint32]bool{7: true})
 
@@ -105,7 +106,7 @@ func TestCheckCounterConflictingOnCurrentChain_StillRejectsMinedCounter(t *testi
 	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
 		Return(&meta.Data{}, nil)
 
-	u := &Server{utxoStore: mockStore}
+	u := &Server{logger: ulogger.NewErrorTestLogger(t), utxoStore: mockStore}
 
 	err := u.checkCounterConflictingOnCurrentChain(ctx, conflictingTxHash, map[uint32]bool{7: true})
 

--- a/services/subtreevalidation/counter_conflicting_ghost_test.go
+++ b/services/subtreevalidation/counter_conflicting_ghost_test.go
@@ -99,9 +99,10 @@ func TestCheckCounterConflictingOnCurrentChain_StillRejectsMinedCounter(t *testi
 	mockStore.On("GetMeta", mock.Anything, hashMatcher(counterTxHash), mock.Anything).
 		Return(&meta.Data{BlockIDs: []uint32{7}}, nil)
 
+	// only the conflicting tx's own cone is walked here; the counter's cone was
+	// already walked (and frozen-checked) inside GetCounterConflictingTxHashes, so
+	// the per-member re-walk was dropped in issue 1391
 	mockStore.On("Get", mock.Anything, hashMatcher(conflictingTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
-		Return(&meta.Data{}, nil)
-	mockStore.On("Get", mock.Anything, hashMatcher(counterTxHash), []fields.FieldName{fields.Utxos, fields.ConflictingChildren, fields.DeletedChildren}).
 		Return(&meta.Data{}, nil)
 
 	u := &Server{utxoStore: mockStore}

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -28,14 +28,22 @@ import (
 
 // conflictingWalkFanOut caps the per-level width of the conflicting-descendant
 // BFS, which previously opened one concurrent store read per level member with
-// no ceiling at all. It matches utxostore_getBatcherSize (settings.conf:1240,
-// 4096) so one full wave fills exactly one Aerospike get batch: the ceiling
-// still stops unbounded goroutine and read explosion, without converting the
-// batcher's fill-triggered flushes into utxostore_getBatcherDurationMillis
-// timer flushes the way a smaller ceiling would. On the SQL backend it makes no
-// difference either way — the ConflictingChildren/Utxos fields force unbatched
-// queries, so level members queue on postgres_maxOpenConns regardless.
-const conflictingWalkFanOut = 4096
+// no ceiling. 128 matches main (where #1393 landed it) and the counter-conflicting
+// GetMeta errgroup in subtreevalidation, and is chosen for the SQL backend:
+// Store.get falls back to getUnbatched whenever the requested bins include
+// ConflictingChildren or Utxos (stores/utxo/sql/sql.go) — exactly the fields this
+// walk requests — so every level member is a concurrent unbatched query against
+// postgres_maxOpenConns (50 by default). A ceiling near the Aerospike get-batcher
+// size would oversubscribe that pool by orders of magnitude, and a waiter still
+// queued when the CheckBlockSubtrees deadline fires returns DeadlineExceeded,
+// which isNotFoundErr does not match — a hard error that fails the block.
+//
+// Known tradeoff, accepted deliberately: on Aerospike a wide level fills the
+// getBatcher (utxostore_getBatcherSize 4096) in ~N/128 timer-triggered waves
+// rather than ~N/4096 fill-triggered flushes, so very wide cones walk slower
+// than a batcher-matched ceiling would allow. The incident cone was fully linear
+// (one node per level), where the ceiling is moot either way.
+const conflictingWalkFanOut = 128
 
 // prometheusUtxoCounterConflictingGhostSpends counts every confirmed ghost spender
 // tolerated by the counter-conflicting walk: a parent output that still records a
@@ -1073,6 +1081,40 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 		}
 
 		var nextLevel []chainhash.Hash
+
+		// enqueue records one child of parent on the walk.
+		//
+		// The reaped mark is OR-ed across every in-cone parent that lists the
+		// child, not just the first one to reach it. reapedByParent decides
+		// settled-mined-spend (fail closed) versus tolerated ghost (silently
+		// dropped from the result), so a first-writer-wins verdict let a child
+		// whose deletedChildren mark lives only on a later parent be demoted as a
+		// ghost — clearing a settled spend. Any parent saying "reaped" now wins,
+		// which makes the verdict order-independent and fail-closed.
+		enqueue := func(child chainhash.Hash, parent *meta.Data) {
+			if parent.DeletedChildren[child] {
+				reapedByParent[child] = true
+			}
+
+			if _, ok := visited[child]; ok {
+				return
+			}
+
+			visited[child] = struct{}{}
+
+			// The frozen / coinbase-placeholder sentinel is a record-less
+			// pseudo-hash marking a frozen output. It must stay in the result set
+			// so callers' frozen-child checks fire, but must never be recursed
+			// into: a Get would return NOT_FOUND and the ghost tolerance would
+			// silently swallow it, defeating frozen-tx rejection during conflict
+			// resolution.
+			if child.Equal(subtree.CoinbasePlaceholderHashValue) {
+				return
+			}
+
+			nextLevel = append(nextLevel, child)
+		}
+
 		for i, txMeta := range results {
 			if txMeta == nil {
 				// tolerated ghost descendant — exclude it from the result set
@@ -1080,47 +1122,17 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 				continue
 			}
 
-			if txMeta.ConflictingChildren != nil {
-				for _, child := range txMeta.ConflictingChildren {
-					if _, ok := visited[child]; !ok {
-						visited[child] = struct{}{}
-
-						// The frozen / coinbase-placeholder sentinel is a record-less
-						// pseudo-hash marking a frozen output. It must stay in the
-						// result set so callers' frozen-child checks fire, but must
-						// never be recursed into: a Get would return NOT_FOUND and the
-						// ghost tolerance would silently swallow it, defeating frozen-tx
-						// rejection during conflict resolution.
-						if child.Equal(subtree.CoinbasePlaceholderHashValue) {
-							continue
-						}
-
-						reapedByParent[child] = txMeta.DeletedChildren[child]
-						nextLevel = append(nextLevel, child)
-					}
-				}
+			for _, child := range txMeta.ConflictingChildren {
+				enqueue(child, txMeta)
 			}
 
-			if txMeta.SpendingDatas != nil {
-				for _, spendingData := range txMeta.SpendingDatas {
-					if spendingData != nil {
-						child := *spendingData.TxID
-						if _, ok := visited[child]; !ok {
-							visited[child] = struct{}{}
-
-							// Frozen output sentinel: keep it in the result for the
-							// caller's frozen check, but do not recurse (see above).
-							if child.Equal(subtree.CoinbasePlaceholderHashValue) {
-								continue
-							}
-
-							reapedByParent[child] = txMeta.DeletedChildren[child]
-							nextLevel = append(nextLevel, child)
-						}
-					}
+			for _, spendingData := range txMeta.SpendingDatas {
+				if spendingData != nil {
+					enqueue(*spendingData.TxID, txMeta)
 				}
 			}
 		}
+
 		currentLevel = nextLevel
 	}
 
@@ -1195,22 +1207,30 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 	// descendant walk is by far the expensive part and its result does not depend
 	// on which input reached the spender, so memoise it per unique spender: one
 	// walk instead of one per input (issue 1391).
-	type spenderWalk struct {
-		children []chainhash.Hash
-		err      error
-	}
-
-	spenderWalks := make(map[chainhash.Hash]spenderWalk, len(txMeta.Tx.Inputs))
+	//
+	// Successes only. Caching a failure would replay it for every later input
+	// sharing the spender, and the ghost probe below is deliberately not
+	// memoised — so a spender that was briefly unreadable on the first input and
+	// is readable by the second would hit a cached NOT_FOUND, pass the probe, and
+	// fail the whole call closed on a stale error. Re-walking on error preserves
+	// the per-input independence the ghost tolerance (#1325) was built on, and
+	// costs nothing in the case the memo exists for: a large cone that reads
+	// successfully is walked exactly once.
+	spenderWalks := make(map[chainhash.Hash][]chainhash.Hash, len(txMeta.Tx.Inputs))
 
 	walkSpender := func(spendingTxID chainhash.Hash) ([]chainhash.Hash, error) {
 		if cached, ok := spenderWalks[spendingTxID]; ok {
-			return cached.children, cached.err
+			return cached, nil
 		}
 
 		children, err := s.GetConflictingChildren(ctx, spendingTxID)
-		spenderWalks[spendingTxID] = spenderWalk{children: children, err: err}
+		if err != nil {
+			return nil, err
+		}
 
-		return children, err
+		spenderWalks[spendingTxID] = children
+
+		return children, nil
 	}
 
 	for _, input := range txMeta.Tx.Inputs {

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -992,7 +992,10 @@ func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]ch
 
 			if txMeta.SpendingDatas != nil {
 				for _, spendingData := range txMeta.SpendingDatas {
-					if spendingData != nil {
+					// same nil-TxID guard as the conflicting walk: dereferencing a
+					// nil TxID here panics an errgroup goroutine and takes the
+					// process down
+					if spendingData != nil && spendingData.TxID != nil {
 						child := *spendingData.TxID
 						if _, ok := visited[child]; ok {
 							continue
@@ -1142,7 +1145,13 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 			}
 
 			for _, spendingData := range txMeta.SpendingDatas {
-				if spendingData != nil {
+				// TxID is guarded as well as the slot: SpendingData.Clone handles a
+				// nil TxID and the counter walk below checks both, so the codebase
+				// treats it as reachable. Dereferencing it here would panic inside
+				// an errgroup goroutine — an unrecovered panic that takes the
+				// process down, not just the block. Skipping matches the counter
+				// walk's handling of the same shape.
+				if spendingData != nil && spendingData.TxID != nil {
 					enqueue(*spendingData.TxID, txMeta)
 				}
 			}

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -1022,6 +1022,9 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
+		// a wide level must not fan out one goroutine (and one store read) per
+		// descendant without bound
+		g.SetLimit(128)
 
 		for i, current := range currentLevel {
 			i := i
@@ -1179,6 +1182,28 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 
 	var ghostSpends []*Spend
 
+	// Several inputs are commonly spent by the same counter-conflicting tx. The
+	// descendant walk is by far the expensive part and its result does not depend
+	// on which input reached the spender, so memoise it per unique spender: one
+	// walk instead of one per input (issue 1391).
+	type spenderWalk struct {
+		children []chainhash.Hash
+		err      error
+	}
+
+	spenderWalks := make(map[chainhash.Hash]spenderWalk, len(txMeta.Tx.Inputs))
+
+	walkSpender := func(spendingTxID chainhash.Hash) ([]chainhash.Hash, error) {
+		if cached, ok := spenderWalks[spendingTxID]; ok {
+			return cached.children, cached.err
+		}
+
+		children, err := s.GetConflictingChildren(ctx, spendingTxID)
+		spenderWalks[spendingTxID] = spenderWalk{children: children, err: err}
+
+		return children, err
+	}
+
 	for _, input := range txMeta.Tx.Inputs {
 		parentTxMeta, ok := parentTxs[*input.PreviousTxIDChainHash()]
 		if ok {
@@ -1193,7 +1218,7 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 			if spendingData != nil && spendingData.TxID != nil {
 				spendingTxID := spendingData.TxID
 
-				childHashes, err := s.GetConflictingChildren(ctx, *spendingTxID)
+				childHashes, err := walkSpender(*spendingTxID)
 				if err != nil {
 					if !isNotFoundErr(err) {
 						return nil, nil, err

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -26,10 +26,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// conflictingWalkFanOut caps the per-level width of the conflicting-descendant
+// ConflictingWalkFanOut caps the per-level width of the conflicting-descendant
 // BFS, which previously opened one concurrent store read per level member with
-// no ceiling. 128 matches main (where #1393 landed it) and the counter-conflicting
-// GetMeta errgroup in subtreevalidation, and is chosen for the SQL backend:
+// no ceiling. 128 matches main, where #1393 landed it. It is exported so the
+// counter-conflicting GetMeta errgroup in subtreevalidation shares it rather than
+// restating the literal — the two are deliberately equal and a tuning pass must
+// move both together.
+//
+// The value is chosen for the SQL backend:
 // Store.get falls back to getUnbatched whenever the requested bins include
 // ConflictingChildren or Utxos (stores/utxo/sql/sql.go) — exactly the fields this
 // walk requests — so every level member is a concurrent unbatched query against
@@ -43,7 +47,7 @@ import (
 // rather than ~N/4096 fill-triggered flushes, so very wide cones walk slower
 // than a batcher-matched ceiling would allow. The incident cone was fully linear
 // (one node per level), where the ceiling is moot either way.
-const conflictingWalkFanOut = 128
+const ConflictingWalkFanOut = 128
 
 // prometheusUtxoCounterConflictingGhostSpends counts every confirmed ghost spender
 // tolerated by the counter-conflicting walk: a parent output that still records a
@@ -1032,16 +1036,31 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	visited[hash] = struct{}{}
 	currentLevel := []chainhash.Hash{hash}
 
-	// reapedByParent records, per enqueued child, whether the node that
-	// enqueued it lists it in deletedChildren — i.e. the pruner deleted the
-	// child's record after it was mined and fully spent. Written between
-	// levels, read only by the next level's goroutines.
+	// reapedByParent records, per reachable child, whether any in-cone parent
+	// lists it in deletedChildren — i.e. the pruner deleted the child's record
+	// after it was mined and fully spent.
+	//
+	// Only the Aerospike store populates DeletedChildren (written by the pruner,
+	// read back in aerospike/get.go); the SQL stores delete transaction rows at
+	// DAH without recording anything on the parents, so on those backends this
+	// map stays empty and every absent descendant takes the ghost-tolerance
+	// branch below. The reaped gate is therefore an Aerospike-only protection,
+	// not a general one.
 	reapedByParent := make(map[chainhash.Hash]bool)
 
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
+
+		// absentErrs[i] holds the NOT_FOUND for a descendant whose record is
+		// gone. Classification (reaped-and-mined versus never-created ghost) is
+		// deliberately NOT done in the goroutine: it depends on deletedChildren
+		// marks contributed by parents that may sit on this very level, which are
+		// not collected until the enqueue pass below has run. Deciding early made
+		// the verdict depend on iteration order.
+		absentErrs := make([]error, len(currentLevel))
+
 		g, gCtx := errgroup.WithContext(ctx)
-		util.SafeSetLimit(g, conflictingWalkFanOut)
+		util.SafeSetLimit(g, ConflictingWalkFanOut)
 
 		for i, current := range currentLevel {
 			i := i
@@ -1056,19 +1075,10 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 						return err
 					}
 
-					// An absent descendant its parent lists in deletedChildren
-					// was reaped after being mined — the subtree holds settled
-					// history and must not be treated as demotable. Fail closed,
-					// mirroring the counter walk's reaped-spender gate.
-					if reapedByParent[current] {
-						return errors.NewProcessingError("[GetConflictingChildren][%s] descendant %s was reaped after being mined (listed in its parent's deletedChildren)", hash.String(), current.String(), err)
-					}
+					// Defer the reaped-versus-ghost decision to the classification
+					// pass below, once this level's deletedChildren marks are in.
+					absentErrs[i] = err
 
-					// A confirmed-absent ghost descendant (spends applied, record
-					// never created): it cannot be demoted and has no readable
-					// descendants — skip it instead of wedging every consumer of
-					// this walk. results[i] stays nil and the hash is dropped
-					// from the visited set below.
 					return nil
 				}
 				results[i] = txMeta
@@ -1088,9 +1098,13 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 		// child, not just the first one to reach it. reapedByParent decides
 		// settled-mined-spend (fail closed) versus tolerated ghost (silently
 		// dropped from the result), so a first-writer-wins verdict let a child
-		// whose deletedChildren mark lives only on a later parent be demoted as a
-		// ghost — clearing a settled spend. Any parent saying "reaped" now wins,
-		// which makes the verdict order-independent and fail-closed.
+		// whose deletedChildren mark lives only on another parent be demoted as a
+		// ghost — clearing a settled spend. Any parent saying "reaped" wins.
+		//
+		// Marks from a parent on a LATER level still arrive after the child was
+		// classified; those are caught because a tolerated ghost is removed from
+		// visited, so the later parent re-enqueues it and the next level re-reads
+		// it with the mark set.
 		enqueue := func(child chainhash.Hash, parent *meta.Data) {
 			if parent.DeletedChildren[child] {
 				reapedByParent[child] = true
@@ -1115,10 +1129,11 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 			nextLevel = append(nextLevel, child)
 		}
 
-		for i, txMeta := range results {
+		// Pass 1: collect every deletedChildren mark this level contributes,
+		// before anything absent is classified. A parent on this level can be the
+		// only node marking a sibling on the same level as reaped.
+		for _, txMeta := range results {
 			if txMeta == nil {
-				// tolerated ghost descendant — exclude it from the result set
-				delete(visited, currentLevel[i])
 				continue
 			}
 
@@ -1131,6 +1146,31 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 					enqueue(*spendingData.TxID, txMeta)
 				}
 			}
+		}
+
+		// Pass 2: the marks are now complete for this level, so absence can be
+		// classified deterministically.
+		for i, absentErr := range absentErrs {
+			if absentErr == nil {
+				continue
+			}
+
+			current := currentLevel[i]
+
+			// An absent descendant that some in-cone parent lists in
+			// deletedChildren was reaped after being mined — the subtree holds
+			// settled history and must not be treated as demotable. Fail closed,
+			// mirroring the counter walk's reaped-spender gate.
+			if reapedByParent[current] {
+				return nil, errors.NewProcessingError("[GetConflictingChildren][%s] descendant %s was reaped after being mined (listed in its parent's deletedChildren)", hash.String(), current.String(), absentErr)
+			}
+
+			// A confirmed-absent ghost descendant (spends applied, record never
+			// created): it cannot be demoted and has no readable descendants — drop
+			// it instead of wedging every consumer of this walk. Removing it from
+			// visited also lets a later-level parent re-enqueue it, so a mark that
+			// only shows up further down still gets its re-check.
+			delete(visited, current)
 		}
 
 		currentLevel = nextLevel

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -26,6 +26,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// conflictingWalkFanOut caps the per-level width of the conflicting-descendant
+// BFS, which previously opened one concurrent store read per level member with
+// no ceiling at all. It matches utxostore_getBatcherSize (settings.conf:1240,
+// 4096) so one full wave fills exactly one Aerospike get batch: the ceiling
+// still stops unbounded goroutine and read explosion, without converting the
+// batcher's fill-triggered flushes into utxostore_getBatcherDurationMillis
+// timer flushes the way a smaller ceiling would. On the SQL backend it makes no
+// difference either way — the ConflictingChildren/Utxos fields force unbatched
+// queries, so level members queue on postgres_maxOpenConns regardless.
+const conflictingWalkFanOut = 4096
+
 // prometheusUtxoCounterConflictingGhostSpends counts every confirmed ghost spender
 // tolerated by the counter-conflicting walk: a parent output that still records a
 // spender whose own record no longer exists (e.g. a never-mined conflicting loser
@@ -1022,9 +1033,7 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	for len(currentLevel) > 0 {
 		results := make([]*meta.Data, len(currentLevel))
 		g, gCtx := errgroup.WithContext(ctx)
-		// a wide level must not fan out one goroutine (and one store read) per
-		// descendant without bound
-		g.SetLimit(128)
+		util.SafeSetLimit(g, conflictingWalkFanOut)
 
 		for i, current := range currentLevel {
 			i := i

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -992,9 +992,7 @@ func GetAndLockChildren(ctx context.Context, s Store, hash chainhash.Hash) ([]ch
 
 			if txMeta.SpendingDatas != nil {
 				for _, spendingData := range txMeta.SpendingDatas {
-					// same nil-TxID guard as the conflicting walk: dereferencing a
-					// nil TxID here panics an errgroup goroutine and takes the
-					// process down
+					// Match the counter walk's handling of an unset spender.
 					if spendingData != nil && spendingData.TxID != nil {
 						child := *spendingData.TxID
 						if _, ok := visited[child]; ok {
@@ -1047,8 +1045,11 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 	// read back in aerospike/get.go); the SQL stores delete transaction rows at
 	// DAH without recording anything on the parents, so on those backends this
 	// map stays empty and every absent descendant takes the ghost-tolerance
-	// branch below. The reaped gate is therefore an Aerospike-only protection,
-	// not a general one.
+	// branch below. Even on Aerospike, the gate only protects descendants whose
+	// marks survived: disabling the pruned-set skip (#1705) prevents new cuckoo
+	// false-positive skips but does not restore previously lost marks. A failed
+	// parent update in the non-defensive combined cleanup batch can also leave a
+	// deleted child without a mark (see flushCleanupBatches).
 	reapedByParent := make(map[chainhash.Hash]bool)
 
 	for len(currentLevel) > 0 {
@@ -1081,7 +1082,6 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 					// Defer the reaped-versus-ghost decision to the classification
 					// pass below, once this level's deletedChildren marks are in.
 					absentErrs[i] = err
-
 					return nil
 				}
 				results[i] = txMeta
@@ -1145,12 +1145,7 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash) (
 			}
 
 			for _, spendingData := range txMeta.SpendingDatas {
-				// TxID is guarded as well as the slot: SpendingData.Clone handles a
-				// nil TxID and the counter walk below checks both, so the codebase
-				// treats it as reachable. Dereferencing it here would panic inside
-				// an errgroup goroutine — an unrecovered panic that takes the
-				// process down, not just the block. Skipping matches the counter
-				// walk's handling of the same shape.
+				// Match the counter walk's handling of an unset spender.
 				if spendingData != nil && spendingData.TxID != nil {
 					enqueue(*spendingData.TxID, txMeta)
 				}
@@ -1265,6 +1260,11 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 	// the per-input independence the ghost tolerance (#1325) was built on, and
 	// costs nothing in the case the memo exists for: a large cone that reads
 	// successfully is walked exactly once.
+	//
+	// This is not a snapshot: if a spender is reaped after a successful walk,
+	// later inputs reuse that success and do not emit ghost-slot clears for it
+	// during this call. Success-only caching avoids stale errors, but does not
+	// guarantee freshness against concurrent pruning.
 	spenderWalks := make(map[chainhash.Hash][]chainhash.Hash, len(txMeta.Tx.Inputs))
 
 	walkSpender := func(spendingTxID chainhash.Hash) ([]chainhash.Hash, error) {
@@ -1313,10 +1313,11 @@ func getCounterConflictingTxHashesAndGhostSpends(ctx context.Context, s Store, t
 
 					// The probe proves the record is gone, not that the spender was
 					// never mined: DAH housekeeping reaps mined, fully-spent records
-					// too. The pruner marks every reaped child in its surviving
-					// parents' deletedChildren map, so a spender listed there held a
+					// too. A spender listed in its parent's deletedChildren held a
 					// settled, mined spend — clearing its slot would bless a
-					// double-spend of a settled output. Fail closed instead.
+					// double-spend of a settled output. Fail closed instead. Absence
+					// of a mark is not proof it was never mined: the same backend and
+					// marker-loss limits documented in GetConflictingChildren apply.
 					if parentTxMeta.DeletedChildren[*spendingTxID] {
 						return nil, nil, errors.NewProcessingError("[GetCounterConflictingTxHashes][%s] spender %s of parent %s was reaped after being mined (listed in the parent's deletedChildren) — its settled spend is not a ghost", txHash.String(), spendingTxID.String(), input.PreviousTxIDChainHash().String(), err)
 					}

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -2,7 +2,10 @@ package utxo
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
@@ -1337,6 +1340,7 @@ func stubCounterConflictingWalk(mockStore *MockUtxostore, rootTx *bt.Tx, spender
 func TestGetCounterConflictingTxHashes_DedupesSpenderWalks(t *testing.T) {
 	ctx := context.Background()
 	mockStore := &MockUtxostore{}
+	mockStore.Test(t)
 
 	txHash := createTestHash("dedupe-tx")
 	parentTxHash := createTestHash("dedupe-parent")
@@ -1379,4 +1383,223 @@ func TestGetCounterConflictingTxHashes_DedupesSpenderWalks(t *testing.T) {
 
 	mockStore.AssertExpectations(t)
 	mockStore.AssertNumberOfCalls(t, "GetConflictingChildren", 1)
+}
+
+// TestGetConflictingChildren_ReapedMarkOrIsOrderIndependent pins the fix for the
+// first-writer-wins reapedByParent verdict. A reaped descendant reachable from
+// two in-cone parents must fail closed even when only the parent that did NOT
+// enqueue it carries the deletedChildren mark; the pre-fix walk recorded the
+// first parent's verdict and silently tolerated the descendant as a ghost,
+// which lets ProcessConflicting clear a settled, mined spend.
+func TestGetConflictingChildren_ReapedMarkOrIsOrderIndependent(t *testing.T) {
+	rootHash := createTestHash("reaped-root")
+	parentAHash := createTestHash("reaped-parent-a")
+	parentBHash := createTestHash("reaped-parent-b")
+	childHash := createTestHash("reaped-child")
+
+	// markOn selects which of the two parents carries the deletedChildren mark.
+	// Both orderings must fail closed; only "b" is red before the fix.
+	newStore := func(markOn string) *MockUtxostore {
+		mockStore := &MockUtxostore{}
+		mockStore.Test(t)
+
+		mockStore.On("Get", mock.Anything, &rootHash, mock.Anything).
+			Return(&meta.Data{
+				SpendingDatas: []*spend.SpendingData{{TxID: &parentAHash}, {TxID: &parentBHash}},
+			}, nil)
+
+		deleted := func(marked bool) map[chainhash.Hash]bool {
+			if !marked {
+				return nil
+			}
+
+			return map[chainhash.Hash]bool{childHash: true}
+		}
+
+		mockStore.On("Get", mock.Anything, &parentAHash, mock.Anything).
+			Return(&meta.Data{
+				SpendingDatas:   []*spend.SpendingData{{TxID: &childHash}},
+				DeletedChildren: deleted(markOn == "a"),
+			}, nil)
+		mockStore.On("Get", mock.Anything, &parentBHash, mock.Anything).
+			Return(&meta.Data{
+				SpendingDatas:   []*spend.SpendingData{{TxID: &childHash}},
+				DeletedChildren: deleted(markOn == "b"),
+			}, nil)
+
+		// the reaped descendant's own record is gone
+		mockStore.On("Get", mock.Anything, &childHash, mock.Anything).
+			Return(nil, errors.NewTxNotFoundError("%v not found", childHash))
+
+		return mockStore
+	}
+
+	for _, markOn := range []string{"a", "b"} {
+		t.Run("mark on parent "+markOn, func(t *testing.T) {
+			result, err := GetConflictingChildren(context.Background(), newStore(markOn), rootHash)
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "was reaped after being mined")
+		})
+	}
+}
+
+// TestGetConflictingChildren_ConflictingChildrenTraversal covers the
+// ConflictingChildren edge of the walk. The scaling and frozen tests link their
+// cones entirely through SpendingDatas, so without this the branch production
+// uses for explicitly-marked conflicting descendants is never exercised.
+func TestGetConflictingChildren_ConflictingChildrenTraversal(t *testing.T) {
+	rootHash := createTestHash("cc-root")
+	midHash := createTestHash("cc-mid")
+	leafHash := createTestHash("cc-leaf")
+
+	mockStore := &MockUtxostore{}
+	mockStore.Test(t)
+
+	mockStore.On("Get", mock.Anything, &rootHash, mock.Anything).
+		Return(&meta.Data{ConflictingChildren: []chainhash.Hash{midHash}}, nil)
+	mockStore.On("Get", mock.Anything, &midHash, mock.Anything).
+		Return(&meta.Data{ConflictingChildren: []chainhash.Hash{leafHash}}, nil)
+	mockStore.On("Get", mock.Anything, &leafHash, mock.Anything).
+		Return(&meta.Data{}, nil)
+
+	result, err := GetConflictingChildren(context.Background(), mockStore, rootHash)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []chainhash.Hash{midHash, leafHash}, result)
+}
+
+// fanOutProbeStore serves a fixed descendant graph and records the peak number
+// of concurrent Get calls, so the per-level errgroup ceiling can be asserted
+// rather than assumed. Only Get is exercised by the walk; the embedded Store is
+// nil and must stay unused.
+type fanOutProbeStore struct {
+	Store
+	children map[chainhash.Hash][]chainhash.Hash
+	inFlight atomic.Int32
+	peak     atomic.Int32
+}
+
+func (f *fanOutProbeStore) Get(_ context.Context, hash *chainhash.Hash, _ ...fields.FieldName) (*meta.Data, error) {
+	cur := f.inFlight.Add(1)
+	defer f.inFlight.Add(-1)
+
+	for {
+		peak := f.peak.Load()
+		if cur <= peak || f.peak.CompareAndSwap(peak, cur) {
+			break
+		}
+	}
+
+	// hold the slot long enough that a level wider than the ceiling actually
+	// overlaps, otherwise the peak measurement is vacuous
+	time.Sleep(2 * time.Millisecond)
+
+	kids := f.children[*hash]
+	spendingDatas := make([]*spend.SpendingData, 0, len(kids))
+
+	for i := range kids {
+		spendingDatas = append(spendingDatas, &spend.SpendingData{TxID: &kids[i]})
+	}
+
+	return &meta.Data{SpendingDatas: spendingDatas}, nil
+}
+
+// TestGetConflictingChildren_FanOutCapped pins the per-level ceiling. Deleting
+// the SafeSetLimit call leaves every other test in these packages green, because
+// their cones are linear (BFS level width 1) — this is the only case with a
+// level wide enough for the cap to matter.
+func TestGetConflictingChildren_FanOutCapped(t *testing.T) {
+	const levelWidth = conflictingWalkFanOut * 3
+
+	rootHash := createTestHash("fanout-root")
+
+	kids := make([]chainhash.Hash, levelWidth)
+	for i := range kids {
+		kids[i] = createTestHash(fmt.Sprintf("fanout-child-%d", i))
+	}
+
+	store := &fanOutProbeStore{children: map[chainhash.Hash][]chainhash.Hash{rootHash: kids}}
+
+	result, err := GetConflictingChildren(context.Background(), store, rootHash)
+	require.NoError(t, err)
+	require.Len(t, result, levelWidth)
+
+	peak := store.peak.Load()
+	require.LessOrEqualf(t, peak, int32(conflictingWalkFanOut),
+		"per-level fan-out must stay at or below %d, peaked at %d", conflictingWalkFanOut, peak)
+	require.Greaterf(t, peak, int32(1),
+		"the probe never observed concurrent reads (peak %d), so the ceiling assertion above proves nothing", peak)
+}
+
+// TestGetCounterConflictingTxHashes_MemoDoesNotCacheErrors pins that the
+// per-spender walk memo caches successes only. A spender briefly unreadable
+// while the first input is processed and readable by the second used to resolve
+// on the second walk; caching the error replayed a stale NOT_FOUND, the
+// un-memoised probe below then found the record present, and the whole call
+// failed closed on an error that no longer reflected the store.
+func TestGetCounterConflictingTxHashes_MemoDoesNotCacheErrors(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+	mockStore.Test(t)
+
+	txHash := createTestHash("memo-tx")
+	parentTxHash := createTestHash("memo-parent")
+	spenderHash := createTestHash("memo-spender")
+	childHash := createTestHash("memo-spender-child")
+
+	// one tx spending two outputs of the same parent, both counter-spent by the
+	// same transaction — so both inputs route through the same memo entry
+	testTx := bt.NewTx()
+
+	for vout := uint32(0); vout < 2; vout++ {
+		input := &bt.Input{PreviousTxOutIndex: vout}
+		_ = input.PreviousTxIDAdd(&parentTxHash)
+		testTx.Inputs = append(testTx.Inputs, input)
+	}
+
+	testTx.Outputs = append(testTx.Outputs, &bt.Output{Satoshis: 1000})
+
+	parentTx := bt.NewTx()
+	for range 2 {
+		parentTx.Outputs = append(parentTx.Outputs, &bt.Output{
+			Satoshis:      1000,
+			LockingScript: bscript.NewFromBytes([]byte{bscript.OpTRUE}),
+		})
+	}
+
+	mockStore.On("Get", mock.Anything, &txHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: testTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Utxos, fields.DeletedChildren}).
+		Return(&meta.Data{
+			SpendingDatas: []*spend.SpendingData{{TxID: &spenderHash}, {TxID: &spenderHash}},
+		}, nil)
+
+	// the walk fails once, then succeeds — the record showed up in between
+	mockStore.On("GetConflictingChildren", mock.Anything, spenderHash).
+		Return(([]chainhash.Hash)(nil), errors.NewTxNotFoundError("%v not found", spenderHash)).Once()
+	mockStore.On("GetConflictingChildren", mock.Anything, spenderHash).
+		Return([]chainhash.Hash{childHash}, nil).Once()
+
+	// the ghost probe agrees with the walk the first time, then sees the record
+	mockStore.On("Get", mock.Anything, &spenderHash, []fields.FieldName{fields.Conflicting}).
+		Return(nil, errors.NewTxNotFoundError("%v not found", spenderHash)).Once()
+	mockStore.On("Get", mock.Anything, &spenderHash, []fields.FieldName{fields.Conflicting}).
+		Return(&meta.Data{}, nil)
+
+	// input 0 is tolerated as a ghost, which builds a slot-clearing spend
+	mockStore.On("Get", mock.Anything, &parentTxHash, []fields.FieldName{fields.Tx}).
+		Return(&meta.Data{Tx: parentTx}, nil)
+
+	result, ghostSpends, err := getCounterConflictingTxHashesAndGhostSpends(ctx, mockStore, txHash)
+	require.NoError(t, err)
+
+	// input 1's fresh walk found the spender, so it is in the counter set
+	assert.Contains(t, result, txHash)
+	assert.Contains(t, result, spenderHash)
+	assert.Contains(t, result, childHash)
+
+	// input 0 still emitted exactly one ghost slot clear
+	assert.Len(t, ghostSpends, 1)
+	assert.Equal(t, uint32(0), ghostSpends[0].Vout)
 }

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -1650,3 +1650,49 @@ func TestGetConflictingChildren_ReapedMarkSameLevelParent(t *testing.T) {
 		})
 	}
 }
+
+// TestConflictingWalks_NilSpendingDataTxID pins the nil-TxID guard on both
+// descendant walks. SpendingData.Clone handles a nil TxID and the counter walk
+// checks it, so the codebase treats it as reachable; dereferencing it inside a
+// BFS goroutine is an unrecovered panic that takes the process down rather than
+// failing the block. The entry is skipped, matching the counter walk.
+func TestConflictingWalks_NilSpendingDataTxID(t *testing.T) {
+	rootHash := createTestHash("niltxid-root")
+	childHash := createTestHash("niltxid-child")
+
+	newStore := func() *MockUtxostore {
+		mockStore := &MockUtxostore{}
+		mockStore.Test(t)
+
+		mockStore.On("Get", mock.Anything, &rootHash, mock.Anything).
+			Return(&meta.Data{
+				SpendingDatas: []*spend.SpendingData{
+					{TxID: nil, Vin: 0}, // frozen/unset slot with no spender recorded
+					{TxID: &childHash, Vin: 1},
+				},
+			}, nil)
+		mockStore.On("Get", mock.Anything, &childHash, mock.Anything).
+			Return(&meta.Data{}, nil)
+
+		return mockStore
+	}
+
+	t.Run("GetConflictingChildren", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			result, err := GetConflictingChildren(context.Background(), newStore(), rootHash)
+			require.NoError(t, err)
+			assert.Equal(t, []chainhash.Hash{childHash}, result)
+		})
+	})
+
+	t.Run("GetAndLockChildren", func(t *testing.T) {
+		store := newStore()
+		store.On("SetLocked", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		require.NotPanics(t, func() {
+			result, err := GetAndLockChildren(context.Background(), store, rootHash)
+			require.NoError(t, err)
+			assert.Contains(t, result, childHash)
+		})
+	})
+}

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -1329,3 +1329,54 @@ func stubCounterConflictingWalk(mockStore *MockUtxostore, rootTx *bt.Tx, spender
 	mockStore.On("GetConflictingChildren", mock.Anything, spenderTxHash).
 		Return([]chainhash.Hash{}, nil).Once()
 }
+
+// TestGetCounterConflictingTxHashes_DedupesSpenderWalks pins the per-input walk
+// dedupe of issue 1391: a tx whose inputs are all counter-spent by the same
+// transaction must walk that spender's descendant cone exactly once, not once
+// per input.
+func TestGetCounterConflictingTxHashes_DedupesSpenderWalks(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &MockUtxostore{}
+
+	txHash := createTestHash("dedupe-tx")
+	parentTxHash := createTestHash("dedupe-parent")
+	spenderHash := createTestHash("dedupe-spender")
+	childHash := createTestHash("dedupe-spender-child")
+
+	// tx spends three outputs of the same parent, all counter-spent by the same tx
+	testTx := bt.NewTx()
+
+	for vout := uint32(0); vout < 3; vout++ {
+		input := &bt.Input{PreviousTxOutIndex: vout}
+		_ = input.PreviousTxIDAdd(&parentTxHash)
+		testTx.Inputs = append(testTx.Inputs, input)
+	}
+
+	testTx.Outputs = append(testTx.Outputs, &bt.Output{Satoshis: 1000})
+
+	mockStore.On("Get", mock.Anything, &txHash, mock.Anything).
+		Return(&meta.Data{Tx: testTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, mock.Anything).
+		Return(&meta.Data{
+			SpendingDatas: []*spend.SpendingData{
+				{TxID: &spenderHash},
+				{TxID: &spenderHash},
+				{TxID: &spenderHash},
+			},
+		}, nil)
+
+	// exactly ONE walk of the unique counter-spender, not one per input
+	mockStore.On("GetConflictingChildren", mock.Anything, spenderHash).
+		Return([]chainhash.Hash{childHash}, nil).Once()
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, txHash)
+	assert.Contains(t, result, spenderHash)
+	assert.Contains(t, result, childHash)
+	assert.Len(t, result, 3)
+
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNumberOfCalls(t, "GetConflictingChildren", 1)
+}

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -1510,7 +1510,7 @@ func (f *fanOutProbeStore) Get(_ context.Context, hash *chainhash.Hash, _ ...fie
 // their cones are linear (BFS level width 1) — this is the only case with a
 // level wide enough for the cap to matter.
 func TestGetConflictingChildren_FanOutCapped(t *testing.T) {
-	const levelWidth = conflictingWalkFanOut * 3
+	const levelWidth = ConflictingWalkFanOut * 3
 
 	rootHash := createTestHash("fanout-root")
 
@@ -1526,8 +1526,8 @@ func TestGetConflictingChildren_FanOutCapped(t *testing.T) {
 	require.Len(t, result, levelWidth)
 
 	peak := store.peak.Load()
-	require.LessOrEqualf(t, peak, int32(conflictingWalkFanOut),
-		"per-level fan-out must stay at or below %d, peaked at %d", conflictingWalkFanOut, peak)
+	require.LessOrEqualf(t, peak, int32(ConflictingWalkFanOut),
+		"per-level fan-out must stay at or below %d, peaked at %d", ConflictingWalkFanOut, peak)
 	require.Greaterf(t, peak, int32(1),
 		"the probe never observed concurrent reads (peak %d), so the ceiling assertion above proves nothing", peak)
 }
@@ -1602,4 +1602,51 @@ func TestGetCounterConflictingTxHashes_MemoDoesNotCacheErrors(t *testing.T) {
 	// input 0 still emitted exactly one ghost slot clear
 	assert.Len(t, ghostSpends, 1)
 	assert.Equal(t, uint32(0), ghostSpends[0].Vout)
+}
+
+// TestGetConflictingChildren_ReapedMarkSameLevelParent pins the harder half of
+// the order-independence property: the parent carrying the deletedChildren mark
+// sits on the SAME BFS level as the reaped descendant, so the mark is not known
+// when the level's goroutines classify the NOT_FOUND.
+//
+// Cone: root spends to A and to X, and X also spends an output of A. Both land
+// on level 1, A lists X in deletedChildren, and X's record was reaped after
+// being mined. Classifying absence inside the goroutine tolerated X as a ghost
+// whenever A happened to be iterated after X was dropped — the verdict flipped
+// on SpendingDatas ordering.
+func TestGetConflictingChildren_ReapedMarkSameLevelParent(t *testing.T) {
+	rootHash := createTestHash("samelevel-root")
+	parentHash := createTestHash("samelevel-parent")
+	reapedHash := createTestHash("samelevel-reaped")
+
+	// both orderings of the root's spending data must reach the same verdict
+	orderings := map[string][]*spend.SpendingData{
+		"parent enqueued first": {{TxID: &parentHash}, {TxID: &reapedHash}},
+		"reaped enqueued first": {{TxID: &reapedHash}, {TxID: &parentHash}},
+	}
+
+	for name, rootSpends := range orderings {
+		t.Run(name, func(t *testing.T) {
+			mockStore := &MockUtxostore{}
+			mockStore.Test(t)
+
+			mockStore.On("Get", mock.Anything, &rootHash, mock.Anything).
+				Return(&meta.Data{SpendingDatas: rootSpends}, nil)
+
+			// the marking parent is on the same level as the reaped descendant
+			mockStore.On("Get", mock.Anything, &parentHash, mock.Anything).
+				Return(&meta.Data{
+					SpendingDatas:   []*spend.SpendingData{{TxID: &reapedHash}},
+					DeletedChildren: map[chainhash.Hash]bool{reapedHash: true},
+				}, nil)
+
+			mockStore.On("Get", mock.Anything, &reapedHash, mock.Anything).
+				Return(nil, errors.NewTxNotFoundError("%v not found", reapedHash))
+
+			result, err := GetConflictingChildren(context.Background(), mockStore, rootHash)
+			require.Error(t, err, "a reaped, marked descendant must fail closed regardless of level ordering")
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "was reaped after being mined")
+		})
+	}
 }

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -1376,10 +1376,10 @@ func TestGetCounterConflictingTxHashes_DedupesSpenderWalks(t *testing.T) {
 	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash)
 	require.NoError(t, err)
 
-	assert.Contains(t, result, txHash)
-	assert.Contains(t, result, spenderHash)
-	assert.Contains(t, result, childHash)
-	assert.Len(t, result, 3)
+	require.Contains(t, result, txHash)
+	require.Contains(t, result, spenderHash)
+	require.Contains(t, result, childHash)
+	require.Len(t, result, 3)
 
 	mockStore.AssertExpectations(t)
 	mockStore.AssertNumberOfCalls(t, "GetConflictingChildren", 1)
@@ -1438,8 +1438,8 @@ func TestGetConflictingChildren_ReapedMarkOrIsOrderIndependent(t *testing.T) {
 		t.Run("mark on parent "+markOn, func(t *testing.T) {
 			result, err := GetConflictingChildren(context.Background(), newStore(markOn), rootHash)
 			require.Error(t, err)
-			assert.Nil(t, result)
-			assert.Contains(t, err.Error(), "was reaped after being mined")
+			require.Nil(t, result)
+			require.Contains(t, err.Error(), "was reaped after being mined")
 		})
 	}
 }
@@ -1466,7 +1466,7 @@ func TestGetConflictingChildren_ConflictingChildrenTraversal(t *testing.T) {
 	result, err := GetConflictingChildren(context.Background(), mockStore, rootHash)
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, []chainhash.Hash{midHash, leafHash}, result)
+	require.ElementsMatch(t, []chainhash.Hash{midHash, leafHash}, result)
 }
 
 // fanOutProbeStore serves a fixed descendant graph and records the peak number
@@ -1595,13 +1595,13 @@ func TestGetCounterConflictingTxHashes_MemoDoesNotCacheErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	// input 1's fresh walk found the spender, so it is in the counter set
-	assert.Contains(t, result, txHash)
-	assert.Contains(t, result, spenderHash)
-	assert.Contains(t, result, childHash)
+	require.Contains(t, result, txHash)
+	require.Contains(t, result, spenderHash)
+	require.Contains(t, result, childHash)
 
 	// input 0 still emitted exactly one ghost slot clear
-	assert.Len(t, ghostSpends, 1)
-	assert.Equal(t, uint32(0), ghostSpends[0].Vout)
+	require.Len(t, ghostSpends, 1)
+	require.Equal(t, uint32(0), ghostSpends[0].Vout)
 }
 
 // TestGetConflictingChildren_ReapedMarkSameLevelParent pins the harder half of
@@ -1645,17 +1645,15 @@ func TestGetConflictingChildren_ReapedMarkSameLevelParent(t *testing.T) {
 
 			result, err := GetConflictingChildren(context.Background(), mockStore, rootHash)
 			require.Error(t, err, "a reaped, marked descendant must fail closed regardless of level ordering")
-			assert.Nil(t, result)
-			assert.Contains(t, err.Error(), "was reaped after being mined")
+			require.Nil(t, result)
+			require.Contains(t, err.Error(), "was reaped after being mined")
 		})
 	}
 }
 
 // TestConflictingWalks_NilSpendingDataTxID pins the nil-TxID guard on both
-// descendant walks. SpendingData.Clone handles a nil TxID and the counter walk
-// checks it, so the codebase treats it as reachable; dereferencing it inside a
-// BFS goroutine is an unrecovered panic that takes the process down rather than
-// failing the block. The entry is skipped, matching the counter walk.
+// descendant walks. The entry is skipped, matching the counter walk, rather
+// than dereferencing an unset spender while collecting the next BFS level.
 func TestConflictingWalks_NilSpendingDataTxID(t *testing.T) {
 	rootHash := createTestHash("niltxid-root")
 	childHash := createTestHash("niltxid-child")
@@ -1681,7 +1679,7 @@ func TestConflictingWalks_NilSpendingDataTxID(t *testing.T) {
 		require.NotPanics(t, func() {
 			result, err := GetConflictingChildren(context.Background(), newStore(), rootHash)
 			require.NoError(t, err)
-			assert.Equal(t, []chainhash.Hash{childHash}, result)
+			require.Equal(t, []chainhash.Hash{childHash}, result)
 		})
 	})
 
@@ -1692,7 +1690,7 @@ func TestConflictingWalks_NilSpendingDataTxID(t *testing.T) {
 		require.NotPanics(t, func() {
 			result, err := GetAndLockChildren(context.Background(), store, rootHash)
 			require.NoError(t, err)
-			assert.Contains(t, result, childHash)
+			require.Contains(t, result, childHash)
 		})
 	})
 }


### PR DESCRIPTION
Minimal partial backport of #1393 to `release/v0.15`, addressing the repeated conflicting-descendant walks behind #1391. The full fix merged into `main` on August 5, 2026 (`86f3113b2`).

Updated onto `release/v0.15` at `45c603513`, including #1705. All six existing backport commits applied unchanged (`git range-diff`).

## Changes

- Replace the O(N²) per-member descendant re-walk with one walk of the blessed transaction’s own descendants. Counter-spender cones are already walked and frozen-checked; the retained walk covers the blessed transaction’s cone.
- Memoise successful descendant walks per unique counter-spender. Failed walks are retried per input so transient NOT_FOUND errors are not replayed from the cache. Per-input ghost-slot handling remains intact.
- Cap each BFS level and the counter-conflicting `GetMeta` group at the shared `ConflictingWalkFanOut = 128`, matching #1393. This limits concurrent unbatched SQL queries; wide Aerospike cones can pay additional timer-flush latency.
- Collect all reaped-child marks contributed by a BFS level before classifying absent descendants. OR marks across parents, preserving same-level order independence and later-level rechecks.
- Warn when the counter-conflicting set exceeds 1,000 transactions or the whole check exceeds 10 seconds, including error and cancellation returns.
- Retain the nil-spender guards added during review. Added tests use `require`, including the length check before indexing ghost spends.

## Latest feedback

The cuckoo-filter marker skip and misleading pruner comment are fixed by the new release base (#1705). The walk comments also state the remaining limits: disabling the skip does not repair historical marker loss; failed parent updates in non-defensive combined cleanup can still leave a deleted child without a marker. SQL pruning does not populate `DeletedChildren`, so this protection is backend-dependent.

The memo comment now explicitly documents that successful walks are not snapshots: concurrent pruning can make a cached success stale and omit a later input’s ghost-slot clear in that call.

## Scope and remaining risks

- No node budget, new settings, error enum, protobuf regeneration, or walk histograms from #1393. The remaining walk is linear in cone depth and still unbounded; production latency/headroom needs measurement in #1396.
- Reorg `GetAndLockChildren` root/descendant error classification and partial-lock cleanup need a separate reorg fix. Ordinary error wrapping does not prevent this repository’s recursive `errors.Is` from matching an inner NOT_FOUND.
- Repeated ghost re-enqueue remains unchanged. Suppressing rechecks needs to preserve later-parent reaped marks and account for concurrent record creation; related coverage/work is tracked in #1530.
- Aggregate concurrency across simultaneous walks, write-side errgroup caps, memo retention, and replacing `GetMeta` with `BatchDecorate(..., fields.BlockIDs)` remain separate work.
- Nil-spender guards retain the counter walk’s existing skip behavior; no stricter malformed-record policy is introduced here.

## Validation

The final rebase also includes the version-script-only release commit `45c603513`. All seven commits remained identical by range-diff. Go source, go.mod, and go.sum are byte-identical to tested head `059f4530e`; only `scripts/determine-git-version.sh` differs in the whole tree. `bash -n` passed for that script.

- `go test -tags testtxmetacache -count=1 ./services/subtreevalidation/... ./stores/utxo` — passed.
- `go test -race -tags testtxmetacache -count=1 ./services/subtreevalidation/... ./stores/utxo/...` — passed, including Aerospike, pruner, and SQL packages.
- `go vet` and `staticcheck` with `-tags testtxmetacache` over both package trees — passed.
- `golangci-lint run --build-tags testtxmetacache --new-from-rev upstream/release/v0.15 --timeout=5m --disable gosec --disable prealloc` over both package trees — passed, 0 issues; flags match repository CI.
- `git diff --check` — passed. Independent review of the follow-up found no issues or runtime changes.

Security scans are not clean: `gosec` reports 104 findings, all mapped to unchanged release lines; `govulncheck` reports 18 reachable advisories in the existing Go 1.26.1 standard library, gRPC, and x/text. `go.mod` and `go.sum` are unchanged from the release base. Repository-wide tests, smoke tests, and production cone-latency measurement were not run locally. Existing regression coverage includes scaling/read-count bounds, frozen checks on all three paths, spender deduplication, uncached errors, fan-out limits, conflicting-child edges, reaped-parent ordering, ghost slots, and nil-spender guards.

Partial backport of #1393; fixes #1391 on `release/v0.15`.
