### PR TITLE
fix(legacy): disconnect peer on outbound write error, clamp advertised block size to wire capacity

### DIFF
--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -252,7 +252,7 @@ func (s *Server) Health(ctx context.Context, checkLiveness bool) (int, string, e
 func (s *Server) Init(ctx context.Context) error {
 	var err error
 
-	wire.SetLimits(maxWireMessagePayload)
+	wire.SetLimits(maxWireBlockPayload)
 
 	// Stream-decode incoming "block" messages straight from the socket
 	// instead of buffering the full payload first. On multi-GB blocks the

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -252,7 +252,7 @@ func (s *Server) Health(ctx context.Context, checkLiveness bool) (int, string, e
 func (s *Server) Init(ctx context.Context) error {
 	var err error
 
-	wire.SetLimits(4000000000)
+	wire.SetLimits(maxWireMessagePayload)
 
 	// Stream-decode incoming "block" messages straight from the socket
 	// instead of buffering the full payload first. On multi-GB blocks the

--- a/services/legacy/config.go
+++ b/services/legacy/config.go
@@ -8,7 +8,6 @@ package legacy
 
 import (
 	"fmt"
-	"math"
 	"net"
 	"net/url"
 	"os"
@@ -28,26 +27,32 @@ import (
 )
 
 const (
-	defaultDataDir            = "data"
-	defaultMaxPeers           = 125
-	defaultMaxPeersPerIP      = 5
-	defaultBanDuration        = time.Hour * 24
-	defaultBanThreshold       = 100
-	defaultConnectTimeout     = time.Second * 30
-	defaultFreeTxRelayLimit   = 15.0
-	defaultTrickleInterval    = peer.DefaultTrickleInterval
-	defaultExcessiveBlockSize = math.MaxUint64
-	// maxWireMessagePayload is the largest message payload the wire protocol
-	// path can actually relay (set via wire.SetLimits in Server.go's Init).
-	// ExcessiveBlockSize is clamped to this value so the advertised EB never
-	// promises more than the transport can deliver.
-	maxWireMessagePayload = 4_000_000_000
-	defaultBlockMinSize   = 0
-	// defaultBlockMaxSize is derived from maxWireMessagePayload, not
-	// defaultExcessiveBlockSize: ExcessiveBlockSize is clamped to
-	// maxWireMessagePayload in loadConfig, so the default block max size must
-	// stay within that same ceiling or the sanity check below rejects it.
-	defaultBlockMaxSize            = maxWireMessagePayload - 1000
+	defaultDataDir          = "data"
+	defaultMaxPeers         = 125
+	defaultMaxPeersPerIP    = 5
+	defaultBanDuration      = time.Hour * 24
+	defaultBanThreshold     = 100
+	defaultConnectTimeout   = time.Second * 30
+	defaultFreeTxRelayLimit = 15.0
+	defaultTrickleInterval  = peer.DefaultTrickleInterval
+	// maxWireBlockPayload is the excessive block size handed to wire.SetLimits
+	// in Server.go's Init. go-wire keeps it as its `ebs` and returns it from
+	// MaxBlockPayload(), which is the per-message cap it enforces on `block`
+	// and `tx` messages on both read and write - so it is the largest block
+	// this node will accept over the legacy wire. It is not the overall
+	// message payload cap: go-wire derives that as ((ebs/1e6)*1MiB)*2, i.e.
+	// roughly 8.39 GB for this value (go-wire v1.2.10 message.go:38-42).
+	maxWireBlockPayload = 4_000_000_000
+	// defaultExcessiveBlockSize is only a placeholder. loadConfig always
+	// replaces it with the limit block validation actually enforces, see
+	// advertisedExcessiveBlockSize.
+	defaultExcessiveBlockSize = maxWireBlockPayload
+	defaultBlockMinSize       = 0
+	// defaultBlockMaxSize is derived from maxWireBlockPayload: there is no
+	// point mining a block larger than the legacy wire path can carry. When
+	// the enforced excessive block size is smaller, loadConfig caps this down
+	// further.
+	defaultBlockMaxSize            = maxWireBlockPayload - 1000
 	blockMaxSizeMin                = 1000
 	defaultGenerate                = false
 	defaultSigCacheMaxSize         = 100000
@@ -128,12 +133,21 @@ func minUint64(a, b uint64) uint64 {
 	return b
 }
 
-// clampExcessiveBlockSize caps a configured (or defaulted) ExcessiveBlockSize
-// at maxWireMessagePayload, the largest payload the wire protocol path can
-// actually relay (see wire.SetLimits in Server.go's Init). Values at or below
-// the ceiling are returned unchanged.
-func clampExcessiveBlockSize(v uint64) uint64 {
-	return minUint64(v, maxWireMessagePayload)
+// advertisedExcessiveBlockSize returns the excessive block size to advertise in
+// the EB user agent comment. It derives from policyExcessiveBlockSize - the
+// limit block validation enforces in ValidateBlock, i.e.
+// settings.Policy.ExcessiveBlockSize - capped at maxWireBlockPayload, the
+// largest block this node can receive over the legacy wire. The advertised
+// value is therefore never larger than the block size this node honours.
+//
+// A non-positive policy value means the policy limit is disabled (see
+// ValidateBlock), leaving the wire cap as the only effective limit.
+func advertisedExcessiveBlockSize(policyExcessiveBlockSize int) uint64 {
+	if policyExcessiveBlockSize <= 0 {
+		return maxWireBlockPayload
+	}
+
+	return minUint64(uint64(policyExcessiveBlockSize), maxWireBlockPayload)
 }
 
 // maxUint32 is a helper function to return the maximum of two uint32s.
@@ -178,7 +192,7 @@ type config struct {
 	CPUProfile              string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
 	DebugLevel              string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	Upnp                    bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
-	ExcessiveBlockSize      uint64        `long:"excessiveblocksize" description:"The maximum size block (in bytes) this node will accept. Cannot be less than 32000000."`
+	ExcessiveBlockSize      uint64        `long:"excessiveblocksize" description:"The maximum size block (in bytes) this node will accept. Derived from the excessiveblocksize policy setting, capped at what the legacy wire path can carry."`
 	MinRelayTxFee           float64       `long:"minrelaytxfee" description:"The minimum transaction fee in BSV/kB to be considered a non-zero fee."`
 	FreeTxRelayLimit        float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
 	NoRelayPriority         bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
@@ -357,7 +371,11 @@ func parseCheckpoints(checkpointStrings []string) ([]chaincfg.Checkpoint, error)
 // The above results in bsvd functioning properly without any config settings
 // while still allowing the user to override settings with config files and
 // command line options.  Command line options always take precedence.
-func loadConfig(logger ulogger.Logger) (*config, []string, error) {
+//
+// policyExcessiveBlockSize is settings.Policy.ExcessiveBlockSize, the block
+// size limit block validation enforces. The advertised EB user agent comment is
+// derived from it so this node cannot advertise a block size it would reject.
+func loadConfig(logger ulogger.Logger, policyExcessiveBlockSize int) (*config, []string, error) {
 	// Default config.
 	cfg := config{
 		MaxPeers:                defaultMaxPeers,
@@ -618,21 +636,32 @@ func loadConfig(logger ulogger.Logger) (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Excessive blocksize can never advertise more than the wire protocol can
-	// actually relay, regardless of what was configured (or defaulted to).
-	cfg.ExcessiveBlockSize = clampExcessiveBlockSize(cfg.ExcessiveBlockSize)
+	// The excessive blocksize we advertise is the one block validation
+	// enforces, capped at what the legacy wire path can carry, so it is never
+	// larger than the block size this node honours.
+	cfg.ExcessiveBlockSize = advertisedExcessiveBlockSize(policyExcessiveBlockSize)
 
 	// Limit the max block size to a sane value.
-	blockMaxSizeMax := cfg.ExcessiveBlockSize - 1000
-	if cfg.BlockMaxSize < blockMaxSizeMin || cfg.BlockMaxSize > blockMaxSizeMax {
-		str := "%s: The blockmaxsize option must be in between %d and %d -- parsed [%d]"
-		err = fmt.Errorf(str, funcName, blockMaxSizeMin,
-			blockMaxSizeMax, cfg.BlockMaxSize)
+	if cfg.BlockMaxSize < blockMaxSizeMin {
+		str := "%s: The blockmaxsize option may not be less than %d -- parsed [%d]"
+		err = fmt.Errorf(str, funcName, blockMaxSizeMin, cfg.BlockMaxSize)
 		logger.Errorf("%v", err)
 		logger.Errorf("%s", usageMessage)
 
 		return nil, nil, err
 	}
+
+	// Never mine a block bigger than the excessive blocksize we accept. This is
+	// capped rather than rejected because the excessive blocksize follows the
+	// enforced policy setting, which an operator can legitimately set below the
+	// default max block size.
+	blockMaxSizeMax := uint64(blockMaxSizeMin)
+	if cfg.ExcessiveBlockSize > blockMaxSizeMin+1000 {
+		blockMaxSizeMax = cfg.ExcessiveBlockSize - 1000
+	}
+
+	cfg.BlockMaxSize = minUint64(cfg.BlockMaxSize, blockMaxSizeMax)
+
 	// Limit the minimum block sizes to max block size.
 	cfg.BlockMinSize = minUint64(cfg.BlockMinSize, cfg.BlockMaxSize)
 

--- a/services/legacy/config.go
+++ b/services/legacy/config.go
@@ -28,17 +28,26 @@ import (
 )
 
 const (
-	defaultDataDir                 = "data"
-	defaultMaxPeers                = 125
-	defaultMaxPeersPerIP           = 5
-	defaultBanDuration             = time.Hour * 24
-	defaultBanThreshold            = 100
-	defaultConnectTimeout          = time.Second * 30
-	defaultFreeTxRelayLimit        = 15.0
-	defaultTrickleInterval         = peer.DefaultTrickleInterval
-	defaultExcessiveBlockSize      = math.MaxUint64
-	defaultBlockMinSize            = 0
-	defaultBlockMaxSize            = defaultExcessiveBlockSize - 1000
+	defaultDataDir            = "data"
+	defaultMaxPeers           = 125
+	defaultMaxPeersPerIP      = 5
+	defaultBanDuration        = time.Hour * 24
+	defaultBanThreshold       = 100
+	defaultConnectTimeout     = time.Second * 30
+	defaultFreeTxRelayLimit   = 15.0
+	defaultTrickleInterval    = peer.DefaultTrickleInterval
+	defaultExcessiveBlockSize = math.MaxUint64
+	// maxWireMessagePayload is the largest message payload the wire protocol
+	// path can actually relay (set via wire.SetLimits in Server.go's Init).
+	// ExcessiveBlockSize is clamped to this value so the advertised EB never
+	// promises more than the transport can deliver.
+	maxWireMessagePayload = 4_000_000_000
+	defaultBlockMinSize   = 0
+	// defaultBlockMaxSize is derived from maxWireMessagePayload, not
+	// defaultExcessiveBlockSize: ExcessiveBlockSize is clamped to
+	// maxWireMessagePayload in loadConfig, so the default block max size must
+	// stay within that same ceiling or the sanity check below rejects it.
+	defaultBlockMaxSize            = maxWireMessagePayload - 1000
 	blockMaxSizeMin                = 1000
 	defaultGenerate                = false
 	defaultSigCacheMaxSize         = 100000
@@ -119,19 +128,17 @@ func minUint64(a, b uint64) uint64 {
 	return b
 }
 
+// clampExcessiveBlockSize caps a configured (or defaulted) ExcessiveBlockSize
+// at maxWireMessagePayload, the largest payload the wire protocol path can
+// actually relay (see wire.SetLimits in Server.go's Init). Values at or below
+// the ceiling are returned unchanged.
+func clampExcessiveBlockSize(v uint64) uint64 {
+	return minUint64(v, maxWireMessagePayload)
+}
+
 // maxUint32 is a helper function to return the maximum of two uint32s.
 // This avoids a math import and the need to cast to floats.
 func maxUint32(a, b uint32) uint32 {
-	if a > b {
-		return a
-	}
-
-	return b
-}
-
-// maxUint64 is a helper function to return the maximum of two uint64s.
-// This avoids a math import and the need to cast to floats.
-func maxUint64(a, b uint64) uint64 {
 	if a > b {
 		return a
 	}
@@ -611,8 +618,9 @@ func loadConfig(logger ulogger.Logger) (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Excessive blocksize cannot be set less than the default, but it can be higher.
-	cfg.ExcessiveBlockSize = maxUint64(cfg.ExcessiveBlockSize, defaultExcessiveBlockSize)
+	// Excessive blocksize can never advertise more than the wire protocol can
+	// actually relay, regardless of what was configured (or defaulted to).
+	cfg.ExcessiveBlockSize = clampExcessiveBlockSize(cfg.ExcessiveBlockSize)
 
 	// Limit the max block size to a sane value.
 	blockMaxSizeMax := cfg.ExcessiveBlockSize - 1000

--- a/services/legacy/config.go
+++ b/services/legacy/config.go
@@ -150,16 +150,6 @@ func advertisedExcessiveBlockSize(policyExcessiveBlockSize int) uint64 {
 	return minUint64(uint64(policyExcessiveBlockSize), maxWireBlockPayload)
 }
 
-// maxUint32 is a helper function to return the maximum of two uint32s.
-// This avoids a math import and the need to cast to floats.
-func maxUint32(a, b uint32) uint32 {
-	if a > b {
-		return a
-	}
-
-	return b
-}
-
 // config defines the configuration options for the legacy BSV Blockchain protocol server.
 // Configuration values can be set via command-line flags, configuration files, or environment variables.
 type config struct {
@@ -659,6 +649,11 @@ func loadConfig(logger ulogger.Logger, policyExcessiveBlockSize int) (*config, [
 	if cfg.ExcessiveBlockSize > blockMaxSizeMin+1000 {
 		blockMaxSizeMax = cfg.ExcessiveBlockSize - 1000
 	}
+
+	// The floor above must never push the cap above the excessive blocksize
+	// itself -- a policy excessiveblocksize at or below blockMaxSizeMin would
+	// otherwise let BlockMaxSize exceed ExcessiveBlockSize.
+	blockMaxSizeMax = minUint64(cfg.ExcessiveBlockSize, blockMaxSizeMax)
 
 	cfg.BlockMaxSize = minUint64(cfg.BlockMaxSize, blockMaxSizeMax)
 

--- a/services/legacy/config_test.go
+++ b/services/legacy/config_test.go
@@ -2,7 +2,6 @@ package legacy
 
 import (
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,13 +9,14 @@ import (
 
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExcessiveBlockSizeUserAgentComment(t *testing.T) {
 	// Wipe test args.
 	os.Args = []string{"bsvd"}
 
-	cfg, _, err := loadConfig(ulogger.TestLogger{})
+	cfg, _, err := loadConfig(ulogger.TestLogger{}, 4294967296)
 	if err != nil {
 		t.Fatal("Failed to load configuration")
 	}
@@ -34,7 +34,7 @@ func TestExcessiveBlockSizeUserAgentComment(t *testing.T) {
 	// Custom excessive block size.
 	os.Args = []string{"bsvd", "--excessiveblocksize=64000000"}
 
-	cfg, _, err = loadConfig(ulogger.TestLogger{})
+	cfg, _, err = loadConfig(ulogger.TestLogger{}, 4294967296)
 	if err != nil {
 		t.Fatal("Failed to load configuration")
 	}
@@ -51,57 +51,59 @@ func TestExcessiveBlockSizeUserAgentComment(t *testing.T) {
 	//	}
 }
 
-// TestClampExcessiveBlockSizeRespectsValueBelowWireCapacity confirms a
-// configured ExcessiveBlockSize below the wire protocol's actual relay
-// capacity is respected as-is, rather than being floored up to some other
-// value.
+// TestAdvertisedExcessiveBlockSizeTracksEnforcedPolicy confirms the advertised
+// excessive block size is derived from the limit block validation actually
+// enforces (settings.Policy.ExcessiveBlockSize), capped at the largest block
+// message the legacy wire path accepts, so the user agent can never claim a
+// block size this node would reject.
+func TestAdvertisedExcessiveBlockSizeTracksEnforcedPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   int
+		expected uint64
+	}{
+		{"policy below the wire block payload cap is advertised verbatim", 64000000, 64000000},
+		{"policy equal to the wire block payload cap", maxWireBlockPayload, maxWireBlockPayload},
+		{"policy above the wire block payload cap is capped", 10737418240, maxWireBlockPayload},
+		{"the 4GiB settings default is capped", 4294967296, maxWireBlockPayload},
+		{"a disabled policy limit falls back to the wire block payload cap", 0, maxWireBlockPayload},
+		{"a negative policy limit falls back to the wire block payload cap", -1, maxWireBlockPayload},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, advertisedExcessiveBlockSize(tt.policy))
+		})
+	}
+}
+
+// TestLoadConfigAdvertisesEnforcedExcessiveBlockSize confirms the derivation is
+// wired into loadConfig, i.e. that the EB user agent comment follows the
+// enforced policy limit rather than a hard-coded constant.
 //
-// Note: this exercises clampExcessiveBlockSize directly rather than going
-// through loadConfig's os.Args-based flag parsing. That CLI parsing path is
-// already dead code in this file (the flags.NewIniParser/parser.Parse calls
-// are commented out), so loadConfig always builds cfg from its hard-coded
-// struct defaults regardless of os.Args -- exercising the clamp via os.Args
-// would silently test nothing.
-func TestClampExcessiveBlockSizeRespectsValueBelowWireCapacity(t *testing.T) {
-	const belowCapacity uint64 = 64000000
-
-	got := clampExcessiveBlockSize(belowCapacity)
-	if got != belowCapacity {
-		t.Fatalf("Expected ExcessiveBlockSize to be respected at %d, got %d", belowCapacity, got)
-	}
-}
-
-// TestClampExcessiveBlockSizeCapsValueAboveWireCapacity confirms a configured
-// (or defaulted) ExcessiveBlockSize above what the wire protocol can
-// actually relay gets clamped down to that ceiling, instead of being
-// advertised as an essentially-infinite value the transport can't back up.
-func TestClampExcessiveBlockSizeCapsValueAboveWireCapacity(t *testing.T) {
-	// Above the wire capacity ceiling.
-	if got := clampExcessiveBlockSize(5000000000); got != maxWireMessagePayload {
-		t.Fatalf("Expected ExcessiveBlockSize to be clamped to %d, got %d", maxWireMessagePayload, got)
-	}
-
-	// The old math.MaxUint64 default should also be clamped down.
-	if got := clampExcessiveBlockSize(math.MaxUint64); got != maxWireMessagePayload {
-		t.Fatalf("Expected default ExcessiveBlockSize to be clamped to %d, got %d", maxWireMessagePayload, got)
-	}
-}
-
-// TestLoadConfigClampsDefaultExcessiveBlockSize confirms the clamp is wired
-// up in loadConfig: since the CLI flag parser is disabled, cfg always starts
-// from defaultExcessiveBlockSize (math.MaxUint64), which must come back
-// clamped to the wire capacity ceiling.
-func TestLoadConfigClampsDefaultExcessiveBlockSize(t *testing.T) {
+// Note: the enforced limit is passed in rather than set via os.Args, because
+// loadConfig's CLI parsing path is dead code (the flags.NewIniParser and
+// parser.Parse calls are commented out), so loadConfig always builds cfg from
+// its hard-coded struct defaults regardless of os.Args.
+func TestLoadConfigAdvertisesEnforcedExcessiveBlockSize(t *testing.T) {
+	// Wipe test args.
 	os.Args = []string{"bsvd"}
 
-	cfg, _, err := loadConfig(ulogger.TestLogger{})
-	if err != nil {
-		t.Fatalf("Failed to load configuration: %v", err)
-	}
+	// A policy limit below the wire cap is what gets advertised.
+	cfg, _, err := loadConfig(ulogger.TestLogger{}, 64000000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(64000000), cfg.ExcessiveBlockSize)
+	require.Equal(t, []string{"EB64.0"}, cfg.UserAgentComments)
 
-	if cfg.ExcessiveBlockSize != maxWireMessagePayload {
-		t.Fatalf("Expected default ExcessiveBlockSize to be clamped to %d, got %d", maxWireMessagePayload, cfg.ExcessiveBlockSize)
-	}
+	// Blocks we mine must stay inside the size we accept.
+	require.LessOrEqual(t, cfg.BlockMaxSize, cfg.ExcessiveBlockSize-1000)
+
+	// The 4GiB settings default exceeds the largest block message the legacy
+	// wire path accepts, so the advertisement is capped there.
+	cfg, _, err = loadConfig(ulogger.TestLogger{}, 4294967296)
+	require.NoError(t, err)
+	require.Equal(t, uint64(maxWireBlockPayload), cfg.ExcessiveBlockSize)
+	require.Equal(t, []string{"EB4000.0"}, cfg.UserAgentComments)
 }
 
 func TestCreateDefaultConfigFile(t *testing.T) {

--- a/services/legacy/config_test.go
+++ b/services/legacy/config_test.go
@@ -25,11 +25,11 @@ func TestExcessiveBlockSizeUserAgentComment(t *testing.T) {
 		t.Fatal("Expected EB UserAgentComment")
 	}
 
-	// uac := cfg.UserAgentComments[0]
-	// uacExpected := "EB32.0"
-	// if uac != uacExpected {
-	//	t.Fatalf("Expected UserAgentComments to contain %s but got %s", uacExpected, uac)
-	// }
+	uac := cfg.UserAgentComments[0]
+	uacExpected := "EB4000.0"
+	if uac != uacExpected {
+		t.Fatalf("Expected UserAgentComments to contain %s but got %s", uacExpected, uac)
+	}
 
 	// Custom excessive block size.
 	os.Args = []string{"bsvd", "--excessiveblocksize=64000000"}
@@ -42,13 +42,15 @@ func TestExcessiveBlockSizeUserAgentComment(t *testing.T) {
 	if len(cfg.UserAgentComments) != 1 {
 		t.Fatal("Expected EB UserAgentComment")
 	}
-	// uac = cfg.UserAgentComments[0]
-	// uacExpected = "EB64.0"
-	// we do not support the command line options an
-	//
-	//	if uac != uacExpected {
-	//		t.Fatalf("Expected UserAgentComments to contain %s but got %s", uacExpected, uac)
-	//	}
+
+	// loadConfig's advertised EB now tracks the enforced policy limit passed
+	// in (4294967296, capped at maxWireBlockPayload), not the CLI flag: the
+	// CLI parsing path is dead code (see TestLoadConfigAdvertisesEnforcedExcessiveBlockSize).
+	uac = cfg.UserAgentComments[0]
+	uacExpected = "EB4000.0"
+	if uac != uacExpected {
+		t.Fatalf("Expected UserAgentComments to contain %s but got %s", uacExpected, uac)
+	}
 }
 
 // TestAdvertisedExcessiveBlockSizeTracksEnforcedPolicy confirms the advertised
@@ -64,8 +66,8 @@ func TestAdvertisedExcessiveBlockSizeTracksEnforcedPolicy(t *testing.T) {
 	}{
 		{"policy below the wire block payload cap is advertised verbatim", 64000000, 64000000},
 		{"policy equal to the wire block payload cap", maxWireBlockPayload, maxWireBlockPayload},
-		{"policy above the wire block payload cap is capped", 10737418240, maxWireBlockPayload},
-		{"the 4GiB settings default is capped", 4294967296, maxWireBlockPayload},
+		{"the 10GiB shipped settings.conf default is capped", 10737418240, maxWireBlockPayload},
+		{"the 4GiB Go struct fallback default is capped", 4294967296, maxWireBlockPayload},
 		{"a disabled policy limit falls back to the wire block payload cap", 0, maxWireBlockPayload},
 		{"a negative policy limit falls back to the wire block payload cap", -1, maxWireBlockPayload},
 	}
@@ -98,12 +100,50 @@ func TestLoadConfigAdvertisesEnforcedExcessiveBlockSize(t *testing.T) {
 	// Blocks we mine must stay inside the size we accept.
 	require.LessOrEqual(t, cfg.BlockMaxSize, cfg.ExcessiveBlockSize-1000)
 
-	// The 4GiB settings default exceeds the largest block message the legacy
-	// wire path accepts, so the advertisement is capped there.
+	// The 4GiB Go struct fallback default exceeds the largest block message
+	// the legacy wire path accepts, so the advertisement is capped there.
 	cfg, _, err = loadConfig(ulogger.TestLogger{}, 4294967296)
 	require.NoError(t, err)
 	require.Equal(t, uint64(maxWireBlockPayload), cfg.ExcessiveBlockSize)
 	require.Equal(t, []string{"EB4000.0"}, cfg.UserAgentComments)
+
+	// The 10GiB shipped settings.conf default likewise exceeds the wire cap.
+	cfg, _, err = loadConfig(ulogger.TestLogger{}, 10737418240)
+	require.NoError(t, err)
+	require.Equal(t, uint64(maxWireBlockPayload), cfg.ExcessiveBlockSize)
+	require.Equal(t, []string{"EB4000.0"}, cfg.UserAgentComments)
+}
+
+// TestBlockMaxSizeNeverExceedsExcessiveBlockSize confirms the invariant stated
+// in loadConfig's comment above the clamp -- "never mine a block bigger than
+// the excessive blocksize we accept" -- holds even for a policy
+// excessiveblocksize at or below blockMaxSizeMin (1000), where the floor
+// applied to blockMaxSizeMax must not itself push BlockMaxSize above
+// ExcessiveBlockSize.
+func TestBlockMaxSizeNeverExceedsExcessiveBlockSize(t *testing.T) {
+	os.Args = []string{"bsvd"}
+
+	tests := []struct {
+		name            string
+		policy          int
+		expectedEB      uint64
+		expectedMaxSize uint64
+	}{
+		{"policy below blockMaxSizeMin", 999, 999, 999},
+		{"policy equal to blockMaxSizeMin", 1000, 1000, 1000},
+		{"policy at the 1000-byte margin boundary", 2000, 2000, 1000},
+		{"policy just above the margin boundary", 2001, 2001, 1001},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _, err := loadConfig(ulogger.TestLogger{}, tt.policy)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedEB, cfg.ExcessiveBlockSize)
+			require.Equal(t, tt.expectedMaxSize, cfg.BlockMaxSize)
+			require.LessOrEqual(t, cfg.BlockMaxSize, cfg.ExcessiveBlockSize)
+		})
+	}
 }
 
 func TestCreateDefaultConfigFile(t *testing.T) {

--- a/services/legacy/config_test.go
+++ b/services/legacy/config_test.go
@@ -2,6 +2,7 @@ package legacy
 
 import (
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,6 +49,59 @@ func TestExcessiveBlockSizeUserAgentComment(t *testing.T) {
 	//	if uac != uacExpected {
 	//		t.Fatalf("Expected UserAgentComments to contain %s but got %s", uacExpected, uac)
 	//	}
+}
+
+// TestClampExcessiveBlockSizeRespectsValueBelowWireCapacity confirms a
+// configured ExcessiveBlockSize below the wire protocol's actual relay
+// capacity is respected as-is, rather than being floored up to some other
+// value.
+//
+// Note: this exercises clampExcessiveBlockSize directly rather than going
+// through loadConfig's os.Args-based flag parsing. That CLI parsing path is
+// already dead code in this file (the flags.NewIniParser/parser.Parse calls
+// are commented out), so loadConfig always builds cfg from its hard-coded
+// struct defaults regardless of os.Args -- exercising the clamp via os.Args
+// would silently test nothing.
+func TestClampExcessiveBlockSizeRespectsValueBelowWireCapacity(t *testing.T) {
+	const belowCapacity uint64 = 64000000
+
+	got := clampExcessiveBlockSize(belowCapacity)
+	if got != belowCapacity {
+		t.Fatalf("Expected ExcessiveBlockSize to be respected at %d, got %d", belowCapacity, got)
+	}
+}
+
+// TestClampExcessiveBlockSizeCapsValueAboveWireCapacity confirms a configured
+// (or defaulted) ExcessiveBlockSize above what the wire protocol can
+// actually relay gets clamped down to that ceiling, instead of being
+// advertised as an essentially-infinite value the transport can't back up.
+func TestClampExcessiveBlockSizeCapsValueAboveWireCapacity(t *testing.T) {
+	// Above the wire capacity ceiling.
+	if got := clampExcessiveBlockSize(5000000000); got != maxWireMessagePayload {
+		t.Fatalf("Expected ExcessiveBlockSize to be clamped to %d, got %d", maxWireMessagePayload, got)
+	}
+
+	// The old math.MaxUint64 default should also be clamped down.
+	if got := clampExcessiveBlockSize(math.MaxUint64); got != maxWireMessagePayload {
+		t.Fatalf("Expected default ExcessiveBlockSize to be clamped to %d, got %d", maxWireMessagePayload, got)
+	}
+}
+
+// TestLoadConfigClampsDefaultExcessiveBlockSize confirms the clamp is wired
+// up in loadConfig: since the CLI flag parser is disabled, cfg always starts
+// from defaultExcessiveBlockSize (math.MaxUint64), which must come back
+// clamped to the wire capacity ceiling.
+func TestLoadConfigClampsDefaultExcessiveBlockSize(t *testing.T) {
+	os.Args = []string{"bsvd"}
+
+	cfg, _, err := loadConfig(ulogger.TestLogger{})
+	if err != nil {
+		t.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	if cfg.ExcessiveBlockSize != maxWireMessagePayload {
+		t.Fatalf("Expected default ExcessiveBlockSize to be clamped to %d, got %d", maxWireMessagePayload, cfg.ExcessiveBlockSize)
+	}
 }
 
 func TestCreateDefaultConfigFile(t *testing.T) {

--- a/services/legacy/peer/peer.go
+++ b/services/legacy/peer/peer.go
@@ -2358,14 +2358,25 @@ out:
 
 			err := p.writeMessage(msg.msg, msg.encoding)
 			if err != nil {
+				// Pick the log level before disconnecting: the disconnect sets
+				// p.disconnect, which makes shouldLogWriteError suppress
+				// everything from then on. An ordinary remote close is not
+				// worth a warning.
+				logFunc := p.logger.Debugf
 				if p.shouldLogWriteError(err) {
-					p.logger.Errorf("Failed to send message to "+
-						"%s: %v", p, err)
+					logFunc = p.logger.Warnf
 				}
+
+				// Disconnect before anything else, as upstream btcd does, so a
+				// caller that queued a message and stopped receiving on its
+				// done channel cannot wedge this handler before the peer is
+				// torn down.
+				p.DisconnectWithLogFunc(fmt.Sprintf("write error: %v", err), logFunc)
+
 				if msg.doneChan != nil {
 					msg.doneChan <- struct{}{}
 				}
-				p.DisconnectWithWarning("write error")
+
 				continue
 			}
 
@@ -2529,11 +2540,15 @@ func (p *Peer) DisconnectWithLogFunc(reason string, logFunc func(format string, 
 	// n := runtime.Stack(buf, false)
 	// stackTrace := string(buf[:n])
 	// p.logger.Debugf("Disconnecting (%s) reason: %s\nStack trace:\n%s", p, reason, stackTrace)
-	logFunc("Disconnecting (%s) reason: %s", p, reason)
 
+	// Only the call that actually disconnects logs, so repeated disconnects for
+	// the same peer - one per message still queued on a dead connection, for
+	// example - do not each add a log line.
 	if atomic.AddInt32(&p.disconnect, 1) != 1 {
 		return
 	}
+
+	logFunc("Disconnecting (%s) reason: %s", p, reason)
 
 	if atomic.LoadInt32(&p.connected) != 0 {
 		p.conn.Close()

--- a/services/legacy/peer/peer.go
+++ b/services/legacy/peer/peer.go
@@ -2365,6 +2365,7 @@ out:
 				if msg.doneChan != nil {
 					msg.doneChan <- struct{}{}
 				}
+				p.DisconnectWithWarning("write error")
 				continue
 			}
 

--- a/services/legacy/peer/peer.go
+++ b/services/legacy/peer/peer.go
@@ -2358,20 +2358,22 @@ out:
 
 			err := p.writeMessage(msg.msg, msg.encoding)
 			if err != nil {
-				// Pick the log level before disconnecting: the disconnect sets
-				// p.disconnect, which makes shouldLogWriteError suppress
-				// everything from then on. An ordinary remote close is not
-				// worth a warning.
-				logFunc := p.logger.Debugf
+				// Evaluate shouldLogWriteError before disconnecting: it reads
+				// p.disconnect, which the disconnect below sets. An ordinary
+				// remote close (broken pipe, connection reset, EOF) is not
+				// worth an extra warning about the underlying error, but the
+				// disconnect event itself is always logged at Info so a peer
+				// whose socket died silently still shows up at the default
+				// log level.
 				if p.shouldLogWriteError(err) {
-					logFunc = p.logger.Warnf
+					p.logger.Warnf("Peer %s write error: %v", p, err)
 				}
 
 				// Disconnect before anything else, as upstream btcd does, so a
 				// caller that queued a message and stopped receiving on its
 				// done channel cannot wedge this handler before the peer is
 				// torn down.
-				p.DisconnectWithLogFunc(fmt.Sprintf("write error: %v", err), logFunc)
+				p.DisconnectWithLogFunc(fmt.Sprintf("write error: %v", err), p.logger.Infof)
 
 				if msg.doneChan != nil {
 					msg.doneChan <- struct{}{}
@@ -2541,10 +2543,13 @@ func (p *Peer) DisconnectWithLogFunc(reason string, logFunc func(format string, 
 	// stackTrace := string(buf[:n])
 	// p.logger.Debugf("Disconnecting (%s) reason: %s\nStack trace:\n%s", p, reason, stackTrace)
 
-	// Only the call that actually disconnects logs, so repeated disconnects for
-	// the same peer - one per message still queued on a dead connection, for
-	// example - do not each add a log line.
+	// Only the call that actually disconnects the peer runs the teardown and
+	// logs at the caller's requested level. Later calls - one per message
+	// still queued on a dead connection, for example - lost the race, but
+	// their reason (e.g. a ban or protocol-violation reason) is still worth
+	// keeping, so log it at Debug rather than dropping it silently.
 	if atomic.AddInt32(&p.disconnect, 1) != 1 {
+		p.logger.Debugf("Disconnecting (%s) reason: %s (already disconnecting)", p, reason)
 		return
 	}
 

--- a/services/legacy/peer/peer_test.go
+++ b/services/legacy/peer/peer_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strconv"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1261,11 +1262,71 @@ func (f *flakyWriter) Write(p []byte) (int, error) {
 	return f.w.Write(p)
 }
 
+func (f *flakyWriter) setUnderlying(w io.Writer) {
+	f.w = w
+}
+
+// opErrorWriter wraps an io.Writer and, once armed, fails all writes with a
+// *net.OpError wrapping syscall.EPIPE - a real broken-pipe error of the kind
+// shouldLogWriteError is meant to suppress from the Warnf path, unlike
+// flakyWriter's plain errors.New error.
+type opErrorWriter struct {
+	w    io.Writer
+	fail atomic.Bool
+}
+
+func (f *opErrorWriter) Write(p []byte) (int, error) {
+	if f.fail.Load() {
+		return 0, &net.OpError{Op: "write", Net: "tcp", Err: syscall.EPIPE}
+	}
+
+	return f.w.Write(p)
+}
+
+func (f *opErrorWriter) setUnderlying(w io.Writer) {
+	f.w = w
+}
+
+// logCounts is a minimal ulogger.Logger spy that counts calls per level,
+// embedding ulogger.TestLogger for the rest of the interface.
+type logCounts struct {
+	ulogger.TestLogger
+	debug atomic.Int32
+	info  atomic.Int32
+	warn  atomic.Int32
+}
+
+func (l *logCounts) Debugf(format string, args ...interface{}) { l.debug.Add(1) }
+func (l *logCounts) Infof(format string, args ...interface{})  { l.info.Add(1) }
+func (l *logCounts) Warnf(format string, args ...interface{})  { l.warn.Add(1) }
+
 // connectedPeerPairWithFlakyWriter wires an in-memory peer pair whose outbound
 // side writes through a flakyWriter, waits for the handshake to complete and
 // arms the write failure. The returned cleanup function tears the inbound peer
 // down.
 func connectedPeerPairWithFlakyWriter(t *testing.T) (outPeer *peer.Peer, cleanup func()) {
+	t.Helper()
+
+	fw := &flakyWriter{}
+
+	outPeer, cleanup = connectedPeerPairWithOutWriter(t, fw, ulogger.TestLogger{})
+
+	// Arm the write failure only after the handshake has completed so the
+	// negotiation itself is unaffected.
+	fw.fail.Store(true)
+
+	return outPeer, cleanup
+}
+
+// connectedPeerPairWithOutWriter wires an in-memory peer pair whose outbound
+// side writes through w (with w.w set to the underlying pipe writer), using
+// outLogger as the outbound peer's logger. Returns once the handshake has
+// completed. The returned cleanup function tears the inbound peer down.
+func connectedPeerPairWithOutWriter(t *testing.T, w interface {
+	io.Writer
+	setUnderlying(io.Writer)
+}, outLogger ulogger.Logger,
+) (outPeer *peer.Peer, cleanup func()) {
 	t.Helper()
 
 	tSettings := test.CreateBaseTestSettings(t)
@@ -1293,15 +1354,15 @@ func connectedPeerPairWithFlakyWriter(t *testing.T) (outPeer *peer.Peer, cleanup
 	inR, outW := io.Pipe()
 	outR, inW := io.Pipe()
 
-	fw := &flakyWriter{w: outW}
+	w.setUnderlying(outW)
 
 	inConn := &conn{raddr: "10.0.0.1:8333", Reader: inR, Writer: inW, Closer: inW}
-	outConn := &conn{raddr: "10.0.0.2:8333", Reader: outR, Writer: fw, Closer: outW}
+	outConn := &conn{raddr: "10.0.0.2:8333", Reader: outR, Writer: w, Closer: outW}
 
 	inPeer := peer.NewInboundPeer(ulogger.TestLogger{}, tSettings, cfg)
 	inPeer.AssociateConnection(inConn)
 
-	outPeer, err := peer.NewOutboundPeer(ulogger.TestLogger{}, tSettings, cfg, "10.0.0.2:8333")
+	outPeer, err := peer.NewOutboundPeer(outLogger, tSettings, cfg, "10.0.0.2:8333")
 	require.NoError(t, err)
 	outPeer.AssociateConnection(outConn)
 
@@ -1314,10 +1375,6 @@ func connectedPeerPairWithFlakyWriter(t *testing.T) (outPeer *peer.Peer, cleanup
 	}
 
 	require.True(t, outPeer.Connected())
-
-	// Arm the write failure only after the handshake has completed so the
-	// negotiation itself is unaffected.
-	fw.fail.Store(true)
 
 	return outPeer, func() {
 		inPeer.DisconnectWithInfo("test cleanup")
@@ -1404,7 +1461,63 @@ func TestDisconnectLogsOnceForRepeatedCalls(t *testing.T) {
 	p.DisconnectWithLogFunc("write error: second", logFunc)
 	p.DisconnectWithLogFunc("write error: third", logFunc)
 
-	require.Equal(t, 1, logged, "only the call that actually disconnects the peer should log")
+	require.Equal(t, 1, logged, "only the call that actually disconnects the peer should log at the caller's requested level")
+}
+
+// TestDisconnectDemotesLosingCallsToDebug verifies that disconnect reasons
+// which lose the race to be first (e.g. a ban or protocol-violation reason
+// racing an unrelated "peer stalled" disconnect) are not silently dropped -
+// they are still logged, just at Debug rather than the caller's requested
+// level, so they stay attributable without adding noise at the default level.
+func TestDisconnectDemotesLosingCallsToDebug(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	spy := &logCounts{}
+	p := peer.NewInboundPeer(spy, tSettings, &peer.Config{
+		ChainParams: &chaincfg.MainNetParams,
+	})
+
+	p.DisconnectWithInfo("peer stalled")
+	p.DisconnectWithWarning("ban score exceeded")
+
+	require.Equal(t, int32(1), spy.info.Load(), "the winning call logs at its requested level")
+	require.Equal(t, int32(0), spy.warn.Load(), "the losing call must not log at its requested level")
+	require.Equal(t, int32(1), spy.debug.Load(), "the losing call's reason must still be logged, at Debug")
+}
+
+// TestOutHandlerLogsWriteErrorDisconnect verifies that the outHandler write
+// error disconnect is always visible at Info level - even for a suppressed
+// *net.OpError like a broken pipe, where shouldLogWriteError gates only the
+// additional Warnf about the raw error, not the disconnect event itself.
+func TestOutHandlerLogsWriteErrorDisconnect(t *testing.T) {
+	t.Run("suppressed net.OpError still logs the disconnect at Info", func(t *testing.T) {
+		ow := &opErrorWriter{}
+		spy := &logCounts{}
+
+		outPeer, cleanup := connectedPeerPairWithOutWriter(t, ow, spy)
+		defer cleanup()
+
+		ow.fail.Store(true)
+		outPeer.QueueMessage(wire.NewMsgPing(1), nil)
+		outPeer.WaitForDisconnect()
+
+		require.Equal(t, int32(1), spy.info.Load(), "disconnect event must log at Info even for a suppressed error")
+		require.Equal(t, int32(0), spy.warn.Load(), "a broken-pipe net.OpError must not also log a Warnf")
+	})
+
+	t.Run("a plain write error still logs a Warnf in addition to the Info disconnect", func(t *testing.T) {
+		fw := &flakyWriter{}
+		spy := &logCounts{}
+
+		outPeer, cleanup := connectedPeerPairWithOutWriter(t, fw, spy)
+		defer cleanup()
+
+		fw.fail.Store(true)
+		outPeer.QueueMessage(wire.NewMsgPing(1), nil)
+		outPeer.WaitForDisconnect()
+
+		require.Equal(t, int32(1), spy.info.Load(), "disconnect event must log at Info")
+		require.Equal(t, int32(1), spy.warn.Load(), "a non-suppressed write error must also log a Warnf")
+	})
 }
 
 func NewTestServer(t *testing.T) (*legacy.Server, error) {

--- a/services/legacy/peer/peer_test.go
+++ b/services/legacy/peer/peer_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1243,6 +1244,96 @@ func TestBanPeer(t *testing.T) {
 		inPeer.WaitForDisconnect()
 		outPeer.WaitForDisconnect()
 	}
+}
+
+// flakyWriter wraps an io.Writer and starts failing all writes once armed,
+// used to simulate a write error on an otherwise healthy connection.
+type flakyWriter struct {
+	w    io.Writer
+	fail atomic.Bool
+}
+
+func (f *flakyWriter) Write(p []byte) (int, error) {
+	if f.fail.Load() {
+		return 0, errors.New("simulated write error")
+	}
+
+	return f.w.Write(p)
+}
+
+// TestOutHandlerDisconnectsOnWriteError verifies that outHandler disconnects
+// the peer when writeMessage fails, rather than leaving the peer marked as
+// connected with a permanently stalled send queue.
+func TestOutHandlerDisconnectsOnWriteError(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	verack := make(chan struct{}, 4)
+	cfg := &peer.Config{
+		Listeners: peer.MessageListeners{
+			OnVerAck: func(p *peer.Peer, msg *wire.MsgVerAck) {
+				verack <- struct{}{}
+			},
+			OnWrite: func(p *peer.Peer, bytesWritten int, msg wire.Message, err error) {
+				if _, ok := msg.(*wire.MsgVerAck); ok {
+					verack <- struct{}{}
+				}
+			},
+		},
+		UserAgentName:          "peer",
+		UserAgentVersion:       "1.0",
+		UserAgentComments:      []string{"comment"},
+		ChainParams:            &chaincfg.MainNetParams,
+		Services:               0,
+		TrickleInterval:        time.Second * 10,
+		TstAllowSelfConnection: true,
+	}
+
+	inR, outW := io.Pipe()
+	outR, inW := io.Pipe()
+
+	fw := &flakyWriter{w: outW}
+
+	inConn := &conn{raddr: "10.0.0.1:8333", Reader: inR, Writer: inW, Closer: inW}
+	outConn := &conn{raddr: "10.0.0.2:8333", Reader: outR, Writer: fw, Closer: outW}
+
+	inPeer := peer.NewInboundPeer(ulogger.TestLogger{}, tSettings, cfg)
+	inPeer.AssociateConnection(inConn)
+
+	outPeer, err := peer.NewOutboundPeer(ulogger.TestLogger{}, tSettings, cfg, "10.0.0.2:8333")
+	require.NoError(t, err)
+	outPeer.AssociateConnection(outConn)
+
+	for i := 0; i < 4; i++ {
+		select {
+		case <-verack:
+		case <-time.After(2 * time.Second):
+			t.Fatal("verack timeout")
+		}
+	}
+
+	require.True(t, outPeer.Connected())
+
+	// Arm the write failure only after the handshake has completed so the
+	// negotiation itself is unaffected.
+	fw.fail.Store(true)
+
+	outPeer.QueueMessage(wire.NewMsgPing(1), nil)
+
+	disconnected := make(chan struct{})
+	go func() {
+		outPeer.WaitForDisconnect()
+		close(disconnected)
+	}()
+
+	select {
+	case <-disconnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("peer did not disconnect after a write error")
+	}
+
+	require.False(t, outPeer.Connected())
+
+	inPeer.DisconnectWithInfo("test cleanup")
+	inPeer.WaitForDisconnect()
 }
 
 func NewTestServer(t *testing.T) (*legacy.Server, error) {

--- a/services/legacy/peer/peer_test.go
+++ b/services/legacy/peer/peer_test.go
@@ -1261,10 +1261,13 @@ func (f *flakyWriter) Write(p []byte) (int, error) {
 	return f.w.Write(p)
 }
 
-// TestOutHandlerDisconnectsOnWriteError verifies that outHandler disconnects
-// the peer when writeMessage fails, rather than leaving the peer marked as
-// connected with a permanently stalled send queue.
-func TestOutHandlerDisconnectsOnWriteError(t *testing.T) {
+// connectedPeerPairWithFlakyWriter wires an in-memory peer pair whose outbound
+// side writes through a flakyWriter, waits for the handshake to complete and
+// arms the write failure. The returned cleanup function tears the inbound peer
+// down.
+func connectedPeerPairWithFlakyWriter(t *testing.T) (outPeer *peer.Peer, cleanup func()) {
+	t.Helper()
+
 	tSettings := test.CreateBaseTestSettings(t)
 	verack := make(chan struct{}, 4)
 	cfg := &peer.Config{
@@ -1316,6 +1319,19 @@ func TestOutHandlerDisconnectsOnWriteError(t *testing.T) {
 	// negotiation itself is unaffected.
 	fw.fail.Store(true)
 
+	return outPeer, func() {
+		inPeer.DisconnectWithInfo("test cleanup")
+		inPeer.WaitForDisconnect()
+	}
+}
+
+// TestOutHandlerDisconnectsOnWriteError verifies that outHandler disconnects
+// the peer when writeMessage fails, rather than leaving the peer marked as
+// connected with a permanently stalled send queue.
+func TestOutHandlerDisconnectsOnWriteError(t *testing.T) {
+	outPeer, cleanup := connectedPeerPairWithFlakyWriter(t)
+	defer cleanup()
+
 	outPeer.QueueMessage(wire.NewMsgPing(1), nil)
 
 	disconnected := make(chan struct{})
@@ -1331,9 +1347,64 @@ func TestOutHandlerDisconnectsOnWriteError(t *testing.T) {
 	}
 
 	require.False(t, outPeer.Connected())
+}
 
-	inPeer.DisconnectWithInfo("test cleanup")
-	inPeer.WaitForDisconnect()
+// TestOutHandlerDisconnectsBeforeSignallingDoneChan verifies outHandler
+// disconnects before it signals the message's done channel, matching upstream
+// btcd. A caller that queued a message with an unbuffered done channel and is
+// not yet receiving on it must not be able to wedge outHandler before the peer
+// is torn down.
+func TestOutHandlerDisconnectsBeforeSignallingDoneChan(t *testing.T) {
+	outPeer, cleanup := connectedPeerPairWithFlakyWriter(t)
+	defer cleanup()
+
+	// Deliberately unbuffered and not received from until the disconnect has
+	// been observed below.
+	doneChan := make(chan struct{})
+	outPeer.QueueMessage(wire.NewMsgPing(1), doneChan)
+
+	disconnected := make(chan struct{})
+	go func() {
+		outPeer.WaitForDisconnect()
+		close(disconnected)
+	}()
+
+	select {
+	case <-disconnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("peer did not disconnect after a write error before signalling doneChan")
+	}
+
+	require.False(t, outPeer.Connected())
+
+	// Release outHandler now that the disconnect has been observed.
+	select {
+	case <-doneChan:
+	case <-time.After(3 * time.Second):
+		t.Fatal("outHandler never signalled doneChan")
+	}
+}
+
+// TestDisconnectLogsOnceForRepeatedCalls verifies the disconnect reason is
+// logged by the call that actually disconnects the peer and not by the
+// subsequent no-op calls. Repeated write errors - one per message still queued
+// on a dead connection - must not each add a log line.
+func TestDisconnectLogsOnceForRepeatedCalls(t *testing.T) {
+	tSettings := test.CreateBaseTestSettings(t)
+	p := peer.NewInboundPeer(ulogger.TestLogger{}, tSettings, &peer.Config{
+		ChainParams: &chaincfg.MainNetParams,
+	})
+
+	logged := 0
+	logFunc := func(format string, args ...interface{}) {
+		logged++
+	}
+
+	p.DisconnectWithLogFunc("write error: first", logFunc)
+	p.DisconnectWithLogFunc("write error: second", logFunc)
+	p.DisconnectWithLogFunc("write error: third", logFunc)
+
+	require.Equal(t, 1, logged, "only the call that actually disconnects the peer should log")
 }
 
 func NewTestServer(t *testing.T) (*legacy.Server, error) {

--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -3508,7 +3508,7 @@ func newServer(ctx context.Context, logger ulogger.Logger, tSettings *settings.S
 	blockAssembly *blockassembly.Client,
 	listenAddrs []string, assetHTTPAddress string) (*server, error) {
 	// init config
-	c, _, err := loadConfig(logger)
+	c, _, err := loadConfig(logger, tSettings.Policy.ExcessiveBlockSize)
 	if err != nil {
 		return nil, err
 	}

--- a/test/sequentialtest/longest_chain/longest_chain_fork_test.go
+++ b/test/sequentialtest/longest_chain/longest_chain_fork_test.go
@@ -299,8 +299,15 @@ func testLongestChainWithDoubleSpendTransaction(t *testing.T, utxoStore string) 
 	require.NoError(t, td.BlockValidation.ValidateBlock(td.Ctx, block6b, "legacy", false, false), "Failed to process block")
 	t.Logf("WaitForBlockBeingMined(t, block6b): %s", block6b.Hash().String())
 	td.WaitForBlockBeingMined(t, block6b)
-	// t.Logf("WaitForBlock(t, block6b, blockWait): %s", block6b.Hash().String())
-	// td.WaitForBlock(t, block6b, blockWait)
+	// WaitForBlockBeingMined only confirms setTxMined has completed on the
+	// blockchain/UTXO side; block assembly's own reorg (moving tx1 back into
+	// its candidate subtrees) happens asynchronously and can still be in
+	// flight at that point. Wait for block assembly itself to report
+	// block6b as its current best block before asserting on its state below,
+	// matching the pattern used for block5b/block6a in the sibling subtests
+	// in this file. Without this, VerifyInBlockAssembly(t, tx1) below is racy.
+	t.Logf("WaitForBlock(t, block6b, blockWait): %s", block6b.Hash().String())
+	td.WaitForBlock(t, block6b, blockWait)
 
 	//                        / 5a [tx1, tx2, parentTx2]
 	// 0 -> 1 ... 2 -> 3 -> 4


### PR DESCRIPTION
Two independent fixes to the legacy (SVNode bridge) service's wire-protocol limit handling:

1. **outHandler write-error recovery.** A write error to a peer's socket was logged but never triggered a disconnect, so a socket left alive by the OS after a failed write could freeze that peer's outbound send queue permanently (sendDoneQueue only drains on successful sends). Restored a disconnect call on the write-error path.

2. **Advertised excessive-block-size vs actual wire capacity.** The service unconditionally floored the configured `ExcessiveBlockSize` to `math.MaxUint64` regardless of user config, so the advertised EB user-agent comment implied an essentially unlimited block size — while the wire path actually caps real message relay at ~4GB (`wire.SetLimits`). The configured value is now respected but clamped to what the wire path can actually deliver, so advertised capacity matches real capacity.

**Out of scope, flagged for follow-up:** a related silent-truncation bug in the vendored `github.com/bsv-blockchain/go-wire` dependency — `WriteMessageWithEncodingN` returns `(0, nil)` instead of an error for payloads over `math.MaxUint32` bytes. That's third-party dependency code, not fixed here; needs an upstream fix or a local `replace` directive as a separate change.