### PR TITLE
fix(model): carry the block transaction count in 64-bit so a huge block validates instead of retrying forever

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -795,10 +795,9 @@ func (b *Block) releaseTxMap() {
 		// Return the pooled in-memory map for reuse on the next block.
 		// b.TransactionCount was set in GetAndValidateSubtrees before
 		// checkDuplicateTransactions ran, so it matches the value used at
-		// GetTxMap time and the map lands in the correct size-class pool.
-		if n, err := safeconversion.Uint64ToUint32(b.TransactionCount); err == nil {
-			PutTxMap(poolable, n)
-		}
+		// GetTxMap time and the map lands in the correct size-class pool
+		// (counts above every size class are dropped by PutTxMap).
+		PutTxMap(poolable, b.TransactionCount)
 	} else if closer, ok := b.txMap.(io.Closer); ok {
 		_ = closer.Close()
 	}
@@ -971,11 +970,6 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 	g := new(errgroup.Group)
 	util.SafeSetLimit(logger, g, concurrency)
 
-	transactionCountUint32, err := safeconversion.Uint64ToUint32(b.TransactionCount)
-	if err != nil {
-		return errors.NewProcessingError("[checkDuplicateTransactions][%s] failed to convert transaction count to int", b.String(), err)
-	}
-
 	// set the expected subtree size based on the first subtree in the block
 	subtreeSize := 0
 	if len(b.SubtreeSlices) > 0 {
@@ -1001,8 +995,10 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 	} else {
 		// Draw the txMap from a size-class pool so the (potentially multi-GB)
 		// backing storage is reused across blocks. PutTxMap is called at
-		// release time below, keyed by the same transactionCountUint32.
-		b.txMap = GetTxMap(transactionCountUint32)
+		// release time below, keyed by the same 64-bit transaction count —
+		// counts above every size class allocate fresh with a clamped
+		// preallocation hint instead of failing the block (issue 1428).
+		b.txMap = GetTxMap(b.TransactionCount)
 	}
 	for subIdx := 0; subIdx < len(b.SubtreeSlices); subIdx++ {
 		subIdx := subIdx
@@ -1013,7 +1009,7 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 		})
 	}
 
