### PR TITLE
refactor(utxo): remove the unused BlockIDs field from utxo.Spend

### DIFF
--- a/docs/references/stores/utxo_reference.md
+++ b/docs/references/stores/utxo_reference.md
@@ -39,9 +39,6 @@ type Spend struct {
     // ConflictingTxID is the transaction ID that conflicts with this UTXO
     ConflictingTxID *chainhash.Hash `json:"conflictingTxId,omitempty"`
 
-    // BlockIDs is the list of blocks the transaction has been mined into
-    BlockIDs []uint32 `json:"blockIDs,omitempty"`
-
     // error is the error that occurred during the spend operation
     Err error `json:"err,omitempty"`
 }

--- a/stores/utxo/Interface.go
+++ b/stores/utxo/Interface.go
@@ -144,9 +144,6 @@ type Spend struct {
 	// ConflictingTxID is the transaction ID that conflicts with this UTXO
 	ConflictingTxID *chainhash.Hash `json:"conflictingTxId,omitempty"`
 
-	// BlockIDs is the list of blocks the transaction has been mined into
-	BlockIDs []uint32 `json:"blockIDs,omitempty"`
-
 	// error is the error that occurred during the spend operation
 	Err error `json:"err,omitempty"`
 }
@@ -180,11 +177,6 @@ func (s *Spend) Clone() *Spend {
 	if s.ConflictingTxID != nil {
 		clone.ConflictingTxID = &chainhash.Hash{}
 		*clone.ConflictingTxID = *s.ConflictingTxID
-	}
-
-	if s.BlockIDs != nil {
-		clone.BlockIDs = make([]uint32, len(s.BlockIDs))
-		copy(clone.BlockIDs, s.BlockIDs)
 	}
 
 	return clone


### PR DESCRIPTION
## What happened

`utxo.Spend` carries a `BlockIDs` field, described in its comment as "the list of blocks the transaction has been mined into". No store has ever populated it and no caller has ever read it. The only code in the tree that touches it is `Clone`, which faithfully allocates a fresh slice and deep-copies a field that is always nil.

This came out of a call-site census of the whole `utxo.Store` interface, looking for places where the store returns or fetches data that nothing consumes.

Worth being explicit about what is *not* changing, because it is the more tempting target and it would be a bad idea. The per-input `[]*Spend` that `SpendAndCreate` returns is discarded at every success-path call site, which makes it look removable. It is not: it carries the per-input `Err` that distinguishes an output that is already spent from one that never existed, and callers depend on that distinction. Weakening it would let a store report generic absence where it currently reports `ErrSpent`, which would silently reject valid blocks on the ordinary block-arrival path. So the return stays exactly as it is; this removes one dead field inside it, so that the response carries only what something actually reads.

## The change

Deletes the field declaration and the corresponding branch in `Clone`. Eight lines, one file.

Nothing serialised changes either. The json tag is `blockIDs,omitempty` and the value is always nil, so the field has never appeared in any encoded `Spend`.

Note that `BlockIDsRemoval.BlockIDs` in the same file is a different type used by `RemoveBlockIDs`, and is untouched. So is `meta.Data.BlockIDs`, which is the one that genuinely carries this information.

## Testing

There is no test that can fail without this change, and I would rather say so than add one that passes either way. A field that nothing references cannot be observed at runtime, so the compiler is the proof: the whole tree builds, and `go vet ./...` compiles the test files too, so any lingering reference in a test would have surfaced as a build failure.

Limits worth stating: `go vet ./...` reports the same four pre-existing issues in `test/utils` either side of this commit, and `stores/utxo/sql` has ten pre-existing `_Postgres` test failures that need a live postgres server I did not have running. Both sets are identical before and after, but I have not run those particular tests green. `stores/utxo` itself passes.