### PR TITLE
fix(legacy): restore plain-inventory fallback for block relay to non-sendheaders peers

### DIFF
--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -2523,6 +2523,13 @@ func (s *server) handleRelayInvMsg(state *peerState, msg relayMsg) {
 			return
 		}
 
+		// Peers that have not negotiated sendheaders still need the block
+		// announced via a plain inventory message.
+		if msg.invVect.Type == wire.InvTypeBlock {
+			s.handleRelayBlockInvMsg(sp, msg)
+			return
+		}
+
 		if msg.invVect.Type == wire.InvTypeTx {
 			// Don't relay the transaction to the peer when it has
 			// transaction relaying disabled.
@@ -2603,6 +2610,13 @@ func (s *server) handleRelayBlockMsg(sp *serverPeer, msg relayMsg) {
 	}
 
 	sp.QueueMessage(msgHeaders, nil)
+}
+
+// handleRelayBlockInvMsg queues a plain inventory vector for a block to a peer
+// that has not negotiated sendheaders. Peers that did negotiate sendheaders are
+// announced via a headers message instead, in handleRelayBlockMsg.
+func (s *server) handleRelayBlockInvMsg(sp serverPeerQueueInventory, msg relayMsg) {
+	sp.QueueInventory(msg.invVect)
 }
 
 // handleBroadcastMsg deals with broadcasting messages to peers.  It is invoked

--- a/services/legacy/peer_server_test.go
+++ b/services/legacy/peer_server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-chaincfg"
+	txmap "github.com/bsv-blockchain/go-tx-map"
 	"github.com/bsv-blockchain/go-wire"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
@@ -213,6 +214,125 @@ func TestHandleRelayBlockInvMsg(t *testing.T) {
 	s.handleRelayBlockInvMsg(sp, msg)
 
 	sp.AssertCalled(t, "QueueInventory", invVect)
+}
+
+// tcpAddrConn wraps a net.Pipe end so both sides report a *net.TCPAddr. peer.Peer
+// builds a wire.NetAddress from the connection's remote address, which only works
+// for TCP (or socks) addresses, and net.Pipe reports a "pipe" address.
+type tcpAddrConn struct {
+	net.Conn
+
+	local  *net.TCPAddr
+	remote *net.TCPAddr
+}
+
+func (c *tcpAddrConn) LocalAddr() net.Addr  { return c.local }
+func (c *tcpAddrConn) RemoteAddr() net.Addr { return c.remote }
+
+// TestHandleRelayInvMsgBlockToNonSendHeadersPeer drives handleRelayInvMsg itself -
+// not just the extracted helper - over a real, fully handshaked peer that never
+// sent "sendheaders", and asserts the block reaches the wire as a plain inv
+// message. This pins the dispatch in handleRelayInvMsg: without the InvTypeBlock
+// fallback branch, a non-sendheaders peer gets no announcement for the block at
+// all and no inv is ever written.
+func TestHandleRelayInvMsgBlockToNonSendHeadersPeer(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	logger := ulogger.TestLogger{}
+
+	invReceived := make(chan *wire.MsgInv, 1)
+
+	// The remote end records the inv messages it receives. Neither side sends
+	// "sendheaders", so WantsHeaders() stays false on both peers.
+	remoteCfg := &peer.Config{
+		Listeners: peer.MessageListeners{
+			OnInv: func(_ *peer.Peer, msg *wire.MsgInv) {
+				select {
+				case invReceived <- msg:
+				default:
+				}
+			},
+		},
+		UserAgentName:          "remote",
+		UserAgentVersion:       "1.0",
+		ChainParams:            &chaincfg.MainNetParams,
+		Services:               wire.SFNodeNetwork,
+		TrickleInterval:        10 * time.Millisecond,
+		TstAllowSelfConnection: true,
+	}
+
+	localCfg := &peer.Config{
+		UserAgentName:          "local",
+		UserAgentVersion:       "1.0",
+		ChainParams:            &chaincfg.MainNetParams,
+		Services:               wire.SFNodeNetwork,
+		TrickleInterval:        10 * time.Millisecond,
+		TstAllowSelfConnection: true,
+	}
+
+	remoteEnd, localEnd := net.Pipe()
+
+	remoteAddr := &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 8333}
+	localAddr := &net.TCPAddr{IP: net.ParseIP("10.0.0.2"), Port: 8333}
+
+	remotePeer := peer.NewInboundPeer(logger, tSettings, remoteCfg)
+	remotePeer.AssociateConnection(&tcpAddrConn{Conn: remoteEnd, local: remoteAddr, remote: localAddr})
+
+	localPeer, err := peer.NewOutboundPeer(logger, tSettings, localCfg, remoteAddr.String())
+	require.NoError(t, err)
+
+	localPeer.AssociateConnection(&tcpAddrConn{Conn: localEnd, local: localAddr, remote: remoteAddr})
+
+	t.Cleanup(func() {
+		localPeer.DisconnectWithInfo("test cleanup")
+		remotePeer.DisconnectWithInfo("test cleanup")
+	})
+
+	// The inv is dropped by the peer's queue handler until the version handshake
+	// has completed, so wait for both sides to finish negotiating.
+	require.Eventually(t, func() bool {
+		return localPeer.VersionKnown() && localPeer.VerAckReceived() &&
+			remotePeer.VersionKnown() && remotePeer.VerAckReceived()
+	}, 10*time.Second, 10*time.Millisecond, "peers did not complete the version handshake")
+
+	s := &server{logger: logger}
+
+	sp := &serverPeer{
+		Peer:   localPeer,
+		server: s,
+		quit:   make(chan struct{}),
+	}
+
+	// Precondition for the fallback: this peer did not negotiate sendheaders.
+	require.False(t, sp.WantsHeaders())
+	require.True(t, sp.Connected())
+
+	state := &peerState{
+		inboundPeers:    txmap.NewSyncedMap[int32, *serverPeer](),
+		outboundPeers:   txmap.NewSyncedMap[int32, *serverPeer](),
+		persistentPeers: txmap.NewSyncedMap[int32, *serverPeer](),
+		banned:          txmap.NewSyncedMap[string, time.Time](),
+		outboundGroups:  txmap.NewSyncedMap[string, int](),
+		connectionCount: txmap.NewSyncedMap[string, int](),
+	}
+	state.inboundPeers.Set(1, sp)
+
+	blockHash := chainhash.Hash{0x0a, 0x0b, 0x0c}
+	invVect := wire.NewInvVect(wire.InvTypeBlock, &blockHash)
+
+	// No msg.data: a non-sendheaders peer must be announced the block by
+	// inventory, which needs nothing but the inv vector. If the dispatch ever
+	// routes this peer to handleRelayBlockMsg instead, that path bails out on the
+	// missing block header and nothing is sent.
+	s.handleRelayInvMsg(state, relayMsg{invVect: invVect})
+
+	select {
+	case msg := <-invReceived:
+		require.Len(t, msg.InvList, 1)
+		require.Equal(t, wire.InvTypeBlock, msg.InvList[0].Type)
+		require.Equal(t, blockHash, msg.InvList[0].Hash)
+	case <-time.After(10 * time.Second):
+		t.Fatal("no inv message relayed to the non-sendheaders peer")
+	}
 }
 
 // TestHandleRelayTxMsg tests the handleRelayTxMsg function's behavior with various fee filter scenarios