-	if err = g.Wait(); err != nil {
+	if err := g.Wait(); err != nil {
 		// return the error from above without wrapping it
 		return err
 	}

--- a/model/Block.go
+++ b/model/Block.go
@@ -797,11 +797,14 @@ func (b *Block) releaseTxMap() {
 		_ = diskMap.Close()
 		ClearTxMapStats()
 	} else if poolable, ok := b.txMap.(*txmap.SplitSwissMapUint64); ok {
-		// Return the pooled in-memory map for reuse on the next block.
-		// b.txMapCount is the value checkDuplicateTransactions sized the map
-		// from, stashed there for exactly this purpose, so the map lands in the
-		// size-class pool it came from (counts above every size class are
-		// dropped by PutTxMap).
+		// Return the pooled in-memory map for reuse on the next block. The
+		// invariant this relies on is narrow and local: checkDuplicateTransactions
+		// assigns b.txMapCount immediately before GetTxMap and nothing between
+		// there and here writes it, so the Put key equals the Get key and the map
+		// lands in the pool it came from (counts above every size class are
+		// dropped by PutTxMap). Deliberately not stated in terms of
+		// b.TransactionCount, which GetAndValidateSubtrees only recomputes when
+		// Valid took the `subtreeStore != nil && len(b.Subtrees) > 0` branch.
 		PutTxMap(poolable, b.txMapCount)
 	} else if closer, ok := b.txMap.(io.Closer); ok {
 		_ = closer.Close()

--- a/model/Block.go
+++ b/model/Block.go
@@ -108,6 +108,11 @@ type Block struct {
 	subtreeLength   uint64
 	subtreeSlicesMu sync.RWMutex
 	txMap           txmap.TxMap
+	// txMapCount is the entry count txMap was sized from, and the pool key it
+	// must be returned with. Derived from the loaded block body by
+	// txMapEntryCount, not from the peer-supplied TransactionCount. Stashed so
+	// the release key cannot drift from the one used at GetTxMap time.
+	txMapCount      uint64
 	medianTimestamp uint32
 	// nodeAllocator, if non-nil, supplies pooled backing slices for the
 	// per-subtree Node arrays during GetAndValidateSubtrees. Only the
@@ -793,11 +798,11 @@ func (b *Block) releaseTxMap() {
 		ClearTxMapStats()
 	} else if poolable, ok := b.txMap.(*txmap.SplitSwissMapUint64); ok {
 		// Return the pooled in-memory map for reuse on the next block.
-		// b.TransactionCount was set in GetAndValidateSubtrees before
-		// checkDuplicateTransactions ran, so it matches the value used at
-		// GetTxMap time and the map lands in the correct size-class pool
-		// (counts above every size class are dropped by PutTxMap).
-		PutTxMap(poolable, b.TransactionCount)
+		// b.txMapCount is the value checkDuplicateTransactions sized the map
+		// from, stashed there for exactly this purpose, so the map lands in the
+		// size-class pool it came from (counts above every size class are
+		// dropped by PutTxMap).
+		PutTxMap(poolable, b.txMapCount)
 	} else if closer, ok := b.txMap.(io.Closer); ok {
 		_ = closer.Close()
 	}
@@ -976,10 +981,14 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 		subtreeSize = b.SubtreeSlices[0].Size()
 	}
 
+	// Size both map variants from the loaded block body rather than the
+	// peer-supplied TransactionCount, and keep the value for the release key.
+	b.txMapCount = b.txMapEntryCount()
+
 	if len(diskMapDirs) > 0 {
-		// An empty (coinbase-only) block has TransactionCount == 0, but the
-		// mmap-backed table rejects a zero capacity — clamp to 1.
-		filterCapacity := b.TransactionCount
+		// An empty (coinbase-only) block inserts nothing, but the mmap-backed
+		// table rejects a zero capacity — clamp to 1.
+		filterCapacity := b.txMapCount
 		if filterCapacity == 0 {
 			filterCapacity = 1
 		}
@@ -995,10 +1004,10 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 	} else {
 		// Draw the txMap from a size-class pool so the (potentially multi-GB)
 		// backing storage is reused across blocks. PutTxMap is called at
-		// release time below, keyed by the same 64-bit transaction count —
-		// counts above every size class allocate fresh with a clamped
-		// preallocation hint instead of failing the block (issue 1428).
-		b.txMap = GetTxMap(b.TransactionCount)
+		// release time below, keyed by the same 64-bit count held in
+		// b.txMapCount — counts above every size class allocate fresh with a
+		// bounded preallocation hint instead of failing the block (issue 1428).
+		b.txMap = GetTxMap(b.txMapCount)
 	}
 	for subIdx := 0; subIdx < len(b.SubtreeSlices); subIdx++ {
 		subIdx := subIdx
@@ -1015,6 +1024,33 @@ func (b *Block) checkDuplicateTransactions(ctx context.Context, logger ulogger.L
 	}
 
 	return nil
+}
+
+// txMapEntryCount returns the number of entries the duplicate check will insert,
+// summed over the loaded subtree bodies. It is exact bar one:
+// checkDuplicateTransactionsInSubtree skips the coinbase placeholder at
+// subIdx 0/txIdx 0 and nothing else.
+//
+// This deliberately does NOT use b.TransactionCount. That field is read straight
+// off a wire varint by readBlockFromReader, and GetAndValidateSubtrees only
+// recomputes it from the real subtree contents inside the
+// `subtreeStore != nil && len(b.Subtrees) > 0` guard in Valid, while the
+// duplicate check runs unconditionally. Sizing an allocation from it therefore
+// trusts a peer-chosen integer on paths where nothing has reconciled it against
+// the body (issue 1501). The slices below are already loaded by the time any
+// caller needs this, so the honest count costs one len() per subtree: for a
+// truthful block the derived number *is* TransactionCount, and for a block
+// claiming more than it carries the map is sized for what it actually carries.
+func (b *Block) txMapEntryCount() uint64 {
+	var n uint64
+
+	for _, subtree := range b.SubtreeSlices {
+		if subtree != nil {
+			n += uint64(len(subtree.Nodes))
+		}
+	}
+
+	return n
 }
 
 // checkDuplicateTransactionsInSubtree checks for duplicate transactions in a subtree.
@@ -1064,6 +1100,35 @@ func (b *Block) checkDuplicateTransactionsInSubtree(subtree *subtreepkg.Subtree,
 	return nil
 }
 
+// parentSpendsCapacity returns the capacity hint for the parent-spends map:
+// entryCount (taken from the loaded block body) times the assumed average
+// inputs per transaction. A multiplier of 0 is treated as 1, and the result is
+// never 0 because the mmap-backed table rejects a zero capacity.
+//
+// entryCount is bounded by the subtrees actually held in memory, so it cannot
+// overflow the product on its own. The multiplier can: it is operator-supplied
+// (block_parentSpendsCapacityMultiplier) and unvalidated. On overflow this
+// returns entryCount unmultiplied — losing the headroom but keeping a real
+// number — because NewSplitSyncedParentMap computes
+// uint32((e + e/5) / nrOfBuckets), which turns a wrapped or saturated hint into
+// an arbitrary per-bucket size rather than merely a small one.
+func parentSpendsCapacity(entryCount, multiplier uint64) uint64 {
+	if multiplier == 0 {
+		multiplier = 1
+	}
+
+	capacity := entryCount * multiplier
+	if capacity/multiplier != entryCount {
+		capacity = entryCount
+	}
+
+	if capacity == 0 {
+		return 1
+	}
+
+	return capacity
+}
+
 type validationDependencies struct {
 	txMetaStore           utxo.Store
 	subtreeStore          SubtreeStore
@@ -1083,20 +1148,19 @@ func (b *Block) validOrderAndBlessed(ctx context.Context, logger ulogger.Logger,
 		return errors.NewStorageError("[validOrderAndBlessed][%s] txMap is nil, cannot check transaction order", b.String())
 	}
 
-	// Size the parent-spends map at TransactionCount * multiplier (assumed
+	// Size the parent-spends map at transaction count * multiplier (assumed
 	// average inputs/tx). For the disk-backed map this is a hard cap, so the
 	// multiplier is configurable (block_parentSpendsCapacityMultiplier); a
 	// consolidation-heavy block exceeding it overflows a segment and halts
 	// (fail-safe). 0 is treated as 1.
-	if parentSpendsCapacityMultiplier == 0 {
-		parentSpendsCapacityMultiplier = 1
-	}
-	expectedInpoints := b.TransactionCount * parentSpendsCapacityMultiplier
-	if expectedInpoints == 0 {
-		// Empty (coinbase-only) block: TransactionCount == 0, but the
-		// mmap-backed table rejects a zero capacity — clamp to 1.
-		expectedInpoints = 1
-	}
+	//
+	// The transaction count comes from the loaded block body, not from the
+	// peer-supplied b.TransactionCount — see txMapEntryCount for why (issue
+	// 1501). That alone bounds this product: the node count is limited by the
+	// subtrees actually held in memory, so a claimed count can no longer drive
+	// it. The remaining overflow route is the multiplier itself, which is
+	// operator-supplied (block_parentSpendsCapacityMultiplier) and unvalidated.
+	expectedInpoints := parentSpendsCapacity(b.txMapEntryCount(), parentSpendsCapacityMultiplier)
 
 	var psMap ParentSpendsMap
 	if len(diskMapDirs) > 0 {

--- a/model/Block.go
+++ b/model/Block.go
@@ -1163,6 +1163,13 @@ func (b *Block) validOrderAndBlessed(ctx context.Context, logger ulogger.Logger,
 	// subtrees actually held in memory, so a claimed count can no longer drive
 	// it. The remaining overflow route is the multiplier itself, which is
 	// operator-supplied (block_parentSpendsCapacityMultiplier) and unvalidated.
+	//
+	// Recomputed here rather than read from b.txMapCount, deliberately: that
+	// field is only set by checkDuplicateTransactions, and callers that invoke
+	// this method directly (rather than through Valid, which always runs step 11
+	// first) would otherwise size from a zero. Recomputing is one len() per
+	// subtree and keeps this method self-contained — please do not "tidy" it into
+	// reading the field.
 	expectedInpoints := parentSpendsCapacity(b.txMapEntryCount(), parentSpendsCapacityMultiplier)
 
 	var psMap ParentSpendsMap

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -40,16 +40,36 @@ func TestTxMapClassIdx64Bit(t *testing.T) {
 	}
 }
 
-// TestTxMapAllocHintClamp pins the preallocation-hint clamp: counts beyond
-// uint32 cap the hint at MaxUint32 (preallocation only — the map resizes on
-// insert), everything else passes through unchanged.
+// TestTxMapAllocHintClamp pins the preallocation-hint bound: any count above
+// the largest pooled size class caps the hint at that class (preallocation only
+// — the map resizes on insert), everything else passes through unchanged.
 func TestTxMapAllocHintClamp(t *testing.T) {
+	largestClass := txMapSizeClasses[len(txMapSizeClasses)-1]
+
 	require.Equal(t, uint32(0), txMapAllocHint(0))
 	require.Equal(t, uint32(1<<20), txMapAllocHint(1<<20))
-	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(math.MaxUint32))
-	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(math.MaxUint32+1))
-	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(1<<40))
-	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(math.MaxUint64))
+	require.Equal(t, largestClass, txMapAllocHint(uint64(largestClass)))
+
+	for _, n := range []uint64{uint64(largestClass) + 1, math.MaxUint32, math.MaxUint32 + 1, 1 << 40, math.MaxUint64} {
+		require.Equal(t, largestClass, txMapAllocHint(n), "count %d must be bounded to the largest class", n)
+	}
+}
+
+// TestTxMapAllocHintAvoidsConstructorOverflow pins the bound below the point
+// where the map constructor's own per-bucket arithmetic wraps. It computes
+// per-bucket size as (hint + hint/5) in uint32, so any hint above ~3.58e9
+// overflows and preallocates an arbitrary amount unrelated to the count
+// (MaxUint32 wraps to ~859M entries). Every hint this package can produce must
+// stay in the range where that arithmetic is exact.
+func TestTxMapAllocHintAvoidsConstructorOverflow(t *testing.T) {
+	for _, n := range []uint64{0, 1 << 20, uint64(txMapSizeClasses[len(txMapSizeClasses)-1]), math.MaxUint32, 1 << 40, math.MaxUint64} {
+		hint := txMapAllocHint(n)
+
+		// The constructor's computation, in uint32 as it performs it, must equal
+		// the same computation carried out without truncation.
+		require.Equal(t, uint64(hint)+uint64(hint)/5, uint64(hint+hint/5),
+			"hint %d (from count %d) overflows the constructor's per-bucket arithmetic", hint, n)
+	}
 }
 
 // TestTxMapPoolRoundTrip64BitKey pins Get/Put with the 64-bit key on pooled

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -1,0 +1,60 @@
+package model
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckDuplicateTransactionsAboveUint32 pins issue 1428: a block whose
+// TransactionCount exceeds 2^32 must go through duplicate checking in 64-bit,
+// not fail a uint32 narrowing with a retryable processing error. Post-Genesis
+// BSV has no block-size limit and SV Node carries the count as a CompactSize,
+// so such a block is consensus-valid; a conversion error here made block
+// validation refetch and revalidate the same block forever, wedging the whole
+// fleet deterministically.
+func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
+	subtree, err := subtreepkg.NewTreeByLeafCount(4)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+
+	for i := byte(1); i <= 3; i++ {
+		hash := chainhash.HashH([]byte{i, 0xdd})
+		require.NoError(t, subtree.AddNode(hash, 1, 0))
+	}
+
+	block := &Block{
+		Header:           &BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}},
+		TransactionCount: math.MaxUint32 + 2, // the count the wire format allows but uint32 cannot hold
+		SubtreeSlices:    []*subtreepkg.Subtree{subtree},
+	}
+
+	err = block.checkDuplicateTransactions(context.Background(), ulogger.TestLogger{}, 4, nil)
+	require.NoError(t, err, "a transaction count above 2^32 must not fail duplicate checking")
+
+	// The pooled map must be releasable with the same 64-bit count.
+	block.releaseTxMap()
+	require.Nil(t, block.txMap)
+}
+
+// TestTxMapPool64Bit pins the pool API on 64-bit counts: any count must yield
+// a usable map (counts above the largest size class allocate fresh with a
+// clamped preallocation hint — the swiss maps grow on demand), and returning
+// it with the same count must not panic.
+func TestTxMapPool64Bit(t *testing.T) {
+	for _, n := range []uint64{0, 1, 1 << 20, 1 << 31, math.MaxUint32 + 1, 1 << 40} {
+		m := GetTxMap(n)
+		require.NotNil(t, m, "count %d", n)
+
+		hash := chainhash.HashH([]byte{byte(n), byte(n >> 8), 0xab})
+		require.NoError(t, m.Put(hash, 1))
+		require.True(t, m.Exists(hash))
+
+		PutTxMap(m, n)
+	}
+}

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -11,14 +11,68 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCheckDuplicateTransactionsAboveUint32 pins issue 1428: a block whose
-// TransactionCount exceeds 2^32 must go through duplicate checking in 64-bit,
-// not fail a uint32 narrowing with a retryable processing error. Post-Genesis
-// BSV has no block-size limit and SV Node carries the count as a CompactSize,
-// so such a block is consensus-valid; a conversion error here made block
-// validation refetch and revalidate the same block forever, wedging the whole
-// fleet deterministically.
-func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
+// These tests pin issue 1428 — a block whose TransactionCount exceeds 2^32
+// must be handled in 64-bit, not fail a uint32 narrowing with a retryable
+// processing error that made block validation refetch the same
+// consensus-valid block forever.
+//
+// Deliberately NOT tested by materialising a >2^32-entry map: GetTxMap
+// preallocates eagerly from its hint, and a single such call costs tens of
+// GB of RSS (the same trap TestGetTxMap_OversizedAllocatesFresh documents
+// removing after it dominated CI memory, issue 1051). The narrowing seam
+// itself no longer exists at the type level — GetTxMap/PutTxMap take uint64 —
+// so the pure classification and clamp logic carries the behavioural pin.
+
+// TestTxMapClassIdx64Bit pins the size-class classification on 64-bit counts:
+// everything at or below the largest class resolves to a pool class, and
+// every count above it — including counts beyond uint32, which previously
+// could not even be expressed — resolves to the allocate-fresh path.
+func TestTxMapClassIdx64Bit(t *testing.T) {
+	largestClass := uint64(txMapSizeClasses[len(txMapSizeClasses)-1])
+
+	require.Equal(t, 0, txMapClassIdxFor(0))
+	require.Equal(t, 0, txMapClassIdxFor(1))
+	require.Equal(t, len(txMapSizeClasses)-1, txMapClassIdxFor(largestClass))
+
+	for _, n := range []uint64{largestClass + 1, math.MaxUint32, math.MaxUint32 + 1, 1 << 40, math.MaxUint64} {
+		require.Equal(t, -1, txMapClassIdxFor(n), "count %d must take the allocate-fresh path", n)
+	}
+}
+
+// TestTxMapAllocHintClamp pins the preallocation-hint clamp: counts beyond
+// uint32 cap the hint at MaxUint32 (preallocation only — the map resizes on
+// insert), everything else passes through unchanged.
+func TestTxMapAllocHintClamp(t *testing.T) {
+	require.Equal(t, uint32(0), txMapAllocHint(0))
+	require.Equal(t, uint32(1<<20), txMapAllocHint(1<<20))
+	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(math.MaxUint32))
+	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(math.MaxUint32+1))
+	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(1<<40))
+	require.Equal(t, uint32(math.MaxUint32), txMapAllocHint(math.MaxUint64))
+}
+
+// TestTxMapPoolRoundTrip64BitKey pins Get/Put with the 64-bit key on pooled
+// (cheap) size classes: the map must be usable and returnable with the same
+// uint64 count a block carries.
+func TestTxMapPoolRoundTrip64BitKey(t *testing.T) {
+	for _, n := range []uint64{0, 1, 1 << 12, 1 << 20} {
+		m := GetTxMap(n)
+		require.NotNil(t, m, "count %d", n)
+
+		hash := chainhash.HashH([]byte{byte(n), byte(n >> 8), 0xab})
+		require.NoError(t, m.Put(hash, 1))
+		require.True(t, m.Exists(hash))
+
+		PutTxMap(m, n)
+	}
+}
+
+// TestCheckDuplicateTransactionsUsesFullCount drives the real duplicate-check
+// path with a pooled-size count and verifies the pooled map is released with
+// the same 64-bit key. The >2^32 seam is covered by the classification and
+// clamp tests above (materialising such a map costs tens of GB — see the
+// header comment).
+func TestCheckDuplicateTransactionsUsesFullCount(t *testing.T) {
 	subtree, err := subtreepkg.NewTreeByLeafCount(4)
 	require.NoError(t, err)
 	require.NoError(t, subtree.AddCoinbaseNode())
@@ -30,31 +84,12 @@ func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
 
 	block := &Block{
 		Header:           &BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}},
