### PR TITLE
fix(p2p): set http.Server timeouts on the p2p HTTP server

### DIFF
--- a/docs/topics/services/p2p.md
+++ b/docs/topics/services/p2p.md
@@ -169,7 +169,8 @@ The `Start` function is responsible for commencing the P2P service:
 2. **HTTP Endpoints**:
 
     - Sets up a health check endpoint (`/health`) that responds with "OK".
-    - Adds a WebSocket endpoint (`/ws`) for real-time communication via `s.HandleWebSocket`.
+    - Adds a WebSocket endpoint (`/p2p-ws`) for real-time communication via `s.HandleWebSocket`.
+    - Configures HTTP server timeouts (read header, read, write, idle) so slow or stalled clients cannot hold connections open indefinitely; established WebSocket connections are exempt because connection deadlines are cleared on upgrade.
 
 3. **Start HTTP Server**:
 

--- a/docs/topics/services/p2p.md
+++ b/docs/topics/services/p2p.md
@@ -148,7 +148,7 @@ The P2P server's `Init` function is in charge of server setup:
 
 2. **Asset HTTP Address Configuration**:
 
-    - Retrieves the Asset HTTP Address URL from the configuration using `gocore.Config().GetURL("asset_httpAddress")`.
+    - Retrieves the Asset HTTP Address URL from the settings, preferring `Asset.HTTPPublicAddress` and falling back to `Asset.HTTPAddress`.
 
 3. **Block Validation Client Initialization**:
 
@@ -170,11 +170,11 @@ The `Start` function is responsible for commencing the P2P service:
 
     - Sets up a health check endpoint (`/health`) that responds with "OK".
     - Adds a WebSocket endpoint (`/p2p-ws`) for real-time communication via `s.HandleWebSocket`.
-    - Configures HTTP server timeouts (read header, read, write, idle) so slow or stalled clients cannot hold connections open indefinitely; established WebSocket connections are exempt because connection deadlines are cleared on upgrade.
+    - Configures HTTP server timeouts (read header, read, write, idle) so slow or stalled clients cannot hold plain HTTP exchanges (or incomplete WebSocket upgrades) open indefinitely. Established WebSocket connections are exempt: connection deadlines are cleared on upgrade, so post-upgrade liveness is handled by separate WebSocket hardening, not these timeouts.
 
 3. **Start HTTP Server**:
 
