### PR TITLE
fix(utxo/sql): honour BlockHeights and SubtreeIdxs when asked for on their own

### DIFF
--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -1650,7 +1650,10 @@ func (s *Store) getUnbatched(ctx context.Context, hash *chainhash.Hash, bins []f
 		}
 	}
 
-	if contains(bins, fields.BlockIDs) {
+	// This one query fills BlockIDs, BlockHeights and SubtreeIdxs together, so asking
+	// for any of the three has to run it. Gating on BlockIDs alone meant a caller that
+	// asked only for BlockHeights or SubtreeIdxs got an empty slice and no error.
+	if contains(bins, fields.BlockIDs) || contains(bins, fields.BlockHeights) || contains(bins, fields.SubtreeIdxs) {
 		q := `
 			SELECT
 			    block_id,
@@ -3683,7 +3686,10 @@ func (s *Store) batchDecorateChunk(ctx context.Context, items []*utxo.Unresolved
 
 	needInputs := contains(bins, fields.Tx) || contains(bins, fields.Inputs) || contains(bins, fields.TxInpoints) || contains(bins, fields.Utxos)
 	needOutputs := contains(bins, fields.Tx) || contains(bins, fields.Outputs) || contains(bins, fields.Utxos)
-	needBlockIDs := contains(bins, fields.BlockIDs)
+	// One query fills BlockIDs, BlockHeights and SubtreeIdxs together, so asking for
+	// any of the three has to run it. Gating on BlockIDs alone meant a caller that
+	// asked only for BlockHeights or SubtreeIdxs got an empty slice and no error.
+	needBlockIDs := contains(bins, fields.BlockIDs) || contains(bins, fields.BlockHeights) || contains(bins, fields.SubtreeIdxs)
 
 	// Query 2: Bulk fetch inputs
 	if needInputs {

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -1446,8 +1446,10 @@ func (s *Store) GetMeta(ctx context.Context, hash *chainhash.Hash, data *meta.Da
 //   - tx: Full transaction data
 //   - inputs: Transaction inputs
 //   - outputs: Transaction outputs
-//   - blockIDs: Block references
-//   - parentTxHashes: Previous transaction hashes
+//   - blockIDs, blockHeights, subtreeIdxs: where this transaction has been mined,
+//     index-aligned — entry i of each describes one placement. All three come from
+//     a single query, so requesting any one of them runs it and fills all three.
+//   - txInpoints: parent outpoints referenced by this transaction
 func (s *Store) Get(ctx context.Context, hash *chainhash.Hash, fields ...fields.FieldName) (*meta.Data, error) {
 	bins := utxo.MetaFieldsWithTx
 	if len(fields) > 0 {
@@ -1650,10 +1652,7 @@ func (s *Store) getUnbatched(ctx context.Context, hash *chainhash.Hash, bins []f
 		}
 	}
 
-	// This one query fills BlockIDs, BlockHeights and SubtreeIdxs together, so asking
-	// for any of the three has to run it. Gating on BlockIDs alone meant a caller that
-	// asked only for BlockHeights or SubtreeIdxs got an empty slice and no error.
-	if contains(bins, fields.BlockIDs) || contains(bins, fields.BlockHeights) || contains(bins, fields.SubtreeIdxs) {
+	if needsBlockIDsQuery(bins) {
 		q := `
 			SELECT
 			    block_id,
@@ -1781,6 +1780,16 @@ func contains(slice []fields.FieldName, item fields.FieldName) bool {
 	}
 
 	return false
+}
+
+// needsBlockIDsQuery reports whether any field served by the single block_ids
+// query was requested. BlockIDs, BlockHeights and SubtreeIdxs all come from that
+// one query, so asking for any of them has to run it. Both read paths call this
+// so the grouping is stated once rather than copied.
+func needsBlockIDsQuery(bins []fields.FieldName) bool {
+	return contains(bins, fields.BlockIDs) ||
+		contains(bins, fields.BlockHeights) ||
+		contains(bins, fields.SubtreeIdxs)
 }
 
 // parseInsertedAtMillis converts the inserted_at column value into Unix
@@ -3686,10 +3695,7 @@ func (s *Store) batchDecorateChunk(ctx context.Context, items []*utxo.Unresolved
 
 	needInputs := contains(bins, fields.Tx) || contains(bins, fields.Inputs) || contains(bins, fields.TxInpoints) || contains(bins, fields.Utxos)
 	needOutputs := contains(bins, fields.Tx) || contains(bins, fields.Outputs) || contains(bins, fields.Utxos)
-	// One query fills BlockIDs, BlockHeights and SubtreeIdxs together, so asking for
-	// any of the three has to run it. Gating on BlockIDs alone meant a caller that
-	// asked only for BlockHeights or SubtreeIdxs got an empty slice and no error.
-	needBlockIDs := contains(bins, fields.BlockIDs) || contains(bins, fields.BlockHeights) || contains(bins, fields.SubtreeIdxs)
+	needBlockIDs := needsBlockIDsQuery(bins)
 
 	// Query 2: Bulk fetch inputs
 	if needInputs {

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -3625,3 +3625,78 @@ func TestMinimalCreate_CoinbaseMaturity_OutpointOnlySpend(t *testing.T) {
 		utxo.IgnoreFlags{IgnoreLocked: true, SkipUTXOHashCheck: true})
 	require.NoError(t, err, "spending at maturity height must succeed")
 }
+
+// TestGetBlockHeightsWithoutBlockIDs pins a field-selection bug that was silent.
+//
+// BlockIDs, BlockHeights and SubtreeIdxs all come from one query against the
+// block_ids table, and that query used to run only when the caller asked for
+// BlockIDs. A caller that asked for BlockHeights or SubtreeIdxs on their own got an
+// empty slice back and no error at all — indistinguishable from a transaction that
+// genuinely has not been mined.
+//
+// Nothing in the tree hits it today, because both callers that want BlockHeights
+// happen to ask for BlockIDs alongside it (Validator.go and
+// check_block_subtrees.go). That makes this a trap rather than a live fault, and
+// an expensive one: BlockHeights feeds the input script block height used for
+// BIP68 relative locktime, so a future caller that dropped the seemingly-unused
+// BlockIDs from its field list would have silently changed consensus-relevant
+// behaviour on every sqlite-backed store — including the sqlitememory store the
+// project's own guidance tells people to use in tests.
+//
+// The aerospike store has the opposite habit: it ADDS BlockHeights and SubtreeIdxs
+// whenever BlockIDs is requested (aerospike/get.go addAbstractedBins). Making the
+// two backends agree is the point of the fix.
+func TestGetBlockHeightsWithoutBlockIDs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	utxoStore, tx := setup(ctx, t)
+
+	_, err := utxoStore.Create(ctx, tx, 0)
+	require.NoError(t, err)
+
+	_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{tx.TxIDChainHash()}, utxo.MinedBlockInfo{
+		BlockID:        7,
+		BlockHeight:    99,
+		SubtreeIdx:     3,
+		OnLongestChain: true,
+	})
+	require.NoError(t, err)
+
+	t.Run("Get with only BlockHeights", func(t *testing.T) {
+		data, err := utxoStore.Get(ctx, tx.TxIDChainHash(), fields.BlockHeights)
+		require.NoError(t, err)
+		require.Equal(t, []uint32{99}, data.BlockHeights,
+			"asking for BlockHeights alone must return them, not an empty slice")
+	})
+
+	t.Run("Get with only SubtreeIdxs", func(t *testing.T) {
+		data, err := utxoStore.Get(ctx, tx.TxIDChainHash(), fields.SubtreeIdxs)
+		require.NoError(t, err)
+		require.Equal(t, []int{3}, data.SubtreeIdxs,
+			"asking for SubtreeIdxs alone must return them, not an empty slice")
+	})
+
+	// BatchDecorate reaches the same block_ids query through a separate gate, so it
+	// needs its own case; fixing only the single-Get path would leave the batched
+	// path — the one the validator's parent prefetch actually uses — still wrong.
+	t.Run("BatchDecorate with only BlockHeights", func(t *testing.T) {
+		items := []*utxo.UnresolvedMetaData{{Hash: *tx.TxIDChainHash(), Idx: 0}}
+
+		require.NoError(t, utxoStore.BatchDecorate(ctx, items, fields.BlockHeights))
+		require.NoError(t, items[0].Err)
+		require.NotNil(t, items[0].Data)
+		require.Equal(t, []uint32{99}, items[0].Data.BlockHeights,
+			"batched read must honour BlockHeights on its own too")
+	})
+
+	// The existing behaviour must be untouched: BlockIDs alone still returns all
+	// three, which is what every caller in the tree relies on today.
+	t.Run("Get with only BlockIDs still returns all three", func(t *testing.T) {
+		data, err := utxoStore.Get(ctx, tx.TxIDChainHash(), fields.BlockIDs)
+		require.NoError(t, err)
+		require.Equal(t, []uint32{7}, data.BlockIDs)
+		require.Equal(t, []uint32{99}, data.BlockHeights)
+		require.Equal(t, []int{3}, data.SubtreeIdxs)
+	})
+}

