### PR TITLE
fix(validator): avoid crash when policy rejection topic is disabled

### DIFF
--- a/daemon/daemon_services.go
+++ b/daemon/daemon_services.go
@@ -990,13 +990,16 @@ func (d *Daemon) startValidatorService(
 		return err
 	}
 
-	var policyRejectedTxKafkaProducerClient *kafka.KafkaAsyncProducer
-
-	policyRejectedTxKafkaProducerClient, err = getKafkaTxPolicyRejectedAsyncProducer(
+	policyRejectedProducer, err := getKafkaTxPolicyRejectedAsyncProducer(
 		ctx, createLogger("kafka-producer-policy-rejected-tx"), appSettings,
 	)
 	if err != nil {
 		return err
+	}
+	// Keep the interface nil when the optional producer is not configured.
+	var policyRejectedTxKafkaProducerClient kafka.KafkaAsyncProducerI
+	if policyRejectedProducer != nil {
+		policyRejectedTxKafkaProducerClient = policyRejectedProducer
 	}
 
 	// Create the BlockAssembly client for the Validator service

--- a/test/e2e/daemon/ready/optional_policy_producer_test.go
+++ b/test/e2e/daemon/ready/optional_policy_producer_test.go
@@ -1,0 +1,42 @@
+package smoke
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/teranode/daemon"
+	"github.com/bsv-blockchain/teranode/services/validator"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/test"
+	"github.com/bsv-blockchain/teranode/test/utils/transactions"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatorRejectsLowFeeWithoutPolicyRejectedTopic(t *testing.T) {
+	td := daemon.NewTestDaemon(t, daemon.TestOptions{
+		EnableRPC:       true,
+		EnableValidator: true,
+		SettingsOverrideFunc: test.ComposeSettings(test.SystemTestSettings(), func(s *settings.Settings) {
+			s.ChainCfgParams.CoinbaseMaturity = 2
+			s.Policy.MinMiningTxFee = 0.000001 // 100 sat/kB, expressed in BSV/kB.
+			s.Kafka.TxPolicyRejectedConfig = nil
+		}),
+	})
+	defer td.Stop(t, true)
+	require.NoError(t, td.BlockchainClient.Run(td.Ctx, "test"))
+	coinbaseTx := td.MineToMaturityAndGetSpendableCoinbaseTx(t, td.Ctx)
+	tx := td.CreateTransactionWithOptions(t,
+		transactions.WithInput(coinbaseTx, 0),
+		transactions.WithP2PKHOutputs(1, coinbaseTx.Outputs[0].Satoshis-1),
+	)
+	require.Equal(t, uint64(1), coinbaseTx.Outputs[0].Satoshis-tx.Outputs[0].Satoshis)
+	require.Greater(t, (uint64(len(tx.Bytes()))*100+999)/1000, uint64(1))
+
+	// Use synchronous validation; propagation may only acknowledge queueing.
+	client, err := validator.NewClient(td.Ctx, td.Logger, td.Settings)
+	require.NoError(t, err)
+	defer client.Close()
+	_, err = client.Validate(td.Ctx, tx, 0)
+	require.ErrorContains(t, err, "transaction fee is too low")
+	td.VerifyNotInUtxoStore(t, tx)
+	td.VerifyNotInBlockAssembly(t, tx)
+}


### PR DESCRIPTION
When `TxPolicyRejectedConfig` is unset, the validator service passes a typed nil producer into a `KafkaAsyncProducerI` interface. A low-fee transaction then reaches `publishPolicyRejectedTx`, passes its interface nil check, and panics in `TryPublish` instead of returning the policy rejection.

Keep the interface nil when the optional producer is absent, matching the existing local-validator construction path. Configured producers and fee policy are unchanged.

The regression starts the real local regtest daemon with SQLite, in-memory messaging and the optional topic explicitly disabled. It submits a signed transaction paying 1 sat, requires the low-fee error, and verifies that the transaction enters neither UTXO storage nor block assembly.

Validation on upstream `40faeb0f0bfcf94baf1eaa69517b5e5889af0d89`:

- Focused real-daemon regression passed, including `-race`.
- Existing local-validator producer construction/cleanup tests passed.
- `git diff --check` passed.

Reproduce the focused test without external services:

```sh
SETTINGS_CONTEXT=dev.system.test CGO_ENABLED=1 go test -v -race -count=1 -parallel=1 -timeout=120s -tags testtxmetacache -run '^TestValidatorRejectsLowFeeWithoutPolicyRejectedTopic$' ./test/e2e/daemon/ready/optional_policy_producer_test.go
```

The full node suite and production-scale testing were not run. This change adds no CPFP acceptance or fee-policy exception.
