### PR TITLE
fix(blockchain): do not cache a negative GetBlockIsMined answer

### DIFF
--- a/stores/blockchain/sql/GetBlockIsMined.go
+++ b/stores/blockchain/sql/GetBlockIsMined.go
@@ -82,7 +82,9 @@ func (s *SQL) GetBlockIsMined(ctx context.Context, blockHash *chainhash.Hash) (b
 	}
 
 	// Cache the mining status result
-	cacheOp.Set(isMined, s.cacheTTL)
+	if isMined {
+		cacheOp.Set(isMined, s.cacheTTL)
+	}
 
 	return isMined, nil
 }

--- a/stores/blockchain/sql/GetBlockIsMined_test.go
+++ b/stores/blockchain/sql/GetBlockIsMined_test.go
@@ -123,3 +123,59 @@ func TestGetBlockIsMined(t *testing.T) {
 		})
 	}
 }
+
+// A negative answer must not be served from the response cache once the
+// mined_set column has changed underneath it.
+func TestGetBlockIsMined_NegativeAnswerIsNotCached(t *testing.T) {
+	logger := ulogger.TestLogger{}
+	dbURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+
+	store, err := New(logger, dbURL, settings.NewSettings())
+	require.NoError(t, err)
+	defer store.Close(context.Background())
+
+	genesisBlock, err := store.GetBlockByID(context.Background(), 0)
+	require.NoError(t, err)
+
+	hashMerkleRoot, err := chainhash.NewHashFromStr("d1de05a65845a49ad63eed887c4cf7cc824e02b5d10de82829f740b748b9737f")
+	require.NoError(t, err)
+
+	bits, err := model.NewNBitFromString("207fffff")
+	require.NoError(t, err)
+
+	coinbaseTx, err := bt.NewTxFromString("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff17030100002f6d312d65752fb670097da68d1b768d8b21f6ffffffff03ac505763000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88acaa505763000000001976a9143c22b6d9ba7b50b6d6e615c69d11ecb2ba3db14588acaa505763000000001976a914b7177c7deb43f3869eabc25cfd9f618215f34d5588ac00000000")
+	require.NoError(t, err)
+
+	subtree, err := chainhash.NewHashFromStr("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098")
+	require.NoError(t, err)
+
+	testBlock := &model.Block{
+		Header: &model.BlockHeader{
+			Version:        1,
+			Timestamp:      1729259727,
+			Nonce:          0,
+			HashPrevBlock:  genesisBlock.Hash(),
+			HashMerkleRoot: hashMerkleRoot,
+			Bits:           *bits,
+		},
+		Height:           1,
+		CoinbaseTx:       coinbaseTx,
+		TransactionCount: 1,
+		Subtrees:         []*chainhash.Hash{subtree},
+	}
+
+	_, _, err = store.StoreBlock(context.Background(), testBlock, "test", options.WithMinedSet(false))
+	require.NoError(t, err)
+
+	isMined, err := store.GetBlockIsMined(context.Background(), testBlock.Hash())
+	require.NoError(t, err)
+	require.False(t, isMined)
+
+	_, err = store.db.ExecContext(context.Background(), "UPDATE blocks SET mined_set = true WHERE hash = $1", testBlock.Hash().CloneBytes())
+	require.NoError(t, err)
+
+	isMined, err = store.GetBlockIsMined(context.Background(), testBlock.Hash())
+	require.NoError(t, err)
+	require.True(t, isMined, "a stale negative answer was served from the response cache")
+}


### PR DESCRIPTION
## Summary

`stores/blockchain/sql` caches `GetBlockIsMined` results in the response cache for the 2-minute TTL — including `false`. A poll that reads `mined_set` just before the update lands caches the negative, and every caller then sees a stale `false` until the TTL expires or another write resets the cache.

Observed live on a mainnet IBD: the svp2p bridge waits ~80 s for the parent's `mined_set` before failing the child block; a cached negative outlives that budget, so block 56 failed repeatedly and sync stalled for 4 hours. `services/svp2p/bridge/handle_block.go` polls `GetBlockIsMined` in exactly this shape, and the same wait exists for any caller that polls.

## Change

Cache only a `true` answer. A positive is permanent; a negative is transient by nature and re-reading it is one indexed row lookup.

## Test

`TestGetBlockIsMined_NegativeAnswerIsNotCached` reproduces the race shape (read false → update `mined_set` directly → read again) and fails on the old code with the stale cached `false`.

`go test ./stores/blockchain/sql/` — ok. `golangci-lint` — 0 issues.