### PR TITLE
docs(chainintegrity): correct comment on harness relationship

### DIFF
--- a/test/e2e/chainintegrity/chain_integrity_test.go
+++ b/test/e2e/chainintegrity/chain_integrity_test.go
@@ -33,7 +33,9 @@ const (
 )
 
 // TestChainIntegrity3Nodes tests chain integrity across 3 nodes with transaction load
-// This test replaces the docker-compose-3blasters.yml approach with a pure Go implementation
+// This is a pure Go implementation of the same scenario as docker-compose-3blasters.yml
+// (which still runs nightly against a full docker-compose stack); the two are
+// complementary, not a replacement of one by the other.
 func TestChainIntegrity3Nodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping chain integrity test in short mode")

--- a/test/e2e/chainintegrity/chain_integrity_test.go
+++ b/test/e2e/chainintegrity/chain_integrity_test.go
@@ -33,9 +33,12 @@ const (
 )
 
 // TestChainIntegrity3Nodes tests chain integrity across 3 nodes with transaction load
-// This is a pure Go implementation of the same scenario as docker-compose-3blasters.yml
-// (which still runs nightly against a full docker-compose stack); the two are
-// complementary, not a replacement of one by the other.
+// This is the in-process Go counterpart to the compose/docker-compose-3blasters.yml harness
+// (still run nightly): the two overlap but are complementary, not one superseding the other.
+// This test trades scale and real container-level P2P for fast, deep structural verification
+// (per-node block hashes, UTXO store, subtree fees, topological order, persister files); the
+// compose harness runs a much longer chain with an SV node in the network and establishes
+// node agreement by log hashing instead.
 func TestChainIntegrity3Nodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping chain integrity test in short mode")


### PR DESCRIPTION
## Summary
- The Go-based chain integrity test's header comment claimed it "replaces" the compose-based `docker-compose-3blasters.yml` nightly test. That's not accurate: the compose-based harness still runs nightly (`nightly_tests.yaml`, cron `0 2 * * *`) against a full docker-compose stack, while the Go harness (`test/e2e/chainintegrity`) runs on every PR via `make chainintegrity` in `teranode_pr_smoketests.yaml`. They exercise overlapping scenarios in different environments and are complementary, not one superseding the other.
- Reworded the comment to describe the relationship accurately.

## Note
Separately, the reusable `chainintegrity.yaml` / `chainintegrity-3blasters.yaml` workflows are currently disabled (commented out) in `teranode_main_build.yaml`. That's an unrelated, pre-existing state and not something this PR touches — if those are genuinely dead weight, retiring them would be a separate decision.

## Test plan
- [x] `go vet ./test/e2e/chainintegrity/...` (comment-only change)