### PR TITLE
fix(blockvalidation): bind quick-validation checkpoint height to what was actually verified this run

### DIFF
--- a/docs/topics/services/blockValidation.md
+++ b/docs/topics/services/blockValidation.md
@@ -267,6 +267,19 @@ Before fetching full block data, the catchup process verifies checkpoints to ens
 - Approximately 10x faster than full validation for historical blocks
 - Currently disabled pending additional testing (`useQuickValidation = false`)
 
+**Behaviour change — quick-validation window is bound to what this run verified:**
+
+The eligibility bound is the highest checkpoint whose hash was actually **matched against a
+header in the current catchup range**, not the highest checkpoint present in
+`ChainCfgParams.Checkpoints`. A checkpoint that is configured but sits outside the range being
+processed proves nothing about this session, so it no longer widens the window.
+
+Operational consequence: in each catchup range, the blocks above the last in-range checkpoint —
+the tail up to the peer's tip — fall back to full validation instead of quick validation. On a
+node syncing far below the highest checkpoint this is one tail per catchup range and only
+affects sync throughput, never which blocks are accepted. Sync of the checkpointed prefix is
+unaffected as long as ranges continue to span checkpoints.
+
 **Safety Guarantees:**
 
 Checkpoint verification ensures:
@@ -450,7 +463,7 @@ Validates transactions by spending their inputs in parallel:
 The quick validation path is only applied to blocks below verified checkpoints:
 
 - **Checkpoint Verification**: During catchup, checkpoints are verified in header chain (see Section 2.2.2)
-- **Eligibility Check**: `block.Height <= highestCheckpointHeight` determines if quick validation can be used
+- **Eligibility Check**: `block.Height <= highestCheckpointHeight` determines if quick validation can be used, where `highestCheckpointHeight` is the highest checkpoint **hash-verified in the current catchup run** — blocks above it fall back to full validation (see Section 2.2.2)
 - **Trust Assumption**: Blocks below checkpoints are known to be valid, allowing optimized processing
 - **Current Status**: Quick validation currently disabled (`useQuickValidation = false`) pending additional testing
 

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -1656,20 +1656,48 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 		// difficulty checks must run first. It also means a peer cannot make us do
 		// full tx validation for a garbage header at zero cost.
 		//
