### PR TITLE
Capture bug severity at intake via a template field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+## Severity (required)
+
+Select one and delete the others:
+
+- severity:critical
+- severity:major
+- severity:minor
+
 ## Describe the bug
 
 A clear and concise description of what the bug is.
@@ -32,7 +40,7 @@ If applicable, add screenshots to help explain your problem.
 
 When did the bug first occur, or when did you first notice it?
 
-## Desktop (please complete the following information):
+## Desktop (please complete the following information)
 
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,11 +9,11 @@ assignees: ''
 
 ## Severity (required)
 
-Select one and delete the others:
+Tick exactly one (see the [severity criteria](../../docs/howto/bugReporting.md#severity)):
 
-- severity:critical
-- severity:major
-- severity:minor
+- [ ] severity:critical — consensus failure, data loss or corruption, funds at risk, or a node that cannot sync or stay up, with no workaround
+- [ ] severity:major — a core function is broken or badly degraded (sustained throughput loss, a service needing manual restarts), but a workaround exists
+- [ ] severity:minor — cosmetic, documentation, or low-impact issues with an easy workaround
 
 ## Describe the bug
 

--- a/docs/howto/bugReporting.md
+++ b/docs/howto/bugReporting.md
@@ -48,12 +48,23 @@ Before submitting a bug report, gather the following information:
 
 ## Severity
 
-New bug reports must select a severity (`severity:critical`, `severity:major`, or
-`severity:minor`) using the "Severity" section of the bug report template, and the
-maintainer triaging the issue applies the matching `severity:*` label. This replaces
-the old convention of encoding severity in the issue title (e.g. `[P2P-003][medium]`)
-for new issues going forward — existing issue titles are not being changed
-retroactively.
+New bug reports must select a severity using the "Severity" section of the bug report
+template, and the maintainer triaging the issue applies the matching `severity:*` label.
+Choose the level that matches the observed impact:
+
+- `severity:critical` — consensus failure, data loss or corruption, funds at risk, or a
+  node that cannot sync or stay up. No workaround.
+- `severity:major` — a core function is broken or badly degraded (e.g. sustained
+  throughput loss, a service that needs manual restarts), but a workaround exists.
+- `severity:minor` — cosmetic, documentation, or low-impact issues with an easy
+  workaround.
+
+This replaces the old convention of encoding severity in the issue title (e.g.
+`[P2P-003][medium]`) for new issues going forward. The retired brackets were
+`[high]`/`[medium]`/`[low]`, which line up positionally with
+`critical`/`major`/`minor`; treat that as orientation when reading old issues, not as an
+exact equivalence — re-grade against the criteria above if it matters. Existing issue
+titles are not being changed retroactively and existing issues are not being relabelled.
 
 ## Submitting the Bug Report
 
@@ -69,10 +80,10 @@ When creating a new issue, GitHub will automatically load a template. The templa
 
 ```markdown
 ## Severity (required)
-Select one and delete the others:
-- severity:critical
-- severity:major
-- severity:minor
+Tick exactly one (see the severity criteria above):
+- [ ] severity:critical — consensus failure, data loss or corruption, funds at risk, or a node that cannot sync or stay up, with no workaround
+- [ ] severity:major — a core function is broken or badly degraded (sustained throughput loss, a service needing manual restarts), but a workaround exists
+- [ ] severity:minor — cosmetic, documentation, or low-impact issues with an easy workaround
 
 ## Describe the bug
 A clear and concise description of what the bug is.
@@ -93,7 +104,7 @@ If applicable, add screenshots to help explain your problem.
 ## Timeline
 When did the bug first occur, or when did you first notice it?
 
-## Desktop (please complete the following information):
+## Desktop (please complete the following information)
 
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]

--- a/docs/howto/bugReporting.md
+++ b/docs/howto/bugReporting.md
@@ -46,6 +46,15 @@ Before submitting a bug report, gather the following information:
 
     - Include any relevant visual information
 
+## Severity
+
+New bug reports must select a severity (`severity:critical`, `severity:major`, or
+`severity:minor`) using the "Severity" section of the bug report template, and the
+maintainer triaging the issue applies the matching `severity:*` label. This replaces
+the old convention of encoding severity in the issue title (e.g. `[P2P-003][medium]`)
+for new issues going forward — existing issue titles are not being changed
+retroactively.
+
 ## Submitting the Bug Report
 
 1. Go to the Teranode GitHub repository.
@@ -59,6 +68,12 @@ Before submitting a bug report, gather the following information:
 When creating a new issue, GitHub will automatically load a template. The template includes the following sections:
 
 ```markdown
+## Severity (required)
+Select one and delete the others:
+- severity:critical
+- severity:major
+- severity:minor
+
 ## Describe the bug
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
## Summary
- Adds a required "Severity" section to `.github/ISSUE_TEMPLATE/bug_report.md` with the `severity:critical` / `severity:major` / `severity:minor` options, so severity is captured at intake instead of assigned afterwards.
- Documents the new convention in `docs/howto/bugReporting.md`, retiring the old bracket-in-title convention (e.g. `[P2P-003][medium]`) for new issues.
- Fixes a pre-existing markdownlint trailing-punctuation violation on an unrelated heading in the same template file, needed to get the pre-commit hook to pass.

The three `severity:*` labels referenced here were created directly on the repo (not through this PR, since label creation isn't a code change).

Existing open issues are intentionally **not** being retroactively relabeled or retitled — this only changes the convention for new issues going forward.

## Test plan
- [x] `npx markdownlint-cli .github/ISSUE_TEMPLATE/bug_report.md docs/howto/bugReporting.md` passes
- [x] Front-matter of `bug_report.md` unchanged/still valid YAML (only body content added)