### PR TITLE
Fix service-inventory doc drift: add Pruner overlay-service section, correct P2P bootstrap description

### DIFF
--- a/daemon/daemon_service_inventory_test.go
+++ b/daemon/daemon_service_inventory_test.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceInventory_MatchesServicesDirectory guards against documentation and
+// code drift: every service name the daemon knows how to start (the "Formal"
+// service-name constants passed to shouldStart/AddService in daemon_services.go)
+// must have a corresponding source package under services/<name>. If a service is
+// added, renamed, or removed here without updating the services/ layout (or vice
+// versa), this test fails instead of silently drifting out of sync with the docs.
+func TestServiceInventory_MatchesServicesDirectory(t *testing.T) {
+	// The set of "Formal" service-name constants the daemon can start, as used in
+	// startServices() (daemon/daemon_services.go). Keep this list in sync with that
+	// function's shouldStart/starters list.
+	daemonServiceNames := []string{
+		serviceAlertFormal,
+		serviceAssetFormal,
+		serviceBlockAssemblyFormal,
+		serviceBlockPersisterFormal,
+		serviceBlockValidationFormal,
+		serviceBlockchainFormal,
+		serviceLegacyFormal,
+		serviceNameP2PFormal,
+		servicePropagationFormal,
+		servicePrunerFormal,
+		serviceRPCFormal,
+		serviceSubtreeValidationFormal,
+		serviceUtxoPersisterFormal,
+		serviceValidatorFormal,
+	}
+
+	servicesDir := filepath.Join("..", "services")
+
+	for _, name := range daemonServiceNames {
+		dirName := strings.ToLower(name)
+		pkgPath := filepath.Join(servicesDir, dirName)
+
+		info, err := os.Stat(pkgPath)
+		require.NoError(t, err, "daemon can start service %q but services/%s does not exist", name, dirName)
+		require.True(t, info.IsDir(), "services/%s exists but is not a directory", dirName)
+	}
+}

--- a/daemon/daemon_service_inventory_test.go
+++ b/daemon/daemon_service_inventory_test.go
@@ -12,13 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// daemonServicesFile is the source file whose shouldStart() call sites define the
-// authoritative set of services the daemon can start.
-const daemonServicesFile = "daemon_services.go"
+// daemonPackageDir is the directory scanned for d.shouldStart(...) call sites,
+// which define the authoritative set of services the daemon can start. Scanning
+// the whole package (rather than just daemon_services.go) catches dispatch calls
+// that live elsewhere, such as daemon.go's "wait_for_postgres" switch.
+const daemonPackageDir = "."
+
+// daemonReceiverIdent is the receiver name a call must use to be treated as a
+// daemon method call (e.g. d.shouldStart(...)), so that an unrelated same-named
+// method or field on another type in the package isn't folded into the inventory.
+const daemonReceiverIdent = "d"
 
 // daemonServiceNames maps the identifier of every "Formal" service-name constant
 // that startServices() dispatches to that constant's value. The identifiers are
