### PR TITLE
perf(blockassembly): use the currentTxMap subtree-index shortcut in batch tx removal

### DIFF
--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -2635,22 +2635,20 @@ func (stp *SubtreeProcessor) Remove(ctx context.Context, hash chainhash.Hash) er
 	return nil
 }
 
-func (stp *SubtreeProcessor) removeTxFromSubtrees(ctx context.Context, hash chainhash.Hash) error {
-	_, _, deferFn := tracing.Tracer("subtreeprocessor").Start(ctx, "removeTxFromSubtrees",
-		tracing.WithParentStat(stp.stats),
-		tracing.WithHistogram(prometheusSubtreeProcessorRemoveTx),
-		tracing.WithLogMessage(stp.logger, "[SubtreeProcessor][removeTxFromSubtrees][%s] removing transaction from subtrees", hash),
-	)
-
-	defer deferFn()
-
-	// find the transaction in the current and all chained subtrees
-	foundIndex := stp.currentSubtree.Load().NodeIndex(hash)
-	foundSubtreeIndex := -1
+// locateTxInSubtrees finds hash in the current subtree or one of the chained
+// subtrees, returning the node index within that subtree and which chained
+// subtree it was found in (-1 if it was found in the current subtree, or if
+// it was not found at all, in which case foundIndex is also -1).
+//
+// When DiskTxMap is active, currentTxMap.SubtreeIndex (stored as chainedIdx+1,
+// so >0 means assigned) gives an O(1) shortcut straight to the chained subtree
+// that holds the hash, avoiding a linear scan across every chained subtree.
+// Otherwise, or if that lookup misses, it falls back to scanning them all.
+func (stp *SubtreeProcessor) locateTxInSubtrees(hash chainhash.Hash) (foundIndex, foundSubtreeIndex int) {
+	foundIndex = stp.currentSubtree.Load().NodeIndex(hash)
+	foundSubtreeIndex = -1
 
 	if foundIndex == -1 {
-		// Use SubtreeIndex for O(1) lookup when DiskTxMap is active.
-		// SubtreeIndex is stored as chainedIdx+1, so >0 means assigned.
 		if stp.diskTxMap != nil {
 			if inpoints, found := stp.currentTxMap.Get(hash); found && inpoints.SubtreeIndex > 0 {
 				chainedIdx := int(inpoints.SubtreeIndex - 1)
@@ -2675,6 +2673,21 @@ func (stp *SubtreeProcessor) removeTxFromSubtrees(ctx context.Context, hash chai
 			}
 		}
 	}
+
+	return foundIndex, foundSubtreeIndex
+}
+
+func (stp *SubtreeProcessor) removeTxFromSubtrees(ctx context.Context, hash chainhash.Hash) error {
+	_, _, deferFn := tracing.Tracer("subtreeprocessor").Start(ctx, "removeTxFromSubtrees",
+		tracing.WithParentStat(stp.stats),
+		tracing.WithHistogram(prometheusSubtreeProcessorRemoveTx),
+		tracing.WithLogMessage(stp.logger, "[SubtreeProcessor][removeTxFromSubtrees][%s] removing transaction from subtrees", hash),
+	)
+
+	defer deferFn()
+
+	// find the transaction in the current and all chained subtrees
+	foundIndex, foundSubtreeIndex := stp.locateTxInSubtrees(hash)
 
 	if foundIndex >= 0 {
 		// Save to deleted backup map before removing (for Server fallback during async storage)
@@ -2746,19 +2759,7 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 
 	for _, hash := range hashes {
 		// find the transaction in the current and all chained subtrees
-		foundIndex := stp.currentSubtree.Load().NodeIndex(hash)
-		foundSubtreeIndex := -1
-
-		if foundIndex == -1 {
-			// not found in the current subtree, check chained subtrees
-			for subtreeIndex, subtree := range stp.chainedSubtrees {
-				idx := subtree.NodeIndex(hash)
-				if idx >= 0 {
-					foundSubtreeIndex = subtreeIndex
-					foundIndex = idx
-				}
-			}
-		}
+		foundIndex, foundSubtreeIndex := stp.locateTxInSubtrees(hash)
 
 		if foundIndex >= 0 {
 			removedAny = true

--- a/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
+++ b/services/blockassembly/subtreeprocessor/SubtreeProcessor.go
@@ -386,6 +386,15 @@ type SubtreeProcessor struct {
 	// goroutine; no synchronisation required.
 	disableCurrentTxMapPool bool
 
+	// disableSubtreeIndexShortcut forces locateTxInSubtrees to skip the
+	// currentTxMap.SubtreeIndex shortcut and always fall back to the linear
+	// scan, even when diskTxMap is active. Test-only: lets benchmarks and
+	// tests compare the shortcut against the fallback on the same DiskTxMap
+	// backend, isolating the algorithmic difference from backend cost. Only
+	// mutated before removeTxsFromSubtrees/removeTxFromSubtrees run; no
+	// synchronisation required.
+	disableSubtreeIndexShortcut bool
+
 	// clock is the source of wall time for codepaths that need a deterministic
 	// substitute in tests (validFromMillis calculations). Replaced in tests.
 	clock clock
@@ -2636,27 +2645,34 @@ func (stp *SubtreeProcessor) Remove(ctx context.Context, hash chainhash.Hash) er
 }
 
 // locateTxInSubtrees finds hash in the current subtree or one of the chained
-// subtrees, returning the node index within that subtree and which chained
+// subtrees, returning the node index within that subtree, which chained
 // subtree it was found in (-1 if it was found in the current subtree, or if
-// it was not found at all, in which case foundIndex is also -1).
+// it was not found at all, in which case foundIndex is also -1), and the
+// TxInpoints value that was already fetched from currentTxMap while resolving
+// the shortcut below (nil if the shortcut didn't run, so the caller must fetch
+// it itself if needed).
 //
 // When DiskTxMap is active, currentTxMap.SubtreeIndex (stored as chainedIdx+1,
 // so >0 means assigned) gives an O(1) shortcut straight to the chained subtree
 // that holds the hash, avoiding a linear scan across every chained subtree.
 // Otherwise, or if that lookup misses, it falls back to scanning them all.
-func (stp *SubtreeProcessor) locateTxInSubtrees(hash chainhash.Hash) (foundIndex, foundSubtreeIndex int) {
+func (stp *SubtreeProcessor) locateTxInSubtrees(hash chainhash.Hash) (foundIndex, foundSubtreeIndex int, inpoints *subtreepkg.TxInpoints) {
 	foundIndex = stp.currentSubtree.Load().NodeIndex(hash)
 	foundSubtreeIndex = -1
 
 	if foundIndex == -1 {
-		if stp.diskTxMap != nil {
-			if inpoints, found := stp.currentTxMap.Get(hash); found && inpoints.SubtreeIndex > 0 {
-				chainedIdx := int(inpoints.SubtreeIndex - 1)
-				if chainedIdx < len(stp.chainedSubtrees) {
-					idx := stp.chainedSubtrees[chainedIdx].NodeIndex(hash)
-					if idx >= 0 {
-						foundSubtreeIndex = chainedIdx
-						foundIndex = idx
+		if stp.diskTxMap != nil && !stp.disableSubtreeIndexShortcut {
+			if fetched, found := stp.currentTxMap.Get(hash); found {
+				inpoints = fetched
+
+				if fetched.SubtreeIndex > 0 {
+					chainedIdx := int(fetched.SubtreeIndex - 1)
+					if chainedIdx < len(stp.chainedSubtrees) {
+						idx := stp.chainedSubtrees[chainedIdx].NodeIndex(hash)
+						if idx >= 0 {
+							foundSubtreeIndex = chainedIdx
+							foundIndex = idx
+						}
 					}
 				}
 			}
@@ -2665,16 +2681,20 @@ func (stp *SubtreeProcessor) locateTxInSubtrees(hash chainhash.Hash) (foundIndex
 		// Fallback: linear scan (when DiskTxMap is not active or SubtreeIndex lookup missed)
 		if foundIndex == -1 {
 			for subtreeIndex, subtree := range stp.chainedSubtrees {
-				idx := subtree.NodeIndex(hash)
-				if idx >= 0 {
+				// a hash lives in at most one subtree (addNode dedupes via currentTxMap),
+				// so the first hit is the only hit - stop before building node indexes
+				// for every subtree after it
+				if idx := subtree.NodeIndex(hash); idx >= 0 {
 					foundSubtreeIndex = subtreeIndex
 					foundIndex = idx
+
+					break
 				}
 			}
 		}
 	}
 
-	return foundIndex, foundSubtreeIndex
+	return foundIndex, foundSubtreeIndex, inpoints
 }
 
 func (stp *SubtreeProcessor) removeTxFromSubtrees(ctx context.Context, hash chainhash.Hash) error {
@@ -2687,11 +2707,17 @@ func (stp *SubtreeProcessor) removeTxFromSubtrees(ctx context.Context, hash chai
 	defer deferFn()
 
 	// find the transaction in the current and all chained subtrees
-	foundIndex, foundSubtreeIndex := stp.locateTxInSubtrees(hash)
+	foundIndex, foundSubtreeIndex, txInpoints := stp.locateTxInSubtrees(hash)
 
 	if foundIndex >= 0 {
-		// Save to deleted backup map before removing (for Server fallback during async storage)
-		if txInpoints, found := stp.currentTxMap.Get(hash); found {
+		// Save to deleted backup map before removing (for Server fallback during async storage).
+		// locateTxInSubtrees already fetched this from currentTxMap when the shortcut ran;
+		// only fetch it again if it didn't (in-memory map, or found in the current subtree).
+		if txInpoints == nil {
+			txInpoints, _ = stp.currentTxMap.Get(hash)
+		}
+
+		if txInpoints != nil {
 			stp.deletedTxs.Set(hash, *txInpoints)
 		}
 		stp.currentTxMap.Delete(hash)
@@ -2759,13 +2785,19 @@ func (stp *SubtreeProcessor) removeTxsFromSubtrees(ctx context.Context, hashes [
 
 	for _, hash := range hashes {
 		// find the transaction in the current and all chained subtrees
-		foundIndex, foundSubtreeIndex := stp.locateTxInSubtrees(hash)
+		foundIndex, foundSubtreeIndex, txInpoints := stp.locateTxInSubtrees(hash)
 
 		if foundIndex >= 0 {
 			removedAny = true
 
-			// Save to deleted backup map before removing (for Server fallback during async storage)
-			if txInpoints, found := stp.currentTxMap.Get(hash); found {
+			// Save to deleted backup map before removing (for Server fallback during async storage).
+			// locateTxInSubtrees already fetched this from currentTxMap when the shortcut ran;
+			// only fetch it again if it didn't (in-memory map, or found in the current subtree).
+			if txInpoints == nil {
+				txInpoints, _ = stp.currentTxMap.Get(hash)
+			}
+
+			if txInpoints != nil {
 				stp.deletedTxs.Set(hash, *txInpoints)
 			}
 			stp.currentTxMap.Delete(hash)

--- a/services/blockassembly/subtreeprocessor/remove_txs_batch_removal_perf_test.go
+++ b/services/blockassembly/subtreeprocessor/remove_txs_batch_removal_perf_test.go
@@ -1,0 +1,223 @@
+package subtreeprocessor
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// setupBatchRemovalProcessor builds a SubtreeProcessor with subtreeSize-sized
+// subtrees, optionally backed by DiskTxMap (which is what maintains the
+// currentTxMap.SubtreeIndex bookkeeping that locateTxInSubtrees uses for its
+// O(1) shortcut).
+func setupBatchRemovalProcessor(tb testing.TB, subtreeSize int, useDiskMap bool) *SubtreeProcessor {
+	tb.Helper()
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///test")
+	require.NoError(tb, err)
+
+	utxoStore, err := sql.New(context.Background(), ulogger.TestLogger{}, test.CreateBaseTestSettings(tb), utxoStoreURL)
+	require.NoError(tb, err)
+
+	blobStore := memory.New()
+
+	settings := test.CreateBaseTestSettings(tb)
+	settings.BlockAssembly.InitialMerkleItemsPerSubtree = subtreeSize
+
+	newSubtreeChan := make(chan NewSubtreeRequest, 10)
+	go func() {
+		for req := range newSubtreeChan {
+			if req.ErrChan != nil {
+				req.ErrChan <- nil
+			}
+		}
+	}()
+	tb.Cleanup(func() {
+		close(newSubtreeChan)
+	})
+
+	var opts []Options
+	if useDiskMap {
+		opts = append(opts, WithTxMapDirs([]string{tb.TempDir()}))
+	}
+
+	stp, err := NewSubtreeProcessor(context.Background(), ulogger.TestLogger{}, settings, blobStore, nil, utxoStore, newSubtreeChan, opts...)
+	require.NoError(tb, err)
+
+	return stp
+}
+
+// populateChainedSubtrees adds numSubtrees*subtreeSize transactions directly,
+// producing numSubtrees complete chained subtrees (plus a fresh, empty current
+// subtree), and returns every hash in insertion order.
+func populateChainedSubtrees(tb testing.TB, stp *SubtreeProcessor, numSubtrees, subtreeSize int) []chainhash.Hash {
+	tb.Helper()
+
+	hashes := make([]chainhash.Hash, 0, numSubtrees*subtreeSize)
+
+	// The first subtree already carries the coinbase placeholder at index 0,
+	// so it only has subtreeSize-1 free slots.
+	for st := 0; st < numSubtrees; st++ {
+		free := subtreeSize
+		if st == 0 {
+			free = subtreeSize - 1
+		}
+
+		for i := 0; i < free; i++ {
+			h := chainhash.HashH([]byte(fmt.Sprintf("batchremoval_%d_%d", st, i)))
+			hashes = append(hashes, h)
+
+			node := &subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}
+			require.NoError(tb, stp.AddDirectly(node, &subtreepkg.TxInpoints{}, true))
+		}
+	}
+
+	require.Equal(tb, numSubtrees, len(stp.chainedSubtrees), "expected exactly numSubtrees complete chained subtrees")
+
+	return hashes
+}
+
+// BenchmarkRemoveTxsFromSubtrees_ManySubtrees exercises removeTxsFromSubtrees
+// under worst-case deep-reorg conditions: many chained subtrees and many
+// transactions to remove in a single batch call, with the hashes scattered
+// across subtrees (including the last one), forcing a linear scan over every
+// chained subtree per hash unless the currentTxMap shortcut is used.
+func BenchmarkRemoveTxsFromSubtrees_ManySubtrees(b *testing.B) {
+	if testing.Short() {
+		b.Skip("heavy benchmark; skipped in -short (CI passes -short)")
+	}
+
+	const (
+		numSubtrees  = 200
+		subtreeSize  = 16
+		removeStride = 4 // remove every 4th tx: ~25% of all transactions
+	)
+
+	b.Run("DiskTxMap_shortcut", func(b *testing.B) {
+		benchmarkRemoveTxsFromSubtrees(b, numSubtrees, subtreeSize, removeStride, true)
+	})
+
+	b.Run("InMemoryMap_linear_scan", func(b *testing.B) {
+		benchmarkRemoveTxsFromSubtrees(b, numSubtrees, subtreeSize, removeStride, false)
+	})
+}
+
+func benchmarkRemoveTxsFromSubtrees(b *testing.B, numSubtrees, subtreeSize, removeStride int, useDiskMap bool) {
+	b.ReportAllocs()
+
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+
+		stp := setupBatchRemovalProcessor(b, subtreeSize, useDiskMap)
+		allHashes := populateChainedSubtrees(b, stp, numSubtrees, subtreeSize)
+
+		toRemove := make([]chainhash.Hash, 0, len(allHashes)/removeStride+1)
+		for idx := 0; idx < len(allHashes); idx += removeStride {
+			toRemove = append(toRemove, allHashes[idx])
+		}
+
+		b.StartTimer()
+
+		if err := stp.removeTxsFromSubtrees(ctx, toRemove); err != nil {
+			b.Fatalf("removeTxsFromSubtrees failed: %v", err)
+		}
+	}
+}
+
+// TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan proves that the
+// currentTxMap-based shortcut used by removeTxsFromSubtrees (when DiskTxMap is
+// active) produces exactly the same result as the linear-scan fallback (when it
+// is not): the same set of transactions removed, and the same subtree structure
+// left behind. This is a pure performance optimization, so the two code paths
+// must be behaviorally identical.
+func TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		numSubtrees  = 12
+		subtreeSize  = 8
+		removeStride = 3
+	)
+
+	buildAndRemove := func(useDiskMap bool) (*SubtreeProcessor, []chainhash.Hash, []chainhash.Hash) {
+		stp := setupBatchRemovalProcessor(t, subtreeSize, useDiskMap)
+		allHashes := populateChainedSubtrees(t, stp, numSubtrees, subtreeSize)
+
+		var toRemove, expectedRemaining []chainhash.Hash
+		for idx, h := range allHashes {
+			if idx%removeStride == 0 {
+				toRemove = append(toRemove, h)
+			} else {
+				expectedRemaining = append(expectedRemaining, h)
+			}
+		}
+
+		require.NoError(t, stp.removeTxsFromSubtrees(ctx, toRemove))
+
+		return stp, toRemove, expectedRemaining
+	}
+
+	stpShortcut, removedShortcut, remainingShortcut := buildAndRemove(true)
+	stpScan, removedScan, remainingScan := buildAndRemove(false)
+
+	occurrences := func(stp *SubtreeProcessor, h chainhash.Hash) int {
+		count := 0
+		if stp.currentSubtree.Load().NodeIndex(h) >= 0 {
+			count++
+		}
+
+		for _, cs := range stp.chainedSubtrees {
+			if cs.NodeIndex(h) >= 0 {
+				count++
+			}
+		}
+
+		return count
+	}
+
+	// Same removed set produces the same absence, on both code paths.
+	for _, h := range removedShortcut {
+		require.Equal(t, 0, occurrences(stpShortcut, h), "removed hash must be absent (shortcut path)")
+	}
+
+	for _, h := range removedScan {
+		require.Equal(t, 0, occurrences(stpScan, h), "removed hash must be absent (linear-scan path)")
+	}
+
+	_, existsShortcut := stpShortcut.currentTxMap.Get(removedShortcut[0])
+	require.False(t, existsShortcut, "removed hash must be gone from currentTxMap (shortcut path)")
+
+	// Same surviving set, present exactly once, on both code paths.
+	require.Equal(t, len(remainingScan), len(remainingShortcut))
+
+	for i, h := range remainingShortcut {
+		require.Equal(t, 1, occurrences(stpShortcut, h), "surviving hash must remain exactly once (shortcut path)")
+		require.Equal(t, 1, occurrences(stpScan, remainingScan[i]), "surviving hash must remain exactly once (linear-scan path)")
+	}
+
+	// Identical resulting subtree structure: same chained-subtree count, and
+	// every chained subtree fully compacted (no holes) on both paths.
+	require.Equal(t, len(stpScan.chainedSubtrees), len(stpShortcut.chainedSubtrees), "chained subtree count must match")
+
+	for i := range stpShortcut.chainedSubtrees {
+		require.True(t, stpShortcut.chainedSubtrees[i].IsComplete(), "chained subtree %d must be complete (shortcut path)", i)
+		require.True(t, stpScan.chainedSubtrees[i].IsComplete(), "chained subtree %d must be complete (linear-scan path)", i)
+		require.Equal(t, stpScan.chainedSubtrees[i].Length(), stpShortcut.chainedSubtrees[i].Length(), "chained subtree %d length must match", i)
+	}
+
+	require.Equal(t, stpScan.currentSubtree.Load().Length(), stpShortcut.currentSubtree.Load().Length(), "current subtree length must match")
+
+	requireCoinbasePlaceholderIntact(t, stpShortcut)
+	requireCoinbasePlaceholderIntact(t, stpScan)
+}

--- a/services/blockassembly/subtreeprocessor/remove_txs_batch_removal_perf_test.go
+++ b/services/blockassembly/subtreeprocessor/remove_txs_batch_removal_perf_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -19,7 +20,16 @@ import (
 // subtrees, optionally backed by DiskTxMap (which is what maintains the
 // currentTxMap.SubtreeIndex bookkeeping that locateTxInSubtrees uses for its
 // O(1) shortcut).
-func setupBatchRemovalProcessor(tb testing.TB, subtreeSize int, useDiskMap bool) *SubtreeProcessor {
+//
+// It returns the processor and a teardown function that stops it (closing the
+// DiskTxMap/Badger store and the reader goroutine) and closes the UTXO store.
+// teardown is safe to call more than once (the returned closure is guarded by
+// a sync.Once), and is also registered via tb.Cleanup as a safety net for
+// callers (e.g. the equivalence test below) that don't invoke it explicitly -
+// callers that build many processors in a loop (e.g. the benchmark) MUST call
+// it themselves at the end of each iteration, since tb.Cleanup only runs once
+// at the very end of the whole test/benchmark function.
+func setupBatchRemovalProcessor(tb testing.TB, subtreeSize int, useDiskMap bool) (*SubtreeProcessor, func()) {
 	tb.Helper()
 
 	utxoStoreURL, err := url.Parse("sqlitememory:///test")
@@ -34,26 +44,46 @@ func setupBatchRemovalProcessor(tb testing.TB, subtreeSize int, useDiskMap bool)
 	settings.BlockAssembly.InitialMerkleItemsPerSubtree = subtreeSize
 
 	newSubtreeChan := make(chan NewSubtreeRequest, 10)
+	readerDone := make(chan struct{})
 	go func() {
+		defer close(readerDone)
 		for req := range newSubtreeChan {
 			if req.ErrChan != nil {
 				req.ErrChan <- nil
 			}
 		}
 	}()
-	tb.Cleanup(func() {
-		close(newSubtreeChan)
-	})
 
 	var opts []Options
 	if useDiskMap {
+		// Registering the temp dir before the teardown below means teardown
+		// runs (via tb.Cleanup LIFO ordering) before the framework removes
+		// this directory, so Badger is closed before its files disappear
+		// underneath it.
 		opts = append(opts, WithTxMapDirs([]string{tb.TempDir()}))
 	}
 
 	stp, err := NewSubtreeProcessor(context.Background(), ulogger.TestLogger{}, settings, blobStore, nil, utxoStore, newSubtreeChan, opts...)
 	require.NoError(tb, err)
 
-	return stp
+	if useDiskMap {
+		require.NotNil(tb, stp.diskTxMap, "DiskTxMap must be active for the shortcut path")
+	}
+
+	var once sync.Once
+
+	teardown := func() {
+		once.Do(func() {
+			stp.Stop(context.Background())
+			close(newSubtreeChan)
+			<-readerDone
+			_ = utxoStore.Close(context.Background())
+		})
+	}
+
+	tb.Cleanup(teardown)
+
+	return stp, teardown
 }
 
 // populateChainedSubtrees adds numSubtrees*subtreeSize transactions directly,
@@ -77,7 +107,8 @@ func populateChainedSubtrees(tb testing.TB, stp *SubtreeProcessor, numSubtrees, 
 			hashes = append(hashes, h)
 
 			node := &subtreepkg.Node{Hash: h, Fee: 1000, SizeInBytes: 250}
-			require.NoError(tb, stp.AddDirectly(node, &subtreepkg.TxInpoints{}, true))
+			inpoints := subtreepkg.NewTxInpoints()
+			require.NoError(tb, stp.AddDirectly(node, &inpoints, true))
 		}
 	}
 
@@ -86,32 +117,57 @@ func populateChainedSubtrees(tb testing.TB, stp *SubtreeProcessor, numSubtrees, 
 	return hashes
 }
 
+// occurrencesOf counts how many times hash is present across the current
+// subtree and every chained subtree (should be 0 or 1 in a well-formed
+// processor).
+func occurrencesOf(stp *SubtreeProcessor, h chainhash.Hash) int {
+	count := 0
+	if stp.currentSubtree.Load().NodeIndex(h) >= 0 {
+		count++
+	}
+
+	for _, cs := range stp.chainedSubtrees {
+		if cs.NodeIndex(h) >= 0 {
+			count++
+		}
+	}
+
+	return count
+}
+
 // BenchmarkRemoveTxsFromSubtrees_ManySubtrees exercises removeTxsFromSubtrees
 // under worst-case deep-reorg conditions: many chained subtrees and many
 // transactions to remove in a single batch call, with the hashes scattered
 // across subtrees (including the last one), forcing a linear scan over every
 // chained subtree per hash unless the currentTxMap shortcut is used.
+//
+// Both arms run on the same DiskTxMap backend; the only difference is whether
+// locateTxInSubtrees is allowed to use the SubtreeIndex shortcut
+// (disableSubtreeIndexShortcut), so the delta between them isolates the
+// algorithmic change from backend cost - the in-memory map is not used here
+// because it never populates SubtreeIndex, so it would only measure Badger
+// vs. map overhead, not the shortcut itself.
 func BenchmarkRemoveTxsFromSubtrees_ManySubtrees(b *testing.B) {
 	if testing.Short() {
 		b.Skip("heavy benchmark; skipped in -short (CI passes -short)")
 	}
 
 	const (
-		numSubtrees  = 200
+		numSubtrees  = 2000
 		subtreeSize  = 16
 		removeStride = 4 // remove every 4th tx: ~25% of all transactions
 	)
 
-	b.Run("DiskTxMap_shortcut", func(b *testing.B) {
-		benchmarkRemoveTxsFromSubtrees(b, numSubtrees, subtreeSize, removeStride, true)
+	b.Run("shortcut", func(b *testing.B) {
+		benchmarkRemoveTxsFromSubtrees(b, numSubtrees, subtreeSize, removeStride, false)
 	})
 
-	b.Run("InMemoryMap_linear_scan", func(b *testing.B) {
-		benchmarkRemoveTxsFromSubtrees(b, numSubtrees, subtreeSize, removeStride, false)
+	b.Run("linear_scan_fallback", func(b *testing.B) {
+		benchmarkRemoveTxsFromSubtrees(b, numSubtrees, subtreeSize, removeStride, true)
 	})
 }
 
-func benchmarkRemoveTxsFromSubtrees(b *testing.B, numSubtrees, subtreeSize, removeStride int, useDiskMap bool) {
+func benchmarkRemoveTxsFromSubtrees(b *testing.B, numSubtrees, subtreeSize, removeStride int, disableShortcut bool) {
 	b.ReportAllocs()
 
 	ctx := context.Background()
@@ -119,7 +175,9 @@ func benchmarkRemoveTxsFromSubtrees(b *testing.B, numSubtrees, subtreeSize, remo
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 
-		stp := setupBatchRemovalProcessor(b, subtreeSize, useDiskMap)
+		stp, teardown := setupBatchRemovalProcessor(b, subtreeSize, true)
+		stp.disableSubtreeIndexShortcut = disableShortcut
+
 		allHashes := populateChainedSubtrees(b, stp, numSubtrees, subtreeSize)
 
 		toRemove := make([]chainhash.Hash, 0, len(allHashes)/removeStride+1)
@@ -132,15 +190,20 @@ func benchmarkRemoveTxsFromSubtrees(b *testing.B, numSubtrees, subtreeSize, remo
 		if err := stp.removeTxsFromSubtrees(ctx, toRemove); err != nil {
 			b.Fatalf("removeTxsFromSubtrees failed: %v", err)
 		}
+
+		b.StopTimer()
+
+		teardown() // don't hold b.N Badger instances open at once
 	}
 }
 
 // TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan proves that the
 // currentTxMap-based shortcut used by removeTxsFromSubtrees (when DiskTxMap is
-// active) produces exactly the same result as the linear-scan fallback (when it
-// is not): the same set of transactions removed, and the same subtree structure
-// left behind. This is a pure performance optimization, so the two code paths
-// must be behaviorally identical.
+// active) produces exactly the same result as the linear-scan fallback: the
+// same set of transactions removed, and the same subtree structure (including
+// node order) left behind. Both processors share the same DiskTxMap backend;
+// only disableSubtreeIndexShortcut differs, so the comparison isolates the
+// shortcut's behavior rather than comparing two different tx-map backends.
 func TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan(t *testing.T) {
 	ctx := context.Background()
 
@@ -150,8 +213,10 @@ func TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan(t *testing.T) 
 		removeStride = 3
 	)
 
-	buildAndRemove := func(useDiskMap bool) (*SubtreeProcessor, []chainhash.Hash, []chainhash.Hash) {
-		stp := setupBatchRemovalProcessor(t, subtreeSize, useDiskMap)
+	buildAndRemove := func(disableShortcut bool) (*SubtreeProcessor, []chainhash.Hash, []chainhash.Hash) {
+		stp, _ := setupBatchRemovalProcessor(t, subtreeSize, true)
+		stp.disableSubtreeIndexShortcut = disableShortcut
+
 		allHashes := populateChainedSubtrees(t, stp, numSubtrees, subtreeSize)
 
 		var toRemove, expectedRemaining []chainhash.Hash
@@ -168,31 +233,16 @@ func TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan(t *testing.T) 
 		return stp, toRemove, expectedRemaining
 	}
 
-	stpShortcut, removedShortcut, remainingShortcut := buildAndRemove(true)
-	stpScan, removedScan, remainingScan := buildAndRemove(false)
-
-	occurrences := func(stp *SubtreeProcessor, h chainhash.Hash) int {
-		count := 0
-		if stp.currentSubtree.Load().NodeIndex(h) >= 0 {
-			count++
-		}
-
-		for _, cs := range stp.chainedSubtrees {
-			if cs.NodeIndex(h) >= 0 {
-				count++
-			}
-		}
-
-		return count
-	}
+	stpShortcut, removedShortcut, remainingShortcut := buildAndRemove(false)
+	stpScan, removedScan, remainingScan := buildAndRemove(true)
 
 	// Same removed set produces the same absence, on both code paths.
 	for _, h := range removedShortcut {
-		require.Equal(t, 0, occurrences(stpShortcut, h), "removed hash must be absent (shortcut path)")
+		require.Equal(t, 0, occurrencesOf(stpShortcut, h), "removed hash must be absent (shortcut path)")
 	}
 
 	for _, h := range removedScan {
-		require.Equal(t, 0, occurrences(stpScan, h), "removed hash must be absent (linear-scan path)")
+		require.Equal(t, 0, occurrencesOf(stpScan, h), "removed hash must be absent (linear-scan path)")
 	}
 
 	_, existsShortcut := stpShortcut.currentTxMap.Get(removedShortcut[0])
@@ -202,22 +252,74 @@ func TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan(t *testing.T) 
 	require.Equal(t, len(remainingScan), len(remainingShortcut))
 
 	for i, h := range remainingShortcut {
-		require.Equal(t, 1, occurrences(stpShortcut, h), "surviving hash must remain exactly once (shortcut path)")
-		require.Equal(t, 1, occurrences(stpScan, remainingScan[i]), "surviving hash must remain exactly once (linear-scan path)")
+		require.Equal(t, 1, occurrencesOf(stpShortcut, h), "surviving hash must remain exactly once (shortcut path)")
+		require.Equal(t, 1, occurrencesOf(stpScan, remainingScan[i]), "surviving hash must remain exactly once (linear-scan path)")
 	}
 
 	// Identical resulting subtree structure: same chained-subtree count, and
-	// every chained subtree fully compacted (no holes) on both paths.
+	// the exact same node sequence (order included) on both paths - not just
+	// count/completeness, which wouldn't catch a lookup bug that removes the
+	// wrong node.
 	require.Equal(t, len(stpScan.chainedSubtrees), len(stpShortcut.chainedSubtrees), "chained subtree count must match")
 
 	for i := range stpShortcut.chainedSubtrees {
 		require.True(t, stpShortcut.chainedSubtrees[i].IsComplete(), "chained subtree %d must be complete (shortcut path)", i)
 		require.True(t, stpScan.chainedSubtrees[i].IsComplete(), "chained subtree %d must be complete (linear-scan path)", i)
-		require.Equal(t, stpScan.chainedSubtrees[i].Length(), stpShortcut.chainedSubtrees[i].Length(), "chained subtree %d length must match", i)
+		require.Equal(t, stpScan.chainedSubtrees[i].Nodes, stpShortcut.chainedSubtrees[i].Nodes, "chained subtree %d node sequence must match", i)
 	}
 
-	require.Equal(t, stpScan.currentSubtree.Load().Length(), stpShortcut.currentSubtree.Load().Length(), "current subtree length must match")
+	require.Equal(t, stpScan.currentSubtree.Load().Nodes, stpShortcut.currentSubtree.Load().Nodes, "current subtree node sequence must match")
 
 	requireCoinbasePlaceholderIntact(t, stpShortcut)
 	requireCoinbasePlaceholderIntact(t, stpScan)
+}
+
+// TestRemoveTxsFromSubtrees_StaleSubtreeIndexFallsBackToScan corrupts
+// currentTxMap.SubtreeIndex directly (via the exported UpdateSubtreeIndex) and
+// proves that the shortcut in locateTxInSubtrees degrades safely: a stale
+// in-range index, and an out-of-range index, both fall through to the linear
+// scan rather than removing the wrong node or silently skipping the removal.
+// This is the load-bearing safety argument for the whole optimization, so it
+// needs its own coverage - the equivalence test above only ever exercises a
+// correct SubtreeIndex.
+func TestRemoveTxsFromSubtrees_StaleSubtreeIndexFallsBackToScan(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		numSubtrees = 4
+		subtreeSize = 8
+	)
+
+	stp, _ := setupBatchRemovalProcessor(t, subtreeSize, true)
+
+	allHashes := populateChainedSubtrees(t, stp, numSubtrees, subtreeSize)
+
+	// target1 actually lives in the last chained subtree; point its
+	// SubtreeIndex at the wrong (but in-range) chained subtree. The range
+	// check passes, so the hash check inside that subtree must miss and fall
+	// through to the full scan.
+	target1 := allHashes[len(allHashes)-1]
+	require.NoError(t, stp.diskTxMap.UpdateSubtreeIndex(target1, 1)) // wrongly claims chainedSubtrees[0]
+	require.NoError(t, stp.removeTxsFromSubtrees(ctx, []chainhash.Hash{target1}))
+	require.Equal(t, 0, occurrencesOf(stp, target1), "linear-scan fallback must still remove a stale in-range-indexed hash")
+
+	// target2 gets an out-of-range SubtreeIndex, guarding the bounds check
+	// itself rather than the hash re-verification.
+	target2 := allHashes[len(allHashes)-2]
+	require.NoError(t, stp.diskTxMap.UpdateSubtreeIndex(target2, int16(len(stp.chainedSubtrees)+5)))
+	require.NoError(t, stp.removeTxsFromSubtrees(ctx, []chainhash.Hash{target2}))
+	require.Equal(t, 0, occurrencesOf(stp, target2), "linear-scan fallback must still remove an out-of-range-indexed hash")
+
+	// A bad index must cost a wasted probe, not a wrong-node removal: every
+	// other hash must still be present exactly once.
+	removed := map[chainhash.Hash]bool{target1: true, target2: true}
+	for _, h := range allHashes {
+		if removed[h] {
+			continue
+		}
+
+		require.Equal(t, 1, occurrencesOf(stp, h), "surviving hash %s must remain exactly once", h.String())
+	}
+
+	requireCoinbasePlaceholderIntact(t, stp)
 }


### PR DESCRIPTION
## Problem

`removeTxsFromSubtrees` (batch tx removal) re-scanned every chained subtree for
every hash it was asked to remove — O(hashes x subtrees). The single-hash path,
`removeTxFromSubtrees`, already avoided this via an O(1) shortcut: when
`DiskTxMap` is active, `currentTxMap` tracks a `SubtreeIndex` per hash (the
chained-subtree index it lives in), so the correct subtree can be looked up
directly instead of scanning all of them. The batch path never picked up that
shortcut.

Under a deep reorg where many transactions need removing from block assembly
at once, this made batch removal scale with subtree count as well as hash
count, and stalled mining-candidate refresh while it ran.

## Fix

Extracted the lookup into a shared `locateTxInSubtrees` helper and used it in
both `removeTxFromSubtrees` and `removeTxsFromSubtrees`, so the batch path now
gets the same O(1) shortcut the single-hash path already had. No behavior
change — same transactions removed, same resulting subtree structure.

`locateTxInSubtrees` returns the `*TxInpoints` it already fetched, so callers
reuse it instead of issuing a second `Get`. On `DiskTxMap` every `Get` is a
flush handshake plus a Badger read, so the earlier fetch-and-discard made a
shortcut-resolved hash cost three round-trips where two suffice, and made a
not-present hash pay a wasted read. The fallback scan also now stops at the
first match rather than continuing to build a node-index map per remaining
subtree.

## Testing

- `TestRemoveTxsFromSubtrees_DiskTxMapShortcutMatchesLinearScan`: proves the
  shortcut path and the linear-scan fallback produce identical results. Both
  processors share one `DiskTxMap` backend and differ only in whether the
  shortcut is used, so the comparison is a true A/B rather than a comparison of
  storage backends. Asserts `stp.diskTxMap` is non-nil (construction failure is
  non-fatal, so without this the test could silently compare the linear scan
  against itself) and compares `Nodes` slices directly, which also covers node
  ordering.
- `TestRemoveTxsFromSubtrees_StaleSubtreeIndexFallsBackToScan` (new): injects
  a stale in-range `SubtreeIndex` and an out-of-range one via
  `DiskTxMap.UpdateSubtreeIndex`, and asserts correct removal with no
  collateral damage. This is the safety argument for the whole change and was
  previously untested.
- `BenchmarkRemoveTxsFromSubtrees_ManySubtrees`: 2000 chained subtrees,
  removing ~25% of all transactions in one batch call, with the shortcut
  enabled vs disabled on the same backend.
- Full existing suite: `go test ./services/blockassembly/subtreeprocessor/... -race` passes.
- `go vet ./services/blockassembly/subtreeprocessor/...` clean, `golangci-lint run` 0 issues.

### Benchmark

Corrected. The figures previously quoted here (129.3 ms/op -> 84.7 ms/op, "~35%
faster") did not measure this change. The two arms differed in tx-map *backend*
— `DiskTxMap` vs in-memory — not in whether the shortcut ran, so the delta was
the cost difference between the two backends. The benchmark now toggles only the
shortcut, on a shared `DiskTxMap` backend.

```
shortcut:               ~760-910 ms/op
linear_scan_fallback:   ~960 ms-1.06 s/op
```

Roughly 10-30%. Direction reproduces across runs; magnitude is noisy, measured
on a 5-CPU-limited machine with other builds contending, so treat the range as
indicative rather than precise.

Two caveats worth stating explicitly:

- **Subtree count is what makes this worth doing.** At the original benchmark's
  200 chained subtrees the two arms were within noise of each other — the
  linear scan is cheap when per-subtree node-index maps are small. The subtree
  count was raised to 2000 to get a benchmark that demonstrates the
  optimization at all. Below a few hundred subtrees this change is
  approximately free rather than a win.
- The in-memory (non-`DiskTxMap`) path is unaffected, since it always falls
  back to the same linear scan.
