### PR TITLE
test: skip container-backed tests without Docker, fix a port-bind test flake, fix gotestsum PATH fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ install-tools:
 .PHONY: test
 test:
 	@command -v gotestsum >/dev/null 2>&1 || { echo "gotestsum not found. Installing..."; $(MAKE) install-tools; }
-	SETTINGS_CONTEXT=test gotestsum --format pkgname -- -race -tags "testtxmetacache" -count=1 -timeout=10m -coverprofile=coverage.out -coverpkg=./... $$(go list ./... | grep -v github.com/bsv-blockchain/teranode/test/ | sort)
+	SETTINGS_CONTEXT=test $$(go env GOPATH)/bin/gotestsum --format pkgname -- -race -tags "testtxmetacache" -count=1 -timeout=10m -coverprofile=coverage.out -coverpkg=./... $$(go list ./... | grep -v github.com/bsv-blockchain/teranode/test/ | sort)
 
 # run tests in the test/longtest directory
 .PHONY: longtest

--- a/services/blockassembly/blockassembly_system_test.go
+++ b/services/blockassembly/blockassembly_system_test.go
@@ -74,6 +74,39 @@ func setupTest(t *testing.T) (*nodehelpers.BlockchainDaemon, *BlockAssembly, con
 	return nil, nil, nil, nil, nil
 }
 
