### PR TITLE
fix(blockchain): apply the checkpoint RUN gate to every source state

### DIFF
--- a/docs/howto/miners/minersHowToInteractWithFSM.md
+++ b/docs/howto/miners/minersHowToInteractWithFSM.md
@@ -98,18 +98,13 @@ rather than silent no-ops:
 
 - **Only RUN may leave CATCHINGBLOCKS.** A node that is catching up cannot be
   moved to IDLE; it must finish catching up first.
-- **RUN never reaches RUNNING while the chain tip is below the network's highest
-  hard-coded checkpoint.** Mainnet and testnet both have checkpoints; regtest has
-  none. What happens instead depends on where the node is:
-    - **From CATCHINGBLOCKS**, RUN is refused with an error naming both your tip
-      height and the checkpoint it must reach. This is expected — the node is
-      already catching up on its own and will move to RUNNING once it gets there.
-    - **From IDLE**, `setfsmstate running` is routed to CATCHINGBLOCKS instead of
-      being refused. "Run" means "put this node into service", and on a node that
-      is not caught up the route there is through catch-up. The command reports
-      the state it actually reached, so you will see `CATCHINGBLOCKS` rather than
-      `RUNNING` — that is the reroute, not a failure. A node already at or above
-      the checkpoint goes straight to RUNNING.
+- **RUN is refused while the chain tip is below the network's highest hard-coded
+  checkpoint.** Mainnet and testnet both have checkpoints; regtest has none. The
+  error names both your tip height and the checkpoint it must reach. From IDLE,
+  the node remains parked so you can inspect or rewind it; use
+  `setfsmstate catchingblocks` when you deliberately want to start synchronization.
+  A node already in CATCHINGBLOCKS remains there and will move to RUNNING once it
+  catches up.
 
 Why the rule exists: going to RUNNING mid-initial-sync lets the mempool and
 validator operate under pre-Genesis output rules, and lets the legacy service
@@ -121,15 +116,16 @@ relay tx invs that post-Genesis peers ban on sight
 > could never be in IDLE below the checkpoint. That is not exhaustive — a node
 > stopped from RUNNING, or one whose store was persisted in IDLE by an older
 > version, both land there — so the rule now applies to every RUN and the IDLE
-> case is rerouted as described above. Out-of-tree boot tooling that forces
-> RUNNING on a below-checkpoint mainnet or testnet node will now land it in
-> CATCHINGBLOCKS instead of RUNNING. Regtest has no checkpoints and is
-> unaffected — `setfsmstate running` still goes straight to RUNNING there.
+> case is refused as described above. Out-of-tree boot tooling that forces
+> RUNNING on a below-checkpoint mainnet or testnet node will now receive an error
+> and leave the FSM unchanged. Regtest has no checkpoints and is unaffected —
+> `setfsmstate running` still goes straight to RUNNING there.
 >
 > **There is no longer a manual route to RUNNING below the checkpoint.** From
-> IDLE the request reroutes; from CATCHINGBLOCKS it is refused. If you are
-> looking for an override to force a below-checkpoint node into RUNNING, it no
-> longer exists — that was the hole this rule closes. Let the node catch up.
+> IDLE, explicitly enter CATCHINGBLOCKS to start synchronization. From
+> CATCHINGBLOCKS, RUN is refused until catchup completes. If you are looking for
+> an override to force a below-checkpoint node into RUNNING, it no longer exists
+> — that was the hole this rule closes. Let the node catch up.
 >
 > **Getting back to IDLE:** there is no `CATCHINGBLOCKS -> IDLE` transition. Once
 > a node is catching up, the only way out is RUN.

--- a/docs/howto/miners/minersHowToInteractWithFSM.md
+++ b/docs/howto/miners/minersHowToInteractWithFSM.md
@@ -98,21 +98,41 @@ rather than silent no-ops:
 
 - **Only RUN may leave CATCHINGBLOCKS.** A node that is catching up cannot be
   moved to IDLE; it must finish catching up first.
-- **RUN is refused while the chain tip is below the network's highest hard-coded
-  checkpoint.** Mainnet and testnet both have checkpoints; regtest has none. A
-  node that is still doing its initial sync will therefore reject
-  `setfsmstate running`, and the error names both your tip height and the
-  checkpoint it must reach. This is expected — the node is already catching up
-  on its own and will move to RUNNING once it has caught up.
+- **RUN never reaches RUNNING while the chain tip is below the network's highest
+  hard-coded checkpoint.** Mainnet and testnet both have checkpoints; regtest has
+  none. What happens instead depends on where the node is:
+    - **From CATCHINGBLOCKS**, RUN is refused with an error naming both your tip
+      height and the checkpoint it must reach. This is expected — the node is
+      already catching up on its own and will move to RUNNING once it gets there.
+    - **From IDLE**, `setfsmstate running` is routed to CATCHINGBLOCKS instead of
+      being refused. "Run" means "put this node into service", and on a node that
+      is not caught up the route there is through catch-up. The command reports
+      the state it actually reached, so you will see `CATCHINGBLOCKS` rather than
+      `RUNNING` — that is the reroute, not a failure. A node already at or above
+      the checkpoint goes straight to RUNNING.
 
-> **Behaviour change:** a fresh node now boots into CATCHINGBLOCKS rather than
-> IDLE, and the checkpoint rule above exempts only IDLE. A brand-new mainnet or
-> testnet node could previously be forced straight to RUNNING with
-> `setfsmstate running`; it now returns the checkpoint error instead, until its
-> tip reaches the checkpoint. Nothing in this repository relied on that
-> shortcut, but out-of-tree boot tooling that forces RUNNING on a fresh node
-> will now get an error where it previously succeeded. Regtest has no
-> checkpoints and is unaffected.
+Why the rule exists: going to RUNNING mid-initial-sync lets the mempool and
+validator operate under pre-Genesis output rules, and lets the legacy service
+relay tx invs that post-Genesis peers ban on sight
+(`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`).
+
+> **Behaviour change:** the checkpoint rule used to exempt `IDLE -> RUNNING`
+> entirely, on the reasoning that a fresh node boots into CATCHINGBLOCKS and so
+> could never be in IDLE below the checkpoint. That is not exhaustive — a node
+> stopped from RUNNING, or one whose store was persisted in IDLE by an older
+> version, both land there — so the rule now applies to every RUN and the IDLE
+> case is rerouted as described above. Out-of-tree boot tooling that forces
+> RUNNING on a below-checkpoint mainnet or testnet node will now land it in
+> CATCHINGBLOCKS instead of RUNNING. Regtest has no checkpoints and is
+> unaffected — `setfsmstate running` still goes straight to RUNNING there.
+>
+> **There is no longer a manual route to RUNNING below the checkpoint.** From
+> IDLE the request reroutes; from CATCHINGBLOCKS it is refused. If you are
+> looking for an override to force a below-checkpoint node into RUNNING, it no
+> longer exists — that was the hole this rule closes. Let the node catch up.
+>
+> **Getting back to IDLE:** there is no `CATCHINGBLOCKS -> IDLE` transition. Once
+> a node is catching up, the only way out is RUN.
 
 ## Validation
 

--- a/docs/howto/miners/minersHowToInteractWithFSM.md
+++ b/docs/howto/miners/minersHowToInteractWithFSM.md
@@ -102,7 +102,8 @@ rather than silent no-ops:
   checkpoint.** Mainnet and testnet both have checkpoints; regtest has none. The
   error names both your tip height and the checkpoint it must reach. From IDLE,
   the node remains parked so you can inspect or rewind it; use