--- a/stores/utxo/sql/sql_test.go
+++ b/stores/utxo/sql/sql_test.go
@@ -3626,27 +3626,21 @@ func TestMinimalCreate_CoinbaseMaturity_OutpointOnlySpend(t *testing.T) {
 	require.NoError(t, err, "spending at maturity height must succeed")
 }
 
-// TestGetBlockHeightsWithoutBlockIDs pins a field-selection bug that was silent.
+// TestGetBlockPlacementFieldsIndependently pins a field-selection bug that was silent.
 //
-// BlockIDs, BlockHeights and SubtreeIdxs all come from one query against the
-// block_ids table, and that query used to run only when the caller asked for
-// BlockIDs. A caller that asked for BlockHeights or SubtreeIdxs on their own got an
-// empty slice back and no error at all — indistinguishable from a transaction that
-// genuinely has not been mined.
+// BlockIDs, BlockHeights and SubtreeIdxs are index-aligned placement fields served by
+// one query against the block_ids table, and that query used to run only when the
+// caller asked for BlockIDs. Asking for either of the other two on its own returned an
+// empty slice and no error — indistinguishable from a transaction never mined.
 //
-// Nothing in the tree hits it today, because both callers that want BlockHeights
-// happen to ask for BlockIDs alongside it (Validator.go and
-// check_block_subtrees.go). That makes this a trap rather than a live fault, and
-// an expensive one: BlockHeights feeds the input script block height used for
-// BIP68 relative locktime, so a future caller that dropped the seemingly-unused
-// BlockIDs from its field list would have silently changed consensus-relevant
-// behaviour on every sqlite-backed store — including the sqlitememory store the
-// project's own guidance tells people to use in tests.
+// It matters because BlockHeights feeds the input script block height used for BIP68
+// relative locktime, so a caller that dropped the apparently-unused BlockIDs from its
+// field list would have changed consensus-relevant behaviour with no failure to see.
 //
