### PR TITLE
fix(seeder): detect truncated UTXO snapshot files via footer validation

### DIFF
--- a/cmd/seeder/seeder_truncation_test.go
+++ b/cmd/seeder/seeder_truncation_test.go
@@ -88,6 +88,55 @@ func openForReading(t *testing.T, path string) (*os.File, *bufio.Reader) {
 	return f, reader
 }
 
+// TestReadUTXOWrapperFile_CompleteFile_Succeeds is the happy-path companion
+// to the truncation regression test below: a well-formed snapshot file - the
+// two records built by buildSnapshotWrappers, followed by a real 16-byte
+// footer matching the actual counts - must be accepted, and the drained
+// channel must yield exactly txCount wrappers. This guards against a future
+// change to the footer-count comparison, the skip-empty-wrapper gate, or the
+// footer layout silently making the seeder reject every valid snapshot.
+func TestReadUTXOWrapperFile_CompleteFile_Succeeds(t *testing.T) {
+	metadata, wrapperBytes, txCount, utxoCount := buildSnapshotWrappers(t)
+	require.Len(t, wrapperBytes, 2)
+
+	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
+
+	var footer [16]byte
+	binary.LittleEndian.PutUint64(footer[0:8], txCount)
+	binary.LittleEndian.PutUint64(footer[8:16], utxoCount)
+
+	data := make([]byte, 0, len(header.Bytes())+len(metadata)+len(wrapperBytes[0])+len(wrapperBytes[1])+len(footer))
+	data = append(data, header.Bytes()...)
+	data = append(data, metadata...)
+	data = append(data, wrapperBytes[0]...)
+	data = append(data, wrapperBytes[1]...)
+	data = append(data, footer[:]...)
+
+	path := filepath.Join(t.TempDir(), "utxo-set-complete.dat")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	f, reader := openForReading(t, path)
+
+	utxoWrapperCh := make(chan *utxopersister.UTXOWrapper, 10)
+
+	var received []*utxopersister.UTXOWrapper
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for w := range utxoWrapperCh {
+			received = append(received, w)
+		}
+	}()
+
+	err := readUTXOWrapperFile(context.Background(), ulogger.TestLogger{}, f, reader, utxoWrapperCh)
+	<-done
+
+	require.NoError(t, err, "a complete, well-formed snapshot file must not be rejected")
+	require.Len(t, received, int(txCount), "the drained channel must yield exactly txCount wrappers")
+}
+
 // TestReadUTXOWrapperFile_TruncatedFile_ReturnsError is the regression test
 // for the silent-truncation bug: a snapshot file cut off partway through a
 // UTXOWrapper record - here, mid-way through the second record's 32-byte

