### PR TITLE
test(seeder): round-trip and complete-file coverage for UTXO snapshot import

### DIFF
--- a/cmd/seeder/seeder.go
+++ b/cmd/seeder/seeder.go
@@ -512,54 +512,8 @@ func processUTXOs(ctx context.Context, logger ulogger.Logger, appSettings *setti
 		return nil, errors.NewProcessingError("couldn't read previous block hash from file", err)
 	}
 
-	var (
-		txProcessed    uint64
-		utxosProcessed uint64
-	)
-
 	g.Go(func() error {
-		defer close(utxoWrapperCh)
-
-	OUTER:
-		for {
-			select {
-			case <-gCtx.Done():
-				// Context canceled, stop reading lines
-				logger.Infof("Context cancelled, stopping reading UTXOWrapper")
-				return gCtx.Err()
-
-			default:
-				var utxoWrapper *utxopersister.UTXOWrapper
-
-				utxoWrapper, err = utxopersister.NewUTXOWrapperFromReader(gCtx, reader)
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break OUTER
-					}
-
-					logger.Errorf("Failed to read UTXO: %v", err)
-					return errors.NewProcessingError("failed to read UTXO", err)
-				}
-
-				select {
-				case <-gCtx.Done():
-					logger.Infof("Context cancelled while sending UTXO to channel, stopping UTXO processing")
-					return gCtx.Err()
-
-				case utxoWrapperCh <- utxoWrapper:
-					txProcessed++
-					utxosProcessed += uint64(len(utxoWrapper.UTXOs))
-
-					if txProcessed%1_000_000 == 0 {
-						logger.Infof("Processed %16s transactions with %16s utxos", formatNumber(txProcessed), formatNumber(utxosProcessed))
-					}
-				}
-			}
-		}
-
-		logger.Infof("FINISHED  %16s transactions with %16s utxos", formatNumber(txProcessed), formatNumber(utxosProcessed))
-
-		return nil
+		return readUTXOWrapperFile(gCtx, logger, f, reader, utxoWrapperCh)
 	})
 
 	if err = g.Wait(); err != nil {
@@ -575,6 +529,88 @@ func processUTXOs(ctx context.Context, logger ulogger.Logger, appSettings *setti
 	}
 
 	return &utxoSetTip{hash: hash, height: height}, nil
+}
+
+// readUTXOWrapperFile reads UTXOWrapper records from reader (backed by f) and
+// sends them to utxoWrapperCh until the record stream is exhausted, then
+// closes the channel.
+//
+// The underlying UTXOWrapperFromReader/errors.Is(err, io.EOF) EOF detection
+// cannot tell a clean end-of-records boundary apart from a file truncated
+// mid-record: both surface as an error whose message contains "EOF" (a real
+// truncation trips io.ErrUnexpectedEOF, whose message "unexpected EOF"
+// contains "EOF" as a substring), so errors.Is treats them identically via
+// this package's substring-matching Is fallback. To make truncation
+// detection exact, every snapshot file carries a trailing 16-byte footer
+// (utxopersister.GetFooter) recording the txCount/utxoCount it was written
+// with; once the read loop ends for any reason, that footer is compared
+// against what was actually processed, and a mismatch is reported as an
+// error instead of silently treated as success.
+func readUTXOWrapperFile(ctx context.Context, logger ulogger.Logger, f *os.File, reader *bufio.Reader, utxoWrapperCh chan<- *utxopersister.UTXOWrapper) error {
+	defer close(utxoWrapperCh)
+
+	var (
+		txProcessed    uint64
+		utxosProcessed uint64
+		err            error
+	)
+
+OUTER:
+	for {
+		select {
+		case <-ctx.Done():
+			// Context canceled, stop reading lines
+			logger.Infof("Context cancelled, stopping reading UTXOWrapper")
+			return ctx.Err()
+
+		default:
+			var utxoWrapper *utxopersister.UTXOWrapper
+
+			utxoWrapper, err = utxopersister.NewUTXOWrapperFromReader(ctx, reader)
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break OUTER
+				}
+
+				logger.Errorf("Failed to read UTXO: %v", err)
+				return errors.NewProcessingError("failed to read UTXO", err)
+			}
+
+			select {
+			case <-ctx.Done():
+				logger.Infof("Context cancelled while sending UTXO to channel, stopping UTXO processing")
+				return ctx.Err()
+
+			case utxoWrapperCh <- utxoWrapper:
+				txProcessed++
+				utxosProcessed += uint64(len(utxoWrapper.UTXOs))
+
+				if txProcessed%1_000_000 == 0 {
+					logger.Infof("Processed %16s transactions with %16s utxos", formatNumber(txProcessed), formatNumber(utxosProcessed))
+				}
+			}
+		}
+	}
+
+	// The read loop above only knows the record stream ended - it cannot
+	// distinguish a clean footer boundary from a truncated file (see the
+	// doc comment above). Validate against the file's own footer counts so
+	// a genuinely truncated snapshot is reported as an error rather than
+	// silently accepted.
+	expectedTxCount, expectedUTXOCount, footerErr := utxopersister.GetFooter(f)
+	if footerErr != nil {
+		return errors.NewProcessingError("failed to read snapshot footer", footerErr)
+	}
+
+	if expectedTxCount != txProcessed || expectedUTXOCount != utxosProcessed {
+		return errors.NewProcessingError(
+			"snapshot file truncated: expected %d transactions/%d UTXOs, processed %d/%d",
+			expectedTxCount, expectedUTXOCount, txProcessed, utxosProcessed)
+	}
+
+	logger.Infof("FINISHED  %16s transactions with %16s utxos", formatNumber(txProcessed), formatNumber(utxosProcessed))
+
+	return nil
 }
 
 // worker processes UTXOWrapper messages from the channel and stores them in the UTXO store.

