### PR TITLE
fix(utxo): tolerate a dangling spender reference under a recent parent (#1214)

### DIFF
--- a/services/subtreevalidation/SubtreeValidation.go
+++ b/services/subtreevalidation/SubtreeValidation.go
@@ -473,7 +473,7 @@ func (u *Server) blessMissingTransaction(ctx context.Context, blockHash chainhas
 func (u *Server) checkCounterConflictingOnCurrentChain(ctx context.Context, txHash chainhash.Hash, blockIds map[uint32]bool) error {
 	// the tx is conflicting, check whether the counter-conflicting transactions have already been mined on our chain
 	// first get the parent transactions and check if they were spent
-	counterConflictingTxHashes, err := utxo.GetCounterConflictingTxHashes(ctx, u.utxoStore, txHash, u.settings.UtxoStore.ConflictingChildrenMaxNodes)
+	counterConflictingTxHashes, err := utxo.GetCounterConflictingTxHashes(ctx, u.utxoStore, txHash, u.settings.UtxoStore.ConflictingChildrenMaxNodes, u.settings.GetUtxoStoreBlockHeightRetention())
 	if err != nil {
 		return errors.NewProcessingError("[checkCounterConflictingOnCurrentChain][%s] failed to get counter conflicting tx hashes", txHash.String(), err)
 	}

--- a/services/subtreevalidation/counter_conflicting_dangling_test.go
+++ b/services/subtreevalidation/counter_conflicting_dangling_test.go
@@ -1,0 +1,120 @@
+package subtreevalidation
+
+// End-to-end coverage, on a real sqlitememory UTXO store, for the parent-depth
+// guard that lets checkCounterConflictingOnCurrentChain tolerate a dangling
+// spender reference — a parent output spent by a counter whose own record is
+// absent (#1214) — instead of hard-erroring and wedging the block, while still
+// failing closed when the parent is buried beyond the pruning horizon, where the
+// absent counter could instead be a mined-then-pruned double-spend.
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// buildDanglingRef sets up, in a fresh sqlitememory store: parentTx1 mined at
+// parentHeight, its output 0 spent by an ABSENT counter (a double-spend clone of
+// tx1 that is spent but never created), and tx1 created as the conflicting winner.
+// The store's tip is set to tip. It returns a Server ready for the check.
+func buildDanglingRef(ctx context.Context, t *testing.T, name string, parentHeight, tip uint32) *Server {
+	t.Helper()
+
+	logger := ulogger.NewErrorTestLogger(t)
+	tSettings := test.CreateBaseTestSettings(t)
+
+	utxoStoreURL, err := url.Parse("sqlitememory:///" + name)
+	require.NoError(t, err)
+
+	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
+	require.NoError(t, err)
+
+	s := &Server{utxoStore: utxoStore, settings: tSettings, logger: logger}
+
+	_, _, err = utxoStore.SpendAndCreate(ctx, parentTx1, parentHeight, utxo.WithCreateOnly())
+	require.NoError(t, err)
+
+	// Pin the parent's confirmed height on the longest chain so the guard can
+	// measure its depth (clears unmined_since and records the block height).
+	_, err = utxoStore.SetMinedMulti(ctx, []*chainhash.Hash{parentTx1.TxIDChainHash()}, utxo.MinedBlockInfo{
+		BlockID:        1,
+		BlockHeight:    parentHeight,
+		SubtreeIdx:     0,
+		OnLongestChain: true,
+	})
+	require.NoError(t, err)
+
+	// The counter double-spends parentTx1's output (taking the first-seen slot)
+	// but its own record is never created: WithSpendOnly with no matching
+	// WithCreateOnly is precisely the spend-first window in SequentialSpendAndCreate
+	// that leaves a dangling spender reference behind.
+	counter := tx1.Clone()
+	counter.Version = 2
+
+	_, _, err = utxoStore.SpendAndCreate(ctx, counter, parentHeight, utxo.WithSpendOnly())
+	require.NoError(t, err)
+
+	// Self-check: the dangling reference must actually exist — the counter's record
+	// is absent, but the parent still records it as a spender.
+	_, gErr := utxoStore.Get(ctx, counter.TxIDChainHash())
+	require.Error(t, gErr, "test setup: counter record must be absent (dangling ref)")
+
+	parentMeta, err := utxoStore.Get(ctx, parentTx1.TxIDChainHash(), fields.Utxos)
+	require.NoError(t, err)
+
+	var refsCounter bool
+
+	for _, sd := range parentMeta.SpendingDatas {
+		if sd != nil && sd.TxID.IsEqual(counter.TxIDChainHash()) {
+			refsCounter = true
+			break
+		}
+	}
+
+	require.True(t, refsCounter, "test setup: parent must still reference the absent counter as a spender")
+
+	// tx1 is the winner that arrives in a block and double-spends the same output;
+	// it is created Conflicting=true, which is what arms the counter-conflicting check.
+	_, _, err = utxoStore.SpendAndCreate(ctx, tx1, tip, utxo.WithConflicting(true), utxo.WithCreateOnly())
+	require.NoError(t, err)
+
+	require.NoError(t, utxoStore.SetBlockHeight(tip))
+
+	return s
+}
+
+// The field-bug repro end to end: the parent is confirmed 5 blocks below tip (well
+// within retention) and the counter record is absent. The check must pass — the
+// block is valid, and SVNode-following peers accept it.
+func TestCheckCounterConflictingOnCurrentChain_ToleratesDanglingRefUnderRecentParent(t *testing.T) {
+	InitPrometheusMetrics()
+
+	ctx := context.Background()
+	s := buildDanglingRef(ctx, t, "dangling_tolerate", 1000, 1005)
+
+	err := s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
+
+	require.NoError(t, err, "a dangling spender ref under a recent parent must be tolerated, not wedge the block")
+}
+
+// The consensus guard end to end: the parent is confirmed far below tip (beyond
+// retention), so the absent counter could be a mined-then-pruned spend on the
+// active chain. The check must still reject — SVNode would reject such a block.
+func TestCheckCounterConflictingOnCurrentChain_FailsClosedOnDanglingRefUnderBuriedParent(t *testing.T) {
+	InitPrometheusMetrics()
+
+	ctx := context.Background()
+	s := buildDanglingRef(ctx, t, "dangling_failclosed", 10, 1000)
+
+	err := s.checkCounterConflictingOnCurrentChain(ctx, *tx1.TxIDChainHash(), map[uint32]bool{})
+
+	require.Error(t, err, "a dangling spender ref under a parent buried beyond retention must fail closed")
+}

--- a/stores/utxo/aerospike/conflicting.go
+++ b/stores/utxo/aerospike/conflicting.go
@@ -25,7 +25,7 @@ func (s *Store) GetCounterConflicting(ctx context.Context, txHash chainhash.Hash
 	// unbounded: this is the conflict-demotion path (ProcessConflicting), which
 	// must always walk the full descendant set to completion — a budget failure
 	// here would wedge block assembly on the block forever (issue 1391)
-	return utxo.GetCounterConflictingTxHashes(ctx, s, txHash, 0)
+	return utxo.GetCounterConflictingTxHashes(ctx, s, txHash, 0, s.settings.GetUtxoStoreBlockHeightRetention())
 }
 
 // GetConflictingChildren returns the conflicting transactions for the given transaction hash

--- a/stores/utxo/counter_conflicting_dangling_test.go
+++ b/stores/utxo/counter_conflicting_dangling_test.go
@@ -1,0 +1,138 @@
+package utxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// A dangling spender reference is a parent output slot naming a spender whose own
+// record was never written — the spend-first ordering in SequentialSpendAndCreate
+// records the spend on the parent before it creates the spender (#1214). The
+// counter-conflicting walk must not wedge block validation on one, but it must
+// still fail closed when the absence could instead be a mined-then-pruned counter.
+
+// danglingCase wires a tx spending one output of one parent, where the parent
+// names a spender the store has no record of.
+func danglingCase(t *testing.T, parentMeta *meta.Data, walkErr error) (*MockUtxostore, context.Context, [32]byte, [32]byte) {
+	t.Helper()
+
+	mockStore := &MockUtxostore{}
+
+	txHash := createTestHash("dangling-test-tx")
+	parentTxHash := createTestHash("dangling-parent-tx")
+	absentSpender := createTestHash("dangling-absent-spender")
+
+	testTx := createTestTransactionWithInputs(parentTxHash, 0)
+
+	parentMeta.SpendingDatas = []*spend.SpendingData{{TxID: &absentSpender}}
+
+	mockStore.On("Get", mock.Anything, &txHash, mock.Anything).
+		Return(&meta.Data{Tx: testTx}, nil)
+	mockStore.On("Get", mock.Anything, &parentTxHash, mock.Anything).
+		Return(parentMeta, nil)
+	mockStore.On("Get", mock.Anything, &absentSpender, mock.Anything).
+		Return(nil, walkErr)
+
+	return mockStore, context.Background(), txHash, absentSpender
+}
+
+// Parent mined inside the retention window: no counter mined on that output slot
+// could have been pruned yet, so the absence is provably a never-created loser.
+// Tolerate it and leave it out of the counter set.
+func TestGetCounterConflictingTxHashes_ToleratesDanglingSpenderInsideRetention(t *testing.T) {
+	notFound := errors.NewTxNotFoundError("no record for spender")
+
+	mockStore, ctx, txHash, absentSpender := danglingCase(t,
+		&meta.Data{BlockHeights: []uint32{900}}, notFound)
+	mockStore.On("GetBlockHeight").Return(uint32(1000))
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
+
+	require.NoError(t, err)
+	require.NotContains(t, result, absentSpender)
+	require.Equal(t, [][32]byte{txHash}, [][32]byte{result[0]})
+	require.Len(t, result, 1)
+}
+
+// Parent confirmed below the pruning horizon: a counter could have been mined on
+// that slot and since been pruned, so the absence is not provably benign. SVNode
+// would reject a block double-spending a confirmed output, so fail closed.
+func TestGetCounterConflictingTxHashes_FailsClosedOnDanglingSpenderBelowRetention(t *testing.T) {
+	notFound := errors.NewTxNotFoundError("no record for spender")
+
+	mockStore, ctx, txHash, _ := danglingCase(t,
+		&meta.Data{BlockHeights: []uint32{100}}, notFound)
+	mockStore.On("GetBlockHeight").Return(uint32(1000))
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, errors.ErrTxNotFound))
+}
+
+// A parent with no mined height and no unmined marker gives us nothing to prove
+// recency with, so the guard must not fire.
+func TestGetCounterConflictingTxHashes_FailsClosedWhenParentDepthUnknown(t *testing.T) {
+	notFound := errors.NewTxNotFoundError("no record for spender")
+
+	mockStore, ctx, txHash, _ := danglingCase(t, &meta.Data{}, notFound)
+	mockStore.On("GetBlockHeight").Return(uint32(1000))
+
+	_, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxNotFound))
+}
+
+// An unmined parent sits at the top of the chain, so nothing spending it can have
+// been pruned. Tolerate.
+func TestGetCounterConflictingTxHashes_ToleratesDanglingSpenderOfUnminedParent(t *testing.T) {
+	notFound := errors.NewTxNotFoundError("no record for spender")
+
+	mockStore, ctx, txHash, absentSpender := danglingCase(t,
+		&meta.Data{UnminedSince: 995}, notFound)
+	mockStore.On("GetBlockHeight").Return(uint32(1000))
+
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
+
+	require.NoError(t, err)
+	require.NotContains(t, result, absentSpender)
+}
+
+// retention 0 disables the guard entirely — every absent record fails closed.
+func TestGetCounterConflictingTxHashes_RetentionZeroDisablesTolerance(t *testing.T) {
+	notFound := errors.NewTxNotFoundError("no record for spender")
+
+	mockStore, ctx, txHash, _ := danglingCase(t,
+		&meta.Data{BlockHeights: []uint32{900}}, notFound)
+	mockStore.On("GetBlockHeight").Return(uint32(1000))
+
+	_, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 0)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrTxNotFound))
+}
+
+// The guard is scoped to an absent record. Any other failure of the descendant
+// walk must still propagate, even for a parent inside the retention window.
+func TestGetCounterConflictingTxHashes_DoesNotTolerateNonNotFoundWalkError(t *testing.T) {
+	other := errors.NewProcessingError("aerospike unavailable")
+
+	mockStore, ctx, txHash, _ := danglingCase(t,
+		&meta.Data{BlockHeights: []uint32{900}}, other)
+
+	_, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "aerospike unavailable")
+	require.False(t, errors.Is(err, errors.ErrTxNotFound))
+	// the tip height must never be read on a non-tolerable path
+	mockStore.AssertNotCalled(t, "GetBlockHeight")
+}

