### PR TITLE
chore: ignore local .mcp.json MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ teranode-dev
 .worktrees
 docs/superpowers/
 compose/generated/
+.mcp.json


### PR DESCRIPTION
A `.mcp.json` in the repo root holds per-developer MCP server endpoints, internal hostnames among them. It is not shared configuration and it is not tracked, so it shows up as an untracked file in every working tree that has one. Ignore it.

No behaviour change; one line in `.gitignore`.

**Verified:** `git check-ignore -v .mcp.json` matches at `.gitignore:124`, and a real `.mcp.json` placed in the tree no longer appears in `git status`.