-// cross-checked against the real shouldStart() call sites in daemonServicesFile, so
+// cross-checked against the real shouldStart() call sites in the daemon package, so
 // this map cannot drift from the code in either direction.
 var daemonServiceNames = map[string]string{
 	"serviceAlertFormal":             serviceAlertFormal,
@@ -38,19 +45,23 @@ var daemonServiceNames = map[string]string{
 }
 
 // nonServiceShouldStartArgs holds shouldStart() arguments that are command-line
-// switches rather than services, and so are exempt from the inventory.
+// switches rather than services, and so are exempt from the inventory. Both
+// identifier names (e.g. serviceHelp) and string-literal switches (e.g.
+// wait_for_postgres) are looked up here, keyed by their literal text.
 var nonServiceShouldStartArgs = map[string]struct{}{
 	// -help only prints usage; it starts nothing and has no services/ package.
 	"serviceHelp": {},
+	// wait_for_postgres (daemon.go) is a startup gate, not a service.
+	"wait_for_postgres": {},
 }
 
-// TestServiceInventory_MatchesServicesDirectory guards against documentation and
-// code drift in both directions: the set of services startServices() can dispatch is
-// derived from the actual shouldStart() call sites in daemon_services.go, so a
-// service added to (or removed from) that function without being added to (or
-// removed from) daemonServiceNames fails the test. Every inventoried service must
-// also have a source package under services/<name>, which is what the architecture
-// docs enumerate.
+// TestServiceInventory_MatchesServicesDirectory guards the daemon's service dispatch
+// against the services/ layout in both directions: the set of services
+// startServices() can dispatch is derived from the actual shouldStart() call sites
+// in the daemon package, so a service added to (or removed from) that dispatch
+// without being added to (or removed from) daemonServiceNames fails the test. Every
+// inventoried service must also have a source package under services/<name>. This
+// does not check the architecture docs — those still need a manual pass.
 func TestServiceInventory_MatchesServicesDirectory(t *testing.T) {
 	dispatched := shouldStartServiceIdents(t)
 
@@ -58,8 +69,8 @@ func TestServiceInventory_MatchesServicesDirectory(t *testing.T) {
 	for ident := range dispatched {
 		_, listed := daemonServiceNames[ident]
 		require.True(t, listed,
-			"%s dispatches shouldStart(%s) but %s is missing from daemonServiceNames: add it here and add its services/<name> package",
-			daemonServicesFile, ident, ident)
+			"daemon package dispatches shouldStart(%s) but %s is missing from daemonServiceNames: add it here and add its services/<name> package",
+			ident, ident)
 	}
 
 	// Direction 2: nothing in the inventory may be a service the daemon no longer
@@ -67,8 +78,8 @@ func TestServiceInventory_MatchesServicesDirectory(t *testing.T) {
 	for ident := range daemonServiceNames {
 		_, ok := dispatched[ident]
 		require.True(t, ok,
-			"daemonServiceNames lists %s but %s never passes it to shouldStart: remove it here or restore the dispatch",
-			ident, daemonServicesFile)
+			"daemonServiceNames lists %s but the daemon package never passes it to shouldStart: remove it here or restore the dispatch",
+			ident)
 	}
 
 	// Every dispatched service must have a source package under services/<name>.
@@ -84,46 +95,77 @@ func TestServiceInventory_MatchesServicesDirectory(t *testing.T) {
 	}
 }
 
-// shouldStartServiceIdents parses daemonServicesFile and returns the identifiers
-// passed as the first argument to every d.shouldStart(...) call, minus the
-// non-service switches. Deriving the set from the source rather than restating it
-// keeps the guard bidirectional.
+// shouldStartServiceIdents parses every non-test .go file in daemonPackageDir and
+// returns the identifiers passed as the first argument to every
+// daemonReceiverIdent.shouldStart(...) call, minus the non-service switches.
+// Deriving the set from the source rather than restating it keeps the guard
+// bidirectional. Scanning the whole package (rather than just daemon_services.go)
+// catches dispatch calls that live elsewhere. shouldStart must be called directly
+// (e.g. d.shouldStart(...)); a method value taken as ss := d.shouldStart and
+// invoked as ss(...) is not visible to this AST match.
 func shouldStartServiceIdents(t *testing.T) map[string]struct{} {
 	t.Helper()
 
 	fset := token.NewFileSet()
 
-	file, err := parser.ParseFile(fset, daemonServicesFile, nil, 0)
-	require.NoError(t, err, "failed to parse %s", daemonServicesFile)
+	entries, err := os.ReadDir(daemonPackageDir)
+	require.NoError(t, err, "failed to read %s", daemonPackageDir)
 
 	idents := make(map[string]struct{})
+	found := false
 
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
 		}
 
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "shouldStart" || len(call.Args) == 0 {
+		path := filepath.Join(daemonPackageDir, name)
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		require.NoError(t, err, "failed to parse %s", path)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "shouldStart" || len(call.Args) == 0 {
+				return true
+			}
+
+			recv, ok := sel.X.(*ast.Ident)
+			if !ok || recv.Name != daemonReceiverIdent {
+				return true
+			}
+
+			found = true
+
+			switch arg := call.Args[0].(type) {
+			case *ast.Ident:
+				if _, exempt := nonServiceShouldStartArgs[arg.Name]; exempt {
+					return true
+				}
+
+				idents[arg.Name] = struct{}{}
+			case *ast.BasicLit:
+				lit := strings.Trim(arg.Value, `"`)
+				_, exempt := nonServiceShouldStartArgs[lit]
+				require.True(t, exempt,
+					"shouldStart(%s) at %s is not in nonServiceShouldStartArgs: add it there if it isn't a service",
+					arg.Value, fset.Position(call.Lparen))
+			default:
+				t.Fatalf("shouldStart is called with an unrecognized argument kind at %s: this guard can only inventory constant identifiers and string literals", fset.Position(call.Lparen))
+			}
+
 			return true
-		}
+		})
+	}
 