--- a/stores/utxo/process_conflicting.go
+++ b/stores/utxo/process_conflicting.go
@@ -55,6 +55,20 @@ var (
 		},
 	)
 
+	// prometheusDanglingSpenderRefTolerated counts absent counter-conflicting records
+	// that the parent-depth guard in GetCounterConflictingTxHashes tolerated (excluded
+	// from the counter set) instead of hard-erroring. A non-zero value means the store
+	// carries dangling spender references (a never-created loser, #1214) that would
+	// otherwise have wedged block validation — surface it so the inconsistency is visible.
+	prometheusDanglingSpenderRefTolerated = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "teranode",
+			Subsystem: "utxo",
+			Name:      "dangling_spender_ref_tolerated_total",
+			Help:      "Number of absent counter-conflicting records tolerated by the parent-depth guard in the counter-conflicting walk",
+		},
+	)
+
 	// prometheusUtxoConflictingWalkDuration replaces the store-method duration
 	// histogram (e.g. aerospike txmeta_get_conflicting) for the walks that
 	// GetCounterConflictingTxHashes now runs via the package-level function —
@@ -1170,7 +1184,12 @@ func GetConflictingChildren(ctx context.Context, s Store, hash chainhash.Hash, m
 // counter-conflicting transaction) and that spender's full descendant set.
 // maxNodes bounds each descendant walk (see GetConflictingChildren); <= 0
 // means unbounded.
-func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhash.Hash, maxNodes int) ([]chainhash.Hash, error) {
+//
+// retention is the UTXO store block-height retention window. It gates the
+// parent-depth guard that tolerates an absent counter-conflicting record (see
+// parentDepthInfo); pass 0 to disable the guard and fail closed on every absent
+// record.
+func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhash.Hash, maxNodes int, retention uint32) ([]chainhash.Hash, error) {
 	ctx, _, deferFn := tracing.Tracer("utxo").Start(ctx, "GetCounterConflictingTxHashes")
 
 	defer deferFn()
@@ -1191,10 +1210,18 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 		parentTxs[*input.PreviousTxIDChainHash()] = nil
 	}
 
