### PR TITLE
MvP-1374 docs(blockvalidation): state the attribution invariants on recordCatchupPeerFailure

### DIFF
--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -611,17 +611,26 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 // its context (context.WithoutCancel) so an aborted fetch still finishes writing,
 // but the goroutine stays inside the errgroup fetchSubtreeDataForBlock waits on,
 // which blockWorker waits on, which catchup waits on before releaseCatchupLock
-// clears the context. A slow peer can therefore delay the end of its cycle — up to
-// the subtree_data fetch timeout — but can never outlive it, so a failure raised by
-// a catchup's own fetch is never charged to a later cycle nor dropped into a cleared
+// clears the context. A slow peer can therefore delay the end of its cycle but can
+// never outlive it. That delay is not a single subtree_data fetch timeout: the
+// deadline is installed per call with no shared budget, and one subtree makes up to
+// two calls per peer (a cache-bypass retry) across each alternative peer, so the
+// drain ceiling is a multiple of that timeout — see fetchAndStoreSubtreeAndSubtreeData.
+// The bound is larger in magnitude but still finite, so a failure raised by a
+// catchup's own fetch is never charged to a later cycle nor dropped into a cleared
 // context. Making any fetch on that path fire-and-forget breaks this and requires the
 // cycle to be threaded from the caller instead.
 //
 // Not every caller is a catchup. RevalidateBlock reaches this path through
 // fetchSubtreeDataForBlock on its own gRPC goroutine with no interlock against a