-  `setfsmstate catchingblocks` when you deliberately want to start synchronization.
+  `setfsmstate --fsmstate catchingblocks` when you deliberately want to start
+  synchronization.
   A node already in CATCHINGBLOCKS remains there and will move to RUNNING once it
   catches up.
 
@@ -119,7 +120,7 @@ relay tx invs that post-Genesis peers ban on sight
 > case is refused as described above. Out-of-tree boot tooling that forces
 > RUNNING on a below-checkpoint mainnet or testnet node will now receive an error
 > and leave the FSM unchanged. Regtest has no checkpoints and is unaffected —
-> `setfsmstate running` still goes straight to RUNNING there.
+> `setfsmstate --fsmstate running` still goes straight to RUNNING there.
 >
 > **There is no longer a manual route to RUNNING below the checkpoint.** From
 > IDLE, explicitly enter CATCHINGBLOCKS to start synchronization. From

--- a/docs/references/services/blockchain_reference.md
+++ b/docs/references/services/blockchain_reference.md
@@ -532,7 +532,7 @@ Sends an event to the finite state machine.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error)
 ```
 
-Transitions the FSM to the RUNNING state.
+Transitions the FSM to the RUNNING state. On a network with checkpoints, a node whose chain tip is below the highest checkpoint does not reach RUNNING: from `IDLE` the request is routed to `CATCHINGBLOCKS`, and from `CATCHINGBLOCKS` it is rejected. This RPC returns only an error, so a reroute is indistinguishable from success — call `GetFSMCurrentState` afterwards, or use `SendFSMEvent`, which returns the state actually reached.
 
 ### CatchUpBlocks
 

--- a/docs/references/services/blockchain_reference.md
+++ b/docs/references/services/blockchain_reference.md
@@ -532,7 +532,7 @@ Sends an event to the finite state machine.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error)
 ```
 
-Transitions the FSM to the RUNNING state. On a network with checkpoints, a node whose chain tip is below the highest checkpoint does not reach RUNNING: from `IDLE` the request is routed to `CATCHINGBLOCKS`, and from `CATCHINGBLOCKS` it is rejected. This RPC returns only an error, so a reroute is indistinguishable from success — call `GetFSMCurrentState` afterwards if the outcome matters.
+Transitions the FSM to the RUNNING state. On a network with checkpoints, a node whose chain tip is below the highest checkpoint receives an error and remains in its current state. An operator in `IDLE` can explicitly enter `CATCHINGBLOCKS` to start synchronization.
 
 ### CatchUpBlocks
 