-// The aerospike store has the opposite habit: it ADDS BlockHeights and SubtreeIdxs
-// whenever BlockIDs is requested (aerospike/get.go addAbstractedBins). Making the
-// two backends agree is the point of the fix.
-func TestGetBlockHeightsWithoutBlockIDs(t *testing.T) {
+// Each read path is checked against each of the two previously-broken fields. The two
+// paths reach the query through separate checks, and each check ORs the two fields
+// separately, so any one of the four could be removed without the others noticing.
+func TestGetBlockPlacementFieldsIndependently(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -3663,36 +3657,58 @@ func TestGetBlockHeightsWithoutBlockIDs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	t.Run("Get with only BlockHeights", func(t *testing.T) {
+	placementFields := []struct {
+		name  string
+		field fields.FieldName
+		check func(*testing.T, *meta.Data)
+	}{
+		{"BlockHeights", fields.BlockHeights, func(t *testing.T, d *meta.Data) {
+			require.Equal(t, []uint32{99}, d.BlockHeights)
+		}},
+		{"SubtreeIdxs", fields.SubtreeIdxs, func(t *testing.T, d *meta.Data) {
+			require.Equal(t, []int{3}, d.SubtreeIdxs)
+		}},
+	}
+
+	// getUnbatched is called directly. Routing it to via the public Get would depend on
+	// configuration: settings.conf sets utxostore_getBatcherSize = 4096, so a plain Get
+	// travels the batched path instead, and a developer running with the struct-tag
+	// default of 1 would silently move these cases onto the other path.
+	for _, tc := range placementFields {
+		t.Run("unbatched read with only "+tc.name, func(t *testing.T) {
+			data, err := utxoStore.getUnbatched(ctx, tx.TxIDChainHash(), []fields.FieldName{tc.field})
+			require.NoError(t, err)
+			tc.check(t, data)
+		})
+	}
+
+	// BatchDecorate is likewise called directly, so this pins the batched path whatever
+	// the batcher is configured to do. It is the path the validator's parent prefetch
+	// uses, via Get when a batcher exists.
+	for _, tc := range placementFields {
+		t.Run("batched read with only "+tc.name, func(t *testing.T) {
+			items := []*utxo.UnresolvedMetaData{{Hash: *tx.TxIDChainHash(), Idx: 0}}
+
+			require.NoError(t, utxoStore.BatchDecorate(ctx, items, tc.field))
+			require.NoError(t, items[0].Err)
+			require.NotNil(t, items[0].Data)
+			tc.check(t, items[0].Data)
+		})
+	}
+
+	// The two direct-call groups above cover the field selection on both paths. This
+	// case additionally confirms the public Get reaches one of them, since Get routes on
+	// both the batcher's presence and the field list.
+	t.Run("public Get with only BlockHeights", func(t *testing.T) {
 		data, err := utxoStore.Get(ctx, tx.TxIDChainHash(), fields.BlockHeights)
 		require.NoError(t, err)
 		require.Equal(t, []uint32{99}, data.BlockHeights,
 			"asking for BlockHeights alone must return them, not an empty slice")
 	})
 
-	t.Run("Get with only SubtreeIdxs", func(t *testing.T) {
-		data, err := utxoStore.Get(ctx, tx.TxIDChainHash(), fields.SubtreeIdxs)
-		require.NoError(t, err)
-		require.Equal(t, []int{3}, data.SubtreeIdxs,
-			"asking for SubtreeIdxs alone must return them, not an empty slice")
-	})
-
-	// BatchDecorate reaches the same block_ids query through a separate gate, so it
-	// needs its own case; fixing only the single-Get path would leave the batched
-	// path — the one the validator's parent prefetch actually uses — still wrong.
-	t.Run("BatchDecorate with only BlockHeights", func(t *testing.T) {
-		items := []*utxo.UnresolvedMetaData{{Hash: *tx.TxIDChainHash(), Idx: 0}}
-
-		require.NoError(t, utxoStore.BatchDecorate(ctx, items, fields.BlockHeights))
-		require.NoError(t, items[0].Err)
-		require.NotNil(t, items[0].Data)
-		require.Equal(t, []uint32{99}, items[0].Data.BlockHeights,
-			"batched read must honour BlockHeights on its own too")
-	})
-
-	// The existing behaviour must be untouched: BlockIDs alone still returns all
-	// three, which is what every caller in the tree relies on today.
-	t.Run("Get with only BlockIDs still returns all three", func(t *testing.T) {
+	// The existing behaviour must be untouched: BlockIDs alone still returns all three,
+	// which is what every caller in the tree relies on today.
+	t.Run("BlockIDs alone still returns all three", func(t *testing.T) {
 		data, err := utxoStore.Get(ctx, tx.TxIDChainHash(), fields.BlockIDs)
 		require.NoError(t, err)
 		require.Equal(t, []uint32{7}, data.BlockIDs)


### PR DESCRIPTION
## What happened

The SQL UTXO store fills `BlockIDs`, `BlockHeights` and `SubtreeIdxs` from a single query against the `block_ids` table, but it only ran that query when the caller asked for `BlockIDs`. Ask for `BlockHeights` or `SubtreeIdxs` on their own and you got nothing back and no error — indistinguishable from a transaction that has genuinely never been mined.

On the batched path it was worse than simply returning nothing, and thanks to @ordishs and @ctnguyen for spotting this. `sendGetBatch` (`sql.go:1493-1509`) collects the union of the field sets of every request in the batch and hands that union to `BatchDecorate`, which then makes the decision on the union. So before this change, a `BlockHeights`-only `Get` returned the right answer *if and only if* some other request that happened to be batched alongside it had asked for `BlockIDs`. Since `settings.conf` sets `utxostore_getBatcherSize = 4096`, every `Get` goes through that batcher in the default configuration. The old behaviour was therefore load-dependent: right sometimes, wrong sometimes, decided by what else was in flight. A test written against it would have been flaky rather than red, which is a good part of why this survived.

No production caller trips over it today, because both callers that want block heights ask for block IDs alongside them (`services/validator/Validator.go:1132` and `services/subtreevalidation/check_block_subtrees.go:1263`). So this is a trap rather than a live fault. It is an expensive one to leave lying around, though, and I found it by nearly walking into it.

Block heights feed the input script block height handed to the script verifier, which is what BIP68 relative locktime reads. If someone later removed the apparently-unused `BlockIDs` from one of those two field lists — a very reasonable-looking cleanup, since nothing reads the returned value — then `Get` would return no block heights for any parent, the validator would take its "unconfirmed parent" branch for every input, and consensus-relevant behaviour would change on every sqlite-backed store. Including the `sqlitememory` store our own testing guidance tells people to prefer. It would pass sync tests, because the sentinel resolves to the candidate height on block paths, and only misbehave once a node is caught up.

One caller does already ask for `BlockHeights` alone: `services/subtreevalidation/legacy_real_validator_integration_test.go:113`, against a real `sqlitememory` store. It asserts the parent is *not* mined, so it passed before and still passes — but before this change that assertion was vacuous. It would have passed even if the parent had been mined. The fix turns it into a real check.

## The change

Both places that decide whether to run the `block_ids` query now ask whether any of the three fields it serves was requested, rather than only `BlockIDs`. That question is now asked once, by a `needsBlockIDsQuery` helper (`sql.go:1786`) that both call sites use. The condition was originally copied into both places, which is precisely the drift that produced the bug, so stating it once is the point rather than a tidy-up.

The two call sites are `getUnbatched` (`sql.go:1653`) and the `needBlockIDs` decision in `batchDecorateChunk` (`sql.go:3696`) — the latter being the one the validator's parent prefetch actually uses. This follows the convention already in use two lines above the second site, where `needInputs` and `needOutputs` each OR together every field served by the same query. `needBlockIDs` was the odd one out.

`Get`'s doc comment now records that the three placement fields travel together and are index-aligned, since that grouping previously existed only in the shape of one SQL statement. It also drops `parentTxHashes`, which has not been a member of `fields.FieldName` for some time — the field is `TxInpoints`.

No caller behaviour changes: asking for `BlockIDs` still returns all three fields exactly as before, which is what everything in the tree relies on today. Widening the condition can only add truthful data, never turn a mined transaction into a seemingly unmined one.

## Testing

`TestGetBlockPlacementFieldsIndependently` checks each of the two read paths against each of the two fields that were previously broken. It calls `getUnbatched` and `BatchDecorate` directly rather than going through `Get`, because which path a `Get` takes is decided by configuration — with `getBatcherSize = 4096` from `settings.conf` every `Get` is batched, and a developer running with the struct-tag default of 1 would move the coverage onto the other path rather than adding to it. One case does drive the public `Get`, to confirm the routing reaches the query at all, and a final case pins the existing behaviour that `BlockIDs` alone still returns all three.

I verified each part fails on its own, rather than checking that the group fails together:

| What I broke | What failed |
|---|---|
| `BlockHeights` term in the helper | both `BlockHeights` cases, plus the public `Get` case |
| `SubtreeIdxs` term in the helper | both `SubtreeIdxs` cases |
| `getUnbatched` call site narrowed back to `BlockIDs` | both unbatched cases |
| `batchDecorateChunk` call site narrowed back to `BlockIDs` | both batched cases, plus the public `Get` case |

Failures are `[]uint32(nil)` where `[]uint32{0x63}` is expected, which is the silent-empty symptom described above. The public `Get` case failing in the fourth experiment and not the third confirms it travels the batched path in the default configuration.

The first version of this PR did not do this. Its test reached only the batched path, so reverting the `getUnbatched` half left all four subtests passing and half the production change was unguarded — caught in review by @ordishs and @ctnguyen, and the reason the test is now structured around direct calls.

Limits worth stating: the `stores/utxo/sql` package has ten pre-existing `_Postgres` test failures that need a live postgres server, which I did not have running. In my environment they fail rather than skip, with `rootless Docker not found`. I checked the names either side of this change and they are identical, so they are unrelated, but I have not run those particular tests green. I also have not exercised this against a real aerospike cluster.

## Two things a reviewer may notice, neither introduced here

Both surfaced in a review pass over this branch. I am recording them so they are not mistaken for new faults.

Neither `block_ids` loop checks `rows.Err()` once `rows.Next()` returns false — `sql.go:1672` in `getUnbatched`, and `sql.go:3872` in `batchDecorateChunk`. If the driver fails part-way through iteration, the caller gets a short but still index-aligned placement list and a nil error, which reads as a transaction mined in fewer blocks than it really was. This change does not create that gap, but it does make those two loops run more often. It is a house-wide pattern rather than a local slip: only five of the thirteen row loops in `sql.go` check `rows.Err()`. Fixing two of the eight unguarded ones here would be arbitrary, so I have left it for a separate sweep of `getUnbatched` and the three `batchDecorate*` helpers together.

The second is a visibility change rather than a behaviour change. `sendGetBatch` hands every member of a batch the union of the batch's field sets, so a caller that asked only for `Tx` can now come back with the placement fields populated because something else in the same batch asked for one of them — where previously the query would not have run at all. The data is truthful, and every downstream reader I checked treats populated placement as "mined", which is the correct reading. This is the same union behaviour described at the top of this description, seen from the other side.

## A note on the two backends

An earlier version of this description claimed the change makes the SQL and aerospike stores agree. That was too strong, and @ctnguyen was right to push back on it.

What is true is that `stores/utxo/aerospike/get.go:601-608` adds `BlockHeights` and `SubtreeIdxs` whenever `BlockIDs` is requested, and that aerospike serves a standalone `BlockHeights` or `SubtreeIdxs` request correctly, because each is its own bin read independently. So aerospike never had this bug.

What is not true is that the two stores now return identical field sets. Aerospike expands only *from* `BlockIDs`, so asking it for `BlockHeights` alone leaves `BlockIDs` nil, whereas SQL fills all three once the query runs. That is not a defect in either — `Interface.go:412-414` says the fields parameter selects what to *retrieve*, and both stores now honour a request for any placement field, which is the contract. The accurate claim is the narrower one: neither backend silently returns empty for a field you asked for.

