### PR TITLE
docs(operator): add monitoring guide, link metrics reference, fix legacy CR resource snippet

### DIFF
--- a/compose/grafana/dashboards/README.md
+++ b/compose/grafana/dashboards/README.md
@@ -9,53 +9,61 @@ Comprehensive monitoring dashboard for BlockAssembler internal state transitions
 ### Panels
 
 #### 1. State Timeline
+
 - **Type:** State Timeline
 - **Shows:** Visual timeline of state changes over time
 - **Colors:**
-  - Green: Running (normal operation)
-  - Blue: GetMiningCandidate (serving miners)
-  - Purple: BlockchainSubscription (processing new block)
-  - Light Blue: MovingUp (advancing chain tip)
-  - Orange: Resetting (full reset)
-  - Red: Reorging (handling chain reorg)
-  - Yellow: Starting (initialization)
+    - Green: Running (normal operation)
+    - Purple: BlockchainSubscription (processing new block)
+    - Light Blue: MovingUp (advancing chain tip)
+    - Orange: Resetting (full reset)
+    - Red: Reorging (handling chain reorg)
+    - Yellow: Starting (initialization)
+    - Blue: Reconciling (catching the tip up after startup or a missed notification)
 
 #### 2. State Durations (P50/P95/P99)
+
 - **Type:** Time Series
 - **Shows:** Percentile distribution of time spent in each state
 - **Use:** Identify performance bottlenecks
 - **Example:** If P95 BlockchainSubscription is 5s, 95% of blocks process in under 5s
 
 #### 3. State Transitions (per second)
+
 - **Type:** Time Series
 - **Shows:** Rate of state transitions
 - **Format:** `from → to`
 - **Use:** Understand state change frequency and patterns
 
 #### 4. Current State
+
 - **Type:** Stat (single value)
 - **Shows:** Current state with color coding
 - **Updates:** Real-time (5s refresh)
 
 #### 5. Time in Current State
+
 - **Type:** Stat with gauge
 - **Shows:** How long in current state
 - **Thresholds:**
-  - Green: < 5s (normal)
-  - Yellow: 5-10s (slow)
-  - Red: > 10s (investigate)
+    - Green: < 5s (normal)
+    - Yellow: 5-10s (slow)
+    - Red: > 10s (investigate)
 
 #### 6. State Distribution (Last 5 min)
+
 - **Type:** Pie Chart
 - **Shows:** Percentage of time in each state
 - **Use:** Understand where BlockAssembler spends most time
 
 #### 7. State Entries (Last 5 min)
+
 - **Type:** Stat (horizontal)
 - **Shows:** How many times each state was entered
 - **Use:** Identify high-frequency states
 
 #### 8. State Transition Matrix
+
 - **Type:** Table
 - **Shows:** All state transitions with rates
 - **Sorted:** By transition frequency
@@ -66,47 +74,59 @@ Comprehensive monitoring dashboard for BlockAssembler internal state transitions
 **Captured even between Prometheus scrapes:**
 
 1. `teranode_blockassembly_current_state`
-   - Gauge: Current state (0-6)
+   - Gauge: Current state as a number — 0 `starting`, 1 `running`, 2 `resetting`,
+     4 `blockchainSubscription`, 5 `reorging`, 6 `movingUp`, 7 `reconciling`
+     (3 is unused; see `StateStrings` in `services/blockassembly/BlockAssembler.go`)
 
 2. `teranode_blockassembly_state_transitions_total{from, to}`
    - Counter: Total transitions between states
    - Incremented on every state change
+   - `from` / `to` label values are the lower-camelCase names above (`running`,
+     `movingUp`, ...), not the capitalised labels the panels display
 
 3. `teranode_blockassembly_state_duration_seconds{state}`
    - Histogram: Time spent in each state
    - Buckets: 1ms, 10ms, 100ms, 500ms, 1s, 2s, 5s, 10s, 30s, 60s
