### PR TITLE
fix(legacy): advertise feefilter in satoshis/kB, not a truncated BSV float

### DIFF
--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"math/rand/v2"
 	"net"
 	"net/url"
@@ -854,8 +855,23 @@ func (sm *SyncManager) startSync() {
 }
 
 func (sm *SyncManager) resetFeeFilterToDefault() {
-	if sm.currentFeeFilter.Load() != uint64(bsvutil.SatoshiPerBitcoin*sm.settings.Policy.MinMiningTxFee) {
-		feeFilter := wire.NewMsgFeeFilter(int64(sm.settings.Policy.MinMiningTxFee)) // nolint:gosec
+	// MinMiningTxFee is configured in BSV/kB while the wire feefilter message
+	// carries satoshis/kB. Convert with math.Round, not truncation: IEEE-754
+	// cannot represent some decimal rates exactly (0.00000250 stores as
+	// 0.0000024999...), and truncating the raw float dropped the value to 0
+	// sat/kB for every real configuration, so peers were told this node wants
+	// all transactions regardless of its fee policy. This mirrors the
+	// conversion pushed into BDK by newScriptVerifierGoBDK.
+	satoshisPerKB := int64(math.Round(sm.settings.Policy.MinMiningTxFee * bsvutil.SatoshiPerBitcoin))
+	if satoshisPerKB < 0 {
+		// A negative rate is rejected at validator startup, but the legacy
+		// service can run in a process without a validator; never advertise a
+		// wrapped-around filter.
+		satoshisPerKB = 0
+	}
+
+	if sm.currentFeeFilter.Load() != uint64(satoshisPerKB) {
+		feeFilter := wire.NewMsgFeeFilter(satoshisPerKB)
 
 		for p := range sm.peerStates.Range() {
 			if p == nil {
@@ -869,7 +885,7 @@ func (sm *SyncManager) resetFeeFilterToDefault() {
 			p.QueueMessage(feeFilter, nil)
 		}
 
-		sm.currentFeeFilter.Store(uint64(bsvutil.SatoshiPerBitcoin * sm.settings.Policy.MinMiningTxFee))
+		sm.currentFeeFilter.Store(uint64(satoshisPerKB))
 	}
 }
 

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -854,38 +854,98 @@ func (sm *SyncManager) startSync() {
 	})
 }
 
-func (sm *SyncManager) resetFeeFilterToDefault() {
-	// MinMiningTxFee is configured in BSV/kB while the wire feefilter message
-	// carries satoshis/kB. Convert with math.Round, not truncation: IEEE-754
-	// cannot represent some decimal rates exactly (0.00000250 stores as
-	// 0.0000024999...), and truncating the raw float dropped the value to 0
-	// sat/kB for every real configuration, so peers were told this node wants
-	// all transactions regardless of its fee policy. This mirrors the
-	// conversion pushed into BDK by newScriptVerifierGoBDK.
-	satoshisPerKB := int64(math.Round(sm.settings.Policy.MinMiningTxFee * bsvutil.SatoshiPerBitcoin))
-	if satoshisPerKB < 0 {
-		// A negative rate is rejected at validator startup, but the legacy
-		// service can run in a process without a validator; never advertise a
-		// wrapped-around filter.
-		satoshisPerKB = 0
+// policyFeeFilterSatoshisPerKB is the feefilter this node advertises to legacy
+// peers whenever it is not catching up: minminingtxfee, converted from the
+// BSV/kB it is configured in to the satoshis/kB the wire message carries.
+//
+// The conversion rounds rather than truncates. Many decimal rates sit just
+// below their integer number of satoshis in IEEE-754 (0.00000003 BSV/kB is
+// 2.9999999999999996 satoshis/kB, which truncates to 2), and before this
+// conversion existed the raw BSV/kB float was truncated, which is 0 for every
+// real configuration. newScriptVerifierGoBDK pushes the same rounded value into
+// BDK.
+//
+// A non-finite rate advertises 0, the accept-everything filter: settings
+// parsing accepts "NaN" and "Inf" without error, and casting such a value is
+// platform-dependent (int64 of +Inf is MaxInt64 on arm64, which would silently
+// stop every peer relaying anything, and MinInt64 on amd64). A finite rate
+// beyond the int64 range is clamped to MaxInt64, the only representation of
+// "reject everything" the message has. A negative rate, rejected at validator
+// startup but reachable in a process that runs legacy without a validator,
+// advertises 0 rather than a wrapped value.
+//
+// What the filter means is a deliberate choice (PR 1659 review). BIP133 says a
+// peer will not relay transactions paying less than the filter, and
+// minminingtxfee is the rate below which this node's validator rejects a
+// transaction outright (BDK's fee floor), so the filter states what the node
+// accepts. The one exception is a free consolidation (isFreeConsolidationTxn in
+// the validator), which this node accepts with no fee and which a filtering
+// peer will therefore not relay to it; such transactions still arrive by
+// direct submission and from peers that do not filter. svnode derives its
+// filter from the mempool's rolling minimum instead, but svnode admits
+// sub-floor transactions to its mempool and only declines to mine them, so its
+// relay floor and its mining floor are different numbers; Teranode has no
+// mempool of that kind and no lower floor to advertise.
+func (sm *SyncManager) policyFeeFilterSatoshisPerKB() int64 {
+	rate := sm.settings.Policy.MinMiningTxFee
+	if math.IsNaN(rate) || math.IsInf(rate, 0) {
+		sm.logger.Warnf("[policyFeeFilter] minminingtxfee %v is not a finite number, advertising a feefilter of 0", rate)
+
+		return 0
 	}
 
-	if sm.currentFeeFilter.Load() != uint64(satoshisPerKB) {
-		feeFilter := wire.NewMsgFeeFilter(satoshisPerKB)
+	satoshisPerKB := math.Round(rate * bsvutil.SatoshiPerBitcoin)
+	if satoshisPerKB < 0 {
+		return 0
+	}
 
-		for p := range sm.peerStates.Range() {
-			if p == nil {
-				continue
-			}
+	// float64(math.MaxInt64) is 2^63 exactly, one above the largest int64, so
+	// anything at or above it does not fit.
+	if satoshisPerKB >= float64(math.MaxInt64) {
+		return math.MaxInt64
+	}
 
-			if !p.Connected() {
-				continue
-			}
+	return int64(satoshisPerKB)
+}
 
-			p.QueueMessage(feeFilter, nil)
+// resetFeeFilterToDefault tells every connected legacy peer the policy fee
+// filter, once per change of the advertised value. It is called on reaching
+// current from more than one goroutine (the block-queue consumer in
+// handleBlockMsg and the message handler in blockHandler), and it races the
+// catch-up raise handleNewPeerMsg stores for a peer that connects while the
+// node is still catching up. The marker is therefore claimed with a
+// compare-and-swap BEFORE the broadcast: two resets broadcast once, and a raise
+// stored after the claim is not overwritten unseen but leaves the marker
+// raised, so the next reset lowers that peer too. (Storing the marker after the
+// broadcast, as this used to, could bury such a raise under the policy value
+// and leave the peer filtered at 1 BSV/kB for good.)
+func (sm *SyncManager) resetFeeFilterToDefault() {
+	satoshisPerKB := sm.policyFeeFilterSatoshisPerKB()
+	want := uint64(satoshisPerKB) //nolint:gosec // never negative, see policyFeeFilterSatoshisPerKB
+
+	for {
+		old := sm.currentFeeFilter.Load()
+		if old == want {
+			return
 		}
 
-		sm.currentFeeFilter.Store(uint64(satoshisPerKB))
+		if sm.currentFeeFilter.CompareAndSwap(old, want) {
+			break
+		}
+	}
+
+	feeFilter := wire.NewMsgFeeFilter(satoshisPerKB)
+
+	for p := range sm.peerStates.Range() {
+		if p == nil {
+			continue
+		}
+
+		if !p.Connected() {
+			continue
+		}
+
+		p.QueueMessage(feeFilter, nil)
 	}
 }
 
@@ -986,26 +1046,38 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
 	// Initialize the peer state
 	isSyncCandidate := sm.isSyncCandidate(peer)
 
-	// While catching up, ask every newly-connected peer to hold back
-	// transaction announcements to reduce load during sync. The raise is queued
-	// per-peer; the global currentFeeFilter is only the marker the reset path
-	// (resetFeeFilterToDefault) checks, so it must NOT gate the per-peer queue —
-	// otherwise only the first peer to connect during catch-up would be told.
-	// The filter is restored to the policy default once we reach RUNNING.
-	if state, ferr := sm.blockchainClient.GetFSMCurrentState(sm.ctx); ferr != nil {
-		sm.logger.Errorf("[handleNewPeerMsg] failed to get current FSM state: %v", ferr)
-	} else if state != nil && *state == teranodeblockchain.FSMStateCATCHINGBLOCKS {
-		feeFilter := wire.NewMsgFeeFilter(bsvutil.SatoshiPerBitcoin)
-		peer.QueueMessage(feeFilter, nil)
-		sm.currentFeeFilter.Store(bsvutil.SatoshiPerBitcoin)
-	}
-
+	// Register the peer BEFORE deciding on its feefilter, so a
+	// resetFeeFilterToDefault running concurrently on another goroutine finds
+	// it in peerStates and lowers whatever is queued for it below.
 	sm.peerStates.Set(peer, &peerSyncState{
 		syncCandidate:   isSyncCandidate,
 		requestQueue:    txmap.NewSyncedSlice[wire.InvVect](maxRequestedBlocks),
 		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second), // allow the node 10 seconds to respond to the tx request
 		requestedBlocks: expiringmap.New[chainhash.Hash, struct{}](60 * time.Minute), // allow the node 1 hour to respond to the requested blocks, needed for legacy sync/checkpoints
 	})
+
+	// While catching up, ask every newly-connected peer to hold back
+	// transaction announcements to reduce load during sync. The raise is queued
+	// per-peer; the global currentFeeFilter is only the marker the reset path
+	// (resetFeeFilterToDefault) checks, so it must NOT gate the per-peer queue,
+	// otherwise only the first peer to connect during catch-up would be told.
+	// The filter is restored to the policy default once we reach RUNNING.
+	//
+	// Otherwise tell the peer the policy fee filter now. The reset path only
+	// runs on the transition to RUNNING, so before this a peer connecting to a
+	// node that had been running for a while was never told anything and kept
+	// relaying every transaction (PR 1659 review). The marker is left alone:
+	// it records what the reset path last broadcast, and this is a per-peer
+	// message.
+	if state, ferr := sm.blockchainClient.GetFSMCurrentState(sm.ctx); ferr != nil {
+		sm.logger.Errorf("[handleNewPeerMsg] failed to get current FSM state: %v", ferr)
+	} else if state != nil && *state == teranodeblockchain.FSMStateCATCHINGBLOCKS {
+		feeFilter := wire.NewMsgFeeFilter(bsvutil.SatoshiPerBitcoin)
+		peer.QueueMessage(feeFilter, nil)
+		sm.currentFeeFilter.Store(bsvutil.SatoshiPerBitcoin)
+	} else {
+		peer.QueueMessage(wire.NewMsgFeeFilter(sm.policyFeeFilterSatoshisPerKB()), nil)
+	}
 
 	// Start syncing by choosing the best candidate if needed.
 	if isSyncCandidate && sm.loadSyncPeer() == nil {

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -1826,3 +1826,60 @@ func TestHandleNewPeerMsg_SkipsDisconnectedPeer(t *testing.T) {
 
 	require.False(t, sm.peerStates.Exists(disconnectedPeer), "disconnected peer must not be registered in peerStates")
 }
+
+// TestResetFeeFilterToDefault_AdvertisesSatoshisPerKB verifies that the
+// feefilter message sent to legacy peers carries the configured policy minimum
+// converted to satoshis/kB. MinMiningTxFee is configured in BSV/kB; before the
+// fix the raw float was truncated to int64, so every real configuration
+// advertised a filter of 0 sat/kB and peers relayed all transactions regardless
+// of this node's fee policy. The rate 0.00000250 is chosen deliberately: it is
+// stored as 0.0000024999... in IEEE-754, so this also pins the math.Round
+// (rather than truncating) conversion, matching newScriptVerifierGoBDK.
+func TestResetFeeFilterToDefault_AdvertisesSatoshisPerKB(t *testing.T) {
+	chainParams := &chaincfg.MainNetParams
+
+	sm := &SyncManager{
+		ctx:         context.Background(),
+		settings:    test.CreateBaseTestSettings(t),
+		logger:      ulogger.TestLogger{},
+		chainParams: chainParams,
+		peerStates:  txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+	}
+	sm.settings.Policy.MinMiningTxFee = 0.00000250 // 250 sat/kB
+
+	var gotFee atomic.Int64
+	gotFee.Store(-1)
+
+	remoteCfg := peer.Config{
+		Listeners: peer.MessageListeners{
+			OnFeeFilter: func(_ *peer.Peer, msg *wire.MsgFeeFilter) {
+				gotFee.Store(msg.MinFee)
+			},
+		},
+		UserAgentName:    "btcdtest",
+		UserAgentVersion: "1.0",
+		ChainParams:      chainParams,
+	}
+	localCfg := peer.Config{
+		Listeners:        peer.MessageListeners{},
+		UserAgentName:    "btcdtest",
+		UserAgentVersion: "1.0",
+		ChainParams:      chainParams,
+	}
+
+	remote, smPeer, err := MakeConnectedPeers(t, remoteCfg, localCfg, 103)
+	require.NoError(t, err)
+	require.True(t, remote.Connected())
+
+	sm.peerStates.Set(smPeer, &peerSyncState{})
+
+	// Simulate the raised catch-up filter so the reset takes the send path.
+	sm.currentFeeFilter.Store(uint64(bsvutil.SatoshiPerBitcoin))
+
+	sm.resetFeeFilterToDefault()
+
+	require.True(t, WaitUntil(func() bool { return gotFee.Load() == 250 }, 2*time.Second),
+		"peer must receive the policy minimum in satoshis/kB, not the truncated BSV/kB float")
+	require.Equal(t, uint64(250), sm.currentFeeFilter.Load(),
+		"internal marker must record the same satoshis/kB value the peers were sent")
+}

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"math"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -1832,9 +1833,11 @@ func TestHandleNewPeerMsg_SkipsDisconnectedPeer(t *testing.T) {
 // converted to satoshis/kB. MinMiningTxFee is configured in BSV/kB; before the
 // fix the raw float was truncated to int64, so every real configuration
 // advertised a filter of 0 sat/kB and peers relayed all transactions regardless
-// of this node's fee policy. The rate 0.00000250 is chosen deliberately: it is
-// stored as 0.0000024999... in IEEE-754, so this also pins the math.Round
-// (rather than truncating) conversion, matching newScriptVerifierGoBDK.
+// of this node's fee policy. The rate 0.00000003 is chosen deliberately: in
+// IEEE-754 the product 0.00000003 * 1e8 is 2.9999999999999996, so truncation
+// gives 2 and only math.Round gives 3. (An earlier revision used 0.00000250,
+// whose product sits just above 250 and truncates correctly, so it could not
+// tell the two apart; the review caught that by mutation.)
 func TestResetFeeFilterToDefault_AdvertisesSatoshisPerKB(t *testing.T) {
 	chainParams := &chaincfg.MainNetParams
 
@@ -1845,7 +1848,7 @@ func TestResetFeeFilterToDefault_AdvertisesSatoshisPerKB(t *testing.T) {
 		chainParams: chainParams,
 		peerStates:  txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
 	}
-	sm.settings.Policy.MinMiningTxFee = 0.00000250 // 250 sat/kB
+	sm.settings.Policy.MinMiningTxFee = 0.00000003 // 3 sat/kB, and 2 if truncated
 
 	var gotFee atomic.Int64
 	gotFee.Store(-1)
@@ -1878,8 +1881,167 @@ func TestResetFeeFilterToDefault_AdvertisesSatoshisPerKB(t *testing.T) {
 
 	sm.resetFeeFilterToDefault()
 
-	require.True(t, WaitUntil(func() bool { return gotFee.Load() == 250 }, 2*time.Second),
-		"peer must receive the policy minimum in satoshis/kB, not the truncated BSV/kB float")
-	require.Equal(t, uint64(250), sm.currentFeeFilter.Load(),
+	require.True(t, WaitUntil(func() bool { return gotFee.Load() == 3 }, 2*time.Second),
+		"peer must receive the policy minimum in satoshis/kB, rounded, not the truncated BSV/kB float")
+	require.Equal(t, uint64(3), sm.currentFeeFilter.Load(),
 		"internal marker must record the same satoshis/kB value the peers were sent")
+}
+
+// TestPolicyFeeFilterSatoshisPerKB pins the conversion and its guards: rounding
+// where truncation loses a satoshi, 0 for a negative or non-finite rate (a NaN
+// or Inf in settings.conf parses without error, and casting it is
+// platform-dependent), and MaxInt64 for a finite rate the message cannot hold.
+func TestPolicyFeeFilterSatoshisPerKB(t *testing.T) {
+	cases := []struct {
+		name string
+		rate float64
+		want int64
+	}{
+		{"rounds up where truncation loses a satoshi", 0.00000003, 3},
+		{"rounds a rate that truncation gets right", 0.00000250, 250},
+		{"default policy", 0.000005, 500},
+		{"zero", 0, 0},
+		{"negative advertises 0", -1, 0},
+		{"NaN advertises 0", math.NaN(), 0},
+		{"+Inf advertises 0", math.Inf(1), 0},
+		{"-Inf advertises 0", math.Inf(-1), 0},
+		{"beyond int64 clamps to MaxInt64", 1e12, math.MaxInt64},
+		{"MaxFloat64 clamps to MaxInt64", math.MaxFloat64, math.MaxInt64},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sm := &SyncManager{
+				settings: test.CreateBaseTestSettings(t),
+				logger:   ulogger.TestLogger{},
+			}
+			sm.settings.Policy.MinMiningTxFee = c.rate
+
+			require.Equal(t, c.want, sm.policyFeeFilterSatoshisPerKB())
+		})
+	}
+}
+
+// newFeeFilterProbePeer returns a peer for handleNewPeerMsg to operate on whose
+// remote end records the MinFee of every feefilter it receives in gotFee.
+func newFeeFilterProbePeer(t *testing.T, chainParams *chaincfg.Params, idx uint8, gotFee *atomic.Int64) *peer.Peer {
+	t.Helper()
+
+	remoteCfg := peer.Config{
+		Listeners: peer.MessageListeners{
+			OnFeeFilter: func(_ *peer.Peer, msg *wire.MsgFeeFilter) {
+				gotFee.Store(msg.MinFee)
+			},
+		},
+		UserAgentName:    "btcdtest",
+		UserAgentVersion: "1.0",
+		ChainParams:      chainParams,
+	}
+	localCfg := peer.Config{
+		Listeners:        peer.MessageListeners{},
+		UserAgentName:    "btcdtest",
+		UserAgentVersion: "1.0",
+		ChainParams:      chainParams,
+	}
+
+	remote, smPeer, err := MakeConnectedPeers(t, remoteCfg, localCfg, idx)
+	require.NoError(t, err)
+	require.True(t, remote.Connected())
+
+	return smPeer
+}
+
+// TestHandleNewPeerMsg_SendsPolicyFilterWhenRunning verifies that a peer which
+// connects while the node is already RUNNING is told the policy fee filter.
+// resetFeeFilterToDefault only runs on the transition to RUNNING, so before
+// this only the peers present at that moment were ever told; on a node that
+// had been up for a while, most peers held no filter and relayed everything
+// (PR 1659 review). The marker is untouched, since it records what the reset
+// path last broadcast.
+func TestHandleNewPeerMsg_SendsPolicyFilterWhenRunning(t *testing.T) {
+	chainParams := &chaincfg.MainNetParams
+
+	running := blockchain2.FSMStateRUNNING
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.Mock.On("GetFSMCurrentState", mock.Anything).Return(&running, nil)
+
+	sm := &SyncManager{
+		ctx:              context.Background(),
+		settings:         test.CreateBaseTestSettings(t),
+		logger:           ulogger.TestLogger{},
+		chainParams:      chainParams,
+		blockchainClient: blockchainClient,
+		peerStates:       txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+	}
+	sm.settings.Policy.MinMiningTxFee = 0.000005 // 500 sat/kB
+	sm.currentFeeFilter.Store(500)               // the reset path already ran
+
+	var gotFee atomic.Int64
+	gotFee.Store(-1)
+
+	p := newFeeFilterProbePeer(t, chainParams, 104, &gotFee)
+
+	sm.handleNewPeerMsg(p)
+
+	require.True(t, WaitUntil(func() bool { return gotFee.Load() == 500 }, 2*time.Second),
+		"a peer connecting while RUNNING must be told the policy fee filter")
+	require.Equal(t, uint64(500), sm.currentFeeFilter.Load(), "the marker must be left alone by a per-peer send")
+	require.True(t, sm.peerStates.Exists(p), "peer must be registered")
+}
+
+// TestResetFeeFilterToDefault_LowersARaiseStoredAfterTheReset pins the
+// compare-and-swap ordering. A peer that connects while the FSM still reads
+// CATCHINGBLOCKS is given the raised filter and the marker is set to it, even
+// if a reset has just run on another goroutine. Because the reset claims the
+// marker before broadcasting, that raise is not buried under the policy value:
+// the marker reads raised, and the next reset lowers the peer. With the old
+// store-after-broadcast ordering the marker would read 500 and the peer would
+// stay at 1 BSV/kB for good.
+func TestResetFeeFilterToDefault_LowersARaiseStoredAfterTheReset(t *testing.T) {
+	chainParams := &chaincfg.MainNetParams
+
+	catchingBlocks := blockchain2.FSMStateCATCHINGBLOCKS
+	blockchainClient := &blockchain2.Mock{}
+	blockchainClient.Mock.On("GetFSMCurrentState", mock.Anything).Return(&catchingBlocks, nil)
+
+	sm := &SyncManager{
+		ctx:              context.Background(),
+		settings:         test.CreateBaseTestSettings(t),
+		logger:           ulogger.TestLogger{},
+		chainParams:      chainParams,
+		blockchainClient: blockchainClient,
+		peerStates:       txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+	}
+	sm.settings.Policy.MinMiningTxFee = 0.000005 // 500 sat/kB
+
+	// The transition to RUNNING happened: the reset lowered everyone present.
+	var feeA atomic.Int64
+	feeA.Store(-1)
+	pA := newFeeFilterProbePeer(t, chainParams, 105, &feeA)
+	sm.peerStates.Set(pA, &peerSyncState{})
+	sm.currentFeeFilter.Store(uint64(bsvutil.SatoshiPerBitcoin))
+
+	sm.resetFeeFilterToDefault()
+
+	require.True(t, WaitUntil(func() bool { return feeA.Load() == 500 }, 2*time.Second))
+	require.Equal(t, uint64(500), sm.currentFeeFilter.Load())
+
+	// A peer connects while the FSM still reads CATCHINGBLOCKS: it is raised,
+	// and the marker records that a raise is outstanding.
+	var feeB atomic.Int64
+	feeB.Store(-1)
+	pB := newFeeFilterProbePeer(t, chainParams, 106, &feeB)
+
+	sm.handleNewPeerMsg(pB)
+
+	require.True(t, WaitUntil(func() bool { return feeB.Load() == int64(bsvutil.SatoshiPerBitcoin) }, 2*time.Second))
+	require.Equal(t, uint64(bsvutil.SatoshiPerBitcoin), sm.currentFeeFilter.Load(), "the raise must be visible to the next reset")
+
+	// The next reset (the message handler calls it again while the FSM is not
+	// RUNNING) lowers the late peer too.
+	sm.resetFeeFilterToDefault()
+
+	require.True(t, WaitUntil(func() bool { return feeB.Load() == 500 }, 2*time.Second),
+		"a peer raised after the reset must be lowered by the next one")
+	require.Equal(t, uint64(500), sm.currentFeeFilter.Load())
 }

--- a/services/validator/ScriptVerifierGoBDK.go
+++ b/services/validator/ScriptVerifierGoBDK.go
@@ -204,9 +204,10 @@ func newScriptVerifierGoBDK(l ulogger.Logger, po *settings.PolicySettings, pa *c
 	se.SetPermitBareMultisig(po.PermitBareMultisig)
 
 	// Convert MinMiningTxFee from float BSV/kB to integer satoshis/kB.
-	// math.Round (not truncation) because IEEE-754 decimal representations can
-	// drop one satoshi otherwise — e.g. 0.00000250 stores as 0.0000024999…,
-	// truncating yields 249 instead of 250.
+	// math.Round (not truncation) because many decimal rates sit just below
+	// their integer number of satoshis in IEEE-754: 0.00000003 BSV/kB is
+	// 2.9999999999999996 satoshis/kB, which truncates to 2. (0.00000250 is not
+	// such a rate; it stores just above 250 and truncates correctly.)
 	//
 	// panic() not l.Fatalf() so the stop guarantee doesn't depend on the logger
 	// implementation — TestLogger.Fatalf only logs, leaving an invalid policy


### PR DESCRIPTION
## What

`resetFeeFilterToDefault` built the wire `feefilter` message from `int64(Policy.MinMiningTxFee)`. `MinMiningTxFee` is configured in BSV/kB (default 0.000005), so the message always carried `MinFee: 0` and every legacy peer was told this node wants all transactions, regardless of its configured fee policy. The bug was invisible internally because the guard and the stored `currentFeeFilter` marker already used the `SatoshiPerBitcoin` conversion; only the value put on the wire was truncated.

## Fix

* Convert once, with `math.Round`, in one helper (`policyFeeFilterSatoshisPerKB`) used by the reset path and the new-peer path. Rounding matters because many decimal rates sit just below their integer number of satoshis in float64: 0.00000003 BSV/kB is 2.9999999999999996 sat/kB and truncates to 2 (79,946 of the million rates between 0.00000001 and 0.01000000 lose a satoshi to truncation). A negative rate advertises 0; a non-finite rate (settings parsing accepts NaN and Inf) advertises 0 with a warning rather than a platform-dependent cast; a finite rate beyond int64 clamps to MaxInt64.
* Tell every peer. The reset only runs on the transition to RUNNING, so a peer connecting to a node that had been running for a while was never told anything. `handleNewPeerMsg` now sends the policy filter whenever the node is not catching up, and registers the peer before deciding its filter so a concurrent reset finds it.
* Claim the marker before broadcasting. The reset's load, broadcast and store were not atomic against the catch-up raise stored for a late peer on another goroutine, which could bury that raise and leave the peer at 1 BSV/kB for good. The marker is now taken with a compare-and-swap first; a raise stored after the claim stays visible and the next reset lowers that peer.

## What the filter means

A deliberate choice, recorded in the helper's comment: the advertised value is `minminingtxfee`, the rate below which this node's validator rejects a transaction outright, so under BIP133 the filter states what the node accepts. The one cost is a zero-fee consolidation, which the node accepts but which a filtering peer will not relay to it; such transactions still arrive by direct submission and from peers that do not filter. svnode advertises its mempool's rolling minimum instead because it admits sub-floor transactions and only declines to mine them; Teranode has no such mempool and no lower floor to advertise.

## Testing

* `TestResetFeeFilterToDefault_AdvertisesSatoshisPerKB` asserts the remote peer receives `MinFee: 3` for a 0.00000003 BSV/kB configuration. With `math.Round` replaced by truncation the test fails (an earlier revision used 0.00000250, which truncates correctly and could not tell the two apart; the review caught that by mutation).
* `TestPolicyFeeFilterSatoshisPerKB` tables the conversion: rounding, negative, NaN, both infinities, and two rates beyond int64.
* `TestHandleNewPeerMsg_SendsPolicyFilterWhenRunning` asserts a peer connecting while RUNNING receives the policy filter and the marker is untouched.
* `TestResetFeeFilterToDefault_LowersARaiseStoredAfterTheReset` pins the compare-and-swap ordering: a peer raised after a reset is lowered by the next one.
* The existing catch-up, nil-FSM-state and disconnected-peer tests still pass.
* `go test -race ./services/legacy/netsync/`, `go build ./...`, `go vet`, `golangci-lint run --new-from-rev upstream/main`, `scripts/check_error_wrap_verbs.sh`, `scripts/check_filenames.sh`: green.

Also corrects the same wrong float example in `ScriptVerifierGoBDK.go`, where it came from (three comment lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
