### PR TITLE
Remove dead build-tx-blaster Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ dev-dashboard:
 	npm install --prefix ./ui/dashboard && npm run dev --prefix ./ui/dashboard
 
 .PHONY: build
-# build-blockchainstatus build-tx-blaster build-propagation-blaster build-aerospiketest build-blockassembly-blaster build-utxostore-blaster build-s3-blaster build-chainintegrity
+# build-propagation-blaster build-aerospiketest build-blockassembly-blaster build-utxostore-blaster build-s3-blaster build-chainintegrity
 build: update_config build-teranode-with-dashboard build-teranode-cli clean_backup
 
 .PHONY: update_config
@@ -140,10 +140,6 @@ build-teranode-dev:
 # .PHONY: build-blockassembly-blaster
 # build-blockassembly-blaster: set_debug_flags
 # 	go build --trimpath -ldflags="-X main.commit=${GITHUB_SHA} -X main.version=MANUAL" -gcflags "all=${DEBUG_FLAGS}" -o blockassemblyblaster.run ./cmd/blockassembly_blaster/main.go
-
-.PHONY: build-blockchainstatus
-build-blockchainstatus:
-	go build -o blockchainstatus.run ./cmd/blockchainstatus/
 
 # .PHONY: build-aerospiketest
 # build-aerospiketest:
@@ -494,8 +490,6 @@ clean_gen:
 .PHONY: clean
 clean:
 	rm -f ./teranode_*.tar.gz
-	rm -f blaster.run
-	rm -f blockchainstatus.run
 	rm -rf build/
 	rm -f coverage.out
 

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,6 @@ build-teranode-ci: set_debug_flags set_txmetacache_flag
 build-chainintegrity: set_debug_flags
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o chainintegrity.run ./compose/cmd/chainintegrity/
 
-.PHONY: build-tx-blaster
-build-tx-blaster: set_debug_flags
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build --trimpath -ldflags="-X main.commit=${GIT_COMMIT} -X main.version=${GIT_VERSION}" -gcflags "all=${DEBUG_FLAGS}" -o blaster.run ./cmd/txblaster/
-
 .PHONY: build-teranode-cli
 build-teranode-cli:
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod=readonly -o teranode-cli ./cmd/teranodecli

--- a/compose/docker-compose-3blasters.yml
+++ b/compose/docker-compose-3blasters.yml
@@ -9,6 +9,7 @@ x-teranode-base: &teranode-base
     - ../data/test/${TEST_ID:-chainintegrity}:/app/data
 
 x-teranode-coinbase-base: &teranode-coinbase-base
+  # coinbase.run/blaster.run/blaster-tui.run come from this externally-built image; the source is not in this repository.
   image: 434394763103.dkr.ecr.eu-north-1.amazonaws.com/teranode-coinbase:latest
   # image: teranode-coinbase:local
   networks:

--- a/docs/howto/makefile.md
+++ b/docs/howto/makefile.md
@@ -103,7 +103,6 @@ This Makefile facilitates a variety of development and build tasks for the Teran
 ### Building Tools and Utilities
 
 - **build-chainintegrity**: Builds the chain integrity testing tool at `./compose/cmd/chainintegrity/`.
-- **build-blockchainstatus**: Builds the blockchain status utility at `./cmd/blockchainstatus/`. **Note:** the `./cmd/blockchainstatus/` source directory does not currently exist; this target will fail if invoked.
 
 ### Testing
 
@@ -190,7 +189,6 @@ The chain integrity test suite validates that multiple Teranode instances mainta
 - **clean**: Cleans up built artifacts:
 
     - Removes `.tar.gz` archives
-    - Removes binary executables (`blaster.run`, `blockchainstatus.run`)
     - Removes build directory
     - Removes coverage output files
 

--- a/docs/howto/makefile.md
+++ b/docs/howto/makefile.md
@@ -103,7 +103,6 @@ This Makefile facilitates a variety of development and build tasks for the Teran
 ### Building Tools and Utilities
 
 - **build-chainintegrity**: Builds the chain integrity testing tool at `./compose/cmd/chainintegrity/`.
-- **build-tx-blaster**: Builds the transaction blaster performance testing tool at `./cmd/txblaster/`. **Note:** the `./cmd/txblaster/` source directory does not currently exist; this target will fail if invoked.
 - **build-blockchainstatus**: Builds the blockchain status utility at `./cmd/blockchainstatus/`. **Note:** the `./cmd/blockchainstatus/` source directory does not currently exist; this target will fail if invoked.
 
 ### Testing


### PR DESCRIPTION
## Summary

- `build-tx-blaster` built `./cmd/txblaster/`, but that directory doesn't exist anywhere in the repo, so the target could only ever fail with a build error. Removed the target and its `.PHONY` entry, plus the now-stale doc line describing it in `docs/howto/makefile.md`.
- The blaster/coinbase binaries used by `compose/docker-compose-3blasters.yml` actually come from an external `teranode-coinbase` image, not from anything built in this repo. Added a comment at the `x-teranode-coinbase-base` anchor so this isn't mistaken for an in-repo build target later.

Checked for other references to `build-tx-blaster` (CI workflows, other Makefile targets) — found none besides the doc line removed here.

## Test plan

- [ ] `make build-tx-blaster` no longer exists as a target
- [ ] `make build` / `make lint` still succeed
- [ ] compose file still parses (`docker compose -f compose/docker-compose-3blasters.yml config`)