-		TransactionCount: math.MaxUint32 + 2, // the count the wire format allows but uint32 cannot hold
+		TransactionCount: 4,
 		SubtreeSlices:    []*subtreepkg.Subtree{subtree},
 	}
 
-	err = block.checkDuplicateTransactions(context.Background(), ulogger.TestLogger{}, 4, nil)
-	require.NoError(t, err, "a transaction count above 2^32 must not fail duplicate checking")
+	require.NoError(t, block.checkDuplicateTransactions(context.Background(), ulogger.TestLogger{}, 4, nil))
 
-	// The pooled map must be releasable with the same 64-bit count.
 	block.releaseTxMap()
 	require.Nil(t, block.txMap)
-}
-
-// TestTxMapPool64Bit pins the pool API on 64-bit counts: any count must yield
-// a usable map (counts above the largest size class allocate fresh with a
-// clamped preallocation hint — the swiss maps grow on demand), and returning
-// it with the same count must not panic.
-func TestTxMapPool64Bit(t *testing.T) {
-	for _, n := range []uint64{0, 1, 1 << 20, 1 << 31, math.MaxUint32 + 1, 1 << 40} {
-		m := GetTxMap(n)
-		require.NotNil(t, m, "count %d", n)
-
-		hash := chainhash.HashH([]byte{byte(n), byte(n >> 8), 0xab})
-		require.NoError(t, m.Put(hash, 1))
-		require.True(t, m.Exists(hash))
-
-		PutTxMap(m, n)
-	}
 }

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -111,9 +111,13 @@ func TestCheckDuplicateTransactionsUsesFullCount(t *testing.T) {
 
 	require.NoError(t, block.checkDuplicateTransactions(context.Background(), ulogger.TestLogger{}, 4, nil))
 
-	// Hold the map across release: PutTxMap clears it only when the 64-bit key
-	// resolves to a pool class, so a wrong or stale release key (which would
-	// silently drop the map instead of pooling it) leaves the 3 entries behind.
+	// The map is sized from the loaded body, not the claimed count.
+	require.Equal(t, uint64(4), block.txMapCount)
+
+	// Hold the map across release and assert PutTxMap cleared it, which only
+	// happens on the pooled branch. This proves the release key still resolves
+	// to a pool class — it does NOT pin the exact key, since at this size any
+	// key at or below the largest class also pools and clears.
 	pooled, ok := block.txMap.(*txmap.SplitSwissMapUint64)
 	require.True(t, ok)
 	require.Equal(t, 3, pooled.Length())
@@ -121,4 +125,108 @@ func TestCheckDuplicateTransactionsUsesFullCount(t *testing.T) {
 	block.releaseTxMap()
 	require.Nil(t, block.txMap)
 	require.Equal(t, 0, pooled.Length(), "released map must be cleared and pooled, not dropped")
+}
+
+// TestCheckDuplicateTransactionsAboveUint32 is the end-to-end pin issue 1428
+// asked for: a block claiming more than math.MaxUint32 transactions must run the
+// real duplicate-check path without returning the retryable processing error the
+// old uint32 narrowing produced.
+//
+// It costs a four-node map. The claimed count no longer sizes anything — the
+// hint comes from the loaded body (txMapEntryCount) — so nothing here
+// materialises a large allocation, which is what previously made this scenario
+// untestable (the CI-memory trap of issue 1051).
+//
+// The size classes are shrunk for the duration anyway, so that if the sizing
+// ever regresses to the claimed count this test stays cheap and fails on the
+// assertion instead of trying to preallocate for 2^32 entries. txMapPools is
+// built from the original classes at init, so every surviving index still
+// resolves to a real pool. The Cleanup restore is mandatory and this test must
+// not run in parallel, since it mutates package state.
+func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
+	origClasses := txMapSizeClasses
+	txMapSizeClasses = []uint32{1 << 12}
+
+	t.Cleanup(func() { txMapSizeClasses = origClasses })
+
+	subtree, err := subtreepkg.NewTreeByLeafCount(4)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+
+	for i := byte(1); i <= 3; i++ {
+		hash := chainhash.HashH([]byte{i, 0x77})
+		require.NoError(t, subtree.AddNode(hash, 1, 0))
+	}
+
+	block := &Block{
+		Header:           &BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}},
+		TransactionCount: math.MaxUint32 + 1,
+		SubtreeSlices:    []*subtreepkg.Subtree{subtree},
+	}
+
+	require.NoError(t, block.checkDuplicateTransactions(context.Background(), ulogger.TestLogger{}, 4, nil),
+		"a count above MaxUint32 must not fail the duplicate check")
+
+	// Sized from the four loaded nodes, not from the claimed 2^32+1.
+	require.Equal(t, uint64(4), block.txMapCount)
+
+	pooled, ok := block.txMap.(*txmap.SplitSwissMapUint64)
+	require.True(t, ok)
+	require.Equal(t, 3, pooled.Length())
+
+	block.releaseTxMap()
+	require.Equal(t, 0, pooled.Length(), "released map must be cleared and pooled, not dropped")
+}
+
+// TestParentSpendsCapacity pins the parent-spends sizing helper: it multiplies
+// the body-derived node count by the assumed inputs per transaction, treats a 0
+// multiplier as 1, never returns 0 (the mmap-backed table rejects a zero
+// capacity), and on an overflowing operator-supplied multiplier degrades to the
+// unmultiplied count rather than carrying a wrapped product into
+// NewSplitSyncedParentMap, whose uint32((e + e/5) / buckets) would turn it into
+// an arbitrary per-bucket size.
+func TestParentSpendsCapacity(t *testing.T) {
+	require.Equal(t, uint64(2_000), parentSpendsCapacity(1_000, 2))
+	require.Equal(t, uint64(1_000), parentSpendsCapacity(1_000, 1))
+	require.Equal(t, uint64(1_000), parentSpendsCapacity(1_000, 0), "a 0 multiplier means 1")
+
+	require.Equal(t, uint64(1), parentSpendsCapacity(0, 2), "capacity must never be 0")
+	require.Equal(t, uint64(1), parentSpendsCapacity(0, 0))
+
+	// An overflowing multiplier degrades to the node count, not a wrapped value.
+	const entryCount = 4
+	require.Equal(t, uint64(entryCount), parentSpendsCapacity(entryCount, math.MaxUint64),
+		"an overflowing multiplier must fall back to the unmultiplied count")
+	require.Equal(t, uint64(entryCount), parentSpendsCapacity(entryCount, math.MaxUint64/2))
+
+	// Every value the helper can return must survive the constructor's per-bucket
+	// arithmetic without truncating, which is the property the fallback protects.
+	for _, m := range []uint64{0, 1, 2, 16, math.MaxUint64 / 2, math.MaxUint64} {
+		c := parentSpendsCapacity(entryCount, m)
+		require.Equal(t, (c+c/5)/uint64(parentSpendsBuckets), uint64(uint32((c+c/5)/uint64(parentSpendsBuckets))),
+			"capacity %d (multiplier %d) truncates in the constructor", c, m)
+	}
+}
+
+// TestTxMapEntryCountIgnoresClaimedCount pins that the sizing hint is taken from
+// the loaded body and never from the peer-supplied TransactionCount: a block
+// claiming a huge count while carrying few (or no) subtree nodes must size for
+// what it carries (issue 1501).
+func TestTxMapEntryCountIgnoresClaimedCount(t *testing.T) {
+	subtree, err := subtreepkg.NewTreeByLeafCount(4)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+	require.NoError(t, subtree.AddNode(chainhash.HashH([]byte{0x01}), 1, 0))
+
+	// A block that claims 2^40 transactions but carries two nodes.
+	block := &Block{TransactionCount: 1 << 40, SubtreeSlices: []*subtreepkg.Subtree{subtree}}
+	require.Equal(t, uint64(2), block.txMapEntryCount())
+
+	// The zero-subtree shape from issue 1501: nothing loaded, so nothing sized.
+	empty := &Block{TransactionCount: math.MaxUint64}
+	require.Equal(t, uint64(0), empty.txMapEntryCount())
+
+	// A nil slice entry must not panic or inflate the count.
+	withNil := &Block{TransactionCount: 1 << 40, SubtreeSlices: []*subtreepkg.Subtree{nil, subtree}}
+	require.Equal(t, uint64(2), withNil.txMapEntryCount())
 }

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -57,18 +57,60 @@ func TestTxMapAllocHintClamp(t *testing.T) {
 
 // TestTxMapAllocHintAvoidsConstructorOverflow pins the bound below the point
 // where the map constructor's own per-bucket arithmetic wraps. It computes
-// per-bucket size as (hint + hint/5) in uint32, so any hint above ~3.58e9
-// overflows and preallocates an arbitrary amount unrelated to the count
-// (MaxUint32 wraps to ~859M entries). Every hint this package can produce must
-// stay in the range where that arithmetic is exact.
+// per-bucket size as (hint + hint/5) in uint32, so any hint above
+// txMapConstructorWrapThreshold overflows and preallocates an arbitrary amount
+// unrelated to the count (math.MaxUint32 wraps to ~859M entries).
+//
+// Asserted two ways on purpose. The threshold constant is checked to be the real
+// wrap point, so it cannot drift from the dependency silently; then every hint
+// the package can produce is checked against that constant. Note the constant is
+// tied to go-tx-map's 20% headroom factor: if a dependency bump changes that
+// factor, the first loop below fails rather than the bound quietly becoming
+// wrong.
 func TestTxMapAllocHintAvoidsConstructorOverflow(t *testing.T) {
-	for _, n := range []uint64{0, 1 << 20, uint64(txMapSizeClasses[len(txMapSizeClasses)-1]), math.MaxUint32, 1 << 40, math.MaxUint64} {
-		hint := txMapAllocHint(n)
+	// The threshold really is the last exact value, and one past it wraps.
+	for _, tc := range []struct {
+		hint  uint32
+		exact bool
+	}{
+		{hint: uint32(txMapConstructorWrapThreshold), exact: true},
+		{hint: uint32(txMapConstructorWrapThreshold) + 1, exact: false},
+		{hint: math.MaxUint32, exact: false},
+	} {
+		got := uint64(tc.hint) + uint64(tc.hint)/5
+		require.Equal(t, tc.exact, got == uint64(tc.hint+tc.hint/5),
+			"hint %d: expected exact=%v for the constructor's (hint + hint/5)", tc.hint, tc.exact)
+	}
 
-		// The constructor's computation, in uint32 as it performs it, must equal
-		// the same computation carried out without truncation.
-		require.Equal(t, uint64(hint)+uint64(hint)/5, uint64(hint+hint/5),
-			"hint %d (from count %d) overflows the constructor's per-bucket arithmetic", hint, n)
+	// Every hint this package can produce stays at or below that threshold.
+	for _, n := range []uint64{0, 1 << 20, uint64(txMapSizeClasses[len(txMapSizeClasses)-1]), math.MaxUint32, 1 << 40, math.MaxUint64} {
+		require.LessOrEqual(t, uint64(txMapAllocHint(n)), txMapConstructorWrapThreshold,
+			"hint for count %d must stay below the constructor's wrap point", n)
+	}
+}
+
+// TestParentSpendsAllocHint pins the parent-spends preallocation bound, which
+// exists for the same reason as txMapAllocHint: NewSplitSyncedParentMap
+// preallocates eagerly per bucket and computes uint32((n + n/5) / nrOfBuckets),
+// so an unbounded hint asks for an unbounded allocation and can truncate.
+func TestParentSpendsAllocHint(t *testing.T) {
+	largestClass := parentSpendsSizeClasses[len(parentSpendsSizeClasses)-1]
+
+	require.Equal(t, uint64(0), parentSpendsAllocHint(0))
+	require.Equal(t, uint64(1<<20), parentSpendsAllocHint(1<<20))
+	require.Equal(t, largestClass, parentSpendsAllocHint(largestClass))
+
+	for _, n := range []uint64{largestClass + 1, 1 << 40, math.MaxUint64} {
+		require.Equal(t, largestClass, parentSpendsAllocHint(n), "count %d must be bounded", n)
+	}
+
+	// Every bounded hint must survive the constructor's per-bucket arithmetic
+	// without truncating to an arbitrary value.
+	for _, n := range []uint64{0, 1 << 20, largestClass, largestClass + 1, math.MaxUint64} {
+		h := parentSpendsAllocHint(n)
+		perBucket := (h + h/5) / uint64(parentSpendsBuckets)
+		require.Equal(t, perBucket, uint64(uint32(perBucket)),
+			"hint %d (from count %d) truncates in the constructor", h, n)
 	}
 }
 
@@ -117,7 +159,15 @@ func TestCheckDuplicateTransactionsUsesFullCount(t *testing.T) {
 	// Hold the map across release and assert PutTxMap cleared it, which only
 	// happens on the pooled branch. This proves the release key still resolves
 	// to a pool class — it does NOT pin the exact key, since at this size any
-	// key at or below the largest class also pools and clears.
+	// key at or below the largest class also pools and clears. The exact key is
+	// pinned by the b.txMapCount assertion above, which is the value releaseTxMap
+	// passes.
+	//
+	// Observing the map after handing it back to a package-global sync.Pool is
+	// only sound because this test owns it until it returns: the assertion must
+	// stay immediately after releaseTxMap, and this test must never be given
+	// t.Parallel() (the package convention anyway), or a concurrent GetTxMap on
+	// the 4K class could take the map first.
 	pooled, ok := block.txMap.(*txmap.SplitSwissMapUint64)
 	require.True(t, ok)
 	require.Equal(t, 3, pooled.Length())
@@ -176,6 +226,44 @@ func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
 
 	block.releaseTxMap()
 	require.Equal(t, 0, pooled.Length(), "released map must be cleared and pooled, not dropped")
+}
+
+// TestGetParentSpendsMapBoundsPreallocation pins the bound at its call site, not
+// just in the helper: GetParentSpendsMap must preallocate from the bounded hint
+// for a count above every size class. Observed through the underlying swiss map's
+// Capacity(), which on a freshly built map is the preallocation limit.
+//
+// The size classes are shrunk so the over-max branch is reachable cheaply; the
+// unbounded reference below is deliberately sized to cost tens of MB rather than
+// the hundreds of GB a realistic over-max count would ask for. parentSpendsPools
+// is built from the original classes at init, so the surviving index still
+// resolves to a real pool. Cleanup restore is mandatory; no t.Parallel().
+func TestGetParentSpendsMapBoundsPreallocation(t *testing.T) {
+	origClasses := parentSpendsSizeClasses
+	parentSpendsSizeClasses = []uint64{1 << 8}
+
+	t.Cleanup(func() { parentSpendsSizeClasses = origClasses })
+
+	const overMax = 1 << 20 // above the shrunk largest class, so idx < 0
+
+	require.Equal(t, -1, parentSpendsClassIdxFor(overMax), "count must take the allocate-fresh path")
+	require.Equal(t, uint64(1<<8), parentSpendsAllocHint(overMax))
+
+	got := GetParentSpendsMap(overMax)
+	require.NotNil(t, got)
+
+	bounded := NewSplitSyncedParentMap(parentSpendsBuckets, parentSpendsAllocHint(overMax))
+	unbounded := NewSplitSyncedParentMap(parentSpendsBuckets, overMax)
+
+	require.Equal(t, bounded.buckets[0].m.Capacity(), got.buckets[0].m.Capacity(),
+		"GetParentSpendsMap must preallocate from the bounded hint")
+	require.NotEqual(t, unbounded.buckets[0].m.Capacity(), got.buckets[0].m.Capacity(),
+		"this assertion is only meaningful if the bounded and unbounded hints differ")
+
+	// The map still accepts entries beyond the bounded preallocation.
+	ok, err := got.SetIfNotExists(subtreepkg.Inpoint{Hash: chainhash.HashH([]byte{0x5a}), Index: 0})
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 // TestParentSpendsCapacity pins the parent-spends sizing helper: it multiplies

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -9,6 +9,7 @@ import (
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/dolthub/swiss"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,6 +24,34 @@ import (
 // removing after it dominated CI memory, issue 1051). The narrowing seam
 // itself no longer exists at the type level — GetTxMap/PutTxMap take uint64 —
 // so the pure classification and clamp logic carries the behavioural pin.
+
+// withTxMapSizeClasses and withParentSpendsSizeClasses swap a package-global
+// size-class table for the duration of one test and restore it afterwards.
+//
+// The tables are global mutable state that the pools were built from at init, so
+// a test that shrinks one must always restore it or it corrupts every later test
+// in the package. Routing every swap through these helpers keeps that restore in
+// one place rather than relying on each test remembering its own t.Cleanup.
+// Shrinking is safe because the pools are indexed by position and every
+// surviving index still resolves to a real pool. Callers must not use
+// t.Parallel().
+func withTxMapSizeClasses(t *testing.T, classes []uint32) {
+	t.Helper()
+
+	orig := txMapSizeClasses
+	txMapSizeClasses = classes
+
+	t.Cleanup(func() { txMapSizeClasses = orig })
+}
+
+func withParentSpendsSizeClasses(t *testing.T, classes []uint64) {
+	t.Helper()
+
+	orig := parentSpendsSizeClasses
+	parentSpendsSizeClasses = classes
+
+	t.Cleanup(func() { parentSpendsSizeClasses = orig })
+}
 
 // TestTxMapClassIdx64Bit pins the size-class classification on 64-bit counts:
 // everything at or below the largest class resolves to a pool class, and
@@ -61,14 +90,15 @@ func TestTxMapAllocHintClamp(t *testing.T) {
 // txMapConstructorWrapThreshold overflows and preallocates an arbitrary amount
 // unrelated to the count (math.MaxUint32 wraps to ~859M entries).
 //
-// Asserted two ways on purpose. The threshold constant is checked to be the real
-// wrap point, so it cannot drift from the dependency silently; then every hint
-// the package can produce is checked against that constant. Note the constant is
-// tied to go-tx-map's 20% headroom factor: if a dependency bump changes that
-// factor, the first loop below fails rather than the bound quietly becoming
-// wrong.
+// Asserted three ways, because the first two alone would be self-referential:
+// the 1/5 headroom below is transcribed from the dependency, so checking the
+// constant against that transcription proves only that the transcription is
+// self-consistent. The third check observes the real constructor, so a
+// dependency bump that changes the factor fails here instead of leaving the
+// constant quietly wrong.
 func TestTxMapAllocHintAvoidsConstructorOverflow(t *testing.T) {
-	// The threshold really is the last exact value, and one past it wraps.
+	// The threshold really is the last value the transcribed arithmetic holds
+	// exactly, and one past it wraps.
 	for _, tc := range []struct {
 		hint  uint32
 		exact bool
@@ -87,6 +117,23 @@ func TestTxMapAllocHintAvoidsConstructorOverflow(t *testing.T) {
 		require.LessOrEqual(t, uint64(txMapAllocHint(n)), txMapConstructorWrapThreshold,
 			"hint for count %d must stay below the constructor's wrap point", n)
 	}
+
+	// The headroom factor really is 1/5, observed rather than transcribed. The
+	// threshold above cannot be probed directly (constructing at that size costs
+	// tens of GB), but the factor that determines it can: with a single bucket the
+	// constructor's per-bucket size is the whole (hint + hint/5), so a fresh map's
+	// capacity exposes the factor for a few hundred KB.
+	const (
+		probeHint    uint32 = 1000
+		probeBuckets uint16 = 1
+	)
+
+	transcribed := (probeHint + probeHint/5) / uint32(probeBuckets)
+	want := swiss.NewMap[chainhash.Hash, uint64](transcribed).Capacity()
+	got := txmap.NewSplitSwissMapUint64(probeHint, probeBuckets).Map()[0].Map().Capacity()
+
+	require.Equal(t, want, got,
+		"go-tx-map's per-bucket headroom factor no longer matches the 1/5 transcribed here, so txMapConstructorWrapThreshold is stale")
 }
 
 // TestParentSpendsAllocHint pins the parent-spends preallocation bound, which
@@ -194,10 +241,7 @@ func TestCheckDuplicateTransactionsUsesFullCount(t *testing.T) {
 // resolves to a real pool. The Cleanup restore is mandatory and this test must
 // not run in parallel, since it mutates package state.
 func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
-	origClasses := txMapSizeClasses
-	txMapSizeClasses = []uint32{1 << 12}
-
-	t.Cleanup(func() { txMapSizeClasses = origClasses })
+	withTxMapSizeClasses(t, []uint32{1 << 12})
 
 	subtree, err := subtreepkg.NewTreeByLeafCount(4)
 	require.NoError(t, err)
@@ -239,10 +283,7 @@ func TestCheckDuplicateTransactionsAboveUint32(t *testing.T) {
 // is built from the original classes at init, so the surviving index still
 // resolves to a real pool. Cleanup restore is mandatory; no t.Parallel().
 func TestGetParentSpendsMapBoundsPreallocation(t *testing.T) {
-	origClasses := parentSpendsSizeClasses
-	parentSpendsSizeClasses = []uint64{1 << 8}
-
-	t.Cleanup(func() { parentSpendsSizeClasses = origClasses })
+	withParentSpendsSizeClasses(t, []uint64{1 << 8})
 
 	const overMax = 1 << 20 // above the shrunk largest class, so idx < 0
 

--- a/model/block_txcount_64bit_test.go
+++ b/model/block_txcount_64bit_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/require"
 )
@@ -90,6 +91,14 @@ func TestCheckDuplicateTransactionsUsesFullCount(t *testing.T) {
 
 	require.NoError(t, block.checkDuplicateTransactions(context.Background(), ulogger.TestLogger{}, 4, nil))
 
+	// Hold the map across release: PutTxMap clears it only when the 64-bit key
+	// resolves to a pool class, so a wrong or stale release key (which would
+	// silently drop the map instead of pooling it) leaves the 3 entries behind.
+	pooled, ok := block.txMap.(*txmap.SplitSwissMapUint64)
+	require.True(t, ok)
+	require.Equal(t, 3, pooled.Length())
+
 	block.releaseTxMap()
 	require.Nil(t, block.txMap)
+	require.Equal(t, 0, pooled.Length(), "released map must be cleared and pooled, not dropped")
 }

--- a/model/block_validation_pools.go
+++ b/model/block_validation_pools.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"math"
 	"sync"
 
 	txmap "github.com/bsv-blockchain/go-tx-map"
@@ -73,24 +72,35 @@ func txMapClassIdxFor(n uint64) int {
 	return -1
 }
 
-// txMapAllocHint clamps a 64-bit entry count to the preallocation hint the
-// map constructor accepts. The constructor preallocates EAGERLY from the hint
-// (tens of GB for counts near the clamp — see the note in
-// TestGetTxMap_OversizedAllocatesFresh about keeping such allocations out of
-// tests), so the clamp caps preallocation only; the swiss maps resize on
+// txMapAllocHint bounds a 64-bit entry count to the preallocation hint passed
+// to the map constructor. It caps preallocation only — the swiss maps resize on
 // insert, so capacity is not limited by it.
+//
+// The bound is the largest pooled size class rather than math.MaxUint32 for two
+// reasons. The constructor preallocates EAGERLY from the hint at roughly 46
+// bytes per entry (see the note in TestGetTxMap_OversizedAllocatesFresh about
+// keeping such allocations out of tests), so a hint near the top of the uint32
+// range asks for well over 100 GB. Worse, it derives its per-bucket size as
+// (hint + hint/5) in uint32, which silently wraps for hints above ~3.58e9 and
+// yields an arbitrary preallocation unrelated to the count — MaxUint32 wraps to
+// ~859M entries. Bounding at the largest class keeps the hint below that
+// wraparound and asks for no more than the biggest allocation this pool design
+// already sanctions.
 func txMapAllocHint(n uint64) uint32 {
-	if n > math.MaxUint32 {
-		return math.MaxUint32
+	largestClass := txMapSizeClasses[len(txMapSizeClasses)-1]
+	if n > uint64(largestClass) {
+		return largestClass
 	}
 
 	return uint32(n)
 }
 
-// GetTxMap returns a *SplitSwissMapUint64 sized for at least n entries.
-// Drawn from the pool when n fits a known size class; allocated fresh
-// otherwise (with the preallocation hint clamped for counts beyond uint32,
-// instead of failing — issue 1428). Pass the same n to PutTxMap.
+// GetTxMap returns a *SplitSwissMapUint64 for n entries. Drawn from the pool
+// when n fits a known size class; allocated fresh otherwise, with the
+// preallocation hint bounded by txMapAllocHint instead of failing on counts
+// beyond uint32 (issue 1428). A bounded hint sizes the initial allocation only:
+// the map still holds n entries, growing on insert. Pass the same n to
+// PutTxMap.
 func GetTxMap(n uint64) *txmap.SplitSwissMapUint64 {
 	idx := txMapClassIdxFor(n)
 	if idx < 0 {

--- a/model/block_validation_pools.go
+++ b/model/block_validation_pools.go
@@ -73,20 +73,28 @@ func txMapClassIdxFor(n uint64) int {
 	return -1
 }
 
+// txMapAllocHint clamps a 64-bit entry count to the preallocation hint the
+// map constructor accepts. The constructor preallocates EAGERLY from the hint
+// (tens of GB for counts near the clamp — see the note in
+// TestGetTxMap_OversizedAllocatesFresh about keeping such allocations out of
+// tests), so the clamp caps preallocation only; the swiss maps resize on
+// insert, so capacity is not limited by it.
+func txMapAllocHint(n uint64) uint32 {
+	if n > math.MaxUint32 {
+		return math.MaxUint32
+	}
+
+	return uint32(n)
+}
+
 // GetTxMap returns a *SplitSwissMapUint64 sized for at least n entries.
 // Drawn from the pool when n fits a known size class; allocated fresh
-// otherwise. Pass the same n to PutTxMap. n is a preallocation hint — the
-// underlying swiss maps grow on demand — so counts beyond uint32 clamp the
-// hint rather than failing.
+// otherwise (with the preallocation hint clamped for counts beyond uint32,
+// instead of failing — issue 1428). Pass the same n to PutTxMap.
 func GetTxMap(n uint64) *txmap.SplitSwissMapUint64 {
 	idx := txMapClassIdxFor(n)
 	if idx < 0 {
-		hint := n
-		if hint > math.MaxUint32 {
-			hint = math.MaxUint32
-		}
-
-		return txmap.NewSplitSwissMapUint64(uint32(hint), txMapBuckets)
+		return txmap.NewSplitSwissMapUint64(txMapAllocHint(n), txMapBuckets)
 	}
 	return txMapPools[idx].Get().(*txmap.SplitSwissMapUint64)
 }

--- a/model/block_validation_pools.go
+++ b/model/block_validation_pools.go
@@ -72,6 +72,19 @@ func txMapClassIdxFor(n uint64) int {
 	return -1
 }
 
+// txMapConstructorWrapThreshold is the largest hint go-tx-map's
+// NewSplitSwissMapUint64 handles exactly. It derives its per-bucket size as
+// (hint + hint/5) computed in uint32, so hints above this wrap and yield an
+// arbitrary preallocation unrelated to the count (math.MaxUint32 wraps to
+// ~859M entries).
+//
+// The value mirrors that dependency's 20% headroom factor, which it does not
+// export, so it cannot be imported and must be revisited on a go-tx-map bump
+// (currently v1.4.1). TestTxMapAllocHintAvoidsConstructorOverflow asserts this
+// really is the last exact value and that one past it wraps, so a changed factor
+// fails the test rather than silently invalidating the bound below.
+const txMapConstructorWrapThreshold uint64 = 3579139413
+
 // txMapAllocHint bounds a 64-bit entry count to the preallocation hint passed
 // to the map constructor. It caps preallocation only — the swiss maps resize on
 // insert, so capacity is not limited by it.
@@ -80,12 +93,21 @@ func txMapClassIdxFor(n uint64) int {
 // reasons. The constructor preallocates EAGERLY from the hint at roughly 46
 // bytes per entry (see the note in TestGetTxMap_OversizedAllocatesFresh about
 // keeping such allocations out of tests), so a hint near the top of the uint32
-// range asks for well over 100 GB. Worse, it derives its per-bucket size as
-// (hint + hint/5) in uint32, which silently wraps for hints above ~3.58e9 and
-// yields an arbitrary preallocation unrelated to the count — MaxUint32 wraps to
-// ~859M entries. Bounding at the largest class keeps the hint below that
-// wraparound and asks for no more than the biggest allocation this pool design
-// already sanctions.
+// range asks for well over 100 GB. Second, it wraps above
+// txMapConstructorWrapThreshold, and the largest class sits safely below that.
+//
+// The cost this accepts: a count in the band between the largest class and the
+// wrap threshold previously got an exact preallocation and now gets the
+// largest-class hint, so filling it rehashes mid-fill across all buckets with a
+// transient peak around 1.5x the final size. That is the intended trade — an
+// unvalidated number should not drive an exact multi-GB allocation — and since
+// the count is now derived from the loaded block body (see txMapEntryCount) the
+// band is only reachable by a block that genuinely carries that many
+// transactions.
+//
+// The function is deliberately total (a min, not an assertion) so it stays
+// correct for any input, although its only current call site reaches it just
+// when n exceeds every class.
 func txMapAllocHint(n uint64) uint32 {
 	largestClass := txMapSizeClasses[len(txMapSizeClasses)-1]
 	if n > uint64(largestClass) {
@@ -93,6 +115,24 @@ func txMapAllocHint(n uint64) uint32 {
 	}
 
 	return uint32(n)
+}
+
+// parentSpendsAllocHint bounds an inpoint count to the capacity hint passed to
+// NewSplitSyncedParentMap, for the same reason txMapAllocHint exists: that
+// constructor preallocates eagerly per bucket and computes
+// uint32((n + n/5) / nrOfBuckets), so an unbounded hint both asks for an
+// unbounded allocation and can truncate into an arbitrary per-bucket size. The
+// bound is the largest pooled size class, which keeps the division exact.
+//
+// A block that genuinely carries more inpoints than the largest class still
+// holds them — the map grows on insert — it just is not preallocated for them.
+func parentSpendsAllocHint(expectedInpoints uint64) uint64 {
+	largestClass := parentSpendsSizeClasses[len(parentSpendsSizeClasses)-1]
+	if expectedInpoints > largestClass {
+		return largestClass
+	}
+
+	return expectedInpoints
 }
 
 // GetTxMap returns a *SplitSwissMapUint64 for n entries. Drawn from the pool
@@ -112,6 +152,13 @@ func GetTxMap(n uint64) *txmap.SplitSwissMapUint64 {
 // PutTxMap clears m and returns it to the size-class pool keyed by n.
 // n must match the value passed to GetTxMap. Maps that did not come from
 // the pool (n above max class) are dropped.
+//
+// Dropping them is deliberate, not an oversight, even though an over-max map is
+// built with the largest class's hint and buckets and so is interchangeable in
+// shape with that pool's contents: such a map has been *filled* past the class
+// it was sized for, so pooling it would retain an oversized backing for every
+// later block that draws the largest class. The cost is that consecutive
+// over-max blocks each allocate fresh.
 func PutTxMap(m *txmap.SplitSwissMapUint64, n uint64) {
 	if m == nil {
 		return
@@ -166,12 +213,17 @@ func parentSpendsClassIdxFor(n uint64) int {
 	return -1
 }
 
-// GetParentSpendsMap returns a *SplitSyncedParentMap sized for at least
-// expectedInpoints entries. Pass the same value to PutParentSpendsMap.
+// GetParentSpendsMap returns a *SplitSyncedParentMap for expectedInpoints
+// entries. Drawn from the pool when the count fits a known size class; allocated
+// fresh otherwise, with the preallocation hint bounded by parentSpendsAllocHint.
+// A bounded hint sizes the initial allocation only — the map still holds every
+// inpoint, growing on insert. Pass the same expectedInpoints to
+// PutParentSpendsMap: the pool class is chosen from the unbounded value, so an
+// over-max map is dropped on Put rather than retained (see PutTxMap for why).
 func GetParentSpendsMap(expectedInpoints uint64) *SplitSyncedParentMap {
 	idx := parentSpendsClassIdxFor(expectedInpoints)
 	if idx < 0 {
-		return NewSplitSyncedParentMap(parentSpendsBuckets, expectedInpoints)
+		return NewSplitSyncedParentMap(parentSpendsBuckets, parentSpendsAllocHint(expectedInpoints))
 	}
 	return parentSpendsPools[idx].Get().(*SplitSyncedParentMap)
 }

--- a/model/block_validation_pools.go
+++ b/model/block_validation_pools.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"math"
 	"sync"
 
 	txmap "github.com/bsv-blockchain/go-tx-map"
@@ -59,10 +60,13 @@ var txMapPools = func() []*sync.Pool {
 
 // txMapClassIdxFor returns the smallest size-class index that holds n
 // entries, or -1 if n exceeds every class (caller allocates fresh + skips
-// the pool).
-func txMapClassIdxFor(n uint32) int {
+// the pool). n is 64-bit because a block's transaction count is: post-Genesis
+// BSV has no block-size limit, and narrowing the count to uint32 turned a
+// consensus-valid block with more than 2^32 transactions into an eternally
+// retried processing error (issue 1428).
+func txMapClassIdxFor(n uint64) int {
 	for i, class := range txMapSizeClasses {
-		if n <= class {
+		if n <= uint64(class) {
 			return i
 		}
 	}
@@ -71,11 +75,18 @@ func txMapClassIdxFor(n uint32) int {
 
 // GetTxMap returns a *SplitSwissMapUint64 sized for at least n entries.
 // Drawn from the pool when n fits a known size class; allocated fresh
-// otherwise. Pass the same n to PutTxMap.
-func GetTxMap(n uint32) *txmap.SplitSwissMapUint64 {
+// otherwise. Pass the same n to PutTxMap. n is a preallocation hint — the
+// underlying swiss maps grow on demand — so counts beyond uint32 clamp the
+// hint rather than failing.
+func GetTxMap(n uint64) *txmap.SplitSwissMapUint64 {
 	idx := txMapClassIdxFor(n)
 	if idx < 0 {
-		return txmap.NewSplitSwissMapUint64(n, txMapBuckets)
+		hint := n
+		if hint > math.MaxUint32 {
+			hint = math.MaxUint32
+		}
+
+		return txmap.NewSplitSwissMapUint64(uint32(hint), txMapBuckets)
 	}
 	return txMapPools[idx].Get().(*txmap.SplitSwissMapUint64)
 }
@@ -83,7 +94,7 @@ func GetTxMap(n uint32) *txmap.SplitSwissMapUint64 {
 // PutTxMap clears m and returns it to the size-class pool keyed by n.
 // n must match the value passed to GetTxMap. Maps that did not come from
 // the pool (n above max class) are dropped.
-func PutTxMap(m *txmap.SplitSwissMapUint64, n uint32) {
+func PutTxMap(m *txmap.SplitSwissMapUint64, n uint64) {
 	if m == nil {
 		return
 	}


### PR DESCRIPTION
## What happened

Post-Genesis BSV has no block-size limit, and the wire format carries a block's transaction count as a CompactSize — up to 2^64. Teranode stores the count as `uint64`, but the duplicate-transaction check narrowed it to `uint32` and returned a *processing* error when the conversion failed. Block validation treats processing errors as transient, so a block with more than about 4.29 billion transactions would be refetched and revalidated forever — never accepted, never cleanly rejected. Because the trigger is deterministic, every node in the fleet wedges on the same block at the same time, while SV Node accepts it and moves on. This is the same rare-state, silent-stall shape as the August 4th outage class the hardening map targets.

Closes #1428.

## Changes

- **`model/block_validation_pools.go`** — the txMap pool API (`GetTxMap`, `PutTxMap`, `txMapClassIdxFor`) now takes the entry count as `uint64`. Counts beyond the largest size class allocate a fresh map with the preallocation hint bounded by `txMapAllocHint`, instead of failing. The bound sizes the initial allocation only — the swiss maps grow on insert, so a bounded hint does not cap capacity.
- **`model/Block.go`** — the failing conversion and its error path are gone. `checkDuplicateTransactions` no longer sizes anything from `b.TransactionCount` at all: a new `txMapEntryCount()` sums `len(subtree.Nodes)` over the loaded subtree bodies, which is an exact upper bound on what the duplicate check inserts (bar the coinbase placeholder it skips). That value is stashed as `b.txMapCount` so the pool release key cannot drift from the value used at `GetTxMap` time, and the disk-backed `FilterCapacity` derives from it too. The release path (`releaseTxMap`) uses `b.txMapCount`, removing a now-dead conditional: the old skip-on-conversion-failure branch was unreachable, because the same narrowing had already failed earlier and left the map unassigned — no production leak existed.
- **`model/Block.go`, parent-spends sizing** — `validOrderAndBlessed` sizes its map from the same body-derived count via a new `parentSpendsCapacity()`, so a claimed count can no longer drive that allocation either. The multiply degrades to the unmultiplied count on overflow; the remaining overflow route is the operator-supplied `block_parentSpendsCapacityMultiplier`, since the body-derived count is bounded by what fits in memory.
- **No new rejection**: per the issue's warning, the ceiling is not converted into a Teranode-only block-invalid verdict — that would split Teranode from BSV on a block SV Node considers valid. A genuine hard cap must be a coordinated consensus change.
- **Tests (`model/block_txcount_64bit_test.go`)** — the issue's own scenario is now pinned end to end: `TestCheckDuplicateTransactionsAboveUint32` drives the real duplicate-check path with `TransactionCount = MaxUint32 + 1` and asserts no error. It costs a four-node map, because the claimed count no longer sizes anything — which is what previously made this untestable without the tens-of-GB allocation this package documents avoiding under issue 1051. The size classes are shrunk for that test regardless, so a future regression to claimed-count sizing fails the assertion instead of preallocating for 2^32 entries. Alongside it: the pure classification and hint functions across counts up to 2^64, a pooled round trip on the 64-bit key, `parentSpendsCapacity` including its overflow fallback, and `txMapEntryCount` on the claim-exceeds-body and zero-subtree shapes. Both new guards are mutation-proved.

## Trade-offs and testing

- The disk-backed map path already carried the count as `uint`/`uint64` and is unchanged.
- **Sizing comes from the block body, not the claimed count** (the substance of ctnguyen's review — see the thread below). An intermediate revision bounded the hint instead, which limited the blast radius of a peer-chosen number rather than declining to trust it. Both approaches are kept: the hint is still bounded by the largest pooled size class, because `MaxUint32` sits past the point where the map constructor's own per-bucket arithmetic — `(length + length/5)`, computed in `uint32` — silently wraps, which would preallocate ~859M entries by wraparound rather than by design. The bound is now defence in depth behind an input that is no longer attacker-chosen.
- **This fix removes the retry loop; it does not make a genuinely >2^32-transaction block validatable in memory mode.** A block that really carries that many transactions needs a multi-hundred-GB txMap (~46 bytes per entry), so on a memory-budgeted node the outcome is an OOM rather than a successful validation, and `block_diskMapDirs` is the real answer at that scale. What changes is that the block is no longer failed by a *type conversion* and refetched forever. Note the memory cost now tracks what a block actually carries rather than what it claims, so a block merely *claiming* a huge count is cheap.
- Two other `uint32` narrowings remain in `model` (block height, coinbase parts loop); both are height- or protocol-bounded, not transaction-count-bounded, and are untouched.
- Ran: `go build ./...`, `go vet ./model/`, `go test ./model/` (549 green), `-race` on the new tests, `golangci-lint run --new-from-rev upstream/main` (0 issues). Peak test RSS for the new file measured under 1GB (the original round-1 version peaked at ~44GB and was reworked). The round-5 overflow guard was mutation-proved: it fails against the previous `MaxUint32` clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