-		// Skip difficulty validation for blocks at or below the highest checkpoint:
-		// these blocks are already verified by checkpoints. block.Height is settled
-		// against the parent before this function runs (Server.deriveBlockHeight on the
-		// peer route; catchup and the operator revalidation endpoint carry authoritative
-		// heights), and BelowCheckpoint applies the mandatory height > 0 guard, so a peer
-		// cannot obtain the skip by declaring height 0 or a fabricated sub-checkpoint
-		// height. The checkpoint hash-match itself was asserted above.
+		// The header hash must meet the target its OWN nBits declares. This is enforced for
+		// every block, including below-checkpoint ones: it is what makes the chainwork the
+		// block contributes (computed from those same declared bits in
+		// getCumulativeChainWork) honestly earned, and it is the cheap gate that stops a
+		// peer buying (fail-open) subtree validation with a garbage header. Unlike the
+		// expected-nBits rule below there is no historical exception to it — no block on any
+		// chain has ever been valid without meeting its own target — so enforcing it here
+		// cannot reject a real block. model.Block.Valid step 1 runs the identical check on
+		// every route that permanently accepts a block, so the accepted-block set is
+		// unchanged; running it here only moves the rejection earlier, ahead of the
+		// optimistic-mining AddBlock that would otherwise put the block on the chain first.
+		// This matters because BelowCheckpoint is true for EVERY height in
+		// 1..highestCheckpoint, not just the checkpoint heights themselves.
+		headerValid, _, err := block.Header.HasMetTargetDifficulty()
+		if !headerValid {
+			reason := "block does not meet target difficulty"
+			if err != nil {
+				reason = fmt.Sprintf("block does not meet target difficulty: %s", err.Error())
+			}
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] block does not meet target difficulty: %s", block.Header.Hash().String(), err)
+		}
+
+		// Skip the expected-nBits (DAA) check for blocks at or below the highest checkpoint:
+		// the difficulty schedule over that prefix is already certified by the pinned
+		// checkpoint hashes, and re-deriving it would require reproducing every historical
+		// retarget rule exactly. block.Height is settled against the parent before this
+		// function runs (Server.deriveBlockHeight on the peer route; catchup and the operator
+		// revalidation endpoint carry authoritative heights), and BelowCheckpoint applies the
+		// mandatory height > 0 guard, so a peer cannot obtain the skip by declaring height 0
+		// or a fabricated sub-checkpoint height. The checkpoint hash-match itself was
+		// asserted above.
 		skipDifficultyCheck := model.BelowCheckpoint(u.settings.ChainCfgParams.Checkpoints, block.Height)
 
 		if skipDifficultyCheck {
-			ctxLogger.Debugf("[ValidateBlock][%s] skipping difficulty validation for block at height %d (at or below highest checkpoint height %d)",
+			ctxLogger.Debugf("[ValidateBlock][%s] skipping expected-nBits validation for block at height %d (at or below highest checkpoint height %d)",
 				block.Header.Hash().String(), block.Height, blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints))
 		} else {
-			// First check that the nBits (difficulty target) is correct for this block
+			// Check that the nBits (difficulty target) is correct for this block
 			expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, block.Header.HashPrevBlock, int64(block.Header.Timestamp))
 			if err != nil {
 				return errors.NewServiceError("[ValidateBlock][%s] failed to get expected work required", block.Header.Hash().String(), err)
@@ -1684,20 +1712,6 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 
 				return errors.NewBlockInvalidError("[ValidateBlock][%s] block has incorrect difficulty bits: got %v, expected %v",
 					block.Header.Hash().String(), block.Header.Bits, expectedNBits)
-			}
-
-			// Then check that the block hash meets the difficulty target
-			headerValid, _, err := block.Header.HasMetTargetDifficulty()
-			if !headerValid {
-				reason := "block does not meet target difficulty"
-				if err != nil {
-					reason = fmt.Sprintf("block does not meet target difficulty: %s", err.Error())
-				}
-				if !opts.IsRevalidation {
-					u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
-				}
-
-				return errors.NewBlockInvalidError("[ValidateBlock][%s] block does not meet target difficulty: %s", block.Header.Hash().String(), err)
 			}
 		}
 
@@ -2304,15 +2318,22 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 		return errors.NewBlockInvalidError("[reValidateBlock][%s] block conflicts with hardcoded checkpoint", blockData.block.Hash().String(), err)
 	}
 
-	// Skip difficulty validation for blocks at or below the highest checkpoint
-	// These blocks are already verified by checkpoints, so we don't need to validate difficulty
+	// The header hash must meet the target its own nBits declares, below checkpoint or not
+	// — see the matching block in ValidateBlockWithOptions for why this half of the old
+	// skip is never safe to take. Enforced before the subtree work below.
+	if headerValid, _, err := blockData.block.Header.HasMetTargetDifficulty(); !headerValid {
+		return errors.NewBlockInvalidError("[reValidateBlock][%s] block does not meet target difficulty: %s", blockData.block.Header.Hash().String(), err)
+	}
+
+	// Skip the expected-nBits (DAA) check for blocks at or below the highest checkpoint:
+	// the difficulty schedule over that prefix is certified by the pinned checkpoint hashes.
 	skipDifficultyCheck := model.BelowCheckpoint(u.settings.ChainCfgParams.Checkpoints, blockData.block.Height)
 
 	if skipDifficultyCheck {
-		u.logger.Debugf("[reValidateBlock][%s] skipping difficulty validation for block at height %d (at or below highest checkpoint height %d)",
+		u.logger.Debugf("[reValidateBlock][%s] skipping expected-nBits validation for block at height %d (at or below highest checkpoint height %d)",
 			blockData.block.Header.Hash().String(), blockData.block.Height, blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints))
 	} else {
-		// First check that the nBits (difficulty target) is correct for this block
+		// Check that the nBits (difficulty target) is correct for this block
 		expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, blockData.block.Header.HashPrevBlock, int64(blockData.block.Header.Timestamp))
 		if err != nil {
 			return errors.NewServiceError("[reValidateBlock][%s] failed to get expected work required", blockData.block.Header.Hash().String(), err)
@@ -2322,12 +2343,6 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 		if expectedNBits != nil && blockData.block.Header.Bits != *expectedNBits {
 			return errors.NewBlockInvalidError("[reValidateBlock][%s] block has incorrect difficulty bits: got %v, expected %v",
 				blockData.block.Header.Hash().String(), blockData.block.Header.Bits, expectedNBits)
-		}
-
-		// Then check that the block hash meets the difficulty target
-		headerValid, _, err := blockData.block.Header.HasMetTargetDifficulty()
-		if !headerValid {
-			return errors.NewBlockInvalidError("[reValidateBlock][%s] block does not meet target difficulty: %s", blockData.block.Header.Hash().String(), err)
 		}
 	}
 