+   - `state` label values are the same lower-camelCase names
 
 ### Common Use Cases
 
 #### Debugging Slow Block Processing
+
 **Question:** Why is block processing slow?
 
 **Dashboard View:**
-```
+
+```text
 State Timeline: [Running][BlockchainSubscription (5s)][Running]
-State Durations: P95 BlockchainSubscription = 5.2s
+State Durations: P95 - blockchainSubscription = 5.2s
 ```
 
 **Conclusion:** Block processing consistently takes ~5s
 
-#### Identifying Mining Candidate Bottlenecks
-**Question:** Are miners waiting for candidates?
+#### Identifying Slow Tip Advances
+
+**Question:** Is the assembler slow to advance onto a new tip?
 
 **Dashboard View:**
-```
-State Transitions: Running → GetMiningCandidate: 5/sec
-State Durations: P95 GetMiningCandidate = 200ms
+
+```text
+State Transitions: running → movingUp: 0.02/sec
+State Durations: P95 - movingUp = 3.5s
 ```
 
-**Conclusion:** Serving 5 candidates/sec, each takes ~200ms
+**Conclusion:** Each tip advance takes ~3.5s, which eats into the time available
+for mining on the new tip
 
 #### Detecting Frequent Reorgs
+
 **Question:** How often do reorgs happen?
 
 **Dashboard View:**
-```
-State Entries: Reorging = 15 (in last 5m)
-Transition Matrix: Running → Reorging: 0.05/sec
+
+```text
+State Entries: reorging = 15 (in last 5m)
+Transition Matrix: running → reorging: 0.05/sec
 ```
 
 **Conclusion:** Reorgs happening every 20 seconds (investigate)
@@ -115,8 +135,12 @@ Transition Matrix: Running → Reorging: 0.05/sec
 
 **Example Prometheus alerts:**
 
+`teranode_blockassembly_current_state` is a numeric gauge, so compare it against
+the state number (`running` is `1`) — a string comparison such as
+`!= "running"` is not valid PromQL.
+
 ```yaml
-# Alert if stuck in any non-Running state for >30s
+# Alert if stuck in any non-running state for >30s
 - alert: BlockAssemblerStuckInState
   expr: |
     teranode_blockassembly_current_state != 1
@@ -124,17 +148,17 @@ Transition Matrix: Running → Reorging: 0.05/sec
     (time() - timestamp(teranode_blockassembly_current_state) > 30)
   for: 1m
   annotations:
-    summary: "BlockAssembler stuck in non-Running state"
+    summary: "BlockAssembler stuck in non-running state"
 
-# Alert if GetMiningCandidate P95 > 1s
-- alert: SlowMiningCandidateGeneration
+# Alert if movingUp P95 > 1s
+- alert: SlowTipAdvance
   expr: |
     histogram_quantile(0.95,
-      sum(rate(teranode_blockassembly_state_duration_seconds_bucket{state="getMiningCandidate"}[5m])) by (le)
+      sum(rate(teranode_blockassembly_state_duration_seconds_bucket{state="movingUp"}[5m])) by (le)
     ) > 1
   for: 5m
   annotations:
-    summary: "Mining candidate generation is slow (P95 > 1s)"
+    summary: "Block assembly tip advance is slow (P95 > 1s)"
 
 # Alert if reorg frequency is high
 - alert: FrequentReorgs

--- a/compose/grafana/dashboards/blockassembly-state.json
+++ b/compose/grafana/dashboards/blockassembly-state.json
@@ -50,25 +50,25 @@
                   "index": 2,
                   "text": "Resetting"
                 },
-                "3": {
-                  "color": "blue",
-                  "index": 3,
-                  "text": "GetMiningCandidate"
-                },
                 "4": {
                   "color": "purple",
-                  "index": 4,
+                  "index": 3,
                   "text": "BlockchainSubscription"
                 },
                 "5": {
                   "color": "red",
-                  "index": 5,
+                  "index": 4,
                   "text": "Reorging"
                 },
                 "6": {
                   "color": "light-blue",
-                  "index": 6,
+                  "index": 5,
                   "text": "MovingUp"
+                },
+                "7": {
+                  "color": "blue",
+                  "index": 6,
+                  "text": "Reconciling"
                 }
               },
               "type": "value"