-		ident, ok := call.Args[0].(*ast.Ident)
-		require.True(t, ok,
-			"shouldStart is called with a non-constant service name at %s: this guard can only inventory constant identifiers",
-			fset.Position(call.Lparen))
-
-		if _, exempt := nonServiceShouldStartArgs[ident.Name]; exempt {
-			return true
-		}
-
-		idents[ident.Name] = struct{}{}
-
-		return true
-	})
-
-	require.NotEmpty(t, idents, "found no shouldStart call sites in %s: has the service dispatch moved?", daemonServicesFile)
+	require.True(t, found, "found no %s.shouldStart call sites in %s: has the service dispatch moved?", daemonReceiverIdent, daemonPackageDir)
+	require.NotEmpty(t, idents, "found no service identifiers among %s.shouldStart call sites in %s", daemonReceiverIdent, daemonPackageDir)
 
 	return idents
 }

--- a/daemon/daemon_service_inventory_test.go
+++ b/daemon/daemon_service_inventory_test.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,41 +12,118 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// daemonServicesFile is the source file whose shouldStart() call sites define the
+// authoritative set of services the daemon can start.
+const daemonServicesFile = "daemon_services.go"
+
+// daemonServiceNames maps the identifier of every "Formal" service-name constant
+// that startServices() dispatches to that constant's value. The identifiers are
+// cross-checked against the real shouldStart() call sites in daemonServicesFile, so
+// this map cannot drift from the code in either direction.
+var daemonServiceNames = map[string]string{
+	"serviceAlertFormal":             serviceAlertFormal,
+	"serviceAssetFormal":             serviceAssetFormal,
+	"serviceBlockAssemblyFormal":     serviceBlockAssemblyFormal,
+	"serviceBlockPersisterFormal":    serviceBlockPersisterFormal,
+	"serviceBlockValidationFormal":   serviceBlockValidationFormal,
+	"serviceBlockchainFormal":        serviceBlockchainFormal,
+	"serviceLegacyFormal":            serviceLegacyFormal,
+	"serviceNameP2PFormal":           serviceNameP2PFormal,
+	"servicePropagationFormal":       servicePropagationFormal,
+	"servicePrunerFormal":            servicePrunerFormal,
+	"serviceRPCFormal":               serviceRPCFormal,
+	"serviceSubtreeValidationFormal": serviceSubtreeValidationFormal,
+	"serviceUtxoPersisterFormal":     serviceUtxoPersisterFormal,
+	"serviceValidatorFormal":         serviceValidatorFormal,
+}
+
+// nonServiceShouldStartArgs holds shouldStart() arguments that are command-line
+// switches rather than services, and so are exempt from the inventory.
+var nonServiceShouldStartArgs = map[string]struct{}{
+	// -help only prints usage; it starts nothing and has no services/ package.
+	"serviceHelp": {},
+}
+
 // TestServiceInventory_MatchesServicesDirectory guards against documentation and