--- a/cmd/seeder/seeder_roundtrip_test.go
+++ b/cmd/seeder/seeder_roundtrip_test.go
@@ -1,0 +1,217 @@
+package seeder
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/utxopersister"
+	utxosql "github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCompleteSnapshotFile assembles a well-formed .utxo-set file byte for
+// byte in the layout CreateUTXOSet writes (services/utxopersister/UTXOSet.go):
+// fileformat header, then blockHash(32)+height(4)+previousBlockHash(32), then
+// one UTXOWrapper.Bytes() record per wrapper, then the trailing 16-byte
+// footer (txCount + utxoCount, little-endian) that GetFooter reads back. It
+// reuses the same per-record encoding (UTXOWrapper.Bytes()) that the real
+// persister writes, so the file the seeder reads back is byte-identical to
+// what production would have produced for these records.
+func writeCompleteSnapshotFile(t *testing.T, wrappers []*utxopersister.UTXOWrapper) string {
+	t.Helper()
+
+	var blockHash chainhash.Hash
+	blockHash[0] = 0xcc
+
+	var prevHash chainhash.Hash
+	prevHash[0] = 0xdd
+
+	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
+
+	data := make([]byte, 0)
+	data = append(data, header.Bytes()...)
+	data = append(data, blockHash[:]...)
+
+	heightBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(heightBytes, 200)
+	data = append(data, heightBytes...)
+
+	data = append(data, prevHash[:]...)
+
+	var txCount, utxoCount uint64
+
+	for _, w := range wrappers {
+		data = append(data, w.Bytes()...)
+		txCount++
+		utxoCount += uint64(len(w.UTXOs))
+	}
+
+	footer := make([]byte, 16)
+	binary.LittleEndian.PutUint64(footer[0:8], txCount)
+	binary.LittleEndian.PutUint64(footer[8:16], utxoCount)
+	data = append(data, footer...)
+
+	path := filepath.Join(t.TempDir(), "roundtrip.utxo-set")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	return path
+}
+
+// importSnapshotFile drives the file through the same functions Seeder's
+// processUTXOs uses: readUTXOWrapperFile feeds a channel that processUTXO
+// drains into store, exactly as worker() does, but without the extra worker
+// pool machinery that's orthogonal to file-format correctness.
+func importSnapshotFile(t *testing.T, path string, store *utxosql.Store) error {
+	t.Helper()
+
+	f, reader := openForReading(t, path)
+
+	utxoWrapperCh := make(chan *utxopersister.UTXOWrapper, 10)
+
+	readErrCh := make(chan error, 1)
+
+	go func() {
+		readErrCh <- readUTXOWrapperFile(context.Background(), ulogger.TestLogger{}, f, reader, utxoWrapperCh)
+	}()
+
+	var processErr error
+
+	for w := range utxoWrapperCh {
+		if err := processUTXO(context.Background(), store, w, nil); err != nil && processErr == nil {
+			processErr = err
+		}
+	}
+
+	readErr := <-readErrCh
+
+	if readErr != nil {
+		return readErr
+	}
+
+	return processErr
+}
+
+// TestSeederImport_RoundTripsRealSnapshotFile writes a real .utxo-set file
+// using the persister's own UTXOWrapper record encoding, feeds it through the
+// seeder's import path (readUTXOWrapperFile -> processUTXO), and checks the
+// exact record content - not just counts - survives into the UTXO store.
+// This is the round-trip half of the two tests the audit recommended
+// alongside the truncated-file regression test.
+func TestSeederImport_RoundTripsRealSnapshotFile(t *testing.T) {
+	ctx := context.Background()
+	store := newTestUtxoStore(ctx, t)
+
+	txA := chainhash.HashH([]byte("roundtrip-tx-a"))
+	txB := chainhash.HashH([]byte("roundtrip-tx-b"))
+
+	wrappers := []*utxopersister.UTXOWrapper{
+		{
+			TxID:   txA,
+			Height: 200,
+			UTXOs: []*utxopersister.UTXO{
+				{Index: 0, Value: 1234, Script: []byte{0x76, 0xa9, 0x14}},
+				{Index: 1, Value: 5678, Script: []byte{0x51}},
+			},
+		},
+		{
+			TxID:   txB,
+			Height: 200,
+			UTXOs: []*utxopersister.UTXO{
+				{Index: 2, Value: 999999, Script: []byte{0x6a, 0x01, 0x02, 0x03}},
+			},
+		},
+	}
+
+	path := writeCompleteSnapshotFile(t, wrappers)
+
+	require.NoError(t, importSnapshotFile(t, path, store))
+
+	gotA, err := store.Get(ctx, &txA)
+	require.NoError(t, err)
+	require.NotNil(t, gotA.Tx)
+	require.Len(t, gotA.Tx.Outputs, 2, "output at index 1 must be present without a leading nil hole")
+	require.Equal(t, uint64(1234), gotA.Tx.Outputs[0].Satoshis)
+	require.Equal(t, []byte{0x76, 0xa9, 0x14}, gotA.Tx.Outputs[0].LockingScript.Bytes())
+	require.Equal(t, uint64(5678), gotA.Tx.Outputs[1].Satoshis)
+	require.Equal(t, []byte{0x51}, gotA.Tx.Outputs[1].LockingScript.Bytes())
+
+	gotB, err := store.Get(ctx, &txB)
+	require.NoError(t, err)
+	require.NotNil(t, gotB.Tx)
+	// txB's only UTXO is at index 2; the store keeps only real (non-nil)
+	// outputs, so the padded holes at indices 0 and 1 (PadUTXOsWithNil) are
+	// not themselves stored - only the surviving output's value and script
+	// round-trip.
+	require.Len(t, gotB.Tx.Outputs, 1)
+	require.Equal(t, uint64(999999), gotB.Tx.Outputs[0].Satoshis)
+	require.Equal(t, []byte{0x6a, 0x01, 0x02, 0x03}, gotB.Tx.Outputs[0].LockingScript.Bytes())
+}
+
+// TestSeederImport_CompleteFile_FinishesCleanly feeds the seeder a
+// well-formed, complete snapshot file (footer counts match the records
+// actually written) and asserts the whole import finishes without error,
+// every record lands in the UTXO store, and the footer counts line up with
+// what was processed - the positive-path counterpart to #14's
+// truncated-file regression test.
+func TestSeederImport_CompleteFile_FinishesCleanly(t *testing.T) {
+	ctx := context.Background()
+	store := newTestUtxoStore(ctx, t)
+
+	metadata, wrapperBytes, txCount, utxoCount := buildSnapshotWrappers(t)
+	require.Len(t, wrapperBytes, 2)
+
+	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
+
+	data := make([]byte, 0)
+	data = append(data, header.Bytes()...)
+	data = append(data, metadata...)
+
+	for _, wb := range wrapperBytes {
+		data = append(data, wb...)
+	}
+
+	footer := make([]byte, 16)
+	binary.LittleEndian.PutUint64(footer[0:8], txCount)
+	binary.LittleEndian.PutUint64(footer[8:16], utxoCount)
+	data = append(data, footer...)
+
+	path := filepath.Join(t.TempDir(), "complete.utxo-set")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	require.NoError(t, importSnapshotFile(t, path, store))
+
+	// The two wrappers built by buildSnapshotWrappers use TxID[0] = 0x01/0x02.
+	var txid1, txid2 chainhash.Hash
+	txid1[0] = 0x01
+	txid2[0] = 0x02
+
+	got1, err := store.Get(ctx, &txid1)
+	require.NoError(t, err)
+	require.NotNil(t, got1.Tx)
+	require.Len(t, got1.Tx.Outputs, 1)
+	require.Equal(t, uint64(5000000000), got1.Tx.Outputs[0].Satoshis)
+
+	got2, err := store.Get(ctx, &txid2)
+	require.NoError(t, err)
+	require.NotNil(t, got2.Tx)
+	require.Len(t, got2.Tx.Outputs, 2)
+	require.Equal(t, uint64(1234), got2.Tx.Outputs[0].Satoshis)
+	require.Equal(t, uint64(5678), got2.Tx.Outputs[1].Satoshis)
+
+	// The footer itself must reflect exactly what was written, confirming the
+	// writer and reader agree on the counts as well as the content.
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	gotTxCount, gotUTXOCount, err := utxopersister.GetFooter(f)
+	require.NoError(t, err)
+	require.Equal(t, txCount, gotTxCount)
+	require.Equal(t, utxoCount, gotUTXOCount)
+}