+	// parentDepth records, per parent, the confirmation depth used to gate tolerance
+	// of an absent counter-conflicting record (see the absent-counter branch below).
+	// Captured from the parent record we already fetch, so no extra round trip.
+	parentDepth := make(map[chainhash.Hash]parentDepthInfo, len(parentTxs))
+
 	for parentTx := range parentTxs {
 		parentTxHash := &parentTx
 
-		parentTxMeta, err := s.Get(ctx, parentTxHash, fields.Utxos)
+		// fields.BlockIDs is requested alongside fields.BlockHeights because the SQL
+		// backend only populates BlockHeights when the block-id join is loaded; the
+		// parent-depth guard below relies on BlockHeights being present for a mined parent.
+		parentTxMeta, err := s.Get(ctx, parentTxHash, fields.Utxos, fields.BlockHeights, fields.BlockIDs, fields.UnminedSince)
 		if err != nil {
 			return nil, err
 		}
@@ -1210,6 +1237,7 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 		}
 
 		parentTxs[*parentTxHash] = spendingTxIDs
+		parentDepth[*parentTxHash] = newParentDepthInfo(parentTxMeta)
 	}
 
 	// validate every input and collect the unique counter-spenders in first-seen
@@ -1220,8 +1248,15 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 	seenSpenders := make(map[chainhash.Hash]struct{}, len(txMeta.Tx.Inputs))
 	uniqueSpendingTxIDs := make([]chainhash.Hash, 0, len(txMeta.Tx.Inputs))
 
