### PR TITLE
refactor(validator): consolidate the 2PC unlock into one deferred exit path

### DIFF
--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -944,6 +944,17 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 		return nil, err
 	}
 
+	// From this point on the tx has been durably persisted with its inputs spent and,
+	// when addToBlockAssembly is set, its own record marked Locked (the 2PC
+	// in-progress marker). Every return path below - success or error - must release
+	// that lock, or the tx is stuck forever: persisted, spent, Locked, and never
+	// delivered to block assembly. This is deliberately separate from spend rollback:
+	// reverseSpends only ever applies before persistence, and spends must stand once
+	// the tx is durably created (see spendAndCreateInUtxoStore). The argument
+	// (txMetaData) is captured now, by value of the pointer, so a later `return nil,
+	// err` in this function does not affect what the deferred call unlocks.
+	defer v.unlockLockedTxOnExit(decoupledCtx, tx, txID, txMetaData, &err)
+
 	if validationOptions.SkipUtxoCreation {
 		// create the tx meta needed for the block assembly
 		if validationOptions.OutpointOnlySpend {
@@ -1001,17 +1012,47 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 		}
 	}
 
-	if txMetaData.Locked {
-		if err = v.twoPhaseCommitTransaction(decoupledCtx, tx, txID); err != nil {
-			v.logger.Warnf("[Validate][%s] error during two phase commit, transaction will be marked as spendable on next block: %v", txID, err)
+	// Unlocking (if the tx is still Locked) happens in the deferred
+	// unlockLockedTxOnExit call registered above, on this and every other return
+	// path from this point in the function.
+	return txMetaData, nil
+}
 
-			return txMetaData, err
-		}
-
-		txMetaData.Locked = false
+// unlockLockedTxOnExit is the single point that releases a tx's two-phase-commit
+// Locked flag on the way out of validateInternal. It is deferred immediately after
+// the tx has been durably persisted with its inputs spent (see validateInternal),
+// so it runs on every return from there on - success or error - and not just the
+// happy path. Without it, an error returned between persistence and the end of
+// the function (e.g. building tx inpoints, or sendToBlockAssembler failing) would
+// leave the tx persisted, spent, and Locked forever, since nothing else ever
+// clears the flag.
+//
+// It does not reverse the spend: that is reverseSpends' job, and it only applies
+// before persistence (see spendAndCreateInUtxoStore) - once the tx is durably
+// created it is valid and its spends must stand.
+//
+// If err is nil on entry (the pure success path) and the unlock itself fails, err
+// is set to the unlock error so the caller is told the tx still needs the
+// fallback recovery ("marked as spendable on next block"). If err is already
+// non-nil (an earlier failure in validateInternal), the unlock is still attempted
+// and its failure only logged, so the tx's original, more informative error is
+// not masked by a lock-release problem.
+func (v *Validator) unlockLockedTxOnExit(ctx context.Context, tx *bt.Tx, txID string, txMetaData *meta.Data, err *error) {
+	if txMetaData == nil || !txMetaData.Locked {
+		return
 	}
 
-	return txMetaData, nil
+	if unlockErr := v.twoPhaseCommitTransaction(ctx, tx, txID); unlockErr != nil {
+		v.logger.Warnf("[Validate][%s] error during two phase commit, transaction will be marked as spendable on next block: %v", txID, unlockErr)
+
+		if *err == nil {
+			*err = unlockErr
+		}
+
+		return
+	}
+
+	txMetaData.Locked = false
 }
 
 // getTransactionInputBlockHeights returns the block heights for each input of the transaction

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -952,9 +952,21 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 	// undelivered tx must stay locked. This is deliberately separate from spend
 	// rollback: spend rollback only ever applies before persistence, and spends must
 	// stand once the tx is durably created (see spendAndCreateInUtxoStore). The
-	// argument (txMetaData) is captured now, by value of the pointer, so a later
-	// `return nil, err` in this function does not affect what the deferred call sees.
-	defer v.unlockLockedTxOnExit(decoupledCtx, tx, txID, txMetaData, &err)
+	// argument (persistedMeta) is captured now, by value of the pointer, so a later
+	// reassignment of txMetaData (e.g. on the SkipUtxoCreation path below) does not
+	// change what the deferred call sees.
+	//
+	// delivered tracks whether the tx has actually reached block assembly, which is
+	// the fact the unlock decision must be gated on. It starts true when this tx
+	// skips block assembly entirely (nothing to deliver), and is flipped to true
+	// only after sendToBlockAssembler returns successfully below. Deliberately NOT
+	// inferred from `err == nil`: a panic between entering the addToBlockAssembly
+	// block and sendToBlockAssembler returning would leave err nil while the tx was
+	// never delivered, and unlocking on that basis would be exactly the hazard this
+	// function exists to prevent.
+	persistedMeta := txMetaData
+	delivered := !addToBlockAssembly
+	defer v.unlockLockedTxOnExit(decoupledCtx, tx, txID, persistedMeta, &err, &delivered)
 
 	if validationOptions.SkipUtxoCreation {
 		// create the tx meta needed for the block assembly
@@ -992,6 +1004,8 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 
 			return nil, err
 		}
+
+		delivered = true
 	}
 
 	// Serialize and enqueue txmeta for the subtree validation kafka topic.
@@ -1035,26 +1049,53 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 // other implementations reject.
 //
 // Staying locked is the documented safe failure mode ("money temporarily can't