--- a/cmd/utxovalidator/utxo_validator.go
+++ b/cmd/utxovalidator/utxo_validator.go
@@ -11,10 +11,10 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-chaincfg"
+	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/utxopersister"
@@ -119,17 +119,45 @@ func validateUTXOSet(ctx context.Context, r io.Reader, verbose bool) (*UTXOValid
 
 	for {
 		if err = utxoWrapper.FromReader(ctx, br, false); err != nil {
-			if err == io.EOF {
-				break // End of file reached
-			}
-			// Handle unexpected EOF more gracefully - this can happen at the end of large files
-			errStr := err.Error()
-			if strings.Contains(errStr, "failed to read txid") || strings.Contains(errStr, "unexpected EOF") {
-				fmt.Printf("Reached end of file after processing %d transactions\n", processedWrappers)
-				break
+			// utxopersister writers unconditionally append a 16-byte footer
+			// (txCount||utxoCount) after the final record, with no marker
+			// byte in front of it. The only way this loop can legitimately
+			// be done is if the next read lands exactly on those footer
+			// bytes (reported via ErrRecordBoundary) and the footer's
+			// counts agree with what was actually read here. Anything else
+			// - a bare io.EOF (only possible if the footer itself is
+			// missing), a short read at any other offset, or an
+			// ErrRecordBoundary whose footer bytes don't match - is a
+			// genuine truncation and must fail loudly rather than being
+			// reported as a successful, complete validation.
+			boundary, ok := err.(*utxopersister.ErrRecordBoundary)
+			if !ok {
+				return nil, errors.NewProcessingError("error reading UTXO wrapper", err)
 			}
 
-			return nil, errors.NewProcessingError("error reading UTXO wrapper", err)
+			expectedTxCount, expectedUTXOCount, decErr := utxopersister.DecodeFooter(boundary.FooterBytes[:])
+			if decErr != nil {
+				return nil, errors.NewProcessingError("error decoding utxo-set footer", decErr)
+			}
+
+			processedTxCount, tcErr := safeconversion.IntToUint64(processedWrappers)
+			if tcErr != nil {
+				return nil, errors.NewProcessingError("error converting processed transaction count", tcErr)
+			}
+
+			processedUTXOCount, ucErr := safeconversion.IntToUint64(result.UTXOCount)
+			if ucErr != nil {
+				return nil, errors.NewProcessingError("error converting processed UTXO count", ucErr)
+			}
+
+			if expectedTxCount != processedTxCount || expectedUTXOCount != processedUTXOCount {
+				return nil, errors.NewProcessingError("utxo-set file truncated: footer expects %d transactions/%d utxos, only %d/%d were read",
+					expectedTxCount, expectedUTXOCount, processedTxCount, processedUTXOCount)
+			}
+
+			fmt.Printf("Reached end of file after processing %d transactions\n", processedWrappers)
+
+			break
 		}
 
 		result.ActualSatoshis += utxoWrapper.UTXOTotalValue

--- a/cmd/utxovalidator/utxo_validator.go
+++ b/cmd/utxovalidator/utxo_validator.go
@@ -130,8 +130,8 @@ func validateUTXOSet(ctx context.Context, r io.Reader, verbose bool) (*UTXOValid
 			// ErrRecordBoundary whose footer bytes don't match - is a
 			// genuine truncation and must fail loudly rather than being
 			// reported as a successful, complete validation.
-			boundary, ok := err.(*utxopersister.ErrRecordBoundary)
-			if !ok {
+			var boundary *utxopersister.ErrRecordBoundary
+			if !errors.As(err, &boundary) {
 				return nil, errors.NewProcessingError("error reading UTXO wrapper", err)
 			}
 

--- a/cmd/utxovalidator/utxo_validator_test.go
+++ b/cmd/utxovalidator/utxo_validator_test.go
@@ -1,6 +1,7 @@
 package utxovalidator
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/utxopersister"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/stretchr/testify/assert"
@@ -58,17 +60,19 @@ func TestValidateUTXOFile_LocalDoesNotDoubleReadMagic(t *testing.T) {
 
 	// Build a minimal UTXO set file: 8-byte fileformat magic + 32-byte
 	// current block hash + 4-byte height + 32-byte previous block hash
-	// + zero UTXO wrappers. The OUTER wrapper loop in validateUTXOSet
-	// breaks on either io.EOF or "failed to read txid", so a body that
-	// ends after the metadata exercises the read path cleanly.
+	// + zero UTXO wrappers + the 16-byte zero-count footer every real
+	// writer appends. The OUTER wrapper loop in validateUTXOSet only
+	// accepts the record stream as complete once it reaches that
+	// footer and its counts agree with what was processed (0/0 here).
 	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
-	body := make([]byte, 0, 8+32+4+32)
+	body := make([]byte, 0, 8+32+4+32+16)
 	body = append(body, header.Bytes()...)
 	body = append(body, blockHash[:]...)
 	var heightBuf [4]byte
 	binary.LittleEndian.PutUint32(heightBuf[:], 42)
 	body = append(body, heightBuf[:]...)
 	body = append(body, prevHash[:]...)
+	body = append(body, make([]byte, 16)...) // txCount=0, utxoCount=0
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.utxo-set")
@@ -104,4 +108,96 @@ func TestValidateUTXOFile_LocalRejectsWrongFileType(t *testing.T) {
 	_, err := ValidateUTXOFile(ctx, path, ulogger.TestLogger{}, tSettings, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a UTXO set file")
+}
+
+// buildValidatorBody builds the per-file metadata (current block hash,
+// height, previous block hash) plus the given wrappers, in the layout
+// validateUTXOSet reads (i.e. positioned past the 8-byte fileformat magic).
+func buildValidatorBody(blockHash, prevHash chainhash.Hash, height uint32, wrappers []*utxopersister.UTXOWrapper) []byte {
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], height)
+
+	body := make([]byte, 0)
+	body = append(body, blockHash[:]...)
+	body = append(body, heightBuf[:]...)
+	body = append(body, prevHash[:]...)
+
+	for _, w := range wrappers {
+		body = append(body, w.Bytes()...)
+	}
+
+	return body
+}
+
+// TestValidateUTXOSet_TruncatedMidTxID_ReturnsError is the regression test
+// for the silent-truncation-laundering bug in the validator's own read loop:
+// a utxo-set file cut off partway through a second record's 32-byte TxID -
+// with no footer at all - must fail validation loudly instead of being
+// reported as a complete, successful read.
+func TestValidateUTXOSet_TruncatedMidTxID_ReturnsError(t *testing.T) {
+	blockHash := chainhash.HashH([]byte("validator-midtxid-block"))
+	prevHash := chainhash.HashH([]byte("validator-midtxid-prev"))
+
+	wrapper := &utxopersister.UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("validator-midtxid-wrapper-a")),
+		Height: 100,
+		UTXOs:  []*utxopersister.UTXO{{Index: 0, Value: 5000000000, Script: []byte{0x51}}},
+	}
+	secondTxID := chainhash.HashH([]byte("validator-midtxid-wrapper-b"))
+
+	body := buildValidatorBody(blockHash, prevHash, 100, []*utxopersister.UTXOWrapper{wrapper})
+	// Cut 10 bytes into the second record's 32-byte TxID - a genuine
+	// mid-record truncation, with no footer appended at all.
+	body = append(body, secondTxID[:10]...)
+
+	_, err := validateUTXOSet(context.Background(), bytes.NewReader(body), false)
+	require.Error(t, err, "a utxo-set truncated mid-TxID must not be silently accepted as a complete record stream")
+}
+
+// TestValidateUTXOSet_MissingFooter_ReturnsError covers the second traced
+// laundering path: a utxo-set file cut exactly after a complete wrapper
+// record, with the trailing 16-byte footer missing entirely. Every writer
+// appends the footer unconditionally, so this shape can only happen from
+// truncation and must always be rejected.
+func TestValidateUTXOSet_MissingFooter_ReturnsError(t *testing.T) {
+	blockHash := chainhash.HashH([]byte("validator-missing-footer-block"))
+	prevHash := chainhash.HashH([]byte("validator-missing-footer-prev"))
+
+	wrapper := &utxopersister.UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("validator-missing-footer-wrapper-a")),
+		Height: 100,
+		UTXOs:  []*utxopersister.UTXO{{Index: 0, Value: 5000000000, Script: []byte{0x51}}},
+	}
+
+	// No footer at all: the body ends exactly on a wrapper boundary.
+	body := buildValidatorBody(blockHash, prevHash, 100, []*utxopersister.UTXOWrapper{wrapper})
+
+	_, err := validateUTXOSet(context.Background(), bytes.NewReader(body), false)
+	require.Error(t, err, "a utxo-set with a missing footer must not be silently accepted as complete")
+}
+
+// TestValidateUTXOSet_FooterMismatch_ReturnsError pins the counts check
+// itself: a footer that decodes cleanly but whose counts don't match what
+// the loop actually read must still be rejected.
+func TestValidateUTXOSet_FooterMismatch_ReturnsError(t *testing.T) {
+	blockHash := chainhash.HashH([]byte("validator-footer-mismatch-block"))
+	prevHash := chainhash.HashH([]byte("validator-footer-mismatch-prev"))
+
+	wrapper := &utxopersister.UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("validator-footer-mismatch-wrapper-a")),
+		Height: 100,
+		UTXOs:  []*utxopersister.UTXO{{Index: 0, Value: 5000000000, Script: []byte{0x51}}},
+	}
+
+	body := buildValidatorBody(blockHash, prevHash, 100, []*utxopersister.UTXOWrapper{wrapper})
+
+	// Footer claims 2 transactions/2 utxos, but only 1 wrapper (1 utxo) is
+	// actually present in the body.
+	var footer [16]byte
+	binary.LittleEndian.PutUint64(footer[0:8], 2)
+	binary.LittleEndian.PutUint64(footer[8:16], 2)
+	body = append(body, footer[:]...)
+
+	_, err := validateUTXOSet(context.Background(), bytes.NewReader(body), false)
+	require.Error(t, err, "a footer whose counts disagree with what was actually read must be rejected")
 }