--- a/cmd/seeder/seeder_roundtrip_test.go
+++ b/cmd/seeder/seeder_roundtrip_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/utxopersister"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
 	utxosql "github.com/bsv-blockchain/teranode/stores/utxo/sql"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/stretchr/testify/require"
@@ -135,7 +136,7 @@ func TestSeederImport_RoundTripsRealSnapshotFile(t *testing.T) {
 	gotA, err := store.Get(ctx, &txA)
 	require.NoError(t, err)
 	require.NotNil(t, gotA.Tx)
-	require.Len(t, gotA.Tx.Outputs, 2, "output at index 1 must be present without a leading nil hole")
+	require.Len(t, gotA.Tx.Outputs, 2, "both outputs must be present; txA has no padded holes")
 	require.Equal(t, uint64(1234), gotA.Tx.Outputs[0].Satoshis)
 	require.Equal(t, []byte{0x76, 0xa9, 0x14}, gotA.Tx.Outputs[0].LockingScript.Bytes())
 	require.Equal(t, uint64(5678), gotA.Tx.Outputs[1].Satoshis)
@@ -147,10 +148,24 @@ func TestSeederImport_RoundTripsRealSnapshotFile(t *testing.T) {
 	// txB's only UTXO is at index 2; the store keeps only real (non-nil)
 	// outputs, so the padded holes at indices 0 and 1 (PadUTXOsWithNil) are
 	// not themselves stored - only the surviving output's value and script
-	// round-trip.
+	// round-trip. Content alone isn't enough to prove this: the store's
+	// compacted read view would return the same slice whether the UTXO was
+	// written at index 2 (correct) or index 0 (an index-computation bug), so
+	// assert against the actual on-disk index directly via GetSpend, which
+	// queries by (txid, vout) rather than by position in a compacted slice.
 	require.Len(t, gotB.Tx.Outputs, 1)
 	require.Equal(t, uint64(999999), gotB.Tx.Outputs[0].Satoshis)
 	require.Equal(t, []byte{0x6a, 0x01, 0x02, 0x03}, gotB.Tx.Outputs[0].LockingScript.Bytes())
+
+	spendAtCorrectIndex, err := store.GetSpend(ctx, &utxo.Spend{TxID: &txB, Vout: 2})
+	require.NoError(t, err)
+	require.Equal(t, int(utxo.Status_OK), spendAtCorrectIndex.Status,
+		"the UTXO must be recorded at vout 2, its real index")
+
+	spendAtWrongIndex, err := store.GetSpend(ctx, &utxo.Spend{TxID: &txB, Vout: 0})
+	require.NoError(t, err)
+	require.Equal(t, int(utxo.Status_NOT_FOUND), spendAtWrongIndex.Status,
+		"the UTXO must not have been mis-indexed to vout 0, the first padded hole")
 }
 
 // TestSeederImport_CompleteFile_FinishesCleanly feeds the seeder a

--- a/cmd/seeder/seeder_truncation_test.go
+++ b/cmd/seeder/seeder_truncation_test.go
@@ -1,0 +1,131 @@
+package seeder
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/utxopersister"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSnapshotWrappers builds the well-formed per-file metadata (current
+// block hash, height, previous block hash) and two UTXOWrapper records, in
+// exactly the layout CreateUTXOSet writes (services/utxopersister/UTXOSet.go)
+// and processUTXOs reads back. The footer is deliberately not included here:
+// callers that want a genuinely truncated file splice in a partial second
+// record instead of the real footer.
+func buildSnapshotWrappers(t *testing.T) (metadata []byte, wrapperBytes [][]byte, txCount, utxoCount uint64) {
+	t.Helper()
+
+	var blockHash chainhash.Hash
+	blockHash[0] = 0xaa
+
+	metadata = append(metadata, blockHash[:]...)
+
+	heightBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(heightBytes, 100)
+	metadata = append(metadata, heightBytes...)
+
+	var prevHash [32]byte
+	prevHash[0] = 0xbb
+
+	metadata = append(metadata, prevHash[:]...)
+
+	wrappers := []*utxopersister.UTXOWrapper{
+		{
+			Height: 100,
+			UTXOs: []*utxopersister.UTXO{
+				{Index: 0, Value: 5000000000, Script: []byte{0x76, 0xa9}},
+			},
+		},
+		{
+			Height: 100,
+			UTXOs: []*utxopersister.UTXO{
+				{Index: 0, Value: 1234, Script: []byte{0x51}},
+				{Index: 1, Value: 5678, Script: []byte{0x52, 0x53}},
+			},
+		},
+	}
+	wrappers[0].TxID[0] = 0x01
+	wrappers[1].TxID[0] = 0x02
+
+	for _, w := range wrappers {
+		wrapperBytes = append(wrapperBytes, w.Bytes())
+		txCount++
+		utxoCount += uint64(len(w.UTXOs))
+	}
+
+	return metadata, wrapperBytes, txCount, utxoCount
+}
+
+// openForReading opens path and positions a bufio.Reader past the per-file
+// header/hash/height/prevHash metadata, exactly as processUTXOs does before
+// handing off to readUTXOWrapperFile.
+func openForReading(t *testing.T, path string) (*os.File, *bufio.Reader) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	reader := bufio.NewReader(f)
+
+	_, err = fileformat.ReadHeader(reader)
+	require.NoError(t, err)
+
+	skip := make([]byte, 32+4+32) // block hash + height + previous block hash
+	_, err = io.ReadFull(reader, skip)
+	require.NoError(t, err)
+
+	return f, reader
+}
+
+// TestReadUTXOWrapperFile_TruncatedFile_ReturnsError is the regression test
+// for the silent-truncation bug: a snapshot file cut off partway through a
+// UTXOWrapper record - here, mid-way through the second record's 32-byte
+// TxID, well short of the real footer - must be rejected outright rather
+// than misread as a clean end-of-records boundary.
+//
+// This exact cut point matters: NewUTXOWrapperFromReader's short read on the
+// TxID field is wrapped into a *errors.Error whose rendered message is
+// "...unexpected EOF", and the seeder's old `errors.Is(err, io.EOF)` check
+// matched it via this package's substring-matching Is() fallback (io.EOF's
+// message "EOF" is a substring of "unexpected EOF") - so the truncation was
+// silently treated as a successful, complete import.
+func TestReadUTXOWrapperFile_TruncatedFile_ReturnsError(t *testing.T) {
+	metadata, wrapperBytes, _, _ := buildSnapshotWrappers(t)
+	require.Len(t, wrapperBytes, 2)
+
+	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
+
+	data := make([]byte, 0, len(header.Bytes())+len(metadata)+len(wrapperBytes[0])+10)
+	data = append(data, header.Bytes()...)
+	data = append(data, metadata...)
+	data = append(data, wrapperBytes[0]...)
+	// Cut off 10 bytes into the second record's 32-byte TxID: a genuine
+	// mid-record truncation, with no footer appended at all.
+	data = append(data, wrapperBytes[1][:10]...)
+
+	path := filepath.Join(t.TempDir(), "utxo-set-truncated.dat")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	f, reader := openForReading(t, path)
+
+	utxoWrapperCh := make(chan *utxopersister.UTXOWrapper, 10)
+
+	go func() {
+		for range utxoWrapperCh { //nolint:revive // drain channel
+		}
+	}()
+
+	err := readUTXOWrapperFile(context.Background(), ulogger.TestLogger{}, f, reader, utxoWrapperCh)
+	require.Error(t, err, "a truncated snapshot file must not be reported as a successful import")
+}