+// startAttemptTimeout bounds how long attemptSetupTest waits, after readyCh
+// closes, for an error that Start's launcher goroutine may still be in the
+// process of delivering. Mirrors cleanupFn's own bounded wait below.
+const startAttemptTimeout = 200 * time.Millisecond
+
+// waitForEarlyStartErr waits for readyCh to close, then waits up to timeout
+// for a value on startErrCh.
+//
+// Start's own defer closes readyCh as Start itself is returning (see
+// Server.go's `defer closeOnce.Do(func() { close(readyCh) })`) - strictly
+// before its launcher goroutine resumes and sends the result on startErrCh.
+// Closing a channel only guarantees the receiver unblocks after the close; it
+// gives no guarantee about when the closing goroutine's later statements
+// (the send on startErrCh) execute relative to what the receiver does next.
+// A non-blocking check right after <-readyCh can therefore race ahead of
+// that send and miss a genuine startup failure. Bounding the wait gives the
+// launcher goroutine a window to deliver the error while still returning
+// promptly on the common (successful-start) path, where Start never returns
+// during the wait (it blocks in g.Wait() until shutdown).
+//
+// found is false when nothing arrived within timeout, which callers must
+// treat as "Start is still running", not "Start failed silently".
+func waitForEarlyStartErr(readyCh <-chan struct{}, startErrCh chan error, timeout time.Duration) (err error, found bool) {
+	<-readyCh
+
+	select {
+	case err = <-startErrCh:
+		return err, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
 // attemptSetupTest performs a single setup attempt, returning an error instead
 // of failing the test outright so setupTest can retry on a port-bind race. Any
 // resource it created before failing is cleaned up before returning the error.
@@ -165,13 +198,15 @@ func attemptSetupTest(t *testing.T) (daemon *nodehelpers.BlockchainDaemon, ba *B
 		startErrCh <- startErr
 	}()
 
-	<-readyCh // Wait for service to be ready (always closed, even on startup failure)
-
-	// A failed bind closes readyCh without the gRPC server ever listening; catch
-	// that here (bounded wait, Start already returned by the time readyCh closed
-	// on the failure path) rather than only in cleanup, so setupTest can retry.
-	select {
-	case startErr := <-startErrCh:
+	// A failed bind closes readyCh without the gRPC server ever listening. Start
+	// has not necessarily returned by the time readyCh closes on the failure
+	// path - its own defer closes readyCh as Start is in the process of
+	// returning, strictly before the launcher goroutine above resumes and sends
+	// on startErrCh - so waitForEarlyStartErr bounds the wait for that send
+	// instead of checking non-blockingly, which would race ahead of it and
+	// miss real startup failures. Catching it here (rather than only in
+	// cleanup) lets setupTest retry.
+	if startErr, found := waitForEarlyStartErr(readyCh, startErrCh, startAttemptTimeout); found {
 		if startErr != nil {
 			cancel()
 			blockchainDaemon.Stop()
@@ -181,8 +216,6 @@ func attemptSetupTest(t *testing.T) (daemon *nodehelpers.BlockchainDaemon, ba *B
 		// nil error: Start returned successfully. Re-buffer it so cleanup's own
 		// receive below still finds it.
 		startErrCh <- startErr
-	default:
-		// Start is still running (the common case): nothing to catch yet.
 	}
 
 	// Check for startup errors in cleanup, not in the goroutine
@@ -209,6 +242,65 @@ func attemptSetupTest(t *testing.T) (daemon *nodehelpers.BlockchainDaemon, ba *B
 	}
 
 	return blockchainDaemon, newBA, ctx, cancel, cleanupFn, nil
+}
+
+// TestWaitForEarlyStartErr_CatchesErrorSentShortlyAfterReadyClose reproduces
+// the exact ordering attemptSetupTest relies on: Start's own defer closes
+// readyCh as Start is returning, strictly before its launcher goroutine
+// resumes and sends the failure on startErrCh (see Server.go's
+// `defer closeOnce.Do(func() { close(readyCh) })`). A caller that checks
+// startErrCh non-blockingly immediately after <-readyCh can therefore race
+// ahead of that send and wrongly conclude "still starting" for a startup
+// that has, in fact, already failed. This test forces exactly that ordering
+// deterministically via a barrier channel (no reliance on real scheduler
+// timing) and asserts the failure is still caught within a bounded wait.
+func TestWaitForEarlyStartErr_CatchesErrorSentShortlyAfterReadyClose(t *testing.T) {
+	readyCh := make(chan struct{}, 1)
+	startErrCh := make(chan error, 1)
+	releaseSend := make(chan struct{})
+	wantErr := errors.NewProcessingError("simulated bind failure")
+
+	go func() {
+		close(readyCh) // simulates Start's deferred close(readyCh) on the failure path
+		<-releaseSend  // simulates the scheduling gap before the launcher goroutine resumes
+		startErrCh <- wantErr
+	}()
+
+	resultCh := make(chan struct {
+		err   error
+		found bool
+	}, 1)
+
+	go func() {
+		err, found := waitForEarlyStartErr(readyCh, startErrCh, 200*time.Millisecond)
+		resultCh <- struct {
+			err   error
+			found bool
+		}{err, found}
+	}()
+
+	// Give waitForEarlyStartErr a moment to reach its check before the send is
+	// released, so we know it genuinely waited rather than winning by luck.
+	time.Sleep(20 * time.Millisecond)
+	close(releaseSend)
+
+	result := <-resultCh
+	require.True(t, result.found, "expected the delayed startup error to be caught within the bounded wait")
+	require.ErrorIs(t, result.err, wantErr)
+}
+
+// TestWaitForEarlyStartErr_TreatsNoErrorWithinBoundAsStillStarting mirrors the
+// successful-start path, where Start never returns during setup (it blocks in
+// g.Wait()), so nothing is ever sent on startErrCh. waitForEarlyStartErr must
+// treat that as "still starting", not as a missed error.
+func TestWaitForEarlyStartErr_TreatsNoErrorWithinBoundAsStillStarting(t *testing.T) {
+	readyCh := make(chan struct{}, 1)
+	startErrCh := make(chan error, 1)
+	close(readyCh)
+
+	err, found := waitForEarlyStartErr(readyCh, startErrCh, 30*time.Millisecond)
+	require.False(t, found, "expected no early error to be reported when Start is still running")
+	require.NoError(t, err)
 }
 
 // TestHealth verifies the health check functionality of the block assembly service.

--- a/services/blockassembly/blockassembly_system_test.go
+++ b/services/blockassembly/blockassembly_system_test.go
@@ -44,14 +44,53 @@ func getFreePort(t *testing.T) int {
 
 // setupTest initializes the test environment and returns a cleanup function.
 // The cleanup function should be deferred by the calling test.
+//
+// Startup allocates "free" ports via listen-then-close (getFreePort) and binds
+// them again moments later in a separate gRPC server goroutine. Under
+// machine-wide parallel test load, another process can grab that exact port in
+// the gap between the two, which fails the blockchain/block-assembly gRPC
+// listener non-deterministically ("can't start GRPC server" / "connection
+// refused") — the classic flaky-under-parallel-load symptom, not a bug in the
+// code under test. Retrying the whole setup with freshly chosen ports resolves
+// it deterministically, the same way test/longtest/util/postgres/container.go
+// already retries the equivalent bind race for its Postgres container.
 func setupTest(t *testing.T) (*nodehelpers.BlockchainDaemon, *BlockAssembly, context.Context, context.CancelFunc, func()) {
-	err := os.RemoveAll("./data")
-	require.NoError(t, err)
+	const maxSetupAttempts = 3
+
+	var lastErr error
+
+	for attempt := 1; attempt <= maxSetupAttempts; attempt++ {
+		daemon, ba, ctx, cancel, cleanup, err := attemptSetupTest(t)
+		if err == nil {
+			return daemon, ba, ctx, cancel, cleanup
+		}
+
+		lastErr = err
+		t.Logf("setupTest: attempt %d/%d failed (likely a port-bind race under parallel load), retrying: %v", attempt, maxSetupAttempts, err)
+	}
+
+	t.Fatalf("setupTest: failed after %d attempts: %v", maxSetupAttempts, lastErr)
+
+	return nil, nil, nil, nil, nil
+}
+
+// attemptSetupTest performs a single setup attempt, returning an error instead
+// of failing the test outright so setupTest can retry on a port-bind race. Any
+// resource it created before failing is cleaned up before returning the error.
+func attemptSetupTest(t *testing.T) (daemon *nodehelpers.BlockchainDaemon, ba *BlockAssembly, ctx context.Context, cancel context.CancelFunc, cleanup func(), err error) {
+	if err = os.RemoveAll("./data"); err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
 
 	blockchainDaemon, err := nodehelpers.NewBlockchainDaemon(t)
-	require.NoError(t, err)
-	err = blockchainDaemon.StartBlockchainService()
-	require.NoError(t, err, "Failed to start blockchain service")
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+
+	if err = blockchainDaemon.StartBlockchainService(); err != nil {
+		blockchainDaemon.Stop()
+		return nil, nil, nil, nil, nil, errors.NewProcessingError("failed to start blockchain service", err)
+	}
 
 	// Setup block assembly service
 	tSettings := blockchainDaemon.Settings
@@ -63,7 +102,7 @@ func setupTest(t *testing.T) (*nodehelpers.BlockchainDaemon, *BlockAssembly, con
 	// Set DoubleSpendWindow to 0 so transactions are dequeued immediately in tests
 	tSettings.BlockAssembly.DoubleSpendWindow = 0
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(context.Background())
 	memStore := memory.New()
 	blobStore := memory.New()
 
@@ -71,24 +110,43 @@ func setupTest(t *testing.T) (*nodehelpers.BlockchainDaemon, *BlockAssembly, con
 	settings := test.CreateBaseTestSettings(t)
 
 	utxoStoreURL, err := url.Parse("sqlitememory:///test")
-	require.NoError(t, err)
+	if err != nil {
+		cancel()
+		blockchainDaemon.Stop()
+
+		return nil, nil, nil, nil, nil, err
+	}
 
 	utxoStore, err := sql.New(ctx, logger, settings, utxoStoreURL)
-	require.NoError(t, err)
+	if err != nil {
+		cancel()
+		blockchainDaemon.Stop()
+
+		return nil, nil, nil, nil, nil, err
+	}
 
 	// Use the blockchain client from the daemon which is already connected and running
-	ba := New(ulogger.TestLogger{}, tSettings, memStore, utxoStore, blobStore, blockchainDaemon.BlockchainClient)
-	require.NotNil(t, ba)
+	newBA := New(ulogger.TestLogger{}, tSettings, memStore, utxoStore, blobStore, blockchainDaemon.BlockchainClient)
+	if newBA == nil {
+		cancel()
+		blockchainDaemon.Stop()
+
+		return nil, nil, nil, nil, nil, errors.NewProcessingError("New returned a nil BlockAssembly")
+	}
 
 	// Skip waiting for pending blocks in tests to prevent hanging
-	ba.SetSkipWaitForPendingBlocks(true)
+	newBA.SetSkipWaitForPendingBlocks(true)
 
 	// Log the gRPC addresses
 	t.Logf("BlockAssembly GRPCListenAddress: %s", tSettings.BlockAssembly.GRPCListenAddress)
 	t.Logf("BlockAssembly GRPCAddress: %s", tSettings.BlockAssembly.GRPCAddress)
 
-	err = ba.Init(ctx)
-	require.NoError(t, err)
+	if err = newBA.Init(ctx); err != nil {
+		cancel()
+		blockchainDaemon.Stop()
+
+		return nil, nil, nil, nil, nil, err
+	}
 
 	readyCh := make(chan struct{}, 1)
 	startErrCh := make(chan error, 1)
@@ -101,38 +159,56 @@ func setupTest(t *testing.T) (*nodehelpers.BlockchainDaemon, *BlockAssembly, con
 			}
 		}()
 
-		err := ba.Start(ctx, readyCh)
+		startErr := newBA.Start(ctx, readyCh)
 		// Send error to channel instead of calling t.Errorf directly
 		// This avoids calling test methods after the test completes
-		startErrCh <- err
+		startErrCh <- startErr
 	}()
 
-	<-readyCh // Wait for service to be ready
+	<-readyCh // Wait for service to be ready (always closed, even on startup failure)
+
+	// A failed bind closes readyCh without the gRPC server ever listening; catch
+	// that here (bounded wait, Start already returned by the time readyCh closed
+	// on the failure path) rather than only in cleanup, so setupTest can retry.
+	select {
+	case startErr := <-startErrCh:
+		if startErr != nil {
+			cancel()
+			blockchainDaemon.Stop()
+
+			return nil, nil, nil, nil, nil, errors.NewProcessingError("failed to start block assembly service", startErr)
+		}
+		// nil error: Start returned successfully. Re-buffer it so cleanup's own
+		// receive below still finds it.
+		startErrCh <- startErr
+	default:
+		// Start is still running (the common case): nothing to catch yet.
+	}
 
 	// Check for startup errors in cleanup, not in the goroutine
-	cleanup := func() {
+	cleanupFn := func() {
 		// First cancel the context to stop ba.Start
 		cancel()
 
 		// Then check if there was a startup error
 		select {
-		case err := <-startErrCh:
+		case startErr := <-startErrCh:
 			// Only report errors if context wasn't cancelled
-			if err != nil && ctx.Err() == nil {
-				t.Errorf("Error starting block assembly service: %v", err)
+			if startErr != nil && ctx.Err() == nil {
+				t.Errorf("Error starting block assembly service: %v", startErr)
 			}
 		case <-time.After(100 * time.Millisecond):
 			// ba.Start is still running, that's okay
 		}
 
-		if err := ba.Stop(ctx); err != nil {
-			t.Logf("Error stopping block assembly service: %v", err)
+		if stopErr := newBA.Stop(ctx); stopErr != nil {
+			t.Logf("Error stopping block assembly service: %v", stopErr)
 		}
 
 		blockchainDaemon.Stop()
 	}
 
-	return blockchainDaemon, ba, ctx, cancel, cleanup
+	return blockchainDaemon, newBA, ctx, cancel, cleanupFn, nil
 }
 
 // TestHealth verifies the health check functionality of the block assembly service.

--- a/services/blockassembly/load_unmined_benchmark_test.go
+++ b/services/blockassembly/load_unmined_benchmark_test.go
@@ -63,7 +63,7 @@ func benchmarkLoadUnminedTransactions(b *testing.B, txCount int) {
 	// Initialize Aerospike container
 	b.Logf("Initializing Aerospike container...")
 	aerospikeURL, teardownAerospike, err := testAerospike.InitAerospikeContainer()
-	require.NoError(b, err)
+	test.SkipIfContainerUnavailable(b, err)
 
 	b.Cleanup(func() {
 		_ = teardownAerospike()
@@ -72,7 +72,7 @@ func benchmarkLoadUnminedTransactions(b *testing.B, txCount int) {
 	b.Logf("Aerospike container initialized at: %s", aerospikeURL)
 
 	postgresURL, teardownPostgres, err := postgres.SetupTestPostgresContainer()
-	require.NoError(b, err)
+	test.SkipIfContainerUnavailable(b, err)
 
 	b.Cleanup(func() {
 		_ = teardownPostgres()
@@ -261,7 +261,7 @@ func BenchmarkLoadUnminedTransactions_MixedStates(b *testing.B) {
 	// Initialize Aerospike container
 	b.Logf("Initializing Aerospike container...")
 	aerospikeURL, teardown, err := testAerospike.InitAerospikeContainer()
-	require.NoError(b, err)
+	test.SkipIfContainerUnavailable(b, err)
 
 	b.Cleanup(func() {
 		_ = teardown()

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -1348,9 +1348,7 @@ func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {
 // and validates transaction processing functionality against the distributed database backend.
 func Test_processTransactionInternalAerospike(t *testing.T) {
 	utxoStore, teardown, err := aerospike.InitAerospikeContainer()
-	if err != nil {
-		t.Skipf("Aerospike container not available: %v", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		_ = teardown()
@@ -1364,9 +1362,7 @@ func Test_processTransactionInternalAerospike(t *testing.T) {
 // and validates transaction processing functionality against the relational database backend.
 func Test_processTransactionInternalPostgres(t *testing.T) {
 	container, err := postgres.RunPostgresTestContainer(context.Background(), "propagation-test")
-	if err != nil {
-		t.Skipf("PostgreSQL container not available: %v", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	defer func() {
 		_ = container.Terminate(context.Background())

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -1348,7 +1348,9 @@ func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {
 // and validates transaction processing functionality against the distributed database backend.
 func Test_processTransactionInternalAerospike(t *testing.T) {
 	utxoStore, teardown, err := aerospike.InitAerospikeContainer()
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Aerospike container not available: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = teardown()
@@ -1362,7 +1364,9 @@ func Test_processTransactionInternalAerospike(t *testing.T) {
 // and validates transaction processing functionality against the relational database backend.
 func Test_processTransactionInternalPostgres(t *testing.T) {
 	container, err := postgres.RunPostgresTestContainer(context.Background(), "propagation-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("PostgreSQL container not available: %v", err)
+	}
 
 	defer func() {
 		_ = container.Terminate(context.Background())

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -985,9 +985,7 @@ func TestExtendedTxa1f6a4ffcfd7bb4775790932aff1f82ac6a9b3b3e76c8faf8b11328e948af
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/services/validator/Validator_test.go
+++ b/services/validator/Validator_test.go
@@ -985,7 +985,9 @@ func TestExtendedTxa1f6a4ffcfd7bb4775790932aff1f82ac6a9b3b3e76c8faf8b11328e948af
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/blockchain/sql/GetNextBlockID_test.go
+++ b/stores/blockchain/sql/GetNextBlockID_test.go
@@ -170,6 +170,7 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
@@ -218,6 +219,7 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
@@ -271,6 +273,7 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
@@ -333,6 +336,7 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))

--- a/stores/blockchain/sql/GetNextBlockID_test.go
+++ b/stores/blockchain/sql/GetNextBlockID_test.go
@@ -171,7 +171,6 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()
@@ -220,7 +219,6 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()
@@ -274,7 +272,6 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()
@@ -337,7 +334,6 @@ func TestGetNextBlockID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()

--- a/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
+++ b/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
@@ -37,6 +37,7 @@ func newSchemaTestDB(t *testing.T) (*url.URL, *usql.DB) {
 				WithStartupTimeout(5*time.Minute),
 		),
 	)
+	test.SkipIfContainerUnavailable(t, err)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
 

--- a/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
+++ b/stores/blockchain/sql/SchemaCurrent_PostgreSQL_test.go
@@ -38,7 +38,6 @@ func newSchemaTestDB(t *testing.T) (*url.URL, *usql.DB) {
 		),
 	)
 	test.SkipIfContainerUnavailable(t, err)
-	require.NoError(t, err)
 	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
 
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")

--- a/stores/blockchain/sql/StoreBlock_WithID_PostgreSQL_test.go
+++ b/stores/blockchain/sql/StoreBlock_WithID_PostgreSQL_test.go
@@ -32,6 +32,7 @@ func TestStoreBlockWithID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
@@ -77,6 +78,7 @@ func TestStoreBlockWithID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
@@ -139,6 +141,7 @@ func TestStoreBlockWithID_Postgres(t *testing.T) {
 					WithStartupTimeout(5*time.Minute),
 			),
 		)
+		test.SkipIfContainerUnavailable(t, err)
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))

--- a/stores/blockchain/sql/StoreBlock_WithID_PostgreSQL_test.go
+++ b/stores/blockchain/sql/StoreBlock_WithID_PostgreSQL_test.go
@@ -33,7 +33,6 @@ func TestStoreBlockWithID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()
@@ -79,7 +78,6 @@ func TestStoreBlockWithID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()
@@ -142,7 +140,6 @@ func TestStoreBlockWithID_Postgres(t *testing.T) {
 			),
 		)
 		test.SkipIfContainerUnavailable(t, err)
-		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, pgContainer.Terminate(ctx))
 		}()

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -965,6 +965,7 @@ func TestStoreBlock_WithPersistedAt_Postgres(t *testing.T) {
 				WithStartupTimeout(5*time.Minute),
 		),
 	)
+	test.SkipIfContainerUnavailable(t, err)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, pgContainer.Terminate(ctx))

--- a/stores/blockchain/sql/StoreBlock_test.go
+++ b/stores/blockchain/sql/StoreBlock_test.go
@@ -966,7 +966,6 @@ func TestStoreBlock_WithPersistedAt_Postgres(t *testing.T) {
 		),
 	)
 	test.SkipIfContainerUnavailable(t, err)
-	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, pgContainer.Terminate(ctx))
 	}()

--- a/stores/utxo/aerospike/aerospike_test.go
+++ b/stores/utxo/aerospike/aerospike_test.go
@@ -137,7 +137,9 @@ func TestUnmined(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 
 	container, err := runAerospikeTestContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -364,7 +366,9 @@ func TestLargeTxStoresExternally(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 
 	container, err := runAerospikeTestContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/aerospike_test.go
+++ b/stores/utxo/aerospike/aerospike_test.go
@@ -137,9 +137,7 @@ func TestUnmined(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 
 	container, err := runAerospikeTestContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -366,9 +364,7 @@ func TestLargeTxStoresExternally(t *testing.T) {
 	tSettings := test.CreateBaseTestSettings(t)
 
 	container, err := runAerospikeTestContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/index_test.go
+++ b/stores/utxo/aerospike/index_test.go
@@ -19,7 +19,9 @@ func TestCreateIndexIfNotExists(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := runAerospikeTestContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -75,7 +77,9 @@ func TestWaitForIndexReady(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := runAerospikeTestContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -132,7 +136,9 @@ func TestIndexWaiterAdapter(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := runAerospikeTestContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/index_test.go
+++ b/stores/utxo/aerospike/index_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/utxo/aerospike/pruner"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,9 +20,7 @@ func TestCreateIndexIfNotExists(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := runAerospikeTestContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -77,9 +76,7 @@ func TestWaitForIndexReady(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := runAerospikeTestContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -136,9 +133,7 @@ func TestIndexWaiterAdapter(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := runAerospikeTestContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/native_op_probe_test.go
+++ b/stores/utxo/aerospike/native_op_probe_test.go
@@ -32,9 +32,7 @@ func TestNativeTeranodeOpProbe_Container(t *testing.T) {
 	tSettings.Aerospike.UseNativeTeranodeOps = true
 
 	container, err := runAerospikeTestContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		_ = container.Terminate(ctx)

--- a/stores/utxo/aerospike/native_op_probe_test.go
+++ b/stores/utxo/aerospike/native_op_probe_test.go
@@ -32,7 +32,9 @@ func TestNativeTeranodeOpProbe_Container(t *testing.T) {
 	tSettings.Aerospike.UseNativeTeranodeOps = true
 
 	container, err := runAerospikeTestContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		_ = container.Terminate(ctx)

--- a/stores/utxo/aerospike/pruner/external_pruning_test.go
+++ b/stores/utxo/aerospike/pruner/external_pruning_test.go
@@ -24,7 +24,9 @@ func TestExternalTransactionPruning(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -122,7 +124,9 @@ func TestExternalTransactionOutputsOnlyPruning(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -212,7 +216,9 @@ func TestMultiRecordExternalTransactionPruning(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -345,7 +351,9 @@ func TestExternalFileAlreadyDeleted(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -425,7 +433,9 @@ func TestMixedExternalAndNormalTransactions(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/pruner/external_pruning_test.go
+++ b/stores/utxo/aerospike/pruner/external_pruning_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	aeroTest "github.com/bsv-blockchain/testcontainers-aerospike-go"
 	"github.com/stretchr/testify/assert"
@@ -24,9 +25,7 @@ func TestExternalTransactionPruning(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -124,9 +123,7 @@ func TestExternalTransactionOutputsOnlyPruning(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -216,9 +213,7 @@ func TestMultiRecordExternalTransactionPruning(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -351,9 +346,7 @@ func TestExternalFileAlreadyDeleted(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -433,9 +426,7 @@ func TestMixedExternalAndNormalTransactions(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/pruner/pruner_service_test.go
+++ b/stores/utxo/aerospike/pruner/pruner_service_test.go
@@ -38,7 +38,9 @@ func TestCleanupServiceLogicWithoutProcessor(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -229,7 +231,9 @@ func TestServiceStartStop(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	host, err := container.Host(ctx)
 	require.NoError(t, err)
@@ -276,7 +280,9 @@ func TestDeleteAtHeight(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Aerospike container not available (%v)", err)
+	}
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/aerospike/pruner/pruner_service_test.go
+++ b/stores/utxo/aerospike/pruner/pruner_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bsv-blockchain/teranode/stores/blob/memory"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/bsv-blockchain/teranode/util/uaerospike"
 	aeroTest "github.com/bsv-blockchain/testcontainers-aerospike-go"
 	"github.com/stretchr/testify/assert"
@@ -38,9 +39,7 @@ func TestCleanupServiceLogicWithoutProcessor(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)
@@ -231,9 +230,7 @@ func TestServiceStartStop(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	host, err := container.Host(ctx)
 	require.NoError(t, err)
@@ -280,9 +277,7 @@ func TestDeleteAtHeight(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := aeroTest.RunContainer(ctx)
-	if err != nil {
-		t.Skipf("Skipping: Aerospike container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		err = container.Terminate(ctx)

--- a/stores/utxo/sql/close_drain_postgres_test.go
+++ b/stores/utxo/sql/close_drain_postgres_test.go
@@ -34,7 +34,6 @@ func startPostgres(t *testing.T) *url.URL {
 		),
 	)
 	test.SkipIfContainerUnavailable(t, err)
-	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, pgContainer.Terminate(ctx)) })
 
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")

--- a/stores/utxo/sql/close_drain_postgres_test.go
+++ b/stores/utxo/sql/close_drain_postgres_test.go
@@ -33,6 +33,7 @@ func startPostgres(t *testing.T) *url.URL {
 				WithStartupTimeout(5*time.Minute),
 		),
 	)
+	test.SkipIfContainerUnavailable(t, err)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, pgContainer.Terminate(ctx)) })
 

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -36,6 +36,7 @@ func setupPostgresStore(t *testing.T) (*Store, context.Context) {
 				WithStartupTimeout(5*time.Minute),
 		),
 	)
+	test.SkipIfContainerUnavailable(t, err)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, pgContainer.Terminate(ctx))

--- a/stores/utxo/sql/unlock_batcher_postgres_test.go
+++ b/stores/utxo/sql/unlock_batcher_postgres_test.go
@@ -37,7 +37,6 @@ func setupPostgresStore(t *testing.T) (*Store, context.Context) {
 		),
 	)
 	test.SkipIfContainerUnavailable(t, err)
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, pgContainer.Terminate(ctx))
 	})

--- a/stores/utxo/tests/unmined_iterator_test.go
+++ b/stores/utxo/tests/unmined_iterator_test.go
@@ -30,9 +30,7 @@ func TestUnminedTxIteratorSQLite(t *testing.T) {
 
 func TestUnminedTxIteratorPostgres(t *testing.T) {
 	utxoStore, teardown, err := postgres.SetupTestPostgresContainer()
-	if err != nil {
-		t.Skipf("PostgreSQL container not available: %v", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	defer func() {
 		_ = teardown()
@@ -43,9 +41,7 @@ func TestUnminedTxIteratorPostgres(t *testing.T) {
 
 func TestUnminedTxIteratorAerospike(t *testing.T) {
 	utxoStore, teardown, err := aerospike.InitAerospikeContainer()
-	if err != nil {
-		t.Skipf("Aerospike container not available: %v", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	t.Cleanup(func() {
 		_ = teardown()

--- a/stores/utxo/tests/unmined_iterator_test.go
+++ b/stores/utxo/tests/unmined_iterator_test.go
@@ -30,7 +30,9 @@ func TestUnminedTxIteratorSQLite(t *testing.T) {
 
 func TestUnminedTxIteratorPostgres(t *testing.T) {
 	utxoStore, teardown, err := postgres.SetupTestPostgresContainer()
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("PostgreSQL container not available: %v", err)
+	}
 
 	defer func() {
 		_ = teardown()
@@ -41,7 +43,9 @@ func TestUnminedTxIteratorPostgres(t *testing.T) {
 
 func TestUnminedTxIteratorAerospike(t *testing.T) {
 	utxoStore, teardown, err := aerospike.InitAerospikeContainer()
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Aerospike container not available: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = teardown()

--- a/util/kafka/flush_bytes_regression_test.go
+++ b/util/kafka/flush_bytes_regression_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
@@ -58,9 +59,7 @@ func startRedpanda(t *testing.T, ctx context.Context) (brokerAddr string, cleanu
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		t.Skipf("Skipping: Redpanda container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	return fmt.Sprintf("localhost:%d", port), func() {
 		_ = container.Terminate(context.Background())

--- a/util/kafka/flush_bytes_regression_test.go
+++ b/util/kafka/flush_bytes_regression_test.go
@@ -58,7 +58,9 @@ func startRedpanda(t *testing.T, ctx context.Context) (brokerAddr string, cleanu
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping: Redpanda container not available (%v)", err)
+	}
 
 	return fmt.Sprintf("localhost:%d", port), func() {
 		_ = container.Terminate(context.Background())

--- a/util/kafka/kafkatest/kafkatest.go
+++ b/util/kafka/kafkatest/kafkatest.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/util/test"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
@@ -41,8 +42,10 @@ type Env struct {
 	mu         sync.Mutex
 }
 
-// MustStartEnv starts a single-node Redpanda container. It calls t.Fatal on
-// error and registers a cleanup function so callers don't need to defer Close.
+// MustStartEnv starts a single-node Redpanda container. It skips the test if
+// the container runtime itself is unavailable, calls t.Fatal on any other
+// startup error, and registers a cleanup function so callers don't need to
+// defer Close.
 func MustStartEnv(t testing.TB, ctx context.Context) *Env {
 	t.Helper()
 
@@ -76,9 +79,7 @@ func MustStartEnv(t testing.TB, ctx context.Context) *Env {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		t.Skipf("kafkatest: Redpanda container not available (%v)", err)
-	}
+	test.SkipIfContainerUnavailable(t, err)
 
 	env := &Env{
 		Container:  container,

--- a/util/kafka/kafkatest/kafkatest.go
+++ b/util/kafka/kafkatest/kafkatest.go
@@ -77,7 +77,7 @@ func MustStartEnv(t testing.TB, ctx context.Context) *Env {
 		Started:          true,
 	})
 	if err != nil {
-		t.Fatalf("kafkatest: start redpanda: %v", err)
+		t.Skipf("kafkatest: Redpanda container not available (%v)", err)
 	}
 
 	env := &Env{

--- a/util/test/helpers.go
+++ b/util/test/helpers.go
@@ -1,12 +1,13 @@
 package test
 
 import (
+	"context"
 	"net/url"
 	"os"
-	"testing"
 
 	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/testcontainers/testcontainers-go"
 )
 
 type TestingT interface {
@@ -56,12 +57,53 @@ func CreateBaseTestSettings(t TestingT) *settings.Settings {
 	return tSettings
 }
 
-// SkipIfContainerUnavailable skips the current test with a clear reason when
-// starting a TestContainers-backed dependency (Docker/OrbStack) failed,
-// instead of letting the test fail hard when no container runtime is
-// reachable. Pass the error returned directly from the container-start call.
-func SkipIfContainerUnavailable(t *testing.T, err error) {
+// containerRuntimeHealthProbe reports whether the TestContainers-backed
+// container runtime (Docker/OrbStack) is reachable and healthy. It is a
+// package variable so tests can substitute a fake probe; production code
+// always uses dockerRuntimeHealth.
+var containerRuntimeHealthProbe = dockerRuntimeHealth
+
+// dockerRuntimeHealth asks testcontainers-go itself whether the configured
+// Docker provider is reachable, the same check testcontainers-go's own
+// SkipIfProviderIsNotHealthy performs. Reusing it avoids re-implementing
+// fragile matching against Docker's connection-error strings.
+func dockerRuntimeHealth(ctx context.Context) error {
+	provider, err := testcontainers.ProviderDocker.GetProvider()
 	if err != nil {
-		t.Skipf("skipping: container runtime unavailable: %v", err)
+		return err
 	}
+
+	return provider.Health(ctx)
+}
+
+// skipT is the subset of *testing.T (and testing.TB) SkipIfContainerUnavailable
+// needs. Declared as an interface, rather than requiring *testing.T directly,
+// so tests can substitute a fake and assert the skip-vs-fail decision without
+// the assertion itself skipping or failing the real test.
+type skipT interface {
+	Helper()
+	Skipf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+}
+
+// SkipIfContainerUnavailable skips the current test only when the container
+// runtime backing TestContainers (Docker/OrbStack) is genuinely unreachable.
+// Pass the error returned directly from the container-start call: if it is
+// nil, this is a no-op. If it is non-nil, the runtime is probed independently
+// of the error's content - a failure unrelated to runtime availability (a
+// missing fixture, an image-pull failure, a readiness-check timeout, etc.)
+// fails the test instead of being silently reported as skipped.
+func SkipIfContainerUnavailable(t skipT, err error) {
+	t.Helper()
+
+	if err == nil {
+		return
+	}
+
+	if probeErr := containerRuntimeHealthProbe(context.Background()); probeErr != nil {
+		t.Skipf("skipping: container runtime unavailable: %v", probeErr)
+		return
+	}
+
+	t.Fatalf("container setup failed for a reason other than runtime unavailability: %v", err)
 }

--- a/util/test/helpers.go
+++ b/util/test/helpers.go
@@ -3,6 +3,7 @@ package test
 import (
 	"net/url"
 	"os"
+	"testing"
 
 	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -53,4 +54,14 @@ func CreateBaseTestSettings(t TestingT) *settings.Settings {
 	}
 
 	return tSettings
+}
+
+// SkipIfContainerUnavailable skips the current test with a clear reason when
+// starting a TestContainers-backed dependency (Docker/OrbStack) failed,
+// instead of letting the test fail hard when no container runtime is
+// reachable. Pass the error returned directly from the container-start call.
+func SkipIfContainerUnavailable(t *testing.T, err error) {
+	if err != nil {
+		t.Skipf("skipping: container runtime unavailable: %v", err)
+	}
 }

--- a/util/test/skip_container_test.go
+++ b/util/test/skip_container_test.go
@@ -1,0 +1,109 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSkipT is a minimal skipT double that records whether Skipf or Fatalf
+// was called, without terminating the goroutine the way the real *testing.T
+// methods do - letting the table test assert the outcome instead of actually
+// failing/skipping itself.
+type fakeSkipT struct {
+	skippedMsg string
+	failedMsg  string
+}
+
+func (f *fakeSkipT) Helper() {}
+
+func (f *fakeSkipT) Skipf(format string, args ...interface{}) {
+	f.skippedMsg = fmt.Sprintf(format, args...)
+}
+
+func (f *fakeSkipT) Fatalf(format string, args ...interface{}) {
+	f.failedMsg = fmt.Sprintf(format, args...)
+}
+
+// withContainerRuntimeHealthProbe swaps the package's Docker/OrbStack health
+// probe for the duration of a test, restoring the previous probe on return.
+func withContainerRuntimeHealthProbe(t *testing.T, probe func(context.Context) error) {
+	t.Helper()
+
+	original := containerRuntimeHealthProbe
+	containerRuntimeHealthProbe = probe
+
+	t.Cleanup(func() {
+		containerRuntimeHealthProbe = original
+	})
+}
+
+// TestSkipIfContainerUnavailable_NilErr verifies the helper is a no-op when
+// the container-start call it guards succeeded.
+func TestSkipIfContainerUnavailable_NilErr(t *testing.T) {
+	withContainerRuntimeHealthProbe(t, func(context.Context) error {
+		t.Fatal("health probe must not run when err is nil")
+		return nil
+	})
+
+	ft := &fakeSkipT{}
+	SkipIfContainerUnavailable(ft, nil)
+
+	require.Empty(t, ft.skippedMsg, "should not skip on a nil error")
+	require.Empty(t, ft.failedMsg, "should not fail on a nil error")
+}
+
+// TestSkipIfContainerUnavailable_RuntimeDown asserts that when the container
+// runtime itself is genuinely unreachable, the helper skips the test -
+// regardless of what the underlying start error says.
+func TestSkipIfContainerUnavailable_RuntimeDown(t *testing.T) {
+	startErrs := map[string]error{
+		"docker daemon unreachable": errors.NewError(
+			"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"),
+		"generic start failure": errors.NewError("failed to start postgres container"),
+	}
+
+	for name, startErr := range startErrs {
+		t.Run(name, func(t *testing.T) {
+			withContainerRuntimeHealthProbe(t, func(context.Context) error {
+				return errors.NewError("Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?")
+			})
+
+			ft := &fakeSkipT{}
+			SkipIfContainerUnavailable(ft, startErr)
+
+			require.NotEmpty(t, ft.skippedMsg, "expected the test to be skipped when the container runtime is down")
+			require.Empty(t, ft.failedMsg, "should not fail when the container runtime is down")
+		})
+	}
+}
+
+// TestSkipIfContainerUnavailable_NonRuntimeErrors asserts that the concrete,
+// confirmed-non-Docker failure modes fail the test loudly instead of being
+// silently skipped, as long as the container runtime itself is healthy.
+func TestSkipIfContainerUnavailable_NonRuntimeErrors(t *testing.T) {
+	startErrs := map[string]error{
+		"project root not found":              errors.NewError("could not resolve absolute path for init script: project root (go.mod) not found"),
+		"container not running after startup": errors.NewError("postgres container is not running after startup"),
+		"db connection verify failed":         errors.NewError("failed to verify database connection: dial tcp 127.0.0.1:5432: connect: connection refused"),
+		"readiness timeout":                   errors.NewError("timeout waiting for database to be ready"),
+		"image pull rate limit":               errors.NewError("failed to pull image postgres:latest: toomanyrequests: You have reached your pull rate limit"),
+	}
+
+	for name, startErr := range startErrs {
+		t.Run(name, func(t *testing.T) {
+			withContainerRuntimeHealthProbe(t, func(context.Context) error {
+				return nil // container runtime is healthy
+			})
+
+			ft := &fakeSkipT{}
+			SkipIfContainerUnavailable(ft, startErr)
+
+			require.NotEmpty(t, ft.failedMsg, "expected the test to fail (not skip) when the runtime is healthy but start failed")
+			require.Empty(t, ft.skippedMsg, "should not skip when the runtime is healthy")
+		})
+	}
+}

--- a/util/usql/advisory_lock_test.go
+++ b/util/usql/advisory_lock_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/util/test"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +37,7 @@ func newPostgresTestDB(t *testing.T) *DB {
 				WithStartupTimeout(5*time.Minute),
 		),
 	)
+	test.SkipIfContainerUnavailable(t, err)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
 

--- a/util/usql/advisory_lock_test.go
+++ b/util/usql/advisory_lock_test.go
@@ -38,7 +38,6 @@ func newPostgresTestDB(t *testing.T) *DB {
 		),
 	)
 	test.SkipIfContainerUnavailable(t, err)
-	require.NoError(t, err)
 	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
 
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")


### PR DESCRIPTION
## Summary

- Several Postgres- and Aerospike-backed unit tests called `require.NoError` directly on the container-start error, so they failed hard instead of skipping when no container runtime (Docker/OrbStack) is reachable. Brought them in line with the skip-with-reason pattern already used elsewhere in the suite (`t.Skipf` on container-start failure), across `stores/blockchain/sql`, `stores/utxo/sql`, `stores/utxo/aerospike` (and its `pruner` package), `stores/utxo/tests`, `util/usql`, `util/kafka`, `services/validator`, and `services/propagation`.
- `Test_CoinbaseSubsidyHeight` (and its siblings in the same test file) start a throwaway blockchain daemon and block-assembly gRPC server on OS-assigned free ports. Reproduced the flake under machine-wide parallel load: the gap between listen-then-close (to pick a free port) and the later gRPC bind lets another process grab that exact port, failing startup non-deterministically ("can't start GRPC server" / connection refused). Retried the whole test setup with freshly chosen ports on that failure, the same way the Postgres test-container helper already retries its own bind race.
- The `test` Makefile recipe's `gotestsum` fallback only installs the binary into `GOPATH/bin` but still invoked the bare `gotestsum` command, which fails on a fresh checkout that hasn't added `GOPATH/bin` to `PATH`. Now invokes it via `$(go env GOPATH)/bin/gotestsum`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (no new findings; two pre-existing unrelated findings in `test/utils/helper.go` / `test/utils/transaction_helper.go`)
- [x] `golangci-lint run` on touched packages (0 issues; 5 pre-existing `prealloc` findings in untouched files)
- [x] Reproduced the original `Test_CoinbaseSubsidyHeight` port-bind flake under real parallel load (multiple concurrent OS processes), confirmed it no longer reproduces with the fix
- [x] `go test -race -count=5 -run Test_CoinbaseSubsidyHeight ./services/blockassembly/...` — green
- [x] `SETTINGS_CONTEXT=test go test -tags testtxmetacache ./util/test/... ./util/usql/... ./util/kafka/... ./stores/blockchain/sql/... ./stores/utxo/sql/... ./stores/utxo/tests/... ./stores/utxo/aerospike/... ./services/validator/... ./services/propagation/...` — green, with the previously-hard-failing container tests now skipping cleanly when no Docker/OrbStack is reachable