+	// spenderParents records every parent output slot that names a given spender.
+	// The absent-record guard below needs all of them: one slot it cannot prove
+	// recent is enough to fail closed for that spender.
+	spenderParents := make(map[chainhash.Hash][]chainhash.Hash, len(txMeta.Tx.Inputs))
+
 	for _, input := range txMeta.Tx.Inputs {
-		parenTxIDS, ok := parentTxs[*input.PreviousTxIDChainHash()]
+		parentHash := *input.PreviousTxIDChainHash()
+
+		parenTxIDS, ok := parentTxs[parentHash]
 		if ok {
 			// check the length of the spending txs, if it's less than the index, then the input is not spent
 			if len(parenTxIDS) <= int(input.PreviousTxOutIndex) {
@@ -1231,7 +1266,7 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 
 			spendingTxID := parenTxIDS[input.PreviousTxOutIndex]
 			if spendingTxID != nil {
-				counterConflictingMap[*spendingTxID] = struct{}{}
+				spenderParents[*spendingTxID] = append(spenderParents[*spendingTxID], parentHash)
 
 				if _, ok := seenSpenders[*spendingTxID]; !ok {
 					seenSpenders[*spendingTxID] = struct{}{}
@@ -1241,13 +1276,53 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 		}
 	}
 
+	// tipHeight is resolved lazily; nil means "not yet read from the store"
+	var tipHeight *uint32
+
 	for _, spendingTxID := range uniqueSpendingTxIDs {
 		// call the package-level walk directly (not the Store method) so the
 		// caller-chosen maxNodes budget flows into the BFS
 		childHashes, err := GetConflictingChildren(ctx, s, spendingTxID, maxNodes)
 		if err != nil {
+			// A counter-conflicting record that is absent from the store has no
+			// BlockIDs, so it is definitionally not mined on our chain. Tolerate it
+			// (exclude from the counter set) only when every parent output slot it
+			// occupies is confirmed within the retention window of tip: there, no
+			// counter mined on that slot could yet have been pruned, so the absence
+			// must be a never-created loser — a spend recorded on the parent whose
+			// own record was never written (#1214). The block is valid; legacy
+			// SVNode-following peers accept it. Below that window we cannot rule out
+			// a mined-then-pruned counter, so we fail closed: SVNode would reject a
+			// block double-spending a confirmed output.
+			if errors.Is(err, errors.ErrTxNotFound) || errors.Is(err, errors.ErrNotFound) {
+				// the tip height is read only on this path, so a store that never
+				// carries a dangling reference is never asked for it
+				if tipHeight == nil {
+					h := s.GetBlockHeight()
+					tipHeight = &h
+				}
+
+				tolerable := true
+
+				for _, parentHash := range spenderParents[spendingTxID] {
+					if !parentDepth[parentHash].withinRetention(*tipHeight, retention) {
+						tolerable = false
+						break
+					}
+				}
+
+				if tolerable && len(spenderParents[spendingTxID]) > 0 {
+					prometheusDanglingSpenderRefTolerated.Inc()
+					continue
+				}
+			}
+
 			return nil, err
 		}
+
+		// admitted only once its record was readable; a tolerated absent spender is
+		// deliberately left out of the counter set
+		counterConflictingMap[spendingTxID] = struct{}{}
 
 		for _, childHash := range childHashes {
 			if childHash.Equal(subtree.FrozenBytesTxHash) {
@@ -1267,4 +1342,67 @@ func GetCounterConflictingTxHashes(ctx context.Context, s Store, txHash chainhas
 	// fmt.Printf("counterConflicting: %v\n", counterConflicting)
 
 	return counterConflicting, nil
+}
+
+// parentDepthInfo captures a parent tx's confirmation depth relative to the
+// pruning horizon, so the counter-conflicting walk can decide whether an absent
+// spender of that parent is provably a never-created loser (safe to tolerate) or
+// a possibly mined-then-pruned counter (must fail closed).
+type parentDepthInfo struct {
+	// unmined is true when the parent carries no mined height (UnminedSince set),
+	// so it is trivially at the top of the chain — no mined spender of it could
+	// yet have been pruned.
+	unmined bool
+	// minHeight is the lowest block height the parent is mined at (valid only when
+	// mined is true).
+	minHeight uint32
+	// mined is true when a concrete mined height is known for the parent.
+	mined bool
+}
+
+func newParentDepthInfo(parent *meta.Data) parentDepthInfo {
+	if parent == nil {
+		return parentDepthInfo{}
+	}
+
+	if parent.UnminedSince != 0 {
+		return parentDepthInfo{unmined: true}
+	}
+
+	if len(parent.BlockHeights) == 0 {
+		return parentDepthInfo{}
+	}
+
+	minHeight := parent.BlockHeights[0]
+	for _, h := range parent.BlockHeights[1:] {
+		if h < minHeight {
+			minHeight = h
+		}
+	}
+
+	return parentDepthInfo{minHeight: minHeight, mined: true}
+}
+
+// withinRetention reports whether the parent is confirmed within retention blocks
+// of tipHeight (or is unmined). When true, no counter-conflicting tx mined on the
+// parent's output slot could yet be prune-eligible — a mined spender's delete-at-height
+// is mined_height + retention, and mined_height >= parent_height — so an absent spender
+// must be a never-created loser. When we cannot prove recency (no mined height known
+// and not flagged unmined), or retention is 0, we return false and fail closed.
+func (d parentDepthInfo) withinRetention(tipHeight, retention uint32) bool {
+	if retention == 0 {
+		return false
+	}
+
+	if d.unmined {
+		return true
+	}
+
+	if !d.mined {
+		return false
+	}
+
+	// Equivalent to minHeight > tipHeight - retention, written as addition to
+	// avoid unsigned underflow when tipHeight < retention.
+	return d.minHeight+retention > tipHeight
 }

--- a/stores/utxo/process_conflicting_test.go
+++ b/stores/utxo/process_conflicting_test.go
@@ -682,7 +682,7 @@ func TestGetCounterConflictingTxHashes_Success(t *testing.T) {
 		Return(&meta.Data{}, nil)
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	require.NoError(t, err)
@@ -703,7 +703,7 @@ func TestGetCounterConflictingTxHashes_GetTxError(t *testing.T) {
 		Return(nil, errors.NewProcessingError("get tx error"))
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	assert.Nil(t, result)
@@ -731,7 +731,7 @@ func TestGetCounterConflictingTxHashes_GetParentError(t *testing.T) {
 		Return(nil, errors.NewProcessingError("get parent error"))
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	assert.Nil(t, result)
@@ -762,7 +762,7 @@ func TestGetCounterConflictingTxHashes_OutOfRangeError(t *testing.T) {
 		}, nil)
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	assert.Nil(t, result)
@@ -806,7 +806,7 @@ func TestGetCounterConflictingTxHashes_FrozenChildError(t *testing.T) {
 		Return(nil, nil).Maybe()
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	assert.Nil(t, result)
@@ -842,7 +842,7 @@ func TestGetCounterConflictingTxHashes_GetConflictingChildrenError(t *testing.T)
 		Return(nil, errors.NewProcessingError("get conflicting children error"))
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	assert.Nil(t, result)
@@ -872,7 +872,7 @@ func TestGetCounterConflictingTxHashes_NilSpendingData(t *testing.T) {
 		}, nil)
 
 	// Execute test
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 
 	// Assertions
 	require.NoError(t, err)
@@ -1030,7 +1030,7 @@ func TestGetCounterConflictingTxHashes_DedupesSpenderWalks(t *testing.T) {
 	mockStore.On("Get", mock.Anything, &spenderHash, mock.Anything).
 		Return(&meta.Data{}, nil)
 
-	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0)
+	result, err := GetCounterConflictingTxHashes(ctx, mockStore, txHash, 0, 288)
 	require.NoError(t, err)
 	assert.Contains(t, result, txHash)
 	assert.Contains(t, result, spenderHash)

--- a/stores/utxo/sql/prune_horizon_test.go
+++ b/stores/utxo/sql/prune_horizon_test.go
@@ -1,0 +1,211 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/pruner"
+	"github.com/bsv-blockchain/teranode/stores/utxo/tests"
+	"github.com/stretchr/testify/require"
+)
+
+// The parent-depth guard in utxo.GetCounterConflictingTxHashes tolerates an absent
+// counter-conflicting record when the parent output slot it occupied is confirmed
+// within `retention` blocks of tip. That is only sound if the store never deletes a
+// transaction mined on the longest chain before mined_height + retention: a counter
+// mined on the parent's slot has mined_height >= parent_height, so its deletion
+// height is at or beyond the parent's.
+//
+// These tests pin that horizon at its exact boundary, on a real store driven by the
+// real pruner service. The earliest DAH the code can produce for a mined transaction
+// comes from SetMinedMulti (sql.go: newDAH = minedBlockInfo.BlockHeight + retention);
+// the spend path stamps tip+1+retention, which is strictly later. So a transaction
+// mined with all outputs already spent is the worst case, and it is what is built here.
+func buildMinedFullySpent(ctx context.Context, t *testing.T, store *Store, tx *bt.Tx, mineHeight uint32) *chainhash.Hash {
+	t.Helper()
+
+	_, _, err := store.SpendAndCreate(ctx, tx, mineHeight, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	txHash := tx.TxIDChainHash()
+
+	// Spend every output BEFORE the mined transition, so SetMinedMulti sees an
+	// all-spent record and stamps the earliest DAH the store can produce.
+	for i, out := range tx.Outputs {
+		spendTx := bt.NewTx()
+		require.NoError(t, spendTx.From(txHash.String(), uint32(i), out.LockingScript.String(), out.Satoshis))
+		require.NoError(t, spendTx.PayToAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", 1000))
+
+		_, _, err = store.SpendAndCreate(ctx, spendTx, mineHeight, utxostore.WithSpendOnly())
+		require.NoError(t, err, "spending output %d", i)
+	}
+
+	_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxostore.MinedBlockInfo{
+		BlockID:        100,
+		BlockHeight:    mineHeight,
+		SubtreeIdx:     0,
+		OnLongestChain: true,
+	})
+	require.NoError(t, err)
+
+	_, err = store.Get(ctx, txHash)
+	require.NoError(t, err, "setup: tx must exist before pruning")
+
+	return txHash
+}
+
+func horizonStore(ctx context.Context, t *testing.T) (*Store, pruner.Service, uint32) {
+	t.Helper()
+
+	ResetPrunerServiceForTests()
+	t.Cleanup(ResetPrunerServiceForTests)
+
+	store, _ := setup(ctx, t)
+
+	provider, ok := any(store).(pruner.PrunerServiceProvider)
+	require.True(t, ok)
+
+	prunerSvc, err := provider.GetPrunerService()
+	require.NoError(t, err)
+	prunerSvc.Start(ctx)
+
+	retention := store.settings.GetUtxoStoreBlockHeightRetention()
+	require.NotZero(t, retention, "retention must be configured for this test to mean anything")
+
+	// tests.Tx spends tests.ParentTx; the parent must exist for SetConflicting to
+	// record conflicting_children against it.
+	_, _, err = store.SpendAndCreate(ctx, tests.ParentTx, 1, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	return store, prunerSvc, retention
+}
+
+// One block BEFORE the horizon the guard relies on, the mined transaction must
+// still be present. If this fails, the guard can tolerate an absent counter that
+// was in fact mined and pruned, and the tolerance is unsound.
+func TestPruneHorizon_MinedTxSurvivesUntilMinedHeightPlusRetention(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, prunerSvc, retention := horizonStore(ctx, t)
+
+	const mineHeight uint32 = 1000
+
+	txHash := buildMinedFullySpent(ctx, t, store, tests.Tx, mineHeight)
+
+	tip := mineHeight + retention - 1
+	require.NoError(t, store.SetBlockHeight(tip))
+
+	_, err := prunerSvc.Prune(ctx, tip, "<horizon-below>")
+	require.NoError(t, err)
+
+	_, err = store.Get(ctx, txHash)
+	require.NoError(t, err,
+		"a tx mined at %d must survive pruning at tip %d (mined_height + retention - 1); "+
+			"the counter-conflicting parent-depth guard depends on this", mineHeight, tip)
+}
+
+// At the horizon itself the transaction is deleted. This is the other half of the
+// boundary: it shows the horizon really is mined_height + retention and not something
+// longer that would make the test above pass for the wrong reason.
+func TestPruneHorizon_MinedTxDeletedAtMinedHeightPlusRetention(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, prunerSvc, retention := horizonStore(ctx, t)
+
+	const mineHeight uint32 = 1000
+
+	txHash := buildMinedFullySpent(ctx, t, store, tests.Tx, mineHeight)
+
+	tip := mineHeight + retention
+	require.NoError(t, store.SetBlockHeight(tip))
+
+	_, err := prunerSvc.Prune(ctx, tip, "<horizon-at>")
+	require.NoError(t, err)
+
+	_, err = store.Get(ctx, txHash)
+	require.Error(t, err,
+		"a tx mined at %d must be pruned at tip %d (mined_height + retention)", mineHeight, tip)
+}
+
+// The hazard path: a transaction flagged conflicting while still unmined is
+// stamped DAH = flag_height + retention (sql.go SetConflicting, and the
+// "conflicting and no existing DAH" branch of teranode.lua setDeleteAtHeight).
+// If it is later mined on the longest chain at a greater height, that earlier
+// stamp must not survive — otherwise a mined transaction becomes deletable
+// before mined_height + retention and the parent-depth guard's assumption breaks.
+//
+// The conflicting flag and its early stamp are written with direct SQL rather
+// than through Store.SetConflicting: that method opens a transaction at
+// sql.go:4325 and then calls s.GetSpend on the pool at sql.go:4383, which
+// deadlocks on SQLite. What is under test here is the DAH arithmetic in
+// SetMinedMulti, and this sets up its precondition exactly.
+func TestPruneHorizon_ConflictingThenMinedDoesNotKeepEarlierStamp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, prunerSvc, retention := horizonStore(ctx, t)
+
+	const (
+		flagHeight uint32 = 1000
+		mineHeight uint32 = 1500
+	)
+
+	tx := tests.Tx
+	txHash := tx.TxIDChainHash()
+
+	require.NoError(t, store.SetBlockHeight(flagHeight))
+
+	_, _, err := store.SpendAndCreate(ctx, tx, flagHeight, utxostore.WithCreateOnly())
+	require.NoError(t, err)
+
+	// Precondition: conflicting, stamped for deletion at flag_height + retention.
+	earlyDAH := flagHeight + retention
+	_, err = store.db.ExecContext(ctx,
+		`UPDATE transactions SET conflicting = true, delete_at_height = $1 WHERE hash = $2`,
+		int64(earlyDAH), txHash[:])
+	require.NoError(t, err)
+
+	var stamped int64
+	require.NoError(t, store.db.QueryRowContext(ctx,
+		`SELECT delete_at_height FROM transactions WHERE hash = $1`, txHash[:]).Scan(&stamped))
+	require.Equal(t, int64(earlyDAH), stamped, "setup: early stamp must be in place")
+
+	// The outputs are deliberately NOT spent: the store refuses to spend a
+	// conflicting transaction's outputs (TX_CONFLICTING), so the all-spent branch is
+	// unreachable while the flag is set. The bump under test does not need them —
+	// it fires purely because the existing stamp is below the new one.
+
+	require.NoError(t, store.SetBlockHeight(mineHeight))
+
+	_, err = store.SetMinedMulti(ctx, []*chainhash.Hash{txHash}, utxostore.MinedBlockInfo{
+		BlockID:        200,
+		BlockHeight:    mineHeight,
+		SubtreeIdx:     0,
+		OnLongestChain: true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.db.QueryRowContext(ctx,
+		`SELECT delete_at_height FROM transactions WHERE hash = $1`, txHash[:]).Scan(&stamped))
+	require.GreaterOrEqual(t, stamped, int64(mineHeight+retention),
+		"SetMinedMulti must bump the stale flag-height stamp forward to at least mined_height + retention")
+
+	// One block before the horizon measured from the MINED height. If the stale
+	// flag-height stamp had survived, the tx would already be gone here.
+	tip := mineHeight + retention - 1
+	require.NoError(t, store.SetBlockHeight(tip))
+
+	_, err = prunerSvc.Prune(ctx, tip, "<horizon-conflicting>")
+	require.NoError(t, err)
+
+	_, err = store.Get(ctx, txHash)
+	require.NoError(t, err,
+		"tx flagged conflicting at %d then mined at %d must survive to %d; "+
+			"a surviving flag-height DAH stamp would break the parent-depth guard",
+		flagHeight, mineHeight, tip)
+}

--- a/stores/utxo/sql/sql.go
+++ b/stores/utxo/sql/sql.go
@@ -4257,7 +4257,7 @@ func (s *Store) GetCounterConflicting(ctx context.Context, hash chainhash.Hash) 
 	// unbounded: this is the conflict-demotion path (ProcessConflicting), which
 	// must always walk the full descendant set to completion — a budget failure
 	// here would wedge block assembly on the block forever (issue 1391)
-	return utxo.GetCounterConflictingTxHashes(ctx, s, hash, 0)
+	return utxo.GetCounterConflictingTxHashes(ctx, s, hash, 0, s.settings.GetUtxoStoreBlockHeightRetention())
 }
 
 // GetConflictingChildren returns a list of conflicting transactions for a given transaction hash.

--- a/test/longtest/stores/utxo/process_conflicting_test.go
+++ b/test/longtest/stores/utxo/process_conflicting_test.go
@@ -102,7 +102,7 @@ func TestGetCounterConflictingTxHashes(t *testing.T) {
 
 	// get the counter conflicting transactions of the conflicting transaction
 	// this should process all indexes from the parents properly
-	txHashes, err := utxostore.GetCounterConflictingTxHashes(t.Context(), utxoStore, *txConflicting.TxIDChainHash(), 0)
+	txHashes, err := utxostore.GetCounterConflictingTxHashes(t.Context(), utxoStore, *txConflicting.TxIDChainHash(), 0, 288)
 	require.NoError(t, err)
 
 	require.Len(t, txHashes, 2)


### PR DESCRIPTION
## The wedge

`SequentialSpendAndCreate` is spend-first. It records a transaction's spends on its parents, then creates the transaction's own record:

```go
spends, err = s.Spend(ctx, tx, blockHeight, options.IgnoreFlags)
// ...
md, err := s.Create(ctx, tx, blockHeight, opts...)
```

A crash in that window, or a rollback that exhausts its three `unspendWithRetry` attempts, leaves a parent output slot naming a spender the store has no record of — a dangling spender reference.

`GetCounterConflictingTxHashes` then walks that absent spender. `GetConflictingChildren` fails on its root read, the error propagates out of `checkCounterConflictingOnCurrentChain`, and block validation wedges on a block that SVNode-following peers accept.

Create-first (#1355) would close the window at source, but it is still open and unmerged. #1393 bounded and deduped the walk; it did not touch the absent-record case.

## The guard

An absent record has no `BlockIDs`, so it is definitionally not mined on our chain. Tolerance is gated on the parent's confirmation depth:

- Every parent output slot naming the spender confirmed **within** the retention window, or unmined → no counter mined on those slots could have been pruned yet, so the absence must be a never-created loser. Drop the spender from the counter set and continue.
- Any slot **below** that window → a mined-then-pruned counter cannot be ruled out. Fail closed; SVNode would reject a block double-spending a confirmed output.
- Parent depth unknown, or `retention == 0` → fail closed.

Tolerance is ANDed across every slot naming the spender, not taken from the first seen, so one unprovable slot is enough to reject.

The guard is scoped to `ErrTxNotFound` / `ErrNotFound`; every other walk error still propagates. The tip height is read lazily, only when an absent record is hit, so a store carrying no dangling reference is never asked for it.

Tolerated absences increment `teranode_utxo_dangling_spender_ref_tolerated_total`, so the inconsistency stays visible rather than silent.

## Proof

The end-to-end tests build the dangling reference on a real `sqlitememory` store — `WithSpendOnly()` with no matching `WithCreateOnly()` is exactly the spend-first window — then run `checkCounterConflictingOnCurrentChain`.

With the guard disabled, identical inputs, pre-fix semantics:

```
--- FAIL: TestCheckCounterConflictingOnCurrentChain_ToleratesDanglingRefUnderRecentParent
--- PASS: TestCheckCounterConflictingOnCurrentChain_FailsClosedOnDanglingRefUnderBuriedParent
```

With the guard:

```
--- PASS: TestCheckCounterConflictingOnCurrentChain_ToleratesDanglingRefUnderRecentParent
--- PASS: TestCheckCounterConflictingOnCurrentChain_FailsClosedOnDanglingRefUnderBuriedParent
```

The fail-closed case passes in **both** configurations: the guard does not weaken the consensus check, it only narrows what wedges.

## Verification

```
go test ./stores/utxo/... ./services/subtreevalidation/...   14 packages ok, exit 0
go test -race ./stores/utxo/ ./services/subtreevalidation/ ./stores/utxo/sql/...   ok, exit 0
go vet ./...                                                 exit 0
golangci-lint run stores/utxo/... services/subtreevalidation/...   exit 0
```

The `go vet` and lint output that remains is pre-existing, in `test/utils` and older test files this PR does not touch.

## Prune horizon — checked

The tolerance is sound only if the store never deletes a transaction mined on the longest chain before `mined_height + retention`. That assumption is now verified rather than assumed, and `stores/utxo/sql/prune_horizon_test.go` pins it against the real pruner service.

The DAH arithmetic agrees across both backends: the Aerospike Go expression (`set_mined_expressions.go`) and the Lua UDF (`teranode.lua:988`) both compute `currentBlockHeight + blockHeightRetention`, and SQL's `SetMinedMulti` uses `minedBlockInfo.BlockHeight + retention` (`sql.go:3346`). The pruner deletes on `delete_at_height <= tip`. The spend path stamps `tip + 1 + retention`, which is strictly later, so the earliest stamp a mined transaction can carry comes from `SetMinedMulti`.

Tests, on a real store with the real pruner:

- mined at 1000, outputs already spent → **survives** pruning at `1000 + retention - 1`
- same → **deleted** at `1000 + retention`
- flagged conflicting at 1000 (stamped `1000 + retention`), then mined at 1500 → `SetMinedMulti` **bumps the stale stamp forward**, and it survives to `1500 + retention - 1`

The boundary is exact, with no slack: the guard tolerates while `parent_height + retention > tip`, and a counter mined at `h >= parent_height` survives while `h + retention > tip`.

## Residual risk

**Aerospike does not bump a stale conflicting stamp.** `teranode.lua` returns early in its conflicting branch (`if rec[BIN_CONFLICTING] then ... return "", nil`), and the Go expression yields `ExpUnknown` for a conflicting record that already has a DAH. SQL bumps it forward; Aerospike does not. For that to shorten the horizon a record would have to be conflicting-flagged *and* mined on the longest chain at once, which is contradictory in the node's own model — conflicting means "we consider this a loser". I could not construct the state (the store refuses to spend a conflicting transaction's outputs with `TX_CONFLICTING`), but I did not prove it unreachable, and I did not write the Aerospike-side equivalent of these tests.

**Unrelated pre-existing bug found while testing.** `Store.SetConflicting` deadlocks on SQLite: it opens a transaction at `sql.go:4325`, then calls `s.GetSpend` on the pool at `sql.go:4383`, which cannot get a connection until that transaction commits. Reproduced as a hang until the 600s test timeout. Every existing `sql_test.go` call passes an empty hash slice, so no current test reaches it. Not touched by this PR — the horizon test writes the conflicting flag with direct SQL to route around it. Worth its own issue.
