### PR TITLE
Fix dead securityLevelGRPC settings.conf key

### DIFF
--- a/cmd/diagnose/config_checks.go
+++ b/cmd/diagnose/config_checks.go
@@ -208,7 +208,7 @@ func checkSecurity(s *settings.Settings) []ConfigResult {
 			Severity:    severity,
 			Check:       "gRPC TLS",
 			Value:       "disabled (level 0)",
-			Recommended: "Set securityLevelGRPC >= 1 for production",
+			Recommended: "Set security_level_grpc >= 1 for production",
 		})
 	} else {
 		results = append(results, ConfigResult{

--- a/docs/howto/diagnose.md
+++ b/docs/howto/diagnose.md
@@ -71,7 +71,7 @@ Checks connectivity to each gRPC service by creating a client and calling its `H
 
 If a service address is empty, the check is skipped. If the service is disabled in settings (e.g. `startValidator=false` for the current context), the skip message says so explicitly:
 
-```
+```text
 Validator gRPC  -  SKIP  -  disabled (startValidator=false)
 ```
 
@@ -123,7 +123,7 @@ These catch subtle problems where services silently fall out of sync:
 
 ### Example Output
 
-```
+```text
 Service Health Checks
 =====================
 SERVICE                  ADDRESS                STATUS  LATENCY  MESSAGE
@@ -175,7 +175,7 @@ Listen addresses checked: Blockchain gRPC/HTTP, Block Assembly gRPC, Block Valid
 
 | Check | Condition | Severity |
 |-------|-----------|----------|
-| gRPC TLS | `securityLevelGRPC = 0` | WARN in prod, INFO in dev |
+| gRPC TLS | `security_level_grpc = 0` | WARN in prod, INFO in dev |
 | HTTP TLS | `securityLevelHTTP = 0` | WARN in prod, INFO in dev |
 | TLS cert files | TLS enabled but `server_certFile` or `server_keyFile` empty | ERROR |
 | gRPC admin API key | Empty or < 16 chars | WARN in prod |
@@ -232,14 +232,14 @@ Checks that the data folder exists, is a directory, and is writable. Catches per
 
 ### Example Output
 
-```
+```text
 Configuration Checks
 ====================
 SEVERITY  CHECK                       VALUE                                       RECOMMENDED
 INFO      Configuration context       dev
 INFO      Network                     mainnet
 OK        Port conflicts              none (16 listen addresses checked)
-INFO      gRPC TLS                    disabled (level 0)                          Set securityLevelGRPC >= 1 for production
+INFO      gRPC TLS                    disabled (level 0)                          Set security_level_grpc >= 1 for production
 INFO      HTTP TLS                    disabled (level 0)                          Set securityLevelHTTP >= 1 for production
 OK        gRPC admin API key          32 chars
 OK        Kafka hosts                 localhost:9092

--- a/docs/references/services/rpc_reference.md
+++ b/docs/references/services/rpc_reference.md
@@ -432,7 +432,7 @@ For GRPC services, certain administrative operations require additional API key 
 - **Usage**: API key must be included in GRPC requests as metadata with the key `x-api-key`.
 
 !!! warning "Security Note"
-    The API key provides administrative access to peer-policy operations. Keep it secret, never commit it, and prefer `securityLevelGRPC >= 2` (verified TLS) when the gRPC listener is not loopback-bound so the key is not exposed in transit. Note that a *configured* key is currently echoed in the node's startup settings dump, so treat startup logs as sensitive and prefer supplying the key via the environment or a secret store.
+    The API key provides administrative access to peer-policy operations. Keep it secret, never commit it, and prefer `security_level_grpc >= 2` (verified TLS) when the gRPC listener is not loopback-bound so the key is not exposed in transit. Note that a *configured* key is currently echoed in the node's startup settings dump, so treat startup logs as sensitive and prefer supplying the key via the environment or a secret store.
 
 ## General Format
 

--- a/settings.conf
+++ b/settings.conf
@@ -1161,7 +1161,7 @@ rpc_pass = bitcoin
 
 rpc_user = bitcoin
 
-securityLevelGRPC = 0
+security_level_grpc = 0
 
 # Security Configuration
 # ---------------------------------------

--- a/settings/settings_conf_dead_key_test.go
+++ b/settings/settings_conf_dead_key_test.go
@@ -1,0 +1,204 @@
+package settings
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This test guards the exact bug class it ships alongside: a settings.conf
+// base key that looks correct by case/underscore analogy to a real,
+// key-tagged setting but does not actually match it, so gocore's exact-case,
+// exact-string lookup (see (*gocore.Configuration).getInternal) silently
+// ignores it forever. That is precisely what happened to securityLevelGRPC:
+// it was typed by analogy to the genuinely-camelCase SecurityLevelHTTP
+// (`key:"securityLevelHTTP"`), but the real key is `security_level_grpc`, so
+// the settings.conf line at its default value of 0 was harmless - until an
+// operator edited it to 1 expecting TLS on inter-service gRPC and got silent
+// plaintext instead.
+//
+// This is deliberately narrower than "every settings.conf key resolves to
+// something real": most of settings.conf's ~400 base keys are legitimate
+// non-setting entries (gocore ${VAR} interpolation targets, keys read
+// outside the reflection-tagged Settings struct, the startXxx bootstrap
+// pattern), and telling those apart from a genuinely dead key needs
+// per-key investigation, not a blanket assertion - see
+// TestSettingsConfHasNoDeadKeys in settings_doc_test.go, which documents the
+// same tradeoff for a related but different check (keys asserted to stay
+// dead once removed, rather than keys asserted to resolve).
+//
+// Instead, this test targets only the specific, mechanically-detectable
+// signature of the securityLevelGRPC bug: a settings.conf key whose
+// lowercase/underscore-stripped form exactly matches a real key tag's
+// normalized form, while the settings.conf key itself does not match that
+// tag exactly. A key with no real-key lookalike at all (e.g. DATADIR,
+// clientName, startPruner) never trips this check.
+
+// settingsConfDeadKeyException documents a settings.conf base key that
+// normalizes to the same string as a real ExportMetadata() key tag but is
+// not a broken variant of it (or, where noted, is a broken variant that was
+// found by this check but is being tracked separately rather than fixed
+// here - see the reason for each).
+type settingsConfDeadKeyException struct {
+	key    string
+	reason string
+}
+
+var settingsConfDeadKeyExceptions = []settingsConfDeadKeyException{
+	{
+		key: "P2P_PORT",
+		reason: "ALL_CAPS interpolation constant, referenced via ${P2P_PORT} elsewhere in settings.conf " +
+			"(p2p_port and coinbase_p2p_static_peers.dev both expand it); a distinct naming convention from " +
+			"the real p2p_port setting it collides with after normalization, not a broken variant of it",
+	},
+	{
+		key: "P2P_PORT_COINBASE",
+		reason: "ALL_CAPS interpolation constant, referenced via ${P2P_PORT_COINBASE} elsewhere in " +
+			"settings.conf (p2p_port_coinbase.dev/.docker/.operator all expand it); distinct from the real " +
+			"p2p_port_coinbase setting it collides with after normalization, not a broken variant of it",
+	},
+	{
+		key: "LOG_LEVEL",
+		reason: "sits in the same ALL_CAPS docker-context-override block as COINBASE_RPC_USER and " +
+			"COINBASE_HTTP_PORT (settings.conf, just after coinbase_rpc_url); no Go code reads this literal " +
+			"key so it may be unused, but it follows that block's naming convention rather than being a typo " +
+			"of the real logLevel setting - flagged for the settings owner to triage as a possible separate " +
+			"cleanup, not fixed here to keep this change to the securityLevelGRPC bug",
+	},
+	{
+		key: "COINBASE_GRPC_ADDRESS",
+		reason: "same ALL_CAPS docker-context-override block as LOG_LEVEL above; docker-compose-3blasters.yml " +
+			"sets it as a container env var, but no Go code reads this literal key and gocore's env lookup is " +
+			"exact-case, so the override appears inert - flagged for the settings owner, not fixed here",
+	},
+	{
+		key: "kafka_unitTest",
+		reason: "builds a full Kafka URL (settings.conf, near the other kafka_*Config entries) but, unlike " +
+			"every sibling kafka_*Config key, is never read by any Go code - the real setting is the ALL_CAPS " +
+			"KAFKA_UNITTEST, a bare topic-name string consumed by settings/kafka_settings.go. Looks dead in " +
+			"the same way securityLevelGRPC was dead, but left for the settings owner to decide whether to " +
+			"delete it or wire it up, to keep this change scoped to securityLevelGRPC",
+	},
+	{
+		key: "coinbase_Store",
+		reason: "settings.conf's only assignment is the context-only \"coinbase_Store.docker =\" line, which " +
+			"cannot resolve to anything on its own (no base assignment); the real key is coinbase_store " +
+			"(lowercase s), which already has its own context overrides a few lines above. Same typo shape as " +
+			"securityLevelGRPC, left for the settings owner to fix or remove so this change stays scoped",
+	},
+}
+
+// settingsConfPath returns the repo-root settings.conf path relative to this
+// test file.
+func settingsConfPath(t *testing.T) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "unable to determine test file location")
+
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	return filepath.Join(repoRoot, "settings.conf")
+}
+
+// settingsConfBaseKeys returns the set of distinct base keys (the part
+// before the first '.', which strips any ".context" suffix) assigned
+// anywhere in settings.conf.
+func settingsConfBaseKeys(t *testing.T) map[string]bool {
+	t.Helper()
+
+	f, err := os.Open(settingsConfPath(t))
+	require.NoError(t, err, "opening settings.conf")
+	defer f.Close()
+
+	keys := make(map[string]bool)
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		eq := strings.Index(line, "=")
+		if eq < 0 {
+			continue
+		}
+
+		left := strings.TrimSpace(line[:eq])
+		if left == "" {
+			continue
+		}
+
+		base := left
+		if dot := strings.Index(left, "."); dot >= 0 {
+			base = left[:dot]
+		}
+
+		keys[base] = true
+	}
+	require.NoError(t, sc.Err(), "scanning settings.conf")
+
+	return keys
+}
+
+// normalizeSettingsKey lowercases a key and strips underscores, so
+// security_level_grpc and securityLevelGRPC (and SecurityLevelGrpc, etc.)
+// all normalize to the same string.
+func normalizeSettingsKey(key string) string {
+	return strings.ToLower(strings.ReplaceAll(key, "_", ""))
+}
+
+// TestSettingsConfNoShadowedKeys guards against the securityLevelGRPC bug
+// class: a settings.conf key that is never read because it only matches a
+// real key tag after case/underscore normalization, not exactly. See the
+// package-level doc comment above for why this check is intentionally
+// narrower than "every settings.conf key resolves".
+func TestSettingsConfNoShadowedKeys(t *testing.T) {
+	exempt := make(map[string]bool, len(settingsConfDeadKeyExceptions))
+	for _, e := range settingsConfDeadKeyExceptions {
+		require.NotEmpty(t, e.reason, "exception for %q must document why it is exempt", e.key)
+		exempt[e.key] = true
+	}
+
+	confKeys := settingsConfBaseKeys(t)
+
+	reg := (&Settings{}).ExportMetadata()
+
+	realExact := make(map[string]bool, len(reg.Settings))
+	realByNormalized := make(map[string]string, len(reg.Settings))
+
+	for _, s := range reg.Settings {
+		realExact[s.Key] = true
+
+		norm := normalizeSettingsKey(s.Key)
+		if _, ok := realByNormalized[norm]; !ok {
+			realByNormalized[norm] = s.Key
+		}
+	}
+
+	for confKey := range confKeys {
+		if realExact[confKey] || exempt[confKey] {
+			continue
+		}
+
+		norm := normalizeSettingsKey(confKey)
+
+		real, collides := realByNormalized[norm]
+		if !collides {
+			continue
+		}
+
+		t.Errorf("settings.conf key %q does not match any Settings key tag exactly, but normalizes "+
+			"(lowercased, underscores stripped) to the same string as the real key %q. Because gocore's "+
+			"config lookup is exact-case and exact-string, %q is never read - this is the securityLevelGRPC "+
+			"bug class. Either correct the settings.conf key to %q, or - if %q is a genuinely distinct, "+
+			"intentionally-named key - add a reasoned entry to settingsConfDeadKeyExceptions",
+			confKey, real, confKey, real, confKey)
+	}
+}