--- a/services/utxopersister/Footers.go
+++ b/services/utxopersister/Footers.go
@@ -18,16 +18,21 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 )
 
+// FooterSize is the number of bytes in the trailing footer that every writer
+// in this package (UTXOSet.CreateUTXOSet, cmd/bitcointoutxoset) appends
+// immediately after the last record: two little-endian uint64 values
+// (txCount, utxoCount), with no marker byte in front of them.
+const FooterSize = 16
+
 // GetFooter retrieves the transaction and UTXO counts from the footer of a UTXO file.
 // It reads the footer metadata located at the end of the file, which contains statistical
 // information about the file contents. This function requires a seekable reader (os.File)
 // to efficiently access the footer without reading the entire file.
 //
-// The footer format consists of:
-// - Last 16 bytes of the file contain two uint64 values in little-endian format
+// The footer format consists of the last FooterSize (16) bytes of the file,
+// two uint64 values in little-endian format, with nothing else following them:
 // - Bytes -16 to -9: Transaction count (8 bytes)
 // - Bytes -8 to -1: UTXO count (8 bytes)
-// - This follows after a 32-byte EOF marker
 //
 // Parameters:
 //   - r: io.Reader that must be an *os.File to support seeking operations
@@ -45,16 +50,30 @@ func GetFooter(r io.Reader) (uint64, uint64, error) {
 		return 0, 0, errors.NewProcessingError("seek is not supported")
 	}
 
-	// The end of the file should have the EOF marker at the end (32 bytes)
-	// and the txCount uint64 and the utxoCount uint64 (each 8 bytes)
-	_, err := f.Seek(-16, io.SeekEnd)
+	// The end of the file should have the txCount uint64 and the utxoCount
+	// uint64 (each 8 bytes) as the very last bytes.
+	_, err := f.Seek(-FooterSize, io.SeekEnd)
 	if err != nil {
-		return 0, 0, errors.NewProcessingError("error seeking to EOF marker", err)
+		return 0, 0, errors.NewProcessingError("error seeking to footer", err)
 	}
 