--- a/services/legacy/peer_server_test.go
+++ b/services/legacy/peer_server_test.go
@@ -192,6 +192,29 @@ func (m *mockServerPeer) QueueInventory(invVect *wire.InvVect) {
 	m.Called(invVect)
 }
 
+// TestHandleRelayBlockInvMsg verifies that a newly-relayed block is announced
+// via a plain inventory message to peers that have NOT negotiated sendheaders.
+// handleRelayInvMsg only special-cases InvTypeBlock when sp.WantsHeaders() is
+// true (sending a headers message via handleRelayBlockMsg); peers that never
+// sent "sendheaders" must still get the block via QueueInventory, or they get
+// no announcement for the block at all.
+func TestHandleRelayBlockInvMsg(t *testing.T) {
+	sp := &mockServerPeer{}
+
+	blockHash := chainhash.Hash{0x0a, 0x0b, 0x0c}
+	invVect := wire.NewInvVect(wire.InvTypeBlock, &blockHash)
+
+	msg := relayMsg{invVect: invVect}
+
+	s := &server{}
+
+	sp.Mock.On("QueueInventory", invVect).Return()
+
+	s.handleRelayBlockInvMsg(sp, msg)
+
+	sp.AssertCalled(t, "QueueInventory", invVect)
+}
+
 // TestHandleRelayTxMsg tests the handleRelayTxMsg function's behavior with various fee filter scenarios
 func TestHandleRelayTxMsg(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What

In the legacy (SVNode bridge) peer server's `handleRelayInvMsg`, a newly relayed block was only announced to a connected peer when that peer had negotiated `sendheaders` (in which case a `headers` message is sent). Peers that did not negotiate `sendheaders` got no announcement for the block at all.

## Why

Before commit f022dde6e (the tx fee-filter refactor for `handleRelayInvMsg`, processing `InvTypeTx` with a fee filter check), the function ended with a single shared `sp.QueueInventory(msg.invVect)` call that ran for any inventory item not otherwise handled — covering both `InvTypeTx` and the non-`sendheaders` `InvTypeBlock` case. That refactor moved the `QueueInventory` call into the `InvTypeTx` branch only (returning immediately after), and made the block/`sendheaders` branch also return. The shared tail call, and with it the block fallback for peers without `sendheaders`, was dropped as a side effect of that reshuffle rather than as a deliberate design choice.

This is currently masked because SVNode, the only legacy peer exercised in practice, does negotiate `sendheaders`. Any other wire-compatible client that instead expects plain `inv` announcements for blocks would never be notified of new blocks over this path.

## Fix

Restore the fallback: for `InvTypeBlock` when the peer has not negotiated `sendheaders`, queue the plain inventory vector via `QueueInventory`, mirroring the pre-refactor behavior. Extracted as `handleRelayBlockInvMsg` (taking the same `serverPeerQueueInventory` interface already used by `handleRelayTxMsg`) so it can be unit tested without a live peer connection.

## Testing

Added `TestHandleRelayBlockInvMsg`, which fails to build before the fix (the function doesn't exist) and passes after. Ran `go test ./services/legacy/... -race` and `go vet ./services/legacy/...` clean.