### PR TITLE
fix(asset): correct GetBlock doc examples, register by-height block routes

### DIFF
--- a/services/asset/httpimpl/GetBlock.go
+++ b/services/asset/httpimpl/GetBlock.go
@@ -131,14 +131,14 @@ type BlockExtended struct {
 //
 // Example Usage:
 //
-//	// Get block in JSON format
-//	GET /block/height/0
-//
 //	// Get block in raw binary format
-//	GET /block/height/0/raw
+//	GET /api/v1/block/height/0
 //
 //	// Get block in hex format
-//	GET /block/height/0/hex
+//	GET /api/v1/block/height/0/hex
+//
+//	// Get block in JSON format
+//	GET /api/v1/block/height/0/json
 func (h *HTTP) GetBlockByHeight(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ctx, _, deferFn := tracing.Tracer("asset").Start(c.Request().Context(), "GetBlockByHeight_http",
@@ -280,14 +280,14 @@ func (h *HTTP) GetBlockByHeight(mode ReadMode) func(c echo.Context) error {
 //
 // Example Usage:
 //
-//	// Get block in JSON format
-//	GET /block/hash/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-//
 //	// Get block in raw binary format
-//	GET /block/hash/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/raw
+//	GET /api/v1/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
 //
 //	// Get block in hex format
-//	GET /block/hash/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/hex
+//	GET /api/v1/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/hex
+//
+//	// Get block in JSON format
+//	GET /api/v1/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f/json
 func (h *HTTP) GetBlockByHash(mode ReadMode) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		return h.getBlockByHash(c, mode)

--- a/services/asset/httpimpl/http.go
+++ b/services/asset/httpimpl/http.go
@@ -381,6 +381,10 @@ func New(logger ulogger.Logger, tSettings *settings.Settings, repo *repository.R
 	apiGroup.GET("/block/:hash/forks", h.GetBlockForks)
 	apiGroup.GET("/block/:hash/nearestforks", h.GetNearestForkHeights)
 
+	apiGroup.GET("/block/height/:height", h.GetBlockByHeight(BINARY_STREAM), heavyMW()...)
+	apiGroup.GET("/block/height/:height/hex", h.GetBlockByHeight(HEX), heavyMW()...)
+	apiGroup.GET("/block/height/:height/json", h.GetBlockByHeight(JSON), heavyMW()...)
+
 	apiGroup.GET("/block/:hash/subtrees/json", h.GetBlockSubtrees(JSON))
 
 	apiGroup.GET("/search", h.Search)

--- a/services/asset/httpimpl/http_test.go
+++ b/services/asset/httpimpl/http_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/services/asset/repository"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -221,6 +222,67 @@ func TestNew(t *testing.T) {
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)
 		assert.Equal(t, http.StatusUnauthorized, rec.Code) // Should return 401 when not authenticated
+	})
+}
+
+// TestGetBlockByHeightRouteRegistered verifies that http.go actually wires the
+// GetBlockByHeight handler up to routes under the API prefix (binary, hex, and
+// json variants), mirroring the by-hash triplet. GetBlockByHeight itself already
+// has thorough handler-level tests in GetBlock_test.go; this test exists to catch
+// the case where the handler exists but is never registered on the router.
+func TestGetBlockByHeightRouteRegistered(t *testing.T) {
+	logger := ulogger.TestLogger{}
+
+	testSettings := &settings.Settings{
+		Asset: settings.AssetSettings{
+			APIPrefix: "/api/v1",
+		},
+		Dashboard: settings.DashboardSettings{
+			Enabled: false,
+		},
+		SecurityLevelHTTP: 0, // HTTP mode
+	}
+
+	mockBlockchainClient := &blockchain.Mock{}
+	mockBlockchainClient.On("GetBlockByHeight", mock.Anything, uint32(0)).Return(testBlock, nil)
+	// GetBlockByHeight(JSON) also looks up height+1 for the "nextblock" field.
+	mockBlockchainClient.On("GetBlockByHeight", mock.Anything, uint32(1)).Return(nil, errors.ErrNotFound)
+
+	repo, err := repository.NewRepository(logger, testSettings, nil, nil, mockBlockchainClient, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	httpServer, err := New(logger, testSettings, repo, nil)
+	require.NoError(t, err)
+	require.NotNil(t, httpServer)
+
+	e := httpServer.e
+
+	t.Run("binary", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/block/height/0", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "application/octet-stream", rec.Header().Get("Content-Type"))
+		assert.Equal(t, testBlockBytes, rec.Body.Bytes())
+	})
+
+	t.Run("hex", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/block/height/0/hex", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, hex.EncodeToString(testBlockBytes), rec.Body.String())
+	})
+
+	t.Run("json", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/block/height/0/json", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 	})
 }
 


### PR DESCRIPTION
The doc comments on the block-serving handlers in `services/asset/httpimpl/GetBlock.go` showed example URLs that don't match the server's real registered routes — a nonexistent `/raw` suffix, wrong content-type claims, and a never-registered `/block/height/...` path. Rewrote them to match the real routes (bare path = binary, `/hex`, `/json`).

Also: `GetBlockByHeight` was a fully implemented, tested handler that `http.go` never registered as a route — unreachable via HTTP, only exercised directly by its test. Registered it following the existing by-hash triplet pattern (binary/hex/json) rather than deleting working, tested code.