-// running catchup, so its per-subtree failures land in that cycle's failedPeers and
-// are charged when the cycle drains. The peer blamed is the one that actually failed
-// to serve the data, so the charge is right by peer and wrong only by cycle.
+// running catchup, so its per-subtree failures land in whatever catchup cycle is
+// active. releaseCatchupLock drains failedPeers only inside its *err != nil branch,
+// so those failures are charged only if that concurrent cycle itself ends in error;
+// a cycle that succeeds discards the map untouched and the RevalidateBlock failure is
+// then charged to no one. When a failure is charged, it lands on the peer that
+// returned it for that fetch, not on some other peer; that does not prove the peer
+// deserves a reputational charge, because a peer that 404s subtree data the pruner
+// removed did nothing wrong.
 func (u *Server) recordCatchupPeerFailure(peerID string, err error) {
 	if peerID == "" || err == nil || errors.IsLocalError(err) {
 		return

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -595,13 +595,33 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 }
 
 // recordCatchupPeerFailure attributes a data-serving failure to the peer that caused
-// it, for the current catchup cycle. Best-effort: with no active catchup context
-// (e.g. a direct block fetch outside catchup) the call is a no-op.
+// it, charging it against whichever catchup cycle is active when the call is made.
+// Best-effort: with no cycle active the call is a no-op.
 //
 // errors.IsLocalError is checked here — not at each call site — so every caller
 // gets the guard for free: a context cancellation (catchup abort / peer switch /
 // shutdown landing mid-retry) or a local storage failure (subtreeStore.Set) is ours,
 // not the peer's, and must never land an innocent peer in failedPeers.
+//
+// Attribution reads the server-wide u.activeCatchupCtx rather than taking a cycle
+// from the caller. Two properties define the limits of that read, and both are worth
+// re-checking before changing anything on this path.
+//
+// A catchup cycle outlives every fetch it starts. fetchAndStoreSubtreeData detaches
+// its context (context.WithoutCancel) so an aborted fetch still finishes writing,
+// but the goroutine stays inside the errgroup fetchSubtreeDataForBlock waits on,
+// which blockWorker waits on, which catchup waits on before releaseCatchupLock
+// clears the context. A slow peer can therefore delay the end of its cycle — up to
+// the subtree_data fetch timeout — but can never outlive it, so a failure raised by
+// a catchup's own fetch is never charged to a later cycle nor dropped into a cleared
+// context. Making any fetch on that path fire-and-forget breaks this and requires the
+// cycle to be threaded from the caller instead.
+//
+// Not every caller is a catchup. RevalidateBlock reaches this path through
+// fetchSubtreeDataForBlock on its own gRPC goroutine with no interlock against a
+// running catchup, so its per-subtree failures land in that cycle's failedPeers and
+// are charged when the cycle drains. The peer blamed is the one that actually failed
+// to serve the data, so the charge is right by peer and wrong only by cycle.
 func (u *Server) recordCatchupPeerFailure(peerID string, err error) {
 	if peerID == "" || err == nil || errors.IsLocalError(err) {
 		return

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -619,7 +619,11 @@ func (u *Server) releaseCatchupLock(ctx *CatchupContext, err *error) {
 // The bound is larger in magnitude but still finite, so a failure raised by a
 // catchup's own fetch is never charged to a later cycle nor dropped into a cleared
 // context. Making any fetch on that path fire-and-forget breaks this and requires the
-// cycle to be threaded from the caller instead.
+// cycle to be threaded from the caller instead — as would an injected
+// fetchSubtreeDataForBlockFn that does not preserve that join.
+// In adaptive-fetch optimistic mode the per-subtree fetch is skipped entirely, so on
+// that branch there is nothing to join and the guarantee holds vacuously rather than
+// by the join above.
 //
 // Not every caller is a catchup. RevalidateBlock reaches this path through
 // fetchSubtreeDataForBlock on its own gRPC goroutine with no interlock against a


### PR DESCRIPTION
Resolves https://github.com/bsv-blockchain/teranode/issues/1374

Follow-up from the review of #1371. Comment-only: one doc comment in
`services/blockvalidation/catchup.go`, no behaviour change.

## Why

`recordCatchupPeerFailure` resolves the failing peer's catchup cycle from the server-wide
`u.activeCatchupCtx` rather than from its caller. Two properties define the limits of that read and
neither was written down, so the next reader has to re-derive both.

The old comment also said that a call outside catchup is a no-op. That holds only when no catchup is
running, which is not the same claim.

## Correction to the issue's premise

The issue asks the comment to say a detached fetch can outlive its cycle and be charged to the next
one. **That is not reachable on the current tree**, so the comment does not say it.

A fetch detached with `context.WithoutCancel` still runs inside the errgroup that
`fetchSubtreeDataForBlock` waits on (`get_blocks.go:430`), which `blockWorker` waits on
(`get_blocks.go:133`), which `catchup` waits on (`catchup.go:1041`) before the deferred
`releaseCatchupLock` clears `activeCatchupCtx` (`catchup.go:473`). A slow peer can delay the end of
its cycle; it cannot survive it. Writing the issue's text verbatim would have documented a
non-existent bug.

What *is* reachable through the same global read is `RevalidateBlock` (`Server.go:1254`): it runs on
its own gRPC goroutine with no interlock against a running catchup, so its per-subtree failures are
booked against whatever cycle happens to be live. The peer blamed is the one that actually failed, so
the charge is right by peer and wrong only by cycle.

The comment therefore records the join as an invariant to preserve (breaking it by making any fetch
on that path fire-and-forget would require threading the cycle from the caller) and the
`RevalidateBlock` overlap as the live caveat.

## Scope

One hunk in `services/blockvalidation/catchup.go`, comment lines only. The `failedPeers` field
comment is untouched — #1372 owns it.

## Verification

`gofmt`, `go build`, `go vet`, `make lint` (0 issues) clean. `services/blockvalidation` green with
and without `-race`, 0 data races. Inertness is proven by the diff shape: one file, every changed
line a comment.

## Follow-up

The `RevalidateBlock` attribution non-determinism deserves its own issue — the fix is to thread a
nil-able `*CatchupContext` from `fetchSubtreeDataForBlock` down to `recordCatchupPeerFailure` and
decide whether non-catchup failures need their own reporting sink. Not bundled here.