@@ -354,25 +354,25 @@
                   "index": 2,
                   "text": "Resetting"
                 },
-                "3": {
-                  "color": "blue",
-                  "index": 3,
-                  "text": "GetMiningCandidate"
-                },
                 "4": {
                   "color": "purple",
-                  "index": 4,
+                  "index": 3,
                   "text": "BlockchainSubscription"
                 },
                 "5": {
                   "color": "red",
-                  "index": 5,
+                  "index": 4,
                   "text": "Reorging"
                 },
                 "6": {
                   "color": "light-blue",
-                  "index": 6,
+                  "index": 5,
                   "text": "MovingUp"
+                },
+                "7": {
+                  "color": "blue",
+                  "index": 6,
+                  "text": "Reconciling"
                 }
               },
               "type": "value"

--- a/docs/howto/miners/docker/minersHowToInstallation.md
+++ b/docs/howto/miners/docker/minersHowToInstallation.md
@@ -220,4 +220,6 @@ See [Reset Teranode](./minersHowToResetTeranode.md) for cleanup options.
 - [Start and Stop Docker Teranode](./minersHowToStopStartDockerTeranode.md)
 - [Syncing the Blockchain](./minersHowToSyncTheNode.md)
 - [Troubleshooting Docker Teranode](./minersHowToTroubleshooting.md)