--- a/util/admin_api_key.go
+++ b/util/admin_api_key.go
@@ -73,7 +73,7 @@ func ValidateAdminAPIKey(logger ulogger.Logger, serviceName, apiKey, listenAddre
 	}
 
 	if securityLevel <= 1 && !isLoopbackListenAddress(listenAddress) {
-		logger.Warnf("[%s] grpc_admin_api_key is set but the gRPC listener %q is not loopback-bound and securityLevelGRPC=%d does not provide verified transport security, so the admin key can be harvested in transit; bind the listener to loopback or set securityLevelGRPC >= 2 with certificate verification", serviceName, listenAddress, securityLevel)
+		logger.Warnf("[%s] grpc_admin_api_key is set but the gRPC listener %q is not loopback-bound and security_level_grpc=%d does not provide verified transport security, so the admin key can be harvested in transit; bind the listener to loopback or set security_level_grpc >= 2 with certificate verification", serviceName, listenAddress, securityLevel)
 	}
 
 	return false


### PR DESCRIPTION
## Problem

`settings.conf` shipped `securityLevelGRPC = 0`. Nothing reads that key. The loader
reads `security_level_grpc` (`settings/settings.go`), and the struct tag is
`key:"security_level_grpc"` (`settings/interface.go`). The committed line is dead.