-// code drift: every service name the daemon knows how to start (the "Formal"
-// service-name constants passed to shouldStart/AddService in daemon_services.go)
-// must have a corresponding source package under services/<name>. If a service is
-// added, renamed, or removed here without updating the services/ layout (or vice
-// versa), this test fails instead of silently drifting out of sync with the docs.
+// code drift in both directions: the set of services startServices() can dispatch is
+// derived from the actual shouldStart() call sites in daemon_services.go, so a
+// service added to (or removed from) that function without being added to (or
+// removed from) daemonServiceNames fails the test. Every inventoried service must
+// also have a source package under services/<name>, which is what the architecture
+// docs enumerate.
 func TestServiceInventory_MatchesServicesDirectory(t *testing.T) {
-	// The set of "Formal" service-name constants the daemon can start, as used in
-	// startServices() (daemon/daemon_services.go). Keep this list in sync with that
-	// function's shouldStart/starters list.
-	daemonServiceNames := []string{
-		serviceAlertFormal,
-		serviceAssetFormal,
-		serviceBlockAssemblyFormal,
-		serviceBlockPersisterFormal,
-		serviceBlockValidationFormal,
-		serviceBlockchainFormal,
-		serviceLegacyFormal,
-		serviceNameP2PFormal,
-		servicePropagationFormal,
-		servicePrunerFormal,
-		serviceRPCFormal,
-		serviceSubtreeValidationFormal,
-		serviceUtxoPersisterFormal,
-		serviceValidatorFormal,
+	dispatched := shouldStartServiceIdents(t)
+
+	// Direction 1: nothing the daemon dispatches may be missing from the inventory.
+	for ident := range dispatched {
+		_, listed := daemonServiceNames[ident]
+		require.True(t, listed,
+			"%s dispatches shouldStart(%s) but %s is missing from daemonServiceNames: add it here and add its services/<name> package",
+			daemonServicesFile, ident, ident)
 	}
 
+	// Direction 2: nothing in the inventory may be a service the daemon no longer
+	// dispatches.
+	for ident := range daemonServiceNames {
+		_, ok := dispatched[ident]
+		require.True(t, ok,
+			"daemonServiceNames lists %s but %s never passes it to shouldStart: remove it here or restore the dispatch",
+			ident, daemonServicesFile)
+	}
+
+	// Every dispatched service must have a source package under services/<name>.
 	servicesDir := filepath.Join("..", "services")
 
-	for _, name := range daemonServiceNames {
+	for ident, name := range daemonServiceNames {
 		dirName := strings.ToLower(name)
 		pkgPath := filepath.Join(servicesDir, dirName)
 
 		info, err := os.Stat(pkgPath)
-		require.NoError(t, err, "daemon can start service %q but services/%s does not exist", name, dirName)
+		require.NoError(t, err, "daemon can start service %q (%s) but services/%s does not exist", name, ident, dirName)
 		require.True(t, info.IsDir(), "services/%s exists but is not a directory", dirName)
 	}
+}
+
+// shouldStartServiceIdents parses daemonServicesFile and returns the identifiers
+// passed as the first argument to every d.shouldStart(...) call, minus the
+// non-service switches. Deriving the set from the source rather than restating it
+// keeps the guard bidirectional.
+func shouldStartServiceIdents(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, daemonServicesFile, nil, 0)
+	require.NoError(t, err, "failed to parse %s", daemonServicesFile)
+
+	idents := make(map[string]struct{})
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "shouldStart" || len(call.Args) == 0 {
+			return true
+		}
+
+		ident, ok := call.Args[0].(*ast.Ident)
+		require.True(t, ok,
+			"shouldStart is called with a non-constant service name at %s: this guard can only inventory constant identifiers",
+			fset.Position(call.Lparen))
+
+		if _, exempt := nonServiceShouldStartArgs[ident.Name]; exempt {
+			return true
+		}
+
+		idents[ident.Name] = struct{}{}
+
+		return true
+	})
+
+	require.NotEmpty(t, idents, "found no shouldStart call sites in %s: has the service dispatch moved?", daemonServicesFile)
+
+	return idents
 }

--- a/docs/references/glossary.md
+++ b/docs/references/glossary.md
@@ -52,7 +52,7 @@
 
 **Legacy Service**: Bridges the gap between traditional BSV nodes and advanced Teranode-BSV nodes, ensuring seamless communication and data translation.
 
