### PR TITLE
fix(seeder): verify checksum sidecar before consuming UTXO snapshot files

### DIFF
--- a/cmd/seeder/README.md
+++ b/cmd/seeder/README.md
@@ -7,10 +7,23 @@ The `seeder` package is a command-line tool designed to process blockchain heade
 This package is typically used to process blockchain data from specified input files and store the results in appropriate stores.
 
 ### Features
+
 - Process UTXO headers and sets
 - Store processed data in configurable storage backends (PostgreSQL, SQLite, or Aerospike based on settings)
 - Handle system signals for graceful termination
 - Start a profiler server for debugging
+
+### Checksum verification
+
+Before consuming a headers or UTXO-set file, the seeder looks for a
+`<file>.sha256` checksum sidecar next to it (the format written by the blob
+file store and by `bitcointoutxoset`: a hex-encoded SHA-256 digest, optionally
+followed by the filename). If the sidecar is present and doesn't match the
+file's actual content, the seeder refuses to import it rather than silently
+seeding from a corrupted snapshot. If no sidecar is present at all, the import
+proceeds with a warning — older snapshots, or ones from a source that never
+produced a sidecar, are not blocked. This check is unauthenticated (it catches
+corruption/transfer errors, not tampering) and cannot be disabled.
 
 ## Development
 

--- a/cmd/seeder/checksum_test.go
+++ b/cmd/seeder/checksum_test.go
@@ -89,3 +89,43 @@ func TestVerifyChecksum_EmptySidecarFails(t *testing.T) {
 	err := verifyChecksum(ulogger.TestLogger{}, filePath)
 	require.Error(t, err)
 }
+
+// TestVerifyChecksum_MalformedSidecarFails guards against a sidecar whose
+// first field isn't a hex-encoded SHA-256 digest (a truncated write, or a
+// BSD/`--tag`-style sidecar such as "SHA256 (f) = ...") falling through to
+// the generic "checksum mismatch" branch, which would misdirect the operator
+// at the snapshot file rather than at the malformed sidecar itself.
+func TestVerifyChecksum_MalformedSidecarFails(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abc123.utxo-set")
+	content := []byte("this is the utxo-set snapshot content")
+
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+	require.NoError(t, os.WriteFile(filePath+checksumSidecarExtension, []byte("SHA256 (abc123.utxo-set) = deadbeef\n"), 0o644))
+
+	err := verifyChecksum(ulogger.TestLogger{}, filePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "checksum sidecar", "the error must name the malformed sidecar, not report a mismatch on the file")
+	require.NotContains(t, err.Error(), "checksum mismatch")
+}
+
+// TestVerifyChecksum_MismatchedFilenameFails guards against a sidecar
+// mistakenly paired with a different snapshot: its checksum field may still
+// happen to match some other file's content, but the filename field
+// identifies it as belonging elsewhere, and that must be reported rather than
+// treated as a plain checksum mismatch (or worse, silently accepted).
+func TestVerifyChecksum_MismatchedFilenameFails(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abc123.utxo-set")
+	content := []byte("this is the utxo-set snapshot content")
+
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+
+	sum := sha256.Sum256(content)
+	sidecar := hex.EncodeToString(sum[:]) + "  " + "someother.utxo-set" + "\n"
+	require.NoError(t, os.WriteFile(filePath+checksumSidecarExtension, []byte(sidecar), 0o644))
+
+	err := verifyChecksum(ulogger.TestLogger{}, filePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "belongs to")
+}