--- a/services/blockvalidation/BlockValidation_difficulty_test.go
+++ b/services/blockvalidation/BlockValidation_difficulty_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
@@ -16,6 +17,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
+	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -257,9 +259,12 @@ func TestValidateBlock_DoesNotMeetTargetDifficulty(t *testing.T) {
 	notificationChan := make(chan *blockchain_api.Notification, 1)
 	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(notificationChan, nil).Maybe()
 
-	// Mock GetNextWorkRequired to return the expected difficulty
+	// GetNextWorkRequired is registered but never expected to fire: the header's PoW
+	// against its own declared target is checked BEFORE the expected-nBits lookup
+	// (bitcoin-sv order: CheckBlockHeader then ContextualCheckBlockHeader), so this
+	// block is rejected first.
 	mockBlockchain.On("GetNextWorkRequired", mock.Anything, prevBlockHeader.Hash(), mock.Anything).
-		Return(expectedNBits, nil).Once()
+		Return(expectedNBits, nil).Maybe()
 
 	// Mock AddBlock to store invalid block when difficulty target is not met
 	mockBlockchain.On("AddBlock", mock.Anything, block, "", mock.Anything).Return(nil).Once()
@@ -297,6 +302,9 @@ func TestValidateBlock_DoesNotMeetTargetDifficulty(t *testing.T) {
 	err = bv.ValidateBlock(ctx, block, "test")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not meet target difficulty")
+
+	// The PoW check short-circuits ahead of the expected-nBits lookup.
+	mockBlockchain.AssertNotCalled(t, "GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything)
 
 	// Verify all mocks were called
 	mockBlockchain.AssertExpectations(t)
@@ -559,8 +567,11 @@ func TestValidateBlock_PoWCheckedBeforeSubtreeValidation(t *testing.T) {
 	notificationChan := make(chan *blockchain_api.Notification, 1)
 	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(notificationChan, nil).Maybe()
 
+	// Registered but never expected to fire: the PoW check against the header's own
+	// declared target runs BEFORE the expected-nBits lookup (bitcoin-sv order:
+	// CheckBlockHeader then ContextualCheckBlockHeader).
 	mockBlockchain.On("GetNextWorkRequired", mock.Anything, prevBlockHeader.Hash(), mock.Anything).
-		Return(expectedNBits, nil).Once()
+		Return(expectedNBits, nil).Maybe()
 
 	// storeInvalidBlock persists the failed block
 	mockBlockchain.On("AddBlock", mock.Anything, block, "", mock.Anything).Return(nil).Once()
@@ -588,6 +599,195 @@ func TestValidateBlock_PoWCheckedBeforeSubtreeValidation(t *testing.T) {
 
 	require.Equal(t, int32(0), countingClient.checkBlockSubtreesCalls.Load(),
 		"CheckBlockSubtrees must NOT be called for a block that fails the difficulty check — PoW must be verified before (fail-open) subtree validation")
+
+	// The PoW check short-circuits ahead of the expected-nBits lookup.
+	mockBlockchain.AssertNotCalled(t, "GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything)
+
+	mockBlockchain.AssertExpectations(t)
+}
+
+// belowCheckpointPoWFixture builds a coinbase-only-subtree block at height 1 whose
+// header declares a target its nonce does not meet, together with a blockchain mock
+// wired for the pre-difficulty stages of ValidateBlock/reValidateBlock. A checkpoint
+// is configured ABOVE the block height so model.BelowCheckpoint(...) is true for it
+// and the below-checkpoint difficulty skip engages.
+//
+// GetNextWorkRequired is deliberately NOT registered on the mock: the expected-nBits
+// (DAA) half of the skip must stay skipped below the checkpoint, so the call must
+// never happen. Registering nothing makes an unexpected call fail loudly.
+func belowCheckpointPoWFixture(t *testing.T, tSettings *settings.Settings) (*model.Block, *blockchain.Mock, *subtreepkg.Subtree) {
+	t.Helper()
+
+	// Checkpoint above the block height: BelowCheckpoint(checkpoints, 1) == true, and no
+	// checkpoint sits AT height 1, so ValidateHeaderAgainstCheckpoints passes.
+	checkpointHash, err := chainhash.NewHashFromStr("00000000000000000000000000000000000000000000000000000000000000ff")
+	require.NoError(t, err)
+	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1000, Hash: checkpointHash}}
+
+	coinbaseTx, err := bt.NewTxFromString(model.CoinbaseHex)
+	require.NoError(t, err)
+	coinbaseTx.Outputs = nil
+	require.NoError(t, coinbaseTx.AddP2PKHOutputFromAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 5000000000))
+
+	subtree, err := subtreepkg.NewTreeByLeafCount(2)
+	require.NoError(t, err)
+	require.NoError(t, subtree.AddCoinbaseNode())
+
+	genesisHash := &chainhash.Hash{}
+	prevBlockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  genesisHash,
+		HashMerkleRoot: &chainhash.Hash{},
+		Timestamp:      uint32(time.Now().Unix()), //nolint:gosec
+	}
+
+	nBits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+	prevBlockHeader.Bits = *nBits
+
+	for {
+		prevBlockHeader.Nonce++
+		if ok, _, _ := prevBlockHeader.HasMetTargetDifficulty(); ok {
+			break
+		}
+
+		if prevBlockHeader.Nonce > 1000000 {
+			t.Fatal("Could not find valid nonce")
+		}
+	}
+
+	// Very high difficulty the bad nonce below cannot meet.
+	declaredBits, err := model.NewNBitFromString("18000001")
+	require.NoError(t, err)
+
+	blockHeader := &model.BlockHeader{
+		Version:        1,
+		HashPrevBlock:  prevBlockHeader.Hash(),
+		HashMerkleRoot: subtree.RootHash(),
+		Timestamp:      uint32(time.Now().Unix() + 1), //nolint:gosec
+		Bits:           *declaredBits,
+		Nonce:          12345, // bad nonce — does not meet the declared target
+	}
+
+	ok, _, _ := blockHeader.HasMetTargetDifficulty()
+	require.False(t, ok, "Block must not meet its declared target with the bad nonce")
+
+	block := &model.Block{
+		Header:           blockHeader,
+		Subtrees:         []*chainhash.Hash{subtree.RootHash()},
+		Height:           1,
+		CoinbaseTx:       coinbaseTx,
+		TransactionCount: uint64(subtree.Length()), //nolint:gosec
+		SizeInBytes:      123123,
+	}
+
+	require.True(t, model.BelowCheckpoint(tSettings.ChainCfgParams.Checkpoints, block.Height),
+		"fixture precondition: the block must be below the configured checkpoint so the skip engages")
+
+	mockBlockchain := new(blockchain.Mock)
+	mockBlockchain.On("GetBlockExists", mock.Anything, blockHeader.Hash()).Return(false, nil).Maybe()
+	mockBlockchain.On("GetBlockHeaders", mock.Anything, prevBlockHeader.Hash(), mock.Anything).
+		Return([]*model.BlockHeader{prevBlockHeader}, []*model.BlockHeaderMeta{{ID: 0, Height: 0}}, nil).Maybe()
+	mockBlockchain.On("GetBlocksMinedNotSet", mock.Anything).Return([]*model.Block{}, nil).Maybe()
+	mockBlockchain.On("GetBlocksSubtreesNotSet", mock.Anything).Return([]*model.Block{}, nil).Maybe()
+
+	notificationChan := make(chan *blockchain_api.Notification, 1)
+	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(notificationChan, nil).Maybe()
+
+	// storeInvalidBlock persists the failed block.
+	mockBlockchain.On("AddBlock", mock.Anything, block, "", mock.Anything).Return(nil).Maybe()
+
+	prevBlock := &model.Block{
+		Header:     prevBlockHeader,
+		CoinbaseTx: coinbaseTx,
+		Subtrees:   []*chainhash.Hash{},
+		Height:     0,
+	}
+	mockBlockchain.On("GetBlock", mock.Anything, prevBlockHeader.Hash()).Return(prevBlock, nil).Maybe()
+	mockBlockchain.On("GetBestBlockHeader", mock.Anything).Return(blockHeader, &model.BlockHeaderMeta{Height: 1}, nil).Maybe()
+	mockBlockchain.On("GetBlockIsMined", mock.Anything, prevBlockHeader.Hash()).Return(true, nil).Maybe()
+
+	return block, mockBlockchain, subtree
+}
+
+// TestValidateBlock_BelowCheckpointStillEnforcesTargetDifficulty pins that the
+// below-checkpoint difficulty skip covers ONLY the expected-nBits (DAA) check, never
+// the header's proof of work against its own declared target.
+//
+// model.BelowCheckpoint is true for EVERY height in 1..highestCheckpoint (945000 on
+// mainnet), not just the checkpoint heights themselves, so before this was narrowed a
+// block anywhere in that range reached (fail-open) subtree validation with no PoW
+// verified at all — and under optimistic mining (the production default) it was added
+// to the blockchain, with its chainwork taken from the bits it merely claimed, before
+// the background block.Valid() rejected it.
+//
+// The accepted-block set is unchanged by enforcing this: model.Block.Valid step 1 runs
+// the identical HasMetTargetDifficulty check unconditionally on every route that
+// permanently accepts a block, so nothing that used to be accepted can now be
+// rejected — only the rejection point moves earlier.
+func TestValidateBlock_BelowCheckpointStillEnforcesTargetDifficulty(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx := context.Background()
+
+	utxoStore, subtreeValidationClient, _, txStore, subtreeStore, cleanup := setup(t)
+	defer cleanup()
+
+	countingClient := &countingSubtreeValidationClient{Interface: subtreeValidationClient}
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.OptimisticMining = false
+
+	block, mockBlockchain, _ := belowCheckpointPoWFixture(t, tSettings)
+
+	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, utxoStore, nil, countingClient)
+
+	err := bv.ValidateBlock(ctx, block, "test")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid), "failed PoW must surface as BlockInvalid, got: %v", err)
+	require.Contains(t, err.Error(), "does not meet target difficulty")
+
+	require.Equal(t, int32(0), countingClient.checkBlockSubtreesCalls.Load(),
+		"CheckBlockSubtrees must NOT be called for a below-checkpoint block that fails its own target difficulty")
+
+	// The DAA half of the skip must remain in place: the expected-nBits lookup is still
+	// skipped below the checkpoint, so historical blocks are unaffected.
+	mockBlockchain.AssertNotCalled(t, "GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything)
+
+	mockBlockchain.AssertExpectations(t)
+}
+
+// TestReValidateBlock_BelowCheckpointStillEnforcesTargetDifficulty is the
+// reValidateBlock counterpart: that path carries the same below-checkpoint difficulty
+// skip and is reachable independently of ValidateBlockWithOptions (the
+// GetBlockHeaders-failure branch enqueues into it), so it must enforce PoW too.
+func TestReValidateBlock_BelowCheckpointStillEnforcesTargetDifficulty(t *testing.T) {
+	initPrometheusMetrics()
+
+	ctx := context.Background()
+
+	utxoStore, subtreeValidationClient, _, txStore, subtreeStore, cleanup := setup(t)
+	defer cleanup()
+
+	countingClient := &countingSubtreeValidationClient{Interface: subtreeValidationClient}
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.BlockValidation.OptimisticMining = false
+
+	block, mockBlockchain, _ := belowCheckpointPoWFixture(t, tSettings)
+	mockBlockchain.On("InvalidateBlock", mock.Anything, mock.Anything).Return([]chainhash.Hash{}, nil).Maybe()
+
+	bv := NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, mockBlockchain, subtreeStore, txStore, utxoStore, nil, countingClient)
+
+	err := bv.reValidateBlock(revalidateBlockData{block: block, baseURL: "test"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid), "failed PoW must surface as BlockInvalid, got: %v", err)
+	require.Contains(t, err.Error(), "does not meet target difficulty")
+
+	require.Equal(t, int32(0), countingClient.checkBlockSubtreesCalls.Load(),
+		"CheckBlockSubtrees must NOT be called for a below-checkpoint block that fails its own target difficulty")
+
+	mockBlockchain.AssertNotCalled(t, "GetNextWorkRequired", mock.Anything, mock.Anything, mock.Anything)
 
 	mockBlockchain.AssertExpectations(t)
 }

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -894,9 +894,12 @@ func (u *Server) verifyCheckpointsInHeaderChain(catchupCtx *CatchupContext) erro
 //   - int: Number of checkpoints successfully verified
 //   - error: If checkpoint verification fails (hash mismatch)
 func (u *Server) verifyCheckpointsAgainstHeaders(catchupCtx *CatchupContext) (int, error) {
-	// Get the highest checkpoint height for reference
-	highestCheckpointHeight := blockchain.HighestCheckpointHeight(catchupCtx.checkpoints)
-	catchupCtx.highestCheckpointHeight = highestCheckpointHeight
+	// Track the highest checkpoint height actually verified (hash-matched) in this run.
+	// Quick validation eligibility must be bound to what was genuinely proven this run,
+	// not to the highest checkpoint in the globally configured list - a checkpoint that
+	// is merely configured but falls outside the current catchup range (or is never
+	// reached by the loop below) provides no cryptographic guarantee for this session.
+	var highestVerifiedCheckpointHeight uint32
 
 	firstBlockHeight := catchupCtx.commonAncestorMeta.Height + 1
 	lastBlockHeight := catchupCtx.commonAncestorMeta.Height + uint32(len(catchupCtx.blockHeaders))
@@ -929,8 +932,14 @@ func (u *Server) verifyCheckpointsAgainstHeaders(catchupCtx *CatchupContext) (in
 
 			u.logger.Infof("[catchup][%s] Verified checkpoint at height %d with hash %s", catchupCtx.blockUpTo.Hash().String(), checkpointHeight, checkpoint.Hash.String())
 			checkpointsChecked++
+
+			if checkpointHeight > highestVerifiedCheckpointHeight {
+				highestVerifiedCheckpointHeight = checkpointHeight
+			}
 		}
 	}