-**libp2p**: A modular peer-to-peer networking framework used by Teranode's P2P Bootstrap Service for peer discovery and network communication, providing features like NAT traversal and multiple transport protocols.
+**libp2p**: A modular peer-to-peer networking framework used by Teranode's P2P Service for peer discovery and network communication, providing features like NAT traversal and multiple transport protocols.
 
 **Lustre Fs**: A parallel distributed file system used for high-performance, large-scale data storage and workloads in Teranode.
 
@@ -66,7 +66,7 @@
 
 **Orphan Block**: A valid block that is not part of the main blockchain because its parent block is unknown or not yet received. Orphan blocks are temporarily stored until their parent arrives or they are discarded if they don't connect to the main chain.
 
-**P2P Bootstrap Service**: Helps new nodes discover peers and join the network, using libp2p and Kademlia.
+**Bootstrap peers**: Initial DHT/relay entry points, configured via `p2p_bootstrap_peers` and dialled by the P2P Service at startup (libp2p/Kademlia).
 
 **P2P Service**: Allows peers to subscribe and receive blockchain notifications about new blocks and subtrees in the network.
 

--- a/docs/topics/architecture/teranode-microservices-overview.md
+++ b/docs/topics/architecture/teranode-microservices-overview.md
@@ -429,7 +429,7 @@ The Pruner Service is an event-driven overlay service that removes stale UTXO da
 
 **Key Responsibilities:**
 
-- Respond to `BlockPersisted` (or `Block`, as a fallback) notifications instead of polling
+- Respond to `BlockPersisted` or `Block` notifications — selected by `pruner_block_trigger` — instead of polling
 - Preserve parent transactions of old unmined transactions so they remain available for resubmission
 - Remove UTXO records marked for deletion once they reach their delete-at-height
 - Coordinate with the Block Persister so transaction data stays accessible until `.subtree_data` files are created