--- a/cmd/seeder/checksum_test.go
+++ b/cmd/seeder/checksum_test.go
@@ -1,0 +1,91 @@
+package seeder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSidecar writes a "<file>.sha256" sidecar for content, using the
+// standard sha256sum layout the blob file store also writes.
+func writeSidecar(t *testing.T, filePath string, content []byte) {
+	t.Helper()
+
+	sum := sha256.Sum256(content)
+	sidecar := hex.EncodeToString(sum[:]) + "  " + filepath.Base(filePath) + "\n"
+
+	require.NoError(t, os.WriteFile(filePath+checksumSidecarExtension, []byte(sidecar), 0o644))
+}
+
+// TestVerifyChecksum_MatchingSidecarSucceeds covers case (a): a snapshot file
+// with a matching, correct checksum sidecar must verify without error.
+func TestVerifyChecksum_MatchingSidecarSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abc123.utxo-set")
+	content := []byte("this is the utxo-set snapshot content")
+
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+	writeSidecar(t, filePath, content)
+
+	err := verifyChecksum(ulogger.TestLogger{}, filePath)
+	require.NoError(t, err)
+}
+
+// TestVerifyChecksum_CorruptedFileFailsVerification covers case (b): a
+// snapshot file whose bytes were corrupted (a bit flip that leaves record
+// counts untouched) but whose sidecar still reflects the original content
+// must be rejected with a clear error, not silently imported.
+func TestVerifyChecksum_CorruptedFileFailsVerification(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abc123.utxo-set")
+	original := []byte("this is the utxo-set snapshot content")
+
+	require.NoError(t, os.WriteFile(filePath, original, 0o644))
+	writeSidecar(t, filePath, original)
+
+	// Simulate corruption: flip a single byte in place, leaving the file
+	// length (and therefore any record count) unchanged.
+	corrupted := append([]byte(nil), original...)
+	corrupted[0] ^= 0xFF
+	require.NoError(t, os.WriteFile(filePath, corrupted, 0o644))
+
+	err := verifyChecksum(ulogger.TestLogger{}, filePath)
+	require.Error(t, err, "corruption must be caught even though the sidecar exists")
+	require.Contains(t, err.Error(), "checksum mismatch")
+}
+
+// TestVerifyChecksum_NoSidecarSucceedsWithWarning covers case (c): an older
+// snapshot (or one from a source that never produced a sidecar) has no
+// ".sha256" file — the import must proceed, not fail, with only a warning
+// logged.
+func TestVerifyChecksum_NoSidecarSucceedsWithWarning(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abc123.utxo-set")
+	content := []byte("this is the utxo-set snapshot content")
+
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+
+	// No sidecar written.
+	err := verifyChecksum(ulogger.TestLogger{}, filePath)
+	require.NoError(t, err, "a missing sidecar must be backward compatible, not fatal")
+}
+
+// TestVerifyChecksum_EmptySidecarFails guards against a truncated/empty
+// sidecar being silently treated as "no sidecar" rather than as a checksum
+// verification failure.
+func TestVerifyChecksum_EmptySidecarFails(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abc123.utxo-set")
+	content := []byte("this is the utxo-set snapshot content")
+
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+	require.NoError(t, os.WriteFile(filePath+checksumSidecarExtension, []byte(""), 0o644))
+
+	err := verifyChecksum(ulogger.TestLogger{}, filePath)
+	require.Error(t, err)
+}

