### PR TITLE
docs(k8s): explain why HPA can't safely target the propagation deployment

### DIFF
--- a/docs/howto/miners/kubernetes/minersHowToInstallation.md
+++ b/docs/howto/miners/kubernetes/minersHowToInstallation.md
@@ -296,29 +296,31 @@ the propagation spec has no `deploymentOverrides` block yet — as in
 `teranode-cr.yaml` — add one.
 
 Not every service in the Cluster CR can be scaled this way. The validator can:
-`teranode-cr-mainnet.yaml` runs it with 8 replicas. Services such as block
-assembly and blockchain are single-instance — block assembly holds the mining
-jobs handed to miners and its assembler state per process, so a second replica
-would lose solved blocks and clobber that state. That is why the example CRs set
-`replicas: 1` for every service except the validator.
+`teranode-cr-mainnet.yaml` runs it with 8 replicas (`teranode-cr.yaml` ships the
+validator disabled, with an empty spec). Services such as block assembly and
+blockchain are single-instance — block assembly holds the mining jobs handed to
+miners and its assembler state per process, so a second replica would lose
+solved blocks and clobber that state. That is why every
+`deploymentOverrides.replicas` entry in both example CRs is `1`, the one
+exception being the validator in `teranode-cr-mainnet.yaml`.
 
-There is currently no supported way to put a `HorizontalPodAutoscaler` in front
-of the operator-managed propagation Deployment. The Teranode Operator's
-`Propagation` custom resource does declare a Kubernetes `/scale` subresource,
-which is the mechanism an HPA would normally use to target a custom resource
-directly. In practice this doesn't hold up: the parent `Cluster` controller
-reconciles every child resource, including `Propagation`, both on a fixed
-one-minute timer and whenever the `Propagation` object's spec changes (which an
-HPA writing to `/scale` would trigger). On each of those reconciles it
-overwrites the entire `Propagation` spec — including the replica count — with
-whatever is stored in the `Cluster` CR itself. Any replica count an HPA sets
-gets reverted within at most a minute, so autoscaling would silently flap
-rather than converge.
+A `HorizontalPodAutoscaler` that targets the `Propagation` custom resource's
+`/scale` endpoint will not work. The Teranode Operator's `Propagation` CR does
+declare a Kubernetes `/scale` subresource, with its `specReplicasPath` pointing
+at `.spec.deploymentOverrides.replicas`, which is the mechanism an HPA would
+normally use to target a custom resource directly. In practice this doesn't hold
+up: the parent `Cluster` controller reconciles every child resource, including
+`Propagation`, both on a fixed one-minute timer and whenever the `Propagation`
+object's spec changes (which an HPA writing to `/scale` would trigger). On each
+of those reconciles it overwrites the entire `Propagation` spec — including the
+replica count — with whatever is stored in the `Cluster` CR itself. Any replica
+count an HPA writes to `/scale` gets reverted within at most a minute, so
+autoscaling against that endpoint silently flaps rather than converging.
 
 Until the operator changes this reconcile behavior (e.g. by leaving
 externally-managed replica counts alone), manual scaling via
-`deploymentOverrides.replicas` remains the supported way to size the
-propagation service.
+`deploymentOverrides.replicas` in the `Cluster` CR remains the supported way to
+size the propagation service.
 
 ## Related Documentation
 