+
+	catchupCtx.highestCheckpointHeight = highestVerifiedCheckpointHeight
 
 	return checkpointsChecked, nil
 }

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -53,7 +53,7 @@ type CatchupContext struct {
 	blockHeaders            []*model.BlockHeader
 	headersFetchResult      *catchup.Result
 	useQuickValidation      bool   // Whether to use quick validation for checkpointed blocks
-	highestCheckpointHeight uint32 // Highest checkpoint height for validation checks
+	highestCheckpointHeight uint32 // Highest checkpoint height hash-verified in THIS catchup run (not the highest configured checkpoint)
 	catchupError            error  // Any error encountered during catchup
 	incompleteBlockHash     string // Block hash reported when a peer serves an incomplete block
 

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -3767,7 +3767,7 @@ func TestQuickValidationBoundToActuallyVerifiedCheckpoint(t *testing.T) {
 	// The core assertion: highestCheckpointHeight must reflect only the checkpoint that
 	// was ACTUALLY verified this run (height 5), not the globally highest CONFIGURED
 	// checkpoint (height 50) which was never checked in this catchup range.
-	assert.Equal(t, uint32(5), catchupCtx.highestCheckpointHeight,
+	require.Equal(t, uint32(5), catchupCtx.highestCheckpointHeight,
 		"highestCheckpointHeight must be bound to the checkpoint actually verified in this run, not the globally configured maximum")
 
 	// A block above the verified checkpoint (5) but below the merely-configured higher
@@ -3779,7 +3779,7 @@ func TestQuickValidationBoundToActuallyVerifiedCheckpoint(t *testing.T) {
 	shouldTryNormal, err := suite.Server.tryQuickValidation(
 		suite.Ctx, blockAboveVerifiedCheckpoint, catchupCtx, "", "http://test", nil)
 	require.NoError(t, err)
-	assert.True(t, shouldTryNormal,
+	require.True(t, shouldTryNormal,
 		"block above the verified checkpoint but below the merely-configured checkpoint must fall back to normal validation")
 }
 

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -3707,6 +3707,82 @@ func TestCheckpointValidationHeightCalculation(t *testing.T) {
 	assert.True(t, catchupCtx.useQuickValidation, "Quick validation should be enabled when checkpoints are verified")
 }
 
+// TestQuickValidationBoundToActuallyVerifiedCheckpoint verifies that when multiple
+// checkpoints are configured but only the LOWER one falls within the current catchup
+// range (and is hash-verified), highestCheckpointHeight is bound to that verified
+// checkpoint - NOT to the highest checkpoint in the global configured list.
+//
+// This guards against a bug where any single successful checkpoint verification in the
+// current range would make quick validation eligible for every block up to the highest
+// CONFIGURED checkpoint, including blocks between the last checkpoint actually verified
+// this run and the true chain tip - blocks that were never cryptographically anchored
+// in this catchup session.
+func TestQuickValidationBoundToActuallyVerifiedCheckpoint(t *testing.T) {
+	suite := NewCatchupTestSuite(t)
+	defer suite.Cleanup()
+
+	// Create a long test chain so we have a "higher" checkpoint far beyond our current
+	// catchup range.
+	blocks := testhelpers.CreateTestBlockChain(t, 60)
+
+	// Two configured checkpoints:
+	//   - height 5:  falls inside the current catchup range and WILL be hash-verified
+	//   - height 50: configured globally, but outside the current catchup range
+	//                (headers only go up to height 10), so it is never checked
+	suite.Server.settings.ChainCfgParams = &chaincfg.Params{
+		Checkpoints: []chaincfg.Checkpoint{
+			{Height: 5, Hash: blocks[5].Header.Hash()},
+			{Height: 50, Hash: blocks[50].Header.Hash()},
+		},
+	}
+	suite.Server.settings.BlockValidation.CatchupAllowQuickValidation = true
+
+	catchupCtx := &CatchupContext{
+		blockUpTo: &model.Block{
+			Header: blocks[10].Header,
+			Height: 10,
+		},
+		commonAncestorMeta: &model.BlockHeaderMeta{
+			Height: 3,
+		},
+		// Headers we're processing: blocks 4-10 (7 blocks). Checkpoint at height 50 is
+		// far outside this range and can never be reached by the verification loop.
+		blockHeaders: []*model.BlockHeader{
+			blocks[4].Header,
+			blocks[5].Header, // height 5 - checkpoint, will be verified
+			blocks[6].Header,
+			blocks[7].Header,
+			blocks[8].Header,
+			blocks[9].Header,
+			blocks[10].Header,
+		},
+		forkDepth:   0,
+		checkpoints: suite.Server.settings.ChainCfgParams.Checkpoints,
+	}
+
+	err := suite.Server.verifyCheckpointsInHeaderChain(catchupCtx)
+	require.NoError(t, err, "checkpoint verification should succeed for the in-range checkpoint")
+	require.True(t, catchupCtx.useQuickValidation, "quick validation should be enabled since a checkpoint was verified")
+
+	// The core assertion: highestCheckpointHeight must reflect only the checkpoint that
+	// was ACTUALLY verified this run (height 5), not the globally highest CONFIGURED
+	// checkpoint (height 50) which was never checked in this catchup range.
+	assert.Equal(t, uint32(5), catchupCtx.highestCheckpointHeight,
+		"highestCheckpointHeight must be bound to the checkpoint actually verified in this run, not the globally configured maximum")
+
+	// A block above the verified checkpoint (5) but below the merely-configured higher
+	// checkpoint (50) must NOT be eligible for quick validation - it was never
+	// cryptographically anchored by a checkpoint in this catchup session.
+	blockAboveVerifiedCheckpoint := testhelpers.CreateTestBlocks(t, 1)[0]
+	blockAboveVerifiedCheckpoint.Height = 8
+
+	shouldTryNormal, err := suite.Server.tryQuickValidation(
+		suite.Ctx, blockAboveVerifiedCheckpoint, catchupCtx, "", "http://test", nil)
+	require.NoError(t, err)
+	assert.True(t, shouldTryNormal,
+		"block above the verified checkpoint but below the merely-configured checkpoint must fall back to normal validation")
+}
+
 // TestCheckpointValidationSkipsCheckpointsBelowAncestor verifies that checkpoint validation
 // correctly skips checkpoints that are below the common ancestor height
 func TestCheckpointValidationSkipsCheckpointsBelowAncestor(t *testing.T) {


### PR DESCRIPTION
## CONSENSUS-RELEVANT - please review carefully

### The bug

`verifyCheckpointsAgainstHeaders` in `services/blockvalidation/catchup.go` set
`catchupCtx.highestCheckpointHeight` to the highest checkpoint height across the
**entire globally configured checkpoint list** (`blockchain.HighestCheckpointHeight(catchupCtx.checkpoints)`),
unconditionally - regardless of whether that specific checkpoint fell within the
current catchup range, or was ever hash-checked against a fetched header.

The verification loop only checks checkpoints whose height falls inside
`[firstBlockHeight, lastBlockHeight]` for the current catchup run, and increments
`checkpointsChecked` when at least one checkpoint's hash actually matches a header.

The quick-validation gate is:

```go
canUseQuickValidation := catchupCtx.useQuickValidation && block.Height <= catchupCtx.highestCheckpointHeight
```

Because `useQuickValidation` is set to `true` as soon as `checkpointsChecked > 0`
(i.e. any single checkpoint in the current range verified), and
`highestCheckpointHeight` was the global configured maximum rather than the
verified one, every block up to the globally highest *configured* checkpoint became
eligible for quick validation - including blocks between the last checkpoint
actually hash-verified in this catchup run and the true chain tip. Those blocks were
never cryptographically anchored during this session.

Quick validation skips full script re-execution. It is only safe under the
invariant (documented in `quick_validate.go`) that checkpoints guarantee the
blocks are valid - and that guarantee only holds for blocks at or below a
checkpoint that was actually verified during this run, not one that merely
appears in the configured checkpoint list.

### The fix

Track a local `highestVerifiedCheckpointHeight` inside
`verifyCheckpointsAgainstHeaders`, updated only when a checkpoint's hash actually
matches a fetched header during the verification loop. Set
`catchupCtx.highestCheckpointHeight` to that verified value instead of the
globally configured maximum. This strictly narrows the quick-validation
eligibility window to only what was genuinely proven during the current catchup
run - it can only make behavior more conservative, never less safe.

### Test

Added `TestQuickValidationBoundToActuallyVerifiedCheckpoint` in
`catchup_test.go`. It configures two checkpoints - one inside the current header
range (verified) and one far above it (outside the range, never checked) - and
asserts:

1. `catchupCtx.highestCheckpointHeight` equals the verified checkpoint's height,
   not the globally configured higher one.
2. A block above the verified checkpoint but below the merely-configured higher
   checkpoint correctly falls back to normal (full) validation via
   `tryQuickValidation`.

Confirmed the test fails against the pre-fix code (`highestCheckpointHeight`
reported as the configured height 50 instead of the verified height 5), and
passes after the fix.

### Verification

- `go build ./services/blockvalidation/...`
- `go vet ./services/blockvalidation/...`
- `go test ./services/blockvalidation/... -race` - all green
- `go test ./services/blockvalidation/...` (full package suite) - all green, no regressions in existing checkpoint/quick-validation tests