--- a/cmd/seeder/seeder.go
+++ b/cmd/seeder/seeder.go
@@ -147,6 +147,17 @@ func Seeder(logger ulogger.Logger, appSettings *settings.Settings, inputDir stri
 		if err := verifyChecksum(logger, headerFile); err != nil {
 			return errors.NewProcessingError("checksum verification failed for headers file %s", headerFile, err)
 		}
+	} else if !skipUTXOs {
+		// The header pass itself is skipped, but processUTXOs still reads
+		// headerFile back (via loadCoinbaseTxs) to recover coinbase inputs, so a
+		// corrupted headers file must not be silently consumed just because
+		// -skipHeaders was passed. Unlike the pass above, absence is fine here —
+		// loadCoinbaseTxs already tolerates a missing headers file.
+		if _, err := os.Stat(headerFile); err == nil {
+			if err := verifyChecksum(logger, headerFile); err != nil {
+				return errors.NewProcessingError("checksum verification failed for headers file %s", headerFile, err)
+			}
+		}
 	}
 
 	if !skipUTXOs {
@@ -849,13 +860,26 @@ func writeBlockAssemblerState(ctx context.Context, logger ulogger.Logger, store 
 func verifyChecksum(logger ulogger.Logger, filePath string) error {
 	sidecarPath := filePath + checksumSidecarExtension
 
-	sidecar, err := os.ReadFile(sidecarPath)
+	// maxSidecarSize bounds the sidecar read: a genuine sidecar is a hex digest
+	// plus an optional filename, well under 1KB. Anything larger is not a
+	// sidecar (e.g. the snapshot file itself, copied to the wrong name), and
+	// reading it in full would pull an arbitrarily large file into memory.
+	const maxSidecarSize = 4096
+
+	f, err := os.Open(sidecarPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Warnf("[verifyChecksum] no checksum sidecar %s found for %s; proceeding without checksum verification", sidecarPath, filePath)
 			return nil
 		}
 
+		return errors.NewStorageError("failed to read checksum sidecar %s", sidecarPath, err)
+	}
+
+	sidecar, err := io.ReadAll(io.LimitReader(f, maxSidecarSize))
+	_ = f.Close()
+
+	if err != nil {
 		return errors.NewStorageError("failed to read checksum sidecar %s", sidecarPath, err)
 	}
 
@@ -866,18 +890,38 @@ func verifyChecksum(logger ulogger.Logger, filePath string) error {
 
 	expected := strings.ToLower(fields[0])
 
-	f, err := os.Open(filePath)
+	if len(expected) != sha256.Size*2 {
+		return errors.NewProcessingError("checksum sidecar %s is malformed: %q is not a hex-encoded SHA-256 digest", sidecarPath, fields[0])
+	}
+
+	if _, err := hex.DecodeString(expected); err != nil {
+		return errors.NewProcessingError("checksum sidecar %s is malformed: %q is not a hex-encoded SHA-256 digest", sidecarPath, fields[0])
+	}
+
+	// The standard sha256sum layout names the file the checksum belongs to as
+	// the second field. When present, it must match filePath's own basename —
+	// otherwise the sidecar was paired with the wrong snapshot, and reporting
+	// that as a checksum mismatch would misdirect the operator.
+	if len(fields) > 1 && fields[1] != filepath.Base(filePath) {
+		return errors.NewProcessingError("checksum sidecar %s belongs to %q, not to %s", sidecarPath, fields[1], filepath.Base(filePath))
+	}
+
+	if st, statErr := os.Stat(filePath); statErr == nil {
+		logger.Infof("[verifyChecksum] verifying %s (%s bytes) against %s; this reads the whole file", filePath, formatNumber(uint64(st.Size())), sidecarPath)
+	}
+
+	sf, err := os.Open(filePath)
 	if err != nil {
 		return errors.NewStorageError("failed to open %s for checksum verification", filePath, err)
 	}
 
 	defer func() {
-		_ = f.Close()
+		_ = sf.Close()
 	}()
 
 	h := sha256.New()
 
-	if _, err = io.Copy(h, f); err != nil {
+	if _, err = io.Copy(h, sf); err != nil {
 		return errors.NewStorageError("failed to read %s for checksum verification", filePath, err)
 	}
 

--- a/cmd/seeder/seeder.go
+++ b/cmd/seeder/seeder.go
@@ -19,8 +19,10 @@ package seeder
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -57,6 +59,12 @@ import (
 
 const (
 	errMsgFailedToReadUTXO = "failed to read UTXO set header"
+
+	// checksumSidecarExtension matches the sidecar extension the blob file
+	// store writes alongside every blob it stores (stores/blob/file), so a
+	// snapshot produced by the UTXO persister and copied into inputDir
+	// carries its checksum sidecar with it.
+	checksumSidecarExtension = ".sha256"
 )
 
 // utxoSetTip identifies the block at which an imported UTXO set is complete.
@@ -135,12 +143,20 @@ func Seeder(logger ulogger.Logger, appSettings *settings.Settings, inputDir stri
 		if _, err := os.Stat(headerFile); os.IsNotExist(err) {
 			usage(fmt.Sprintf("Headers file %s does not exist", headerFile))
 		}
+
+		if err := verifyChecksum(logger, headerFile); err != nil {
+			return errors.NewProcessingError("checksum verification failed for headers file %s", headerFile, err)
+		}
 	}
 
 	if !skipUTXOs {
 		// Check the UTXO file exists
 		if _, err := os.Stat(utxoFile); os.IsNotExist(err) {
 			usage(fmt.Sprintf("UTXO file %s does not exist", utxoFile))
+		}
+
+		if err := verifyChecksum(logger, utxoFile); err != nil {
+			return errors.NewProcessingError("checksum verification failed for UTXO file %s", utxoFile, err)
 		}
 	}
 
@@ -815,6 +831,64 @@ func writeBlockAssemblerState(ctx context.Context, logger ulogger.Logger, store 
 	}
 
 	logger.Infof("Set BlockAssembler state to utxo-set tip %s at height %d", tip.hash.String(), tip.height)
+
+	return nil
+}
+
+// verifyChecksum checks a snapshot file against its "<file>.sha256" checksum
+// sidecar, matching the sidecar format the blob file store (stores/blob/file)
+// writes alongside every blob: hex-encoded SHA-256, optionally followed by
+// whitespace and the filename (the standard sha256sum layout).
+//
+// If no sidecar is present — e.g. an older snapshot predating checksum
+// sidecars, or one fetched from a source that doesn't produce one — the
+// import proceeds with only a warning logged: mandating a sidecar for every
+// possible snapshot source is not realistic. If a sidecar IS present but
+// doesn't match the file's actual content, the import is refused: a
+// corrupted-but-count-consistent file must never be silently imported.
+func verifyChecksum(logger ulogger.Logger, filePath string) error {
+	sidecarPath := filePath + checksumSidecarExtension
+
+	sidecar, err := os.ReadFile(sidecarPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warnf("[verifyChecksum] no checksum sidecar %s found for %s; proceeding without checksum verification", sidecarPath, filePath)
+			return nil
+		}
+
+		return errors.NewStorageError("failed to read checksum sidecar %s", sidecarPath, err)
+	}
+
+	fields := strings.Fields(string(sidecar))
+	if len(fields) == 0 {
+		return errors.NewProcessingError("checksum sidecar %s is empty", sidecarPath)
+	}
+
+	expected := strings.ToLower(fields[0])
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return errors.NewStorageError("failed to open %s for checksum verification", filePath, err)
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	h := sha256.New()
+
+	if _, err = io.Copy(h, f); err != nil {
+		return errors.NewStorageError("failed to read %s for checksum verification", filePath, err)
+	}
+
+	actual := hex.EncodeToString(h.Sum(nil))
+
+	if actual != expected {
+		return errors.NewProcessingError("checksum mismatch for %s: sidecar %s says %s, actual content hashes to %s (file may be corrupted)",
+			filePath, sidecarPath, expected, actual)
+	}
+
+	logger.Infof("[verifyChecksum] checksum verified for %s against %s", filePath, sidecarPath)
 
 	return nil
 }

--- a/cmd/seeder/seeder_skip_headers_test.go
+++ b/cmd/seeder/seeder_skip_headers_test.go
@@ -1,0 +1,90 @@
+package seeder
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEmptyUTXOSetFile writes a minimal, valid, zero-UTXO ".utxo-set" file:
+// just the header, tip hash, height and previous-block-hash fields that
+// processUTXOs reads before it starts iterating UTXOWrapper records.
+func writeEmptyUTXOSetFile(t *testing.T, path string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	header := fileformat.NewHeader(fileformat.FileTypeUtxoSet)
+	require.NoError(t, header.Write(&buf))
+
+	var tipHash chainhash.Hash
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, tipHash))
+
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(1)))
+
+	var prevHash [32]byte
+	buf.Write(prevHash[:])
+
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+}
+
+// TestSeeder_SkipHeaders_CorruptedHeaderFileFailsVerification guards against
+// the headers file being consumed unverified when -skipHeaders is set.
+//
+// headerFile is not only read by the header-import pass: processUTXOs reads
+// it back unconditionally (via loadCoinbaseTxs) to recover coinbase inputs.
+// So the documented "-skipHeaders" flow (headers already imported, now do the
+// UTXOs) must still verify the headers file whenever it is present, even
+// though the header-import pass itself is skipped.
+//
+// A checksum sidecar that doesn't match the header file's actual content
+// must cause Seeder to fail fast, before any store is constructed -- not be
+// silently consumed by processUTXOs.
+func TestSeeder_SkipHeaders_CorruptedHeaderFileFailsVerification(t *testing.T) {
+	dir := t.TempDir()
+	hash := "abc123"
+
+	headerFile := filepath.Join(dir, hash+".utxo-headers")
+	original := []byte("this is the utxo-headers content")
+
+	require.NoError(t, os.WriteFile(headerFile, original, 0o644))
+
+	// Sidecar reflects the ORIGINAL content.
+	sum := sha256.Sum256(original)
+	sidecar := hex.EncodeToString(sum[:]) + "  " + filepath.Base(headerFile) + "\n"
+	require.NoError(t, os.WriteFile(headerFile+checksumSidecarExtension, []byte(sidecar), 0o644))
+
+	// Corrupt the header file in place after the sidecar was written, leaving
+	// the sidecar stale -- exactly the corruption this check exists to catch.
+	corrupted := append([]byte(nil), original...)
+	corrupted[0] ^= 0xFF
+	require.NoError(t, os.WriteFile(headerFile, corrupted, 0o644))
+
+	utxoFile := filepath.Join(dir, hash+".utxo-set")
+	writeEmptyUTXOSetFile(t, utxoFile)
+
+	tSettings := test.CreateBaseTestSettings(t)
+
+	blockchainStoreURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	tSettings.BlockChain.StoreURL = blockchainStoreURL
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	tSettings.UtxoStore.UtxoStore = utxoStoreURL
+
+	err = Seeder(ulogger.TestLogger{}, tSettings, dir, hash, true /* skipHeaders */, false /* skipUTXOs */, false /* force */)
+	require.Error(t, err, "a corrupted headers file must not be silently consumed when -skipHeaders is set")
+	require.Contains(t, err.Error(), "checksum verification failed for headers file")
+}

