### PR TITLE
fix(p2p): ban peers serving consensus-invalid blocks during catchup

### DIFF
--- a/services/blockchain/peer_registry.go
+++ b/services/blockchain/peer_registry.go
@@ -913,8 +913,19 @@ func (r *CentralizedPeerRegistry) ReconsiderBadPeers(cooldown time.Duration) int
 	peersRecovered := 0
 	now := time.Now()
 
-	for _, info := range r.peers {
+	for peerID, info := range r.peers {
 		if info.ReputationScore >= 20 {
+			continue
+		}
+
+		// Peers with outstanding ban score are excluded from automatic recovery:
+		// a non-zero score means confirmed misbehaviour (consensus-invalid block,
+		// checkpoint violation, protocol violation) that has not yet decayed.
+		// Without this gate a peer feeding invalid blocks during catchup would be
+		// readmitted as a sync candidate every cooldown window (issue #1161).
+		// Ban score decays on its own schedule (StartBanDecay), so recovery is
+		// merely deferred, not permanently denied.
+		if entry, ok := r.banScores[peerID]; ok && (entry.Banned || entry.Score > 0) {
 			continue
 		}
 		if info.LastInteractionFailure.IsZero() || now.Sub(info.LastInteractionFailure) < cooldown {

--- a/services/blockchain/peer_registry_ban_test.go
+++ b/services/blockchain/peer_registry_ban_test.go
@@ -314,6 +314,92 @@ func TestBanReconsiderBadPeers_ReturnsCount(t *testing.T) {
 	require.Equal(t, 3, count)
 }
 
+// TestBanReconsiderBadPeers_SkipsPeersWithOutstandingBanScore covers issue #1161:
+// a peer that fed consensus-invalid blocks during catchup accrues ban score, and
+// must NOT be auto-recovered back into the sync-candidate pool while that score
+// is outstanding.
+func TestBanReconsiderBadPeers_SkipsPeersWithOutstandingBanScore(t *testing.T) {
+	r := NewCentralizedPeerRegistry(DefaultBanConfig())
+
+	r.Register(&PeerInfo{ID: "invalid-block-peer"})
+	r.UpdateMetrics("invalid-block-peer", 0, 0, 0, false, false, true, 0)
+	r.AddBanScore("invalid-block-peer", "invalid_block", 0)
+
+	got, _ := r.Get("invalid-block-peer")
+	require.Less(t, got.ReputationScore, 20.0)
+	require.Positive(t, got.BanScore)
+
+	// Backdate the failure so only the ban score keeps the peer out.
+	r.mu.Lock()
+	r.peers["invalid-block-peer"].LastInteractionFailure = time.Now().Add(-2 * time.Hour)
+	r.mu.Unlock()
+
+	require.Equal(t, 0, r.ReconsiderBadPeers(1*time.Hour), "peer with outstanding ban score must not recover")
+
+	got, _ = r.Get("invalid-block-peer")
+	require.Less(t, got.ReputationScore, 20.0)
+	require.Positive(t, got.MaliciousCount)
+
+	// Once the ban score has decayed to zero, normal recovery resumes.
+	r.mu.Lock()
+	r.banScores["invalid-block-peer"].Score = 0
+	r.mu.Unlock()
+
+	require.Equal(t, 1, r.ReconsiderBadPeers(1*time.Hour))
+}
+
+// TestBanReconsiderBadPeers_SkipsBannedPeers ensures an actively banned peer is
+// never handed back a usable reputation by the recovery sweep.
+func TestBanReconsiderBadPeers_SkipsBannedPeers(t *testing.T) {
+	r := NewCentralizedPeerRegistry(DefaultBanConfig())
+
+	r.Register(&PeerInfo{ID: "banned-peer"})
+	r.UpdateMetrics("banned-peer", 0, 0, 0, false, false, true, 0)
+
+	_, banned := r.AddBanScore("banned-peer", "test", DefaultBanConfig().Threshold)
+	require.True(t, banned)
+
+	r.mu.Lock()
+	r.peers["banned-peer"].LastInteractionFailure = time.Now().Add(-2 * time.Hour)
+	r.mu.Unlock()
+
+	require.Equal(t, 0, r.ReconsiderBadPeers(1*time.Hour))
+}
+
+// TestBanScoreAccumulatesToBanForRepeatedInvalidBlocks documents the escalation
+// path for a peer repeatedly delivering consensus-invalid blocks during catchup.
+func TestBanScoreAccumulatesToBanForRepeatedInvalidBlocks(t *testing.T) {
+	cfg := DefaultBanConfig()
+	// Disable decay so the test measures pure accumulation.
+	cfg.DecayInterval = 0
+	r := NewCentralizedPeerRegistry(cfg)
+
+	r.Register(&PeerInfo{ID: "repeat-invalid"})
+
+	points := cfg.ReasonPoints["invalid_block"]
+	require.Positive(t, points, "invalid_block must carry ban points")
+
+	var banned bool
+	attempts := 0
+	for i := 0; i < int(cfg.Threshold/points)+1; i++ {
+		r.UpdateMetrics("repeat-invalid", 0, 0, 0, false, false, true, 0)
+		_, banned = r.AddBanScore("repeat-invalid", "invalid_block", 0)
+		attempts++
+		if banned {
+			break
+		}
+	}
+
+	require.True(t, banned, "peer should be banned after %d invalid blocks", attempts)
+	require.True(t, r.IsBannedPeer("repeat-invalid"))
+
+	// And recovery must not readmit it.
+	r.mu.Lock()
+	r.peers["repeat-invalid"].LastInteractionFailure = time.Now().Add(-2 * time.Hour)
+	r.mu.Unlock()
+	require.Equal(t, 0, r.ReconsiderBadPeers(1*time.Hour))
+}
+
 // ---------------------------------------------------------------------------
 // decayBanScores
 // ---------------------------------------------------------------------------

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/blockvalidation_api"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
+	"github.com/bsv-blockchain/teranode/services/p2p"
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -1820,7 +1821,7 @@ func (u *Server) processCatchupChItem(ctx context.Context, c processBlockCatchup
 			// Mark peer as malicious only for a genuinely invalid (consensus-failing)
 			// block. Transient catchup-state errors fall through to alternative-peer
 			// retry, same as ErrBlockIncomplete. See issue #1031.
-			u.reportCatchupMalicious(ctx, c.peerID, "invalid_block")
+			u.reportCatchupMaliciousAndBan(ctx, c.peerID, "invalid_block", p2p.ReasonInvalidBlock)
 
 			// Clean up the processing notification for this block
 			u.processBlockNotify.Delete(*c.block.Hash())

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
 	"github.com/bsv-blockchain/teranode/services/blockchain/work"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
+	"github.com/bsv-blockchain/teranode/services/p2p"
 	"github.com/bsv-blockchain/teranode/util/blockassemblyutil"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 	"golang.org/x/sync/errgroup"
@@ -1120,7 +1121,7 @@ func (u *Server) validateBlocksOnChannel(validateBlocksChan chan blockForValidat
 					} else if errors.Is(err, errors.ErrBlockInvalid) || errors.Is(err, errors.ErrTxInvalid) {
 						// ValidateBlockWithOptions already stored the block as invalid if it's a consensus violation
 						u.logger.Warnf("[catchup:validateBlocksOnChannel][%s] block %s violates consensus rules (already stored as invalid by ValidateBlockWithOptions)", blockUpTo.Hash().String(), block.Hash().String())
-						u.reportCatchupMalicious(gCtx, peerID, "invalid_block_validation")
+						u.reportCatchupMaliciousAndBan(gCtx, peerID, "invalid_block_validation", p2p.ReasonInvalidBlock)
 					}
 
 					// Record metric for validation failure

--- a/services/blockvalidation/catchup_ban_escalation_test.go
+++ b/services/blockvalidation/catchup_ban_escalation_test.go
@@ -1,0 +1,120 @@
+package blockvalidation
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/services/p2p"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+// banScoreRecordingP2PClient records malicious reports and ban-score escalations
+// so tests can assert that a confirmed consensus violation does both.
+type banScoreRecordingP2PClient struct {
+	P2PClientI
+
+	mu             sync.Mutex
+	maliciousPeers []string
+	banCalls       []string // "peerID:reason"
+	banErr         error
+}
+
+func (b *banScoreRecordingP2PClient) RecordCatchupMalicious(_ context.Context, peerID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maliciousPeers = append(b.maliciousPeers, peerID)
+
+	return nil
+}
+
+func (b *banScoreRecordingP2PClient) AddBanScore(_ context.Context, peerID string, reason string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.banCalls = append(b.banCalls, peerID+":"+reason)
+
+	return b.banErr
+}
+
+func (b *banScoreRecordingP2PClient) snapshot() ([]string, []string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return append([]string(nil), b.maliciousPeers...), append([]string(nil), b.banCalls...)
+}
+
+// TestReportCatchupMaliciousAndBan verifies that confirmed catchup misbehaviour is
+// escalated to the ban-score system, not just penalised in reputation (issue #1161).
+func TestReportCatchupMaliciousAndBan(t *testing.T) {
+	t.Run("EscalatesToBanScore", func(t *testing.T) {
+		client := &banScoreRecordingP2PClient{}
+		server := &Server{logger: ulogger.TestLogger{}, p2pClient: client}
+
+		server.reportCatchupMaliciousAndBan(context.Background(), "peer-1", "invalid_block_validation", p2p.ReasonInvalidBlock)
+
+		malicious, bans := client.snapshot()
+		require.Equal(t, []string{"peer-1"}, malicious)
+		require.Equal(t, []string{"peer-1:" + p2p.ReasonInvalidBlock}, bans)
+	})
+
+	t.Run("RepeatedInvalidBlocksAccumulateBanScore", func(t *testing.T) {
+		client := &banScoreRecordingP2PClient{}
+		server := &Server{logger: ulogger.TestLogger{}, p2pClient: client}
+
+		for i := 0; i < 5; i++ {
+			server.reportCatchupMaliciousAndBan(context.Background(), "peer-2", "invalid_block", p2p.ReasonInvalidBlock)
+		}
+
+		malicious, bans := client.snapshot()
+		require.Len(t, malicious, 5)
+		require.Len(t, bans, 5, "every confirmed invalid block must add ban score")
+	})
+
+	t.Run("BanScoreErrorIsNonFatal", func(t *testing.T) {
+		client := &banScoreRecordingP2PClient{banErr: errors.NewServiceError("p2p down")}
+		server := &Server{logger: ulogger.TestLogger{}, p2pClient: client}
+
+		require.NotPanics(t, func() {
+			server.reportCatchupMaliciousAndBan(context.Background(), "peer-3", "invalid_block", p2p.ReasonInvalidBlock)
+		})
+
+		malicious, bans := client.snapshot()
+		require.Equal(t, []string{"peer-3"}, malicious)
+		require.Len(t, bans, 1)
+	})
+
+	t.Run("EmptyPeerIDIsIgnored", func(t *testing.T) {
+		client := &banScoreRecordingP2PClient{}
+		server := &Server{logger: ulogger.TestLogger{}, p2pClient: client}
+
+		server.reportCatchupMaliciousAndBan(context.Background(), "", "invalid_block", p2p.ReasonInvalidBlock)
+
+		malicious, bans := client.snapshot()
+		require.Empty(t, malicious)
+		require.Empty(t, bans)
+	})
+
+	t.Run("SoftMaliciousReportDoesNotBan", func(t *testing.T) {
+		// Ambiguous / transient failures must stay soft: reputation only.
+		client := &banScoreRecordingP2PClient{}
+		server := &Server{logger: ulogger.TestLogger{}, p2pClient: client}
+
+		server.reportCatchupMalicious(context.Background(), "peer-4", "validation_failure")
+
+		malicious, bans := client.snapshot()
+		require.Equal(t, []string{"peer-4"}, malicious)
+		require.Empty(t, bans, "transient failures must not accrue ban score")
+	})
+
+	t.Run("NilP2PClientIsSafe", func(t *testing.T) {
+		server := &Server{logger: ulogger.TestLogger{}}
+
+		require.NotPanics(t, func() {
+			server.reportCatchupMaliciousAndBan(context.Background(), "peer-5", "invalid_block", p2p.ReasonInvalidBlock)
+		})
+	})
+}

--- a/services/blockvalidation/catchup_get_block_headers.go
+++ b/services/blockvalidation/catchup_get_block_headers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
+	"github.com/bsv-blockchain/teranode/services/p2p"
 	"github.com/bsv-blockchain/teranode/util/tracing"
 )
 
@@ -320,9 +321,9 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 			// Check if error indicates malicious behavior
 			if errors.IsMaliciousResponseError(parseErr) {
 				// Report malicious behavior to P2P service
-				u.reportCatchupMalicious(ctx, identifier, "malicious response during header parsing")
+				u.reportCatchupMaliciousAndBan(ctx, identifier, "malicious response during header parsing", p2p.ReasonProtocolViolation)
 
-				u.logger.Errorf("[catchup][%s] SECURITY: Peer %s sent malicious headers - should be banned (banning not yet implemented)", chainTipHash.String(), baseURL)
+				u.logger.Errorf("[catchup][%s] SECURITY: Peer %s sent malicious headers - ban score applied", chainTipHash.String(), baseURL)
 
 				return catchup.CreateCatchupResult(
 					allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,
@@ -362,7 +363,7 @@ func (u *Server) catchupGetBlockHeaders(ctx context.Context, blockUpTo *model.Bl
 		if err = u.validateBatchHeaders(ctx, blockHeaders); err != nil {
 			if errors.IsMaliciousResponseError(err) {
 				// Report malicious behavior for checkpoint violation to P2P service
-				u.reportCatchupMalicious(ctx, identifier, "checkpoint violation during header validation")
+				u.reportCatchupMaliciousAndBan(ctx, identifier, "checkpoint violation during header validation", p2p.ReasonProtocolViolation)
 
 				return catchup.CreateCatchupResult(
 					allCatchupHeaders, blockUpTo.Hash(), startHash, startHeight, startTime, baseURL,

--- a/services/blockvalidation/catchup_malicious_abort_test.go
+++ b/services/blockvalidation/catchup_malicious_abort_test.go
@@ -53,6 +53,9 @@ func (m *maliciousAbortP2PClient) RecordCatchupFailure(_ context.Context, _ stri
 func (m *maliciousAbortP2PClient) RecordCatchupMalicious(_ context.Context, _ string) error {
 	return nil
 }
+func (m *maliciousAbortP2PClient) AddBanScore(_ context.Context, _ string, _ string) error {
+	return nil
+}
 func (m *maliciousAbortP2PClient) UpdateCatchupError(_ context.Context, _ string, _ string) error {
 	return nil
 }

--- a/services/blockvalidation/p2p_client_interface.go
+++ b/services/blockvalidation/p2p_client_interface.go
@@ -24,6 +24,12 @@ type P2PClientI interface {
 	// RecordCatchupMalicious records malicious behavior detected during catchup.
 	RecordCatchupMalicious(ctx context.Context, peerID string) error
 
+	// AddBanScore escalates confirmed peer misbehaviour to the ban-score system,
+	// which eventually bans and disconnects the peer. Unlike
+	// RecordCatchupMalicious (a soft reputation penalty that automatic reputation
+	// recovery can undo), ban score decays only with time.
+	AddBanScore(ctx context.Context, peerID string, reason string) error
+
 	// UpdateCatchupError stores the last catchup error for a peer.
 	UpdateCatchupError(ctx context.Context, peerID string, errorMsg string) error
 

--- a/services/blockvalidation/peer_metrics_helpers.go
+++ b/services/blockvalidation/peer_metrics_helpers.go
@@ -123,6 +123,41 @@ func (u *Server) reportCatchupMalicious(ctx context.Context, peerID string, reas
 	// Fallback: No local metrics needed since we're using P2P service for all peer tracking
 }
 
+// reportCatchupMaliciousAndBan records malicious catchup behaviour AND escalates it
+// to the ban-score system. Use this only for confirmed misbehaviour (a block that
+// failed consensus validation, a checkpoint violation, a malformed/malicious
+// response) — never for transient or ambiguous failures.
+//
+// The reputation penalty alone is insufficient: ReconsiderBadPeers can restore a
+// low-reputation peer, so a peer alternating valid and consensus-invalid responses
+// would otherwise remain a sync candidate indefinitely (see issue #1161). Ban score
+// accumulates across offences and decays only with time.
+//
+// Parameters:
+//   - ctx: Context for the gRPC calls
+//   - peerID: Peer identifier
+//   - reason: Description of the malicious behaviour (for logging)
+//   - banReason: Ban reason key understood by the peer registry's ban config
+//     (see p2p.Reason* constants)
+func (u *Server) reportCatchupMaliciousAndBan(ctx context.Context, peerID string, reason string, banReason string) {
+	if peerID == "" {
+		return
+	}
+
+	u.reportCatchupMalicious(ctx, peerID, reason)
+
+	if u.p2pClient == nil {
+		return
+	}
+
+	if err := u.p2pClient.AddBanScore(ctx, peerID, banReason); err != nil {
+		u.logger.Warnf("[peer_metrics] Failed to add ban score %q for peer %s: %v", banReason, peerID, err)
+		return
+	}
+
+	u.logger.Warnf("[peer_metrics] Added ban score %q for peer %s (%s)", banReason, peerID, reason)
+}
+
 // isPeerMalicious checks if a peer is marked as malicious.
 // Queries the P2P service for the peer's status.
 //


### PR DESCRIPTION
Fixes #1161.

## Problem

A block that fails validation during catchup routed only to `RecordCatchupMalicious` (reputation pinned low, `MaliciousCount++`) and never to `AddBanScore`. `ReconsiderBadPeers` then reset reputation to 30 and cleared `MaliciousCount`, so a peer alternating valid and consensus-invalid responses remained a repeatedly-selected sync candidate indefinitely — unlike the gossip path, which escalates via `AddBanScore("invalid_block")`.

## Change

**`services/blockvalidation`**
- `P2PClientI` gains `AddBanScore(ctx, peerID, reason)`.
- New helper `reportCatchupMaliciousAndBan` records the malicious event **and** adds ban score; failures are logged, never fatal.
- Applied only at confirmed-violation callsites:
  - `catchup.go` — block failed consensus validation during catchup (`invalid_block`)
  - `Server.go` — unvalidatable (consensus-failing) block (`invalid_block`)
  - `catchup_get_block_headers.go` — malicious header response and checkpoint violation (`protocol_violation`)
- Transient/ambiguous failures (`validation_failure`, `secret_mining`) intentionally keep the soft reputation-only path.

**`services/blockchain`**
- `ReconsiderBadPeers` skips peers that are banned or carry outstanding ban score. Recovery is deferred, not permanently denied: ban score decays on its own schedule (`StartBanDecay`), after which normal recovery resumes.

## Tests

- `services/blockvalidation/catchup_ban_escalation_test.go`: escalation adds ban score, repeated invalid blocks accumulate, RPC error is non-fatal, empty peer ID / nil client are safe, and the soft path does **not** ban.
- `services/blockchain/peer_registry_ban_test.go`: recovery skipped while ban score outstanding (and resumed after decay), banned peers never recovered, repeated `invalid_block` accrues to a ban that recovery cannot undo.

## Verification

```
go build ./...                                                        ok
go test ./services/blockchain/ ./services/blockvalidation/... ./services/p2p/...  ok
make lint                                                             0 issues
```

## Residual risk

Ban-score points come from `BanConfig.ReasonPoints` (`invalid_block` = 10, `protocol_violation` = 20 by default), so ~10 confirmed invalid catchup blocks reach the default threshold of 100. Operators wanting faster escalation can raise the per-reason points. Honest peers serving incomplete blocks (`ErrBlockIncomplete`) are unaffected.