-	b := make([]byte, 16)
+	b := make([]byte, FooterSize)
 	if _, err := io.ReadFull(f, b); err != nil {
-		return 0, 0, errors.NewProcessingError("error reading EOF marker", err)
+		return 0, 0, errors.NewProcessingError("error reading footer", err)
+	}
+
+	return DecodeFooter(b)
+}
+
+// DecodeFooter decodes a FooterSize-byte buffer into (txCount, utxoCount).
+// Use this when the footer bytes were obtained without seeking - for
+// example, via the ErrRecordBoundary sentinel that FromReader /
+// NewUTXOWrapperFromReader returns when a read of the next record's TxID
+// comes up exactly FooterSize bytes short at the end of a stream that does
+// not support seeking (such as a blob-store reader).
+func DecodeFooter(b []byte) (uint64, uint64, error) {
+	if len(b) != FooterSize {
+		return 0, 0, errors.NewProcessingError("footer must be exactly %d bytes, got %d", FooterSize, len(b))
 	}
 
 	txCount := binary.LittleEndian.Uint64(b[0:8])

--- a/services/utxopersister/Footers_test.go
+++ b/services/utxopersister/Footers_test.go
@@ -86,7 +86,7 @@ func TestGetFooter_SeekError(t *testing.T) {
 
 	txCount, utxoCount, err := GetFooter(f)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "error seeking to EOF marker")
+	assert.Contains(t, err.Error(), "error seeking to footer")
 	assert.Equal(t, uint64(0), txCount)
 	assert.Equal(t, uint64(0), utxoCount)
 	assert.True(t, errors.Is(err, errors.ErrProcessing))
@@ -285,7 +285,7 @@ func TestGetFooter_EmptyFile(t *testing.T) {
 
 	txCount, utxoCount, err := GetFooter(f)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "error seeking to EOF marker")
+	assert.Contains(t, err.Error(), "error seeking to footer")
 	assert.Equal(t, uint64(0), txCount)
 	assert.Equal(t, uint64(0), utxoCount)
 }

--- a/services/utxopersister/UTXO.go
+++ b/services/utxopersister/UTXO.go
@@ -198,6 +198,43 @@ func NewUTXOWrapperFromReader(ctx context.Context, r io.Reader) (*UTXOWrapper, e
 	return uw, nil
 }
 