--- a/docs/topics/commands/seeder.md
+++ b/docs/topics/commands/seeder.md
@@ -147,6 +147,33 @@ Options:
 - `-skipHeaders`: (Optional) Skip processing of headers.
 - `-skipUTXOs`: (Optional) Skip processing of UTXOs.
 
+### Checksum verification
+
+Before reading the headers file and/or the UTXO-set file, the seeder checks
+for a `<file>.sha256` checksum sidecar next to it — the same format the UTXO
+Persister's blob file store, and `bitcointoutxoset`, write alongside every
+snapshot: a hex-encoded SHA-256 digest, optionally followed by the snapshot's
+filename.
+
+- If a sidecar is present and matches, the import proceeds.
+- If a sidecar is present and does **not** match (wrong checksum, or a
+  filename field naming a different snapshot), the seeder refuses to import
+  and returns an error — a corrupted-but-otherwise-well-formed snapshot must
+  never be silently seeded.
+- If no sidecar is present, the import proceeds with only a warning logged;
+  mandating a sidecar for every possible snapshot source isn't realistic, so
+  this is not a fatal condition.
+
+This applies to the headers file even when `-skipHeaders` is set: the UTXO
+pass still reads the headers file back to recover coinbase inputs, so it is
+verified whenever it will be consumed, not only when the header-import pass
+itself runs.
+
+This check is a defense against transfer/storage corruption, not tampering:
+the sidecar itself is unauthenticated, so it cannot detect a snapshot and its
+sidecar being modified together. There is no flag to make the sidecar
+mandatory; a missing sidecar always falls back to a warning.
+
 ## 7. Configuration Options
 
 The Seeder uses various configuration options, which can be set through a configuration system:

