### PR TITLE
docs: list all wired Kafka topics in microservices overview

### DIFF
--- a/docs/topics/architecture/teranode-microservices-overview.md
+++ b/docs/topics/architecture/teranode-microservices-overview.md
@@ -511,6 +511,10 @@ Kafka serves as the messaging middleware for inter-service communication in Tera
 - `kafka_blocksConfig`: Used for propagating new blocks from P2P to Block Validation
 - `kafka_subtreesConfig`: Used for sending new subtrees from P2P to Subtree Validation
 - `kafka_blocksFinalConfig`: Used for sending finalized blocks from Blockchain to Block Persister
+- `kafka_invalidBlocksConfig`: Used for notifying P2P about blocks that failed validation, for peer reputation management
+- `kafka_invalidSubtreesConfig`: Used for notifying P2P about subtrees that failed validation, for peer quality tracking
+- `kafka_txPolicyRejectedConfig`: Used for sending consensus-valid but policy-rejected transactions from Validator to Subtree Validation
+- `kafka_legacyInvConfig`: Used by the Legacy Sync Manager to bridge legacy Bitcoin wire protocol inventory messages to and from Kafka
 
 **Key Features:**
 


### PR DESCRIPTION
## Summary

The Kafka section of the microservices overview doc listed only 6 topics, undercounting the topics actually wired up as producers/consumers in `daemon/daemon_kafka.go` and `services/legacy/netsync/manager.go`. Added the four missing ones: `kafka_invalidBlocksConfig`, `kafka_invalidSubtreesConfig`, `kafka_txPolicyRejectedConfig`, and `kafka_legacyInvConfig`, bringing the documented list to the full 10 real topics.

Note: the related stale "currently unused in codebase" note on the `kafka_validatortxsConfig` longdesc in `settings/kafka_settings.go` was already fixed by a prior PR (#1561) — this PR only addresses the topic-count undercount in the architecture doc.

## Test plan

- [x] Doc-only change, no functional test needed