### PR TITLE
fix(blockassembly): floor the mining-candidate timestamp at median-time-past+1 so block assembly never hands miners a block its own rule rejects

### DIFF
--- a/docs/references/prometheusMetrics.md
+++ b/docs/references/prometheusMetrics.md
@@ -57,6 +57,7 @@ All metrics are CounterVec type with labels: `function` (handler function name),
 | `teranode_blockassembly_submit_mining_solution`               | Histogram | Histogram of SubmitMiningSolution in the blockassembly service                   |
 | `teranode_blockassembly_update_subtrees_dah`                  | Histogram | Histogram of updating subtrees DAH in the blockassembly service                  |
 | `teranode_blockassembly_block_assembler_get_mining_candidate` | Counter   | Number of calls to GetMiningCandidate in the block assembler                     |
+| `teranode_blockassembly_block_assembler_candidate_time_clock_skew` | Counter | Mining-candidate polls refused because the parent's median-time-past floor is above the two-hour future bound, so no valid block timestamp exists; a non-zero rate means the local clock is far behind the network and block production has stopped |
 | `teranode_blockassembly_subtree_stored`                       | Histogram | Histogram of subtree stored duration in block assembler                          |
 | `teranode_blockassembly_transactions`                         | Gauge     | Number of transactions currently in the block assembler subtree processor        |
 | `teranode_blockassembly_queued_transactions`                  | Gauge     | Number of transactions currently queued in the block assembler subtree processor |

--- a/docs/topics/services/blockAssembly.md
+++ b/docs/topics/services/blockAssembly.md
@@ -518,6 +518,15 @@ The Block Assembly service implements robust error handling across multiple laye
 - **Transaction Recovery**: Non-conflicting transactions are automatically re-added to new subtrees
 - **Deep Reorg Protection**: Reorganizations affecting more than the coinbase maturity threshold (typically 100 blocks) trigger a full service reset for safety
 
+#### Clock Skew Stopping Block Production
+
+Every block's timestamp must be strictly greater than the median timestamp of the previous 11 blocks, and no more than two hours ahead of local time. Block assembly floors each mining candidate at median-time-past+1 so it never hands miners work the network would refuse. When the local clock falls far enough behind the parent chain, that floor rises above the two-hour ceiling and **no** timestamp satisfies both rules.
+
+- **Symptom**: `GetMiningCandidate` starts failing for every miner, and block production stops. The counter `teranode_blockassembly_block_assembler_candidate_time_clock_skew` becomes non-zero and keeps climbing; a single log line names the parent block and the size of the gap.
+- **Cause**: either this node's clock is behind the network, or the parent chain carries headers stamped into the future by an upstream miner. The node cannot tell which from its own view — the log line names both.
+- **Remedy**: check NTP on the node first, since a local clock is the common case and the one you control. If the clock is correct, inspect the tip's recent header timestamps for a future-stamped run from upstream; the condition clears by itself once wall-clock time passes the floor.
+- **Why it fails rather than degrades**: emitting an unfloored candidate would make every solution fail the local submit path, which treats an invalid block as a subtree-processor fault and resets block assembly. Refusing the poll is the smaller failure. On chains where the median rule is advisory (regtest), the wall-clock candidate is still valid and is served instead.
+
 #### UTXO Store Unavailability
 
 - **Connection Monitoring**: The service monitors UTXO store connectivity and handles temporary unavailability
@@ -539,6 +548,7 @@ The service integrates comprehensive Prometheus metrics for operational monitori
 
 - `teranode_blockassembly_get_mining_candidate`: Mining candidate requests
 - `teranode_blockassembly_submit_mining_solution`: Mining solution submissions