--- a/docs/references/services/blockchain_reference.md
+++ b/docs/references/services/blockchain_reference.md
@@ -532,7 +532,7 @@ Sends an event to the finite state machine.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error)
 ```
 
-Transitions the FSM to the RUNNING state. On a network with checkpoints, a node whose chain tip is below the highest checkpoint does not reach RUNNING: from `IDLE` the request is routed to `CATCHINGBLOCKS`, and from `CATCHINGBLOCKS` it is rejected. This RPC returns only an error, so a reroute is indistinguishable from success — call `GetFSMCurrentState` afterwards, or use `SendFSMEvent`, which returns the state actually reached.
+Transitions the FSM to the RUNNING state. On a network with checkpoints, a node whose chain tip is below the highest checkpoint does not reach RUNNING: from `IDLE` the request is routed to `CATCHINGBLOCKS`, and from `CATCHINGBLOCKS` it is rejected. This RPC returns only an error, so a reroute is indistinguishable from success — call `GetFSMCurrentState` afterwards if the outcome matters.
 
 ### CatchUpBlocks
 

--- a/docs/topics/architecture/stateManagement.md
+++ b/docs/topics/architecture/stateManagement.md
@@ -157,9 +157,11 @@ The Block Assembler will only mine blocks when the node is in the `Running` stat
 #### 3.3.3. FSM: Catching Blocks State
 
 The `CatchingBlocks` state represents the node catching up on blocks. It is entered
-either by BlockValidation, when a running node finds it has fallen behind the
-network, or at startup, because a fresh node with no persisted state boots
-straight into it (see section 3.1). In this state:
+by BlockValidation when a running node finds it has fallen behind the network; at
+startup, because a fresh node with no persisted state boots straight into it (see
+section 3.1); or from `Idle`, when a RUN request arrives on a node whose tip is
+still below the network's highest checkpoint, in which case the request is routed
+here instead of to `Running`. In this state:
 
 Allowed Operations in Catching Blocks State:
 

--- a/docs/topics/architecture/stateManagement.md
+++ b/docs/topics/architecture/stateManagement.md
@@ -159,9 +159,7 @@ The Block Assembler will only mine blocks when the node is in the `Running` stat
 The `CatchingBlocks` state represents the node catching up on blocks. It is entered
 by BlockValidation when a running node finds it has fallen behind the network; at
 startup, because a fresh node with no persisted state boots straight into it (see
-section 3.1); or from `Idle`, when a RUN request arrives on a node whose tip is
-still below the network's highest checkpoint, in which case the request is routed
-here instead of to `Running`. In this state:
+section 3.1); or through an explicit CATCHUPBLOCKS event from `Idle`. In this state:
 
 Allowed Operations in Catching Blocks State:
 

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2948,7 +2948,7 @@ func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
 
 	if meta.Height < highest {
 		return errors.NewStateError(
-			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s; use CATCHUPBLOCKS to start synchronization",
+			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s; use setfsmstate catchingblocks to start synchronization",
 			meta.Height, highest, b.settings.ChainCfgParams.Name,
 		)
 	}

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2822,9 +2822,15 @@ func (b *Blockchain) IsFullyReady(ctx context.Context) (bool, error) {
 //
 // The returned state is not always the one the event names: a RUN from IDLE on a
 // node whose tip is below the network's highest checkpoint is routed to
-// CATCHINGBLOCKS instead of RUNNING (see the gate below). Callers that care about
-// the outcome must read the response rather than infer it from the event, which
-// is what teranode-cli setfsmstate and the asset FSM handler do.
+// CATCHINGBLOCKS instead of RUNNING (see the gate below). So the outcome must be
+// observed, never inferred from the event.
+//
+// Note that the Go client discards this response — Client.SendFSMEvent returns
+// only an error (Client.go) — so in-tree callers observe the outcome by
+// re-reading GetFSMCurrentState afterwards, which is what teranode-cli
+// setfsmstate (cmd/setfsmstate/set_fsm_state.go) and the asset FSM handler
+// (services/asset/httpimpl/fsm_handler.go) both do. A caller speaking to the RPC
+// directly can read the response instead.
 func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.SendFSMEventRequest) (*blockchain_api.GetFSMStateResponse, error) {
 	// Serialise FSM transitions. SendFSMEvent performs a read-modify-write across
 	// the FSM (prior-state checks -> Event -> stateChangeTimestamp update) that
@@ -2869,12 +2875,13 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 	// both reach the exempt path with a tip below the checkpoint. The property
 	// belongs in this gate rather than in the choice of boot state.
 	//
-	// From IDLE a below-checkpoint RUN is rerouted to CATCHUPBLOCKS rather than
-	// rejected. "Run" from an operator means "put this node into service", and on
-	// a node that is not caught up the route there is through catch-up; rejecting
-	// would leave the operator to translate the error into a second command. The
-	// reroute is not silent: the response carries the state actually reached, and
-	// teranode-cli setfsmstate re-reads and prints it.
+	// From IDLE a below-checkpoint RUN is routed to CATCHINGBLOCKS rather than
+	// rejected, by substituting the CATCHUPBLOCKS event below. "Run" from an
+	// operator means "put this node into service", and on a node that is not
+	// caught up the route there is through catch-up; rejecting would leave the
+	// operator to translate the error into a second command. The reroute is not
+	// silent: the response carries the state actually reached, and teranode-cli
+	// setfsmstate re-reads the state and prints it.
 	//
 	// From CATCHINGBLOCKS the same RUN is still rejected: the node is already
 	// catching up, so rerouting would be a no-op and the error is the useful
@@ -3001,8 +3008,7 @@ func HighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 // This RPC cannot report that. It returns *emptypb.Empty, and Client.Run returns
 // only an error, so a reroute looks exactly like success: the caller gets a nil
 // error and no way to tell which state it landed in. Call GetFSMCurrentState
-// afterwards if the outcome matters, or use SendFSMEvent, which returns the state
-// actually reached.
+// afterwards if the outcome matters.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
 	// check whether the FSM is already in the RUNNING state
 	if b.finiteStateMachine.Is(blockchain_api.FSMStateType_RUNNING.String()) {

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2818,19 +2818,7 @@ func (b *Blockchain) IsFullyReady(ctx context.Context) (bool, error) {
 }
 
 // SendFSMEvent sends an event to the finite state machine and returns the state
-// actually reached.
-//
-// The returned state is not always the one the event names: a RUN from IDLE on a
-// node whose tip is below the network's highest checkpoint is routed to
-// CATCHINGBLOCKS instead of RUNNING (see the gate below). So the outcome must be
-// observed, never inferred from the event.
-//
-// Note that the Go client discards this response — Client.SendFSMEvent returns
-// only an error (Client.go) — so in-tree callers observe the outcome by
-// re-reading GetFSMCurrentState afterwards, which is what teranode-cli
-// setfsmstate (cmd/setfsmstate/set_fsm_state.go) and the asset FSM handler
-// (services/asset/httpimpl/fsm_handler.go) both do. A caller speaking to the RPC
-// directly can read the response instead.
+// reached by an accepted transition.
 func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.SendFSMEventRequest) (*blockchain_api.GetFSMStateResponse, error) {
 	// Serialise FSM transitions. SendFSMEvent performs a read-modify-write across
 	// the FSM (prior-state checks -> Event -> stateChangeTimestamp update) that
@@ -2856,9 +2844,9 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 		}
 	}
 
-	// Refuse to transition to RUNNING while the local chain tip is still below
+	// Refuse a valid transition to RUNNING while the local chain tip is still below
 	// the network's highest hard-coded checkpoint. Pre-checkpoint heights are
-	// guaranteed to be deep history (mainnet's highest is block 938000), so a
+	// guaranteed to be deep history, so a
 	// node sitting below them is mid-IBD even if a catchup worker thinks it
 	// has finished its current chunk. Going to RUNNING in that state lets the
 	// mempool/validator operate under pre-Genesis output rules and the legacy
@@ -2875,32 +2863,19 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 	// both reach the exempt path with a tip below the checkpoint. The property
 	// belongs in this gate rather than in the choice of boot state.
 	//
-	// From IDLE a below-checkpoint RUN is routed to CATCHINGBLOCKS rather than
-	// rejected, by substituting the CATCHUPBLOCKS event below. "Run" from an
-	// operator means "put this node into service", and on a node that is not
-	// caught up the route there is through catch-up; rejecting would leave the
-	// operator to translate the error into a second command. The reroute is not
-	// silent: the response carries the state actually reached, and teranode-cli
-	// setfsmstate re-reads the state and prints it.
+	// Rejecting from IDLE preserves the operator's choice to remain parked or to
+	// enter CATCHINGBLOCKS explicitly. It also keeps the RUN API truthful: a nil
+	// error means the FSM reached RUNNING.
 	//
-	// From CATCHINGBLOCKS the same RUN is still rejected: the node is already
-	// catching up, so rerouting would be a no-op and the error is the useful
-	// signal that it has not got there yet.
-	if eventReq.Event == blockchain_api.FSMEventType_RUN {
-		belowCheckpoint, guardErr := b.guardRunBelowHighestCheckpoint(ctx)
-		if guardErr != nil {
-			// Only a confirmed below-checkpoint verdict is rerouteable. If the tip
-			// could not be read at all, reject: an operator who asked for RUNNING
-			// should see the store error, not a node that silently went to
-			// catch-up.
-			if !belowCheckpoint || priorState != blockchain_api.FSMStateType_IDLE.String() {
-				b.logger.Warnf("[Blockchain Server] RUN refused: %s", guardErr.Error())
-				return nil, errors.WrapGRPC(guardErr)
-			}
-
-			b.logger.Infof("[Blockchain Server] RUN from IDLE: %s, routing to CATCHINGBLOCKS instead of RUNNING", guardErr.Error())
-
-			eventReq = &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_CATCHUPBLOCKS}
+	// Check Can before consulting the store. Direct SendFSMEvent callers can send
+	// RUN from RUNNING even though the convenience Run RPC short-circuits it; an
+	// invalid transition should return the FSM error without an unrelated store
+	// read or checkpoint error.
+	if eventReq.Event == blockchain_api.FSMEventType_RUN &&
+		b.finiteStateMachine.Can(eventReq.Event.String()) {
+		if err := b.guardRunBelowHighestCheckpoint(ctx); err != nil {
+			b.logger.Warnf("[Blockchain Server] RUN refused: %s", err.Error())
+			return nil, errors.WrapGRPC(err)
 		}
 	}
 
@@ -2950,45 +2925,35 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 // chain tip has not yet reached the highest hard-coded checkpoint for the
 // active network.
 //
-// The two return values separate "the tip is genuinely behind" from "we could
-// not tell", because the caller treats them differently: a below-checkpoint
-// verdict from IDLE is rerouted to catch-up, while an inability to read the tip
-// is propagated so the operator sees the store problem rather than a node that
-// quietly went to catch-up instead of running.
-//
-//   - (false, nil)  the chain has reached the checkpoint, or the network defines
-//     no checkpoints at all (regtest, brand-new networks)
-//   - (true, err)   the tip is below the highest checkpoint; err says by how much
-//   - (false, err)  the tip could not be determined; do not infer anything from it
-func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) (bool, error) {
+// Returns nil when the chain has reached the checkpoint or the network defines
+// no checkpoints. Store failures, missing tip metadata, and a tip below the
+// checkpoint all fail closed.
+func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
 	if b.settings == nil || b.settings.ChainCfgParams == nil {
-		return false, nil
+		return nil
 	}
 
 	highest := HighestCheckpointHeight(b.settings.ChainCfgParams.Checkpoints)
 	if highest == 0 {
-		return false, nil
+		return nil
 	}
 
 	_, meta, err := b.store.GetBestBlockHeader(ctx)
 	if err != nil {
-		return false, errors.NewStateError("cannot read best block header to evaluate RUN gate", err)
+		return errors.NewStateError("cannot read best block header to evaluate RUN gate", err)
 	}
 	if meta == nil {
-		return false, errors.NewStateError("best block header meta unavailable, cannot evaluate RUN gate")
+		return errors.NewStateError("best block header meta unavailable, cannot evaluate RUN gate")
 	}
 
 	if meta.Height < highest {
-		// State the condition, not the verdict: the caller decides whether this
-		// means "reject" (from CATCHINGBLOCKS) or "route via catch-up" (from IDLE),
-		// and says so in its own words.
-		return true, errors.NewStateError(
-			"chain tip height %d is below highest checkpoint %d for %s",
+		return errors.NewStateError(
+			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s; use CATCHUPBLOCKS to start synchronization",
 			meta.Height, highest, b.settings.ChainCfgParams.Name,
 		)
 	}
 
-	return false, nil
+	return nil
 }
 
 // HighestCheckpointHeight returns the largest Height in the supplied
@@ -3002,13 +2967,8 @@ func HighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 // Run transitions the blockchain service to the running state.
 //
 // On a network with checkpoints, a node whose chain tip is still below the
-// highest checkpoint does not reach RUNNING: from IDLE the request is routed to
-// CATCHINGBLOCKS instead, and from CATCHINGBLOCKS it is rejected.
-//
-// This RPC cannot report that. It returns *emptypb.Empty, and Client.Run returns
-// only an error, so a reroute looks exactly like success: the caller gets a nil
-// error and no way to tell which state it landed in. Call GetFSMCurrentState
-// afterwards if the outcome matters.
+// highest checkpoint remains in its current state and receives an error. An
+// operator in IDLE can explicitly enter CATCHINGBLOCKS with CATCHUPBLOCKS.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
 	// check whether the FSM is already in the RUNNING state
 	if b.finiteStateMachine.Is(blockchain_api.FSMStateType_RUNNING.String()) {

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2817,7 +2817,14 @@ func (b *Blockchain) IsFullyReady(ctx context.Context) (bool, error) {
 	return isReady, nil
 }
 
-// SendFSMEvent sends an event to the finite state machine.
+// SendFSMEvent sends an event to the finite state machine and returns the state
+// actually reached.
+//
+// The returned state is not always the one the event names: a RUN from IDLE on a
+// node whose tip is below the network's highest checkpoint is routed to
+// CATCHINGBLOCKS instead of RUNNING (see the gate below). Callers that care about
+// the outcome must read the response rather than infer it from the event, which
+// is what teranode-cli setfsmstate and the asset FSM handler do.
 func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.SendFSMEventRequest) (*blockchain_api.GetFSMStateResponse, error) {
 	// Serialise FSM transitions. SendFSMEvent performs a read-modify-write across
 	// the FSM (prior-state checks -> Event -> stateChangeTimestamp update) that
@@ -2852,17 +2859,41 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 	// service relay tx invs that post-Genesis peers ban on sight
 	// (`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`).
 	//
-	// The gate only applies when the prior state already implies a "caught up"
-	// claim (CATCHINGBLOCKS -> RUNNING). IDLE -> RUNNING is an operator override
-	// (e.g. teranodecli setfsmstate running) and stays exempt: a fresh node has
-	// no tip yet and tx relay is suppressed while FSM != RUNNING. Automatic boot
-	// no longer uses IDLE -> RUNNING; fresh nodes boot into CATCHINGBLOCKS (see
-	// Init) and only reach RUNNING by completing catchup above the checkpoint.
-	if eventReq.Event == blockchain_api.FSMEventType_RUN &&
-		priorState != blockchain_api.FSMStateType_IDLE.String() {
-		if err := b.guardRunBelowHighestCheckpoint(ctx); err != nil {
-			b.logger.Warnf("[Blockchain Server] RUN rejected: %s", err.Error())
-			return nil, errors.WrapGRPC(err)
+	// The rule applies to every RUN, whatever the source state. It used to exempt
+	// IDLE -> RUNNING as an operator override, on the reasoning that a fresh node
+	// boots into CATCHINGBLOCKS (see Init) and so could never take the exempt
+	// path. That reasoning makes a safety property depend on a boot default, and
+	// the default has already changed once. It is also not exhaustive: a store
+	// persisted in IDLE before the default changed, or a node stopped from
+	// RUNNING to IDLE and then overtaken by a checkpoint bump in go-chaincfg,
+	// both reach the exempt path with a tip below the checkpoint. The property
+	// belongs in this gate rather than in the choice of boot state.
+	//
+	// From IDLE a below-checkpoint RUN is rerouted to CATCHUPBLOCKS rather than
+	// rejected. "Run" from an operator means "put this node into service", and on
+	// a node that is not caught up the route there is through catch-up; rejecting
+	// would leave the operator to translate the error into a second command. The
+	// reroute is not silent: the response carries the state actually reached, and
+	// teranode-cli setfsmstate re-reads and prints it.
+	//
+	// From CATCHINGBLOCKS the same RUN is still rejected: the node is already
+	// catching up, so rerouting would be a no-op and the error is the useful
+	// signal that it has not got there yet.
+	if eventReq.Event == blockchain_api.FSMEventType_RUN {
+		belowCheckpoint, guardErr := b.guardRunBelowHighestCheckpoint(ctx)
+		if guardErr != nil {
+			// Only a confirmed below-checkpoint verdict is rerouteable. If the tip
+			// could not be read at all, reject: an operator who asked for RUNNING
+			// should see the store error, not a node that silently went to
+			// catch-up.
+			if !belowCheckpoint || priorState != blockchain_api.FSMStateType_IDLE.String() {
+				b.logger.Warnf("[Blockchain Server] RUN refused: %s", guardErr.Error())
+				return nil, errors.WrapGRPC(guardErr)
+			}
+
+			b.logger.Infof("[Blockchain Server] RUN from IDLE: %s, routing to CATCHINGBLOCKS instead of RUNNING", guardErr.Error())
+
+			eventReq = &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_CATCHUPBLOCKS}
 		}
 	}
 
@@ -2910,35 +2941,47 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 
 // guardRunBelowHighestCheckpoint blocks the RUN transition when the local
 // chain tip has not yet reached the highest hard-coded checkpoint for the
-// active network. Returns nil when the chain has reached the checkpoint, the
-// network defines no checkpoints (regtest, brand-new networks), or the store
-// has no chain tip yet (returns a state error so the caller retries later).
-func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
+// active network.
+//
+// The two return values separate "the tip is genuinely behind" from "we could
+// not tell", because the caller treats them differently: a below-checkpoint
+// verdict from IDLE is rerouted to catch-up, while an inability to read the tip
+// is propagated so the operator sees the store problem rather than a node that
+// quietly went to catch-up instead of running.
+//
+//   - (false, nil)  the chain has reached the checkpoint, or the network defines
+//     no checkpoints at all (regtest, brand-new networks)
+//   - (true, err)   the tip is below the highest checkpoint; err says by how much
+//   - (false, err)  the tip could not be determined; do not infer anything from it
+func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) (bool, error) {
 	if b.settings == nil || b.settings.ChainCfgParams == nil {
-		return nil
+		return false, nil
 	}
 
 	highest := HighestCheckpointHeight(b.settings.ChainCfgParams.Checkpoints)
 	if highest == 0 {
-		return nil
+		return false, nil
 	}
 
 	_, meta, err := b.store.GetBestBlockHeader(ctx)
 	if err != nil {
-		return errors.NewStateError("cannot read best block header to evaluate RUN gate", err)
+		return false, errors.NewStateError("cannot read best block header to evaluate RUN gate", err)
 	}
 	if meta == nil {
-		return errors.NewStateError("best block header meta unavailable; refusing RUN")
+		return false, errors.NewStateError("best block header meta unavailable, cannot evaluate RUN gate")
 	}
 
 	if meta.Height < highest {
-		return errors.NewStateError(
-			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s",
+		// State the condition, not the verdict: the caller decides whether this
+		// means "reject" (from CATCHINGBLOCKS) or "route via catch-up" (from IDLE),
+		// and says so in its own words.
+		return true, errors.NewStateError(
+			"chain tip height %d is below highest checkpoint %d for %s",
 			meta.Height, highest, b.settings.ChainCfgParams.Name,
 		)
 	}
 
-	return nil
+	return false, nil
 }
 
 // HighestCheckpointHeight returns the largest Height in the supplied
@@ -2950,6 +2993,16 @@ func HighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 }
 
 // Run transitions the blockchain service to the running state.
+//
+// On a network with checkpoints, a node whose chain tip is still below the
+// highest checkpoint does not reach RUNNING: from IDLE the request is routed to
+// CATCHINGBLOCKS instead, and from CATCHINGBLOCKS it is rejected.
+//
+// This RPC cannot report that. It returns *emptypb.Empty, and Client.Run returns
+// only an error, so a reroute looks exactly like success: the caller gets a nil
+// error and no way to tell which state it landed in. Call GetFSMCurrentState
+// afterwards if the outcome matters, or use SendFSMEvent, which returns the state
+// actually reached.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
 	// check whether the FSM is already in the RUNNING state
 	if b.finiteStateMachine.Is(blockchain_api.FSMStateType_RUNNING.String()) {
@@ -2966,7 +3019,7 @@ func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty,
 		return nil, err
 	}
 
-	return nil, nil
+	return &emptypb.Empty{}, nil
 }
 
 // CatchUpBlocks transitions the service to catch up missing blocks.
@@ -2986,7 +3039,7 @@ func (b *Blockchain) CatchUpBlocks(ctx context.Context, _ *emptypb.Empty) (*empt
 		return nil, err
 	}
 
-	return nil, nil
+	return &emptypb.Empty{}, nil
 }
 
 // ReportPeerFailure handles reports of peer download failures and broadcasts to subscribers.

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2948,7 +2948,7 @@ func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
 
 	if meta.Height < highest {
 		return errors.NewStateError(
-			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s; use setfsmstate catchingblocks to start synchronization",
+			"refusing RUN: chain tip height %d is below highest checkpoint %d for %s; use setfsmstate --fsmstate catchingblocks to start synchronization",
 			meta.Height, highest, b.settings.ChainCfgParams.Name,
 		)
 	}
@@ -2968,7 +2968,8 @@ func HighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
 //
 // On a network with checkpoints, a node whose chain tip is still below the
 // highest checkpoint remains in its current state and receives an error. An
-// operator in IDLE can explicitly enter CATCHINGBLOCKS with CATCHUPBLOCKS.
+// operator in IDLE can explicitly enter CATCHINGBLOCKS through the CatchUpBlocks
+// RPC or with setfsmstate --fsmstate catchingblocks.
 func (b *Blockchain) Run(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
 	// check whether the FSM is already in the RUNNING state
 	if b.finiteStateMachine.Is(blockchain_api.FSMStateType_RUNNING.String()) {

--- a/services/blockchain/server_fsm_run_gate_test.go
+++ b/services/blockchain/server_fsm_run_gate_test.go
@@ -338,8 +338,9 @@ func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 // hard-coded checkpoints are untouched by the gate change. regtest is the case
 // that matters: the guard short-circuits on highest == 0 before it reads the
 // chain tip, so RUN from IDLE still goes straight to RUNNING and local dev keeps
-// working with a single setfsmstate running (block assembly refuses to hand out
-// a mining candidate outside RUNNING, so dev needs to get there).
+// working with a single setfsmstate --fsmstate running command (block assembly
+// refuses to hand out a mining candidate outside RUNNING, so dev needs to get
+// there).
 func TestSendFSMEvent_RunFromIdle_NoCheckpoints(t *testing.T) {
 	ctx := context.Background()
 	require.Zero(t, HighestCheckpointHeight(chaincfg.RegressionNetParams.Checkpoints))
@@ -384,7 +385,7 @@ func TestRunFromIdle_BelowCheckpointRejectsAndPreservesIdle(t *testing.T) {
 	_, err := b.Run(ctx, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "below highest checkpoint")
-	require.ErrorContains(t, err, "setfsmstate catchingblocks")
+	require.ErrorContains(t, err, "setfsmstate --fsmstate catchingblocks")
 	require.Equal(t, blockchain_api.FSMStateType_IDLE.String(), b.finiteStateMachine.Current())
 
 	persisted, perr := store.GetFSMState(ctx)

--- a/services/blockchain/server_fsm_run_gate_test.go
+++ b/services/blockchain/server_fsm_run_gate_test.go
@@ -123,7 +123,7 @@ func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
 			params:     &chaincfg.MainNetParams,
 			height:     highest - 1,
 			wantErr:    true,
-			wantSubstr: "refusing RUN",
+			wantSubstr: "below highest checkpoint",
 		},
 		{
 			name:    "exactly at highest checkpoint permits",
@@ -171,7 +171,7 @@ func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
 
 			b := newTestBlockchainForGate(t, tt.params, store)
 
-			err := b.guardRunBelowHighestCheckpoint(ctx)
+			_, err := b.guardRunBelowHighestCheckpoint(ctx)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantSubstr != "" {
@@ -190,12 +190,14 @@ func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
 func TestGuardRunBelowHighestCheckpoint_NilSettings(t *testing.T) {
 	t.Run("nil settings", func(t *testing.T) {
 		b := &Blockchain{logger: ulogger.TestLogger{}}
-		require.NoError(t, b.guardRunBelowHighestCheckpoint(context.Background()))
+		_, guardErr := b.guardRunBelowHighestCheckpoint(context.Background())
+		require.NoError(t, guardErr)
 	})
 
 	t.Run("nil ChainCfgParams", func(t *testing.T) {
 		b := &Blockchain{logger: ulogger.TestLogger{}, settings: &settings.Settings{}}
-		require.NoError(t, b.guardRunBelowHighestCheckpoint(context.Background()))
+		_, guardErr := b.guardRunBelowHighestCheckpoint(context.Background())
+		require.NoError(t, guardErr)
 	})
 }
 
@@ -223,11 +225,18 @@ func TestInit_MigratesPersistedLegacySyncingToCatchingBlocks(t *testing.T) {
 }
 
 // TestSendFSMEvent_RunGate_SourceState pins the source-state semantics of
-// the RUN gate added in PR #844 and fixed here: IDLE → RUNNING is the boot
-// path and must succeed even when the local tip sits below the highest
-// checkpoint (a fresh node has tip 0 and nothing else can move the FSM
-// forward), while CATCHINGBLOCKS → RUNNING claims "I'm caught up" and must
-// still be rejected when the tip is below the checkpoint.
+// the RUN gate: the checkpoint rule applies to every RUN regardless of source
+// state, and the source state decides what happens when it fails. From IDLE a
+// below-checkpoint RUN is rerouted to CATCHINGBLOCKS — "run" means "put this
+// node into service", and the route there is through catch-up. From
+// CATCHINGBLOCKS the same RUN claims "I'm caught up" and is rejected outright.
+// At or above the checkpoint, RUN reaches RUNNING from either source.
+//
+// The IDLE cases used to expect RUNNING, on the reasoning that a fresh node
+// boots into CATCHINGBLOCKS so the exemption could never be reached. That made a
+// safety property depend on a boot default, and it was never exhaustive: a store
+// persisted in IDLE before that default changed, or a node stopped from RUNNING
+// and then overtaken by a checkpoint bump, both sit in IDLE below the checkpoint.
 func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 	ctx := context.Background()
 	highest := HighestCheckpointHeight(chaincfg.MainNetParams.Checkpoints)
@@ -242,16 +251,26 @@ func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 		wantSubstr string
 	}{
 		{
-			name:       "fresh boot IDLE with tip 0 below checkpoint succeeds",
+			name:       "fresh boot IDLE with tip 0 below checkpoint routes to CATCHINGBLOCKS",
 			startState: blockchain_api.FSMStateType_IDLE,
 			tipHeight:  0,
 			wantErr:    false,
-			wantState:  blockchain_api.FSMStateType_RUNNING,
+			wantState:  blockchain_api.FSMStateType_CATCHINGBLOCKS,
 		},
 		{
-			name:       "IDLE with tip 100 still below checkpoint succeeds",
+			name:       "IDLE with tip 100 still below checkpoint routes to CATCHINGBLOCKS",
 			startState: blockchain_api.FSMStateType_IDLE,
 			tipHeight:  100,
+			wantErr:    false,
+			wantState:  blockchain_api.FSMStateType_CATCHINGBLOCKS,
+		},
+		{
+			// A node that is genuinely caught up must still reach RUNNING
+			// directly from IDLE, otherwise removing the exemption would cost
+			// every stopped node a pointless trip through catch-up.
+			name:       "IDLE with tip above checkpoint reaches RUNNING",
+			startState: blockchain_api.FSMStateType_IDLE,
+			tipHeight:  highest + 50,
 			wantErr:    false,
 			wantState:  blockchain_api.FSMStateType_RUNNING,
 		},
@@ -261,7 +280,7 @@ func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 			tipHeight:  highest - 1,
 			wantErr:    true,
 			wantState:  blockchain_api.FSMStateType_CATCHINGBLOCKS,
-			wantSubstr: "refusing RUN",
+			wantSubstr: "below highest checkpoint",
 		},
 		{
 			name:       "CATCHINGBLOCKS above checkpoint succeeds",
@@ -277,9 +296,9 @@ func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 			store := &fsmGateStore{}
 			hdr := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
 			meta := &model.BlockHeaderMeta{Height: tt.tipHeight}
-			// GetBestBlockHeader is only consulted when the gate runs (non-IDLE
-			// sources). Always-on Maybe lets IDLE tests skip the call without
-			// failing strict expectations.
+			// The gate now runs for every RUN, so GetBestBlockHeader is consulted
+			// for IDLE sources too. Maybe() is kept because networks with no
+			// checkpoints short-circuit before the store read.
 			store.On("GetBestBlockHeader", mock.Anything).Return(hdr, meta, nil).Maybe()
 
 			b := newTestBlockchainForGate(t, &chaincfg.MainNetParams, store)
@@ -302,7 +321,133 @@ func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 				require.NotNil(t, resp)
 				require.Equal(t, tt.wantState, resp.State)
 				require.Equal(t, tt.wantState.String(), b.finiteStateMachine.Current())
+
+				// Every accepted transition must also reach the store, so a restart
+				// resumes where the node actually got to. resp.State and the FSM are
+				// the same in-memory object, so neither can show this.
+				persisted, perr := store.GetFSMState(ctx)
+				require.NoError(t, perr)
+				require.Equal(t, tt.wantState.String(), persisted,
+					"reached state must be persisted, not just set in memory")
 			}
+		})
+	}
+}
+
+// TestSendFSMEvent_RunFromIdle_NoCheckpoints pins that networks with no
+// hard-coded checkpoints are untouched by the gate change. regtest is the case
+// that matters: the guard short-circuits on highest == 0 before it reads the
+// chain tip, so RUN from IDLE still goes straight to RUNNING and local dev keeps
+// working with a single setfsmstate running (block assembly refuses to hand out
+// a mining candidate outside RUNNING, so dev needs to get there).
+func TestSendFSMEvent_RunFromIdle_NoCheckpoints(t *testing.T) {
+	ctx := context.Background()
+	require.Zero(t, HighestCheckpointHeight(chaincfg.RegressionNetParams.Checkpoints))
+
+	store := &fsmGateStore{}
+	// Deliberately no GetBestBlockHeader expectation: the guard must not reach
+	// the store when the network defines no checkpoints.
+
+	b := newTestBlockchainForGate(t, &chaincfg.RegressionNetParams, store)
+	b.settings.BlockChain.FSMStateChangeDelay = 0
+	b.finiteStateMachine = b.NewFiniteStateMachine()
+	b.finiteStateMachine.SetState(blockchain_api.FSMStateType_IDLE.String())
+
+	resp, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{
+		Event: blockchain_api.FSMEventType_RUN,
+	})
+	require.NoError(t, err)
+	require.Equal(t, blockchain_api.FSMStateType_RUNNING, resp.State)
+	require.Equal(t, blockchain_api.FSMStateType_RUNNING.String(), b.finiteStateMachine.Current())
+	store.AssertNotCalled(t, "GetBestBlockHeader", mock.Anything)
+}
+
+// TestSendFSMEvent_RunFromIdle_RerouteIsReportedToCaller pins that the reroute
+// is visible rather than silent: the response carries the state actually
+// reached, which is what teranode-cli setfsmstate prints back to the operator.
+func TestSendFSMEvent_RunFromIdle_RerouteIsReportedToCaller(t *testing.T) {
+	ctx := context.Background()
+	highest := HighestCheckpointHeight(chaincfg.MainNetParams.Checkpoints)
+	require.Greater(t, highest, uint32(0))
+
+	store := &fsmGateStore{}
+	hdr := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
+	store.On("GetBestBlockHeader", mock.Anything).Return(hdr, &model.BlockHeaderMeta{Height: 0}, nil)
+
+	b := newTestBlockchainForGate(t, &chaincfg.MainNetParams, store)
+	b.settings.BlockChain.FSMStateChangeDelay = 0
+	b.finiteStateMachine = b.NewFiniteStateMachine()
+	b.finiteStateMachine.SetState(blockchain_api.FSMStateType_IDLE.String())
+
+	resp, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{
+		Event: blockchain_api.FSMEventType_RUN,
+	})
+	require.NoError(t, err)
+	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS, resp.State,
+		"caller must be told it landed in CATCHINGBLOCKS, not RUNNING")
+
+	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS.String(), b.finiteStateMachine.Current())
+
+	// The durable half of the safety property: the rerouted state must reach the
+	// store, so a restart resumes catching up rather than the RUNNING the operator
+	// asked for. Asserting on b.finiteStateMachine above cannot show this — it is
+	// the same object resp.State was read from, so a SetFSMState that never fired,
+	// or fired with the wrong state, would still leave the test green. That failure
+	// would be quiet in production too: SendFSMEvent only logs a SetFSMState error
+	// rather than returning it.
+	persisted, perr := store.GetFSMState(ctx)
+	require.NoError(t, perr)
+	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS.String(), persisted,
+		"rerouted state must be persisted, not just set in memory")
+
+	store.AssertExpectations(t)
+}
+
+// TestSendFSMEvent_RunFromIdle_StoreErrorIsNotRerouted pins that only a
+// confirmed below-checkpoint verdict is rerouted. If the chain tip cannot be
+// read at all, an operator who asked for RUNNING must see the store error rather
+// than a node that quietly went to catch-up instead — the two look identical
+// from the outside otherwise.
+func TestSendFSMEvent_RunFromIdle_StoreErrorIsNotRerouted(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		hdr        *model.BlockHeader
+		meta       *model.BlockHeaderMeta
+		storeErr   error
+		wantSubstr string
+	}{
+		{
+			name:       "store read fails",
+			storeErr:   errors.NewStorageError("boom"),
+			wantSubstr: "cannot read best block header",
+		},
+		{
+			name:       "meta unavailable",
+			hdr:        &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}},
+			meta:       nil,
+			wantSubstr: "best block header meta unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fsmGateStore{}
+			store.On("GetBestBlockHeader", mock.Anything).Return(tt.hdr, tt.meta, tt.storeErr)
+
+			b := newTestBlockchainForGate(t, &chaincfg.MainNetParams, store)
+			b.settings.BlockChain.FSMStateChangeDelay = 0
+			b.finiteStateMachine = b.NewFiniteStateMachine()
+			b.finiteStateMachine.SetState(blockchain_api.FSMStateType_IDLE.String())
+
+			_, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{
+				Event: blockchain_api.FSMEventType_RUN,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantSubstr)
+			require.Equal(t, blockchain_api.FSMStateType_IDLE.String(), b.finiteStateMachine.Current(),
+				"FSM must stay in IDLE when the gate cannot reach a verdict")
 		})
 	}
 }

--- a/services/blockchain/server_fsm_run_gate_test.go
+++ b/services/blockchain/server_fsm_run_gate_test.go
@@ -171,7 +171,7 @@ func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
 
 			b := newTestBlockchainForGate(t, tt.params, store)
 
-			_, err := b.guardRunBelowHighestCheckpoint(ctx)
+			err := b.guardRunBelowHighestCheckpoint(ctx)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantSubstr != "" {
@@ -190,13 +190,13 @@ func TestGuardRunBelowHighestCheckpoint(t *testing.T) {
 func TestGuardRunBelowHighestCheckpoint_NilSettings(t *testing.T) {
 	t.Run("nil settings", func(t *testing.T) {
 		b := &Blockchain{logger: ulogger.TestLogger{}}
-		_, guardErr := b.guardRunBelowHighestCheckpoint(context.Background())
+		guardErr := b.guardRunBelowHighestCheckpoint(context.Background())
 		require.NoError(t, guardErr)
 	})
 
 	t.Run("nil ChainCfgParams", func(t *testing.T) {
 		b := &Blockchain{logger: ulogger.TestLogger{}, settings: &settings.Settings{}}
-		_, guardErr := b.guardRunBelowHighestCheckpoint(context.Background())
+		guardErr := b.guardRunBelowHighestCheckpoint(context.Background())
 		require.NoError(t, guardErr)
 	})
 }
@@ -225,12 +225,10 @@ func TestInit_MigratesPersistedLegacySyncingToCatchingBlocks(t *testing.T) {
 }
 
 // TestSendFSMEvent_RunGate_SourceState pins the source-state semantics of
-// the RUN gate: the checkpoint rule applies to every RUN regardless of source
-// state, and the source state decides what happens when it fails. From IDLE a
-// below-checkpoint RUN is rerouted to CATCHINGBLOCKS — "run" means "put this
-// node into service", and the route there is through catch-up. From
-// CATCHINGBLOCKS the same RUN claims "I'm caught up" and is rejected outright.
-// At or above the checkpoint, RUN reaches RUNNING from either source.
+// the RUN gate: the checkpoint rule applies to every valid RUN regardless of
+// source state. Below the checkpoint, RUN is rejected and the FSM remains in
+// its source state. At or above the checkpoint, RUN reaches RUNNING from IDLE
+// or CATCHINGBLOCKS.
 //
 // The IDLE cases used to expect RUNNING, on the reasoning that a fresh node
 // boots into CATCHINGBLOCKS so the exemption could never be reached. That made a
@@ -251,18 +249,20 @@ func TestSendFSMEvent_RunGate_SourceState(t *testing.T) {
 		wantSubstr string
 	}{
 		{
-			name:       "fresh boot IDLE with tip 0 below checkpoint routes to CATCHINGBLOCKS",
+			name:       "fresh boot IDLE with tip 0 below checkpoint rejects",
 			startState: blockchain_api.FSMStateType_IDLE,
 			tipHeight:  0,
-			wantErr:    false,
-			wantState:  blockchain_api.FSMStateType_CATCHINGBLOCKS,
+			wantErr:    true,
+			wantState:  blockchain_api.FSMStateType_IDLE,
+			wantSubstr: "below highest checkpoint",
 		},
 		{
-			name:       "IDLE with tip 100 still below checkpoint routes to CATCHINGBLOCKS",
+			name:       "IDLE with tip 100 still below checkpoint rejects",
 			startState: blockchain_api.FSMStateType_IDLE,
 			tipHeight:  100,
-			wantErr:    false,
-			wantState:  blockchain_api.FSMStateType_CATCHINGBLOCKS,
+			wantErr:    true,
+			wantState:  blockchain_api.FSMStateType_IDLE,
+			wantSubstr: "below highest checkpoint",
 		},
 		{
 			// A node that is genuinely caught up must still reach RUNNING
@@ -362,10 +362,11 @@ func TestSendFSMEvent_RunFromIdle_NoCheckpoints(t *testing.T) {
 	store.AssertNotCalled(t, "GetBestBlockHeader", mock.Anything)
 }
 
-// TestSendFSMEvent_RunFromIdle_RerouteIsReportedToCaller pins that the reroute
-// is visible rather than silent: the response carries the state actually
-// reached, which is what teranode-cli setfsmstate prints back to the operator.
-func TestSendFSMEvent_RunFromIdle_RerouteIsReportedToCaller(t *testing.T) {
+// TestRunFromIdle_BelowCheckpointRejectsAndPreservesIdle protects the Run RPC
+// contract: a nil error means the node reached RUNNING. A below-checkpoint node
+// must therefore reject RUN and remain durably parked in IDLE rather than
+// silently entering the irreversible CATCHINGBLOCKS state.
+func TestRunFromIdle_BelowCheckpointRejectsAndPreservesIdle(t *testing.T) {
 	ctx := context.Background()
 	highest := HighestCheckpointHeight(chaincfg.MainNetParams.Checkpoints)
 	require.Greater(t, highest, uint32(0))
@@ -378,37 +379,48 @@ func TestSendFSMEvent_RunFromIdle_RerouteIsReportedToCaller(t *testing.T) {
 	b.settings.BlockChain.FSMStateChangeDelay = 0
 	b.finiteStateMachine = b.NewFiniteStateMachine()
 	b.finiteStateMachine.SetState(blockchain_api.FSMStateType_IDLE.String())
+	require.NoError(t, store.SetFSMState(ctx, blockchain_api.FSMStateType_IDLE.String()))
 
-	resp, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{
-		Event: blockchain_api.FSMEventType_RUN,
-	})
-	require.NoError(t, err)
-	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS, resp.State,
-		"caller must be told it landed in CATCHINGBLOCKS, not RUNNING")
+	_, err := b.Run(ctx, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "below highest checkpoint")
+	require.Equal(t, blockchain_api.FSMStateType_IDLE.String(), b.finiteStateMachine.Current())
 
-	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS.String(), b.finiteStateMachine.Current())
-
-	// The durable half of the safety property: the rerouted state must reach the
-	// store, so a restart resumes catching up rather than the RUNNING the operator
-	// asked for. Asserting on b.finiteStateMachine above cannot show this — it is
-	// the same object resp.State was read from, so a SetFSMState that never fired,
-	// or fired with the wrong state, would still leave the test green. That failure
-	// would be quiet in production too: SendFSMEvent only logs a SetFSMState error
-	// rather than returning it.
 	persisted, perr := store.GetFSMState(ctx)
 	require.NoError(t, perr)
-	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS.String(), persisted,
-		"rerouted state must be persisted, not just set in memory")
+	require.Equal(t, blockchain_api.FSMStateType_IDLE.String(), persisted,
+		"rejected RUN must not change the persisted state")
 
 	store.AssertExpectations(t)
 }
 
-// TestSendFSMEvent_RunFromIdle_StoreErrorIsNotRerouted pins that only a
-// confirmed below-checkpoint verdict is rerouted. If the chain tip cannot be
-// read at all, an operator who asked for RUNNING must see the store error rather
-// than a node that quietly went to catch-up instead — the two look identical
-// from the outside otherwise.
-func TestSendFSMEvent_RunFromIdle_StoreErrorIsNotRerouted(t *testing.T) {
+// TestSendFSMEvent_InvalidRunSkipsCheckpointRead protects error ordering for
+// direct SendFSMEvent callers. RUN is not a valid event from RUNNING, so the FSM
+// error must be returned without consulting the chain tip while holding fsmMu.
+func TestSendFSMEvent_InvalidRunSkipsCheckpointRead(t *testing.T) {
+	ctx := context.Background()
+	store := &fsmGateStore{}
+	hdr := &model.BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}}
+	store.On("GetBestBlockHeader", mock.Anything).Return(hdr, &model.BlockHeaderMeta{Height: 0}, nil).Maybe()
+
+	b := newTestBlockchainForGate(t, &chaincfg.MainNetParams, store)
+	b.settings.BlockChain.FSMStateChangeDelay = 0
+	b.finiteStateMachine = b.NewFiniteStateMachine()
+	b.finiteStateMachine.SetState(blockchain_api.FSMStateType_RUNNING.String())
+
+	_, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{
+		Event: blockchain_api.FSMEventType_RUN,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FSM event RUN rejected in state RUNNING")
+	require.Equal(t, blockchain_api.FSMStateType_RUNNING.String(), b.finiteStateMachine.Current())
+	store.AssertNotCalled(t, "GetBestBlockHeader", mock.Anything)
+}
+
+// TestSendFSMEvent_RunFromIdle_StoreErrorRejects pins fail-closed behavior when
+// the chain tip cannot be read. The operator must see the store error and the
+// node must remain in IDLE.
+func TestSendFSMEvent_RunFromIdle_StoreErrorRejects(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {

--- a/services/blockchain/server_fsm_run_gate_test.go
+++ b/services/blockchain/server_fsm_run_gate_test.go
@@ -383,7 +383,8 @@ func TestRunFromIdle_BelowCheckpointRejectsAndPreservesIdle(t *testing.T) {
 
 	_, err := b.Run(ctx, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "below highest checkpoint")
+	require.ErrorContains(t, err, "below highest checkpoint")
+	require.ErrorContains(t, err, "setfsmstate catchingblocks")
 	require.Equal(t, blockchain_api.FSMStateType_IDLE.String(), b.finiteStateMachine.Current())
 
 	persisted, perr := store.GetFSMState(ctx)


### PR DESCRIPTION
## Why

The checkpoint gate on the RUN event exempts `IDLE -> RUNNING`. Its own comment gives the justification:

> IDLE -> RUNNING is an operator override (e.g. teranodecli setfsmstate --fsmstate running) and stays exempt: a fresh node has no tip yet and tx relay is suppressed while FSM != RUNNING. Automatic boot no longer uses IDLE -> RUNNING; fresh nodes boot into CATCHINGBLOCKS (see Init) and only reach RUNNING by completing catchup above the checkpoint.

Two problems with that.

**It makes a safety property depend on a boot default.** The default changed once already (#1135, which is what the comment is describing). Any future change to it silently reopens the exemption. The property the gate exists to enforce — a node below the highest checkpoint must not reach RUNNING — should not be contingent on which state `Init` happens to pick.

**It is not exhaustive.** "A fresh node is never in IDLE" is true; "a below-checkpoint node is never in IDLE" is not. Two paths reach IDLE with a tip below the checkpoint today:

- a store persisted in `IDLE` by a pre-#1135 build, restored on a newer one (`Server.go` `Init`, the persisted-state branch)
- a node stopped from RUNNING to IDLE and then overtaken by a checkpoint bump in `go-chaincfg`

In both, `teranode-cli setfsmstate --fsmstate running` currently goes straight to RUNNING. That is the hole the gate was built to close: RUNNING switches on live subtree validation and block-assembly transaction feeding, and lets the legacy service relay transaction inventory messages that post-Genesis peers ban on sight (`bad-txns-vout-p2sh BAN THRESHOLD EXCEEDED`).

## Change

The gate now evaluates every valid RUN, whatever the source state:

| Source | Tip vs highest checkpoint | Result |
|---|---|---|
| `IDLE` | below | rejected; remains `IDLE` |
| `IDLE` | at/above | `RUNNING` (unchanged) |
| `CATCHINGBLOCKS` | below | rejected; remains `CATCHINGBLOCKS` (unchanged) |
| `CATCHINGBLOCKS` | at/above | `RUNNING` (unchanged) |
| any valid source | network has no checkpoints (regtest) | `RUNNING` (unchanged) |

**A rejected RUN preserves IDLE.** CATCHINGBLOCKS has no manual route back to IDLE. Silently routing an operator's RUN request there would spend the parked state for one saved command. Rejection leaves both choices open: remain parked for inspection or rewind, or deliberately run `teranode-cli setfsmstate --fsmstate catchingblocks` to start synchronization.

Rejection also keeps the API contract truthful. `Run` and its Go client return only an error, so a nil error should mean the node reached RUNNING rather than an unreported intermediate state.

**Invalid RUN events skip the checkpoint lookup.** A direct `SendFSMEvent(RUN)` from RUNNING is already invalid in the FSM transition table. The server checks that validity before reading the chain tip, avoiding a needless store read while holding `fsmMu` and preserving the correct FSM error.

**The guard fails closed.** A tip below the checkpoint, a store read failure, or missing tip metadata rejects RUN. Networks without checkpoints short-circuit before reading the store.

### Incidental

`Run` and `CatchUpBlocks` returned `(nil, nil)` on success while returning `&emptypb.Empty{}` on their own early-exit paths. Both now return a non-nil empty response consistently.

## What this does not do

Nothing about boot state. A fresh node still boots into `CATCHINGBLOCKS` in every context. This is the prerequisite half of #1671: any change that makes `IDLE` a normal state for a not-yet-caught-up node must not put RUNNING one command away below the checkpoint.

Also unchanged: #1670 (no `CATCHINGBLOCKS -> IDLE` edge).

## Behaviour change for operators

There is no manual route to RUNNING below the highest checkpoint from any state. From IDLE, RUN returns an error and leaves the node parked; use `setfsmstate --fsmstate catchingblocks` to start synchronization deliberately. From CATCHINGBLOCKS, RUN remains refused until catchup completes. Regtest has no checkpoints and is unaffected.

## Testing

- `go test ./services/blockchain` — pass
- focused `go test -race ./services/blockchain` covering the checkpoint gate, IDLE preservation, invalid transition ordering, store errors, and regtest — pass
- `go vet ./services/blockchain` — pass
- `golangci-lint run ./services/blockchain/... --disable gosec --disable prealloc` — 0 issues

Refs: #1671, #1670, #1135
