### PR TITLE
fix(p2p): add sync-peer hysteresis and near-equal band diversity

### DIFF
--- a/docs/topics/features/peer_registry_reputation.md
+++ b/docs/topics/features/peer_registry_reputation.md
@@ -109,7 +109,8 @@ The `PeerSelector` implements the peer selection algorithm. It takes a list of p
 type SelectionCriteria struct {
     LocalHeight         int32         // Current local blockchain height
     ForcedPeerID        peer.ID       // Force selection of specific peer
-    PreviousPeer        peer.ID       // Previously selected peer (for rotation)
+    PreviousPeer        peer.ID       // Previously selected peer (kept unless a challenger is materially better)
+    PreviousPeerFailed  bool          // PreviousPeer failed (catchup failure / no-progress stall): rotate it off
     SyncAttemptCooldown time.Duration // Cooldown before retrying a peer
 }
 ```
@@ -226,22 +227,35 @@ The peer selector uses a two-phase approach for optimal selection:
    - Average response time (lowest first, peers with measurements first) - **quaternary**
    - Ban score (lowest first) - **quinary**
    - Validated block height (highest first) - **senary**
-3. Exclude the previously selected peer when any alternative exists
-4. Select uniformly at random among the top-ranked candidates that tie on
-   every criterion above
+3. Exclude the previously selected peer only when the coordinator reports it
+   failed (catchup failure or no-progress stall) and an alternative exists
+4. Form the **top band**: the highest-ranked candidate plus every following
+   candidate that is *near-equal* to it. Proven-delivery tier, validated chain
+   work and validated height must match exactly; reputation (±5), average
+   response time (±25 ms or ±25%) and ban score (±5) are compared with
+   equivalence margins
+5. If the previous peer is in the band and has not failed, keep it
+   (**hysteresis**); otherwise select uniformly at random from the band
+
+Hysteresis exists because unconditional rotation makes two near-equal peers
+ping-pong the sync slot every evaluation cycle, and each switch re-triggers
+catchup over Kafka and splits the download stream. The slot therefore only moves
+when a challenger is materially better, or when the incumbent actually fails.
 
 There is deliberately no peer-ID tiebreak: peer IDs are attacker-grindable
 (cheap libp2p keypair generation), so a deterministic ID ordering would let a
 Sybil attacker mint an ID that always wins selection among otherwise equal
 candidates. Random selection within the top band caps a Sybil set's capture
-probability at its proportional share of that band.
+probability at its proportional share of that band, and — because the band spans
+near-equal peers, not only exact ties — independent nodes spread their sync load
+over the whole band instead of herding onto one marginally-best peer.
 
 #### Phase 2: Pruned Node Fallback
 
 If no full nodes are available and fallback is enabled:
 
 1. Filter for peers not in "full" mode but meeting other criteria
-2. Rank and select using the same criteria and random tiebreak as Phase 1
+2. Rank and select using the same criteria, hysteresis and random band draw as Phase 1
 
 ### 5.3. Fallback to Pruned Nodes
 

--- a/services/p2p/peer_selector.go
+++ b/services/p2p/peer_selector.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"math"
 	"math/rand/v2"
 	"net/http"
 	"sort"
@@ -27,6 +28,32 @@ const (
 	// It spans the full-node and pruned-node passes of one selection as well as
 	// closely spaced selection ticks.
 	peerHealthCacheTTL = 10 * time.Second
+
+	// The margins below define "materially better". Two candidates whose soft
+	// merit metrics differ by no more than these margins are treated as members
+	// of the same top band: the incumbent is kept (hysteresis, so near-equal
+	// peers cannot ping-pong the sync slot) and, when there is no incumbent, the
+	// winner is drawn uniformly from the band (diversity, so independent nodes do
+	// not all herd onto the same marginally-best peer). Validated chain work and
+	// proven-delivery tier are never softened this way.
+
+	// peerReputationEquivalenceMargin is the reputation-score difference below
+	// which two candidates count as equally reputable.
+	peerReputationEquivalenceMargin = 5.0
+
+	// peerResponseTimeEquivalenceMargin is the absolute average-response-time
+	// difference (ms) below which two candidates count as equally fast; it keeps
+	// jitter on fast peers from looking like a material difference.
+	peerResponseTimeEquivalenceMargin = 25
+
+	// peerResponseTimeEquivalenceRatio is the relative average-response-time
+	// ratio below which two candidates count as equally fast, so the margin also
+	// scales for slower links.
+	peerResponseTimeEquivalenceRatio = 1.25
+
+	// peerBanScoreEquivalenceMargin is the ban-score difference below which two
+	// candidates count as equally well-behaved.
+	peerBanScoreEquivalenceMargin = 5
 )
 
 // peerHealthCacheEntry is a cached availability probe result.
@@ -45,10 +72,19 @@ type SelectionCriteria struct {
 	ForcedPeerID                 string        // If set, only this peer (canonical libp2p ID string) will be selected
 	PreviousPeer                 string        // The previously selected peer (canonical libp2p ID string), if any
 	SyncAttemptCooldown          time.Duration // Cooldown period before retrying a peer
+
+	// PreviousPeerFailed reports that PreviousPeer failed (catchup failure or a
+	// no-progress stall) and the caller wants it rotated off. When false the
+	// previous peer is sticky: it is re-selected as long as no challenger is
+	// materially better than it (see peersNearEqual), which stops two
+	// near-equal peers from alternating the sync slot every cycle and
+	// re-triggering catchup on each switch. When true it is excluded from
+	// selection whenever an alternative exists.
+	PreviousPeerFailed bool
 }
 
 // PeerSelector handles peer selection logic.
-// Selection among candidates that are equal on every merit criterion is
+// Selection among candidates that are near-equal on every merit criterion is
 // randomized so a Sybil attacker cannot capture selection by grinding peer
 // IDs. When settings.P2P.HealthCheckEnabled is set it probes candidate DataHub
 // URLs over HTTP (bounded concurrency, overall deadline) and keeps a short-TTL
@@ -96,7 +132,10 @@ func (ps *PeerSelector) randomIndex(n int) int {
 // SelectSyncPeer selects the best peer for syncing using two-phase selection:
 // Phase 1: Try to select from full nodes (nodes with complete block data)
 // Phase 2: If no full nodes and fallback enabled, select from non-full nodes
-// Ties among equally ranked candidates are broken randomly, never by peer ID.
+// Near-equally ranked candidates form a top band (see selectFromCandidates):
+// the previous peer is kept if it is in that band and has not failed
+// (hysteresis), otherwise the winner is drawn randomly from the band, never by
+// peer ID.
 // When settings.P2P.HealthCheckEnabled is set, candidate DataHub URLs are
 // probed over HTTP before either phase: concurrently (bounded by
 // peerHealthCheckConcurrency), full-node tier first so slow pruned peers
@@ -248,11 +287,86 @@ func (ps *PeerSelector) comparePeerCandidates(a, b *blockchain.PeerInfo, now tim
 	return 0
 }
 
+// peersNearEqual reports whether two candidates are close enough on every merit
+// criterion that switching from one to the other is not a material improvement.
+// It is reflexive and symmetric, and it is a strict relaxation of
+// comparePeerCandidates == 0: exact ties are always near-equal.
+//
+// Hard criteria are never softened, because picking the weaker peer would
+// directly slow or stall catchup: proven recent full-block delivery and
+// validated chain work must match exactly. The soft criteria (reputation,
+// average response time, ban score) are compared with the equivalence margins
+// above. Validated height is also hard: peers at the same tip report the same
+// validated height, so requiring equality costs no band width in practice while
+// keeping validated progress — the only progress signal for advertised-probe
+// peers, which carry no validated chain work at all — from being softened away.
+//
+// Near-equality is deliberately not transitive, so callers must always evaluate
+// it against the band leader (see selectFromCandidates).
+func (ps *PeerSelector) peersNearEqual(a, b *blockchain.PeerInfo, now time.Time, freshnessWindow time.Duration) bool {
+	if peerHasRecentFullBlockDelivery(a, now, freshnessWindow) != peerHasRecentFullBlockDelivery(b, now, freshnessWindow) {
+		return false
+	}
+	if compareChainWork(a.ValidatedChainWork, b.ValidatedChainWork) != 0 {
+		return false
+	}
+	if a.ValidatedHeight != b.ValidatedHeight {
+		return false
+	}
+	if math.Abs(a.ReputationScore-b.ReputationScore) > peerReputationEquivalenceMargin {
+		return false
+	}
+	// A measured response time is information the other peer lacks, so a
+	// measured peer and an unmeasured one are never near-equal (mirroring
+	// comparePeerCandidates, which prefers the measured one).
+	if (a.AvgResponseTimeMs > 0) != (b.AvgResponseTimeMs > 0) {
+		return false
+	}
+	if a.AvgResponseTimeMs > 0 && b.AvgResponseTimeMs > 0 &&
+		!responseTimesNearEqual(a.AvgResponseTimeMs, b.AvgResponseTimeMs) {
+		return false
+	}
+
+	banDelta := a.BanScore - b.BanScore
+	if banDelta < 0 {
+		banDelta = -banDelta
+	}
+
+	return banDelta <= peerBanScoreEquivalenceMargin
+}
+
+// responseTimesNearEqual reports whether two measured average response times are
+// within either the absolute or the relative equivalence margin.
+func responseTimesNearEqual(a, b int64) bool {
+	fast, slow := a, b
+	if fast > slow {
+		fast, slow = slow, fast
+	}
+	if slow-fast <= peerResponseTimeEquivalenceMargin {
+		return true
+	}
+	return float64(slow) <= float64(fast)*peerResponseTimeEquivalenceRatio
+}
+
 // selectFromCandidates selects the best peer from a list of candidates
 // using validation-gated delivery evidence and locally validated work.
-// Candidates that tie on every merit criterion form the top band, and the
-// winner is drawn uniformly at random from that band so an attacker cannot
-// deterministically capture selection by grinding peer IDs.
+// Candidates that are near-equal to the highest-ranked one (peersNearEqual)
+// form the top band, and:
+//   - if the previous peer is in that band and the caller did not report it
+//     failed, it is kept (hysteresis): the slot only moves when a challenger is
+//     materially better, so near-equal peers cannot ping-pong the slot and
+//     re-trigger catchup every cycle;
+//   - otherwise the winner is drawn uniformly at random from the band, so an
+//     attacker cannot deterministically capture selection by grinding peer IDs
+//     and independent nodes spread their load over near-equal peers instead of
+//     herding onto one.
+//
+// The band is the prefix of the merit order that is near-equal to the leader.
+// Because near-equality is not transitive, the scan stops at the first
+// non-near-equal candidate, which can make the band smaller than the set of all
+// peers near-equal to the leader; it can never make it contain a materially
+// worse peer.
+//
 // The candidates slice is consumed: it is reordered and may be filtered in
 // place, so callers must not reuse it afterwards.
 func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, criteria SelectionCriteria, isFullNode bool) string {
@@ -260,9 +374,10 @@ func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, 
 		return ""
 	}
 
-	// Rotate off the previously selected peer whenever an alternative exists,
-	// so a tied previous peer cannot be re-drawn from the top band.
-	if len(candidates) > 1 && criteria.PreviousPeer != "" {
+	// Rotate off the previous peer only when the caller reports it failed, and
+	// only while an alternative exists. Rotating unconditionally is what makes
+	// two near-equal peers alternate every cycle.
+	if len(candidates) > 1 && criteria.PreviousPeer != "" && criteria.PreviousPeerFailed {
 		filtered := candidates[:0]
 		for _, c := range candidates {
 			if c.ID != criteria.PreviousPeer {
@@ -270,7 +385,7 @@ func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, 
 			}
 		}
 		if len(filtered) > 0 && len(filtered) < len(candidates) {
-			ps.logger.Debugf("[PeerSelector] Excluding previous peer %s from selection", criteria.PreviousPeer)
+			ps.logger.Debugf("[PeerSelector] Excluding failed previous peer %s from selection", criteria.PreviousPeer)
 			candidates = filtered
 		}
 	}
@@ -282,13 +397,26 @@ func (ps *PeerSelector) selectFromCandidates(candidates []*blockchain.PeerInfo, 
 
 	topBandSize := 1
 	for topBandSize < len(candidates) &&
-		ps.comparePeerCandidates(candidates[0], candidates[topBandSize], now, criteria.FullDeliveryFreshnessWindow) == 0 {
+		ps.peersNearEqual(candidates[0], candidates[topBandSize], now, criteria.FullDeliveryFreshnessWindow) {
 		topBandSize++
 	}
 
-	selectedIndex := 0
-	if topBandSize > 1 {
-		selectedIndex = ps.randomIndex(topBandSize)
+	selectedIndex := -1
+	if criteria.PreviousPeer != "" && !criteria.PreviousPeerFailed {
+		for i := range topBandSize {
+			if candidates[i].ID == criteria.PreviousPeer {
+				selectedIndex = i
+				ps.logger.Debugf("[PeerSelector] Keeping previous peer %s: no challenger is materially better", criteria.PreviousPeer)
+				break
+			}
+		}
+	}
+
+	if selectedIndex < 0 {
+		selectedIndex = 0
+		if topBandSize > 1 {
+			selectedIndex = ps.randomIndex(topBandSize)
+		}
 	}
 
 	selected := candidates[selectedIndex]
@@ -358,8 +486,15 @@ func (ps *PeerSelector) isEligibleBasic(p *blockchain.PeerInfo, criteria Selecti
 		return false
 	}
 
-	// Check sync attempt cooldown BEFORE health check (avoids re-checking failed peers)
-	if criteria.SyncAttemptCooldown > 0 && !p.LastSyncAttempt.IsZero() {
+	// Check sync attempt cooldown BEFORE health check (avoids re-checking failed peers).
+	// The incumbent sync peer is exempt while it has not failed: the cooldown exists to
+	// stop us hammering peers we just tried and bounced off, whereas keeping the current
+	// peer (hysteresis) is not a retry. Without the exemption the incumbent would drop
+	// out of its own selection for the whole cooldown window, so every evaluation in that
+	// window would rotate the slot onto another peer — exactly the oscillation hysteresis
+	// is meant to stop.
+	incumbentExempt := criteria.PreviousPeer != "" && p.ID == criteria.PreviousPeer && !criteria.PreviousPeerFailed
+	if !incumbentExempt && criteria.SyncAttemptCooldown > 0 && !p.LastSyncAttempt.IsZero() {
 		timeSinceLastAttempt := time.Since(p.LastSyncAttempt)
 		if timeSinceLastAttempt < criteria.SyncAttemptCooldown {
 			ps.logger.Debugf("[PeerSelector] Peer %s attempted recently (%v ago, cooldown: %v)",

--- a/services/p2p/peer_selector_test.go
+++ b/services/p2p/peer_selector_test.go
@@ -122,7 +122,9 @@ func TestPeerSelector_SelectSyncPeer_ForcedPeerNotConnected(t *testing.T) {
 	require.Empty(t, got, "missing forced peer means no selection, not fallback")
 }
 
-func TestPeerSelector_SelectSyncPeer_PreviousPeerSecondChoiceWhenTopMatches(t *testing.T) {
+// A failed previous peer is rotated off even when it still ranks top, so the
+// coordinator gets a genuine replacement.
+func TestPeerSelector_SelectSyncPeer_FailedPreviousPeerRotatedOffWhenTopMatches(t *testing.T) {
 	ps := newSelectorForTest()
 
 	peers := []*blockchain.PeerInfo{
@@ -132,8 +134,139 @@ func TestPeerSelector_SelectSyncPeer_PreviousPeerSecondChoiceWhenTopMatches(t *t
 
 	criteria := advertisedProbeCriteria(50)
 	criteria.PreviousPeer = "a"
+	criteria.PreviousPeerFailed = true
 	got := ps.SelectSyncPeer(context.Background(), peers, criteria)
-	require.Equal(t, "b", got, "rotate off the previous peer if it would be top again")
+	require.Equal(t, "b", got, "a failed previous peer must be rotated off even if it would be top again")
+}
+
+// Hysteresis: a previous peer that is still top-ranked is kept, so a healthy
+// sync peer is not swapped out (and catchup re-triggered) for no gain.
+func TestPeerSelector_SelectSyncPeer_PreviousPeerKeptWhenStillTop(t *testing.T) {
+	ps := newSelectorForTest()
+
+	peers := []*blockchain.PeerInfo{
+		newPeer("a", 100, "full", 90, 0),
+		newPeer("b", 100, "full", 80, 0),
+	}
+
+	criteria := advertisedProbeCriteria(50)
+	criteria.PreviousPeer = "a"
+	require.Equal(t, "a", ps.SelectSyncPeer(context.Background(), peers, criteria))
+}
+
+// Hysteresis must not pin a materially worse incumbent: a challenger outside the
+// incumbent's band still wins.
+func TestPeerSelector_SelectSyncPeer_MateriallyBetterChallengerBeatsPreviousPeer(t *testing.T) {
+	ps := newSelectorForTest()
+
+	peers := []*blockchain.PeerInfo{
+		newPeer("weak-incumbent", 100, "full", 40, 0),
+		newPeer("strong", 100, "full", 95, 0),
+	}
+
+	criteria := advertisedProbeCriteria(50)
+	criteria.PreviousPeer = "weak-incumbent"
+	require.Equal(t, "strong", ps.SelectSyncPeer(context.Background(), peers, criteria),
+		"a materially better challenger must take the slot from the incumbent")
+}
+
+// Two peers that are equal on every criterion must not alternate the sync slot
+// cycle after cycle (issue: deterministic selection oscillates A<->B).
+func TestPeerSelector_SelectSyncPeer_EqualCandidatesDoNotOscillate(t *testing.T) {
+	ps := newSelectorForTest()
+
+	criteria := advertisedProbeCriteria(50)
+	first := ps.SelectSyncPeer(context.Background(), []*blockchain.PeerInfo{
+		newPeer("a", 100, "full", 80, 0),
+		newPeer("b", 100, "full", 80, 0),
+	}, criteria)
+	require.Contains(t, []string{"a", "b"}, first)
+
+	for range 20 {
+		criteria.PreviousPeer = first
+		got := ps.SelectSyncPeer(context.Background(), []*blockchain.PeerInfo{
+			newPeer("a", 100, "full", 80, 0),
+			newPeer("b", 100, "full", 80, 0),
+		}, criteria)
+		require.Equal(t, first, got, "equal candidates must not alternate the sync slot absent a failure")
+	}
+}
+
+// Near-equal (not exactly tied) candidates are also non-oscillating and share
+// the load: no single peer wins every fresh selection.
+func TestPeerSelector_SelectSyncPeer_NearEqualCandidatesShareLoad(t *testing.T) {
+	ps := newSelectorForTest()
+
+	newNearEqualPeers := func() []*blockchain.PeerInfo {
+		// Reputation spread of 4 and response times within 25ms / 25% keep all
+		// three inside one band even though none is an exact tie.
+		a := newPeer("near-a", 100, "full", 80, 0)
+		a.AvgResponseTimeMs = 100
+		b := newPeer("near-b", 100, "full", 82, 1)
+		b.AvgResponseTimeMs = 110
+		c := newPeer("near-c", 100, "full", 84, 2)
+		c.AvgResponseTimeMs = 120
+		return []*blockchain.PeerInfo{a, b, c}
+	}
+
+	// Fresh nodes (no previous peer) must spread over the whole band instead of
+	// herding onto the single highest-reputation peer.
+	// P(some band member never wins in 100 rounds) <= 3 * (2/3)^100 ~ 7e-18.
+	wins := map[string]int{}
+	for range 100 {
+		wins[ps.SelectSyncPeer(context.Background(), newNearEqualPeers(), advertisedProbeCriteria(50))]++
+	}
+	require.Len(t, wins, 3, "every near-equal peer must win at least once, got %v", wins)
+
+	// An established node keeps its incumbent even though it is not the
+	// nominally best peer in the band.
+	criteria := advertisedProbeCriteria(50)
+	criteria.PreviousPeer = "near-a"
+	for range 20 {
+		require.Equal(t, "near-a", ps.SelectSyncPeer(context.Background(), newNearEqualPeers(), criteria))
+	}
+}
+
+func TestPeerSelector_PeersNearEqual(t *testing.T) {
+	ps := newSelectorForTest()
+	now := time.Now()
+	window := 24 * time.Hour
+
+	base := newPeer("base", 100, "full", 80, 0)
+	base.AvgResponseTimeMs = 100
+
+	withResponse := func(p *blockchain.PeerInfo, ms int64) *blockchain.PeerInfo {
+		p.AvgResponseTimeMs = ms
+		return p
+	}
+
+	tests := []struct {
+		name  string
+		other *blockchain.PeerInfo
+		want  bool
+	}{
+		{"identical", withResponse(newPeer("x", 100, "full", 80, 0), 100), true},
+		{"reputation within margin", withResponse(newPeer("x", 100, "full", 85, 0), 100), true},
+		{"reputation beyond margin", withResponse(newPeer("x", 100, "full", 86, 0), 100), false},
+		{"ban score within margin", withResponse(newPeer("x", 100, "full", 80, 5), 100), true},
+		{"ban score beyond margin", withResponse(newPeer("x", 100, "full", 80, 6), 100), false},
+		{"response time within absolute margin", withResponse(newPeer("x", 100, "full", 80, 0), 124), true},
+		{"response time within relative margin", withResponse(newPeer("x", 100, "full", 80, 0), 125), true},
+		{"response time beyond both margins", withResponse(newPeer("x", 100, "full", 80, 0), 126), false},
+		{"unmeasured response time", newPeer("x", 100, "full", 80, 0), false},
+		{"different validated work", withResponse(withValidatedWork(newPeer("x", 100, "full", 80, 0), 100, []byte{0x05}), 100), false},
+		{"different validated height", withResponse(withValidatedWork(newPeer("x", 100, "full", 80, 0), 101, nil), 100), false},
+		{"proven delivery differs", withResponse(withRecentFullBlockDelivery(newPeer("x", 100, "full", 80, 0)), 100), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ps.peersNearEqual(base, tt.other, now, window))
+			require.Equal(t, tt.want, ps.peersNearEqual(tt.other, base, now, window), "must be symmetric")
+		})
+	}
+
+	require.True(t, ps.peersNearEqual(base, base, now, window), "must be reflexive")
 }
 
 func TestPeerSelector_SelectSyncPeer_SkipsLowReputation(t *testing.T) {
@@ -179,6 +312,29 @@ func TestPeerSelector_SelectSyncPeer_SyncCooldownExcludesRecentlyAttempted(t *te
 	criteria.SyncAttemptCooldown = time.Minute
 	got := ps.SelectSyncPeer(context.Background(), peers, criteria)
 	require.Equal(t, "fresh", got, "peer within cooldown must be skipped")
+}
+
+// The retry cooldown must not evict the incumbent from its own selection: every
+// activation records a sync attempt, so applying the cooldown to the incumbent
+// would rotate the slot on each evaluation inside the cooldown window.
+func TestPeerSelector_SelectSyncPeer_SyncCooldownExemptsHealthyIncumbent(t *testing.T) {
+	ps := newSelectorForTest()
+
+	newPeers := func() []*blockchain.PeerInfo {
+		incumbent := newPeer("incumbent", 100, "full", 80, 0)
+		incumbent.LastSyncAttempt = time.Now().Add(-30 * time.Second)
+		return []*blockchain.PeerInfo{incumbent, newPeer("fresh", 100, "full", 80, 0)}
+	}
+
+	criteria := advertisedProbeCriteria(50)
+	criteria.SyncAttemptCooldown = time.Minute
+	criteria.PreviousPeer = "incumbent"
+	require.Equal(t, "incumbent", ps.SelectSyncPeer(context.Background(), newPeers(), criteria),
+		"a healthy incumbent must not be excluded by its own sync-attempt cooldown")
+
+	criteria.PreviousPeerFailed = true
+	require.Equal(t, "fresh", ps.SelectSyncPeer(context.Background(), newPeers(), criteria),
+		"a failed incumbent stays subject to the cooldown")
 }
 
 func TestPeerSelector_SelectSyncPeer_PrunedFallbackDisabled(t *testing.T) {
@@ -321,11 +477,12 @@ func TestPeerSelector_SelectSyncPeer_GrindableIDCannotCaptureSelection(t *testin
 	require.Less(t, wins[ids[0]], rounds, "attacker with lexicographically smallest ID must not win every selection")
 }
 
-func TestPeerSelector_SelectSyncPeer_PreviousPeerExcludedFromTiedTopBand(t *testing.T) {
+func TestPeerSelector_SelectSyncPeer_FailedPreviousPeerExcludedFromTiedTopBand(t *testing.T) {
 	ps := newSelectorForTest()
 
-	// Previous peer ties with two other candidates, so after it is excluded
-	// the random draw still runs over a band of two; it must never be re-drawn.
+	// Failed previous peer ties with two other candidates, so after it is
+	// excluded the random draw still runs over a band of two; it must never be
+	// re-drawn.
 	for range 50 {
 		peers := []*blockchain.PeerInfo{
 			newPeer("prev", 100, "full", 80, 0),
@@ -334,6 +491,7 @@ func TestPeerSelector_SelectSyncPeer_PreviousPeerExcludedFromTiedTopBand(t *test
 		}
 		criteria := advertisedProbeCriteria(50)
 		criteria.PreviousPeer = "prev"
+		criteria.PreviousPeerFailed = true
 		got := ps.SelectSyncPeer(context.Background(), peers, criteria)
 		require.Contains(t, []string{"other-a", "other-b"}, got)
 	}
@@ -376,7 +534,8 @@ func TestPeerSelector_SelectSyncPeer_PreviousPeerKeptWhenOnlyCandidate(t *testin
 	peers := []*blockchain.PeerInfo{newPeer("prev", 100, "full", 80, 0)}
 	criteria := advertisedProbeCriteria(50)
 	criteria.PreviousPeer = "prev"
-	require.Equal(t, "prev", ps.SelectSyncPeer(context.Background(), peers, criteria), "sole candidate is selected even if it was the previous peer")
+	criteria.PreviousPeerFailed = true
+	require.Equal(t, "prev", ps.SelectSyncPeer(context.Background(), peers, criteria), "sole candidate is selected even if it was the failed previous peer")
 }
 
 func TestPeerSelector_SelectSyncPeer_UnprovenProbeBudgetBoundsHeaderOnlyPeers(t *testing.T) {

--- a/services/p2p/sync_coordinator.go
+++ b/services/p2p/sync_coordinator.go
@@ -702,20 +702,33 @@ func (sc *SyncCoordinator) HandleCatchupFailure(reason string) {
 
 // selectNewSyncPeer selects a new sync peer based on current criteria.
 // The returned ID is a canonical libp2p ID string.
-func (sc *SyncCoordinator) selectNewSyncPeer() string {
+//
+// previousPeerFailed states whether the incumbent sync peer has demonstrably
+// failed (a no-progress stall). When it has, the incumbent is excluded from the
+// candidate set so the call returns a genuine replacement. When it has not, the
+// incumbent stays in the candidate set and the selector's hysteresis re-selects
+// it unless a challenger is materially better — so an opportunistic evaluation
+// returns the incumbent (meaning "stay put") instead of rotating the slot onto a
+// near-equal peer and re-triggering catchup every cycle.
+func (sc *SyncCoordinator) selectNewSyncPeer(previousPeerFailed bool) string {
 	localHeight, localChainWork, localWorkOK := sc.getLocalTipWorkSafe()
 	previousPeer := sc.currentSyncPeerLocked()
 
+	excludedPeer := ""
+	if previousPeerFailed {
+		excludedPeer = previousPeer
+	}
+
 	peers := sc.listAllPeers()
-	eligiblePeers := sc.filterEligiblePeersWithTip(peers, previousPeer, localHeight, localChainWork, localWorkOK)
+	eligiblePeers := sc.filterEligiblePeersWithTip(peers, excludedPeer, localHeight, localChainWork, localWorkOK)
 	if sc.settings != nil && sc.settings.P2P.ForceSyncPeer != "" {
 		eligiblePeers = peers
 	}
 
-	return sc.selectSyncPeerFromCandidates(eligiblePeers, localHeight, localChainWork, previousPeer)
+	return sc.selectSyncPeerFromCandidates(eligiblePeers, localHeight, localChainWork, previousPeer, previousPeerFailed)
 }
 
-func (sc *SyncCoordinator) selectionCriteria(localHeight uint32, localChainWork []byte, previousPeer string) SelectionCriteria {
+func (sc *SyncCoordinator) selectionCriteria(localHeight uint32, localChainWork []byte, previousPeer string, previousPeerFailed bool) SelectionCriteria {
 	unprovenProbeBudgetRemaining := sc.unprovenProbeBudgetRemainingValue()
 	criteria := SelectionCriteria{
 		LocalHeight:                  int32(localHeight),
@@ -724,6 +737,7 @@ func (sc *SyncCoordinator) selectionCriteria(localHeight uint32, localChainWork 
 		UnprovenProbeBudgetRemaining: unprovenProbeBudgetRemaining,
 		FullDeliveryFreshnessWindow:  sc.fullDeliveryFreshnessWindow(),
 		PreviousPeer:                 previousPeer,
+		PreviousPeerFailed:           previousPeerFailed,
 		SyncAttemptCooldown:          1 * time.Minute, // Don't retry peers for at least 1 minute
 	}
 	// Check for forced peer
@@ -741,8 +755,8 @@ func (sc *SyncCoordinator) selectionCriteria(localHeight uint32, localChainWork 
 	return criteria
 }
 
-func (sc *SyncCoordinator) selectSyncPeerFromCandidates(peers []*blockchain.PeerInfo, localHeight uint32, localChainWork []byte, previousPeer string) string {
-	criteria := sc.selectionCriteria(localHeight, localChainWork, previousPeer)
+func (sc *SyncCoordinator) selectSyncPeerFromCandidates(peers []*blockchain.PeerInfo, localHeight uint32, localChainWork []byte, previousPeer string, previousPeerFailed bool) string {
+	criteria := sc.selectionCriteria(localHeight, localChainWork, previousPeer, previousPeerFailed)
 	return sc.selector.SelectSyncPeer(sc.ctx, peers, criteria)
 }
 
@@ -937,7 +951,9 @@ func (sc *SyncCoordinator) selectAndActivateNewPeer(localHeight uint32, oldPeer 
 	}
 
 	// Select from eligible peers
-	newSyncPeer := sc.selectSyncPeerFromCandidates(eligiblePeers, localHeight, localChainWork, oldPeer)
+	// oldPeer is always empty here (the guard above returns early otherwise), so
+	// there is no incumbent to keep or rotate off.
+	newSyncPeer := sc.selectSyncPeerFromCandidates(eligiblePeers, localHeight, localChainWork, oldPeer, false)
 	if newSyncPeer == "" {
 		sc.logger.Warnf("[SyncCoordinator] No suitable new sync peer found (different from %s)", oldPeer)
 		sc.logCandidateList(eligiblePeers)
@@ -1158,7 +1174,10 @@ func (sc *SyncCoordinator) evaluateSyncPeer() {
 	if !peerAheadByValidatedWork(peerInfo, localChainWork) {
 		sc.logger.Infof("[SyncCoordinator] Caught up to sync peer %s by validated work", currentPeer)
 		// Don't clear peer yet, but look for better peer.
-		if betterPeer := sc.selectNewSyncPeer(); betterPeer != currentPeer && betterPeer != "" {
+		// The incumbent has not failed — we simply caught up to it — so it stays in
+		// the candidate set and selector hysteresis returns it unless a challenger is
+		// materially better. Only a different peer causes a switch.
+		if betterPeer := sc.selectNewSyncPeer(false); betterPeer != currentPeer && betterPeer != "" {
 			sc.logger.Infof("[SyncCoordinator] Found better sync peer %s", betterPeer)
 			sc.clearSyncPeerIfCurrent("")
 			_ = sc.triggerSyncLocked()
@@ -1182,7 +1201,11 @@ func (sc *SyncCoordinator) evaluateSyncPeer() {
 	if progressAge <= sc.preemptionProgressGuard() {
 		return
 	}
-	candidate := sc.selectNewSyncPeer()
+	// The incumbent has gone longer than preemptionProgressGuard() without
+	// delivering a validated block: that is an actual failure signal, so it is
+	// excluded from the candidate set and this call returns a real replacement
+	// rather than the (sticky) incumbent.
+	candidate := sc.selectNewSyncPeer(true)
 	if candidate == "" || candidate == currentPeer {
 		return
 	}

--- a/services/p2p/sync_coordinator_test.go
+++ b/services/p2p/sync_coordinator_test.go
@@ -347,7 +347,62 @@ func TestSyncCoordinator_SelectNewSyncPeer_PrefersFullNode(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, "full", sc.selectNewSyncPeer())
+	require.Equal(t, "full", sc.selectNewSyncPeer(false))
+}
+
+// Hysteresis through the real coordinator path: an incumbent sync peer that is
+// still merit-tied with its rivals keeps the slot cycle after cycle (no A<->B
+// oscillation and no fresh Kafka catchup trigger per switch), while an actual
+// failure signal rotates it off.
+func TestSyncCoordinator_SelectNewSyncPeer_KeepsIncumbentUntilChallengerMateriallyBetter(t *testing.T) {
+	sc, reg := newTestSyncCoordinator(t)
+	setSyncCoordinatorLocalTip(t, sc, 100, []byte{0x02})
+
+	registerPeer := func(id string) {
+		reg.Register(&blockchain.PeerInfo{
+			ID:                 id,
+			DataHubURL:         "http://" + id,
+			Height:             200,
+			BlockHash:          syncCoordinatorTestHash(t),
+			Storage:            "full",
+			ValidatedHeight:    150,
+			ValidatedBlockHash: syncCoordinatorTestHash(t),
+			ValidatedChainWork: []byte{0x03},
+		})
+	}
+	registerPeer("peer-a")
+	registerPeer("peer-b")
+
+	sc.mu.Lock()
+	sc.currentSyncPeer = "peer-a"
+	sc.mu.Unlock()
+
+	// Activation records a sync attempt on the incumbent; the retry cooldown must
+	// not then exclude it from its own re-selection.
+	reg.RecordSyncAttempt("peer-a")
+
+	for range 20 {
+		require.Equal(t, "peer-a", sc.selectNewSyncPeer(false),
+			"a merit-tied incumbent must keep the sync slot")
+	}
+
+	require.Equal(t, "peer-b", sc.selectNewSyncPeer(true),
+		"a failed incumbent must be replaced")
+
+	// A materially better challenger (higher validated work) takes the slot even
+	// without a failure.
+	reg.Register(&blockchain.PeerInfo{
+		ID:                 "peer-c",
+		DataHubURL:         "http://peer-c",
+		Height:             300,
+		BlockHash:          syncCoordinatorTestHash(t),
+		Storage:            "full",
+		ValidatedHeight:    250,
+		ValidatedBlockHash: syncCoordinatorTestHash(t),
+		ValidatedChainWork: []byte{0x09},
+	})
+	require.Equal(t, "peer-c", sc.selectNewSyncPeer(false),
+		"a materially better challenger must take the slot from the incumbent")
 }
 
 func TestSyncCoordinator_SelectNewSyncPeer_MeritTiedSybilCannotCapture(t *testing.T) {
@@ -378,7 +433,7 @@ func TestSyncCoordinator_SelectNewSyncPeer_MeritTiedSybilCannotCapture(t *testin
 
 	wins := map[string]int{}
 	for range 100 {
-		got := sc.selectNewSyncPeer()
+		got := sc.selectNewSyncPeer(false)
 		require.Contains(t, ids, got)
 		wins[got]++
 	}
@@ -1116,7 +1171,7 @@ func TestSyncCoordinator_MaxUnvalidatedAdvertisedHeightLead_AllowsProbeAtTenThou
 	})
 
 	require.False(t, sc.isCaughtUp())
-	require.Equal(t, "bounded", sc.selectNewSyncPeer())
+	require.Equal(t, "bounded", sc.selectNewSyncPeer(false))
 }
 
 func TestSyncCoordinator_SendSyncTriggerToKafka_NilProducerNoOp(t *testing.T) {


### PR DESCRIPTION
Closes #1162

## Problem

`selectFromCandidates` rotated off the previously selected sync peer on **every** cycle whenever any alternative existed. Two near-equal peers therefore alternated the sync slot each evaluation — each switch re-triggers catchup over Kafka and splits the download stream. The top band used for the random tiebreak only covered *exact* ties, so many nodes still herded onto the same marginally-best peer (weak eclipse resistance, no load diversity).

## Change

- `SelectionCriteria.PreviousPeerFailed` (new): the previous peer is rotated off **only** when the coordinator reports an actual failure (no-progress stall). Otherwise it is sticky.
- **Hysteresis + band diversity** in `selectFromCandidates`: the top band is now the prefix of the merit order that is *near-equal* to the leader (`peersNearEqual`). Hard criteria — proven recent full-block delivery, validated chain work, validated height — must match exactly; soft criteria use equivalence margins (reputation ±5, avg response time ±25 ms or ±25 %, ban score ±5). If the previous peer is in the band and has not failed it is kept; otherwise the winner is drawn uniformly at random from the band, so independent nodes spread load over near-equal peers instead of all picking one.
- **Cooldown exemption**: a healthy incumbent is exempt from `SyncAttemptCooldown`. Activation records a sync attempt, so without the exemption the incumbent dropped out of its own re-selection for the whole cooldown window and every evaluation in that window rotated the slot — the very oscillation being fixed.
- **Coordinator**: `selectNewSyncPeer(previousPeerFailed bool)` threads the failure signal. The opportunistic no-progress preemption path passes `true`, so the stalled incumbent is still excluded and slow-dripper eviction is unchanged; the caught-up path passes `false`, keeping the incumbent in the candidate set so it is only replaced by a materially better peer.
- Docs updated (`docs/topics/features/peer_registry_reputation.md`).

Per-subnet / per-IP connection caps remain out of scope (tracked separately as P2P-005).

## Tests

New:
- `TestPeerSelector_SelectSyncPeer_EqualCandidatesDoNotOscillate` — 20 cycles with two equal peers, no A↔B alternation.
- `TestPeerSelector_SelectSyncPeer_NearEqualCandidatesShareLoad` — fresh nodes spread over the whole near-equal band; an established node keeps its incumbent.
- `TestPeerSelector_SelectSyncPeer_PreviousPeerKeptWhenStillTop`, `..._MateriallyBetterChallengerBeatsPreviousPeer`, `..._FailedPreviousPeerRotatedOffWhenTopMatches`, `..._FailedPreviousPeerExcludedFromTiedTopBand`, `..._SyncCooldownExemptsHealthyIncumbent`.
- `TestPeerSelector_PeersNearEqual` — table covering every margin boundary, plus symmetry and reflexivity.
- `TestSyncCoordinator_SelectNewSyncPeer_KeepsIncumbentUntilChallengerMateriallyBetter` — end-to-end through the registry: incumbent (with a recorded sync attempt) keeps the slot for 20 rounds, is replaced on a failure signal, and is beaten by a higher-work challenger.

Updated: the two tests that asserted the old unconditional rotation now assert it under `PreviousPeerFailed`.

## Verification

```
go build ./...                              # OK
go vet ./services/p2p/...                   # OK
go test -count=1 -race ./services/p2p/...   # ok (17s)
golangci-lint run services/p2p/...          # only pre-existing mock.go prealloc hint
```

## Residual risk

Hysteresis makes the sync slot stickier: a peer inside the band but slightly worse than the best available peer can hold the slot until it stalls (no-progress timeout / preemption guard) or falls out of the band. That is the intended trade against churn; the eviction paths (catchup failure, no-progress timeout, low reputation, disconnect) are untouched and all clear the slot directly.