+- `teranode_blockassembly_block_assembler_candidate_time_clock_skew`: Mining candidates refused because no timestamp satisfies both consensus rules. Alert on any non-zero rate — block production has stopped (see [Clock Skew Stopping Block Production](#clock-skew-stopping-block-production))
 - Duration histograms for critical operations with microsecond precision
 
 #### State Monitoring

--- a/model/Block.go
+++ b/model/Block.go
@@ -46,6 +46,14 @@ var bufioReaderPool = sync.Pool{
 
 const GenesisBlockID = 0
 
+// MaxFutureBlockTime is how far ahead of local time a block header's timestamp
+// may be stamped. CheckHeaderContextual rejects anything beyond it, so it is the
+// ceiling every block producer has to stay under; block assembly reads it to
+// decide whether a candidate can satisfy both timestamp rules at once. Producer
+// and validator must agree on the value or the producer emits work the validator
+// refuses, so it lives here, next to the check that enforces it.
+const MaxFutureBlockTime = 2 * time.Hour
+
 // heightAtOrAfterActivation reports whether block height h is at or after an activation height
 // taken from chaincfg. chaincfg activation heights are int32 and non-negative for BIP34/65/66; a
 // negative value (should not occur) is treated as "never active" so it can never wrongly reject.
@@ -517,7 +525,7 @@ type SubtreeStore interface {
 // median-time-past rule is skipped (same as Valid()). Returns nil when the header passes.
 func (b *Block) CheckHeaderContextual(currentChain []*BlockHeader, settings *settings.Settings, logger ulogger.Logger) error {
 	// 2. Check that the block timestamp is not more than two hours in the future.
-	twoHoursToTheFutureTimestampUint32, err := safeconversion.Int64ToUint32(time.Now().Add(2 * time.Hour).Unix())
+	twoHoursToTheFutureTimestampUint32, err := safeconversion.Int64ToUint32(time.Now().Add(MaxFutureBlockTime).Unix())
 	if err != nil {
 		return errors.NewProcessingError("[BLOCK][%s] failed to convert two hours to the future timestamp to uint32", b.String(), err)
 	}

--- a/model/Block.go
+++ b/model/Block.go
@@ -46,14 +46,6 @@ var bufioReaderPool = sync.Pool{
 
 const GenesisBlockID = 0
 
-// MaxFutureBlockTime is how far ahead of local time a block header's timestamp
-// may be stamped. CheckHeaderContextual rejects anything beyond it, so it is the
-// ceiling every block producer has to stay under; block assembly reads it to
-// decide whether a candidate can satisfy both timestamp rules at once. Producer
-// and validator must agree on the value or the producer emits work the validator
-// refuses, so it lives here, next to the check that enforces it.
-const MaxFutureBlockTime = 2 * time.Hour
-
 // heightAtOrAfterActivation reports whether block height h is at or after an activation height
 // taken from chaincfg. chaincfg activation heights are int32 and non-negative for BIP34/65/66; a
 // negative value (should not occur) is treated as "never active" so it can never wrongly reject.
@@ -525,7 +517,7 @@ type SubtreeStore interface {
 // median-time-past rule is skipped (same as Valid()). Returns nil when the header passes.
 func (b *Block) CheckHeaderContextual(currentChain []*BlockHeader, settings *settings.Settings, logger ulogger.Logger) error {
 	// 2. Check that the block timestamp is not more than two hours in the future.
-	twoHoursToTheFutureTimestampUint32, err := safeconversion.Int64ToUint32(time.Now().Add(MaxFutureBlockTime).Unix())
+	twoHoursToTheFutureTimestampUint32, err := safeconversion.Int64ToUint32(time.Now().Add(2 * time.Hour).Unix())
 	if err != nil {
 		return errors.NewProcessingError("[BLOCK][%s] failed to convert two hours to the future timestamp to uint32", b.String(), err)
 	}

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -1429,7 +1429,7 @@ func (b *BlockAssembler) GetMiningCandidate(ctx context.Context) (*model.MiningC
 			return nil, nil, errors.NewProcessingError("failed to get best block header during block processing", err)
 		}
 
-		return b.generateEmptyBlockCandidate(bestBlockHeader, bestBlockMeta.Height)
+		return b.generateEmptyBlockCandidate(ctx, bestBlockHeader, bestBlockMeta.Height)
 	}
 
 	// Get current block state first (single atomic read for consistency)
@@ -1456,7 +1456,7 @@ func (b *BlockAssembler) GetMiningCandidate(ctx context.Context) (*model.MiningC
 			data = incompleteData
 			subtrees = incompleteData.Subtrees
 		} else {
-			return b.generateEmptyBlockCandidate(baBestBlockHeader, baBestBlockHeight)
+			return b.generateEmptyBlockCandidate(ctx, baBestBlockHeader, baBestBlockHeight)
 		}
 	}
 
@@ -1513,8 +1513,15 @@ func (b *BlockAssembler) GetMiningCandidate(ctx context.Context) (*model.MiningC
 
 	subtreeCountUint32, _ := safeconversion.IntToUint32(len(subtrees))
 
-	// Compute time-sensitive fields
-	timeNow := time.Now().Unix()
+	// Compute time-sensitive fields. The candidate time is the wall clock
+	// floored at the parent chain's median-time-past+1, so the block we hand
+	// to miners cannot violate the median-time rule that block validation
+	// enforces (see candidateTime).
+	timeNow, err := b.candidateTime(ctx, data.PreviousHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	timeNowUint32, err := safeconversion.Int64ToUint32(timeNow)
 	if err != nil {
 		return nil, nil, errors.NewProcessingError("error converting time now", err)
@@ -1588,9 +1595,14 @@ func (b *BlockAssembler) filterSubtreesByMaxSize(subtrees []*subtree.Subtree, ma
 	return includedSubtrees, nil
 }
 
-func (b *BlockAssembler) generateEmptyBlockCandidate(bestBlockHeader *model.BlockHeader, bestBlockHeight uint32) (*model.MiningCandidate, []*subtree.Subtree, error) {
+func (b *BlockAssembler) generateEmptyBlockCandidate(ctx context.Context, bestBlockHeader *model.BlockHeader, bestBlockHeight uint32) (*model.MiningCandidate, []*subtree.Subtree, error) {
 	nextBlockHeight := bestBlockHeight + 1
-	timeNow := time.Now().Unix()
+
+	// Same median-time-past floor as the main candidate path (see candidateTime).
+	timeNow, err := b.candidateTime(ctx, bestBlockHeader)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	b.logger.Infof("[generateEmptyBlockCandidate] Generating empty block template for height %d (prev: %s)", nextBlockHeight, bestBlockHeader.Hash())
 

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -122,10 +122,12 @@ type BlockAssembler struct {
 	// bestBlock atomically stores the current best block header and height together
 	bestBlock atomic.Pointer[BestBlockInfo]
 
-	// mtpFloorWarnedTip remembers the last parent block for which candidateTime
-	// warned that the median-time-past floor engaged, so the warning fires once
-	// per tip instead of once per miner poll (see candidateTime)
-	mtpFloorWarnedTip atomic.Pointer[chainhash.Hash]
+	// mtpFloorMemo caches the median-time-past floor per parent block so a miner
+	// poll costs no blockchain round-trip once the tip's floor is known. Two
+	// slots because the busy and main candidate paths key on different parents
+	// (see mtpFloor); mtpFloorMemoNext round-robins writes between them
+	mtpFloorMemo     [2]atomic.Pointer[mtpFloorEntry]
+	mtpFloorMemoNext atomic.Uint64
 
 	// stateChangeCh notifies listeners of state changes
 	// Protected by stateChangeMu to prevent race conditions

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bsv-blockchain/teranode/util/retry"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"github.com/ordishs/gocore"
+	"golang.org/x/sync/singleflight"
 )
 
 // State represents the current operational state of the BlockAssembler.
@@ -134,6 +135,11 @@ type BlockAssembler struct {
 	// logFloorLookupFailure). Separate from mtpFloorMemo because those paths
 	// produce no entry to hang a flag on
 	mtpFloorFailureLoggedTip atomic.Pointer[chainhash.Hash]
+
+	// mtpFloorFlight collapses concurrent memo misses on the same parent into one
+	// lookup, so a cold tip polled by several miners at once fetches, warns and
+	// occupies a slot exactly once (see mtpFloor)
+	mtpFloorFlight singleflight.Group
 
 	// stateChangeCh notifies listeners of state changes
 	// Protected by stateChangeMu to prevent race conditions

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -122,6 +122,11 @@ type BlockAssembler struct {
 	// bestBlock atomically stores the current best block header and height together
 	bestBlock atomic.Pointer[BestBlockInfo]
 
+	// mtpFloorWarnedTip remembers the last parent block for which candidateTime
+	// warned that the median-time-past floor engaged, so the warning fires once
+	// per tip instead of once per miner poll (see candidateTime)
+	mtpFloorWarnedTip atomic.Pointer[chainhash.Hash]
+
 	// stateChangeCh notifies listeners of state changes
 	// Protected by stateChangeMu to prevent race conditions
 	stateChangeMu sync.RWMutex

--- a/services/blockassembly/BlockAssembler.go
+++ b/services/blockassembly/BlockAssembler.go
@@ -129,6 +129,12 @@ type BlockAssembler struct {
 	mtpFloorMemo     [2]atomic.Pointer[mtpFloorEntry]
 	mtpFloorMemoNext atomic.Uint64
 
+	// mtpFloorFailureLoggedTip latches the floor-lookup failure log to one parent,
+	// so a condition that persists across polls is reported once (see
+	// logFloorLookupFailure). Separate from mtpFloorMemo because those paths
+	// produce no entry to hang a flag on
+	mtpFloorFailureLoggedTip atomic.Pointer[chainhash.Hash]
+
 	// stateChangeCh notifies listeners of state changes
 	// Protected by stateChangeMu to prevent race conditions
 	stateChangeMu sync.RWMutex

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1507,6 +1507,28 @@ func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSub
 		return nil, errors.NewProcessingError("[BlockAssembly][%s] candidate is stale: chain has already advanced past its parent", jobID)
 	}
 
+	nTime := job.MiningCandidate.Time
+	if req.Time != nil {
+		nTime = *req.Time
+	}
+
+	// A miner may replace the candidate's timestamp, and the block.Valid call
+	// below passes no currentChain, so it skips the median-time rule entirely.
+	// Without this guard an ntime-rolling miner — or a pool restamping from its
+	// own lagging clock — puts us straight back to a locally accepted,
+	// peer-rejected block, the exact defect the candidate-time floor exists to
+	// prevent. The comparison is against the consensus floor rather than the
+	// candidate's own Time, which is usually just the wall clock: rolling ntime
+	// back a few seconds within a job is normal pool behaviour and must stay
+	// legal. Rejecting here rather than letting it reach block.Valid matters
+	// because that failure path treats an invalid block as a subtree-processor
+	// fault and resets block assembly; a bad miner timestamp is not that. The
+	// floor is the memoized value the candidate was built from, so this costs no
+	// round-trip, and when it is unknown there is nothing to enforce.
+	if minTime, ok := ba.blockAssembler.MinCandidateTime(hashPrevBlock); ok && int64(nTime) < minTime {
+		return nil, errors.NewProcessingError("[BlockAssembly][%s] submitted nTime %d is below the parent chain's median-time-past floor %d, so every peer would reject the block", jobID, nTime, minTime)
+	}
+
 	var coinbaseTx *bt.Tx
 
 	if req.CoinbaseTx != nil {
@@ -1610,11 +1632,6 @@ func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSub
 	version := job.MiningCandidate.Version
 	if req.Version != nil {
 		version = *req.Version
-	}
-
-	nTime := job.MiningCandidate.Time
-	if req.Time != nil {
-		nTime = *req.Time
 	}
 
 	block := &model.Block{

--- a/services/blockassembly/Server.go
+++ b/services/blockassembly/Server.go
@@ -1526,6 +1526,19 @@ func (ba *BlockAssembly) submitMiningSolution(ctx context.Context, req *BlockSub
 	// floor is the memoized value the candidate was built from, so this costs no
 	// round-trip, and when it is unknown there is nothing to enforce.
 	if minTime, ok := ba.blockAssembler.MinCandidateTime(hashPrevBlock); ok && int64(nTime) < minTime {
+		// Distinguish the two ways to arrive here, because they are different
+		// operator problems. Usually the miner replaced the timestamp and the
+		// candidate itself was fine. But when the offending nTime is the
+		// candidate's own, this node served work below the floor: the lookup was
+		// failing when the job was built, so it memoized nothing and degraded to
+		// the wall clock, and a later poll on the same parent then succeeded and
+		// memoized the floor this now enforces. Rejecting is still right — that
+		// block is peer-invalid — but "we served bad work" needs to be visible
+		// as ours rather than read as a misbehaving miner.
+		if nTime == job.MiningCandidate.Time {
+			ba.logger.Warnf("[BlockAssembly][%s] rejecting a solution against a candidate this node served below the parent chain's median-time-past floor: candidate nTime %d, floor %d; the floor lookup was failing when the candidate was built and has since recovered", jobID, nTime, minTime)
+		}
+
 		return nil, errors.NewProcessingError("[BlockAssembly][%s] submitted nTime %d is below the parent chain's median-time-past floor %d, so every peer would reject the block", jobID, nTime, minTime)
 	}
 

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -1,0 +1,67 @@
+package blockassembly
+
+import (
+	"context"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+)
+
+// candidateTime returns the timestamp to stamp on a mining candidate built on
+// parentHeader: the local wall clock, floored at median-time-past+1 of the
+// parent chain. Block validation (model.Block CheckHeaderContextual) rejects
+// any block whose timestamp is not strictly greater than the median timestamp
+// of the previous 11 blocks, so without the floor a lagging local clock — or a
+// run of forward-stamped blocks dragging the median above wall-clock time —
+// makes the assembler hand miners a candidate the node itself rejects once
+// mined. SV Node applies the same floor in UpdateTime (max of the parent's
+// median-time-past+1 and adjusted time).
+//
+// Headers are fetched by parent hash rather than height so a candidate built
+// on a side chain gets the median of its own chain. The returned run is
+// verified to be anchored at the parent and correctly linked, mirroring the
+// candidate-parent MTP helpers in subtreevalidation and legacy/netsync; a
+// mismatch means the chain reorganised between fetch and use, and the error
+// simply fails this poll — the miner's next GetMiningCandidate retries.
+func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.BlockHeader) (int64, error) {
+	parentHash := parentHeader.Hash()
+
+	headers, _, err := b.blockchainClient.GetBlockHeaders(ctx, parentHash, blockchain.MedianTimeBlocks)
+	if err != nil {
+		return 0, errors.NewProcessingError("[candidateTime] failed to fetch parent-chain headers for %s", parentHash.String(), err)
+	}
+
+	if len(headers) == 0 || headers[0] == nil || !headers[0].Hash().IsEqual(parentHash) {
+		return 0, errors.NewProcessingError("[candidateTime] returned chain head does not match requested parent %s (possible reorg between fetch and use)", parentHash.String())
+	}
+
+	timestamps := make([]time.Time, 0, len(headers))
+
+	for i, header := range headers {
+		if header == nil {
+			return 0, errors.NewProcessingError("[candidateTime] nil header at depth %d below parent %s", i, parentHash.String())
+		}
+
+		if i > 0 && !headers[i-1].HashPrevBlock.IsEqual(header.Hash()) {
+			return 0, errors.NewProcessingError("[candidateTime] parent-chain link broken at depth %d below parent %s (possible reorg between fetch and use)", i, parentHash.String())
+		}
+
+		timestamps = append(timestamps, time.Unix(int64(header.Timestamp), 0))
+	}
+
+	medianTimestamp, err := model.CalculateMedianTimestamp(timestamps)
+	if err != nil {
+		return 0, errors.NewProcessingError("[candidateTime] failed to calculate median timestamp for parent %s", parentHash.String(), err)
+	}
+
+	timeNow := time.Now().Unix()
+
+	if minTime := medianTimestamp.Unix() + 1; timeNow < minTime {
+		b.logger.Warnf("[candidateTime] local clock %d is at or below the parent chain's median-time-past %d, flooring candidate time to %d", timeNow, medianTimestamp.Unix(), minTime)
+		timeNow = minTime
+	}
+
+	return timeNow, nil
+}

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -35,8 +35,11 @@ type mtpFloorEntry struct {
 // (model.Block CheckHeaderContextual), so without the floor a lagging local
 // clock — or a run of forward-stamped blocks dragging the median above
 // wall-clock time — makes the assembler hand miners a candidate that the
-// network refuses once mined. SV Node applies the same floor in UpdateTime
-// (max of the parent's median-time-past+1 and adjusted time).
+// network refuses once mined. SV Node applies the same floor in UpdateTime, as
+// max(median-time-past+1, GetAdjustedTime()); note it floors against
+// network-adjusted time where this floors against the raw local clock, so a
+// skewed node here has nothing pulling it back towards its peers. Consulting
+// the MedianTimeSource in services/legacy/blockchain would close that gap.
 //
 // The two consensus bounds on a block timestamp are a pair, and this function
 // honours both. The median rule is the floor; the two-hours-in-the-future rule

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -174,7 +174,20 @@ func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHeader *model.Block
 	// its own round-robin slot, so one parent occupies both and evicts the other
 	// candidate path's entry. Sharing one flight per parent makes the entry a
 	// single object again, which is what the per-entry log latches assume.
-	shared, _, _ := b.mtpFloorFlight.Do(parentHash.String(), func() (interface{}, error) {
+	//
+	// DoChan rather than Do so that sharing the flight does not also share the
+	// leader's deadline: Do blocks every follower until the leader's fetch
+	// returns, however long after their own contexts died. Each caller therefore
+	// waits on its own context and degrades to the wall clock when it expires,
+	// which is the same degradation a failed lookup already takes. A caller that
+	// gives up memoizes nothing, so the next poll re-flights.
+	//
+	// The flight itself still runs on whichever context entered it first, so a
+	// leader that is cancelled mid-fetch returns nil to the followers waiting on
+	// it and costs them a floor for that one poll. Detaching the flight from its
+	// leader would fix that too, but it would leave the fetch with no deadline at
+	// all and nothing to cancel it; one self-healing poll is the cheaper problem.
+	ch := b.mtpFloorFlight.DoChan(parentHash.String(), func() (interface{}, error) {
 		// Re-check inside the flight: a previous flight for this parent may have
 		// completed between the read above and getting here.
 		if entry := b.memoizedMtpFloor(parentHash); entry != nil {
@@ -184,9 +197,17 @@ func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHeader *model.Block
 		return b.computeMtpFloor(ctx, parentHeader, parentHash), nil
 	})
 
-	entry, _ := shared.(*mtpFloorEntry)
+	select {
+	case res := <-ch:
+		entry, _ := res.Val.(*mtpFloorEntry)
 
-	return entry
+		return entry
+	case <-ctx.Done():
+		// No log line: the caller is abandoning this poll, so the candidate this
+		// feeds is already on its way to being discarded. computeMtpFloor logs
+		// the causes that matter.
+		return nil
+	}
 }
 
 // memoizedMtpFloor returns the memo entry for parentHash, or nil on a miss.

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -2,6 +2,7 @@ package blockassembly
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -10,6 +11,23 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 )
 
+// maxFutureBlockTime mirrors the two-hours-in-the-future ceiling that
+// model.Block CheckHeaderContextual applies to every header unconditionally —
+// unlike the median-time rule, that check needs no currentChain, so the local
+// submit path does enforce it (model/Block.go).
+const maxFutureBlockTime = 2 * time.Hour
+
+// mtpFloorEntry is the median-time-past floor for one parent block. The median
+// of the 11 headers ending at a given hash can never change — headers are
+// immutable once stored — so it is computed once per parent and reused for
+// every miner poll on that tip. warned latches the "floor engaged" log line so
+// it fires once per parent rather than once per poll.
+type mtpFloorEntry struct {
+	parent  chainhash.Hash
+	minTime int64
+	warned  atomic.Bool
+}
+
 // candidateTime returns the timestamp to stamp on a mining candidate built on
 // parentHeader: the local wall clock, floored at median-time-past+1 of the
 // parent chain. Block validation rejects any block whose timestamp is not
@@ -17,34 +35,120 @@ import (
 // (model.Block CheckHeaderContextual), so without the floor a lagging local
 // clock — or a run of forward-stamped blocks dragging the median above
 // wall-clock time — makes the assembler hand miners a candidate that the
-// network refuses once mined. The submit path itself does not catch it:
-// SubmitMiningSolution calls block.Valid with no currentChain, which skips
-// the median-time rule, so the bad block is accepted locally and then
-// rejected by every peer that validates it. SV Node applies the same floor
-// in UpdateTime (max of the parent's median-time-past+1 and adjusted time).
+// network refuses once mined. SV Node applies the same floor in UpdateTime
+// (max of the parent's median-time-past+1 and adjusted time).
 //
-// Headers are fetched by parent hash rather than height so a candidate built
-// on a side chain gets the median of its own chain. The batched fetch is
-// verified to be anchored at the parent and correctly linked; on any mismatch
-// (the store's batched lookup ranges over main-chain flags and can race a
-// reorg) candidateTime falls back to a hash-keyed walk of the parent chain,
-// whose per-hash reads are immutable and immune to that race — the same
-// two-step strategy as the candidate-parent MTP helpers in subtreevalidation
-// and legacy/netsync. Only when both attempts fail does the candidate request
-// error, failing that one miner poll.
+// The two consensus bounds on a block timestamp are a pair, and this function
+// honours both. The median rule is the floor; the two-hours-in-the-future rule
+// is the ceiling. A local clock lagging far enough behind the network puts
+// median-time-past+1 above now+2h, leaving no timestamp that satisfies both.
+// Flooring anyway would hand miners a candidate whose every solution fails
+// block.Valid on our own submit path, and that failure is treated as a
+// subtree-processor fault: it deletes the job and calls Reset, so each solution
+// would trigger a full block-assembly reset. Rather than emit unmineable work,
+// candidateTime fails the poll and names the clock skew. Chains with
+// GenerateSupported downgrade the median rule to a warning, so there the
+// wall-clock candidate is still valid and is served instead of failing.
+//
+// Availability is preserved everywhere else. The floor only changes the outcome
+// when the wall clock is at or below median-time-past, which is rare, whereas
+// the lookup it needs is a blockchain round-trip that can fail at any time. A
+// lookup failure therefore degrades to the bare wall clock with an error log —
+// exactly the pre-PR behaviour — rather than failing the poll. That matters
+// most for generateEmptyBlockCandidate, whose whole purpose is to keep handing
+// miners work while a block is being processed.
+//
+// Headers are fetched by parent hash rather than height so a candidate built on
+// a side chain gets the median of its own chain.
 func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.BlockHeader) (int64, error) {
 	if parentHeader == nil {
 		return 0, errors.NewProcessingError("[candidateTime] nil parent header")
 	}
 
 	parentHash := parentHeader.Hash()
+	timeNow := time.Now().Unix()
+
+	entry := b.mtpFloor(ctx, parentHash)
+	if entry == nil {
+		// mtpFloor has already logged the cause. Serve the wall clock rather
+		// than stopping mining on a blockchain hiccup.
+		return timeNow, nil
+	}
+
+	// Check the ceiling before applying the floor: when the two cross there is
+	// no valid timestamp at all and flooring makes things worse, not better.
+	if maxTime := timeNow + int64(maxFutureBlockTime/time.Second); entry.minTime > maxTime {
+		if b.generateSupported() {
+			b.logger.Warnf("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d; serving the wall clock %d because this chain treats the median-time rule as advisory", parentHash.String(), entry.minTime, maxTime, timeNow)
+
+			return timeNow, nil
+		}
+
+		return 0, errors.NewProcessingError("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d, so no timestamp satisfies both consensus rules; the local clock is skewed by at least %d seconds", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
+	}
+
+	if timeNow < entry.minTime {
+		if entry.warned.CompareAndSwap(false, true) {
+			b.logger.Warnf("[candidateTime] local clock %d is at or below the parent chain's median-time-past; flooring candidate time to %d for blocks on parent %s", timeNow, entry.minTime, parentHash.String())
+		}
+
+		timeNow = entry.minTime
+	}
+
+	return timeNow, nil
+}
+
+// MinCandidateTime returns the median-time-past floor candidateTime computed for
+// parentHash, and whether it is known. It is a pure memo read: the entry is warm
+// whenever a candidate was just built on that parent, so the submit path can
+// reject a miner-supplied nTime below the consensus floor without a round-trip.
+// A false second return means no floor was established for that parent (the
+// candidate was served on the degraded wall-clock path, or the tip has since
+// moved twice), in which case the submit path has nothing to enforce and behaves
+// as it did before the floor existed.
+func (b *BlockAssembler) MinCandidateTime(parentHash *chainhash.Hash) (int64, bool) {
+	if parentHash == nil {
+		return 0, false
+	}
+
+	for i := range b.mtpFloorMemo {
+		if entry := b.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(parentHash) {
+			return entry.minTime, true
+		}
+	}
+
+	return 0, false
+}
+
+// mtpFloor returns the memoized median-time-past floor for parentHash,
+// computing it on a miss. It returns nil — having logged the cause — when the
+// floor cannot be established, leaving the caller to decide how to degrade.
+//
+// The memo has two slots because the two candidate paths key on different
+// parents: GetMiningCandidate's busy branch uses the blockchain service's tip
+// while the main path uses the subtree processor's precomputed parent. A single
+// slot would thrash whenever those two alternate, refetching on every poll and
+// re-firing the floor warning each time.
+func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHash *chainhash.Hash) *mtpFloorEntry {
+	for i := range b.mtpFloorMemo {
+		if entry := b.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(parentHash) {
+			return entry
+		}
+	}
 
 	run, batchedErr := b.batchedParentChain(ctx, parentHash)
 	if batchedErr != nil {
 		walked, walkErr := b.walkParentChain(ctx, parentHash, blockchain.MedianTimeBlocks)
 		if walkErr != nil {
-			return 0, errors.NewProcessingError("[candidateTime] batched header fetch failed (%v); hash-keyed parent-chain walk also failed for %s", batchedErr, parentHash.String(), walkErr)
+			b.logger.Errorf("[candidateTime] cannot establish the median-time-past floor for parent %s: batched header fetch failed (%v) and the hash-keyed parent-chain walk also failed (%v); serving an unfloored candidate time", parentHash.String(), batchedErr, walkErr)
+
+			return nil
 		}
+
+		// Name the cause of the slower path rather than discarding the batched
+		// error silently: the walk costs one round-trip per header, so an
+		// operator seeing the extra latency needs to know why it engaged.
+		b.logger.Warnf("[candidateTime] batched header fetch for parent %s was unusable (%v); fell back to the hash-keyed parent-chain walk", parentHash.String(), batchedErr)
 
 		run = walked
 	}
@@ -54,33 +158,37 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 		timestamps[i] = time.Unix(int64(header.Timestamp), 0)
 	}
 
+	// Defensive only: CalculateMedianTimestamp errors on an empty slice, and both
+	// producers above guarantee at least one header.
 	medianTimestamp, err := model.CalculateMedianTimestamp(timestamps)
 	if err != nil {
-		return 0, errors.NewProcessingError("[candidateTime] failed to calculate median timestamp for parent %s", parentHash.String(), err)
+		b.logger.Errorf("[candidateTime] failed to calculate the median timestamp for parent %s over %d headers: %v; serving an unfloored candidate time", parentHash.String(), len(run), err)
+
+		return nil
 	}
 
-	timeNow := time.Now().Unix()
+	entry := &mtpFloorEntry{parent: *parentHash, minTime: medianTimestamp.Unix() + 1}
 
-	if minTime := medianTimestamp.Unix() + 1; timeNow < minTime {
-		// Warn once per tip rather than once per call: miners poll several
-		// times a second, and while a clock-lag condition lasts every poll
-		// floors, which would flood the log with identical lines.
-		if prev := b.mtpFloorWarnedTip.Swap(parentHash); prev == nil || !prev.IsEqual(parentHash) {
-			b.logger.Warnf("[candidateTime] local clock %d is at or below the parent chain's median-time-past %d, flooring candidate time to %d for blocks on parent %s", timeNow, medianTimestamp.Unix(), minTime, parentHash.String())
-		}
+	slot := b.mtpFloorMemoNext.Add(1) % uint64(len(b.mtpFloorMemo))
+	b.mtpFloorMemo[slot].Store(entry)
 
-		timeNow = minTime
-	}
-
-	return timeNow, nil
+	return entry
 }
 
-// batchedParentChain fetches up to MedianTimeBlocks headers ending at
-// parentHash in one batched call and verifies the run is anchored at the
-// parent and correctly linked. A mismatch means the batched lookup raced a
-// chain reorganisation (its fast path is a height-range scan over main-chain
-// flags, not an atomic parent-chain walk); the caller falls back to
-// walkParentChain when that happens.
+// generateSupported reports whether this chain lets blocks be generated quickly,
+// in which case model.Block CheckHeaderContextual downgrades a median-time
+// violation from an error to a warning. Guarded because a nil Settings deref
+// past the struct's guard page is an unrecoverable fault.
+func (b *BlockAssembler) generateSupported() bool {
+	return b.settings != nil && b.settings.ChainCfgParams != nil && b.settings.ChainCfgParams.GenerateSupported
+}
+
+// batchedParentChain fetches the MedianTimeBlocks headers ending at parentHash
+// in one batched call and verifies the run is complete, anchored at the parent
+// and correctly linked. Any mismatch means the batched lookup cannot be trusted
+// — its fast path is a height-range scan over main-chain flags and its CTE
+// stops early on an unresolved parent_id, neither of which is an atomic
+// parent-chain walk — and the caller falls back to walkParentChain.
 func (b *BlockAssembler) batchedParentChain(ctx context.Context, parentHash *chainhash.Hash) ([]*model.BlockHeader, error) {
 	headers, _, err := b.blockchainClient.GetBlockHeaders(ctx, parentHash, blockchain.MedianTimeBlocks)
 	if err != nil {
@@ -91,6 +199,10 @@ func (b *BlockAssembler) batchedParentChain(ctx context.Context, parentHash *cha
 		return nil, errors.NewProcessingError("returned chain head does not match requested parent %s", parentHash.String())
 	}
 
+	if uint64(len(headers)) > blockchain.MedianTimeBlocks {
+		return nil, errors.NewProcessingError("batched run below parent %s returned %d headers, more than the %d requested", parentHash.String(), len(headers), blockchain.MedianTimeBlocks)
+	}
+
 	for i := 1; i < len(headers); i++ {
 		if headers[i] == nil {
 			return nil, errors.NewProcessingError("nil header at depth %d below parent %s", i, parentHash.String())
@@ -99,6 +211,15 @@ func (b *BlockAssembler) batchedParentChain(ctx context.Context, parentHash *cha
 		if !headers[i-1].HashPrevBlock.IsEqual(headers[i].Hash()) {
 			return nil, errors.NewProcessingError("parent-chain link broken at depth %d below parent %s", i, parentHash.String())
 		}
+	}
+
+	// The anchor and link checks cannot see a run truncated at its oldest end:
+	// such a run is still anchored at the parent and still correctly linked, but
+	// its median is taken over a narrower window and is biased high, which feeds
+	// straight into the two-hour ceiling above. A short run is only legitimate
+	// when it reaches the start of the chain.
+	if uint64(len(headers)) < blockchain.MedianTimeBlocks && !isChainStart(headers[len(headers)-1]) {
+		return nil, errors.NewProcessingError("short parent-chain run (%d of %d) below parent %s does not reach the chain start", len(headers), blockchain.MedianTimeBlocks, parentHash.String())
 	}
 
 	return headers, nil
@@ -117,6 +238,10 @@ func (b *BlockAssembler) walkParentChain(ctx context.Context, startHash *chainha
 	cur := startHash
 
 	for i := uint64(0); i < depth; i++ {
+		if cur == nil {
+			return nil, errors.NewProcessingError("nil parent hash at depth %d below %s", i, startHash.String())
+		}
+
 		header, _, err := b.blockchainClient.GetBlockHeader(ctx, cur)
 		if err != nil {
 			return nil, errors.NewProcessingError("failed to fetch header %s at depth %d", cur.String(), i, err)
@@ -128,8 +253,7 @@ func (b *BlockAssembler) walkParentChain(ctx context.Context, startHash *chainha
 
 		headers = append(headers, header)
 
-		// The genesis block's HashPrevBlock is all zeroes: the chain start.
-		if header.HashPrevBlock == nil || header.HashPrevBlock.IsEqual(&chainhash.Hash{}) {
+		if isChainStart(header) {
 			break
 		}
 
@@ -137,4 +261,10 @@ func (b *BlockAssembler) walkParentChain(ctx context.Context, startHash *chainha
 	}
 
 	return headers, nil
+}
+
+// isChainStart reports whether header is the start of the chain: the genesis
+// block's HashPrevBlock is all zeroes, so nothing links below it.
+func isChainStart(header *model.BlockHeader) bool {
+	return header.HashPrevBlock == nil || header.HashPrevBlock.IsEqual(&chainhash.Hash{})
 }

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -226,14 +226,14 @@ func (b *BlockAssembler) computeMtpFloor(ctx context.Context, parentHeader *mode
 	// A transport failure and an unusable result call for opposite responses, so
 	// the fetch and the verification are separate steps. If the call itself fails
 	// the blockchain service is unhealthy, and walking it once per header would
-	// add MedianTimeBlocks more sequential reads without adding any information —
+	// add MedianTimeBlocks-1 more sequential reads without adding any information —
 	// exactly the amplification to avoid, since a saturated service is what caused
 	// the failure. Only a result that arrives but cannot be trusted (mis-anchored,
 	// unlinked, or short) is worth the walk, because that is the reorg race the
 	// walk exists to recover from and its per-hash reads cannot hit it.
 	headers, fetchErr := b.fetchParentChainHeaders(ctx, parentHash)
 	if fetchErr != nil {
-		b.logFloorLookupFailure(parentHash, "the blockchain service did not answer the batched header fetch (%v); not attempting the %d-read parent-chain walk against a service that is already failing", fetchErr, blockchain.MedianTimeBlocks)
+		b.logFloorLookupFailure(parentHash, "the blockchain service did not answer the batched header fetch (%v); not attempting the %d-read parent-chain walk against a service that is already failing", fetchErr, blockchain.MedianTimeBlocks-1)
 
 		return nil
 	}

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -20,12 +20,15 @@ const maxFutureBlockTime = 2 * time.Hour
 // mtpFloorEntry is the median-time-past floor for one parent block. The median
 // of the 11 headers ending at a given hash can never change — headers are
 // immutable once stored — so it is computed once per parent and reused for
-// every miner poll on that tip. warned latches the "floor engaged" log line so
-// it fires once per parent rather than once per poll.
+// every miner poll on that tip. The two flags latch their log lines so each
+// fires once per parent rather than once per poll: both conditions stay engaged
+// for as long as the underlying clock problem lasts, on a path miners poll
+// several times a second.
 type mtpFloorEntry struct {
-	parent  chainhash.Hash
-	minTime int64
-	warned  atomic.Bool
+	parent        chainhash.Hash
+	minTime       int64
+	warnedFloor   atomic.Bool
+	warnedCeiling atomic.Bool
 }
 
 // candidateTime returns the timestamp to stamp on a mining candidate built on
@@ -71,7 +74,7 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 	parentHash := parentHeader.Hash()
 	timeNow := time.Now().Unix()
 
-	entry := b.mtpFloor(ctx, parentHash)
+	entry := b.mtpFloor(ctx, parentHeader, parentHash)
 	if entry == nil {
 		// mtpFloor has already logged the cause. Serve the wall clock rather
 		// than stopping mining on a blockchain hiccup.
@@ -82,7 +85,12 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 	// no valid timestamp at all and flooring makes things worse, not better.
 	if maxTime := timeNow + int64(maxFutureBlockTime/time.Second); entry.minTime > maxTime {
 		if b.generateSupported() {
-			b.logger.Warnf("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d; serving the wall clock %d because this chain treats the median-time rule as advisory", parentHash.String(), entry.minTime, maxTime, timeNow)
+			// Latched per parent like the floor warning below: this branch stays
+			// engaged for as long as the clock condition lasts, and it sits on a
+			// path polled several times a second per connected miner.
+			if entry.warnedCeiling.CompareAndSwap(false, true) {
+				b.logger.Warnf("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d; serving the wall clock %d because this chain treats the median-time rule as advisory", parentHash.String(), entry.minTime, maxTime, timeNow)
+			}
 
 			return timeNow, nil
 		}
@@ -91,7 +99,7 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 	}
 
 	if timeNow < entry.minTime {
-		if entry.warned.CompareAndSwap(false, true) {
+		if entry.warnedFloor.CompareAndSwap(false, true) {
 			b.logger.Warnf("[candidateTime] local clock %d is at or below the parent chain's median-time-past; flooring candidate time to %d for blocks on parent %s", timeNow, entry.minTime, parentHash.String())
 		}
 
@@ -105,12 +113,20 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 // parentHash, and whether it is known. It is a pure memo read: the entry is warm
 // whenever a candidate was just built on that parent, so the submit path can
 // reject a miner-supplied nTime below the consensus floor without a round-trip.
-// A false second return means no floor was established for that parent (the
-// candidate was served on the degraded wall-clock path, or the tip has since
-// moved twice), in which case the submit path has nothing to enforce and behaves
-// as it did before the floor existed.
+// A false second return means there is no floor for the submit path to enforce —
+// the candidate was served on the degraded wall-clock path, the tip has since
+// moved twice, or this chain treats the median rule as advisory — in which case
+// the submit path behaves as it did before the floor existed.
 func (b *BlockAssembler) MinCandidateTime(parentHash *chainhash.Hash) (int64, bool) {
-	if parentHash == nil {
+	// The "this chain treats the median rule as advisory" decision has to live in
+	// one place or the producer and the guard drift apart. candidateTime's ceiling
+	// branch deliberately serves an unfloored wall-clock candidate on chains with
+	// GenerateSupported, while the memo entry it read still carries a minTime above
+	// now+2h. mining.Mine copies the candidate's own time into the solution
+	// unconditionally, so enforcing that floor here would reject every solution
+	// against a candidate this package chose to hand out — turning the carve-out
+	// that keeps rapid generation working into the thing that stops it.
+	if parentHash == nil || b.generateSupported() {
 		return 0, false
 	}
 
@@ -132,26 +148,42 @@ func (b *BlockAssembler) MinCandidateTime(parentHash *chainhash.Hash) (int64, bo
 // while the main path uses the subtree processor's precomputed parent. A single
 // slot would thrash whenever those two alternate, refetching on every poll and
 // re-firing the floor warning each time.
-func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHash *chainhash.Hash) *mtpFloorEntry {
+func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHeader *model.BlockHeader, parentHash *chainhash.Hash) *mtpFloorEntry {
 	for i := range b.mtpFloorMemo {
 		if entry := b.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(parentHash) {
 			return entry
 		}
 	}
 
-	run, batchedErr := b.batchedParentChain(ctx, parentHash)
-	if batchedErr != nil {
-		walked, walkErr := b.walkParentChain(ctx, parentHash, blockchain.MedianTimeBlocks)
+	// A transport failure and an unusable result call for opposite responses, so
+	// the fetch and the verification are separate steps. If the call itself fails
+	// the blockchain service is unhealthy, and walking it once per header would
+	// add MedianTimeBlocks more sequential reads without adding any information —
+	// exactly the amplification to avoid, since a saturated service is what caused
+	// the failure. Only a result that arrives but cannot be trusted (mis-anchored,
+	// unlinked, or short) is worth the walk, because that is the reorg race the
+	// walk exists to recover from and its per-hash reads cannot hit it.
+	headers, fetchErr := b.fetchParentChainHeaders(ctx, parentHash)
+	if fetchErr != nil {
+		b.logFloorLookupFailure(parentHash, "the blockchain service did not answer the batched header fetch (%v); not attempting the %d-read parent-chain walk against a service that is already failing", fetchErr, blockchain.MedianTimeBlocks)
+
+		return nil
+	}
+
+	run := headers
+
+	if verifyErr := verifyParentChainRun(parentHash, headers); verifyErr != nil {
+		walked, walkErr := b.walkParentChain(ctx, parentHeader, blockchain.MedianTimeBlocks)
 		if walkErr != nil {
-			b.logger.Errorf("[candidateTime] cannot establish the median-time-past floor for parent %s: batched header fetch failed (%v) and the hash-keyed parent-chain walk also failed (%v); serving an unfloored candidate time", parentHash.String(), batchedErr, walkErr)
+			b.logFloorLookupFailure(parentHash, "the batched header fetch returned an unusable run (%v) and the hash-keyed parent-chain walk also failed (%v)", verifyErr, walkErr)
 
 			return nil
 		}
 
-		// Name the cause of the slower path rather than discarding the batched
-		// error silently: the walk costs one round-trip per header, so an
-		// operator seeing the extra latency needs to know why it engaged.
-		b.logger.Warnf("[candidateTime] batched header fetch for parent %s was unusable (%v); fell back to the hash-keyed parent-chain walk", parentHash.String(), batchedErr)
+		// Name the cause of the slower path rather than discarding the error
+		// silently: the walk costs one round-trip per header, so an operator
+		// seeing the extra latency needs to know why it engaged.
+		b.logger.Warnf("[candidateTime] batched header fetch for parent %s was unusable (%v); fell back to the hash-keyed parent-chain walk", parentHash.String(), verifyErr)
 
 		run = walked
 	}
@@ -165,7 +197,7 @@ func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHash *chainhash.Has
 	// producers above guarantee at least one header.
 	medianTimestamp, err := model.CalculateMedianTimestamp(timestamps)
 	if err != nil {
-		b.logger.Errorf("[candidateTime] failed to calculate the median timestamp for parent %s over %d headers: %v; serving an unfloored candidate time", parentHash.String(), len(run), err)
+		b.logFloorLookupFailure(parentHash, "the median timestamp over %d headers could not be calculated (%v)", len(run), err)
 
 		return nil
 	}
@@ -186,33 +218,54 @@ func (b *BlockAssembler) generateSupported() bool {
 	return b.settings != nil && b.settings.ChainCfgParams != nil && b.settings.ChainCfgParams.GenerateSupported
 }
 
-// batchedParentChain fetches the MedianTimeBlocks headers ending at parentHash
-// in one batched call and verifies the run is complete, anchored at the parent
-// and correctly linked. Any mismatch means the batched lookup cannot be trusted
-// — its fast path is a height-range scan over main-chain flags and its CTE
-// stops early on an unresolved parent_id, neither of which is an atomic
-// parent-chain walk — and the caller falls back to walkParentChain.
-func (b *BlockAssembler) batchedParentChain(ctx context.Context, parentHash *chainhash.Hash) ([]*model.BlockHeader, error) {
+// logFloorLookupFailure reports that the median-time-past floor could not be
+// established, latched to the last parent it fired for. The floor-lookup failure
+// modes persist while the underlying problem does, and this sits on a path polled
+// several times a second per connected miner, so an unlatched line floods the log
+// during precisely the incident an operator is trying to read it through. The
+// latch is a single slot rather than per-entry because these are the paths where
+// no memo entry exists to hang a flag on.
+func (b *BlockAssembler) logFloorLookupFailure(parentHash *chainhash.Hash, format string, args ...interface{}) {
+	if prev := b.mtpFloorFailureLoggedTip.Swap(parentHash); prev != nil && prev.IsEqual(parentHash) {
+		return
+	}
+
+	b.logger.Errorf("[candidateTime] cannot establish the median-time-past floor for parent %s: "+format+"; serving an unfloored candidate time", append([]interface{}{parentHash.String()}, args...)...)
+}
+
+// fetchParentChainHeaders performs the batched header fetch and nothing else, so
+// its caller can tell a transport failure apart from a result that arrived but
+// cannot be trusted. The two want opposite responses: see mtpFloor.
+func (b *BlockAssembler) fetchParentChainHeaders(ctx context.Context, parentHash *chainhash.Hash) ([]*model.BlockHeader, error) {
 	headers, _, err := b.blockchainClient.GetBlockHeaders(ctx, parentHash, blockchain.MedianTimeBlocks)
 	if err != nil {
 		return nil, errors.NewProcessingError("failed to fetch parent-chain headers for %s", parentHash.String(), err)
 	}
 
+	return headers, nil
+}
+
+// verifyParentChainRun checks that a batched run is complete, anchored at the
+// parent and correctly linked. Any mismatch means the batched lookup cannot be
+// trusted — its fast path is a height-range scan over main-chain flags and its
+// CTE stops early on an unresolved parent_id, neither of which is an atomic
+// parent-chain walk — and the caller falls back to walkParentChain.
+func verifyParentChainRun(parentHash *chainhash.Hash, headers []*model.BlockHeader) error {
 	if len(headers) == 0 || headers[0] == nil || !headers[0].Hash().IsEqual(parentHash) {
-		return nil, errors.NewProcessingError("returned chain head does not match requested parent %s", parentHash.String())
+		return errors.NewProcessingError("returned chain head does not match requested parent %s", parentHash.String())
 	}
 
 	if uint64(len(headers)) > blockchain.MedianTimeBlocks {
-		return nil, errors.NewProcessingError("batched run below parent %s returned %d headers, more than the %d requested", parentHash.String(), len(headers), blockchain.MedianTimeBlocks)
+		return errors.NewProcessingError("batched run below parent %s returned %d headers, more than the %d requested", parentHash.String(), len(headers), blockchain.MedianTimeBlocks)
 	}
 
 	for i := 1; i < len(headers); i++ {
 		if headers[i] == nil {
-			return nil, errors.NewProcessingError("nil header at depth %d below parent %s", i, parentHash.String())
+			return errors.NewProcessingError("nil header at depth %d below parent %s", i, parentHash.String())
 		}
 
 		if !headers[i-1].HashPrevBlock.IsEqual(headers[i].Hash()) {
-			return nil, errors.NewProcessingError("parent-chain link broken at depth %d below parent %s", i, parentHash.String())
+			return errors.NewProcessingError("parent-chain link broken at depth %d below parent %s", i, parentHash.String())
 		}
 	}
 
@@ -222,45 +275,51 @@ func (b *BlockAssembler) batchedParentChain(ctx context.Context, parentHash *cha
 	// straight into the two-hour ceiling above. A short run is only legitimate
 	// when it reaches the start of the chain.
 	if uint64(len(headers)) < blockchain.MedianTimeBlocks && !isChainStart(headers[len(headers)-1]) {
-		return nil, errors.NewProcessingError("short parent-chain run (%d of %d) below parent %s does not reach the chain start", len(headers), blockchain.MedianTimeBlocks, parentHash.String())
+		return errors.NewProcessingError("short parent-chain run (%d of %d) below parent %s does not reach the chain start", len(headers), blockchain.MedianTimeBlocks, parentHash.String())
 	}
 
-	return headers, nil
+	return nil
 }
 
-// walkParentChain fetches up to depth headers ending at startHash by following
-// HashPrevBlock one header at a time. Each read is keyed by hash — immutable
-// once stored — so the result cannot be poisoned by a reorg happening between
-// reads, at the cost of one round-trip per header. Unlike the equivalents in
+// walkParentChain returns up to depth headers ending at startHeader by following
+// HashPrevBlock one header at a time. Each read is keyed by hash — immutable once
+// stored — so the result cannot be poisoned by a reorg happening between reads,
+// at the cost of one round-trip per header. Unlike the equivalents in
 // subtreevalidation and legacy/netsync it tolerates reaching the start of the
 // chain (returning fewer than depth headers), because block assembly runs from
-// genesis on fresh networks; the validator applies the median rule over
-// however many headers exist in the same way.
-func (b *BlockAssembler) walkParentChain(ctx context.Context, startHash *chainhash.Hash, depth uint64) ([]*model.BlockHeader, error) {
+// genesis on fresh networks; the validator applies the median rule over however
+// many headers exist in the same way.
+//
+// The run is seeded with startHeader rather than re-fetching it: the caller
+// already holds the parent header, so fetching it again would spend one of the
+// depth round-trips re-reading data in hand — on the path that engages precisely
+// when the blockchain service is struggling.
+func (b *BlockAssembler) walkParentChain(ctx context.Context, startHeader *model.BlockHeader, depth uint64) ([]*model.BlockHeader, error) {
+	if startHeader == nil {
+		return nil, errors.NewProcessingError("nil start header")
+	}
+
 	headers := make([]*model.BlockHeader, 0, depth)
-	cur := startHash
+	headers = append(headers, startHeader)
 
-	for i := uint64(0); i < depth; i++ {
-		if cur == nil {
-			return nil, errors.NewProcessingError("nil parent hash at depth %d below %s", i, startHash.String())
-		}
+	cur := startHeader
 
-		header, _, err := b.blockchainClient.GetBlockHeader(ctx, cur)
-		if err != nil {
-			return nil, errors.NewProcessingError("failed to fetch header %s at depth %d", cur.String(), i, err)
-		}
-
-		if header == nil {
-			return nil, errors.NewProcessingError("nil header for %s at depth %d", cur.String(), i)
-		}
-
-		headers = append(headers, header)
-
-		if isChainStart(header) {
+	for uint64(len(headers)) < depth {
+		if isChainStart(cur) {
 			break
 		}
 
-		cur = header.HashPrevBlock
+		header, _, err := b.blockchainClient.GetBlockHeader(ctx, cur.HashPrevBlock)
+		if err != nil {
+			return nil, errors.NewProcessingError("failed to fetch header %s at depth %d", cur.HashPrevBlock.String(), len(headers), err)
+		}
+
+		if header == nil {
+			return nil, errors.NewProcessingError("nil header for %s at depth %d", cur.HashPrevBlock.String(), len(headers))
+		}
+
+		headers = append(headers, header)
+		cur = header
 	}
 
 	return headers, nil

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -95,6 +95,19 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 			return timeNow, nil
 		}
 
+		// This is the only new branch that takes mining output to zero, and the
+		// error it returns is never logged locally: GetMiningCandidate and
+		// generateEmptyBlockCandidate propagate it verbatim, and the gRPC handler
+		// returns errors.WrapGRPC(err) without a log line. Unlogged, an operator
+		// whose node has stopped producing blocks has to reconstruct the cause
+		// from the miners' error strings. Latched on the same flag as the
+		// carve-out above, which is mutually exclusive with this branch.
+		if entry.warnedCeiling.CompareAndSwap(false, true) {
+			b.logger.Errorf("[candidateTime] block production has stopped for parent %s: its median-time-past floor %d is above the two-hour future bound %d, so no timestamp satisfies both consensus rules; the local clock is at least %d seconds slow and must be corrected", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
+		}
+
+		prometheusBlockAssemblerCandidateTimeClockSkew.Inc()
+
 		return 0, errors.NewProcessingError("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d, so no timestamp satisfies both consensus rules; the local clock is skewed by at least %d seconds", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
 	}
 
@@ -149,12 +162,67 @@ func (b *BlockAssembler) MinCandidateTime(parentHash *chainhash.Hash) (int64, bo
 // slot would thrash whenever those two alternate, refetching on every poll and
 // re-firing the floor warning each time.
 func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHeader *model.BlockHeader, parentHash *chainhash.Hash) *mtpFloorEntry {
+	if entry := b.memoizedMtpFloor(parentHash); entry != nil {
+		return entry
+	}
+
+	// Single-flight the miss. Neither GetMiningCandidate entry point holds a lock
+	// and every miner polls several times a second, so a cold tip is entered
+	// concurrently as a matter of course — the check-then-compute-then-store
+	// below is not atomic. Unflighted, each racer fetches the same eleven
+	// headers, each wins its own CompareAndSwap and warns, and each stores into
+	// its own round-robin slot, so one parent occupies both and evicts the other
+	// candidate path's entry. Sharing one flight per parent makes the entry a
+	// single object again, which is what the per-entry log latches assume.
+	shared, _, _ := b.mtpFloorFlight.Do(parentHash.String(), func() (interface{}, error) {
+		// Re-check inside the flight: a previous flight for this parent may have
+		// completed between the read above and getting here.
+		if entry := b.memoizedMtpFloor(parentHash); entry != nil {
+			return entry, nil
+		}
+
+		return b.computeMtpFloor(ctx, parentHeader, parentHash), nil
+	})
+
+	entry, _ := shared.(*mtpFloorEntry)
+
+	return entry
+}
+
+// memoizedMtpFloor returns the memo entry for parentHash, or nil on a miss.
+// Reads stay lock-free: the slots are atomic pointers and entries are immutable
+// apart from their own atomic log latches.
+func (b *BlockAssembler) memoizedMtpFloor(parentHash *chainhash.Hash) *mtpFloorEntry {
 	for i := range b.mtpFloorMemo {
 		if entry := b.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(parentHash) {
 			return entry
 		}
 	}
 
+	return nil
+}
+
+// placeMtpFloor stores entry, reusing the slot its parent already occupies so a
+// single parent can never hold both and evict the other candidate path's entry.
+// The round-robin victim is therefore always a different parent.
+func (b *BlockAssembler) placeMtpFloor(entry *mtpFloorEntry) {
+	for i := range b.mtpFloorMemo {
+		if cur := b.mtpFloorMemo[i].Load(); cur != nil && cur.parent.IsEqual(&entry.parent) {
+			b.mtpFloorMemo[i].Store(entry)
+
+			return
+		}
+	}
+
+	slot := b.mtpFloorMemoNext.Add(1) % uint64(len(b.mtpFloorMemo))
+	b.mtpFloorMemo[slot].Store(entry)
+}
+
+// computeMtpFloor does the actual lookup and median calculation for one parent.
+// It runs inside a single flight, so at most one caller per parent is here at a
+// time. It returns nil — having logged the cause — when the floor cannot be
+// established, leaving the caller to decide how to degrade.
+func (b *BlockAssembler) computeMtpFloor(ctx context.Context, parentHeader *model.BlockHeader, parentHash *chainhash.Hash) *mtpFloorEntry {
 	// A transport failure and an unusable result call for opposite responses, so
 	// the fetch and the verification are separate steps. If the call itself fails
 	// the blockchain service is unhealthy, and walking it once per header would
@@ -204,8 +272,7 @@ func (b *BlockAssembler) mtpFloor(ctx context.Context, parentHeader *model.Block
 
 	entry := &mtpFloorEntry{parent: *parentHash, minTime: medianTimestamp.Unix() + 1}
 
-	slot := b.mtpFloorMemoNext.Add(1) % uint64(len(b.mtpFloorMemo))
-	b.mtpFloorMemo[slot].Store(entry)
+	b.placeMtpFloor(entry)
 
 	return entry
 }

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -11,12 +11,6 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 )
 
-// maxFutureBlockTime mirrors the two-hours-in-the-future ceiling that
-// model.Block CheckHeaderContextual applies to every header unconditionally —
-// unlike the median-time rule, that check needs no currentChain, so the local
-// submit path does enforce it (model/Block.go).
-const maxFutureBlockTime = 2 * time.Hour
-
 // mtpFloorEntry is the median-time-past floor for one parent block. The median
 // of the 11 headers ending at a given hash can never change — headers are
 // immutable once stored — so it is computed once per parent and reused for
@@ -83,7 +77,11 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 
 	// Check the ceiling before applying the floor: when the two cross there is
 	// no valid timestamp at all and flooring makes things worse, not better.
-	if maxTime := timeNow + int64(maxFutureBlockTime/time.Second); entry.minTime > maxTime {
+	// model.MaxFutureBlockTime rather than a local copy: this is the ceiling
+	// CheckHeaderContextual will judge the mined block against, and it needs no
+	// currentChain, so the local submit path enforces it too. A second copy here
+	// would let the producer and its own validator drift apart silently.
+	if maxTime := timeNow + int64(model.MaxFutureBlockTime/time.Second); entry.minTime > maxTime {
 		if b.generateSupported() {
 			// Latched per parent like the floor warning below: this branch stays
 			// engaged for as long as the clock condition lasts, and it sits on a
@@ -102,13 +100,21 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 		// whose node has stopped producing blocks has to reconstruct the cause
 		// from the miners' error strings. Latched on the same flag as the
 		// carve-out above, which is mutually exclusive with this branch.
+		//
+		// Both messages name the two causes rather than only the local clock.
+		// The condition is a gap between this node's clock and the parent
+		// chain's timestamps, and it is silent about which of the two moved: a
+		// slow local clock produces it, and so does a parent chain stamped into
+		// the future by a misconfigured or hostile upstream miner. An operator
+		// reading only "fix your clock" chases NTP while the real cause is
+		// upstream.
 		if entry.warnedCeiling.CompareAndSwap(false, true) {
-			b.logger.Errorf("[candidateTime] block production has stopped for parent %s: its median-time-past floor %d is above the two-hour future bound %d, so no timestamp satisfies both consensus rules; the local clock is at least %d seconds slow and must be corrected", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
+			b.logger.Errorf("[candidateTime] block production has stopped for parent %s: its median-time-past floor %d is above the two-hour future bound %d, so no timestamp satisfies both consensus rules; either the local clock is at least %d seconds behind the network and must be corrected, or the parent chain is future-stamped by an upstream miner", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
 		}
 
 		prometheusBlockAssemblerCandidateTimeClockSkew.Inc()
 
-		return 0, errors.NewProcessingError("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d, so no timestamp satisfies both consensus rules; the local clock is skewed by at least %d seconds", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
+		return 0, errors.NewProcessingError("[candidateTime] parent %s median-time-past floor %d exceeds the two-hour future bound %d, so no timestamp satisfies both consensus rules; the local clock is at least %d seconds behind the parent chain, which is either local clock skew or a future-stamped parent chain", parentHash.String(), entry.minTime, maxTime, entry.minTime-maxTime)
 	}
 
 	if timeNow < entry.minTime {
@@ -130,6 +136,14 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 // the candidate was served on the degraded wall-clock path, the tip has since
 // moved twice, or this chain treats the median rule as advisory — in which case
 // the submit path behaves as it did before the floor existed.
+//
+// That is a property of the moment the solution arrives, not of the job it was
+// built from, and the two can disagree. A degraded poll memoizes nothing, so a
+// later poll on the same parent can succeed and memoize a floor that a solution
+// against the earlier job then fails; within a job's TTL the guard can therefore
+// reject a candidate this node itself served unfloored. The rejection is right —
+// that block is peer-invalid either way — and submitMiningSolution logs that
+// case as ours rather than as a miner's bad timestamp.
 func (b *BlockAssembler) MinCandidateTime(parentHash *chainhash.Hash) (int64, bool) {
 	// The "this chain treats the median rule as advisory" decision has to live in
 	// one place or the producer and the guard drift apart. candidateTime's ceiling
@@ -143,10 +157,8 @@ func (b *BlockAssembler) MinCandidateTime(parentHash *chainhash.Hash) (int64, bo
 		return 0, false
 	}
 
-	for i := range b.mtpFloorMemo {
-		if entry := b.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(parentHash) {
-			return entry.minTime, true
-		}
+	if entry := b.memoizedMtpFloor(parentHash); entry != nil {
+		return entry.minTime, true
 	}
 
 	return 0, false

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
@@ -11,44 +12,46 @@ import (
 
 // candidateTime returns the timestamp to stamp on a mining candidate built on
 // parentHeader: the local wall clock, floored at median-time-past+1 of the
-// parent chain. Block validation (model.Block CheckHeaderContextual) rejects
-// any block whose timestamp is not strictly greater than the median timestamp
-// of the previous 11 blocks, so without the floor a lagging local clock — or a
-// run of forward-stamped blocks dragging the median above wall-clock time —
-// makes the assembler hand miners a candidate the node itself rejects once
-// mined. SV Node applies the same floor in UpdateTime (max of the parent's
-// median-time-past+1 and adjusted time).
+// parent chain. Block validation rejects any block whose timestamp is not
+// strictly greater than the median timestamp of the previous 11 blocks
+// (model.Block CheckHeaderContextual), so without the floor a lagging local
+// clock — or a run of forward-stamped blocks dragging the median above
+// wall-clock time — makes the assembler hand miners a candidate that the
+// network refuses once mined. The submit path itself does not catch it:
+// SubmitMiningSolution calls block.Valid with no currentChain, which skips
+// the median-time rule, so the bad block is accepted locally and then
+// rejected by every peer that validates it. SV Node applies the same floor
+// in UpdateTime (max of the parent's median-time-past+1 and adjusted time).
 //
 // Headers are fetched by parent hash rather than height so a candidate built
-// on a side chain gets the median of its own chain. The returned run is
-// verified to be anchored at the parent and correctly linked, mirroring the
-// candidate-parent MTP helpers in subtreevalidation and legacy/netsync; a
-// mismatch means the chain reorganised between fetch and use, and the error
-// simply fails this poll — the miner's next GetMiningCandidate retries.
+// on a side chain gets the median of its own chain. The batched fetch is
+// verified to be anchored at the parent and correctly linked; on any mismatch
+// (the store's batched lookup ranges over main-chain flags and can race a
+// reorg) candidateTime falls back to a hash-keyed walk of the parent chain,
+// whose per-hash reads are immutable and immune to that race — the same
+// two-step strategy as the candidate-parent MTP helpers in subtreevalidation
+// and legacy/netsync. Only when both attempts fail does the candidate request
+// error, failing that one miner poll.
 func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.BlockHeader) (int64, error) {
+	if parentHeader == nil {
+		return 0, errors.NewProcessingError("[candidateTime] nil parent header")
+	}
+
 	parentHash := parentHeader.Hash()
 
-	headers, _, err := b.blockchainClient.GetBlockHeaders(ctx, parentHash, blockchain.MedianTimeBlocks)
-	if err != nil {
-		return 0, errors.NewProcessingError("[candidateTime] failed to fetch parent-chain headers for %s", parentHash.String(), err)
-	}
-
-	if len(headers) == 0 || headers[0] == nil || !headers[0].Hash().IsEqual(parentHash) {
-		return 0, errors.NewProcessingError("[candidateTime] returned chain head does not match requested parent %s (possible reorg between fetch and use)", parentHash.String())
-	}
-
-	timestamps := make([]time.Time, 0, len(headers))
-
-	for i, header := range headers {
-		if header == nil {
-			return 0, errors.NewProcessingError("[candidateTime] nil header at depth %d below parent %s", i, parentHash.String())
+	run, batchedErr := b.batchedParentChain(ctx, parentHash)
+	if batchedErr != nil {
+		walked, walkErr := b.walkParentChain(ctx, parentHash, blockchain.MedianTimeBlocks)
+		if walkErr != nil {
+			return 0, errors.NewProcessingError("[candidateTime] batched header fetch failed (%v); hash-keyed parent-chain walk also failed for %s", batchedErr, parentHash.String(), walkErr)
 		}
 
-		if i > 0 && !headers[i-1].HashPrevBlock.IsEqual(header.Hash()) {
-			return 0, errors.NewProcessingError("[candidateTime] parent-chain link broken at depth %d below parent %s (possible reorg between fetch and use)", i, parentHash.String())
-		}
+		run = walked
+	}
 
-		timestamps = append(timestamps, time.Unix(int64(header.Timestamp), 0))
+	timestamps := make([]time.Time, len(run))
+	for i, header := range run {
+		timestamps[i] = time.Unix(int64(header.Timestamp), 0)
 	}
 
 	medianTimestamp, err := model.CalculateMedianTimestamp(timestamps)
@@ -59,9 +62,79 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 	timeNow := time.Now().Unix()
 
 	if minTime := medianTimestamp.Unix() + 1; timeNow < minTime {
-		b.logger.Warnf("[candidateTime] local clock %d is at or below the parent chain's median-time-past %d, flooring candidate time to %d", timeNow, medianTimestamp.Unix(), minTime)
+		// Warn once per tip rather than once per call: miners poll several
+		// times a second, and while a clock-lag condition lasts every poll
+		// floors, which would flood the log with identical lines.
+		if prev := b.mtpFloorWarnedTip.Swap(parentHash); prev == nil || !prev.IsEqual(parentHash) {
+			b.logger.Warnf("[candidateTime] local clock %d is at or below the parent chain's median-time-past %d, flooring candidate time to %d for blocks on parent %s", timeNow, medianTimestamp.Unix(), minTime, parentHash.String())
+		}
+
 		timeNow = minTime
 	}
 
 	return timeNow, nil
+}
+
+// batchedParentChain fetches up to MedianTimeBlocks headers ending at
+// parentHash in one batched call and verifies the run is anchored at the
+// parent and correctly linked. A mismatch means the batched lookup raced a
+// chain reorganisation (its fast path is a height-range scan over main-chain
+// flags, not an atomic parent-chain walk); the caller falls back to
+// walkParentChain when that happens.
+func (b *BlockAssembler) batchedParentChain(ctx context.Context, parentHash *chainhash.Hash) ([]*model.BlockHeader, error) {
+	headers, _, err := b.blockchainClient.GetBlockHeaders(ctx, parentHash, blockchain.MedianTimeBlocks)
+	if err != nil {
+		return nil, errors.NewProcessingError("failed to fetch parent-chain headers for %s", parentHash.String(), err)
+	}
+
+	if len(headers) == 0 || headers[0] == nil || !headers[0].Hash().IsEqual(parentHash) {
+		return nil, errors.NewProcessingError("returned chain head does not match requested parent %s", parentHash.String())
+	}
+
+	for i := 1; i < len(headers); i++ {
+		if headers[i] == nil {
+			return nil, errors.NewProcessingError("nil header at depth %d below parent %s", i, parentHash.String())
+		}
+
+		if !headers[i-1].HashPrevBlock.IsEqual(headers[i].Hash()) {
+			return nil, errors.NewProcessingError("parent-chain link broken at depth %d below parent %s", i, parentHash.String())
+		}
+	}
+
+	return headers, nil
+}
+
+// walkParentChain fetches up to depth headers ending at startHash by following
+// HashPrevBlock one header at a time. Each read is keyed by hash — immutable
+// once stored — so the result cannot be poisoned by a reorg happening between
+// reads, at the cost of one round-trip per header. Unlike the equivalents in
+// subtreevalidation and legacy/netsync it tolerates reaching the start of the
+// chain (returning fewer than depth headers), because block assembly runs from
+// genesis on fresh networks; the validator applies the median rule over
+// however many headers exist in the same way.
+func (b *BlockAssembler) walkParentChain(ctx context.Context, startHash *chainhash.Hash, depth uint64) ([]*model.BlockHeader, error) {
+	headers := make([]*model.BlockHeader, 0, depth)
+	cur := startHash
+
+	for i := uint64(0); i < depth; i++ {
+		header, _, err := b.blockchainClient.GetBlockHeader(ctx, cur)
+		if err != nil {
+			return nil, errors.NewProcessingError("failed to fetch header %s at depth %d", cur.String(), i, err)
+		}
+
+		if header == nil {
+			return nil, errors.NewProcessingError("nil header for %s at depth %d", cur.String(), i)
+		}
+
+		headers = append(headers, header)
+
+		// The genesis block's HashPrevBlock is all zeroes: the chain start.
+		if header.HashPrevBlock == nil || header.HashPrevBlock.IsEqual(&chainhash.Hash{}) {
+			break
+		}
+
+		cur = header.HashPrevBlock
+	}
+
+	return headers, nil
 }

--- a/services/blockassembly/candidate_time.go
+++ b/services/blockassembly/candidate_time.go
@@ -11,6 +11,19 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 )
 
+// maxFutureBlockTime mirrors the two-hours-in-the-future ceiling that
+// model.Block CheckHeaderContextual applies to every header unconditionally —
+// unlike the median-time rule, that check needs no currentChain, so the local
+// submit path does enforce it (model/Block.go).
+//
+// Deliberately a second copy rather than a shared constant, for now. Declaring
+// it once is issue #1528, which settles on `settings` as the home — the same
+// place PR #1481 had to put the eleven-block window, since `settings` cannot
+// import `model` without an import cycle. Doing it here would edit
+// model/Block.go while #1481 is changing that same consensus-critical function,
+// which is a merge conflict worth not having.
+const maxFutureBlockTime = 2 * time.Hour
+
 // mtpFloorEntry is the median-time-past floor for one parent block. The median
 // of the 11 headers ending at a given hash can never change — headers are
 // immutable once stored — so it is computed once per parent and reused for
@@ -77,11 +90,7 @@ func (b *BlockAssembler) candidateTime(ctx context.Context, parentHeader *model.
 
 	// Check the ceiling before applying the floor: when the two cross there is
 	// no valid timestamp at all and flooring makes things worse, not better.
-	// model.MaxFutureBlockTime rather than a local copy: this is the ceiling
-	// CheckHeaderContextual will judge the mined block against, and it needs no
-	// currentChain, so the local submit path enforces it too. A second copy here
-	// would let the producer and its own validator drift apart silently.
-	if maxTime := timeNow + int64(model.MaxFutureBlockTime/time.Second); entry.minTime > maxTime {
+	if maxTime := timeNow + int64(maxFutureBlockTime/time.Second); entry.minTime > maxTime {
 		if b.generateSupported() {
 			// Latched per parent like the floor warning below: this branch stays
 			// engaged for as long as the clock condition lasts, and it sits on a

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -2,6 +2,8 @@ package blockassembly
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -134,6 +136,42 @@ func TestCandidateTime(t *testing.T) {
 
 		medianTimePast := int64(baseTime + 5)
 		require.Equal(t, medianTimePast+1, got)
+	})
+
+	t.Run("the real store satisfies the batched-run contract without the walk", func(t *testing.T) {
+		// Every other batched-success subtest supplies the run shape itself via
+		// blockchain.Mock, and the real-store tests assert only the resulting
+		// floor — which walkParentChain reproduces identically. So the three
+		// assumptions verifyParentChainRun encodes about GetBlockHeaders(parent, 11)
+		// — newest-first, anchor-inclusive, and at most 11 — are a live
+		// cross-package contract with nothing pinning them.
+		//
+		// Flip ORDER BY b.height DESC to ASC in stores/blockchain/sql, or make the
+		// fast path exclusive of the anchor, and every miner poll would silently
+		// take MedianTimeBlocks-1 extra sequential GetBlockHeader round-trips plus
+		// a warning per tip, with the rest of the suite still green. This asserts
+		// the batched run is accepted as-is against the sqlitememory store: exactly
+		// one warning, the floor line, and no "was unusable" fallback line.
+		server, _ := setupServer(t)
+
+		// The logger is swapped before anything starts: assigning it to a running
+		// assembler races the channel-listener goroutines that read b.logger.
+		// candidateTime needs only the blockchain client, so nothing is started
+		// here — which also keeps unrelated background logging out of the counts.
+		logger := &warnCountingLogger{}
+		server.blockAssembler.logger = logger
+
+		baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+		tipHeader := buildFutureChain(t, t.Context(), server.blockchainClient, baseTime)
+
+		got, err := server.blockAssembler.candidateTime(t.Context(), tipHeader)
+		require.NoError(t, err)
+		require.Equal(t, int64(baseTime+5)+1, got)
+
+		// Count the specific line rather than all of them: the fallback line only
+		// appears when verifyParentChainRun rejected the store's run.
+		require.Zero(t, logger.countMatching("was unusable"), "the real store's batched run must be accepted as-is, not routed through walkParentChain")
+		require.Equal(t, 1, logger.countMatching("flooring candidate time"), "the floor must still engage, so this test cannot pass by never reaching the median at all")
 	})
 }
 
@@ -345,6 +383,56 @@ func TestCandidateTimeFallback(t *testing.T) {
 		mockClient.AssertNumberOfCalls(t, "GetBlockHeaders", 1)
 	})
 
+	t.Run("concurrent misses on one cold tip fetch, warn and occupy a slot once", func(t *testing.T) {
+		// The ordinary state on a cold tip: neither GetMiningCandidate entry point
+		// takes a lock and every miner polls several times a second, so the
+		// check-then-compute-then-store sequence is entered concurrently. Without
+		// single-flighting, each racer fetches, each warns, and the round-robin
+		// slot has no per-parent affinity so the same parent lands in both slots —
+		// evicting the other candidate path's entry and making MinCandidateTime
+		// report no floor for a live tip.
+		const racers = 8
+
+		logger := &warnCountingLogger{}
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := &BlockAssembler{logger: logger, blockchainClient: mockClient}
+
+		start := make(chan struct{})
+
+		var wg sync.WaitGroup
+
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+				<-start
+
+				got, err := assembler.candidateTime(t.Context(), tip)
+				require.NoError(t, err)
+				require.Equal(t, wantFloor, got)
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeaders", 1)
+		require.Equal(t, int32(1), logger.warns.Load(), "a cold tip must warn once however many polls race")
+
+		occupied := 0
+
+		for i := range assembler.mtpFloorMemo {
+			if entry := assembler.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(tip.Hash()) {
+				occupied++
+			}
+		}
+
+		require.Equal(t, 1, occupied, "one parent must occupy at most one slot, or it evicts the other candidate path's entry")
+	})
+
 	t.Run("both candidate paths' parents stay memoized together", func(t *testing.T) {
 		// The busy branch keys on the blockchain service's tip while the main
 		// path keys on the subtree processor's precomputed parent, so a
@@ -436,6 +524,11 @@ func TestCandidateTimeFallback(t *testing.T) {
 // assembly. Flooring regardless would therefore turn every solution found into
 // a full assembler reset, so candidateTime must fail the poll instead.
 func TestCandidateTimeTwoHourCeiling(t *testing.T) {
+	// The fail-closed branch increments a counter, and these subtests build the
+	// assembler directly rather than through New(), which is what registers the
+	// package's metrics in production.
+	initPrometheusMetrics()
+
 	// Stamped five hours ahead: the floor lands ~3h above the ceiling.
 	baseTime := uint32(time.Now().Add(5 * time.Hour).Unix())
 	headers := linkedHeaders(t, 11, baseTime)
@@ -458,6 +551,32 @@ func TestCandidateTimeTwoHourCeiling(t *testing.T) {
 		_, err := newAssembler(false).candidateTime(t.Context(), tip)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "two-hour future bound")
+	})
+
+	t.Run("reports the stopped block production once per tip", func(t *testing.T) {
+		// This branch is the only one that takes mining output to zero, and the
+		// error it returns is never logged locally — GetMiningCandidate propagates
+		// it and the gRPC handler wraps it without a log line. So it has to log
+		// here, and latched, because every poll takes this branch for as long as
+		// the clock stays out.
+		logger := &warnCountingLogger{}
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := &BlockAssembler{
+			logger:           logger,
+			blockchainClient: mockClient,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.Params{GenerateSupported: false},
+			},
+		}
+
+		for i := 0; i < 4; i++ {
+			_, err := assembler.candidateTime(t.Context(), tip)
+			require.Error(t, err)
+		}
+
+		require.Equal(t, int32(1), logger.errs.Load(), "the operator must be told once, not on every poll")
 	})
 
 	t.Run("serves the wall clock on chains where the median rule is advisory", func(t *testing.T) {
@@ -535,6 +654,52 @@ func TestCandidateTimeTwoHourCeiling(t *testing.T) {
 	})
 }
 
+// TestPlaceMtpFloor pins the one-slot-per-parent invariant directly on the
+// helper. Single-flighting the miss already prevents two concurrent computations
+// of the same parent from reaching here, so the reuse branch is defence against
+// a future change to that flighting rather than a live path — which is exactly
+// why the invariant is worth stating in a test rather than left implicit. If a
+// parent could hold both slots it would evict the other candidate path's entry,
+// and MinCandidateTime would report no floor for a live tip.
+func TestPlaceMtpFloor(t *testing.T) {
+	parentA := chainhash.Hash{1}
+	parentB := chainhash.Hash{2}
+
+	assembler := &BlockAssembler{logger: ulogger.TestLogger{}}
+
+	occupiedBy := func(parent chainhash.Hash) int {
+		count := 0
+
+		for i := range assembler.mtpFloorMemo {
+			if entry := assembler.mtpFloorMemo[i].Load(); entry != nil && entry.parent.IsEqual(&parent) {
+				count++
+			}
+		}
+
+		return count
+	}
+
+	assembler.placeMtpFloor(&mtpFloorEntry{parent: parentA, minTime: 100})
+	assembler.placeMtpFloor(&mtpFloorEntry{parent: parentB, minTime: 200})
+
+	require.Equal(t, 1, occupiedBy(parentA))
+	require.Equal(t, 1, occupiedBy(parentB))
+
+	// Re-placing an existing parent must reuse its slot, not consume the other's.
+	assembler.placeMtpFloor(&mtpFloorEntry{parent: parentA, minTime: 300})
+
+	require.Equal(t, 1, occupiedBy(parentA), "a parent must never occupy both slots")
+	require.Equal(t, 1, occupiedBy(parentB), "re-placing one parent must not evict the other")
+
+	got, ok := assembler.MinCandidateTime(&parentA)
+	require.True(t, ok)
+	require.Equal(t, int64(300), got, "the slot must carry the newest entry")
+
+	got, ok = assembler.MinCandidateTime(&parentB)
+	require.True(t, ok)
+	require.Equal(t, int64(200), got)
+}
+
 // TestMinCandidateTime covers the memo read the submit path uses to reject a
 // miner-supplied nTime below the consensus floor.
 func TestMinCandidateTime(t *testing.T) {
@@ -578,14 +743,44 @@ type warnCountingLogger struct {
 	ulogger.TestLogger
 	warns atomic.Int32
 	errs  atomic.Int32
+
+	mu      sync.Mutex
+	formats []string
 }
 
 func (l *warnCountingLogger) Warnf(format string, args ...interface{}) {
 	l.warns.Add(1)
+	l.record(format)
 }
 
 func (l *warnCountingLogger) Errorf(format string, args ...interface{}) {
 	l.errs.Add(1)
+	l.record(format)
+}
+
+func (l *warnCountingLogger) record(format string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.formats = append(l.formats, format)
+}
+
+// countMatching returns how many recorded lines contain substr. Counting a
+// specific line is more durable than counting all of them when the assembler
+// under test may log for unrelated reasons.
+func (l *warnCountingLogger) countMatching(substr string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	count := 0
+
+	for _, f := range l.formats {
+		if strings.Contains(f, substr) {
+			count++
+		}
+	}
+
+	return count
 }
 
 // TestMiningCandidateTimeFlooredAtMedianTimePast drives the public

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -169,14 +169,21 @@ func TestCandidateTimeFallback(t *testing.T) {
 		mockClient.AssertNotCalled(t, "GetBlockHeader", mock.Anything, mock.Anything)
 	})
 
-	t.Run("batched fetch error falls back to the hash-keyed walk", func(t *testing.T) {
+	t.Run("transport failure degrades without attempting the walk", func(t *testing.T) {
+		// A failed call means the blockchain service is unhealthy. Walking it once
+		// per header would add MedianTimeBlocks more sequential reads without
+		// adding information, against a service that is already failing — so this
+		// path degrades immediately rather than amplifying the load.
 		mockClient := &blockchain.Mock{}
 		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
 		stubWalk(mockClient)
 
+		before := time.Now().Unix()
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
 		require.NoError(t, err)
-		require.Equal(t, wantFloor, got)
+		require.GreaterOrEqual(t, got, before)
+		require.Less(t, got, wantFloor, "a transport failure must not yield a floored time")
+		mockClient.AssertNotCalled(t, "GetBlockHeader", mock.Anything, mock.Anything)
 	})
 
 	t.Run("mis-anchored batched run falls back to the hash-keyed walk", func(t *testing.T) {
@@ -195,7 +202,7 @@ func TestCandidateTimeFallback(t *testing.T) {
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
 		require.NoError(t, err)
 		require.Equal(t, wantFloor, got)
-		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 11)
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 10)
 	})
 
 	t.Run("broken link in the batched run falls back to the hash-keyed walk", func(t *testing.T) {
@@ -214,7 +221,7 @@ func TestCandidateTimeFallback(t *testing.T) {
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
 		require.NoError(t, err)
 		require.Equal(t, wantFloor, got)
-		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 11)
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 10)
 	})
 
 	t.Run("nil header in the batched run falls back to the hash-keyed walk", func(t *testing.T) {
@@ -239,7 +246,7 @@ func TestCandidateTimeFallback(t *testing.T) {
 		// generateEmptyBlockCandidate, the path whose job is to keep serving
 		// work while a block is processed.
 		mockClient := &blockchain.Mock{}
-		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(linkedHeaders(t, 11, baseTime+1000), []*model.BlockHeaderMeta{}, nil)
 		mockClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
 
 		before := time.Now().Unix()
@@ -251,7 +258,7 @@ func TestCandidateTimeFallback(t *testing.T) {
 
 	t.Run("nil header from the walk degrades to the wall clock", func(t *testing.T) {
 		mockClient := &blockchain.Mock{}
-		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(linkedHeaders(t, 11, baseTime+1000), []*model.BlockHeaderMeta{}, nil)
 		mockClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return((*model.BlockHeader)(nil), &model.BlockHeaderMeta{}, nil)
 
 		before := time.Now().Unix()
@@ -307,7 +314,7 @@ func TestCandidateTimeFallback(t *testing.T) {
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
 		require.NoError(t, err)
 		require.Equal(t, wantFloor, got)
-		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 11)
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 10)
 	})
 
 	t.Run("over-long batched run falls back to the walk", func(t *testing.T) {
@@ -388,12 +395,13 @@ func TestCandidateTimeFallback(t *testing.T) {
 	t.Run("walk stops cleanly at the chain start", func(t *testing.T) {
 		// A 3-block chain whose oldest header points at the all-zero genesis
 		// parent: the walk must return the short run, and the median over 3
-		// headers is the middle timestamp.
+		// headers is the middle timestamp. The walk is reached via an unusable
+		// batched result rather than a transport failure, which no longer walks.
 		short := linkedHeadersFromGenesis(t, 3, baseTime)
 		shortTip := short[0]
 
 		mockClient := &blockchain.Mock{}
-		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(linkedHeaders(t, 11, baseTime+1000), []*model.BlockHeaderMeta{}, nil)
 		for _, h := range short {
 			mockClient.On("GetBlockHeader", mock.Anything, h.Hash()).Return(h, &model.BlockHeaderMeta{}, nil)
 		}
@@ -401,6 +409,8 @@ func TestCandidateTimeFallback(t *testing.T) {
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), shortTip)
 		require.NoError(t, err)
 		require.Equal(t, int64(baseTime+1)+1, got)
+		// 2, not 3: the walk is seeded with the parent header the caller holds.
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 2)
 	})
 
 	t.Run("short batched run reaching the chain start is accepted without a walk", func(t *testing.T) {
@@ -460,6 +470,46 @@ func TestCandidateTimeTwoHourCeiling(t *testing.T) {
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, got, before)
 		require.LessOrEqual(t, got, time.Now().Unix())
+	})
+
+	t.Run("the advisory-chain warning fires once per tip, not once per poll", func(t *testing.T) {
+		// Same reasoning as the floor warning: this branch stays engaged for as
+		// long as the clock condition lasts, on a path polled several times a
+		// second, so an unlatched line floods the log during the incident an
+		// operator is trying to read it through.
+		logger := &warnCountingLogger{}
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := &BlockAssembler{
+			logger:           logger,
+			blockchainClient: mockClient,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.Params{GenerateSupported: true},
+			},
+		}
+
+		for i := 0; i < 4; i++ {
+			_, err := assembler.candidateTime(t.Context(), tip)
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, int32(1), logger.warns.Load(), "repeated polls past the ceiling must warn once")
+	})
+
+	t.Run("the floor-lookup failure error fires once per tip, not once per poll", func(t *testing.T) {
+		logger := &warnCountingLogger{}
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+
+		assembler := &BlockAssembler{logger: logger, blockchainClient: mockClient}
+
+		for i := 0; i < 4; i++ {
+			_, err := assembler.candidateTime(t.Context(), tip)
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, int32(1), logger.errs.Load(), "a persistent lookup failure must be reported once per tip")
 	})
 
 	t.Run("nil settings does not fault and fails closed", func(t *testing.T) {
@@ -527,10 +577,15 @@ func TestMinCandidateTime(t *testing.T) {
 type warnCountingLogger struct {
 	ulogger.TestLogger
 	warns atomic.Int32
+	errs  atomic.Int32
 }
 
 func (l *warnCountingLogger) Warnf(format string, args ...interface{}) {
 	l.warns.Add(1)
+}
+
+func (l *warnCountingLogger) Errorf(format string, args ...interface{}) {
+	l.errs.Add(1)
 }
 
 // TestMiningCandidateTimeFlooredAtMedianTimePast drives the public

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -7,7 +7,11 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,10 +19,10 @@ import (
 // current best block, stamped with strictly increasing timestamps starting at
 // baseTime, and returns the new tip header. With timestamps baseTime..baseTime+10
 // the median-time-past seen by a candidate on the tip is baseTime+5.
-func buildFutureChain(t *testing.T, ctx context.Context, server *BlockAssembly, baseTime uint32) *model.BlockHeader {
+func buildFutureChain(t *testing.T, ctx context.Context, blockchainClient blockchain.ClientI, baseTime uint32) *model.BlockHeader {
 	t.Helper()
 
-	prevHeader, _, err := server.blockchainClient.GetBestBlockHeader(ctx)
+	prevHeader, _, err := blockchainClient.GetBestBlockHeader(ctx)
 	require.NoError(t, err)
 
 	coinbaseTx, err := bt.NewTxFromString("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff03510101ffffffff0100f2052a01000000232103656065e6886ca1e947de3471c9e723673ab6ba34724476417fa9fcef8bafa604ac00000000")
@@ -37,7 +41,7 @@ func buildFutureChain(t *testing.T, ctx context.Context, server *BlockAssembly, 
 			Nonce:          i,
 		}
 
-		require.NoError(t, server.blockchainClient.AddBlock(ctx, &model.Block{
+		require.NoError(t, blockchainClient.AddBlock(ctx, &model.Block{
 			Header:           header,
 			CoinbaseTx:       coinbaseTx,
 			TransactionCount: 1,
@@ -48,6 +52,34 @@ func buildFutureChain(t *testing.T, ctx context.Context, server *BlockAssembly, 
 	}
 
 	return prevHeader
+}
+
+// linkedHeaders builds count in-memory headers linked via HashPrevBlock with
+// timestamps baseTime, baseTime+1, ... and returns them newest-first — the
+// order GetBlockHeaders returns them in.
+func linkedHeaders(t *testing.T, count int, baseTime uint32) []*model.BlockHeader {
+	t.Helper()
+
+	nbits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	prev := &chainhash.Hash{1}
+	newestFirst := make([]*model.BlockHeader, count)
+
+	for i := 0; i < count; i++ {
+		header := &model.BlockHeader{
+			Version:        0x20000000,
+			HashPrevBlock:  prev,
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      baseTime + uint32(i),
+			Bits:           *nbits,
+			Nonce:          uint32(i),
+		}
+		newestFirst[count-1-i] = header
+		prev = header.Hash()
+	}
+
+	return newestFirst
 }
 
 func TestCandidateTime(t *testing.T) {
@@ -76,7 +108,7 @@ func TestCandidateTime(t *testing.T) {
 		// local clock — the scenario where the unfloored candidate violated
 		// the median-time rule.
 		baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
-		tipHeader := buildFutureChain(t, t.Context(), server, baseTime)
+		tipHeader := buildFutureChain(t, t.Context(), server.blockchainClient, baseTime)
 
 		got, err := server.blockAssembler.candidateTime(t.Context(), tipHeader)
 		require.NoError(t, err)
@@ -86,17 +118,157 @@ func TestCandidateTime(t *testing.T) {
 	})
 }
 
+// TestCandidateTimeFallback covers the defensive branches: when the batched
+// GetBlockHeaders call errors or returns a run that is not anchored at the
+// requested parent or not correctly linked (a reorg race in the store's
+// batched lookup), candidateTime must recover via the hash-keyed parent-chain
+// walk — and only error when both attempts fail.
+func TestCandidateTimeFallback(t *testing.T) {
+	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+	headers := linkedHeaders(t, 11, baseTime)
+	tip := headers[0]
+	wantFloor := int64(baseTime+5) + 1
+
+	stubWalk := func(mockClient *blockchain.Mock) {
+		for _, h := range headers {
+			mockClient.On("GetBlockHeader", mock.Anything, h.Hash()).Return(h, &model.BlockHeaderMeta{}, nil)
+		}
+		// the walk stops at depth 11 before dereferencing the oldest header's parent
+	}
+
+	newAssembler := func(mockClient *blockchain.Mock) *BlockAssembler {
+		return &BlockAssembler{logger: ulogger.TestLogger{}, blockchainClient: mockClient}
+	}
+
+	t.Run("anchored batched run needs no fallback", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+		mockClient.AssertNotCalled(t, "GetBlockHeader", mock.Anything, mock.Anything)
+	})
+
+	t.Run("batched fetch error falls back to the hash-keyed walk", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+	})
+
+	t.Run("mis-anchored batched run falls back to the hash-keyed walk", func(t *testing.T) {
+		// The run starts at the wrong block — what a reorg between the batched
+		// lookup's height probe and its range scan produces.
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(headers[1:], []*model.BlockHeaderMeta{}, nil)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+	})
+
+	t.Run("broken link in the batched run falls back to the hash-keyed walk", func(t *testing.T) {
+		broken := make([]*model.BlockHeader, len(headers))
+		copy(broken, headers)
+		broken[5], broken[6] = broken[6], broken[5]
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(broken, []*model.BlockHeaderMeta{}, nil)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+	})
+
+	t.Run("nil header in the batched run falls back to the hash-keyed walk", func(t *testing.T) {
+		withNil := make([]*model.BlockHeader, len(headers))
+		copy(withNil, headers)
+		withNil[7] = nil
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(withNil, []*model.BlockHeaderMeta{}, nil)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+	})
+
+	t.Run("errors only when the batched fetch and the walk both fail", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		mockClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+
+		_, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.Error(t, err)
+	})
+
+	t.Run("walk stops cleanly at the chain start", func(t *testing.T) {
+		// A 3-block chain whose oldest header points at the all-zero genesis
+		// parent: the walk must return the short run, and the median over 3
+		// headers is the middle timestamp.
+		short := linkedHeadersFromGenesis(t, 3, baseTime)
+		shortTip := short[0]
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		for _, h := range short {
+			mockClient.On("GetBlockHeader", mock.Anything, h.Hash()).Return(h, &model.BlockHeaderMeta{}, nil)
+		}
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), shortTip)
+		require.NoError(t, err)
+		require.Equal(t, int64(baseTime+1)+1, got)
+	})
+}
+
+// linkedHeadersFromGenesis is linkedHeaders but the oldest header's parent is
+// the all-zero hash, marking the start of the chain for walkParentChain.
+func linkedHeadersFromGenesis(t *testing.T, count int, baseTime uint32) []*model.BlockHeader {
+	t.Helper()
+
+	nbits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	prev := &chainhash.Hash{}
+	newestFirst := make([]*model.BlockHeader, count)
+
+	for i := 0; i < count; i++ {
+		header := &model.BlockHeader{
+			Version:        0x20000000,
+			HashPrevBlock:  prev,
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      baseTime + uint32(i),
+			Bits:           *nbits,
+			Nonce:          uint32(i),
+		}
+		newestFirst[count-1-i] = header
+		prev = header.Hash()
+	}
+
+	return newestFirst
+}
+
 // TestMiningCandidateTimeFlooredAtMedianTimePast drives the public
-// GetMiningCandidate path: with the best block on a future-stamped chain, the
-// candidate's Time must come back strictly greater than the median-time-past
-// of the previous 11 blocks. Before the floor it came back at the (lagging)
-// wall clock, producing a block the node's own validation rejects.
+// GetMiningCandidate entry point with the best block on a future-stamped
+// chain: the candidate's Time must come back strictly greater than the
+// median-time-past of the previous 11 blocks. Before the floor it came back
+// at the (lagging) wall clock, producing a block every peer rejects. This
+// exercises whichever internal branch the assembler's state selects (busy or
+// empty-block); the subtree-populated main path is covered by
+// TestMiningCandidateMainPathTimeFloored below.
 func TestMiningCandidateTimeFlooredAtMedianTimePast(t *testing.T) {
 	server, _ := setupServer(t)
 	require.NoError(t, server.blockAssembler.Start(t.Context()))
 
 	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
-	tipHeader := buildFutureChain(t, t.Context(), server, baseTime)
+	tipHeader := buildFutureChain(t, t.Context(), server.blockchainClient, baseTime)
 	server.blockAssembler.setBestBlockHeader(tipHeader, 11)
 
 	candidate, _, err := server.blockAssembler.GetMiningCandidate(t.Context())
@@ -108,6 +280,47 @@ func TestMiningCandidateTimeFlooredAtMedianTimePast(t *testing.T) {
 	require.Equal(t, medianTimePast+1, candidate.Time)
 }
 
+// TestMiningCandidateMainPathTimeFloored pins the floor on the main
+// (subtree-populated) candidate path: the assembler holds transactions for
+// the future-stamped tip, so GetMiningCandidate must return a candidate with
+// those transactions AND the floored timestamp.
+func TestMiningCandidateMainPathTimeFloored(t *testing.T) {
+	initPrometheusMetrics()
+
+	testItems := setupBlockAssemblyTest(t)
+	ba := testItems.blockAssembler
+	_, _, _ = setupBlockchainClient(t, testItems)
+
+	ctx := t.Context()
+
+	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+	tipHeader := buildFutureChain(t, ctx, ba.blockchainClient, baseTime)
+
+	ba.setBestBlockHeader(tipHeader, 11)
+	ba.subtreeProcessor.InitCurrentBlockHeader(tipHeader)
+
+	for i := 0; i < 5; i++ {
+		txHash := chainhash.HashH([]byte{byte(i), 0xBB})
+		ba.AddTxBatch(
+			[]subtreepkg.Node{{Hash: txHash, Fee: uint64(100), SizeInBytes: 250}},
+			[]*subtreepkg.TxInpoints{{}},
+		)
+	}
+
+	medianTimePast := baseTime + 5
+
+	var candidate *model.MiningCandidate
+
+	require.Eventually(t, func() bool {
+		var err error
+		candidate, _, err = ba.GetMiningCandidate(ctx)
+
+		return err == nil && candidate != nil && candidate.NumTxs > 0
+	}, 5*time.Second, 50*time.Millisecond, "expected a subtree-populated candidate for the future-stamped tip")
+
+	require.Equal(t, medianTimePast+1, candidate.Time, "main-path candidate time must be floored at median-time-past+1")
+}
+
 // TestEmptyBlockCandidateTimeFlooredAtMedianTimePast covers the empty-block
 // path directly, which previously had the same unfloored wall-clock gap.
 func TestEmptyBlockCandidateTimeFlooredAtMedianTimePast(t *testing.T) {
@@ -115,7 +328,7 @@ func TestEmptyBlockCandidateTimeFlooredAtMedianTimePast(t *testing.T) {
 	require.NoError(t, server.blockAssembler.Start(t.Context()))
 
 	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
-	tipHeader := buildFutureChain(t, t.Context(), server, baseTime)
+	tipHeader := buildFutureChain(t, t.Context(), server.blockchainClient, baseTime)
 
 	candidate, _, err := server.blockAssembler.generateEmptyBlockCandidate(t.Context(), tipHeader, 11)
 	require.NoError(t, err)

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -1,0 +1,126 @@
+package blockassembly
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/stretchr/testify/require"
+)
+
+// buildFutureChain stores medianTimeBlocks (11) linked blocks on top of the
+// current best block, stamped with strictly increasing timestamps starting at
+// baseTime, and returns the new tip header. With timestamps baseTime..baseTime+10
+// the median-time-past seen by a candidate on the tip is baseTime+5.
+func buildFutureChain(t *testing.T, ctx context.Context, server *BlockAssembly, baseTime uint32) *model.BlockHeader {
+	t.Helper()
+
+	prevHeader, _, err := server.blockchainClient.GetBestBlockHeader(ctx)
+	require.NoError(t, err)
+
+	coinbaseTx, err := bt.NewTxFromString("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff03510101ffffffff0100f2052a01000000232103656065e6886ca1e947de3471c9e723673ab6ba34724476417fa9fcef8bafa604ac00000000")
+	require.NoError(t, err)
+
+	nbits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	for i := uint32(0); i < 11; i++ {
+		header := &model.BlockHeader{
+			Version:        0x20000000,
+			HashPrevBlock:  prevHeader.Hash(),
+			HashMerkleRoot: &chainhash.Hash{},
+			Timestamp:      baseTime + i,
+			Bits:           *nbits,
+			Nonce:          i,
+		}
+
+		require.NoError(t, server.blockchainClient.AddBlock(ctx, &model.Block{
+			Header:           header,
+			CoinbaseTx:       coinbaseTx,
+			TransactionCount: 1,
+			Subtrees:         []*chainhash.Hash{},
+		}, ""))
+
+		prevHeader = header
+	}
+
+	return prevHeader
+}
+
+func TestCandidateTime(t *testing.T) {
+	t.Run("tracks the wall clock when the median-time-past is in the past", func(t *testing.T) {
+		server, _ := setupServer(t)
+		require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+		bestHeader, _, err := server.blockchainClient.GetBestBlockHeader(t.Context())
+		require.NoError(t, err)
+
+		before := time.Now().Unix()
+		got, err := server.blockAssembler.candidateTime(t.Context(), bestHeader)
+		after := time.Now().Unix()
+
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, got, before)
+		require.LessOrEqual(t, got, after)
+	})
+
+	t.Run("floors at median-time-past+1 when the median is at or above the wall clock", func(t *testing.T) {
+		server, _ := setupServer(t)
+		require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+		// Stamp the last 11 blocks ~100 minutes into the future (within the
+		// 2-hour future window peers accept), dragging the median above the
+		// local clock — the scenario where the unfloored candidate violated
+		// the median-time rule.
+		baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+		tipHeader := buildFutureChain(t, t.Context(), server, baseTime)
+
+		got, err := server.blockAssembler.candidateTime(t.Context(), tipHeader)
+		require.NoError(t, err)
+
+		medianTimePast := int64(baseTime + 5)
+		require.Equal(t, medianTimePast+1, got)
+	})
+}
+
+// TestMiningCandidateTimeFlooredAtMedianTimePast drives the public
+// GetMiningCandidate path: with the best block on a future-stamped chain, the
+// candidate's Time must come back strictly greater than the median-time-past
+// of the previous 11 blocks. Before the floor it came back at the (lagging)
+// wall clock, producing a block the node's own validation rejects.
+func TestMiningCandidateTimeFlooredAtMedianTimePast(t *testing.T) {
+	server, _ := setupServer(t)
+	require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+	tipHeader := buildFutureChain(t, t.Context(), server, baseTime)
+	server.blockAssembler.setBestBlockHeader(tipHeader, 11)
+
+	candidate, _, err := server.blockAssembler.GetMiningCandidate(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, candidate)
+
+	medianTimePast := baseTime + 5
+	require.Greater(t, candidate.Time, medianTimePast, "candidate time must be strictly greater than the median-time-past of the previous 11 blocks")
+	require.Equal(t, medianTimePast+1, candidate.Time)
+}
+
+// TestEmptyBlockCandidateTimeFlooredAtMedianTimePast covers the empty-block
+// path directly, which previously had the same unfloored wall-clock gap.
+func TestEmptyBlockCandidateTimeFlooredAtMedianTimePast(t *testing.T) {
+	server, _ := setupServer(t)
+	require.NoError(t, server.blockAssembler.Start(t.Context()))
+
+	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+	tipHeader := buildFutureChain(t, t.Context(), server, baseTime)
+
+	candidate, _, err := server.blockAssembler.generateEmptyBlockCandidate(t.Context(), tipHeader, 11)
+	require.NoError(t, err)
+	require.NotNil(t, candidate)
+
+	medianTimePast := baseTime + 5
+	require.Equal(t, medianTimePast+1, candidate.Time)
+}

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -2,6 +2,7 @@ package blockassembly
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -221,6 +222,31 @@ func TestCandidateTimeFallback(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("floor warning fires once per tip, not once per poll", func(t *testing.T) {
+		logger := &warnCountingLogger{}
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := &BlockAssembler{logger: logger, blockchainClient: mockClient}
+
+		for i := 0; i < 3; i++ {
+			got, err := assembler.candidateTime(t.Context(), tip)
+			require.NoError(t, err)
+			require.Equal(t, wantFloor, got)
+		}
+
+		require.Equal(t, int32(1), logger.warns.Load(), "repeated polls on the same tip must warn once")
+
+		// A new tip is a new condition: it must warn again.
+		nextHeaders := linkedHeaders(t, 11, baseTime+100)
+		nextTip := nextHeaders[0]
+		mockClient.On("GetBlockHeaders", mock.Anything, nextTip.Hash(), mock.Anything).Return(nextHeaders, []*model.BlockHeaderMeta{}, nil)
+
+		_, err := assembler.candidateTime(t.Context(), nextTip)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), logger.warns.Load(), "a different tip must warn again")
+	})
+
 	t.Run("walk stops cleanly at the chain start", func(t *testing.T) {
 		// A 3-block chain whose oldest header points at the all-zero genesis
 		// parent: the walk must return the short run, and the median over 3
@@ -238,6 +264,17 @@ func TestCandidateTimeFallback(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(baseTime+1)+1, got)
 	})
+}
+
+// warnCountingLogger counts Warnf calls so tests can pin the once-per-tip
+// warning latch in candidateTime; everything else is the no-op TestLogger.
+type warnCountingLogger struct {
+	ulogger.TestLogger
+	warns atomic.Int32
+}
+
+func (l *warnCountingLogger) Warnf(format string, args ...interface{}) {
+	l.warns.Add(1)
 }
 
 // linkedHeadersFromGenesis is linkedHeaders but the oldest header's parent is

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -639,6 +639,32 @@ func TestCandidateTimeTwoHourCeiling(t *testing.T) {
 		require.Equal(t, int32(1), logger.errs.Load(), "the operator must be told once, not on every poll")
 	})
 
+	t.Run("names the future-stamped parent chain as well as the local clock", func(t *testing.T) {
+		// A floor above now+2h is equally consistent with a parent chain stamped
+		// into the future by a misconfigured or hostile upstream miner as with a
+		// slow local clock. This is the one line an operator reads when block
+		// production has gone to zero, so naming only the clock sends them to
+		// chase NTP when the cause may be upstream.
+		logger := &warnCountingLogger{}
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := &BlockAssembler{
+			logger:           logger,
+			blockchainClient: mockClient,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.Params{GenerateSupported: false},
+			},
+		}
+
+		_, err := assembler.candidateTime(t.Context(), tip)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "local clock")
+		require.Contains(t, err.Error(), "future-stamped")
+		require.Equal(t, 1, logger.countMatching("local clock"))
+		require.Equal(t, 1, logger.countMatching("future-stamped"))
+	})
+
 	t.Run("serves the wall clock on chains where the median rule is advisory", func(t *testing.T) {
 		// GenerateSupported downgrades the median-time violation to a warning in
 		// CheckHeaderContextual, so an unfloored candidate is still valid there

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -433,6 +433,66 @@ func TestCandidateTimeFallback(t *testing.T) {
 		require.Equal(t, 1, occupied, "one parent must occupy at most one slot, or it evicts the other candidate path's entry")
 	})
 
+	t.Run("a caller joining an in-flight fetch waits on its own context, not the leader's", func(t *testing.T) {
+		// Single-flighting makes one caller's fetch serve every other caller on
+		// that parent, which is the point — but it must not make them hostage to
+		// it. Miners poll several times a second with their own gRPC deadlines,
+		// so a follower whose own deadline fires has to give up and degrade to
+		// the wall clock for that poll rather than block until the leader's fetch
+		// returns. Nothing is memoized on that path, so its next poll re-flights.
+		var enterOnce sync.Once
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).
+			Return(headers, []*model.BlockHeaderMeta{}, nil).
+			Run(func(mock.Arguments) {
+				enterOnce.Do(func() { close(entered) })
+				<-release
+			})
+
+		assembler := newAssembler(mockClient)
+
+		leaderDone := make(chan int64, 1)
+
+		go func() {
+			got, _ := assembler.candidateTime(context.WithoutCancel(t.Context()), tip)
+			leaderDone <- got
+		}()
+
+		<-entered
+
+		// The leader is inside the fetch, so this caller joins its flight rather
+		// than starting one of its own.
+		followerCtx, cancelFollower := context.WithCancel(t.Context())
+		followerDone := make(chan int64, 1)
+		followerErr := make(chan error, 1)
+
+		go func() {
+			got, err := assembler.candidateTime(followerCtx, tip)
+			followerErr <- err
+			followerDone <- got
+		}()
+
+		cancelFollower()
+
+		select {
+		case got := <-followerDone:
+			require.NoError(t, <-followerErr)
+			require.Less(t, got, wantFloor, "a caller that gave up must degrade to the wall clock, not report a floor it never fetched")
+		case <-time.After(5 * time.Second):
+			close(release)
+			t.Fatal("a follower blocked past its own cancelled context waiting on the leader's fetch")
+		}
+
+		close(release)
+
+		require.Equal(t, wantFloor, <-leaderDone, "the leader's own fetch must still complete and floor its candidate")
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeaders", 1)
+	})
+
 	t.Run("both candidate paths' parents stay memoized together", func(t *testing.T) {
 		// The busy branch keys on the blockchain service's tip while the main
 		// path keys on the subtree processor's precomputed parent, so a

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -161,21 +161,32 @@ func TestCandidateTimeFallback(t *testing.T) {
 	})
 
 	t.Run("mis-anchored batched run falls back to the hash-keyed walk", func(t *testing.T) {
-		// The run starts at the wrong block — what a reorg between the batched
-		// lookup's height probe and its range scan produces.
+		// The run is a correctly-linked chain anchored at the WRONG block with
+		// different timestamps — what a reorg between the batched lookup's
+		// height probe and its range scan produces (the winning fork's blocks
+		// at the same heights). Its median differs from the true chain's, so
+		// this test fails if the anchor guard is ever weakened: the floor
+		// would come out of the wrong fork's timestamps.
+		wrongFork := linkedHeaders(t, 11, baseTime+1000)
+
 		mockClient := &blockchain.Mock{}
-		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(headers[1:], []*model.BlockHeaderMeta{}, nil)
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(wrongFork, []*model.BlockHeaderMeta{}, nil)
 		stubWalk(mockClient)
 
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
 		require.NoError(t, err)
 		require.Equal(t, wantFloor, got)
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 11)
 	})
 
 	t.Run("broken link in the batched run falls back to the hash-keyed walk", func(t *testing.T) {
+		// Replace one mid-run header with a differently-stamped stray so the
+		// run's median differs from the true chain's — swapping two elements
+		// would leave the (sorted) median identical and the link guard
+		// unpinned under mutation.
 		broken := make([]*model.BlockHeader, len(headers))
 		copy(broken, headers)
-		broken[5], broken[6] = broken[6], broken[5]
+		broken[6] = linkedHeaders(t, 1, baseTime+1000)[0]
 
 		mockClient := &blockchain.Mock{}
 		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(broken, []*model.BlockHeaderMeta{}, nil)
@@ -184,6 +195,7 @@ func TestCandidateTimeFallback(t *testing.T) {
 		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
 		require.NoError(t, err)
 		require.Equal(t, wantFloor, got)
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 11)
 	})
 
 	t.Run("nil header in the batched run falls back to the hash-keyed walk", func(t *testing.T) {

--- a/services/blockassembly/candidate_time_test.go
+++ b/services/blockassembly/candidate_time_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -61,10 +63,26 @@ func buildFutureChain(t *testing.T, ctx context.Context, blockchainClient blockc
 func linkedHeaders(t *testing.T, count int, baseTime uint32) []*model.BlockHeader {
 	t.Helper()
 
+	// A non-zero seed so the oldest header does not look like the chain start.
+	return linkedHeadersFrom(t, count, baseTime, &chainhash.Hash{1})
+}
+
+// linkedHeadersFromGenesis is linkedHeaders but the oldest header's parent is
+// the all-zero hash, marking the start of the chain.
+func linkedHeadersFromGenesis(t *testing.T, count int, baseTime uint32) []*model.BlockHeader {
+	t.Helper()
+
+	return linkedHeadersFrom(t, count, baseTime, &chainhash.Hash{})
+}
+
+// linkedHeadersFrom builds the run, seeding the oldest header's HashPrevBlock
+// with prev.
+func linkedHeadersFrom(t *testing.T, count int, baseTime uint32, prev *chainhash.Hash) []*model.BlockHeader {
+	t.Helper()
+
 	nbits, err := model.NewNBitFromString("207fffff")
 	require.NoError(t, err)
 
-	prev := &chainhash.Hash{1}
 	newestFirst := make([]*model.BlockHeader, count)
 
 	for i := 0; i < count; i++ {
@@ -213,13 +231,133 @@ func TestCandidateTimeFallback(t *testing.T) {
 		require.Equal(t, wantFloor, got)
 	})
 
-	t.Run("errors only when the batched fetch and the walk both fail", func(t *testing.T) {
+	t.Run("degrades to the wall clock when the batched fetch and the walk both fail", func(t *testing.T) {
+		// A blockchain hiccup must not stop mining. The floor only changes the
+		// outcome when the wall clock is at or below median-time-past, so an
+		// unfloored candidate is no worse than the pre-floor behaviour, whereas
+		// failing the poll takes mining down outright — including on
+		// generateEmptyBlockCandidate, the path whose job is to keep serving
+		// work while a block is processed.
 		mockClient := &blockchain.Mock{}
 		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
 		mockClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
 
-		_, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		before := time.Now().Unix()
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, got, before)
+		require.LessOrEqual(t, got, time.Now().Unix())
+	})
+
+	t.Run("nil header from the walk degrades to the wall clock", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, context.DeadlineExceeded)
+		mockClient.On("GetBlockHeader", mock.Anything, mock.Anything).Return((*model.BlockHeader)(nil), &model.BlockHeaderMeta{}, nil)
+
+		before := time.Now().Unix()
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, got, before)
+		require.Less(t, got, wantFloor, "a nil header must not yield a floored time")
+	})
+
+	t.Run("nil parent header is rejected", func(t *testing.T) {
+		_, err := newAssembler(&blockchain.Mock{}).candidateTime(t.Context(), nil)
 		require.Error(t, err)
+	})
+
+	t.Run("empty batched run falls back to the hash-keyed walk", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return([]*model.BlockHeader{}, []*model.BlockHeaderMeta{}, nil)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+	})
+
+	t.Run("nil head in the batched run falls back to the hash-keyed walk", func(t *testing.T) {
+		// The anchor guard, not the loop guard: a nil at index 0 is the shape
+		// that would otherwise reach the median calculation.
+		withNilHead := make([]*model.BlockHeader, len(headers))
+		copy(withNilHead, headers)
+		withNilHead[0] = nil
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(withNilHead, []*model.BlockHeaderMeta{}, nil)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+	})
+
+	t.Run("short batched run that does not reach the chain start falls back to the walk", func(t *testing.T) {
+		// Truncated at its OLDEST end, so it is still anchored at the parent and
+		// still correctly linked — invisible to both of those guards. Its median
+		// is taken over a narrower window and comes out higher than the true
+		// median, so this test fails if the run-length guard is removed.
+		truncated := headers[:4]
+		require.NotEqual(t, int64(truncated[len(truncated)/2].Timestamp)+1, wantFloor, "fixture must make the short-run median differ from the true one")
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(truncated, []*model.BlockHeaderMeta{}, nil)
+		stubWalk(mockClient)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.Equal(t, wantFloor, got)
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeader", 11)
+	})
+
+	t.Run("over-long batched run falls back to the walk", func(t *testing.T) {
+		tooMany := linkedHeaders(t, 12, baseTime)
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, mock.Anything, mock.Anything).Return(tooMany, []*model.BlockHeaderMeta{}, nil)
+		for _, h := range tooMany {
+			mockClient.On("GetBlockHeader", mock.Anything, h.Hash()).Return(h, &model.BlockHeaderMeta{}, nil)
+		}
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), tooMany[0])
+		require.NoError(t, err)
+		require.Equal(t, int64(baseTime+6)+1, got, "the walk's 11 headers end at the over-long run's tip")
+	})
+
+	t.Run("the median is fetched once per tip, not once per poll", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := newAssembler(mockClient)
+		for i := 0; i < 5; i++ {
+			got, err := assembler.candidateTime(t.Context(), tip)
+			require.NoError(t, err)
+			require.Equal(t, wantFloor, got)
+		}
+
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeaders", 1)
+	})
+
+	t.Run("both candidate paths' parents stay memoized together", func(t *testing.T) {
+		// The busy branch keys on the blockchain service's tip while the main
+		// path keys on the subtree processor's precomputed parent, so a
+		// single-slot memo would refetch on every alternation.
+		otherHeaders := linkedHeaders(t, 11, baseTime+100)
+		other := otherHeaders[0]
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+		mockClient.On("GetBlockHeaders", mock.Anything, other.Hash(), mock.Anything).Return(otherHeaders, []*model.BlockHeaderMeta{}, nil)
+
+		assembler := newAssembler(mockClient)
+		for i := 0; i < 4; i++ {
+			_, err := assembler.candidateTime(t.Context(), tip)
+			require.NoError(t, err)
+			_, err = assembler.candidateTime(t.Context(), other)
+			require.NoError(t, err)
+		}
+
+		mockClient.AssertNumberOfCalls(t, "GetBlockHeaders", 2)
 	})
 
 	t.Run("floor warning fires once per tip, not once per poll", func(t *testing.T) {
@@ -264,6 +402,124 @@ func TestCandidateTimeFallback(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(baseTime+1)+1, got)
 	})
+
+	t.Run("short batched run reaching the chain start is accepted without a walk", func(t *testing.T) {
+		short := linkedHeadersFromGenesis(t, 3, baseTime)
+		shortTip := short[0]
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, shortTip.Hash(), mock.Anything).Return(short, []*model.BlockHeaderMeta{}, nil)
+
+		got, err := newAssembler(mockClient).candidateTime(t.Context(), shortTip)
+		require.NoError(t, err)
+		require.Equal(t, int64(baseTime+1)+1, got)
+		mockClient.AssertNotCalled(t, "GetBlockHeader", mock.Anything, mock.Anything)
+	})
+}
+
+// TestCandidateTimeTwoHourCeiling pins the upper bound. The median-time rule is
+// a floor and the two-hours-in-the-future rule is a ceiling; when a lagging
+// local clock puts median-time-past+1 above now+2h no timestamp satisfies both.
+// model.Block CheckHeaderContextual enforces the ceiling with no currentChain,
+// so submitMiningSolution's block.Valid call does catch it — and treats the
+// failure as a subtree-processor fault, deleting the job and resetting block
+// assembly. Flooring regardless would therefore turn every solution found into
+// a full assembler reset, so candidateTime must fail the poll instead.
+func TestCandidateTimeTwoHourCeiling(t *testing.T) {
+	// Stamped five hours ahead: the floor lands ~3h above the ceiling.
+	baseTime := uint32(time.Now().Add(5 * time.Hour).Unix())
+	headers := linkedHeaders(t, 11, baseTime)
+	tip := headers[0]
+
+	newAssembler := func(generateSupported bool) *BlockAssembler {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		return &BlockAssembler{
+			logger:           ulogger.TestLogger{},
+			blockchainClient: mockClient,
+			settings: &settings.Settings{
+				ChainCfgParams: &chaincfg.Params{GenerateSupported: generateSupported},
+			},
+		}
+	}
+
+	t.Run("fails the poll rather than emitting an unmineable candidate", func(t *testing.T) {
+		_, err := newAssembler(false).candidateTime(t.Context(), tip)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "two-hour future bound")
+	})
+
+	t.Run("serves the wall clock on chains where the median rule is advisory", func(t *testing.T) {
+		// GenerateSupported downgrades the median-time violation to a warning in
+		// CheckHeaderContextual, so an unfloored candidate is still valid there
+		// and rapid generation must keep working.
+		before := time.Now().Unix()
+
+		got, err := newAssembler(true).candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, got, before)
+		require.LessOrEqual(t, got, time.Now().Unix())
+	})
+
+	t.Run("nil settings does not fault and fails closed", func(t *testing.T) {
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+		_, err := (&BlockAssembler{logger: ulogger.TestLogger{}, blockchainClient: mockClient}).candidateTime(t.Context(), tip)
+		require.Error(t, err)
+	})
+
+	t.Run("a floor just inside the ceiling still applies", func(t *testing.T) {
+		// baseTime+5 is the median, so the floor is baseTime+6. Placing the
+		// median an hour ahead keeps the floor well below now+2h.
+		insideBase := uint32(time.Now().Add(time.Hour).Unix())
+		inside := linkedHeaders(t, 11, insideBase)
+
+		mockClient := &blockchain.Mock{}
+		mockClient.On("GetBlockHeaders", mock.Anything, inside[0].Hash(), mock.Anything).Return(inside, []*model.BlockHeaderMeta{}, nil)
+
+		got, err := (&BlockAssembler{logger: ulogger.TestLogger{}, blockchainClient: mockClient}).candidateTime(t.Context(), inside[0])
+		require.NoError(t, err)
+		require.Equal(t, int64(insideBase+5)+1, got)
+	})
+}
+
+// TestMinCandidateTime covers the memo read the submit path uses to reject a
+// miner-supplied nTime below the consensus floor.
+func TestMinCandidateTime(t *testing.T) {
+	baseTime := uint32(time.Now().Add(100 * time.Minute).Unix())
+	headers := linkedHeaders(t, 11, baseTime)
+	tip := headers[0]
+
+	mockClient := &blockchain.Mock{}
+	mockClient.On("GetBlockHeaders", mock.Anything, tip.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+	assembler := &BlockAssembler{logger: ulogger.TestLogger{}, blockchainClient: mockClient}
+
+	t.Run("unknown before a candidate is built", func(t *testing.T) {
+		_, ok := assembler.MinCandidateTime(tip.Hash())
+		require.False(t, ok)
+	})
+
+	t.Run("nil hash is unknown", func(t *testing.T) {
+		_, ok := assembler.MinCandidateTime(nil)
+		require.False(t, ok)
+	})
+
+	t.Run("returns the floor the candidate was built from", func(t *testing.T) {
+		_, err := assembler.candidateTime(t.Context(), tip)
+		require.NoError(t, err)
+
+		minTime, ok := assembler.MinCandidateTime(tip.Hash())
+		require.True(t, ok)
+		require.Equal(t, int64(baseTime+5)+1, minTime)
+	})
+
+	t.Run("unknown for a parent no candidate was built on", func(t *testing.T) {
+		_, ok := assembler.MinCandidateTime(linkedHeaders(t, 11, baseTime+500)[0].Hash())
+		require.False(t, ok)
+	})
 }
 
 // warnCountingLogger counts Warnf calls so tests can pin the once-per-tip
@@ -275,33 +531,6 @@ type warnCountingLogger struct {
 
 func (l *warnCountingLogger) Warnf(format string, args ...interface{}) {
 	l.warns.Add(1)
-}
-
-// linkedHeadersFromGenesis is linkedHeaders but the oldest header's parent is
-// the all-zero hash, marking the start of the chain for walkParentChain.
-func linkedHeadersFromGenesis(t *testing.T, count int, baseTime uint32) []*model.BlockHeader {
-	t.Helper()
-
-	nbits, err := model.NewNBitFromString("207fffff")
-	require.NoError(t, err)
-
-	prev := &chainhash.Hash{}
-	newestFirst := make([]*model.BlockHeader, count)
-
-	for i := 0; i < count; i++ {
-		header := &model.BlockHeader{
-			Version:        0x20000000,
-			HashPrevBlock:  prev,
-			HashMerkleRoot: &chainhash.Hash{},
-			Timestamp:      baseTime + uint32(i),
-			Bits:           *nbits,
-			Nonce:          uint32(i),
-		}
-		newestFirst[count-1-i] = header
-		prev = header.Hash()
-	}
-
-	return newestFirst
 }
 
 // TestMiningCandidateTimeFlooredAtMedianTimePast drives the public

--- a/services/blockassembly/empty_block_version_test.go
+++ b/services/blockassembly/empty_block_version_test.go
@@ -19,7 +19,7 @@ func TestGenerateEmptyBlockCandidateUsesSafeVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, bestHeader)
 
-	candidate, _, err := server.blockAssembler.generateEmptyBlockCandidate(bestHeader, meta.Height)
+	candidate, _, err := server.blockAssembler.generateEmptyBlockCandidate(t.Context(), bestHeader, meta.Height)
 	require.NoError(t, err)
 	require.NotNil(t, candidate)
 	require.Equal(t, uint32(0x20000000), candidate.Version)

--- a/services/blockassembly/metrics.go
+++ b/services/blockassembly/metrics.go
@@ -37,6 +37,7 @@ var (
 
 	// Additional metrics for block assembler operations
 	prometheusBlockAssemblerGetMiningCandidate          prometheus.Counter
+	prometheusBlockAssemblerCandidateTimeClockSkew      prometheus.Counter
 	prometheusBlockAssemblerSubtreeCreated              prometheus.Counter
 	prometheusBlockAssemblerTransactions                prometheus.Gauge
 	prometheusBlockAssemblerQueuedTransactions          prometheus.Gauge
@@ -161,6 +162,15 @@ func _initPrometheusMetrics() {
 			Subsystem: "blockassembly",
 			Name:      "block_assembler_get_mining_candidate",
 			Help:      "Number of calls to GetMiningCandidate in the block assembler",
+		},
+	)
+
+	prometheusBlockAssemblerCandidateTimeClockSkew = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "blockassembly",
+			Name:      "block_assembler_candidate_time_clock_skew",
+			Help:      "Mining-candidate polls refused because the parent's median-time-past floor is above the two-hour future bound, so no valid block timestamp exists; a non-zero rate means the local clock is far behind the network and block production has stopped",
 		},
 	)
 

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockassembly/blockassembly_api"
 	"github.com/bsv-blockchain/teranode/services/blockassembly/subtreeprocessor"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/testutil"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -481,8 +484,16 @@ func TestSubmitMiningSolution_NTimeFloor(t *testing.T) {
 		s, common := newServerForChanTest(t)
 
 		// The zero-value assembler newServerForChanTest wires has no settings,
-		// which the coinbase rebuild below the guard dereferences.
-		s.blockAssembler.settings = common.Settings
+		// which the coinbase rebuild below the guard dereferences. The test
+		// harness runs regtest, where GenerateSupported downgrades the
+		// median-time rule to a warning and the guard therefore stands down —
+		// so pin the chain params to the enforcing case explicitly. The advisory
+		// case is covered by TestSubmitMiningSolution_NTimeFloorAdvisoryChain.
+		tSettings := *common.Settings
+		params := *common.Settings.ChainCfgParams
+		params.GenerateSupported = false
+		tSettings.ChainCfgParams = &params
+		s.blockAssembler.settings = &tSettings
 
 		// A best block whose parent differs from the job's, so the candidate is
 		// not stale and execution reaches the nTime guard.
@@ -554,6 +565,77 @@ func TestSubmitMiningSolution_NTimeFloor(t *testing.T) {
 			require.NotContains(t, err.Error(), "median-time-past floor")
 		}
 	})
+}
+
+// TestSubmitMiningSolution_NTimeFloorAdvisoryChain pins the seam between the two
+// mechanisms: on chains where GenerateSupported downgrades the median-time rule
+// to a warning, candidateTime's two-hour-ceiling branch deliberately serves an
+// unfloored wall-clock candidate — while the memo entry it read still carries a
+// minTime above now+2h. mining.Mine copies the candidate's own time into the
+// solution unconditionally, so a submit guard that enforced that memoized floor
+// would refuse every solution against a candidate this package chose to hand
+// out, turning the carve-out that keeps rapid generation working into the thing
+// that stops it. This drives the real carve-out rather than seeding the memo by
+// hand, which is why the two tests either side of it did not catch the pair.
+func TestSubmitMiningSolution_NTimeFloorAdvisoryChain(t *testing.T) {
+	s, common := newServerForChanTest(t)
+
+	tSettings := *common.Settings
+	params := *common.Settings.ChainCfgParams
+	params.GenerateSupported = true
+	tSettings.ChainCfgParams = &params
+
+	// Stamped five hours ahead so median+1 lands above now+2h and candidateTime
+	// takes the ceiling branch.
+	baseTime := uint32(time.Now().Add(5 * time.Hour).Unix())
+	headers := linkedHeaders(t, 11, baseTime)
+	parentHeader := headers[0]
+
+	mockClient := &blockchain.Mock{}
+	mockClient.On("GetBlockHeaders", mock.Anything, parentHeader.Hash(), mock.Anything).Return(headers, []*model.BlockHeaderMeta{}, nil)
+
+	s.blockAssembler.settings = &tSettings
+	s.blockAssembler.logger = ulogger.TestLogger{}
+	s.blockAssembler.blockchainClient = mockClient
+	s.blockAssembler.bestBlock.Store(&BestBlockInfo{
+		Header: &model.BlockHeader{HashPrevBlock: &chainhash.Hash{7}},
+		Height: 100,
+	})
+
+	// Go through the real producer: it must serve the wall clock, not the floor.
+	candidateTime, err := s.blockAssembler.candidateTime(t.Context(), parentHeader)
+	require.NoError(t, err)
+	require.Less(t, candidateTime, int64(baseTime+5)+1, "the carve-out must serve the unfloored wall clock")
+
+	// And the submit path must have nothing to enforce for that parent.
+	_, ok := s.blockAssembler.MinCandidateTime(parentHeader.Hash())
+	require.False(t, ok, "an advisory-median chain must expose no floor to the submit path")
+
+	idBytes := make([]byte, 32)
+	idBytes[0] = 0x01
+
+	id, err := chainhash.NewHash(idBytes)
+	require.NoError(t, err)
+
+	parentHash := parentHeader.Hash()
+	s.jobStore.Set(*id, &subtreeprocessor.Job{
+		ID: id,
+		MiningCandidate: &model.MiningCandidate{
+			Id:           idBytes,
+			PreviousHash: parentHash[:],
+			Time:         uint32(candidateTime),
+		},
+	}, time.Minute)
+
+	// mining.Mine forwards candidate.Time as req.Time, so submit the same value.
+	nTime := uint32(candidateTime)
+	_, err = s.submitMiningSolution(context.Background(), &BlockSubmissionRequest{
+		SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{Id: idBytes, Time: &nTime},
+	})
+
+	if err != nil {
+		require.NotContains(t, err.Error(), "median-time-past floor", "the guard must not refuse the candidate the carve-out served")
+	}
 }
 
 // TestWaitForBestBlockHeaderUpdate_ToleratesNilCurrentBlock verifies that the polling

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -463,6 +463,25 @@ func TestSubmitMiningSolution_NoCurrentBlock(t *testing.T) {
 	require.Contains(t, err.Error(), "no current best block")
 }
 
+// requirePastFloorGuard asserts that a submission got past the median-time-past
+// guard, and does so durably.
+//
+// The accept direction cannot assert success: these fixtures carry no real
+// subtrees or nBits, so the submission always dies further down. Asserting only
+// "the error does not mention the floor" would pass just as happily if a future
+// fixture change made it die *above* the guard, or stop erroring at all — the
+// assertion would be vacuous and nothing would say so. Pinning the specific
+// downstream failure keeps it honest: if the fixture stops dying exactly there,
+// this fails loudly and whoever changed it re-checks that the guard is still on
+// the path being exercised.
+func requirePastFloorGuard(t *testing.T, err error) {
+	t.Helper()
+
+	require.Error(t, err, "fixture is expected to fail below the guard; if it now succeeds, the guard may no longer be on this path")
+	require.NotContains(t, err.Error(), "median-time-past floor", "the floor guard must not be what stopped this submission")
+	require.Contains(t, err.Error(), "failed to convert bits", "expected the known downstream failure; a different one means the path above the guard changed and this assertion may no longer prove anything")
+}
+
 // TestSubmitMiningSolution_NTimeFloor pins the submit-path guard against a
 // miner-supplied timestamp below the parent chain's median-time-past. The
 // block.Valid call further down passes no currentChain, so it skips the
@@ -548,10 +567,7 @@ func TestSubmitMiningSolution_NTimeFloor(t *testing.T) {
 		s, idBytes := setup(t)
 		at := uint32(floor)
 
-		err := submit(t, s, idBytes, &at)
-		if err != nil {
-			require.NotContains(t, err.Error(), "median-time-past floor")
-		}
+		requirePastFloorGuard(t, submit(t, s, idBytes, &at))
 	})
 
 	t.Run("enforces nothing when no floor is known for the parent", func(t *testing.T) {
@@ -560,10 +576,7 @@ func TestSubmitMiningSolution_NTimeFloor(t *testing.T) {
 
 		below := uint32(floor - 1)
 
-		err := submit(t, s, idBytes, &below)
-		if err != nil {
-			require.NotContains(t, err.Error(), "median-time-past floor")
-		}
+		requirePastFloorGuard(t, submit(t, s, idBytes, &below))
 	})
 }
 
@@ -633,9 +646,7 @@ func TestSubmitMiningSolution_NTimeFloorAdvisoryChain(t *testing.T) {
 		SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{Id: idBytes, Time: &nTime},
 	})
 
-	if err != nil {
-		require.NotContains(t, err.Error(), "median-time-past floor", "the guard must not refuse the candidate the carve-out served")
-	}
+	requirePastFloorGuard(t, err)
 }
 
 // TestWaitForBestBlockHeaderUpdate_ToleratesNilCurrentBlock verifies that the polling

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -460,6 +460,102 @@ func TestSubmitMiningSolution_NoCurrentBlock(t *testing.T) {
 	require.Contains(t, err.Error(), "no current best block")
 }
 
+// TestSubmitMiningSolution_NTimeFloor pins the submit-path guard against a
+// miner-supplied timestamp below the parent chain's median-time-past. The
+// block.Valid call further down passes no currentChain, so it skips the
+// median-time rule entirely — without this guard an ntime-rolling miner, or a
+// pool restamping from its own lagging clock, reintroduces exactly the
+// locally-accepted, peer-rejected block that the candidate-time floor exists to
+// prevent. The floor is read from the memo candidateTime populated, so the check
+// costs no round-trip.
+func TestSubmitMiningSolution_NTimeFloor(t *testing.T) {
+	const floor = int64(1_700_000_000)
+
+	parent := &chainhash.Hash{9}
+
+	// setup returns a server whose job is built on parent, with the floor already
+	// memoized for that parent — the state a real submit arrives in.
+	setup := func(t *testing.T) (*BlockAssembly, []byte) {
+		t.Helper()
+
+		s, common := newServerForChanTest(t)
+
+		// The zero-value assembler newServerForChanTest wires has no settings,
+		// which the coinbase rebuild below the guard dereferences.
+		s.blockAssembler.settings = common.Settings
+
+		// A best block whose parent differs from the job's, so the candidate is
+		// not stale and execution reaches the nTime guard.
+		s.blockAssembler.bestBlock.Store(&BestBlockInfo{
+			Header: &model.BlockHeader{HashPrevBlock: &chainhash.Hash{7}},
+			Height: 100,
+		})
+		s.blockAssembler.mtpFloorMemo[0].Store(&mtpFloorEntry{parent: *parent, minTime: floor})
+
+		idBytes := make([]byte, 32)
+		idBytes[0] = 0x01
+
+		id, err := chainhash.NewHash(idBytes)
+		require.NoError(t, err)
+
+		s.jobStore.Set(*id, &subtreeprocessor.Job{
+			ID: id,
+			MiningCandidate: &model.MiningCandidate{
+				Id:           idBytes,
+				PreviousHash: parent[:],
+				Time:         uint32(floor),
+			},
+		}, time.Minute)
+
+		return s, idBytes
+	}
+
+	submit := func(t *testing.T, s *BlockAssembly, idBytes []byte, nTime *uint32) error {
+		t.Helper()
+
+		_, err := s.submitMiningSolution(context.Background(), &BlockSubmissionRequest{
+			SubmitMiningSolutionRequest: &blockassembly_api.SubmitMiningSolutionRequest{Id: idBytes, Time: nTime},
+		})
+
+		return err
+	}
+
+	t.Run("rejects an nTime below the floor", func(t *testing.T) {
+		s, idBytes := setup(t)
+		below := uint32(floor - 1)
+
+		err := submit(t, s, idBytes, &below)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "median-time-past floor")
+	})
+
+	t.Run("accepts an nTime at the floor", func(t *testing.T) {
+		// Rolling ntime back within a job is normal pool behaviour, so the
+		// comparison must be against the consensus floor, not the candidate's
+		// own wall-clock Time. This submission fails later for unrelated
+		// reasons — the point is that it is not the floor that stops it.
+		s, idBytes := setup(t)
+		at := uint32(floor)
+
+		err := submit(t, s, idBytes, &at)
+		if err != nil {
+			require.NotContains(t, err.Error(), "median-time-past floor")
+		}
+	})
+
+	t.Run("enforces nothing when no floor is known for the parent", func(t *testing.T) {
+		s, idBytes := setup(t)
+		s.blockAssembler.mtpFloorMemo[0].Store(nil)
+
+		below := uint32(floor - 1)
+
+		err := submit(t, s, idBytes, &below)
+		if err != nil {
+			require.NotContains(t, err.Error(), "median-time-past floor")
+		}
+	})
+}
+
 // TestWaitForBestBlockHeaderUpdate_ToleratesNilCurrentBlock verifies that the polling
 // loop skips ticks where CurrentBlock() returns nil (best block not loaded) without
 // panicking, and returns cleanly once the context times out. newServerForChanTest's

--- a/services/blockassembly/submit_mining_solution_test.go
+++ b/services/blockassembly/submit_mining_solution_test.go
@@ -570,6 +570,52 @@ func TestSubmitMiningSolution_NTimeFloor(t *testing.T) {
 		requirePastFloorGuard(t, submit(t, s, idBytes, &at))
 	})
 
+	t.Run("warns when the rejected nTime is the one this node served", func(t *testing.T) {
+		// The guard's usual subject is a miner-supplied timestamp. But it also
+		// fires on a candidate this node served unfloored — the floor lookup was
+		// failing when the job was built, memoized nothing, and a later poll on
+		// the same parent then succeeded and memoized the floor. Rejecting is
+		// right, that block is peer-invalid, but "we served bad work" is a
+		// different operator problem from "a miner sent a bad ntime" and the log
+		// has to tell them apart.
+		s, idBytes := setup(t)
+
+		logger := &warnCountingLogger{}
+		s.logger = logger
+
+		id, err := chainhash.NewHash(idBytes)
+		require.NoError(t, err)
+
+		// Re-stamp the stored job below the floor and submit with no nTime of our
+		// own, so the offending timestamp is provably the candidate's own.
+		s.jobStore.Set(*id, &subtreeprocessor.Job{
+			ID: id,
+			MiningCandidate: &model.MiningCandidate{
+				Id:           idBytes,
+				PreviousHash: parent[:],
+				Time:         uint32(floor - 1),
+			},
+		}, time.Minute)
+
+		err = submit(t, s, idBytes, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "median-time-past floor")
+		require.Equal(t, 1, logger.countMatching("this node served"), "a candidate we served below the floor must be reported as ours, not as a miner's bad ntime")
+	})
+
+	t.Run("does not blame this node for a miner's own bad nTime", func(t *testing.T) {
+		s, idBytes := setup(t)
+
+		logger := &warnCountingLogger{}
+		s.logger = logger
+
+		below := uint32(floor - 1)
+
+		err := submit(t, s, idBytes, &below)
+		require.Error(t, err)
+		require.Equal(t, 0, logger.countMatching("this node served"), "the candidate this node served was at the floor; only the miner's replacement was below it")
+	})
+
 	t.Run("enforces nothing when no floor is known for the parent", func(t *testing.T) {
 		s, idBytes := setup(t)
 		s.blockAssembler.mtpFloorMemo[0].Store(nil)


### PR DESCRIPTION
## What happened

Every block must carry a timestamp strictly greater than the median timestamp of the previous 11 blocks (the "median time past" rule). Block assembly, however, stamped mining candidates with the raw local wall clock — `time.Now()` with no floor. If the node's clock lags, or if recent blocks were stamped into the future (allowed up to 2 hours) and dragged the median above local time, the assembler hands miners a candidate at or below the median. The miner solves and submits it, and the network refuses the block. The damage is not caught locally: the submit path calls `block.Valid` with no header chain, which skips the median-time rule, so the bad block is accepted by the producing node and rejected by every peer that validates it. Because a whole fleet typically shares one NTP source, a skew event hits every assembler at once, and the fleet quietly mines blocks the rest of the network throws away until wall-clock time catches back up.

SV Node avoids this by construction: its `UpdateTime` sets a candidate's time to `max(median-time-past + 1, adjusted-now)`. This change brings Teranode's two candidate paths (the normal subtree path and the empty-block path) up to the same guarantee.

Closes #1445.

## Changes

- **New `candidateTime` helper (`services/blockassembly/candidate_time.go`)** — computes the wall clock floored at median-time-past+1 of the candidate's parent chain, using the same `model.CalculateMedianTimestamp` the validator uses. Headers are fetched by parent hash (so a side-chain candidate gets the median of *its own* chain) in two steps: a batched `GetBlockHeaders` call whose result is verified to be anchored at the parent and correctly linked, with a fallback to a hash-keyed walk of the parent chain (one `GetBlockHeader` per header) when that verification fails. The fallback matters because the store's batched lookup ranges over main-chain flags and can race a reorg; the per-hash reads are immutable and immune. This is the same two-step strategy as the candidate-parent MTP helpers in `subtreevalidation` and `legacy/netsync`. Only when both attempts fail does the candidate request error, failing that one miner poll.
- **Both candidate paths now use it (`BlockAssembler.go`)** — `GetMiningCandidate`'s main path and `generateEmptyBlockCandidate` (which gains a `context.Context` parameter). The floored time also feeds `getNextNbits`, so the testnet 20-minute difficulty rule sees the same timestamp the candidate carries — the same ordering SV Node uses. When the floor engages, a warning is logged once per tip (not once per miner poll — pools poll several times a second).
- **Tests (`candidate_time_test.go`)** — a chain of 11 blocks stamped ~100 minutes into the future drags the median above the test's wall clock; tests assert the helper, the public `GetMiningCandidate` entry point, the subtree-populated main path (`TestMiningCandidateMainPathTimeFloored`, which holds real transactions for the future-stamped tip), and the empty-block path all return exactly median+1, and that a normal past-median chain still tracks the wall clock. The defensive branches are covered with a stubbed blockchain client, and the mis-anchored/broken-link fixtures are built so the wrong chain's median *differs* from the right one — mutation-tested: deadening either guard turns the suite red.

## Trade-offs and testing

- Candidate generation now performs one extra `GetBlockHeaders` (11 headers) call per `GetMiningCandidate` poll, and 11 sequential `GetBlockHeader` calls in the rare fallback case. The function already makes blockchain-client calls on the same path (`GetNextWorkRequired`), so this adds no new failure-mode class.
- If both the batched fetch and the hash-keyed walk fail, candidate generation fails loudly rather than silently emitting an unfloored timestamp — consistent with how every other step in `GetMiningCandidate` handles errors.
- Review of this PR surfaced a **pre-existing** defect on `main`, deliberately not bundled here: block validation evaluates the median-time rule against the oldest 11 of the 100 headers it fetches, not the 11 ending at the parent — filed as #1467.
- Ran: `go test -race ./services/blockassembly/...` (813 tests green), `go vet`, `golangci-lint run --new-from-rev origin/main` (0 issues), plus the two guard-deletion mutations (both now fail the suite).

## Related work and review scope: the median-time-past family

Three open PRs touch the same consensus quantity — the median timestamp of the eleven blocks ending at a given block — at three different points in the pipeline. They share no files and impose no merge order on each other, but they only add up to a coherent median-time story together:

- **#1466 (this PR) — producing blocks.** Block assembly stamped mining candidates with the raw local wall clock, so a lagging clock (or recent blocks stamped into the future, which drag the median up) could hand miners a candidate at or below the median — a block the network then refuses. The candidate time is now floored at median+1. Closes #1445.
- **#1481 — validating blocks.** `CheckHeaderContextual` measured the median over the wrong eleven headers: the oldest of the roughly one hundred it fetches, some ninety blocks below the parent instead of the eleven ending at it. On mainnet that median sits about fifteen hours behind the correct one, so Teranode accepted past-stamped blocks that SV Node rejects. The window is now anchored on the block's parent. Closes #1467.
- **#1485 — judging transactions.** The UTXO store published the median block time and the block height as two separate writes, so the validator's nLockTime finality check could pair a new height with the previous tip's median time and decide finality from two different chain tips. The pair is now one atomic snapshot. Closes #1443.

**Please review each PR against its own scope only.** The three were kept as separate minimal diffs on purpose, so a gap you notice here is frequently another PR's subject rather than an omission in this one.

- **In scope here:** the mining-candidate timestamp floor in block assembly (both the subtree path and the empty-block path) and the header fetch that feeds it.
- **Belongs to #1481, not here:** whether block validation measures the median over the right eleven headers. This PR's notes already flag that defect as pre-existing and deliberately unbundled — it is fixed in #1481.
- **Belongs to #1485, not here:** the UTXO store publishing block height and median time as one atomic pair, and anything about nLockTime transaction finality.

**Cross-cutting, and owned by none of the three.** `model.CalculateMedianTimestamp` already has six call sites on `main` — `model/Block.go:548`, `services/blockchain/Server.go:3107`, `services/blockchain/LocalClient.go:538`, `services/blockchain/median_time_past.go:37`, `services/rpc/handlers.go:1596` and `stores/blockchain/sql/StoreBlock.go:1035` — each doing its own header fetch and anchor handling, and #1466 adds a seventh. Consolidating them behind one helper is a fair suggestion, but it is a pre-existing condition and larger than any of these diffs: please raise it as its own issue rather than folding it into one of these three reviews.

Two further things worth knowing if you are looking at more than one of these.

**The three windows coincide by construction, not by accident.** After all three land, every path measures the median over the same eleven blocks — the chain tip and its ten ancestors. Block validation's window ends at the block's *parent*, which for the next block on the tip is the tip itself. Block assembly computes its floor from the candidate's parent chain, the same set. And the store's median comes from `GetBestHeightAndTime`, which fetches eleven headers inclusive of the best header. So a future change that "aligns" one of these to another would be moving it off the correct rule, not onto it.

**Neither producer-side nor consumer-side alone is sufficient.** #1466 stops this node handing miners a block its own rule rejects; #1481 stops this node accepting a block the rest of the network rejects. With only #1466 merged, a correctly floored candidate still sails through a validation window too lenient to notice anything. With only #1481 merged, validation is right but assembly can still produce candidates that fail it. #1485 is the transaction-level counterpart: the same median value, used to decide whether an individual transaction is final rather than whether a block is.

#1443 and #1445 came out of the same production-hardening sweep. #1467 is different — it was surfaced by the adversarial review of #1466, which is why that PR flags a pre-existing defect it deliberately did not bundle.

**Follow-ups this review raised, all deferred to their own tickets.** Six things came out of reviewing this PR that are real but do not belong in this diff. They are listed here so a reviewer can see at a glance that they were considered rather than missed, and each carries the full reasoning for why it was deferred:

- **#1505** — the submit path calls `block.Valid` with a nil `currentChain`, so the median rule is structurally skipped for the one block this node broadcasts itself. The miner-`nTime` half is fixed here; the remainder needs the `block.Valid` failure path reclassified first, since today a header-contextual rejection triggers a full block-assembly reset.
- **#1506** — this PR floors against the raw local clock, where SV Node's `UpdateTime` floors against network-adjusted time. That is the difference between skew that self-corrects and skew that stops mining, but it is a behaviour change needing SV Node's adversarial bounds ported with it.
- **#1528** — the two-hour future bound is declared twice. The fix belongs in `settings` rather than `model` (import cycle), and should wait until #1481 stops editing `model/Block.go`. Attempted on this branch and backed out in `33910fb24`; a third copy in `blockvalidation/catchup` is noted on the ticket.
- **#1529** — floor lookups are memoized on success only, so a persistent failure repeats per poll. The expensive half was fixed here in `4d748b670`; the remainder is a real trade-off about negative-cache TTLs and its own honest default is "measure first".
- **#1541** — the `model.CalculateMedianTimestamp` consolidation this description asked to be raised separately. Filing it turned up the sharper version of the problem: the seven call sites give **four different answers** to "what if there are fewer than eleven headers", and most take the store's word for anchoring. That substrate is what made #1467 easy to write and hard to see.
- **#1542** — the single-flight added in `911bb73bb` runs on whichever caller's context entered it first, so a leader cancelled mid-fetch costs its followers a floor for one poll. The caller-side half was fixed here in `98ef94c84`; the remainder is self-healing and its honest default is "leave it".

All nine tickets in this family now carry the same ownership map, so it should be clear which one owns any given line before work starts on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
