### PR TITLE
fix(blockvalidation): verify a served block is the one requested, bound peer error bodies

### DIFF
--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -376,7 +376,14 @@ func New(
 		// when catchup completes or fails, but a missed Delete on any error/early-return
 		// branch would otherwise leak the entry permanently. Mirrors catchupAlternatives,
 		// the sibling cache for the same in-flight block.
-		processBlockNotify:  ttlcache.New[chainhash.Hash, bool](ttlcache.WithTTL[chainhash.Hash, bool](10 * time.Minute)),
+		processBlockNotify: ttlcache.New[chainhash.Hash, bool](
+			ttlcache.WithTTL[chainhash.Hash, bool](10*time.Minute),
+			// Do not extend the window on reads, for the same reason as
+			// blockCatchupAttempts below: the enqueue gate reads this entry on every
+			// duplicate announcement, so touch-on-hit would let a stream of duplicates
+			// hold the suppression open past the safety-net TTL.
+			ttlcache.WithDisableTouchOnHit[chainhash.Hash, bool](),
+		),
 		catchupAlternatives: ttlcache.New[chainhash.Hash, []processBlockCatchup](ttlcache.WithTTL[chainhash.Hash, []processBlockCatchup](10 * time.Minute)),
 		blockCatchupAttempts: ttlcache.New[chainhash.Hash, int](
 			ttlcache.WithTTL[chainhash.Hash, int](10*time.Minute),

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -512,6 +512,30 @@ func TestServer_processBlockNotifyHasTTL(t *testing.T) {
 	require.True(t, item.ExpiresAt().After(time.Now()), "processBlockNotify entry expiry must be in the future")
 }
 
+// TestServer_processBlockNotifyDoesNotTouchOnHit pins the companion property to the
+// TTL above: the safety-net expiry only helps if reads cannot keep pushing it out.
+// The enqueue gate in addBlockToPriorityQueue reads this entry on every duplicate
+// announcement of an in-flight block, so with touch-on-hit a peer that keeps
+// announcing would hold the suppression open indefinitely and the TTL would never
+// fire. blockCatchupAttempts already disables touch-on-hit for the same reason.
+func TestServer_processBlockNotifyDoesNotTouchOnHit(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.ChainCfgParams = &chaincfg.MainNetParams
+
+	s := New(ulogger.TestLogger{}, tSettings, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	var hash chainhash.Hash
+	originalExpiry := s.processBlockNotify.Set(hash, true, ttlcache.DefaultTTL).ExpiresAt()
+
+	// Any non-zero gap is enough: touch-on-hit recomputes the expiry from "now", so a
+	// read after the clock has moved would push it out measurably.
+	time.Sleep(10 * time.Millisecond)
+
+	item := s.processBlockNotify.Get(hash)
+	require.NotNil(t, item, "entry must still be present")
+	require.Equal(t, originalExpiry, item.ExpiresAt(), "reads must not extend the suppression window")
+}
+
 func TestServer_processBlockFoundChannel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -986,6 +986,17 @@ func (u *Server) fetchSingleBlock(ctx context.Context, hash *chainhash.Hash, pee
 			hash.String(), len(blockBytes))
 	}
 
+	// The peer chooses the response body, so a well-formed block is not necessarily the
+	// block that was asked for. Callers treat the two identities interchangeably (the
+	// in-flight marker is keyed on the requested hash while every later lookup keys on
+	// the served block), so a substitution would leave that marker undeletable and
+	// suppress every subsequent honest announcement of the requested hash. Reject the
+	// substitution here instead, mirroring verifyBlockHeaders on the batch path.
+	if !block.Hash().IsEqual(hash) {
+		return nil, errors.NewProcessingError("[catchup:fetchSingleBlock][%s] peer served block %s for a different hash",
+			hash.String(), block.Hash().String())
+	}
+
 	// Reputation is credited post-validation in validateBlocksOnChannel via reportValidBlockForPeers
 
 	return block, nil

--- a/services/blockvalidation/get_blocks_test.go
+++ b/services/blockvalidation/get_blocks_test.go
@@ -898,6 +898,44 @@ func TestFetchSingleBlock_CurrentBehavior(t *testing.T) {
 	})
 }
 
