### PR TITLE
fix(blockchain): bound FSM work and survive RPC cancellation

### DIFF
--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2932,7 +2932,7 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 func (b *Blockchain) fsmStoreContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	timeout := time.Duration(b.settings.BlockChain.StoreDBTimeoutMillis) * time.Millisecond
 	if timeout <= 0 {
-		timeout = 5 * time.Second
+		timeout = time.Duration(settings.DefaultBlockchainStoreDBTimeoutMillis) * time.Millisecond
 	}
 	return context.WithTimeout(ctx, timeout)
 }

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2879,11 +2879,15 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 		}
 	}
 
-	err := b.finiteStateMachine.Event(ctx, eventReq.Event.String())
+	// Once admitted, complete the local transition even if the RPC is cancelled.
+	// looplab/fsm v1.0.2 leaves a pending transition behind when its context is
+	// cancelled during Event, rejecting every subsequent event until restart.
+	transitionCtx := context.WithoutCancel(ctx)
+	err := b.finiteStateMachine.Event(transitionCtx, eventReq.Event.String())
 	if err != nil {
 		b.logger.Debugf("[Blockchain Server] Error sending event to FSM, state has not changed.")
 		switch err.(type) {
-		case fsm.InvalidEventError, fsm.NoTransitionError:
+		case fsm.InvalidEventError, fsm.NoTransitionError, fsm.InTransitionError:
 			return nil, errors.WrapGRPC(errors.NewStateError("[Blockchain Server] FSM event %s rejected in state %s", eventReq.Event.String(), priorState, err))
 		default:
 			return nil, errors.WrapGRPC(err)
@@ -2893,7 +2897,9 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 	state := b.finiteStateMachine.Current()
 
 	// set the state in persistent storage
-	err = b.store.SetFSMState(ctx, state)
+	storeCtx, cancel := b.fsmStoreContext(transitionCtx)
+	defer cancel()
+	err = b.store.SetFSMState(storeCtx, state)
 	// check if there was an error setting the state
 	if err != nil {
 		b.logger.Errorf("[Blockchain Server] Error setting the state in blockchain db: %v", err)
@@ -2921,6 +2927,16 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 	return resp, nil
 }
 
+// fsmStoreContext bounds store operations performed while fsmMu is held.
+// Non-positive configuration falls back to the default database timeout.
+func (b *Blockchain) fsmStoreContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	timeout := time.Duration(b.settings.BlockChain.StoreDBTimeoutMillis) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
 // guardRunBelowHighestCheckpoint blocks the RUN transition when the local
 // chain tip has not yet reached the highest hard-coded checkpoint for the
 // active network.
@@ -2938,7 +2954,9 @@ func (b *Blockchain) guardRunBelowHighestCheckpoint(ctx context.Context) error {
 		return nil
 	}
 
-	_, meta, err := b.store.GetBestBlockHeader(ctx)
+	storeCtx, cancel := b.fsmStoreContext(ctx)
+	defer cancel()
+	_, meta, err := b.store.GetBestBlockHeader(storeCtx)
 	if err != nil {
 		return errors.NewStateError("cannot read best block header to evaluate RUN gate", err)
 	}

--- a/services/blockchain/Server.go
+++ b/services/blockchain/Server.go
@@ -2898,8 +2898,8 @@ func (b *Blockchain) SendFSMEvent(ctx context.Context, eventReq *blockchain_api.
 
 	// set the state in persistent storage
 	storeCtx, cancel := b.fsmStoreContext(transitionCtx)
-	defer cancel()
 	err = b.store.SetFSMState(storeCtx, state)
+	cancel()
 	// check if there was an error setting the state
 	if err != nil {
 		b.logger.Errorf("[Blockchain Server] Error setting the state in blockchain db: %v", err)

--- a/services/blockchain/server_fsm_hardening_test.go
+++ b/services/blockchain/server_fsm_hardening_test.go
@@ -1,0 +1,138 @@
+package blockchain
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain/blockchain_api"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/stores/blockchain/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/ordishs/gocore"
+	"github.com/stretchr/testify/require"
+)
+
+func newFSMHardeningBlockchain(t *testing.T) *Blockchain {
+	t.Helper()
+	initPrometheusMetrics()
+	tSettings := test.CreateBaseTestSettings(t)
+	params := chaincfg.RegressionNetParams
+	tSettings.ChainCfgParams = &params
+	tSettings.BlockChain.FSMStateChangeDelay = 0
+	logger := ulogger.TestLogger{}
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	store, err := sql.New(logger, storeURL, tSettings)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close(context.Background())) })
+	require.NoError(t, store.SetFSMState(context.Background(), "IDLE"))
+	b := &Blockchain{
+		logger: logger, store: store, settings: tSettings,
+		notifications: make(chan *blockchain_api.Notification, 10),
+		stats:         gocore.NewStat("blockchain-fsm-hardening-test"),
+	}
+	b.finiteStateMachine = b.NewFiniteStateMachine()
+	return b
+}
+
+// Cancellation after admission must neither poison looplab's pending transition
+// nor prevent the accepted state from being persisted.
+func TestSendFSMEvent_AcceptedCancellationDoesNotWedge(t *testing.T) {
+	b := newFSMHardeningBlockchain(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resp, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_RUN})
+	require.NoError(t, err)
+	require.Equal(t, blockchain_api.FSMStateType_RUNNING, resp.State)
+	state, err := b.store.GetFSMState(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "RUNNING", state)
+	resp, err = b.SendFSMEvent(context.Background(), &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_STOP})
+	require.NoError(t, err, "the next transition must remain usable after request cancellation")
+	require.Equal(t, blockchain_api.FSMStateType_IDLE, resp.State)
+}
+
+func TestSendFSMEvent_InTransitionReturnsStateError(t *testing.T) {
+	b := newFSMHardeningBlockchain(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Reproduce an already-wedged looplab FSM without routing through the fix.
+	require.ErrorIs(t, b.finiteStateMachine.Event(ctx, "RUN"), context.Canceled)
+	_, err := b.SendFSMEvent(context.Background(), &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_RUN})
+	require.Error(t, err)
+	require.Equal(t, errors.ERR_STATE_ERROR, errors.UnwrapGRPC(err).Code())
+}
+
+// Only the checkpoint read is fault-injected; persistence uses real SQLite.
+type fsmHardeningReadStore struct {
+	blockchainstore.Store
+	read func(context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error)
+}
+
+func (s *fsmHardeningReadStore) GetBestBlockHeader(ctx context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+	return s.read(ctx)
+}
+
+func TestSendFSMEvent_CheckpointTimeoutReleasesTransitionLock(t *testing.T) {
+	b := newFSMHardeningBlockchain(t)
+	b.settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1}}
+	b.settings.BlockChain.StoreDBTimeoutMillis = 20
+	// The outer deadline bounds the regression run even before the fix exists.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	b.store = &fsmHardeningReadStore{Store: b.store, read: func(ctx context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	}}
+	_, err := b.SendFSMEvent(ctx, &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_RUN})
+	require.Error(t, err)
+	require.NoError(t, ctx.Err(), "the server's DB timeout must expire before the caller deadline")
+	require.Equal(t, "IDLE", b.finiteStateMachine.Current())
+	state, err := b.store.GetFSMState(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "IDLE", state)
+	resp, err := b.SendFSMEvent(context.Background(), &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_CATCHUPBLOCKS})
+	require.NoError(t, err, "timeout must release fsmMu for the next event")
+	require.Equal(t, blockchain_api.FSMStateType_CATCHINGBLOCKS, resp.State)
+}
+
+func TestGuardRunBelowHighestCheckpoint_RespectsEarlierDeadline(t *testing.T) {
+	b := newFSMHardeningBlockchain(t)
+	b.settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1}}
+	b.settings.BlockChain.StoreDBTimeoutMillis = 1000
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	deadline, _ := ctx.Deadline()
+	b.store = &fsmHardeningReadStore{Store: b.store, read: func(ctx context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+		actual, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Equal(t, deadline, actual)
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	}}
+	require.Error(t, b.guardRunBelowHighestCheckpoint(ctx))
+	require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+}
+
+func TestGuardRunBelowHighestCheckpoint_NonPositiveTimeoutStillBounded(t *testing.T) {
+	for _, timeout := range []int{0, -1} {
+		t.Run(time.Duration(timeout).String(), func(t *testing.T) {
+			b := newFSMHardeningBlockchain(t)
+			b.settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1}}
+			b.settings.BlockChain.StoreDBTimeoutMillis = timeout
+			b.store = &fsmHardeningReadStore{Store: b.store, read: func(ctx context.Context) (*model.BlockHeader, *model.BlockHeaderMeta, error) {
+				deadline, ok := ctx.Deadline()
+				require.True(t, ok, "invalid configuration must not leave the FSM lock held indefinitely")
+				require.Positive(t, time.Until(deadline))
+				return nil, nil, context.DeadlineExceeded
+			}}
+			require.Error(t, b.guardRunBelowHighestCheckpoint(context.Background()))
+		})
+	}
+}