--- a/docs/howto/miners/kubernetes/minersHowToInstallation.md
+++ b/docs/howto/miners/kubernetes/minersHowToInstallation.md
@@ -14,6 +14,7 @@ Last modified: 29-October-2025
     - [Deploy Teranode](#deploy-teranode)
 - [Verifying the Deployment](#verifying-the-deployment)
 - [Production Considerations](#production-considerations)
+    - [Scaling the Propagation Service](#scaling-the-propagation-service)
 - [Other Resources](#other-resources)
 
 ## Introduction
@@ -284,6 +285,31 @@ For production deployments, consider:
 - Setting up proper backup and disaster recovery procedures
 
 An example CR for a mainnet deployment is available in [kubernetes/teranode/teranode-cr-mainnet.yaml](https://github.com/bsv-blockchain/teranode/blob/main/deploy/kubernetes/teranode/teranode-cr-mainnet.yaml).
+
+### Scaling the Propagation Service
+
+The propagation service (and every other service in the Cluster CR) is
+horizontally scalable: set `propagation.spec.deploymentOverrides.replicas` in
+`teranode-cr.yaml` (or `teranode-cr-mainnet.yaml`) to the desired pod count and
+re-apply the CR.
+
+There is currently no supported way to put a `HorizontalPodAutoscaler` in front
+of the operator-managed propagation Deployment. The Teranode Operator's
+`Propagation` custom resource does declare a Kubernetes `/scale` subresource,
+which is the mechanism an HPA would normally use to target a custom resource
+directly. In practice this doesn't hold up: the parent `Cluster` controller
+reconciles every child resource, including `Propagation`, both on a fixed
+one-minute timer and whenever the `Propagation` object's spec changes (which an
+HPA writing to `/scale` would trigger). On each of those reconciles it
+overwrites the entire `Propagation` spec — including the replica count — with
+whatever is stored in the `Cluster` CR itself. Any replica count an HPA sets
+gets reverted within at most a minute, so autoscaling would silently flap
+rather than converge.
+
+Until the operator changes this reconcile behavior (e.g. by leaving
+externally-managed replica counts alone), manual scaling via
+`deploymentOverrides.replicas` remains the supported way to size the
+propagation service.
 
 ## Related Documentation
 

--- a/docs/howto/miners/kubernetes/minersHowToInstallation.md
+++ b/docs/howto/miners/kubernetes/minersHowToInstallation.md
@@ -288,10 +288,19 @@ An example CR for a mainnet deployment is available in [kubernetes/teranode/tera
 
 ### Scaling the Propagation Service
 
-The propagation service (and every other service in the Cluster CR) is
-horizontally scalable: set `propagation.spec.deploymentOverrides.replicas` in
-`teranode-cr.yaml` (or `teranode-cr-mainnet.yaml`) to the desired pod count and
-re-apply the CR.
+The propagation service is stateless and horizontally scalable: set
+`propagation.enabled: true` (both shipped example CRs ship it disabled) and
+`propagation.spec.deploymentOverrides.replicas` in `teranode-cr.yaml` (or
+`teranode-cr-mainnet.yaml`) to the desired pod count, then re-apply the CR. If
+the propagation spec has no `deploymentOverrides` block yet — as in
+`teranode-cr.yaml` — add one.
+
+Not every service in the Cluster CR can be scaled this way. The validator can:
+`teranode-cr-mainnet.yaml` runs it with 8 replicas. Services such as block
+assembly and blockchain are single-instance — block assembly holds the mining
+jobs handed to miners and its assembler state per process, so a second replica
+would lose solved blocks and clobber that state. That is why the example CRs set
+`replicas: 1` for every service except the validator.
 
 There is currently no supported way to put a `HorizontalPodAutoscaler` in front
 of the operator-managed propagation Deployment. The Teranode Operator's


### PR DESCRIPTION
## Summary

An audit recommended shipping an example `HorizontalPodAutoscaler` manifest for the operator-managed propagation Deployment, as a convenience for operators who want automatic scale-out on top of the existing manual `deploymentOverrides.replicas` control.

Investigated whether that's actually wireable against the Teranode Operator before writing one. It isn't, so this ships a documentation note instead of a manifest that would silently misbehave.

## What I found

- The propagation service is manually horizontally scalable today via `propagation.spec.deploymentOverrides.replicas` in the Cluster CR — confirmed in `deploy/kubernetes/teranode/teranode-cr.yaml` and `teranode-cr-mainnet.yaml`.
- The operator's `Propagation` CRD (`api/v1alpha1/propagation_types.go` in `bsv-blockchain/teranode-operator`) does declare a `/scale` subresource (`+kubebuilder:subresource:scale:specpath=.spec.deploymentOverrides.replicas,...`), which is the mechanism an HPA normally uses to target a custom resource directly — so on paper this looks HPA-ready.
- In practice it isn't safe: the parent `Cluster` controller reconciles every child resource including `Propagation` (`cluster_controller.go`'s `ReconcileBatch`) both on a fixed one-minute `RequeueAfter` and whenever the `Propagation` object's own spec changes (which writing to `/scale` triggers, since it bumps `.metadata.generation` and the controller watches `Owns(&Propagation{})` with `GenerationChangedPredicate`). Each reconcile does `propagation.Spec = *cluster.Spec.Propagation.Spec` unconditionally — overwriting the replica count an HPA just set back to whatever's baked into the Cluster CR, within at most a minute.
- Net effect: pointing an HPA at the propagation Deployment (or at the Propagation CR's scale subresource) wouldn't converge — it would flap.

Given that, shipping an example HPA manifest would be worse than not shipping one: it would look like working autoscaling while actually racing the operator's own reconciler.

## Change

Added a "Scaling the Propagation Service" subsection to `docs/howto/miners/kubernetes/minersHowToInstallation.md` explaining the constraint and pointing at the supported manual-scaling path (`deploymentOverrides.replicas`).

## Test plan

- [x] Doc-only change; verified rendering and links via the existing markdown lint pre-commit hook (passed).
- [x] No manifest was added since none would actually function against the current operator.