-// be spent") and it is self-healing, in the right order: the block assembler's
-// unmined-transaction loader adds such a tx to the subtree processor and only
-// then clears its Locked flag (see BlockAssembler.loadUnminedTransactions).
+// be spent") and it is normally self-healing, in the right order: the block
+// assembler's unmined-transaction loader adds such a tx to the subtree processor
+// and only then clears its Locked flag (see BlockAssembler.loadUnminedTransactions).
+// One exception: under the default OnRestartValidateParentChain /
+// OnRestartRemoveInvalidParentChainTxs settings, a transaction that gets filtered
+// out of the parent-chain validation during a block-assembly restart is
+// unconditionally unlocked as part of the same batch even though it was never
+// re-added - this is pre-existing block-assembly behaviour, not introduced here.
 //
 // It does not reverse the spend: spend rollback only applies before persistence
 // (see spendAndCreateInUtxoStore) - once the tx is durably created it is valid
 // and its spends must stand.
 //
-// On the success path, if the unlock itself fails, err is set to the unlock error
-// so the caller is told the tx still needs the fallback recovery ("marked as
-// spendable on next block").
-func (v *Validator) unlockLockedTxOnExit(ctx context.Context, tx *bt.Tx, txID string, txMetaData *meta.Data, err *error) {
+// On the success path, if the unlock itself fails, err is set to the unlock error.
+// No caller currently acts on that signal specifically - the real recovery path is
+// the same self-healing loadUnminedTransactions route described above (see
+// docs/topics/features/two_phase_commit.md), not caller-side handling of this
+// error. Setting err is mainly for observability of the failure at the point it
+// happened.
+//
+// The unlock decision is gated on delivered, not on *err being nil. delivered only
+// becomes true once sendToBlockAssembler has actually returned successfully, so it
+// stays false across a panic unwinding from anywhere in that window - unlike *err,
+// which is nil for the entire window regardless of whether delivery happened. Using
+// *err as the proxy would unlock a tx that was never delivered to block assembly if
+// something panicked in that narrow window, which is the exact state this function
+// exists to prevent.
+func (v *Validator) unlockLockedTxOnExit(ctx context.Context, tx *bt.Tx, txID string, txMetaData *meta.Data, err *error, delivered *bool) {
 	if txMetaData == nil || !txMetaData.Locked {
 		return
 	}
 
 	// Not delivered to block assembly - leave it locked for the unmined-transaction
-	// loader to heal, and keep the original, more informative error.
+	// loader to heal. This covers both ordinary error returns and a panic unwinding
+	// through the window between entering the addToBlockAssembly block and
+	// sendToBlockAssembler returning.
+	if delivered == nil || !*delivered {
+		v.logger.Warnf("[Validate][%s] tx stays locked, it was not delivered to block assembly", txID)
+
+		return
+	}
+
+	// Defensive: delivered is true but an error was still recorded. This should not
+	// happen given the current control flow (every return path after delivery sets
+	// no error), but keep it locked rather than trust an inconsistent state.
 	if *err != nil {
-		v.logger.Warnf("[Validate][%s] tx stays locked, it was not delivered to block assembly: %v", txID, *err)
+		v.logger.Warnf("[Validate][%s] tx stays locked despite being delivered, due to a later error: %v", txID, *err)
 
 		return
 	}

--- a/services/validator/Validator.go
+++ b/services/validator/Validator.go
@@ -946,13 +946,14 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 
 	// From this point on the tx has been durably persisted with its inputs spent and,
 	// when addToBlockAssembly is set, its own record marked Locked (the 2PC
-	// in-progress marker). Every return path below - success or error - must release
-	// that lock, or the tx is stuck forever: persisted, spent, Locked, and never
-	// delivered to block assembly. This is deliberately separate from spend rollback:
-	// reverseSpends only ever applies before persistence, and spends must stand once
-	// the tx is durably created (see spendAndCreateInUtxoStore). The argument
-	// (txMetaData) is captured now, by value of the pointer, so a later `return nil,
-	// err` in this function does not affect what the deferred call unlocks.
+	// in-progress marker). Routing every return path below through one deferred
+	// cleanup keeps the release in a single place instead of only on the tail of the
+	// happy path. It does NOT unlock on error: see unlockLockedTxOnExit for why an
+	// undelivered tx must stay locked. This is deliberately separate from spend
+	// rollback: spend rollback only ever applies before persistence, and spends must
+	// stand once the tx is durably created (see spendAndCreateInUtxoStore). The
+	// argument (txMetaData) is captured now, by value of the pointer, so a later
+	// `return nil, err` in this function does not affect what the deferred call sees.
 	defer v.unlockLockedTxOnExit(decoupledCtx, tx, txID, txMetaData, &err)
 
 	if validationOptions.SkipUtxoCreation {
@@ -1019,35 +1020,49 @@ func (v *Validator) validateInternal(ctx context.Context, tx *bt.Tx, blockHeight
 }
 
 // unlockLockedTxOnExit is the single point that releases a tx's two-phase-commit
-// Locked flag on the way out of validateInternal. It is deferred immediately after
-// the tx has been durably persisted with its inputs spent (see validateInternal),
-// so it runs on every return from there on - success or error - and not just the
-// happy path. Without it, an error returned between persistence and the end of
-// the function (e.g. building tx inpoints, or sendToBlockAssembler failing) would
-// leave the tx persisted, spent, and Locked forever, since nothing else ever
-// clears the flag.
+// Locked flag on the way out of validateInternal. It is deferred immediately
+// after the tx has been durably persisted with its inputs spent (see
+// validateInternal), so the release lives in one place rather than only on the
+// tail of the happy path.
 //
-// It does not reverse the spend: that is reverseSpends' job, and it only applies
-// before persistence (see spendAndCreateInUtxoStore) - once the tx is durably
-// created it is valid and its spends must stand.
+// It releases the lock ONLY when validateInternal is returning success. The 2PC
+// invariant is that a tx is unlocked after it has reached block assembly, never
+// before (docs/topics/features/two_phase_commit.md). On the error paths between
+// persistence and the end of the function - building tx inpoints, or
+// sendToBlockAssembler failing - the tx is persisted and spent but is NOT in
+// block assembly, so unlocking it here would let a child spending it validate
+// and enter this node's mining template without its parent, producing a block
+// other implementations reject.
 //
-// If err is nil on entry (the pure success path) and the unlock itself fails, err
-// is set to the unlock error so the caller is told the tx still needs the
-// fallback recovery ("marked as spendable on next block"). If err is already
-// non-nil (an earlier failure in validateInternal), the unlock is still attempted
-// and its failure only logged, so the tx's original, more informative error is
-// not masked by a lock-release problem.
+// Staying locked is the documented safe failure mode ("money temporarily can't
+// be spent") and it is self-healing, in the right order: the block assembler's
+// unmined-transaction loader adds such a tx to the subtree processor and only
+// then clears its Locked flag (see BlockAssembler.loadUnminedTransactions).
+//
+// It does not reverse the spend: spend rollback only applies before persistence
+// (see spendAndCreateInUtxoStore) - once the tx is durably created it is valid
+// and its spends must stand.
+//
+// On the success path, if the unlock itself fails, err is set to the unlock error
+// so the caller is told the tx still needs the fallback recovery ("marked as
+// spendable on next block").
 func (v *Validator) unlockLockedTxOnExit(ctx context.Context, tx *bt.Tx, txID string, txMetaData *meta.Data, err *error) {
 	if txMetaData == nil || !txMetaData.Locked {
+		return
+	}
+
+	// Not delivered to block assembly - leave it locked for the unmined-transaction
+	// loader to heal, and keep the original, more informative error.
+	if *err != nil {
+		v.logger.Warnf("[Validate][%s] tx stays locked, it was not delivered to block assembly: %v", txID, *err)
+
 		return
 	}
 
 	if unlockErr := v.twoPhaseCommitTransaction(ctx, tx, txID); unlockErr != nil {
 		v.logger.Warnf("[Validate][%s] error during two phase commit, transaction will be marked as spendable on next block: %v", txID, unlockErr)
 
-		if *err == nil {
-			*err = unlockErr
-		}
+		*err = unlockErr
 
 		return
 	}

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -499,6 +499,81 @@ func TestValidate_BlockAssemblyError(t *testing.T) {
 	require.Equal(t, 0, len(rejectedTxKafkaProducerClient.PublishChannel()), "rejectedTxKafkaChan should have 1 message")
 }
 
+// TestValidate_PanicDuringBlockAssemblyDeliveryKeepsLock covers the specific
+// failure mode unlockLockedTxOnExit's `delivered` flag exists to close: a panic
+// unwinding from inside the addToBlockAssembly window (after the tx is durably
+// persisted and Locked, before sendToBlockAssembler returns), rather than an
+// ordinary error return. On main, before the deferred-unlock refactor, a panic
+// there simply skipped the tail-of-function unlock statement, so the tx stayed
+// Locked. If the deferred helper used `err == nil` as its proxy for "delivered",
+// this would incorrectly unlock the tx, since err is nil for the entire window
+// regardless of whether a panic occurs. Gating on an explicit `delivered` flag
+// that is only set true after sendToBlockAssembler actually returns keeps this
+// panic-safe.
+func TestValidate_PanicDuringBlockAssemblyDeliveryKeepsLock(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	txHex := "010000000000000000ef01febe0cbd7d87d44cbd4b5adac0a5bfcdbd2b672c9113f5d74a6459a2b85569db010000008b48304502207ec38d0a4ef79c3a4286ba3e5a5b6ede1fa678af9242465140d78a901af9e4e0022100c26c377d44b761469cf0bdcdbf4931418f2c5a02ce6b72bbb7af52facd7228c1014104bc9eb4fe4cb53e35df7e7734c4c3cd91c6af7840be80f4a1fff283e2cd6ae8f7713cb263a4590263240e3c01ec36bc603c32281ac08773484dc69b8152e48cecffffffff60b74700000000001976a9148ac9bdc626352d16e18c26f431e834f9aae30e2888ac0230424700000000001976a9148ac9bdc626352d16e18c26f431e834f9aae30e2888ac1027000000000000166a148ac9bdc626352d16e18c26f431e834f9aae30e2800000000"
+	tx, err := bt.NewTxFromString(txHex)
+	require.NoError(t, err)
+
+	parenTxHex := "010000000000000000ef01154d5d31268f7ea94c80a7bf6de54e47812712feec25c17b8feceb570dfd9daf000000008b4830450220612b3ec065ec2b2a1757d97b7f57fba3c363645355cf6e1a5a1834411e6ab425022100bd071b90d391eb75dc9e2eea8b6774f36bf9c55439a971f0d1f4470b6448aef601410426e4e0654f72721b97a03c8170417c9ddabadcef97fe8ea626176ea62665b55ca2ff485f84df12ddec171e01ee8f9c7472c6c8467b0cf74ae8b3b614ed16cbdbffffffff008a6600000000001976a91429be45311cc66a5a6cc4a42516dbb7c9b126a3c188ac0280841e00000000001976a914996ed5e55d68aef653c85339f83873fac1321f0788ac60b74700000000001976a9148ac9bdc626352d16e18c26f431e834f9aae30e2888ac00000000"
+
+	parentTx, err := bt.NewTxFromString(parenTxHex)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+
+	tSettings := test.CreateBaseTestSettings(t)
+	tSettings.ChainCfgParams = &chaincfg.MainNetParams
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test_panic_during_block_assembly")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	_ = utxoStore.SetBlockHeight(257727)
+	//nolint:gosec
+	_ = utxoStore.SetMedianBlockTime(uint32(time.Now().Unix()))
+
+	_, err = utxoStore.Create(context.Background(), parentTx, 257726, utxostore.WithMinedBlockInfo(utxostore.MinedBlockInfo{BlockID: 1, BlockHeight: 257726, SubtreeIdx: 0}))
+	require.NoError(t, err)
+
+	initPrometheusMetrics()
+
+	blockAssembler := &MockBlockAssemblyStore{panicOnStore: true}
+
+	v := &Validator{
+		logger:                        logger,
+		settings:                      tSettings,
+		txValidator:                   NewTxValidator(logger, tSettings),
+		utxoStore:                     utxoStore,
+		blockAssembler:                blockAssembler,
+		stats:                         gocore.NewStat("validator"),
+		txmetaKafkaProducerClient:     kafka.NewKafkaAsyncProducerMock(),
+		rejectedTxKafkaProducerClient: kafka.NewKafkaAsyncProducerMock(),
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "the mock must actually panic for this test to exercise anything")
+		}()
+
+		_, _ = v.Validate(t.Context(), tx, 257727, WithSkipPolicyChecks(true))
+	}()
+
+	// The tx was durably persisted, spent, and Locked before the panic. It was
+	// never delivered to block assembly (the panic unwound from inside
+	// sendToBlockAssembler), so it must stay Locked - exactly as it would on the
+	// ordinary sendToBlockAssembler-returns-an-error path.
+	txMeta, err := utxoStore.Get(t.Context(), tx.TxIDChainHash())
+	require.NoError(t, err)
+	require.True(t, txMeta.Locked, "a tx must stay locked when a panic unwinds before it was actually delivered to block assembly")
+}
+
 // TestValidate_ConsensusRejectsUnconfirmedParent: a tx whose parent exists in
 // the UTXO store but has no recorded BlockHeights (i.e. parent UTXO is not yet
 // confirmed) must be rejected in consensus mode with
@@ -907,12 +982,19 @@ type txFeeSize struct {
 
 // MockBlockAssemblyStore provides a test double for block assembly storage operations.
 type MockBlockAssemblyStore struct {
-	returnError error
-	storedTxs   []txFeeSize
-	removedTxs  []chainhash.Hash
+	returnError  error
+	panicOnStore bool
+	storedTxs    []txFeeSize
+	removedTxs   []chainhash.Hash
 }
 
 func (s *MockBlockAssemblyStore) Store(_ context.Context, hash *chainhash.Hash, fee, size uint64, txInpoints subtree.TxInpoints) (bool, error) {
+	if s.panicOnStore {
+		// Simulates a nil/misconfigured block-assembly client panicking mid-delivery,
+		// e.g. inside the real gRPC client's Store() call.
+		panic("simulated panic: block assembler Store()")
+	}
+
 	if s.returnError != nil {
 		return false, s.returnError
 	}
@@ -1356,8 +1438,9 @@ func TestValidator_UnlockLockedTxOnExit_KeepsLockOnError(t *testing.T) {
 	// sendToBlockAssembler failure) when the deferred cleanup runs.
 	originalErr := errors.NewProcessingError("[Validate][%s] error getting tx inpoints", tx.TxID())
 	deferredErr := error(originalErr)
+	delivered := false
 
-	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr, &delivered)
 
 	require.True(t, txMetaData.Locked, "an undelivered tx must stay locked, or a child can be mined without its parent")
 	require.Same(t, originalErr, deferredErr, "the original, more informative error must be preserved")
@@ -1404,7 +1487,9 @@ func TestValidator_UnlockLockedTxOnExit_ClearsLockOnSuccess(t *testing.T) {
 
 	var deferredErr error
 
-	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+	delivered := true
+
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr, &delivered)
 
 	require.NoError(t, deferredErr)
 	require.False(t, txMetaData.Locked, "a delivered tx must be unlocked on the success path")
@@ -1426,8 +1511,6 @@ func TestValidator_UnlockLockedTxOnExit_NoopWhenNotLocked(t *testing.T) {
 	require.NoError(t, err)
 
 	utxoStore := NewFailingUtxoStore(t) // any SetLocked call would error here, proving it was never called
-	_, err = utxoStore.Create(context.Background(), tx, 100, utxostore.WithLocked(false))
-	require.NoError(t, err)
 
 	v := &Validator{
 		logger:      ulogger.TestLogger{},
@@ -1443,9 +1526,11 @@ func TestValidator_UnlockLockedTxOnExit_NoopWhenNotLocked(t *testing.T) {
 	txMetaData := &meta.Data{Locked: false}
 	var deferredErr error
 
-	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+	delivered := true
 
-	assert.NoError(t, deferredErr)
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr, &delivered)
+
+	require.NoError(t, deferredErr)
 }
 
 // TestValidator_UnlockLockedTxOnExit_SetsErrOnUnlockFailure covers the
@@ -1479,7 +1564,9 @@ func TestValidator_UnlockLockedTxOnExit_SetsErrOnUnlockFailure(t *testing.T) {
 	txMetaData := &meta.Data{Locked: true}
 	var deferredErr error
 
-	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+	delivered := true
+
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr, &delivered)
 
 	require.Error(t, deferredErr, "the unlock failure must be surfaced via the deferred error")
 	require.True(t, txMetaData.Locked, "the in-memory Locked flag must not be cleared when the unlock itself fails")
@@ -1601,6 +1688,63 @@ func TestValidator_LockedFlagChangedIfBlockAssemblyStoreSucceeds(t *testing.T) {
 	err = utxoStore.GetMeta(ctx, txs[1].TxIDChainHash(), metaData)
 	require.NoError(t, err)
 	assert.False(t, metaData.Locked, "Flag should be unset after successful block assembly")
+}
+
+// TestValidator_ValidateWithOptions_ReturnsUnlockFailureError drives the real
+// ValidateWithOptions entry point end-to-end with a store whose SetLocked fails,
+// and asserts the RETURNED error reflects the unlock failure - rather than
+// invoking unlockLockedTxOnExit directly, as the other unlock tests do. This
+// exercises the named-return/defer mechanism itself (err is a named return at
+// validateInternal's signature, and the deferred call writes to it through the
+// *error argument): a test that only calls the helper directly would still pass
+// even if that plumbing were broken (e.g. the signature changed to unnamed
+// returns), which would silently swallow unlock failures on the success path.
+func TestValidator_ValidateWithOptions_ReturnsUnlockFailureError(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	ctx := context.Background()
+
+	utxoStore := NewFailingUtxoStore(t) // SetLocked always errors here
+
+	txs := transactions.CreateTestTransactionChainWithCount(t, 3)
+
+	_, err := utxoStore.Create(
+		ctx,
+		txs[0],
+		1,
+		utxostore.WithLocked(false),
+	)
+	require.NoError(t, err)
+
+	blockAsmMock := blockassembly.NewMock()
+
+	settings := test.CreateBaseTestSettings(t)
+	settings.BlockAssembly.Disabled = false
+
+	v := &Validator{
+		logger:         ulogger.TestLogger{},
+		utxoStore:      utxoStore,
+		blockAssembler: blockAsmMock,
+		settings:       settings,
+		txValidator:    NewTxValidator(ulogger.TestLogger{}, test.CreateBaseTestSettings(t)),
+		stats:          gocore.NewStat("validator"),
+	}
+
+	blockAsmMock.On("Store", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(true, nil).Times(1)
+
+	require.NoError(t, utxoStore.SetBlockHeight(2))
+	require.NoError(t, utxoStore.SetMedianBlockTime(1700000000))
+
+	opts := &Options{AddTXToBlockAssembly: true}
+
+	_, err = v.ValidateWithOptions(ctx, txs[1], 2, opts)
+	require.Error(t, err, "the unlock failure must be surfaced through the real named-return/defer path, not swallowed")
+
+	metaData := &meta.Data{}
+	err = utxoStore.GetMeta(ctx, txs[1].TxIDChainHash(), metaData)
+	require.NoError(t, err)
+	require.True(t, metaData.Locked, "the tx was delivered to block assembly but the unlock itself failed, so it must stay locked in the store")
 }
 
 func TestValidator_LockedFlagNotChangedIfBlockAssemblyDidNotStoreTx(t *testing.T) {

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -484,10 +484,14 @@ func TestValidate_BlockAssemblyError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, txMetaData)
 
-	// the tx should be stored in the utxo store as locked
+	// The tx was already durably persisted with its inputs spent before
+	// sendToBlockAssembler failed. It must NOT be left Locked: validateInternal
+	// never sends it to block assembly, and nothing else will ever clear the
+	// flag, so a stuck Locked record here means the tx is spent, persisted, and
+	// permanently un-spendable and un-retryable.
 	txMeta, err := utxoStore.Get(t.Context(), tx.TxIDChainHash())
 	require.NoError(t, err)
-	assert.Equal(t, true, txMeta.Locked)
+	assert.Equal(t, false, txMeta.Locked, "tx must be unlocked even though sendToBlockAssembler failed, or it is stuck forever")
 
 	// check the kafka channels, nothing should have been sent, since the tx never was sent correctly to the block assembly
 	require.Equal(t, 0, len(txmetaKafkaProducerClient.PublishChannel()), "txMetaKafkaChan should be empty")
@@ -1295,6 +1299,105 @@ func TestValidator_TwoPhaseCommitTransaction_AlreadySpendable(t *testing.T) {
 	err = utxoStore.GetMeta(ctx, tx.TxIDChainHash(), metaData)
 	require.NoError(t, err)
 	assert.False(t, metaData.Locked, "TX should remain spendable after 2-phase commit")
+}
+
+// TestValidator_UnlockLockedTxOnExit_ClearsLockOnError is the direct, white-box
+// regression test for the mechanism validateInternal now defers immediately
+// after a tx is durably persisted+spent+Locked (see the two error returns in the
+// addToBlockAssembly block: building tx inpoints via subtree.NewTxInpointsFromTx,
+// and sendToBlockAssembler). Both paths return an error before validateInternal
+// otherwise ever reaches the two-phase-commit unlock, which - pre-fix - left the
+// tx Locked forever. unlockLockedTxOnExit is the single place both paths (and the
+// success path) now route through to release the lock.
+//
+// subtree.NewTxInpointsFromTx cannot currently be made to return an error (its
+// implementation is infallible in the pinned go-subtree version), so that
+// specific call site cannot be forced end-to-end without changing production
+// code paths outside validateInternal's control. This test instead calls the
+// shared cleanup function directly with an already-set error, which is exactly
+// the state validateInternal is in on both of those return paths: it proves the
+// tx is unlocked (Locked -> false) while the original, more informative error is
+// preserved rather than being overwritten by the (successful) unlock.
+func TestValidator_UnlockLockedTxOnExit_ClearsLockOnError(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	tx, err := bt.NewTxFromString("010000000000000000ef01b136c673a9b815af2bfdeccc9479deec3273ee98a188c26d3c14b5e6bfcbca0b010000006b48304502200241ac9536c536f21e522dec152e69674094b371b14c26edf706e1db0e6487190221008ee66bdafc7d39ee041e1425a7b2df780702e9b066c3a1e9715b03b23fbd99be41210373c9cb2feaa59dd208ad90dc4c8f32dac7a30a65e590fa16e2a421637927ae63feffffff4004fb0b000000001976a91471902a65346b0d951358ec9a1b306ecd36d284ae88ac0280969800000000001976a914dd37ee4ce93278fbc398abcda001d1d855841e0788ac3cd35d0b000000001976a914d04ad25d93764cf83aca0ca0c7cbb7ba8850f75888ac00000000")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test_unlock_on_exit_clears_lock")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	// Mirrors what spendAndCreateInUtxoStore leaves behind on the addToBlockAssembly
+	// path: the tx durably persisted, spent, and Locked.
+	txMetaData, err := utxoStore.Create(ctx, tx, 100, utxostore.WithLocked(true))
+	require.NoError(t, err)
+	require.True(t, txMetaData.Locked)
+
+	v := &Validator{
+		logger:      ulogger.TestLogger{},
+		utxoStore:   utxoStore,
+		settings:    tSettings,
+		txValidator: NewTxValidator(ulogger.TestLogger{}, tSettings),
+		stats:       gocore.NewStat("validator"),
+	}
+
+	ctx, _, endSpan := tracing.Tracer("validator").Start(context.Background(), "Test")
+	defer endSpan()
+
+	// Simulate validateInternal already holding an error (e.g. the tx-inpoints or
+	// sendToBlockAssembler failure) when the deferred cleanup runs.
+	originalErr := errors.NewProcessingError("[Validate][%s] error getting tx inpoints", tx.TxID())
+	deferredErr := error(originalErr)
+
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+
+	assert.False(t, txMetaData.Locked, "unlockLockedTxOnExit must clear the in-memory Locked flag")
+	assert.Same(t, originalErr, deferredErr, "the original, more informative error must not be overwritten by a successful unlock")
+
+	storedMeta := &meta.Data{}
+	err = utxoStore.GetMeta(ctx, tx.TxIDChainHash(), storedMeta)
+	require.NoError(t, err)
+	assert.False(t, storedMeta.Locked, "the store record must be unlocked, or the tx is stuck: persisted, spent, and Locked forever")
+}
+
+// TestValidator_UnlockLockedTxOnExit_SuccessPathSetsErrOnUnlockFailure covers the
+// pure-success-path behaviour that predates this fix: if the tx was never Locked
+// to begin with, unlockLockedTxOnExit must be a no-op (SetLocked must not be
+// called at all). This is the SkipUtxoCreation / not-added-to-block-assembly case.
+func TestValidator_UnlockLockedTxOnExit_NoopWhenNotLocked(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	tx, err := bt.NewTxFromString("010000000000000000ef01b136c673a9b815af2bfdeccc9479deec3273ee98a188c26d3c14b5e6bfcbca0b010000006b48304502200241ac9536c536f21e522dec152e69674094b371b14c26edf706e1db0e6487190221008ee66bdafc7d39ee041e1425a7b2df780702e9b066c3a1e9715b03b23fbd99be41210373c9cb2feaa59dd208ad90dc4c8f32dac7a30a65e590fa16e2a421637927ae63feffffff4004fb0b000000001976a91471902a65346b0d951358ec9a1b306ecd36d284ae88ac0280969800000000001976a914dd37ee4ce93278fbc398abcda001d1d855841e0788ac3cd35d0b000000001976a914d04ad25d93764cf83aca0ca0c7cbb7ba8850f75888ac00000000")
+	require.NoError(t, err)
+
+	utxoStore := NewFailingUtxoStore(t) // any SetLocked call would error here, proving it was never called
+	_, err = utxoStore.Create(context.Background(), tx, 100, utxostore.WithLocked(false))
+	require.NoError(t, err)
+
+	v := &Validator{
+		logger:      ulogger.TestLogger{},
+		utxoStore:   utxoStore,
+		settings:    test.CreateBaseTestSettings(t),
+		txValidator: NewTxValidator(ulogger.TestLogger{}, test.CreateBaseTestSettings(t)),
+		stats:       gocore.NewStat("validator"),
+	}
+
+	ctx, _, endSpan := tracing.Tracer("validator").Start(context.Background(), "Test")
+	defer endSpan()
+
+	txMetaData := &meta.Data{Locked: false}
+	var deferredErr error
+
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+
+	assert.NoError(t, deferredErr)
 }
 
 // FailingUtxoStore provides a test double that simulates UTXO store failures.

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -1415,10 +1415,10 @@ func TestValidator_UnlockLockedTxOnExit_ClearsLockOnSuccess(t *testing.T) {
 	require.False(t, storedMeta.Locked, "the store record must be unlocked on the success path")
 }
 
-// TestValidator_UnlockLockedTxOnExit_SuccessPathSetsErrOnUnlockFailure covers the
-// pure-success-path behaviour that predates this fix: if the tx was never Locked
-// to begin with, unlockLockedTxOnExit must be a no-op (SetLocked must not be
-// called at all). This is the SkipUtxoCreation / not-added-to-block-assembly case.
+// TestValidator_UnlockLockedTxOnExit_NoopWhenNotLocked covers the case where the
+// tx was never Locked to begin with: unlockLockedTxOnExit must be a no-op
+// (SetLocked must not be called at all). This is the SkipUtxoCreation /
+// not-added-to-block-assembly case.
 func TestValidator_UnlockLockedTxOnExit_NoopWhenNotLocked(t *testing.T) {
 	tracing.SetupMockTracer()
 
@@ -1446,6 +1446,43 @@ func TestValidator_UnlockLockedTxOnExit_NoopWhenNotLocked(t *testing.T) {
 	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
 
 	assert.NoError(t, deferredErr)
+}
+
+// TestValidator_UnlockLockedTxOnExit_SetsErrOnUnlockFailure covers the
+// success-path-so-far case: the tx was Locked and delivered to block assembly
+// (incoming deferred error is nil), but the unlock (SetLocked(false) via the
+// two-phase commit) itself fails. unlockLockedTxOnExit must surface that
+// failure by setting the deferred error to the unlock error, and must leave
+// the in-memory Locked flag untouched (it stays true) since the store record
+// was never actually unlocked.
+func TestValidator_UnlockLockedTxOnExit_SetsErrOnUnlockFailure(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	tx, err := bt.NewTxFromString("010000000000000000ef01b136c673a9b815af2bfdeccc9479deec3273ee98a188c26d3c14b5e6bfcbca0b010000006b48304502200241ac9536c536f21e522dec152e69674094b371b14c26edf706e1db0e6487190221008ee66bdafc7d39ee041e1425a7b2df780702e9b066c3a1e9715b03b23fbd99be41210373c9cb2feaa59dd208ad90dc4c8f32dac7a30a65e590fa16e2a421637927ae63feffffff4004fb0b000000001976a91471902a65346b0d951358ec9a1b306ecd36d284ae88ac0280969800000000001976a914dd37ee4ce93278fbc398abcda001d1d855841e0788ac3cd35d0b000000001976a914d04ad25d93764cf83aca0ca0c7cbb7ba8850f75888ac00000000")
+	require.NoError(t, err)
+
+	utxoStore := NewFailingUtxoStore(t) // SetLocked always errors here
+	_, err = utxoStore.Create(context.Background(), tx, 100, utxostore.WithLocked(true))
+	require.NoError(t, err)
+
+	v := &Validator{
+		logger:      ulogger.TestLogger{},
+		utxoStore:   utxoStore,
+		settings:    test.CreateBaseTestSettings(t),
+		txValidator: NewTxValidator(ulogger.TestLogger{}, test.CreateBaseTestSettings(t)),
+		stats:       gocore.NewStat("validator"),
+	}
+
+	ctx, _, endSpan := tracing.Tracer("validator").Start(context.Background(), "Test")
+	defer endSpan()
+
+	txMetaData := &meta.Data{Locked: true}
+	var deferredErr error
+
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+
+	require.Error(t, deferredErr, "the unlock failure must be surfaced via the deferred error")
+	require.True(t, txMetaData.Locked, "the in-memory Locked flag must not be cleared when the unlock itself fails")
 }
 
 // FailingUtxoStore provides a test double that simulates UTXO store failures.

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -484,14 +484,15 @@ func TestValidate_BlockAssemblyError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, txMetaData)
 
-	// The tx was already durably persisted with its inputs spent before
-	// sendToBlockAssembler failed. It must NOT be left Locked: validateInternal
-	// never sends it to block assembly, and nothing else will ever clear the
-	// flag, so a stuck Locked record here means the tx is spent, persisted, and
-	// permanently un-spendable and un-retryable.
+	// The tx is durably persisted with its inputs spent, but sendToBlockAssembler
+	// failed, so it is NOT in block assembly. It must stay Locked: unlocking an
+	// undelivered tx would let a child spending it enter this node's mining
+	// template without its parent. The block assembler's unmined-transaction
+	// loader heals this in the safe order - add to the subtree processor first,
+	// clear Locked second.
 	txMeta, err := utxoStore.Get(t.Context(), tx.TxIDChainHash())
 	require.NoError(t, err)
-	assert.Equal(t, false, txMeta.Locked, "tx must be unlocked even though sendToBlockAssembler failed, or it is stuck forever")
+	assert.Equal(t, true, txMeta.Locked)
 
 	// check the kafka channels, nothing should have been sent, since the tx never was sent correctly to the block assembly
 	require.Equal(t, 0, len(txmetaKafkaProducerClient.PublishChannel()), "txMetaKafkaChan should be empty")
@@ -1301,14 +1302,15 @@ func TestValidator_TwoPhaseCommitTransaction_AlreadySpendable(t *testing.T) {
 	assert.False(t, metaData.Locked, "TX should remain spendable after 2-phase commit")
 }
 
-// TestValidator_UnlockLockedTxOnExit_ClearsLockOnError is the direct, white-box
-// regression test for the mechanism validateInternal now defers immediately
-// after a tx is durably persisted+spent+Locked (see the two error returns in the
+// TestValidator_UnlockLockedTxOnExit_KeepsLockOnError is the direct, white-box
+// test for the mechanism validateInternal defers immediately after a tx is
+// durably persisted+spent+Locked (see the two error returns in the
 // addToBlockAssembly block: building tx inpoints via subtree.NewTxInpointsFromTx,
-// and sendToBlockAssembler). Both paths return an error before validateInternal
-// otherwise ever reaches the two-phase-commit unlock, which - pre-fix - left the
-// tx Locked forever. unlockLockedTxOnExit is the single place both paths (and the
-// success path) now route through to release the lock.
+// and sendToBlockAssembler). On both paths the tx never reaches block assembly,
+// so the 2PC lock must NOT be released: an unlocked-but-undelivered parent lets a
+// child enter the mining template without it. Staying locked is the documented
+// safe failure mode, and the block assembler's unmined-transaction loader heals
+// it in the correct order (add to subtree processor, then unlock).
 //
 // subtree.NewTxInpointsFromTx cannot currently be made to return an error (its
 // implementation is infallible in the pinned go-subtree version), so that
@@ -1316,9 +1318,8 @@ func TestValidator_TwoPhaseCommitTransaction_AlreadySpendable(t *testing.T) {
 // code paths outside validateInternal's control. This test instead calls the
 // shared cleanup function directly with an already-set error, which is exactly
 // the state validateInternal is in on both of those return paths: it proves the
-// tx is unlocked (Locked -> false) while the original, more informative error is
-// preserved rather than being overwritten by the (successful) unlock.
-func TestValidator_UnlockLockedTxOnExit_ClearsLockOnError(t *testing.T) {
+// record stays locked and the original, more informative error is preserved.
+func TestValidator_UnlockLockedTxOnExit_KeepsLockOnError(t *testing.T) {
 	tracing.SetupMockTracer()
 
 	tx, err := bt.NewTxFromString("010000000000000000ef01b136c673a9b815af2bfdeccc9479deec3273ee98a188c26d3c14b5e6bfcbca0b010000006b48304502200241ac9536c536f21e522dec152e69674094b371b14c26edf706e1db0e6487190221008ee66bdafc7d39ee041e1425a7b2df780702e9b066c3a1e9715b03b23fbd99be41210373c9cb2feaa59dd208ad90dc4c8f32dac7a30a65e590fa16e2a421637927ae63feffffff4004fb0b000000001976a91471902a65346b0d951358ec9a1b306ecd36d284ae88ac0280969800000000001976a914dd37ee4ce93278fbc398abcda001d1d855841e0788ac3cd35d0b000000001976a914d04ad25d93764cf83aca0ca0c7cbb7ba8850f75888ac00000000")
@@ -1358,13 +1359,60 @@ func TestValidator_UnlockLockedTxOnExit_ClearsLockOnError(t *testing.T) {
 
 	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
 
-	assert.False(t, txMetaData.Locked, "unlockLockedTxOnExit must clear the in-memory Locked flag")
-	assert.Same(t, originalErr, deferredErr, "the original, more informative error must not be overwritten by a successful unlock")
+	require.True(t, txMetaData.Locked, "an undelivered tx must stay locked, or a child can be mined without its parent")
+	require.Same(t, originalErr, deferredErr, "the original, more informative error must be preserved")
 
 	storedMeta := &meta.Data{}
 	err = utxoStore.GetMeta(ctx, tx.TxIDChainHash(), storedMeta)
 	require.NoError(t, err)
-	assert.False(t, storedMeta.Locked, "the store record must be unlocked, or the tx is stuck: persisted, spent, and Locked forever")
+	require.True(t, storedMeta.Locked, "the store record must stay locked until the unmined-transaction loader delivers it to block assembly")
+}
+
+// TestValidator_UnlockLockedTxOnExit_ClearsLockOnSuccess is the counterpart: when
+// validateInternal is returning success the tx has reached block assembly, so the
+// 2PC lock is released - in memory and in the store.
+func TestValidator_UnlockLockedTxOnExit_ClearsLockOnSuccess(t *testing.T) {
+	tracing.SetupMockTracer()
+
+	tx, err := bt.NewTxFromString("010000000000000000ef01b136c673a9b815af2bfdeccc9479deec3273ee98a188c26d3c14b5e6bfcbca0b010000006b48304502200241ac9536c536f21e522dec152e69674094b371b14c26edf706e1db0e6487190221008ee66bdafc7d39ee041e1425a7b2df780702e9b066c3a1e9715b03b23fbd99be41210373c9cb2feaa59dd208ad90dc4c8f32dac7a30a65e590fa16e2a421637927ae63feffffff4004fb0b000000001976a91471902a65346b0d951358ec9a1b306ecd36d284ae88ac0280969800000000001976a914dd37ee4ce93278fbc398abcda001d1d855841e0788ac3cd35d0b000000001976a914d04ad25d93764cf83aca0ca0c7cbb7ba8850f75888ac00000000")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test_unlock_on_exit_clears_lock_on_success")
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	txMetaData, err := utxoStore.Create(ctx, tx, 100, utxostore.WithLocked(true))
+	require.NoError(t, err)
+	require.True(t, txMetaData.Locked)
+
+	v := &Validator{
+		logger:      ulogger.TestLogger{},
+		utxoStore:   utxoStore,
+		settings:    tSettings,
+		txValidator: NewTxValidator(ulogger.TestLogger{}, tSettings),
+		stats:       gocore.NewStat("validator"),
+	}
+
+	ctx, _, endSpan := tracing.Tracer("validator").Start(context.Background(), "Test")
+	defer endSpan()
+
+	var deferredErr error
+
+	v.unlockLockedTxOnExit(ctx, tx, tx.TxID(), txMetaData, &deferredErr)
+
+	require.NoError(t, deferredErr)
+	require.False(t, txMetaData.Locked, "a delivered tx must be unlocked on the success path")
+
+	storedMeta := &meta.Data{}
+	err = utxoStore.GetMeta(ctx, tx.TxIDChainHash(), storedMeta)
+	require.NoError(t, err)
+	require.False(t, storedMeta.Locked, "the store record must be unlocked on the success path")
 }
 
 // TestValidator_UnlockLockedTxOnExit_SuccessPathSetsErrOnUnlockFailure covers the


### PR DESCRIPTION
## What this is

Not a bug fix. On `main`, both error paths between UTXO persistence and the end of `validateInternal` (tx-inpoints construction failing, `sendToBlockAssembler` failing) already keep the transaction `Locked`. That's the correct, intentional behaviour: an undelivered-to-block-assembly transaction must stay locked, or a child spending it could validate and enter a mining template before its parent, producing a block other implementations reject.

This PR:

- Consolidates the lock release into a single deferred helper, `unlockLockedTxOnExit`, registered once right after the tx is durably persisted and spent, instead of releasing the lock only at the tail of the happy path.
- Documents the invariant directly on the helper: why those two error paths must stay locked, and why staying locked is a safe, self-healing failure mode.
- Gates the unlock decision on an explicit `delivered` flag rather than inferring "was this tx delivered to block assembly" from "is `err` nil". `err` is nil for the entire window between entering the add-to-block-assembly code and `sendToBlockAssembler` returning, so a panic in that window (e.g. a nil/misconfigured block-assembly client) would incorrectly unlock an undelivered tx if the decision were based on `err == nil` alone. `delivered` only flips to `true` once `sendToBlockAssembler` has actually returned successfully, so it stays panic-safe.
- Adds unit tests: the two headline behaviours (stays locked on error, unlocks on success), a no-op case, an unlock-failure-is-surfaced case, a panic-during-delivery case (new - the deferred/flag-based approach has to get this right, the old tail-of-function code never had this failure mode), and an end-to-end test through `ValidateWithOptions` that exercises the real named-return/defer mechanism rather than calling the helper directly.

## Recovery path

The self-healing recovery is `BlockAssembler.loadUnminedTransactions`: it adds a still-locked, undelivered transaction to the subtree processor and only then clears its `Locked` flag, so a child transaction can never validate against an unlocked-but-undelivered parent. See `docs/topics/features/two_phase_commit.md`. Note this ordering guarantee has one pre-existing exception under default `OnRestartValidateParentChain`/`OnRestartRemoveInvalidParentChainTxs` settings, called out in the updated doc comment.
