### PR TITLE
fix(netsync): unskip four legacy netsync tests broken by incomplete fixtures

### DIFF
--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/legacy/bsvutil"
 	"github.com/bsv-blockchain/teranode/services/legacy/peer"
 	"github.com/bsv-blockchain/teranode/services/legacy/testdata"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
@@ -367,41 +368,64 @@ func Benchmark_createSubtrees(b *testing.B) {
 
 // Test extendTransactions to increase coverage
 func TestSyncManager_extendTransactions(t *testing.T) {
-	t.Skip("Skipping test due to nil pointer issue")
+	initPrometheusMetrics()
+
 	block, err := testdata.ReadBlockFromFile("../testdata/000000000000000009631dd3dd7357675d8a1f8925be5e7851c68255531ac5fb.bin")
 	require.NoError(t, err)
 
 	sm := &SyncManager{
-		settings: test.CreateBaseTestSettings(t),
-		logger:   ulogger.TestLogger{},
+		settings:  test.CreateBaseTestSettings(t),
+		logger:    ulogger.TestLogger{},
+		utxoStore: &nullstore.NullStore{},
 	}
 
 	txMap := txmap.NewSyncedMap[chainhash.Hash, *TxMapWrapper](len(block.Transactions()))
 	txOrder, err := sm.createTxMap(context.Background(), block, txMap)
 	require.NoError(t, err)
 
-	// Test extending transactions
+	// Test extending transactions: with a real block, non-coinbase txs whose
+	// inputs reference same-block parents get extended via phase 1 (txMap
+	// lookup); the rest fall through to phase 2's BatchPreviousOutputsDecorate.
 	err = sm.extendTransactions(context.Background(), testBlockIdent(block), txOrder, txMap, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	sawExtendedInput := false
+
+	for _, txHash := range txOrder[1:] {
+		wrapper, found := txMap.Get(txHash)
+		require.True(t, found)
+
+		for _, in := range wrapper.Tx.Inputs {
+			if in.PreviousTxScript != nil {
+				sawExtendedInput = true
+			}
+		}
+	}
+
+	assert.True(t, sawExtendedInput, "at least one input should have been extended from an in-block parent")
 }
 
 // Test createUtxos to increase coverage
 func TestSyncManager_createUtxos(t *testing.T) {
-	t.Skip("Skipping test due to nil pointer issue")
 	sm := &SyncManager{
-		settings: test.CreateBaseTestSettings(t),
-		logger:   ulogger.TestLogger{},
+		settings:  test.CreateBaseTestSettings(t),
+		logger:    ulogger.TestLogger{},
+		utxoStore: &nullstore.NullStore{},
 	}
 
-	// Create a simple coinbase transaction
+	// Create a simple coinbase transaction. IsCoinbase() (called by
+	// util.GetFees via NullStore.Create) requires a zeroed PreviousTxID, so it
+	// must be set explicitly rather than left as the input's nil default.
+	coinbaseInput := &bt.Input{
+		PreviousTxSatoshis: 0,
+		PreviousTxOutIndex: 0xffffffff,
+		SequenceNumber:     0xffffffff,
+	}
+	require.NoError(t, coinbaseInput.PreviousTxIDAdd(&chainhash.Hash{}))
+
 	coinbaseTx := &bt.Tx{
 		Version: 1,
-		Inputs: []*bt.Input{
-			{
-				PreviousTxSatoshis: 0,
-				PreviousTxOutIndex: 0xffffffff,
-			},
-		},
+		Inputs:  []*bt.Input{coinbaseInput},
 		Outputs: []*bt.Output{
 			{
 				Satoshis:      50 * 100000000,
@@ -427,13 +451,12 @@ func TestSyncManager_createUtxos(t *testing.T) {
 	block.SetHeight(100)
 
 	// Test createUtxos
-	utxos := sm.createUtxos(context.Background(), txMap, testBlockIdent(block), 0, false)
-	assert.NotNil(t, utxos)
+	err := sm.createUtxos(context.Background(), txMap, testBlockIdent(block), 0, false)
+	assert.NoError(t, err)
 }
 
 // Test validateTransactions to increase coverage
 func TestSyncManager_validateTransactions(t *testing.T) {
-	t.Skip("Skipping test due to nil pointer issue")
 	initPrometheusMetrics()
 
 	validationClient := &validator.MockValidator{}
@@ -442,6 +465,7 @@ func TestSyncManager_validateTransactions(t *testing.T) {
 		settings:         test.CreateBaseTestSettings(t),
 		logger:           ulogger.TestLogger{},
 		validationClient: validationClient,
+		chainParams:      &chaincfg.RegressionNetParams,
 	}
 
 	// Create transaction levels map
@@ -457,11 +481,19 @@ func TestSyncManager_validateTransactions(t *testing.T) {
 	}
 	txsPerLevel[0] = []*bt.Tx{tx}
 
-	// Create a block
+	// Create a block. Timestamp must be non-zero: candidateFinalityTimesForBlock
+	// converts it to a uint32 Unix time, which fails closed on the zero-value
+	// time.Time's large-negative Unix seconds.
 	msgBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Timestamp: time.Now(),
+		},
 		Transactions: []*wire.MsgTx{},
 	}
 	block := bsvutil.NewBlock(msgBlock)
+	// Below chainParams.CSVHeight (576 on regtest) so candidateFinalityTimesForBlock
+	// takes the pre-CSV branch and doesn't need a blockchainClient to resolve MTP.
+	block.SetHeight(100)
 
 	// Test validateTransactions - it should handle validation gracefully even without mocks
 	err := sm.validateTransactions(context.Background(), 1, txsPerLevel, testBlockIdent(block))
@@ -471,12 +503,11 @@ func TestSyncManager_validateTransactions(t *testing.T) {
 
 // Test prepareSubtrees with simple block
 func TestSyncManager_prepareSubtrees(t *testing.T) {
-	t.Skip("Skipping test due to nil pointer issue")
 	initPrometheusMetrics()
 
-	// Create a simple block with one transaction
-	msgTx := wire.NewMsgTx(1)
-	msgTx.AddTxIn(&wire.TxIn{
+	// Coinbase transaction (index 0).
+	coinbaseMsgTx := wire.NewMsgTx(1)
+	coinbaseMsgTx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{
 			Hash:  chainhash.Hash{},
 			Index: 0xffffffff,
@@ -484,8 +515,23 @@ func TestSyncManager_prepareSubtrees(t *testing.T) {
 		SignatureScript: []byte{0x00},
 		Sequence:        0xffffffff,
 	})
-	msgTx.AddTxOut(&wire.TxOut{
+	coinbaseMsgTx.AddTxOut(&wire.TxOut{
 		Value:    50 * 100000000,
+		PkScript: []byte{0x76, 0xa9, 0x14},
+	})
+
+	// A second, regular transaction so the block has more than one tx: a
+	// single-tx block exits prepareSubtrees early (txCount <= 1) without
+	// touching chainParams/quickValidationAllowed/subtreeValidation at all,
+	// which is what hid the nil-pointer bugs this test exists to catch.
+	regularMsgTx := wire.NewMsgTx(1)
+	regularMsgTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{0x01}, Index: 0},
+		SignatureScript:  []byte{0x00},
+		Sequence:         0xffffffff,
+	})
+	regularMsgTx.AddTxOut(&wire.TxOut{
+		Value:    1000,
 		PkScript: []byte{0x76, 0xa9, 0x14},
 	})
 
@@ -497,33 +543,39 @@ func TestSyncManager_prepareSubtrees(t *testing.T) {
 			Bits:      0x1d00ffff,
 			Nonce:     0,
 		},
-		Transactions: []*wire.MsgTx{msgTx},
+		Transactions: []*wire.MsgTx{coinbaseMsgTx, regularMsgTx},
 	}
 
 	block := bsvutil.NewBlock(msgBlock)
 	block.SetHeight(100)
 
-	blockchainClient := &blockchain.Mock{}
-	blockchainClient.On("IsFSMCurrentState", mock.Anything, mock.Anything).Return(false, nil)
-
 	validationClient := &validator.MockValidator{}
 
+	subtreeValidationClient := &subtreevalidation.MockSubtreeValidation{}
+	subtreeValidationClient.On("CheckSubtreeFromBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
 	sm := &SyncManager{
-		settings:         test.CreateBaseTestSettings(t),
-		logger:           ulogger.TestLogger{},
-		blockchainClient: blockchainClient,
-		validationClient: validationClient,
-		subtreeStore:     memory.New(),
-		ctx:              context.Background(),
+		settings: test.CreateBaseTestSettings(t),
+		logger:   ulogger.TestLogger{},
+		// Regtest has no checkpoints, so quickValidationAllowed is false and
+		// prepareSubtrees is forced down the non-quick path, which is what
+		// exercises checkSubtreeFromBlock / sm.subtreeValidation below.
+		chainParams:       &chaincfg.RegressionNetParams,
+		validationClient:  validationClient,
+		utxoStore:         &nullstore.NullStore{},
+		subtreeStore:      memory.New(),
+		subtreeValidation: subtreeValidationClient,
+		ctx:               context.Background(),
 	}
 
-	// For single transaction blocks, prepareSubtrees returns empty
-	subtrees, _, blockID, err := sm.prepareSubtrees(context.Background(), block)
-	assert.NoError(t, err)
-	assert.NotNil(t, subtrees)
-	assert.Equal(t, uint32(0), blockID) // single-tx block exits early, IsFSMCurrentState=false → blockID stays 0
+	subtrees, subtreeSlices, blockID, err := sm.prepareSubtrees(context.Background(), block)
+	require.NoError(t, err)
+	assert.Len(t, subtrees, 1, "2 txs fit in a single subtree")
+	assert.Equal(t, uint32(0), blockID, "non-quick-validation path never assigns a block ID")
+	// legacyUnified is off by default, so the in-memory slices aren't returned.
+	assert.Nil(t, subtreeSlices)
 
-	blockchainClient.AssertExpectations(t)
+	subtreeValidationClient.AssertExpectations(t)
 }
 
 // buildOOBFixture constructs a parent (2 outputs) and a child whose only input

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -389,20 +389,25 @@ func TestSyncManager_extendTransactions(t *testing.T) {
 	err = sm.extendTransactions(context.Background(), testBlockIdent(block), txOrder, txMap, false)
 	require.NoError(t, err)
 
-	sawExtendedInput := false
+	// Assert on SomeParentsInBlock rather than on PreviousTxScript: it is set
+	// only by phase 1 (extendFromTxMap) when a parent is found in the same
+	// block via txMap, and phase 2 never touches it. PreviousTxScript is not a
+	// valid signal here because NullStore.PreviousOutputsDecorate (invoked by
+	// phase 2's BatchPreviousOutputsDecorate) unconditionally overwrites it on
+	// every input regardless of what phase 1 did, so checking it would pass
+	// even if phase 1 were completely broken.
+	sawInBlockParent := false
 
 	for _, txHash := range txOrder[1:] {
 		wrapper, found := txMap.Get(txHash)
 		require.True(t, found)
 
-		for _, in := range wrapper.Tx.Inputs {
-			if in.PreviousTxScript != nil {
-				sawExtendedInput = true
-			}
+		if wrapper.SomeParentsInBlock {
+			sawInBlockParent = true
 		}
 	}
 
-	assert.True(t, sawExtendedInput, "at least one input should have been extended from an in-block parent")
+	assert.True(t, sawInBlockParent, "at least one transaction should have had an in-block parent resolved via phase 1 (extendFromTxMap)")
 }
 
 // Test createUtxos to increase coverage

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -475,9 +475,31 @@ func TestQueueInv_NoPanicWhenChannelsClosedDuringShutdown(t *testing.T) {
 
 // Test blockchain syncing protocol. SyncManager should request, processes, and
 // relay blocks to/from peers.
-// TODO: Test is timing out, needs to be fixed.
+//
+// Investigated: the original "timing out" symptom has (at least) two distinct
+// causes stacked on top of each other, both below the assumptions this
+// btcd-derived test was written against:
+//
+//  1. startSync() (manager.go) now short-circuits to FSMStateRUNNING and never
+//     calls PushGetBlocksMsg whenever the sync peer's advertised height equals
+//     ours. This test's remotePeerCfg never sets peer.Config.NewestBlock, so
+//     the peer always reports height 0 == our genesis-only height, and the
+//     very first `remoteMessages.getBlocksChan` receive times out. Making the
+//     remote peer advertise a height ahead of ours (via NewestBlock) fixes
+//     that first timeout and gets the test past the initial handshake.
+//  2. With (1) worked around, the test still times out later, waiting on
+//     errChan after the first QueueBlock call ("Timeout waiting for sync
+//     manager to process block 0"). This harness's testContext.Setup passes a
+//     nil block-assembly client into New(...) and never configures the
+//     subtreeValidation mock's CheckBlockSubtrees/CheckSubtreeFromBlock
+//     expectations for a real block payload, either of which plausibly stalls
+//     real block-processing deep inside HandleBlockDirect. Root-causing that
+//     needs a proper block-processing harness (real/mocked block assembly +
+//     subtree validation expectations for an actual 3-block regtest chain),
+//     which is beyond a bounded triage pass - left skipped rather than force
+//     enabled against an unresolved hang.
 func TestBlockchainSync(t *testing.T) {
-	t.Skip("skipping")
+	t.Skip("times out: startSync skips PushGetBlocksMsg when the peer's advertised height ties ours (no NewestBlock configured here), and even past that, block processing via QueueBlock never signals errChan - likely missing block-assembly/subtreeValidation wiring in this harness; needs a real block-processing harness fix, not a quick nil-pointer patch")
 
 	chainParams := chaincfg.RegressionNetParams
 	chainParams.CoinbaseMaturity = 1


### PR DESCRIPTION
## Summary

Four tests in `services/legacy/netsync` were skipped with a generic "nil pointer issue" comment. In every case the nil pointer was in the test's own `SyncManager` fixture, not in the code under test:

- `TestSyncManager_extendTransactions` - fixture never set `utxoStore`; `extendTransactions`'s phase-2 bulk decorate calls `sm.utxoStore.BatchPreviousOutputsDecorate` unconditionally. Added `utxoStore: &nullstore.NullStore{}` and strengthened the assertion to actually check inputs got extended.
- `TestSyncManager_createUtxos` - same missing `utxoStore`. Also fixed a stale assertion: the test called `utxos := sm.createUtxos(...); assert.NotNil(t, utxos)`, but `createUtxos` only returns `error` - there's no value to be non-nil. Now asserts on the actual error. The coinbase tx fixture also needed an explicit zeroed `PreviousTxID` (`IsCoinbase()` dereferences it via `util.GetFees`).
- `TestSyncManager_validateTransactions` - fixture never set `chainParams`; `validateTransactions` -> `candidateFinalityTimesForBlock` dereferences `sm.chainParams.CSVHeight`. Added regtest chain params and a non-zero block timestamp (the zero-value `time.Time` converts to a huge negative Unix time and fails the conversion).
- `TestSyncManager_prepareSubtrees` - fixture set `blockchainClient`/`validationClient`/`subtreeStore` but not `chainParams`, so `quickValidationAllowed` nil-guarded to `false`, forcing the non-quick path that needs `sm.subtreeValidation` (also never set). Rebuilt the test with a 2-tx block (a single-tx block returns from `prepareSubtrees` before touching any of this) and added chain params + a `subtreevalidation.MockSubtreeValidation`.

## TestBlockchainSync disposition: still skipped, with an accurate reason

`TestBlockchainSync` (`manager_test.go`) was skipped as "TODO: needs to be fixed" / "timing out". Investigated and found two distinct issues stacked on top of each other:

1. `startSync()` now short-circuits to `FSMStateRUNNING` and never sends `PushGetBlocksMsg` whenever the sync peer's advertised height ties ours. This test's remote peer config never sets `NewestBlock`, so it always reports height 0 = our genesis-only height, and the very first `getblocks` wait times out immediately.
2. Working around (1) (by advertising a higher peer height) gets past the handshake, but the test then times out later waiting for `QueueBlock`'s error channel during real block processing. This harness passes a `nil` block-assembly client into `New(...)` and never configures `subtreeValidation`'s block-level expectations, either of which plausibly stalls block processing deep in `HandleBlockDirect`.

Root-causing (2) needs a proper block-processing test harness (real/mocked block assembly + subtree validation wired for an actual block), which is a bigger lift than a fixture nil-pointer fix. Left skipped, with the skip reason now describing both findings instead of the stale placeholder.

## Test plan

- [x] `go test ./services/legacy/netsync/... -race -v -run 'TestSyncManager_extendTransactions|TestSyncManager_createUtxos|TestSyncManager_validateTransactions|TestSyncManager_prepareSubtrees|TestBlockchainSync'` - all pass (`TestBlockchainSync` correctly skipped)
- [x] `go test ./services/legacy/...` - full package suite passes, no regressions