--- a/services/utxopersister/checksum_sidecar_test.go
+++ b/services/utxopersister/checksum_sidecar_test.go
@@ -1,0 +1,88 @@
+package utxopersister
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/blob/file"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateUTXOSet_WritesChecksumSidecar confirms that when the UTXO
+// Persister writes a .utxo-set snapshot through the blob file store, a
+// "<file>.sha256" sidecar is written alongside it, and that the sidecar's
+// hash matches the actual bytes of the written file. This is exactly the
+// sidecar the seeder's checksum verification (cmd/seeder) relies on when a
+// snapshot produced this way is copied into its input directory.
+func TestCreateUTXOSet_WritesChecksumSidecar(t *testing.T) {
+	ctx := context.Background()
+	logger := ulogger.TestLogger{}
+	tSettings := test.CreateBaseTestSettings(t)
+
+	dir := t.TempDir()
+
+	storeURL, err := url.Parse("file://" + dir)
+	require.NoError(t, err)
+
+	blockStore, err := file.New(logger, storeURL)
+	require.NoError(t, err)
+
+	currentBlockHash := chainhash.HashH([]byte("current-block-hash-for-sidecar-test"))
+
+	// firstPreviousBlockHash = genesis so CreateUTXOSet skips reading a
+	// previous UTXO set and just writes the new file.
+	c := NewConsolidator(logger, tSettings, nil, nil, blockStore, tSettings.ChainCfgParams.GenesisHash)
+	c.lastBlockHash = &currentBlockHash
+	c.lastBlockHeight = 1
+	c.previousBlockHash = tSettings.ChainCfgParams.GenesisHash
+
+	us, err := GetUTXOSet(ctx, logger, tSettings, blockStore, &currentBlockHash)
+	require.NoError(t, err)
+
+	require.NoError(t, us.CreateUTXOSet(ctx, c))
+
+	// The file store names blobs "<reversed-hex-key>.<filetype>" with no
+	// hash-prefix subdirectory by default - the same layout the seeder
+	// expects in its -inputDir.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var (
+		snapshotPath string
+		sidecarPath  string
+	)
+
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, ".utxo-set") {
+			snapshotPath = filepath.Join(dir, name)
+		} else if strings.HasSuffix(name, ".utxo-set.sha256") {
+			sidecarPath = filepath.Join(dir, name)
+		}
+	}
+
+	require.NotEmpty(t, snapshotPath, "expected a .utxo-set file to have been written")
+	require.NotEmpty(t, sidecarPath, "expected a .utxo-set.sha256 checksum sidecar to have been written alongside it")
+
+	content, err := os.ReadFile(snapshotPath)
+	require.NoError(t, err)
+
+	sidecar, err := os.ReadFile(sidecarPath)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(content)
+	expectedHex := hex.EncodeToString(sum[:])
+
+	fields := strings.Fields(string(sidecar))
+	require.NotEmpty(t, fields, "sidecar must not be empty")
+	require.Equal(t, expectedHex, strings.ToLower(fields[0]), "sidecar checksum must match the actual file content")
+}