+- [Monitoring Teranode](../minersHowToMonitoring.md)
+- [Prometheus Metrics Reference](../../../references/prometheusMetrics.md)
 - [teranode-quickstart README](https://github.com/bsv-blockchain/teranode-quickstart)

--- a/docs/howto/miners/kubernetes/minersHowToInstallation.md
+++ b/docs/howto/miners/kubernetes/minersHowToInstallation.md
@@ -232,6 +232,13 @@ By default, this configuration deploys Teranode to connect to the **teratestnet*
               memory: 256Mi
     ```
 
+    The `imagePullPolicy: Never` and `cpu: 100m` / `memory: 256Mi` values above
+    are Minikube/local-dev defaults — the legacy service scans the full
+    historical chain and needs far more than that in practice. For testnet or
+    mainnet, size resources from the shipped mainnet CR instead, which requests
+    `cpu: 2` / `memory: 64Gi` for legacy: see
+    [teranode-cr-mainnet.yaml](https://github.com/bsv-blockchain/teranode/blob/main/deploy/kubernetes/teranode/teranode-cr-mainnet.yaml).
+
 3. Apply the updated configuration:
 
     ```bash
@@ -272,11 +279,16 @@ For production deployments, consider:
 
 - Deploying dependencies (Aerospike, PostgreSQL, Kafka) in separate clusters or using managed services
 - Implementing proper security measures (network policies, RBAC, etc.)
-- Setting up monitoring and alerting
+- Setting up [monitoring and alerting](../minersHowToMonitoring.md)
 - Configuring appropriate resource requests and limits
 - Setting up proper backup and disaster recovery procedures
 
 An example CR for a mainnet deployment is available in [kubernetes/teranode/teranode-cr-mainnet.yaml](https://github.com/bsv-blockchain/teranode/blob/main/deploy/kubernetes/teranode/teranode-cr-mainnet.yaml).
+
+## Related Documentation
+
+- [Monitoring Teranode](../minersHowToMonitoring.md)
+- [Prometheus Metrics Reference](../../../references/prometheusMetrics.md)
 
 ## Resetting Teranode
 

--- a/docs/howto/miners/minersHowToMonitoring.md
+++ b/docs/howto/miners/minersHowToMonitoring.md
@@ -3,32 +3,43 @@
 This guide covers the dashboards Teranode ships out of the box, the metrics
 that distinguish a healthy node from a degraded one, and how to get started
 with alerting. It applies to both the Docker quickstart and Kubernetes
-operator deployments — the underlying metrics and dashboards are the same;
-only how you reach Grafana/Prometheus differs.
+operator deployments — the metrics and the dashboard files are the same; what
+differs is how you reach Grafana/Prometheus and which dashboards are provisioned
+for you.
 
 ## Dashboards
 
-Teranode ships pre-built Grafana dashboards, provisioned automatically wherever
-Prometheus and Grafana are deployed alongside it:
+Teranode ships pre-built Grafana dashboards. Not all of them are provisioned by
+every stack — the `Provisioned by` column says which one mounts each file:
 
-| Dashboard | File | What it shows |
-| --- | --- | --- |
-| Teranode Service Overview | `deploy/docker/base/grafana_dashboards/teranode/teranode-overview-dashboard.json` | Top-level health across all services: throughput, latencies, error rates |
-| Aerospike Batch Index Bottleneck Diagnostic | `deploy/docker/base/grafana_dashboards/teranode/teranode-batch-index-dashboard.json` | Aerospike batch index buffer pressure, a common scaling bottleneck |
-| Aerospike Namespace | `deploy/docker/base/grafana_dashboards/aerospike/aerospike-namespace.json` | Namespace-level memory, disk, and object counts |
-| Aerospike Latency | `deploy/docker/base/grafana_dashboards/aerospike/aerospike-latency.json` | Read/write/batch latency buckets for the UTXO store |
-| BlockAssembler State Monitoring | `compose/grafana/dashboards/blockassembly-state.json` | Block assembler state timeline (Running, Reorging, GetMiningCandidate, ...), state durations, and transition rates — see [dashboard notes](https://github.com/bsv-blockchain/teranode/blob/main/compose/grafana/dashboards/README.md) |
+| Dashboard | File | Provisioned by | What it shows |
+| --- | --- | --- | --- |
+| Teranode Service Overview | `deploy/docker/base/grafana_dashboards/teranode/teranode-overview-dashboard.json` | Operator Docker stacks (`deploy/docker/mainnet`, `deploy/docker/testnet`, `deploy/docker/monitoring`) | Top-level health across all services: throughput, latencies, error rates |
+| Aerospike Batch Index Bottleneck Diagnostic | `deploy/docker/base/grafana_dashboards/teranode/teranode-batch-index-dashboard.json` | Operator Docker stacks | Aerospike batch index buffer pressure, a common scaling bottleneck |
+| Aerospike Namespace | `deploy/docker/base/grafana_dashboards/aerospike/aerospike-namespace.json` | Operator Docker stacks | Namespace-level memory, disk, and object counts |
+| Aerospike Latency | `deploy/docker/base/grafana_dashboards/aerospike/aerospike-latency.json` | Operator Docker stacks | Read/write/batch latency buckets for the UTXO store |
+| BlockAssembler State Monitoring | `compose/grafana/dashboards/blockassembly-state.json` | Nothing on the operator paths — **import by hand** (only the developer multi-node stacks `compose/docker-compose-ss.yml` and `test/docker-compose-host.yml` mount it) | Block assembler state timeline (`running`, `reorging`, `movingUp`, ...), state durations, and transition rates — see [dashboard notes](https://github.com/bsv-blockchain/teranode/blob/main/compose/grafana/dashboards/README.md) |
 
-On the Docker quickstart path, these dashboards are provisioned automatically
-when the `monitoring` compose profile is enabled (the default). Grafana is
-reachable at `http://localhost:3005` and Prometheus at `http://localhost:9090`
-(both loopback-only by default). See [Installing with
+The Grafana service in the Docker stacks mounts a single dashboards directory,
+`deploy/docker/base/grafana_dashboards`, so the four dashboards in that directory
+— and only those — are provisioned automatically. On the quickstart, Grafana and
+Prometheus come up with the `monitoring` compose profile, which is part of the
+default `COMPOSE_PROFILES` (`legacy,p2p,monitoring`). Grafana is then reachable
+at `http://localhost:3005` and Prometheus at `http://localhost:9090` (both
+loopback-only by default). See [Installing with
 Docker](docker/minersHowToInstallation.md) and its [Troubleshooting
 guide](docker/minersHowToTroubleshooting.md) if Grafana shows no data.
 
+The BlockAssembler State Monitoring dashboard is **not** provisioned on either
+operator path. To use it, import
+`compose/grafana/dashboards/blockassembly-state.json` manually (Grafana →
+Dashboards → Import → Upload JSON file), or drop the file into
+`deploy/docker/base/grafana_dashboards/teranode/` before starting the stack so
+the existing provisioning picks it up.
+
 On Kubernetes, Prometheus and Grafana are not deployed by the Teranode
 operator itself — point your cluster's existing Prometheus at the Teranode
-services' metrics endpoints and import the dashboards above manually
+services' metrics endpoints and import all of the dashboards above manually
 (Grafana → Dashboards → Import).
 
 ## Metrics: Healthy vs. Degraded
@@ -40,20 +51,54 @@ dashboard.
 
 ### FSM and sync state
 
-- `teranode_blockchain_fsm_current_state` — should sit on `RUNNING` once
-  initial sync completes. Stuck on `CATCHINGBLOCKS` or oscillating indicates a
-  sync problem; see [Syncing the
-  Node](docker/minersHowToSyncTheNode.md).
+`teranode_blockchain_fsm_current_state` is a **numeric** gauge, not a string — it
+carries the enum ordinal of the blockchain FSM state:
+
+| Value | State |
+| --- | --- |
+| 0 | `IDLE` |
+| 1 | `RUNNING` |
+| 2 | `CATCHINGBLOCKS` |
+
+A healthy node sits on `1` (`RUNNING`) once initial sync completes. Stuck on `2`
+(`CATCHINGBLOCKS`) or oscillating indicates a sync problem; see [Syncing the
+Node](docker/minersHowToSyncTheNode.md). The gauge is written on FSM transitions
+only, so the series is absent until the node makes its first transition — use
+`absent(...)` if you want to alert on that case as well.
+
+Also watch:
+
 - `teranode_blockvalidation_catchup_active` and
   `teranode_blockvalidation_processing_blocks_stuck` — non-zero for extended
   periods means the node has fallen behind or a block is wedged.
 
 ### Block assembly
 
-- `teranode_blockassembly_current_state` /
-  `teranode_blockassembly_state_duration_seconds` — a healthy node spends
-  almost all its time in `Running`. Long dwell time in `Reorging` or
-  `MovingUp` is worth investigating.
+`teranode_blockassembly_current_state` is a **numeric** gauge too:
+
+| Value | State |
+| --- | --- |
+| 0 | `starting` |
+| 1 | `running` |
+| 2 | `resetting` |
+| 4 | `blockchainSubscription` |
+| 5 | `reorging` |
+| 6 | `movingUp` |
+| 7 | `reconciling` |
+
+Value `3` is unused — that state was removed. A healthy node spends almost all of
+its time on `1` (`running`).
+
+`teranode_blockassembly_state_duration_seconds` (histogram) and
+`teranode_blockassembly_state_transitions_total` (counter) carry the state in a
+`state` / `from` / `to` label. The label values are the lower-camelCase names in
+the table above — `running`, `movingUp`, `blockchainSubscription`, and so on —
+**not** the capitalised names the dashboard panels display, so a selector such as
+`{state="Running"}` matches nothing. Long dwell time in `reorging` or `movingUp`
+is worth investigating.
+
+Also watch:
+
 - `teranode_blockassembly_best_block_height` vs. your own chain tip — a gap
   that doesn't close means block assembly is falling behind validation.
 
@@ -88,22 +133,63 @@ dashboard.
 
 Teranode does not ship Prometheus alerting rules — alert thresholds depend on
 your hardware, network, and risk tolerance, so this is left to the operator.
-As a starting point, consider alerting on:
 
-- `teranode_blockchain_fsm_current_state` not `RUNNING` for more than a few
-  minutes after startup completes.
-- A sustained non-zero rate of `teranode_validator_invalid_transactions`,
-  `teranode_aerospike_utxo_errors`, or `teranode_sql_utxo_errors`.
-- `teranode_blockvalidation_processing_blocks_stuck` > 0 for more than a
-  couple of minutes.
-- `teranode_blockassembly_current_state` stuck outside `Running` beyond the
-  block time you'd expect for your network.
+Both state metrics are numeric gauges, so state alerts must be written as
+numeric comparisons; a string comparison such as
+`teranode_blockchain_fsm_current_state != "RUNNING"` is not valid PromQL and
+will be rejected. As a starting point, consider:
+
+```yaml
+groups:
+  - name: teranode-starter
+    rules:
+      # Blockchain FSM not RUNNING (1) for 5 minutes.
+      - alert: TeranodeFSMNotRunning
+        expr: teranode_blockchain_fsm_current_state != 1
+        for: 5m
+        annotations:
+          summary: "Blockchain FSM is not RUNNING"
+
+      # Block assembly stuck outside running (1) for 5 minutes. Tune the window
+      # to the block time you expect on your network.
+      - alert: TeranodeBlockAssemblyNotRunning
+        expr: teranode_blockassembly_current_state != 1
+        for: 5m
+        annotations:
+          summary: "Block assembly is not in the running state"
+
+      # A block is wedged in validation.
+      - alert: TeranodeBlockProcessingStuck
+        expr: teranode_blockvalidation_processing_blocks_stuck > 0
+        for: 2m
+        annotations:
+          summary: "Block validation reports stuck blocks"
+
+      # Sustained store or validation errors.
+      - alert: TeranodeErrorRate
+        expr: |
+          rate(teranode_validator_invalid_transactions[5m]) > 0
+          or rate(teranode_aerospike_utxo_errors[5m]) > 0
+          or rate(teranode_sql_utxo_errors[5m]) > 0
+        for: 10m
+        annotations:
+          summary: "Sustained validation or UTXO store errors"
+
+      # Reorgs happening more than once every 10 seconds.
+      - alert: TeranodeFrequentReorgs
+        expr: sum(rate(teranode_blockassembly_state_transitions_total{to="reorging"}[5m])) > 0.1
+        for: 5m
+        annotations:
+          summary: "Frequent block assembly reorgs"
+```
+
+Note the `to="reorging"` label value: the `state`, `from`, and `to` labels carry
+the lower-camelCase state names listed above, so capitalised selectors return an
+empty series and the alert silently never fires.
 
 The [BlockAssembler State Monitoring dashboard
 notes](https://github.com/bsv-blockchain/teranode/blob/main/compose/grafana/dashboards/README.md#alerting-rules)
-include worked example Prometheus alert rules (stuck-state, slow mining
-candidate generation, reorg frequency) you can adapt as a template rather than
-writing rules from scratch.
+carry further examples in the same style.
 
 ## Related Documentation
 

--- a/docs/howto/miners/minersHowToMonitoring.md
+++ b/docs/howto/miners/minersHowToMonitoring.md
@@ -1,0 +1,114 @@
+# Monitoring Teranode
+
+This guide covers the dashboards Teranode ships out of the box, the metrics
+that distinguish a healthy node from a degraded one, and how to get started
+with alerting. It applies to both the Docker quickstart and Kubernetes
+operator deployments — the underlying metrics and dashboards are the same;
+only how you reach Grafana/Prometheus differs.
+
+## Dashboards
+
+Teranode ships pre-built Grafana dashboards, provisioned automatically wherever
+Prometheus and Grafana are deployed alongside it:
+
+| Dashboard | File | What it shows |
+| --- | --- | --- |
+| Teranode Service Overview | `deploy/docker/base/grafana_dashboards/teranode/teranode-overview-dashboard.json` | Top-level health across all services: throughput, latencies, error rates |
+| Aerospike Batch Index Bottleneck Diagnostic | `deploy/docker/base/grafana_dashboards/teranode/teranode-batch-index-dashboard.json` | Aerospike batch index buffer pressure, a common scaling bottleneck |
+| Aerospike Namespace | `deploy/docker/base/grafana_dashboards/aerospike/aerospike-namespace.json` | Namespace-level memory, disk, and object counts |
+| Aerospike Latency | `deploy/docker/base/grafana_dashboards/aerospike/aerospike-latency.json` | Read/write/batch latency buckets for the UTXO store |
+| BlockAssembler State Monitoring | `compose/grafana/dashboards/blockassembly-state.json` | Block assembler state timeline (Running, Reorging, GetMiningCandidate, ...), state durations, and transition rates — see [dashboard notes](https://github.com/bsv-blockchain/teranode/blob/main/compose/grafana/dashboards/README.md) |
+
+On the Docker quickstart path, these dashboards are provisioned automatically
+when the `monitoring` compose profile is enabled (the default). Grafana is
+reachable at `http://localhost:3005` and Prometheus at `http://localhost:9090`
+(both loopback-only by default). See [Installing with
+Docker](docker/minersHowToInstallation.md) and its [Troubleshooting
+guide](docker/minersHowToTroubleshooting.md) if Grafana shows no data.
+
+On Kubernetes, Prometheus and Grafana are not deployed by the Teranode
+operator itself — point your cluster's existing Prometheus at the Teranode
+services' metrics endpoints and import the dashboards above manually
+(Grafana → Dashboards → Import).
+
+## Metrics: Healthy vs. Degraded
+
+The full metric catalogue is in the [Prometheus Metrics
+Reference](../../references/prometheusMetrics.md). The signals below are the
+ones worth watching first — most are visible directly on the Service Overview
+dashboard.
+
+### FSM and sync state
+
+- `teranode_blockchain_fsm_current_state` — should sit on `RUNNING` once
+  initial sync completes. Stuck on `CATCHINGBLOCKS` or oscillating indicates a
+  sync problem; see [Syncing the
+  Node](docker/minersHowToSyncTheNode.md).
+- `teranode_blockvalidation_catchup_active` and
+  `teranode_blockvalidation_processing_blocks_stuck` — non-zero for extended
+  periods means the node has fallen behind or a block is wedged.
+
+### Block assembly
+
+- `teranode_blockassembly_current_state` /
+  `teranode_blockassembly_state_duration_seconds` — a healthy node spends
+  almost all its time in `Running`. Long dwell time in `Reorging` or
+  `MovingUp` is worth investigating.
+- `teranode_blockassembly_best_block_height` vs. your own chain tip — a gap
+  that doesn't close means block assembly is falling behind validation.
+
+### Validation and propagation errors
+
+- `teranode_validator_invalid_transactions` and
+  `teranode_propagation_invalid_transactions` — a sustained non-zero rate
+  (rather than occasional spikes from normal network traffic) suggests policy
+  misconfiguration or an upstream data problem.
+- `teranode_aerospike_utxo_errors`, `teranode_aerospike_txmeta_errors`, and
+  the SQL-store equivalents (`teranode_sql_utxo_errors`) — any sustained rate
+  here points at store-level trouble (disk, memory pressure, connectivity),
+  not the chain itself.
+
+### Fork and reorg activity
+
+- `teranode_blockvalidation_fork_count` and
+  `teranode_blockvalidation_fork_orphaned_total` — occasional forks are
+  normal; a rapidly growing fork count or frequent orphaning suggests network
+  or peering issues.
+
+### Cache and store pressure
+
+- `teranode_tx_meta_cache_hits` vs. `teranode_tx_meta_cache_misses` — a
+  degrading hit ratio under steady load usually precedes increased UTXO store
+  latency.
+- `teranode_aerospike_utxo_create_batch` / `_spend_batch` (histograms) —
+  rising batch durations are an early indicator of Aerospike contention,
+  before it shows up as user-visible slowdown.
+
+## Starter Alerting
+
+Teranode does not ship Prometheus alerting rules — alert thresholds depend on
+your hardware, network, and risk tolerance, so this is left to the operator.
+As a starting point, consider alerting on:
+
+- `teranode_blockchain_fsm_current_state` not `RUNNING` for more than a few
+  minutes after startup completes.
+- A sustained non-zero rate of `teranode_validator_invalid_transactions`,
+  `teranode_aerospike_utxo_errors`, or `teranode_sql_utxo_errors`.
+- `teranode_blockvalidation_processing_blocks_stuck` > 0 for more than a
+  couple of minutes.
+- `teranode_blockassembly_current_state` stuck outside `Running` beyond the
+  block time you'd expect for your network.
+
+The [BlockAssembler State Monitoring dashboard
+notes](https://github.com/bsv-blockchain/teranode/blob/main/compose/grafana/dashboards/README.md#alerting-rules)
+include worked example Prometheus alert rules (stuck-state, slow mining
+candidate generation, reorg frequency) you can adapt as a template rather than
+writing rules from scratch.
+
+## Related Documentation
+
+- [Prometheus Metrics Reference](../../references/prometheusMetrics.md)
+- [Installing with Docker](docker/minersHowToInstallation.md)
+- [Installing with Kubernetes](kubernetes/minersHowToInstallation.md)
+- [Troubleshooting (Docker)](docker/minersHowToTroubleshooting.md)
+- [Troubleshooting (Kubernetes)](kubernetes/minersHowToTroubleshooting.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
           - Sync the Node:
               - Docker: howto/miners/docker/minersHowToSyncTheNode.md
               - Kubernetes: howto/miners/kubernetes/minersHowToSyncTheNode.md
+          - Monitoring: howto/miners/minersHowToMonitoring.md
           - Additional:
               - Backup Teranode: howto/miners/minersHowToBackup.md
               - CPU Mining Setup: howto/miners/minersHowToCPUMiner.md


### PR DESCRIPTION
## Summary

- Adds a deployment-agnostic monitoring guide (`docs/howto/miners/minersHowToMonitoring.md`), wired into the nav under Miners, covering the Grafana dashboards shipped in-repo (Teranode Service Overview, Aerospike batch-index/namespace/latency, BlockAssembler State Monitoring), the metrics that distinguish a healthy node from a degraded one, and a starter-alerting note (alert rules are operator-defined; none ship in-repo).
- Links `references/prometheusMetrics.md` from the Docker and Kubernetes miner installation docs, and from the new monitoring guide. Previously it was reachable only from the References nav and other reference docs, not from the miner-facing installation path.
- Fixes the legacy-service resource snippet in the Kubernetes installation doc: the `cpu: 100m` / `memory: 256Mi` / `imagePullPolicy: Never` values are Minikube/local-dev defaults, not appropriate for testnet/mainnet. Added a caveat and a pointer to the shipped mainnet CR (`cpu: 2` / `memory: 64Gi`) for real deployments.

## Out of scope

The audit also recommended converting the 5 "Production Considerations" bullets in the Kubernetes installation doc into full procedures. That's a larger doc-authoring effort and is left as a follow-up; this PR only turns the monitoring bullet into a link to the new guide.

## Test plan

- [x] Verified all new/updated relative doc links resolve to existing files
- [x] `markdownlint` passes on the new doc
- [x] Verified the legacy CR values against `deploy/kubernetes/teranode/teranode-cr-mainnet.yaml`