+// TestFetchSingleBlock_RejectsSubstitutedBlock pins the requested-hash check.
+//
+// The response body is entirely peer-chosen, so parsing to a well-formed block says
+// nothing about it being the block that was asked for. Returning a substituted block
+// is not a cosmetic mismatch: callers key the in-flight catchup marker on the
+// requested hash but every later lookup on the served block, so accepting one leaves
+// that marker undeletable and silently suppresses every subsequent honest
+// announcement of the requested hash.
+func TestFetchSingleBlock_RejectsSubstitutedBlock(t *testing.T) {
+	suite := NewCatchupTestSuite(t)
+	defer suite.Cleanup()
+
+	blocks := testhelpers.CreateTestBlockChain(t, 3)
+	requestedHash := blocks[2].Header.Hash()
+	substitutedHash := blocks[1].Header.Hash()
+	require.False(t, requestedHash.IsEqual(substitutedHash), "test needs two distinct blocks")
+
+	httpmock.ActivateNonDefault(util.HTTPClient())
+	defer httpmock.DeactivateAndReset()
+
+	// The peer answers the request for blocks[2] with a valid, parseable block that is
+	// simply a different one.
+	substitutedBytes, err := blocks[1].Bytes()
+	require.NoError(t, err)
+
+	httpmock.RegisterResponder(
+		"GET",
+		fmt.Sprintf("http://test-peer/block/%s", requestedHash.String()),
+		httpmock.NewBytesResponder(200, substitutedBytes),
+	)
+
+	fetchedBlock, err := suite.Server.fetchSingleBlock(suite.Ctx, requestedHash, "12D3KooWL1NF6fdTJ9cucEuwvuX8V8KtpJZZnUE4umdLBuK15eUZ", "http://test-peer")
+	require.Error(t, err)
+	require.Nil(t, fetchedBlock, "a substituted block must not reach the caller")
+	require.Contains(t, err.Error(), "for a different hash")
+	require.Contains(t, err.Error(), substitutedHash.String(), "error should name what was actually served")
+}
+
 // Phase 2: Tests for optimized batch fetching and ordered delivery
 func TestFetchBlocksConcurrently_OptimizedBehavior(t *testing.T) {
 	t.Run("Ordered_Delivery_With_Batching", func(t *testing.T) {

--- a/util/http.go
+++ b/util/http.go
@@ -440,12 +440,22 @@ func executeHTTPRequest(ctx context.Context, cancelFn context.CancelFunc, rawURL
 	return resp.Body, cancelFn, nil
 }
 
+// maxHTTPErrorBodyBytes bounds how much of a non-2xx response body is read for the
+// error message. The body is peer-supplied and is read on every failure path,
+// including the ones reached from DoHTTPRequestBounded: without a bound, a hostile
+// peer defeats that function's cap simply by answering with an error status and then
+// streaming indefinitely. An error message only needs enough to be diagnosable.
+const maxHTTPErrorBodyBytes = 8 * 1024
+
 // buildHTTPError constructs an appropriate error from a non-OK HTTP response.
 //
 // The error type is chosen to let callers branch with errors.Is:
 //   - 404 → ErrNotFound
 //   - 503 → ErrServiceUnavailable (typically retryable; see DoHTTPRequestBodyReaderWithRetry)
 //   - other → generic ServiceError
+//
+// The body is read up to maxHTTPErrorBodyBytes; anything beyond that is discarded
+// rather than retained in the error string.
 func buildHTTPError(resp *http.Response, rawURL string) error {
 	errFn := errors.NewServiceError
 	switch resp.StatusCode {
@@ -460,7 +470,7 @@ func buildHTTPError(resp *http.Response, rawURL string) error {
 			_ = resp.Body.Close()
 		}()
 
-		b, readErr := io.ReadAll(resp.Body)
+		b, readErr := io.ReadAll(io.LimitReader(resp.Body, maxHTTPErrorBodyBytes))
 		if readErr != nil {
 			return errFn("http request [%s] returned status code [%d]", rawURL, resp.StatusCode, readErr)
 		}

--- a/util/http.go
+++ b/util/http.go
@@ -445,7 +445,11 @@ func executeHTTPRequest(ctx context.Context, cancelFn context.CancelFunc, rawURL
 // including the ones reached from DoHTTPRequestBounded: without a bound, a hostile
 // peer defeats that function's cap simply by answering with an error status and then
 // streaming indefinitely. An error message only needs enough to be diagnosable.
-const maxHTTPErrorBodyBytes = 8 * 1024
+//
+// Kept small because the snippet is %q-escaped below, and escaping expands: a body of
+// control bytes becomes up to four characters each, so this is the bound on bytes read,
+// not on the length of the resulting message.
+const maxHTTPErrorBodyBytes = 2 * 1024
 
 // buildHTTPError constructs an appropriate error from a non-OK HTTP response.
 //
@@ -455,7 +459,10 @@ const maxHTTPErrorBodyBytes = 8 * 1024
 //   - other → generic ServiceError
 //
 // The body is read up to maxHTTPErrorBodyBytes; anything beyond that is discarded
-// rather than retained in the error string.
+// rather than retained in the error string. The snippet is %q-escaped because this
+// message is logged verbatim and forwarded to the peer registry: raw peer bytes would
+// otherwise let a peer embed newlines to forge log lines, or terminal escapes, and
+// would break the single-line log convention.
 func buildHTTPError(resp *http.Response, rawURL string) error {
 	errFn := errors.NewServiceError
 	switch resp.StatusCode {
@@ -476,7 +483,7 @@ func buildHTTPError(resp *http.Response, rawURL string) error {
 		}
 
 		if b != nil {
-			return errFn("http request [%s] returned status code [%d] with body [%s]", rawURL, resp.StatusCode, string(b))
+			return errFn("http request [%s] returned status code [%d] with body %q", rawURL, resp.StatusCode, string(b))
 		}
 	}
 

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -193,6 +193,36 @@ func TestBuildHTTPErrorBodyIsBounded(t *testing.T) {
 	})
 }
 
+// TestBuildHTTPErrorBodyIsEscaped pins the companion property to the size bound: the
+// snippet is peer-controlled, and this error string is logged verbatim and forwarded
+// to the peer registry. Bounding the length without escaping the content still lets a
+// peer embed newlines to forge log lines, or terminal escapes, and breaks the
+// project's single-line log convention.
+func TestBuildHTTPErrorBodyIsEscaped(t *testing.T) {
+	// A forged log line, an ANSI escape, and a NUL, in a body well under the cap so
+	// this test can only fail on escaping, never on truncation.
+	hostileBody := "real\nERROR forged log line\x1b[31m\x00tail"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, err := w.Write([]byte(hostileBody))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	_, err := DoHTTPRequest(context.Background(), server.URL)
+	require.Error(t, err)
+
+	msg := err.Error()
+	require.NotContains(t, msg, "\n", "a peer must not be able to split the message across log lines")
+	require.NotContains(t, msg, "\x1b", "terminal escapes must not survive into operator logs")
+	require.NotContains(t, msg, "\x00", "control bytes must not survive into operator logs")
+
+	// The content is still present, just escaped, so the message stays diagnosable.
+	require.Contains(t, msg, `\n`, "the newline should appear in escaped form")
+	require.Contains(t, msg, "forged log line")
+}
+
 func TestDoHTTPRequestServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -221,8 +251,8 @@ func TestDoHTTPRequestServerErrorNoBody(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "400")
-	// When body is empty, it still shows "with body []"
-	assert.Contains(t, err.Error(), "with body []")
+	// An empty body is %q-escaped to an empty quoted string.
+	assert.Contains(t, err.Error(), `with body ""`)
 }
 
 func TestDoHTTPRequestHTMLResponse(t *testing.T) {
@@ -515,8 +545,8 @@ func TestDoHTTPRequestServerErrorWithNilBody(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
-	// Should not contain "with body" since body is effectively nil
-	assert.Contains(t, err.Error(), "with body []")
+	// An effectively-nil body is %q-escaped to an empty quoted string.
+	assert.Contains(t, err.Error(), `with body ""`)
 }
 
 func TestDoHTTPRequestLargeResponse(t *testing.T) {
@@ -825,8 +855,8 @@ func TestDoHTTPRequest_ErrorResponseNilBody(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "400")
-	// Empty body still creates "with body []" message
-	assert.Contains(t, err.Error(), "with body []")
+	// An empty body is %q-escaped to an empty quoted string.
+	assert.Contains(t, err.Error(), `with body ""`)
 }
 
 func TestDoHTTPRequest_CreateRequestError(t *testing.T) {

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -149,6 +149,50 @@ func TestDoHTTPRequestNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+// TestBuildHTTPErrorBodyIsBounded pins the cap on the non-2xx error body.
+//
+// The body of a failed response is peer-supplied and is read on every failure path,
+// including the ones reached from DoHTTPRequestBounded. An unbounded read there lets
+// a hostile peer defeat that function's cap outright: answer with an error status,
+// then stream indefinitely. The bytes never reach the caller, but they are still
+// allocated, and they are interpolated into the error string.
+func TestBuildHTTPErrorBodyIsBounded(t *testing.T) {
+	// Markers at both ends: the head must survive, the tail must be cut. Asserting on
+	// both is what distinguishes a real truncation from a body that merely happened to
+	// be short.
+	const headMarker = "ERRBODYHEAD"
+	const tailMarker = "ERRBODYTAIL"
+
+	oversizedBody := headMarker + strings.Repeat("A", 4*maxHTTPErrorBodyBytes) + tailMarker
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, err := w.Write([]byte(oversizedBody))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	t.Run("unbounded caller", func(t *testing.T) {
+		_, err := DoHTTPRequest(ctx, server.URL)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), headMarker, "the start of the body should still be diagnosable")
+		require.NotContains(t, err.Error(), tailMarker, "the body must be truncated, not read to completion")
+		require.Less(t, len(err.Error()), len(oversizedBody), "error must not retain the whole body")
+	})
+
+	t.Run("bounded caller keeps its cap on an error status", func(t *testing.T) {
+		// The response never reaches the body-cap logic in DoHTTPRequestBounded, because
+		// a non-2xx status short-circuits into buildHTTPError. Without the bound there,
+		// the maxBytes argument below would be meaningless.
+		_, err := DoHTTPRequestBounded(ctx, server.URL, 1024)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), tailMarker, "an error status must not bypass the allocation cap")
+		require.Less(t, len(err.Error()), len(oversizedBody))
+	})
+}
+
 func TestDoHTTPRequestServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Two independent hardening fixes on the peer-fetch path, both confirmed against `main` before writing any code.

Closes bitcoin-sv/teranode#4744. Addresses the second finding of bitcoin-sv/teranode#4742.

## 1. `fetchSingleBlock` accepted any block the peer chose to return

`fetchSingleBlock` requested `/block/<hash>` from a peer-supplied `baseURL` and returned whatever the body parsed to, with no check that it was the block asked for. The sibling batch path already does exactly this check in `verifyBlockHeaders`, twelve lines below.

The consequence is worse than a mismatched return value, because callers treat the requested and served identities interchangeably:

- `addBlockToPriorityQueue` sets the in-flight marker on the **requested** hash (`Server.go`, `processBlockNotify.Set(*blockFound.hash, ...)`)
- the item handed to `catchupCh` carries the **served** block
- all nine downstream `Delete` calls key on `c.block.Hash()`, the served block

So when served differs from requested, the marker under the requested hash is never deleted. From then on the enqueue gate takes its suppression branch for that hash, which only appends to `catchupAlternatives`, and that list is drained solely from a `catchupCh` item for that hash which now never arrives. The block stops being processable, and the peer chose which hash to do that to.

One check upstream collapses the whole chain: once served is guaranteed to equal requested, the marker leak, the suppression and the stall all become unreachable. That is why this fixes the reported issue without touching the identity handling in the caller, which is better addressed with bitcoin-sv/teranode#4746.

**Also disables touch-on-hit on `processBlockNotify`.** The 10 minute TTL exists as the safety net for exactly the missed-`Delete` case above, and a safety net only holds if reads cannot keep pushing the expiry out. The enqueue gate reads this entry on every duplicate announcement, so with touch-on-hit a stream of duplicates held the suppression open past the TTL indefinitely. `blockCatchupAttempts` already disables it, with a comment describing the same hazard.

This is a trade rather than pure hardening, and the cost side is worth stating: a catchup that legitimately runs longer than 10 minutes now loses its suppression marker, so the next duplicate announcement re-enqueues onto `catchupCh`. The blast radius is bounded by `CatchupChBufferSize`, and the duplicate hits `ErrCatchupInProgress` and returns without consuming an attempt, so the exchange is a bounded re-enqueue on slow catchups against an unbounded suppression window on fast ones.

## 2. The non-2xx error body was read unbounded, defeating `DoHTTPRequestBounded`

`buildHTTPError` read the entire failed-response body with `io.ReadAll` and interpolated it into the error message.

That path is reached from `DoHTTPRequestBounded` too, because a non-2xx status short-circuits into `buildHTTPError` before the caller's cap is ever applied. A hostile peer therefore bypassed the cap completely: answer with an error status, then stream forever. `DoHTTPRequestBounded`'s own doc comment says callers fetching peer-controlled data must bound the allocation, so the error path was quietly exempting itself from the guarantee the function advertises.

Now bounded at 2KB and `%q`-escaped. The escaping is the second half of the same finding: the snippet is logged verbatim and forwarded to the peer registry, so bounding the length while leaving the bytes raw still let a peer embed newlines to forge log lines, or terminal escapes. `%q` also keeps the message single-line, which the project convention requires. The cap is deliberately small because `%q` expands its input, up to four characters per control byte, so the constant bounds bytes read rather than the length of the resulting message.

## Verification

```
go build ./...                                                      -> clean
go vet ./util/ ./services/blockvalidation/                           -> clean
gofmt -l <changed files>                                             -> clean
gci diff --skip-generated -s standard -s default <changed files>     -> clean

go test -count=1 ./util/
  ok  github.com/bsv-blockchain/teranode/util                        7.690s
go test -count=1 -timeout 1800s -tags testtxmetacache ./services/blockvalidation/...
  ok  github.com/bsv-blockchain/teranode/services/blockvalidation    274.861s
  ok  github.com/bsv-blockchain/teranode/services/blockvalidation/catchup  13.338s
```

All five new assertions are mutation-verified, each failing its intended test and only that test:

| Mutation | Result |
|---|---|
| disable the requested-hash check | only `TestFetchSingleBlock_RejectsSubstitutedBlock` fails |
| make the hash check always reject | only the pre-existing `Successful_Fetch` positive controls fail, the new test still passes |
| remove `WithDisableTouchOnHit` | only `TestServer_processBlockNotifyDoesNotTouchOnHit` fails |
| restore the unbounded error-body read | only `TestBuildHTTPErrorBodyIsBounded` fails, both subtests |
| revert `%q` to `%s` | `TestBuildHTTPErrorBodyIsEscaped` fails, plus the three pre-existing empty-body assertions |

The error-body test asserts on markers at **both** ends of an oversized body, so it distinguishes a real truncation from a body that merely happened to be short, and it covers the bounded caller separately to pin that an error status cannot bypass the cap.

`-race` and the full repository suite were not run locally.

## Residual risk and scope

The 2KB truncation and the `%q` escaping apply to every HTTP caller in the repo, not just the peer-fetch paths. Error bodies are diagnostic strings and nothing parses them, so the exposure is a shorter, quoted message when a server returns more than 2KB of error text.

Deliberately **not** included, since each needs a number agreed rather than a mechanical fix:

- **First finding of bitcoin-sv/teranode#4742**, the unbounded `io.ReadAll` on the two block downloads (`/block/` and `/blocks/`). Worth noting that the issue's suggested fix, converting them to `DoHTTPRequestBounded`, is not the right shape: BSV has no maximum block size, so there is no byte cap to choose. It also is not needed. A `model.Block` on the wire is a header, three varints, N subtree hashes and a coinbase, not the transactions, so the response size is unrelated to the size of the block, and `readBlockFromReader` already caps the one attacker-controlled dimension (it bounds the speculative `Subtrees` pre-allocation at 1024 and relies on `append`). The actual defect is that both fetchers buffer the whole body before parsing something that is already parseable from a stream: `fetchBlocksBatch` does `io.ReadAll` and then wraps the result in `bytes.NewReader` for `model.NewBlockFromReader`. Streaming the response body into the parser bounds the allocation structurally with no constant to agree on. Two details for whoever picks it up: `RecordBytesDownloaded` currently uses `len(blockBytes)` and would need a counting reader, and the batch loop reads until EOF so it needs to stop at the `n` blocks it asked for.
- **bitcoin-sv/teranode#4743**, `context.WithoutCancel` stripping the deadline from the subtree_data fetch. Confirmed: `WithoutCancel` yields a nil `Done()` channel, so the retry loop's only abort guard can never fire and the loop runs to all 6 attempts, each installing a fresh 10 minute streaming timeout. Note that fix 2 above substantially defuses it, since the uncapped error body was what let an attempt consume its full 10 minutes.
- **bitcoin-sv/teranode#4746**, the unbounded `catchupAlternatives` list. Fix 1 does not close it: duplicate announcements of a genuinely valid hash from distinct peers still accumulate a full `*model.Block` each, drained serially on the single goroutine that services `catchupCh`.

One thing found while verifying that none of the issues mention: `services/blockvalidation/catchup/helpers.go` fetches headers with the unbounded `DoHTTPRequest` as well, a third site alongside the two block downloads.