It is harmless at its current value because the real default is also `0` - but an
operator who edits it to `1` expecting to enable TLS on inter-service gRPC gets
silent plaintext instead: `util/grpc_helper.go` `GetGRPCClient()` never sees the
change and keeps picking `insecure.NewCredentials()`.

The likely cause: the sibling setting genuinely is camelCase - `SecurityLevelHTTP`
carries `key:"securityLevelHTTP"` (`settings/interface.go`) - so `securityLevelGRPC`
looked correct by analogy. `securityLevelHTTP` itself is untouched by this PR; the
broader camelCase/snake_case inconsistency across the settings package is a
separate, larger question and remains a follow-up.

## Fix

- `settings.conf`: `securityLevelGRPC` -> `security_level_grpc`, value and comments
  unchanged.
- Same wrong spelling also appeared in operator-facing recommendation text, which
  told operators to set the dead key - corrected in `cmd/diagnose/config_checks.go`,
  `util/admin_api_key.go`, `docs/howto/diagnose.md`, and
  `docs/references/services/rpc_reference.md`.
- Searched `deploy/`, `kubernetes/`, `compose/`, and every `.conf`/`.yml`/`.yaml`/`.env`
  file in the repo for other occurrences of the wrong spelling (including
  context-suffixed variants like `securityLevelGRPC.docker`) - found none beyond the
  ones listed above.

