### PR TITLE
fix(test): make the disk-txmap throughput floor an order-of-magnitude gate

### DIFF
--- a/services/blockassembly/subtreeprocessor/disk_tx_map_benchmark_test.go
+++ b/services/blockassembly/subtreeprocessor/disk_tx_map_benchmark_test.go
@@ -289,8 +289,18 @@ func TestDiskTxMap_ExistenceLayerThroughput(t *testing.T) {
 	t.Logf("Ops/sec:       %.0f", opsPerSec)
 	t.Logf("Ns/op:         %.0f", float64(elapsed.Nanoseconds())/float64(totalOps))
 
-	// Threshold is 1M ops/sec to pass under -race (race detector adds ~10x overhead).
-	// Without -race, this achieves ~35M ops/sec.
-	require.Greaterf(t, opsPerSec, 1_000_000.0,
-		"Existence layer must achieve >1M ops/sec (with -race), got %.0f ops/sec", opsPerSec)
+	// The 1M ops/sec target is informational, not a hard gate: a fixed >1M floor under
+	// -race flakes on shared CI runners (saw ~953k ops/sec on a 16-core runner vs >1M
+	// on the temporary 32-core one, #1051). Without -race this achieves ~35M ops/sec.
+	// Log a note when below target; real perf tuning belongs in the Benchmark in this
+	// package. A generous 100k floor (10x below target, ~35x below a measured slow CI
+	// run) still fails the run on an order-of-magnitude regression — e.g. an accidental
+	// lock serialising the existence layer — without reintroducing runner-speed flakes.
+	const targetOpsPerSec = 1_000_000.0
+	const floorOpsPerSec = 100_000.0
+	if opsPerSec < targetOpsPerSec {
+		t.Logf("NOTE: below %.0f ops/sec target (%.0f) — expected on slower/shared runners under -race; not a failure.", targetOpsPerSec, opsPerSec)
+	}
+	require.Greaterf(t, opsPerSec, floorOpsPerSec,
+		"existence layer throughput collapsed: %.0f ops/sec is below the %.0f floor (target %.0f); this indicates an order-of-magnitude regression, not runner noise", opsPerSec, floorOpsPerSec, targetOpsPerSec)
 }


### PR DESCRIPTION
Backport of the assertion change in `25c0f2c43` (#1051 / #1058), which `release/v0.15` never received.

`TestDiskTxMap_ExistenceLayerThroughput` gates on >1M ops/sec under `-race`. The CI runners land below that — 970482 then 910122 ops/sec on two consecutive runs of the same commit — so the `test` job fails on every PR targeting this branch, #1705 included.

The 1M figure becomes an informational log; the hard assertion drops to a 100k floor. That still fails on an order-of-magnitude regression (an accidental lock serialising the existence layer, say) without gating on runner speed.

`services/blockassembly/subtreeprocessor/disk_tx_map_benchmark_test.go` is now byte-identical to `main`.

Local: `go test -race -run TestDiskTxMap_ExistenceLayerThroughput` passes, 6249184 ops/sec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)