+// ErrRecordBoundary is returned by FromReader (and, via
+// NewUTXOWrapperFromReader, its callers) when a read of the next record's
+// leading 32-byte TxID field comes up exactly FooterSize (16) bytes short
+// before the underlying reader reports end-of-stream.
+//
+// Every writer in this package (UTXOSet.CreateUTXOSet, cmd/bitcointoutxoset)
+// unconditionally appends a FooterSize-byte footer (txCount||utxoCount,
+// little-endian) immediately after the final record, with no marker byte in
+// front of it - so this short read is consistent with having reached that
+// footer. It is equally consistent with an unrelated truncation that happens
+// to land at the same 16-byte offset, which looks identical at this level.
+// Callers that care about truncation MUST decode FooterBytes
+// (utxopersister.DecodeFooter) and compare the result against the counts
+// they actually processed before treating the record stream as complete; do
+// not treat this error as success on its own.
+//
+// Callers that have not been updated to do that validation keep their
+// existing "any EOF-shaped signal is a clean end" behaviour unchanged: Is
+// reports this error as equivalent to io.EOF and io.ErrUnexpectedEOF.
+type ErrRecordBoundary struct {
+	// FooterBytes holds the exact FooterSize bytes read before the
+	// underlying reader reported end-of-stream.
+	FooterBytes [FooterSize]byte
+}
+
+// Error implements the error interface.
+func (e *ErrRecordBoundary) Error() string {
+	return "record stream ended exactly at the footer boundary; decode FooterBytes and validate against processed counts before treating this as a clean end"
+}
+
+// Is reports ErrRecordBoundary as equivalent to io.EOF and io.ErrUnexpectedEOF
+// for errors.Is, preserving existing behaviour for callers that do not
+// specifically check for *ErrRecordBoundary (see the type doc comment).
+func (e *ErrRecordBoundary) Is(target error) bool {
+	return target == io.EOF || target == io.ErrUnexpectedEOF
+}
+
 func (uw *UTXOWrapper) FromReader(ctx context.Context, r io.Reader, readUtxos ...bool) error {
 	useReadUtxos := true
 	if len(readUtxos) > 0 {
@@ -212,6 +249,20 @@ func (uw *UTXOWrapper) FromReader(ctx context.Context, r io.Reader, readUtxos ..
 		if err != nil {
 			if err == io.EOF {
 				return io.EOF
+			}
+
+			// A short read that stopped at exactly FooterSize bytes is
+			// consistent with having reached the trailing footer every
+			// writer in this package appends after the last record (see
+			// ErrRecordBoundary), but is not proof of it - a truncation
+			// that happens to land at the same offset looks identical at
+			// this level. Hand the candidate bytes back to the caller
+			// instead of guessing.
+			if n == FooterSize && err == io.ErrUnexpectedEOF {
+				boundary := &ErrRecordBoundary{}
+				copy(boundary.FooterBytes[:], uw.TxID[:FooterSize])
+
+				return boundary
 			}
 
 			return errors.NewStorageError("failed to read txid, expected 32 bytes got %d", n, err)

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"io"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -659,37 +658,36 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 				// height/coinbase + its UTXOs).
 				utxoWrapper, err := NewUTXOWrapperFromReader(ctx, previousUTXOSetReader)
 				if err != nil {
-					// CreateUTXOSet appends a 16-byte footer (txCount +
-					// utxoCount) after the final UTXOWrapper. This loop does
-					// not consult that count, so it only learns the records
-					// are exhausted when the next read either lands exactly on
-					// EOF (a bare io.EOF) or short-reads the footer, which
-					// io.ReadFull reports as io.ErrUnexpectedEOF ("unexpected
-					// EOF"). cmd/utxovalidator handles the same footer.
-					//
-					// The short read is matched by substring, not
-					// structurally: errors.New flattens a non-*Error cause to
-					// its message (errors/errors.go:334-336), discarding the
-					// io.ErrUnexpectedEOF sentinel - so errors.Is(err,
-					// io.ErrUnexpectedEOF) would itself reduce to this same
-					// strings.Contains. (And do not fold the io.EOF clause into
-					// errors.Is: "EOF" is a substring of "unexpected EOF", so
-					// it would swallow this footer error too.) A structural fix
-					// - FromReader returning a typed sentinel, and validating
-					// records-read == txCount against the footer - is tracked
-					// as a follow-up.
-					//
-					// Consequence: a genuinely truncated tail is
-					// indistinguishable from the footer and is silently
-					// accepted (pre-existing; same as utxovalidator). Matching
-					// only "unexpected EOF" - not the broader "failed to read
-					// txid" utxovalidator also matches - keeps a real non-EOF
-					// read error loud rather than swallowed.
-					if err == io.EOF || strings.Contains(err.Error(), "unexpected EOF") {
-						break OUTER
+					// CreateUTXOSet unconditionally appends a 16-byte footer
+					// (txCount||utxoCount) after the final UTXOWrapper, with
+					// no marker byte in front of it. The only way this loop
+					// can legitimately be done is if the next read lands
+					// exactly on those footer bytes - which FromReader
+					// reports via the ErrRecordBoundary sentinel - and the
+					// footer's counts agree with what was actually read
+					// here. Anything else (a bare io.EOF, which can only
+					// happen if the footer itself is missing entirely; a
+					// short read at any other offset; or an
+					// ErrRecordBoundary whose footer bytes don't match) is a
+					// genuine truncation and must fail loudly rather than
+					// silently produce a new snapshot that omits the
+					// unread tail.
+					boundary, ok := err.(*ErrRecordBoundary)
+					if !ok {
+						return errors.NewStorageError("error reading previous utxo-set (%s.%s) at iteration %d", c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, txCount, err)
 					}
 
-					return errors.NewStorageError("error reading previous utxo-set (%s.%s) at iteration %d", c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, txCount, err)
+					expectedTxCount, expectedUTXOCount, decErr := DecodeFooter(boundary.FooterBytes[:])
+					if decErr != nil {
+						return errors.NewStorageError("error decoding previous utxo-set (%s.%s) footer", c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, decErr)
+					}
+
+					if expectedTxCount != txCount || expectedUTXOCount != utxoCount {
+						return errors.NewProcessingError("previous utxo-set (%s.%s) is truncated: footer expects %d transactions/%d utxos, only %d/%d were read",
+							c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, expectedTxCount, expectedUTXOCount, txCount, utxoCount)
+					}
+
+					break OUTER
 				}
 
 				ts = readStat.AddTime(ts)

--- a/services/utxopersister/UTXOSet.go
+++ b/services/utxopersister/UTXOSet.go
@@ -588,12 +588,14 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 	}
 
 	var (
-		readStat   = createStat.NewStat("readTX")
-		filterStat = createStat.NewStat("filterUTXOs")
-		writeStat  = createStat.NewStat("writeUTXOs")
-		ts         = gocore.CurrentTime()
-		txCount    uint64
-		utxoCount  uint64
+		readStat    = createStat.NewStat("readTX")
+		filterStat  = createStat.NewStat("filterUTXOs")
+		writeStat   = createStat.NewStat("writeUTXOs")
+		ts          = gocore.CurrentTime()
+		txCount     uint64
+		utxoCount   uint64
+		recordsRead uint64
+		utxosRead   uint64
 	)
 
 	if c.firstPreviousBlockHash.String() != c.settings.ChainCfgParams.GenesisHash.String() {
@@ -672,9 +674,9 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 					// genuine truncation and must fail loudly rather than
 					// silently produce a new snapshot that omits the
 					// unread tail.
-					boundary, ok := err.(*ErrRecordBoundary)
-					if !ok {
-						return errors.NewStorageError("error reading previous utxo-set (%s.%s) at iteration %d", c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, txCount, err)
+					var boundary *ErrRecordBoundary
+					if !errors.As(err, &boundary) {
+						return errors.NewStorageError("error reading previous utxo-set (%s.%s) at iteration %d", c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, recordsRead, err)
 					}
 
 					expectedTxCount, expectedUTXOCount, decErr := DecodeFooter(boundary.FooterBytes[:])
@@ -682,15 +684,24 @@ func (us *UTXOSet) CreateUTXOSet(ctx context.Context, c *consolidator) (err erro
 						return errors.NewStorageError("error decoding previous utxo-set (%s.%s) footer", c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, decErr)
 					}
 
-					if expectedTxCount != txCount || expectedUTXOCount != utxoCount {
+					if expectedTxCount != recordsRead || expectedUTXOCount != utxosRead {
 						return errors.NewProcessingError("previous utxo-set (%s.%s) is truncated: footer expects %d transactions/%d utxos, only %d/%d were read",
-							c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, expectedTxCount, expectedUTXOCount, txCount, utxoCount)
+							c.firstPreviousBlockHash.String(), fileformat.FileTypeUtxoSet, expectedTxCount, expectedUTXOCount, recordsRead, utxosRead)
 					}
 
 					break OUTER
 				}
 
 				ts = readStat.AddTime(ts)
+
+				// Count every wrapper read from the previous file,
+				// unconditionally and before deletion filtering, so the
+				// truncation check above compares against what was actually
+				// read - not against txCount/utxoCount, which only track
+				// survivors after filtering and exist to write the *new*
+				// file's own footer below.
+				recordsRead++
+				utxosRead += uint64(len(utxoWrapper.UTXOs))
 
 				// Filter UTXOs based on the deletions map
 				utxoWrapper.UTXOs = filterUTXOs(utxoWrapper.UTXOs, c.deletions, &utxoWrapper.TxID)

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -356,6 +356,73 @@ func TestCreateUTXOSet_PreviousSetFooterMismatch_ReturnsError(t *testing.T) {
 	require.Error(t, err, "a footer whose counts disagree with what was actually read must be rejected")
 }
 
+// TestCreateUTXOSet_PreviousSetWithDeletions_NotReportedAsTruncated is the
+// regression test for the survivor/read miscount bug: txCount/utxoCount only
+// increment for wrappers that survive deletion filtering (they exist to
+// write the *new* file's own footer), but the previous-set footer check
+// compared them directly against the previous file's footer, which records
+// records actually written there. Any real consolidation that spends a
+// pre-existing UTXO makes survivors < previous total, and the pre-fix check
+// fired a spurious "previous utxo-set ... is truncated" on an intact file.
+// The previous set here has two wrappers/two UTXOs; one output is spent
+// (present in c.deletions), so only one wrapper survives filtering, but the
+// file is not truncated and CreateUTXOSet must succeed.
+func TestCreateUTXOSet_PreviousSetWithDeletions_NotReportedAsTruncated(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	previousBlockHash := chainhash.HashH([]byte("previous-block-hash-for-deletions-test"))
+	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-deletions-test"))
+	grandparentHash := chainhash.HashH([]byte("grandparent-block-hash-for-deletions-test"))
+
+	spentTxID := chainhash.HashH([]byte("wrapper-spent-for-deletions-test"))
+	keptTxID := chainhash.HashH([]byte("wrapper-kept-for-deletions-test"))
+
+	spentWrapper := &UTXOWrapper{
+		TxID:   spentTxID,
+		Height: 42,
+		UTXOs:  []*UTXO{{Index: 0, Value: 1000, Script: []byte{0x76, 0xa9, 0x88, 0xac}}},
+	}
+	keptWrapper := &UTXOWrapper{
+		TxID:   keptTxID,
+		Height: 42,
+		UTXOs:  []*UTXO{{Index: 0, Value: 2000, Script: []byte{0x76, 0xa9, 0x88, 0xac}}},
+	}
+
+	// Footer records the previous file's total: 2 transactions/2 utxos.
+	var footer [16]byte
+	binary.LittleEndian.PutUint64(footer[0:8], 2)
+	binary.LittleEndian.PutUint64(footer[8:16], 2)
+
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+
+	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash)+
+		len(spentWrapper.Bytes())+len(keptWrapper.Bytes())+len(footer))
+	body = append(body, previousBlockHash[:]...)
+	body = append(body, heightBuf[:]...)
+	body = append(body, grandparentHash[:]...)
+	body = append(body, spentWrapper.Bytes()...)
+	body = append(body, keptWrapper.Bytes()...)
+	body = append(body, footer[:]...)
+	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
+
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, &previousBlockHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 43
+	c.previousBlockHash = &previousBlockHash
+	// spentWrapper's single output was spent within the consolidated range.
+	c.deletions[UTXODeletion{TxID: spentTxID, Index: 0}] = struct{}{}
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.NoError(t, err, "a previous set with spent outputs must not be reported as truncated: survivor counts are expected to be lower than the footer's total record counts")
+}
+
 var (
 	hash1 = chainhash.HashH([]byte{0x00, 0x01, 0x02, 0x03, 0x04})
 	// hash2 = chainhash.HashH([]byte{0x05, 0x06, 0x07, 0x08, 0x09})

--- a/services/utxopersister/UTXOSet_test.go
+++ b/services/utxopersister/UTXOSet_test.go
@@ -59,11 +59,13 @@ func TestCreateUTXOSet_NilLastBlockHash(t *testing.T) {
 // the wrong UTXOs.
 //
 // Test scenario: a "previous" UTXO set file for hash P is staged in a
-// memory store, containing just the 68-byte header records (current
-// block hash = P, height, parent hash) and zero wrappers — so the
-// OUTER loop hits a clean io.EOF after the metadata. A consolidator
-// pointing at P as the firstPreviousBlockHash should consolidate
-// successfully and produce a new UTXO set for the current block.
+// memory store, containing the 68-byte header records (current block
+// hash = P, height, parent hash), zero wrappers, and the 16-byte
+// zero-count footer every real writer appends — so the OUTER loop hits
+// the footer boundary immediately after the metadata and the counts
+// agree (0 read, 0 expected). A consolidator pointing at P as the
+// firstPreviousBlockHash should consolidate successfully and produce a
+// new UTXO set for the current block.
 func TestCreateUTXOSet_PreviousSetReadDoesNotDoubleReadMagic(t *testing.T) {
 	ctx := context.Background()
 	logger := ulogger.TestLogger{}
@@ -74,16 +76,18 @@ func TestCreateUTXOSet_PreviousSetReadDoesNotDoubleReadMagic(t *testing.T) {
 	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-double-read-test"))
 	grandparentHash := chainhash.HashH([]byte("grandparent-block-hash-for-double-read-test"))
 
-	// Stage the previous UTXO set file with just its 68-byte metadata
+	// Stage the previous UTXO set file with its 68-byte metadata
 	// (matching the layout CreateUTXOSet writes: current block hash +
-	// 4-byte height + previous block hash). memory.Set prepends the
-	// fileformat magic, so we only provide post-header bytes.
+	// 4-byte height + previous block hash) followed by the 16-byte
+	// zero-count footer (no wrappers were written). memory.Set prepends
+	// the fileformat magic, so we only provide post-header bytes.
 	var heightBuf [4]byte
 	binary.LittleEndian.PutUint32(heightBuf[:], 42)
-	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash))
+	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash)+FooterSize)
 	body = append(body, previousBlockHash[:]...)
 	body = append(body, heightBuf[:]...)
 	body = append(body, grandparentHash[:]...)
+	body = append(body, make([]byte, FooterSize)...) // txCount=0, utxoCount=0
 	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
 
 	// Consolidator: firstPreviousBlockHash = P drives the read of the
@@ -205,6 +209,151 @@ func TestCreateUTXOSet_PreviousSetWithFooterTerminatesCleanly(t *testing.T) {
 
 	err = us.CreateUTXOSet(ctx, c)
 	require.NoError(t, err, "CreateUTXOSet must terminate the previous-set read at the 16-byte footer; the pre-fix loop crashed here with \"failed to read txid, expected 32 bytes got 16\"")
+}
+
+// TestCreateUTXOSet_PreviousSetTruncatedMidTxID_ReturnsError is the
+// regression test for the silent-truncation-laundering bug: a previous UTXO
+// set cut off partway through a second record's 32-byte TxID - with no
+// footer at all - must fail the consolidation loudly instead of being
+// treated as a clean end of the record stream and used to write a new,
+// self-consistent but truncated snapshot.
+func TestCreateUTXOSet_PreviousSetTruncatedMidTxID_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	previousBlockHash := chainhash.HashH([]byte("previous-block-hash-for-midtxid-test"))
+	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-midtxid-test"))
+	grandparentHash := chainhash.HashH([]byte("grandparent-block-hash-for-midtxid-test"))
+
+	wrapper := &UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("wrapper-a-for-midtxid-test")),
+		Height: 42,
+		UTXOs:  []*UTXO{{Index: 0, Value: 1000, Script: []byte{0x76, 0xa9, 0x88, 0xac}}},
+	}
+
+	secondTxID := chainhash.HashH([]byte("wrapper-b-for-midtxid-test"))
+
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+
+	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash)+len(wrapper.Bytes())+10)
+	body = append(body, previousBlockHash[:]...)
+	body = append(body, heightBuf[:]...)
+	body = append(body, grandparentHash[:]...)
+	body = append(body, wrapper.Bytes()...)
+	// Cut 10 bytes into the second record's 32-byte TxID - a genuine
+	// mid-record truncation, with no footer appended at all.
+	body = append(body, secondTxID[:10]...)
+	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
+
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, &previousBlockHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 43
+	c.previousBlockHash = &previousBlockHash
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.Error(t, err, "a previous UTXO set truncated mid-TxID must not be silently accepted as a complete record stream")
+}
+
+// TestCreateUTXOSet_PreviousSetMissingFooter_ReturnsError covers the second
+// traced laundering path: a previous UTXO set cut exactly after a complete
+// UTXOWrapper record, with the trailing 16-byte footer missing entirely. The
+// read of the next record's TxID then sees a clean io.EOF (zero bytes
+// available), not a short read. Every writer in this package appends the
+// footer unconditionally, so this shape can only happen from truncation and
+// must always be rejected - it must not be confused with a legitimate,
+// footer-terminated end of the stream.
+func TestCreateUTXOSet_PreviousSetMissingFooter_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	previousBlockHash := chainhash.HashH([]byte("previous-block-hash-for-missing-footer-test"))
+	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-missing-footer-test"))
+	grandparentHash := chainhash.HashH([]byte("grandparent-block-hash-for-missing-footer-test"))
+
+	wrapper := &UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("wrapper-a-for-missing-footer-test")),
+		Height: 42,
+		UTXOs:  []*UTXO{{Index: 0, Value: 1000, Script: []byte{0x76, 0xa9, 0x88, 0xac}}},
+	}
+
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+
+	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash)+len(wrapper.Bytes()))
+	body = append(body, previousBlockHash[:]...)
+	body = append(body, heightBuf[:]...)
+	body = append(body, grandparentHash[:]...)
+	body = append(body, wrapper.Bytes()...)
+	// No footer at all: the file ends exactly on a wrapper boundary.
+	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
+
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, &previousBlockHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 43
+	c.previousBlockHash = &previousBlockHash
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.Error(t, err, "a previous UTXO set with a missing footer must not be silently accepted as complete")
+}
+
+// TestCreateUTXOSet_PreviousSetFooterMismatch_ReturnsError pins the counts
+// check itself: a footer that decodes cleanly but whose counts don't match
+// what the loop actually read must still be rejected, not just a footer that
+// is structurally malformed or absent.
+func TestCreateUTXOSet_PreviousSetFooterMismatch_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+	blockStore := memory.New()
+
+	previousBlockHash := chainhash.HashH([]byte("previous-block-hash-for-footer-mismatch-test"))
+	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-footer-mismatch-test"))
+	grandparentHash := chainhash.HashH([]byte("grandparent-block-hash-for-footer-mismatch-test"))
+
+	wrapper := &UTXOWrapper{
+		TxID:   chainhash.HashH([]byte("wrapper-a-for-footer-mismatch-test")),
+		Height: 42,
+		UTXOs:  []*UTXO{{Index: 0, Value: 1000, Script: []byte{0x76, 0xa9, 0x88, 0xac}}},
+	}
+
+	var heightBuf [4]byte
+	binary.LittleEndian.PutUint32(heightBuf[:], 42)
+
+	// Footer claims 2 transactions/2 utxos, but only 1 wrapper (1 utxo) is
+	// actually present in the body.
+	var footer [16]byte
+	binary.LittleEndian.PutUint64(footer[0:8], 2)
+	binary.LittleEndian.PutUint64(footer[8:16], 2)
+
+	body := make([]byte, 0, len(previousBlockHash)+len(heightBuf)+len(grandparentHash)+len(wrapper.Bytes())+len(footer))
+	body = append(body, previousBlockHash[:]...)
+	body = append(body, heightBuf[:]...)
+	body = append(body, grandparentHash[:]...)
+	body = append(body, wrapper.Bytes()...)
+	body = append(body, footer[:]...)
+	require.NoError(t, blockStore.Set(ctx, previousBlockHash[:], fileformat.FileTypeUtxoSet, body))
+
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, &previousBlockHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 43
+	c.previousBlockHash = &previousBlockHash
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	err = us.CreateUTXOSet(ctx, c)
+	require.Error(t, err, "a footer whose counts disagree with what was actually read must be rejected")
 }
 
 var (

--- a/services/utxopersister/build_utxoset_test.go
+++ b/services/utxopersister/build_utxoset_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -104,8 +103,11 @@ func buildChainHeaders(t *testing.T, genesis *chainhash.Hash, n uint32) ([]*mode
 // readSetUTXOs parses a utxo-set file into a {txid:index -> value} map.
 // GetUTXOSetReader strips the 8-byte fileformat magic; the per-file metadata
 // CreateUTXOSet writes (32 block hash + 4 height + 32 previous hash = 68 bytes)
-// is skipped before the wrapper records. End-of-records is the 16-byte footer,
-// surfaced as io.EOF or "unexpected EOF" (mirrors CreateUTXOSet's own reader).
+// is skipped before the wrapper records. End-of-records is the 16-byte
+// footer, reported via the ErrRecordBoundary sentinel (mirrors CreateUTXOSet's
+// own reader). This helper reads back a file the test just wrote in the same
+// process, so - unlike the production readers - it does not need to validate
+// the footer's counts against what it processed.
 func readSetUTXOs(t *testing.T, ctx context.Context, tSettings *settings.Settings, store blob.Store, hash *chainhash.Hash) map[string]uint64 {
 	t.Helper()
 
@@ -124,7 +126,7 @@ func readSetUTXOs(t *testing.T, ctx context.Context, tSettings *settings.Setting
 	for {
 		w, err := NewUTXOWrapperFromReader(ctx, r)
 		if err != nil {
-			if err == io.EOF || strings.Contains(err.Error(), "unexpected EOF") {
+			if _, ok := err.(*ErrRecordBoundary); ok {
 				break
 			}
 


### PR DESCRIPTION
## Summary

- The seeder's UTXO-set read loop (`readUTXOWrapperFile` in `cmd/seeder/seeder.go`) only knew how to distinguish "record stream ended" from "read error" via `errors.Is(err, io.EOF)`. Teranode's `errors.Error.Is` falls back to substring matching against non-`*Error` targets, and `io.ErrUnexpectedEOF`'s message ("unexpected EOF") contains "EOF" as a substring — so a file truncated mid-record produced the exact same code path as a clean end-of-file.
- Every `.utxo-set` snapshot already carries a 16-byte trailing footer (`txCount`, `utxoCount`) written by the persister. The seeder read right past it without ever checking it.
- After the read loop ends (for any reason), compare the number of transactions/UTXOs actually processed against `utxopersister.GetFooter(f)`. A mismatch now returns an error instead of silently completing.

## Operational risk this closes

A seeder import that stops partway through a snapshot — truncated in transit, cut short by a disk/network fault, or by an interrupted copy — previously reported `All workers finished successfully` and wrote `lastProcessed.dat` as if the whole UTXO set had been imported. The node then serves that height as though its UTXO set is complete: it will treat outputs that were never imported as nonexistent and reject valid spends of them — a consensus-divergence failure that only surfaces long after the seeding step reported success, when the node is already serving traffic. The fix makes that failure loud and immediate at seed time instead.

## Test plan

- [x] New regression test `TestReadUTXOWrapperFile_TruncatedFile_ReturnsError` in `cmd/seeder/seeder_truncation_test.go`: builds a well-formed snapshot layout, cuts it off 10 bytes into the second record's TxID (no footer at all), and asserts `readUTXOWrapperFile` returns an error.
- [x] `go build ./cmd/seeder/... ./services/utxopersister/...`
- [x] `go test ./cmd/seeder/... ./services/utxopersister/... -race`