## Regression test

Added `TestSettingsConfNoShadowedKeys` (`settings/settings_conf_dead_key_test.go`),
which fails on any `settings.conf` key whose case/underscore-normalized form
collides with a real `key:` tag while the literal key does not match it exactly -
the precise failure mode that let `securityLevelGRPC` through silently, since
gocore's config lookup is exact-case and exact-string.

This is deliberately narrower than a full "every settings.conf key resolves to
something real" sweep. `TestSettingsConfHasNoDeadKeys` (added on `main` separately)
already covers a related but different case - asserting that two specific,
already-removed keys stay removed - and does not attempt the full sweep either,
since most unresolved base keys are legitimate (interpolation `${VAR}` targets,
`startXxx` bootstrap flags, keys read outside the reflection-tagged struct). This
test targets only the mechanically-detectable signature of a copy-paste-by-analogy
typo.

Six existing normalized collisions are exempted in the test with individual
reasoning. Four are genuinely distinct ALL_CAPS interpolation constants
(`P2P_PORT`, `P2P_PORT_COINBASE` - confirmed referenced via `${...}` elsewhere in
settings.conf; `LOG_LEVEL`, `COINBASE_GRPC_ADDRESS` - same naming block, no
confirmed Go reader). The other two look like the same bug class as
`securityLevelGRPC` but are left for the settings owner to triage rather than fixed
here, to keep this change scoped:

- `kafka_unitTest` (settings.conf, builds a full Kafka URL) is never read by any Go
  code; the real setting is the ALL_CAPS `KAFKA_UNITTEST`, a bare topic-name string.
- `coinbase_Store.docker` is a lone context-only override with no base assignment,
  so it cannot resolve to anything regardless; the real key is `coinbase_store`.

## Verification

- `go build ./...`
- `go vet ./settings/... ./util/...`
- `go test ./settings/... -race`
- `go test ./util/ -race` (admin API key + gRPC TLS/security-level tests)
- `golangci-lint run` / `staticcheck` on the touched packages - no new issues (three
  pre-existing `prealloc` warnings confirmed present on `main` before this change)
- End-to-end contrast, run as a standalone binary against isolated `settings.conf`
  fixtures so gocore's config singleton can't carry state between runs:
  - `security_level_grpc = 1` -> `NewSettings().SecurityLevelGRPC == 1`
  - `securityLevelGRPC = 1` (old spelling) -> `NewSettings().SecurityLevelGRPC == 0`
- Reintroduced the misspelling to confirm `TestSettingsConfNoShadowedKeys` fails and
  names the dead key, then reverted.