### PR TITLE
Remove unused id-token: write permission from CI workflows

### DIFF
--- a/.github/workflows/chainintegrity.yaml
+++ b/.github/workflows/chainintegrity.yaml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  id-token: write
   packages: read
 
 env:
@@ -79,26 +78,26 @@ jobs:
           REQUIRED_HEIGHT=120
           MAX_ATTEMPTS=120  # 5 minutes with 5s sleep
           SLEEP=5
-          
+
           # Function to check for errors in all teranode container logs at once
           check_errors() {
             # Get current time for this check
             local current_time
             current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            
+
             # Check for errors - if last_check_time is empty, it will check all logs
             local since_param=""
             if [ ! -z "$last_check_time" ]; then
               since_param="--since=$last_check_time"
             fi
-            
+
             # Single command pattern that works for both initial and subsequent checks
             local errors
             errors=$(docker compose -f compose/docker-compose-chainintegrity.yml logs --no-color $since_param teranode1 teranode2 teranode3 | grep -i "| ERROR |" || true)
-            
+
             # Update timestamp for next check
             last_check_time=$current_time
-            
+
             if [[ ! -z "$errors" ]]; then
               echo "ERROR: Found error logs in teranode containers:"
               echo "$errors"
@@ -106,22 +105,22 @@ jobs:
             fi
             return 0
           }
-          
+
           # Initialize empty for first check to get all logs
           last_check_time=""
-          
+
           for ((i=1; i<=MAX_ATTEMPTS; i++)); do
             h1=$(curl -s http://localhost:18090/api/v1/bestblockheader/json | jq -r .height)
             h2=$(curl -s http://localhost:28090/api/v1/bestblockheader/json | jq -r .height)
             h3=$(curl -s http://localhost:38090/api/v1/bestblockheader/json | jq -r .height)
             echo "Attempt $i: heights: $h1 $h2 $h3"
-            
+
             # Check for errors in all teranode containers
             if ! check_errors; then
               echo "Errors found in container logs. Exiting."
               exit 1
             fi
-            
+
             if [[ -z "$h1" || -z "$h2" || -z "$h3" ]]; then
               if [[ $i -gt 10 ]]; then
                 echo "Error: One or more nodes are not responding after 10 attempts. Exiting."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 # Cancel any in-flight CCR run for the same PR when a new one starts.
 # Prevents zombie "In Progress" sticky comments when two reviews race on the same PR.

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -13,7 +13,6 @@ env:
 permissions:
   contents: read
   pull-requests: read
-  id-token: write
   packages: write
 
 jobs:

--- a/.github/workflows/teranode_main_build.yaml
+++ b/.github/workflows/teranode_main_build.yaml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      id-token: write
     secrets: inherit
 
   # Calculate version information
@@ -57,16 +56,3 @@ jobs:
       architectures: '["amd64", "arm64"]'
       runner_labels: '{"amd64":"teranode-runner-16-core","arm64":"teranode-runner-16-core-arm","manifest":"ubuntu-latest"}'
     secrets: inherit
-
-  # Run chain integrity test
-  # Disabled for now, since they depend on private teranode-commands/teranode-coinbase packages
-  #chainintegrity:
-  #  needs: build-and-deploy
-  #  uses: ./.github/workflows/chainintegrity-3blasters.yaml
-  #  # uses: ./.github/workflows/chainintegrity.yaml
-  #  permissions:
-  #    contents: read
-  #    pull-requests: read
-  #    id-token: write
-  #    packages: read
-  #  secrets: inherit

--- a/.github/workflows/teranode_main_tests.yaml
+++ b/.github/workflows/teranode_main_tests.yaml
@@ -14,7 +14,6 @@ env:
 permissions:
   contents: read
   pull-requests: read
-  id-token: write
 
 jobs:
   go-test:

--- a/.github/workflows/teranode_pr_smoketests.yaml
+++ b/.github/workflows/teranode_pr_smoketests.yaml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
-  id-token: write
 
 env:
   REPO: teranode

--- a/.github/workflows/teranode_pr_tests.yaml
+++ b/.github/workflows/teranode_pr_tests.yaml
@@ -15,7 +15,6 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 env:
   REPO: teranode


### PR DESCRIPTION
## Summary

An earlier fix removed AWS credential access from CI entirely (moved off long-lived keys), but several workflow files kept declaring an `id-token: write` permission left over from before that change. Nothing in these workflows consumes it — no `aws-actions/configure-aws-credentials` or other OIDC-consuming action is present.

- Removed unused `id-token: write` from:
  - `.github/workflows/teranode_main_tests.yaml`
  - `.github/workflows/nightly_tests.yaml`
  - `.github/workflows/teranode_pr_tests.yaml`
  - `.github/workflows/teranode_pr_smoketests.yaml`
  - `.github/workflows/claude-code-review.yml`
  - `.github/workflows/chainintegrity.yaml`
  - `.github/workflows/teranode_main_build.yaml` (`test_and_lint` job's own permission block, granted only for the now-cleaned-up local callee)
- Deleted a dead commented-out `chainintegrity` job block in `teranode_main_build.yaml` left over from the same cleanup.

Left alone: the `build-and-deploy` job in `teranode_main_build.yaml`, which calls the reusable workflow `bsv-blockchain/teranode-shared-workflows/.github/workflows/build_and_deploy.yaml@main`. That permission is passed through to a workflow defined in a different repository, so whether it's actually consumed there can't be verified from this repo — left untouched pending confirmation from that repo's maintainers.

## Follow-up (out of scope here)

`bsv-blockchain/teranode-shared-workflows` reportedly has ~3 more instances of the same leftover `id-token: write` permission. That's a separate repository, so cleaning those up is a follow-up for that repo's maintainers.

## Test plan

- [x] Confirmed via grep that none of the touched workflows reference `aws-actions/configure-aws-credentials` or any other OIDC-consuming action
- [x] Validated YAML syntax for all touched files (`YAML.load_file`)