--- a/services/blockchain/server_fsm_hardening_test.go
+++ b/services/blockchain/server_fsm_hardening_test.go
@@ -58,6 +58,48 @@ func TestSendFSMEvent_AcceptedCancellationDoesNotWedge(t *testing.T) {
 	require.Equal(t, blockchain_api.FSMStateType_IDLE, resp.State)
 }
 
+type fsmHardeningWriteStore struct {
+	blockchainstore.Store
+	contexts chan context.Context
+}
+
+func (s *fsmHardeningWriteStore) SetFSMState(ctx context.Context, state string) error {
+	s.contexts <- ctx
+	return s.Store.SetFSMState(ctx, state)
+}
+
+func TestSendFSMEvent_ReleasesStoreContextBeforeResponseDelay(t *testing.T) {
+	b := newFSMHardeningBlockchain(t)
+	b.settings.BlockChain.FSMStateChangeDelay = time.Second
+	b.stateChangeTimestamp = time.Now()
+	contexts := make(chan context.Context, 1)
+	b.store = &fsmHardeningWriteStore{Store: b.store, contexts: contexts}
+	done := make(chan error, 1)
+	go func() {
+		_, err := b.SendFSMEvent(context.Background(), &blockchain_api.SendFSMEventRequest{Event: blockchain_api.FSMEventType_RUN})
+		done <- err
+	}()
+	t.Cleanup(func() {
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			t.Error("FSM request did not finish")
+		}
+	})
+	select {
+	case storeCtx := <-contexts:
+		select {
+		case <-storeCtx.Done():
+			require.ErrorIs(t, storeCtx.Err(), context.Canceled)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("store context remained alive during the response delay")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("FSM request did not reach persistence")
+	}
+}
+
 func TestSendFSMEvent_InTransitionReturnsStateError(t *testing.T) {
 	b := newFSMHardeningBlockchain(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/settings/blockchain_settings.go
+++ b/settings/blockchain_settings.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// DefaultBlockchainStoreDBTimeoutMillis supplies both the configured database
+// timeout default and the FSM fallback for non-positive configuration.
+const DefaultBlockchainStoreDBTimeoutMillis = 5000
+
 // BlockChainSettings configures the blockchain state management service.
 type BlockChainSettings struct {
 	GRPCAddress           string            `key:"blockchain_grpcAddress" desc:"gRPC address for Blockchain service" default:"localhost:8087" category:"BlockChain" usage:"Address for inter-service communication" type:"string" longdesc:"### Purpose\nSpecifies the client connection address for the Blockchain gRPC service.\n\n### How It Works\nOther services connect to this address to query blockchain state, headers, and chain information.\n\n### Used By\n- **Block Validation** - Get headers, check chain\n- **Block Assembly** - Get best block\n- **Asset Server** - Query blocks\n- **RPC** - getblock, getblockheader\n\n### Format\n**host:port** - Where host is a hostname, IP address, or DNS name.\n\n### Examples\n- **localhost:8087** - Local development (default)\n- **blockchain.internal:8087** - Internal DNS\n- **10.0.1.50:8087** - Direct IP address\n\n### Recommendations\n- Use internal DNS or service mesh addresses in production\n- Use localhost only for local development"`

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -325,7 +325,7 @@ func NewSettings(alternativeContext ...string) *Settings {
 			StoreURL:              getURL("blockchain_store", "sqlite:///blockchain", alternativeContext...),
 			FSMStateRestore:       getBool("fsm_state_restore", false, alternativeContext...),
 			FSMStateChangeDelay:   getDuration("fsm_state_change_delay", 0, alternativeContext...),
-			StoreDBTimeoutMillis:  getInt("blockchain_store_dbTimeoutMillis", 5000, alternativeContext...),
+			StoreDBTimeoutMillis:  getInt("blockchain_store_dbTimeoutMillis", DefaultBlockchainStoreDBTimeoutMillis, alternativeContext...),
 			InitializeNodeInState: getString("blockchain_initializeNodeInState", "", alternativeContext...),
 			PostgresPool:          getPostgresPoolSettings("blockchain", alternativeContext...),
 			UseInMemoryChainCheck: getBool("blockchain_use_in_memory_chain_check", false, alternativeContext...),


### PR DESCRIPTION
Superseded by #1696, which includes the bounded-transition hardening together with persistence-before-notification, uncertain-write reconciliation, and bounded promotion retries. Review and merge #1696 next.

An RPC cancellation during `looplab/fsm` v1.0.2's transition can leave the FSM permanently in transition, rejecting later events until restart. A checkpoint lookup can also hold the transition lock indefinitely when the caller supplies no deadline.

Complete accepted in-process transitions independently of caller cancellation, and bound checkpoint reads and accepted-state persistence with `blockchain_store_dbTimeoutMillis` (5 seconds for nonpositive values). Checkpoint admission still respects an earlier caller deadline and fails closed. Classify an already-pending transition as a state error.

This is a prerequisite for durable operator pause in #1670. It consumes the checkpoint gate merged in #1685 and leaves boot policy in #1693. Runtime persistence failure reporting and notification ordering are handled in #1696.

Validation: regression tests observed failing before implementation; blockchain package tests, race tests, `go vet`, and `golangci-lint` passed (zero lint issues). Tests use real SQLite plus a narrow blocking-read wrapper and cover cancellation followed by another transition, checkpoint timeout with preserved state and released lock, earlier caller deadline, and zero/negative timeout settings.

Accepted work may finish after the client disconnects. Store timeouts depend on the store honoring context cancellation.

Store contexts are canceled immediately after persistence, before the optional response delay. Configuration and the nonpositive FSM fallback share one database-timeout default. A regression reproduces the former timer lifetime issue and verifies prompt cancellation. The updated blockchain/settings race suites, vet, and changed-code lint pass.