-    - Initiates the HTTP server using a goroutine, which is executed via `s.StartHttp`.
+    - Starts the HTTP server via `s.StartHTTP`, which binds the listener synchronously (so configuration errors fail startup) and then serves in a goroutine.
 
 4. **PubSub Topics Setup**:
 

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -682,21 +682,29 @@ func (s *Server) Init(ctx context.Context) (err error) {
 //
 // Returns an error if any component fails to start, or nil on successful startup.
 
+// HTTP server timeouts for the p2p HTTP surface. They bound every phase of a
+// plain HTTP exchange (e.g. /health) plus the request/header/idle phases of a
+// /p2p-ws connection that never completes its upgrade. They do NOT bound an
+// established /p2p-ws stream: net/http clears the connection deadlines on
+// Hijack (and gorilla/websocket clears them again on upgrade), so post-upgrade
+// liveness (read deadlines, ping/pong, connection caps) is separate websocket
+// hardening work.
+const (
+	httpReadHeaderTimeout = 10 * time.Second
+	httpReadTimeout       = 30 * time.Second
+	httpWriteTimeout      = 30 * time.Second
+	httpIdleTimeout       = 120 * time.Second
+)
+
 func (s *Server) setupHTTPServer() *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
 
-	// Bound every phase of a plain HTTP exchange so slow or stalled clients
-	// cannot hold connections (and their goroutines/fds) forever. The
-	// long-lived /p2p-ws stream is unaffected: net/http clears the connection
-	// deadlines on Hijack (and gorilla/websocket clears them again on
-	// upgrade), so none of these timeouts apply once a websocket is
-	// established.
-	e.Server.ReadHeaderTimeout = 10 * time.Second
-	e.Server.ReadTimeout = 30 * time.Second
-	e.Server.WriteTimeout = 30 * time.Second
-	e.Server.IdleTimeout = 120 * time.Second
+	e.Server.ReadHeaderTimeout = httpReadHeaderTimeout
+	e.Server.ReadTimeout = httpReadTimeout
+	e.Server.WriteTimeout = httpWriteTimeout
+	e.Server.IdleTimeout = httpIdleTimeout
 
 	e.Use(middleware.Recover())
 

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -687,6 +687,16 @@ func (s *Server) setupHTTPServer() *echo.Echo {
 	e.HideBanner = true
 	e.HidePort = true
 
+	// Bound the request/header phase and idle keep-alives so slow or stalled
+	// clients cannot hold connections (and their goroutines/fds) forever.
+	// WriteTimeout is deliberately left unset: it would cap the lifetime of the
+	// long-lived /p2p-ws stream; the websocket handler applies its own
+	// per-connection write deadlines instead. ReadTimeout is safe for /p2p-ws
+	// because gorilla/websocket clears the connection deadlines on upgrade.
+	e.Server.ReadHeaderTimeout = 10 * time.Second
+	e.Server.ReadTimeout = 30 * time.Second
+	e.Server.IdleTimeout = 120 * time.Second
+
 	e.Use(middleware.Recover())
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -687,14 +687,15 @@ func (s *Server) setupHTTPServer() *echo.Echo {
 	e.HideBanner = true
 	e.HidePort = true
 
-	// Bound the request/header phase and idle keep-alives so slow or stalled
-	// clients cannot hold connections (and their goroutines/fds) forever.
-	// WriteTimeout is deliberately left unset: it would cap the lifetime of the
-	// long-lived /p2p-ws stream; the websocket handler applies its own
-	// per-connection write deadlines instead. ReadTimeout is safe for /p2p-ws
-	// because gorilla/websocket clears the connection deadlines on upgrade.
+	// Bound every phase of a plain HTTP exchange so slow or stalled clients
+	// cannot hold connections (and their goroutines/fds) forever. The
+	// long-lived /p2p-ws stream is unaffected: net/http clears the connection
+	// deadlines on Hijack (and gorilla/websocket clears them again on
+	// upgrade), so none of these timeouts apply once a websocket is
+	// established.
 	e.Server.ReadHeaderTimeout = 10 * time.Second
 	e.Server.ReadTimeout = 30 * time.Second
+	e.Server.WriteTimeout = 30 * time.Second
 	e.Server.IdleTimeout = 120 * time.Second
 
 	e.Use(middleware.Recover())

--- a/services/p2p/server_http_timeouts_test.go
+++ b/services/p2p/server_http_timeouts_test.go
@@ -1,0 +1,81 @@
+package p2p
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetupHTTPServerTimeouts guards against the HTTP server regressing to a
+// zero-value http.Server with unlimited timeouts (slowloris / fd exhaustion).
+func TestSetupHTTPServerTimeouts(t *testing.T) {
+	s := &Server{
+		gCtx:   t.Context(),
+		logger: &ulogger.TestLogger{},
+	}
+
+	e := s.setupHTTPServer()
+
+	require.NotZero(t, e.Server.ReadHeaderTimeout, "ReadHeaderTimeout must be set to bound the header phase")
+	require.NotZero(t, e.Server.ReadTimeout, "ReadTimeout must be set to bound the request read")
+	require.NotZero(t, e.Server.IdleTimeout, "IdleTimeout must be set to reap idle keep-alive connections")
+	require.Zero(t, e.Server.WriteTimeout, "WriteTimeout must stay unset or it would cap the lifetime of /p2p-ws streams")
+}
+
+// TestHTTPServerClosesSlowHeaderClient opens a raw connection, sends a partial
+// request and never completes the headers, then asserts the server closes the
+// connection once ReadHeaderTimeout fires instead of holding it open forever.
+// The timeouts are shortened to keep the test fast; the production values are
+// asserted in TestSetupHTTPServerTimeouts.
+func TestHTTPServerClosesSlowHeaderClient(t *testing.T) {
+	s := &Server{
+		gCtx:   t.Context(),
+		logger: &ulogger.TestLogger{},
+	}
+
+	e := s.setupHTTPServer()
+	e.Server.ReadHeaderTimeout = 200 * time.Millisecond
+	e.Server.ReadTimeout = 200 * time.Millisecond
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	e.Listener = listener
+
+	go func() {
+		_ = e.Server.Serve(listener)
+	}()
+
+	defer func() {
+		_ = e.Close()
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+
+	defer conn.Close()
+
+	// Partial request: request line plus one header, never the terminating CRLF.
+	_, err = conn.Write([]byte("GET /health HTTP/1.1\r\nHost: teranode\r\n"))
+	require.NoError(t, err)
+
+	// Well past the shortened ReadHeaderTimeout; only hit if the server
+	// never closes the connection.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	// Drain until the server closes the connection. io.Copy returns nil on a
+	// clean EOF; a reset is also acceptable. A read deadline hit means the
+	// server held the slow connection open, which is the bug.
+	_, err = io.Copy(io.Discard, conn)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			t.Fatal("server held the slow-header connection open past ReadHeaderTimeout")
+		}
+	}
+}

--- a/services/p2p/server_http_timeouts_test.go
+++ b/services/p2p/server_http_timeouts_test.go
@@ -23,10 +23,15 @@ func TestSetupHTTPServerTimeouts(t *testing.T) {
 
 	e := s.setupHTTPServer()
 
-	require.NotZero(t, e.Server.ReadHeaderTimeout, "ReadHeaderTimeout must be set to bound the header phase")
-	require.NotZero(t, e.Server.ReadTimeout, "ReadTimeout must be set to bound the request read")
-	require.NotZero(t, e.Server.WriteTimeout, "WriteTimeout must be set to bound the response write")
-	require.NotZero(t, e.Server.IdleTimeout, "IdleTimeout must be set to reap idle keep-alive connections")
+	require.Equal(t, httpReadHeaderTimeout, e.Server.ReadHeaderTimeout, "ReadHeaderTimeout must be set to bound the header phase")
+	require.Equal(t, httpReadTimeout, e.Server.ReadTimeout, "ReadTimeout must be set to bound the request read")
+	require.Equal(t, httpWriteTimeout, e.Server.WriteTimeout, "WriteTimeout must be set to bound the response write")
+	require.Equal(t, httpIdleTimeout, e.Server.IdleTimeout, "IdleTimeout must be set to reap idle keep-alive connections")
+
+	// Sanity relationships: values that individually pass NotZero could still
+	// be nonsensical (e.g. header timeout longer than the whole read budget).
+	require.LessOrEqual(t, e.Server.ReadHeaderTimeout, e.Server.ReadTimeout, "header phase must fit inside the request read budget")
+	require.GreaterOrEqual(t, e.Server.IdleTimeout, e.Server.ReadTimeout, "keep-alive reuse should outlive a single request read")
 }
 
 // TestHTTPServerClosesSlowHeaderClient opens a raw connection, sends a partial

--- a/services/p2p/server_http_timeouts_test.go
+++ b/services/p2p/server_http_timeouts_test.go
@@ -1,13 +1,15 @@
 package p2p
 
 import (
-	"errors"
 	"io"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,15 +25,15 @@ func TestSetupHTTPServerTimeouts(t *testing.T) {
 
 	require.NotZero(t, e.Server.ReadHeaderTimeout, "ReadHeaderTimeout must be set to bound the header phase")
 	require.NotZero(t, e.Server.ReadTimeout, "ReadTimeout must be set to bound the request read")
+	require.NotZero(t, e.Server.WriteTimeout, "WriteTimeout must be set to bound the response write")
 	require.NotZero(t, e.Server.IdleTimeout, "IdleTimeout must be set to reap idle keep-alive connections")
-	require.Zero(t, e.Server.WriteTimeout, "WriteTimeout must stay unset or it would cap the lifetime of /p2p-ws streams")
 }
 
 // TestHTTPServerClosesSlowHeaderClient opens a raw connection, sends a partial
 // request and never completes the headers, then asserts the server closes the
 // connection once ReadHeaderTimeout fires instead of holding it open forever.
-// The timeouts are shortened to keep the test fast; the production values are
-// asserted in TestSetupHTTPServerTimeouts.
+// The timeouts are shortened to keep the test fast; that the fields are set at
+// all is guarded by TestSetupHTTPServerTimeouts.
 func TestHTTPServerClosesSlowHeaderClient(t *testing.T) {
 	s := &Server{
 		gCtx:   t.Context(),
@@ -44,8 +46,6 @@ func TestHTTPServerClosesSlowHeaderClient(t *testing.T) {
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-
-	e.Listener = listener
 
 	go func() {
 		_ = e.Server.Serve(listener)
@@ -78,4 +78,62 @@ func TestHTTPServerClosesSlowHeaderClient(t *testing.T) {
 			t.Fatal("server held the slow-header connection open past ReadHeaderTimeout")
 		}
 	}
+}
+
+// TestWebsocketSurvivesHTTPServerTimeouts proves the risky half of the change:
+// the http.Server timeouts must not apply to an established /p2p-ws stream
+// (net/http clears the connection deadlines on Hijack). The timeouts are
+// shortened so an affected stream would die within the test's window.
+func TestWebsocketSurvivesHTTPServerTimeouts(t *testing.T) {
+	s := &Server{
+		gCtx:           t.Context(),
+		logger:         &ulogger.TestLogger{},
+		settings:       test.CreateBaseTestSettings(t),
+		notificationCh: make(chan *notificationMsg, 10),
+		startTime:      time.Now(),
+	}
+
+	e := s.setupHTTPServer()
+	e.Server.ReadHeaderTimeout = 300 * time.Millisecond
+	e.Server.ReadTimeout = 300 * time.Millisecond
+	e.Server.WriteTimeout = 300 * time.Millisecond
+	e.Server.IdleTimeout = 300 * time.Millisecond
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		_ = e.Server.Serve(listener)
+	}()
+
+	defer func() {
+		_ = e.Close()
+	}()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://"+listener.Addr().String()+"/p2p-ws", nil)
+	require.NoError(t, err)
+
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+
+	defer conn.Close()
+
+	// The initial node_status message is sent on connect.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Contains(t, string(msg), "node_status")
+
+	// Outlive every configured timeout, then confirm the stream still works.
+	time.Sleep(1200 * time.Millisecond)
+
+	s.notificationCh <- &notificationMsg{Type: "ping-after-timeouts"}
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	_, msg, err = conn.ReadMessage()
+	require.NoError(t, err, "established websocket must outlive the http.Server timeouts")
+	require.Contains(t, string(msg), "ping-after-timeouts")
 }


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4737.**

### Problem

The p2p service's echo HTTP server was a zero-value `http.Server`: `ReadTimeout`, `ReadHeaderTimeout`, `WriteTimeout` and `IdleTimeout` all unset, i.e. unlimited, on a port that binds all interfaces by default. A client that dribbles request headers (slowloris) or parks idle keep-alive connections holds a connection, a goroutine and an fd forever. The validator, asset and blockpersister servers all set these; p2p was the outlier. Confirmed still present at `services/p2p/Server.go` (`setupHTTPServer` / `StartHTTP`).

### Fix

Set the timeouts in `setupHTTPServer`, where the server is built, as named constants asserted by the regression test:

- `ReadHeaderTimeout` 10s, `ReadTimeout` 30s, `WriteTimeout` 30s, `IdleTimeout` 120s.

These land on the served instance for both paths: `StartHTTP` serves via `s.e.Server.Serve` / `s.e.Server.ServeTLS` and never uses echo's `Start`/`StartTLS`, so `e.TLSServer` is never involved.

One improvement over the issue's proposal: the issue said `WriteTimeout` must stay unset or it would kill `/p2p-ws` streams. That's not how `net/http` behaves - `Hijack` clears the connection deadlines before the handler gets the conn (and gorilla/websocket clears them again on upgrade, including when a `HandshakeTimeout` is set). So none of these timeouts apply to an established websocket, and `WriteTimeout` is set too, matching every sibling service and closing the slow-read half of the same DoS. This is proven by a dedicated test (see below).

The in-code comment and the docs scope the claim precisely: the timeouts bound plain HTTP exchanges and incomplete `/p2p-ws` upgrades; they do not bound an established websocket stream, whose liveness (read deadlines, ping/pong, connection caps) is separate hardening work (see Residual).

Also fixed adjacent stale docs in `docs/topics/services/p2p.md`: the route name (`/ws` → `/p2p-ws`), `s.StartHttp` → `StartHTTP` (which binds synchronously and serves in a goroutine), and the long-gone `gocore.Config().GetURL("asset_httpAddress")` reference (now `Asset.HTTPPublicAddress` with `Asset.HTTPAddress` fallback).

### Residual

Deliberately out of scope, from the issue's "Also" list:

- **Loopback default for `p2p_httpListenAddress`**: the asset service's centrifuge client connects to `/p2p-ws` cross-pod (`p2p_httpAddress.operator = peer.${clientName}.svc.cluster.local`), and there is no `p2p_httpListenAddress.operator` override - a loopback committed default would break operator/k8s deployments on upgrade. Needs a deployment decision plus per-context overrides.
- **CORS `*` / always-true `CheckOrigin`**: needs an operator-facing allow-list setting; flipping `CheckOrigin` also breaks the dashboard's cross-origin `wstest` page. Separate change.
- **`netutil.LimitListener` connection cap**: no sibling precedent and the cap value should be a setting; separate change.
- **Post-upgrade websocket hardening** (client cap, read deadlines/ping-pong on established conns): pre-existing gap tracked by the `/p2p-ws` hardening work (PR #1380); these `http.Server` timeouts cover the request/header/idle phases, not hijacked conns. An attacker can still park established websockets; that is unchanged by this PR and explicitly not claimed by it.
- **Asset service TLS timeouts are dead code** (`h.e.StartTLS` serves from `e.TLSServer`, but the timeouts are set on `e.Server`): separate pre-existing bug, deserves its own issue rather than being bundled here.

### Tests

Added `services/p2p/server_http_timeouts_test.go`:

- `TestSetupHTTPServerTimeouts` - regression guard asserting the four fields equal the named constants, plus sanity relationships (`ReadHeaderTimeout <= ReadTimeout`, `IdleTimeout >= ReadTimeout`), so a revert or a nonsense value fails the test.
- `TestHTTPServerClosesSlowHeaderClient` - slowloris repro: raw conn, partial headers, asserts the server closes the connection when `ReadHeaderTimeout` fires instead of holding it open.
- `TestWebsocketSurvivesHTTPServerTimeouts` - proves the risky half: with all timeouts shortened to 300ms, an established `/p2p-ws` stream still delivers a notification pushed 1.2s after upgrade.

Run (affected package only):

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...
```

All green, including after rebasing onto latest upstream/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