--- a/services/utxopersister/checksum_sidecar_test.go
+++ b/services/utxopersister/checksum_sidecar_test.go
@@ -83,6 +83,7 @@ func TestCreateUTXOSet_WritesChecksumSidecar(t *testing.T) {
 	expectedHex := hex.EncodeToString(sum[:])
 
 	fields := strings.Fields(string(sidecar))
-	require.NotEmpty(t, fields, "sidecar must not be empty")
+	require.Len(t, fields, 2, "sidecar must be '<hex-sha256>  <filename>'")
 	require.Equal(t, expectedHex, strings.ToLower(fields[0]), "sidecar checksum must match the actual file content")
+	require.Equal(t, filepath.Base(snapshotPath), fields[1], "sidecar must name the snapshot it belongs to")
 }


### PR DESCRIPTION
## Summary
- `cmd/seeder/seeder.go` now verifies the headers and UTXO snapshot files against their `.sha256` sidecar (written by `services/utxopersister`) before using them.
- A checksum mismatch fails loudly and clearly; a missing sidecar (e.g. an older snapshot predating checksum sidecars) logs a warning and proceeds, for backward compatibility.
- Added `cmd/seeder/checksum_test.go` covering: matching checksum succeeds, mismatched checksum fails, and missing sidecar warns-and-proceeds.
- Added `services/utxopersister/checksum_sidecar_test.go` confirming the UTXO persister writes the sidecar alongside the UTXO set file.

## Test plan
- [x] `go test ./cmd/seeder/... ./services/utxopersister/... -race -count=1`
- [x] Manually confirmed the three checksum scenarios: matching, mismatched, missing sidecar