### PR DESCRIPTION
## Summary

Adds the two remaining tests from the original audit recommendation on the seeder's UTXO snapshot import path, alongside the truncated-file regression test in PR #1563:

- `TestSeederImport_RoundTripsRealSnapshotFile` - writes a `.utxo-set` file using the persister's own `UTXOWrapper` record encoding, feeds it through the seeder's import path (`readUTXOWrapperFile` -> `processUTXO`), and checks the actual record content (values, scripts, coinbase handling) survives into the UTXO store, not just that footer counts line up. Also asserts the surviving UTXO's actual on-disk index via `GetSpend`, not just its content, since the store's compacted read view can't otherwise distinguish a correctly-indexed UTXO from one landed at the wrong index by an import bug.
- `TestSeederImport_CompleteFile_FinishesCleanly` - feeds a well-formed, complete snapshot file through the same path and asserts it finishes without error, every record lands in the store, and the footer counts match what was actually processed.

Both share the existing `buildSnapshotWrappers` / `openForReading` / `newTestUtxoStore` helpers from `seeder_truncation_test.go` and `coinbase_restore_test.go` rather than adding new scaffolding.

This PR is now test-only. A real behavioral fix (headers-truncation detection) that was previously bundled into this branch has been split out into #1604 per review feedback, so it can be reviewed on its own terms.

## Dependency

This branches off `fix/audit-14-seeder-truncation-safety` (PR #1563), which introduces `readUTXOWrapperFile` and its footer validation. That PR is not yet merged, so this diff currently also contains its commit. It should be rebased onto `main` (and this PR's diff will shrink to just the new test file) once #1563 lands.

## Test plan

- [x] `go test ./cmd/seeder/... ./services/utxopersister/... -race`
- [x] `go vet ./cmd/seeder/... ./services/utxopersister/...`
- [x] `golangci-lint run cmd/seeder/...`