--- a/docs/topics/architecture/teranode-microservices-overview.md
+++ b/docs/topics/architecture/teranode-microservices-overview.md
@@ -20,6 +20,7 @@
         - [3.3 P2P Service](#33-p2p-service)
         - [3.4 Legacy Service](#34-legacy-service)
         - [3.5 RPC Service](#35-rpc-service)
+        - [3.6 Pruner Service](#36-pruner-service)
     - [4. Stores](#4-stores)
         - [4.1 TX and Subtree Store (Blob Server)](#41-tx-and-subtree-store-blob-server)
         - [4.2 UTXO Store](#42-utxo-store)
@@ -420,6 +421,31 @@ The RPC Service provides compatibility with the Bitcoin RPC interface, allowing 
 
 You can read more about this service in the [RPC Service documentation](../services/rpc.md).
 
+### 3.6 Pruner Service
+
+The Pruner Service is an event-driven overlay service that removes stale UTXO data to prevent unbounded database growth.
+
+![Pruner_Service_Container_Diagram.png](../services/img/Pruner_Service_Container_Diagram.png)
+
+**Key Responsibilities:**
+
+- Respond to `BlockPersisted` (or `Block`, as a fallback) notifications instead of polling
+- Preserve parent transactions of old unmined transactions so they remain available for resubmission
+- Remove UTXO records marked for deletion once they reach their delete-at-height
+- Coordinate with the Block Persister so transaction data stays accessible until `.subtree_data` files are created
+- Clean up external transaction blobs from blob storage (S3/filesystem)
+
+![Pruner_Service_Component_Diagram.png](../services/img/Pruner_Service_Component_Diagram.png)
+
+**Key Processes:**
+
+- Subscribing to blockchain notifications to trigger pruning runs
+- Running a two-phase pruning process to prevent data loss
+- Coordinating with Block Persister during catchup
+- Managing a job queue and worker pool for pruning and blob-deletion work
+
+You can read more about this service in the [Pruner Service documentation](../services/pruner.md).
+
 ## 4. Stores
 
 ### 4.1 TX and Subtree Store (Blob Server)
@@ -573,6 +599,7 @@ The Teranode microservices communicate through a combination of synchronous gRPC
     - [P2P Service](../services/p2p.md)
     - [Legacy Service](../services/legacy.md)
     - [RPC Server](../services/rpc.md)
+    - [Pruner Service](../services/pruner.md)
 - Stores:
 
     - [Blob Server](../stores/blob.md)

--- a/docs/topics/architecture/teranode-overall-system-design.md
+++ b/docs/topics/architecture/teranode-overall-system-design.md
@@ -123,9 +123,9 @@ Key components of the Teranode architecture include:
     - Block Persister Service
     - UTXO Persister Service
     - P2P Service
-    - P2P Bootstrap Service
     - Legacy Service
     - RPC Service
+    - Pruner Service
 
 3. Stores:
 

--- a/docs/topics/services/p2p.md
+++ b/docs/topics/services/p2p.md
@@ -38,7 +38,7 @@ The p2p package implements a peer-to-peer (P2P) server using `libp2p` (`github.c
 
 The p2p service allows peers to subscribe and receive blockchain notifications, effectively allowing nodes to receive notifications about new blocks and subtrees in the network.
 
-The p2p peers can form a private network. Network bootstrapping is a configuration option, not a separate service: the P2P service reads the `p2p_bootstrap_peers` setting at startup to obtain initial DHT entry points for peer discovery (see `p2p_static_peers` for permanently maintained connections instead).
+The p2p peers can form a private network. Network bootstrapping is a configuration option, not a separate service: the P2P service reads the `p2p_bootstrap_peers` setting at startup to obtain initial DHT and relay entry points for peer discovery. Blanking it does not isolate the node — the client then falls back to the default public IPFS bootstrap peers — so a private network should point it at its own bootstrap servers, alongside `p2p_static_peers` and `p2p_dht_mode = off`.
 
 1. **Initialization and Configuration**:
 

--- a/docs/topics/services/p2p.md
+++ b/docs/topics/services/p2p.md
@@ -38,7 +38,7 @@ The p2p package implements a peer-to-peer (P2P) server using `libp2p` (`github.c
 
 The p2p service allows peers to subscribe and receive blockchain notifications, effectively allowing nodes to receive notifications about new blocks and subtrees in the network.
 
-The p2p peers are part of a private network. This private network is managed by the p2p bootstrap service, which is responsible for bootstrapping the network and managing the network topology.
+The p2p peers can form a private network. Network bootstrapping is a configuration option, not a separate service: the P2P service reads the `p2p_bootstrap_peers` setting at startup to obtain initial DHT entry points for peer discovery (see `p2p_static_peers` for permanently maintained connections instead).
 
 1. **Initialization and Configuration**:
 


### PR DESCRIPTION
## Summary

- Adds a "Pruner Service" subsection to the Overlay Services section of
  `docs/topics/architecture/teranode-microservices-overview.md`. The daemon starts
  six overlay services (`daemon/daemon_services.go`), but the doc only documented
  five — Pruner was missing entirely.
- Rewrites the stale description in `docs/topics/services/p2p.md` that referred to
  a standalone "p2p bootstrap service" managing the private network. That service
  doesn't exist; bootstrapping is a configuration option (`p2p_bootstrap_peers`)
  read by the P2P service itself at startup.
- Drops the same phantom "P2P Bootstrap Service" from `docs/references/glossary.md`
  (replaced with a "Bootstrap peers" entry describing the actual config option), and
  fixes the libp2p entry's reference to it.
- Adds a guard test (`daemon/daemon_service_inventory_test.go`) asserting the
  daemon's service dispatch (`daemon_services.go`) matches the `services/<name>`
  directory layout in both directions. This turns drift between the dispatch table
  and the services/ layout into an automatic CI failure. It does not check the
  architecture docs — those still need a manual pass.

## Test plan

- [x] `go test ./daemon/...` passes
- [x] `go vet ./daemon/...` passes
- [x] Verified the guard test actually catches drift: temporarily added a fake
      service name to the test's list (no matching `services/` directory), confirmed
      the test failed with a clear error message, then reverted the temporary change
- [x] Visually reviewed the doc edits for formatting/style consistency with the
      surrounding sections
