### PR TITLE
p2p: carry received counters over GetPeerRegistry

### DIFF
--- a/docs/references/protobuf_docs/p2pProto.md
+++ b/docs/references/protobuf_docs/p2pProto.md
@@ -374,6 +374,12 @@ Represents comprehensive peer information with all registry metadata.
 | client_name | [string](#string) |  | Human-readable name of the client software |
 | last_catchup_error | [string](#string) |  | Last error message from catchup attempt |
 | last_catchup_error_time | [int64](#int64) |  | Time of last catchup error (Unix timestamp) |
+| catchup_attempts | [int64](#int64) |  | Number of catchup attempts with this peer |
+| catchup_successes | [int64](#int64) |  | Number of successful catchup operations |
+| catchup_failures | [int64](#int64) |  | Number of failed catchup operations |
+| blocks_received | [int64](#int64) |  | Number of blocks received from this peer |
+| subtrees_received | [int64](#int64) |  | Number of subtrees received from this peer |
+| transactions_received | [int64](#int64) |  | Number of transactions received from this peer |
 
 <a name="RecordBytesDownloadedRequest"></a>
 

--- a/services/asset/httpimpl/peer_auth_middleware_test.go
+++ b/services/asset/httpimpl/peer_auth_middleware_test.go
@@ -2,6 +2,7 @@ package httpimpl
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/teranode/services/p2p"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util"
 	"github.com/labstack/echo/v4"
@@ -372,6 +374,54 @@ func TestPeerAuthMiddleware_AllowlistMember_GetsTier(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, tierMiner, *captured)
+}
+
+// registryStubP2PClient is a p2p.ClientI that only answers GetPeerRegistry.
+type registryStubP2PClient struct {
+	p2p.ClientI
+	peers []*p2p.PeerInfo
+}
+
+func (c *registryStubP2PClient) GetPeerRegistry(_ context.Context) ([]*p2p.PeerInfo, error) {
+	return c.peers, nil
+}
+
+// TestPeerTierCache_Refresh_ClassifiesByBlocksReceived — refresh's
+// classification predicate: tierMiner requires BlocksReceived > 0 together with
+// ReputationScore >= threshold (inclusive); every other registered peer is
+// tierPeer and an unknown peer stays tierUnverified. The guard that
+// BlocksReceived actually survives the p2p gRPC hop lives in
+// services/p2p/server_handler_test.go (TestServer_GetPeerRegistry_ReceivedCountersSurviveWire).
+func TestPeerTierCache_Refresh_ClassifiesByBlocksReceived(t *testing.T) {
+	newPeerID := func() peer.ID {
+		k, _, err := crypto.GenerateEd25519Key(rand.Reader)
+		require.NoError(t, err)
+		id, err := peer.IDFromPublicKey(k.GetPublic())
+		require.NoError(t, err)
+		return id
+	}
+
+	miner := newPeerID()
+	atThreshold := newPeerID()
+	noBlocks := newPeerID()
+	lowRep := newPeerID()
+	unknown := newPeerID()
+
+	client := &registryStubP2PClient{peers: []*p2p.PeerInfo{
+		{ID: miner, BlocksReceived: 1, ReputationScore: 90},
+		{ID: atThreshold, BlocksReceived: 1, ReputationScore: 50},
+		{ID: noBlocks, BlocksReceived: 0, ReputationScore: 100},
+		{ID: lowRep, BlocksReceived: 50, ReputationScore: 10},
+	}}
+
+	cache := newPeerTierCache(ulogger.TestLogger{}, client, 50)
+	cache.refresh(context.Background())
+
+	require.Equal(t, tierMiner, cache.GetTier(miner))
+	require.Equal(t, tierMiner, cache.GetTier(atThreshold), "reputation exactly at threshold qualifies")
+	require.Equal(t, tierPeer, cache.GetTier(noBlocks), "no blocks received must not be a miner")
+	require.Equal(t, tierPeer, cache.GetTier(lowRep), "reputation below threshold must not be a miner")
+	require.Equal(t, tierUnverified, cache.GetTier(unknown))
 }
 
 // TestParsePeerAuthAllowlist — parsing of the pipe-separated config value.

--- a/services/p2p/Client.go
+++ b/services/p2p/Client.go
@@ -877,6 +877,9 @@ func convertFromAPIPeerInfo(apiPeer interface{}) (*PeerInfo, error) {
 			CatchupAttempts:        p.CatchupAttempts,
 			CatchupSuccesses:       p.CatchupSuccesses,
 			CatchupFailures:        p.CatchupFailures,
+			BlocksReceived:         p.BlocksReceived,
+			SubtreesReceived:       p.SubtreesReceived,
+			TransactionsReceived:   p.TransactionsReceived,
 		}, nil
 
 	default:

--- a/services/p2p/Client_test.go
+++ b/services/p2p/Client_test.go
@@ -957,7 +957,14 @@ func TestSimpleClientGetPeerRegistry(t *testing.T) {
 			GetPeerRegistryFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*p2p_api.GetPeerRegistryResponse, error) {
 				return &p2p_api.GetPeerRegistryResponse{
 					Peers: []*p2p_api.PeerRegistryInfo{
-						{Id: "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz", Height: 99, IsConnected: true},
+						{
+							Id:                   "12D3KooWBhWMmHCXuyfM48dEPRsBzkemQQu71yC9rR2zHGmAjzQz",
+							Height:               99,
+							IsConnected:          true,
+							BlocksReceived:       3,
+							SubtreesReceived:     4,
+							TransactionsReceived: 5,
+						},
 					},
 				}, nil
 			},
@@ -966,6 +973,9 @@ func TestSimpleClientGetPeerRegistry(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, peers, 1)
 		require.Equal(t, uint32(99), peers[0].Height)
+		require.Equal(t, int64(3), peers[0].BlocksReceived)
+		require.Equal(t, int64(4), peers[0].SubtreesReceived)
+		require.Equal(t, int64(5), peers[0].TransactionsReceived)
 	})
 	t.Run("grpc_error", func(t *testing.T) {
 		client := newClientWithMock(&MockPeerServiceClient{

--- a/services/p2p/Interface.go
+++ b/services/p2p/Interface.go
@@ -213,7 +213,10 @@ type ClientI interface {
 	IsPeerUnhealthy(ctx context.Context, peerID string) (bool, string, float32, error)
 
 	// GetPeerRegistry retrieves the comprehensive peer registry data.
-	// Returns all peers in the registry with their complete information.
+	// Returns all peers in the registry with the subset of PeerInfo carried by
+	// p2p_api.PeerRegistryInfo (see convertFromAPIPeerInfo); in-process sync
+	// backoff state (LastSyncAttempt, SyncAttemptCount, LastReputationReset,
+	// ReputationResetCount) and CatchupBlocks are not transmitted.
 	GetPeerRegistry(ctx context.Context) ([]*PeerInfo, error)
 
 	// RecordBytesDownloaded records the number of bytes downloaded via HTTP from a peer.

--- a/services/p2p/Server.go
+++ b/services/p2p/Server.go
@@ -3139,6 +3139,9 @@ func peerInfoToP2PProto(p *blockchain.PeerInfo) *p2p_api.PeerRegistryInfo {
 		CatchupAttempts:        p.CatchupAttempts,
 		CatchupSuccesses:       p.CatchupSuccesses,
 		CatchupFailures:        p.CatchupFailures,
+		BlocksReceived:         p.BlocksReceived,
+		SubtreesReceived:       p.SubtreesReceived,
+		TransactionsReceived:   p.TransactionsReceived,
 	}
 }
 

--- a/services/p2p/p2p_api/p2p_api.pb.go
+++ b/services/p2p/p2p_api/p2p_api.pb.go
@@ -2399,8 +2399,15 @@ type PeerRegistryInfo struct {
 	CatchupAttempts  int64 `protobuf:"varint,27,opt,name=catchup_attempts,json=catchupAttempts,proto3" json:"catchup_attempts,omitempty"`
 	CatchupSuccesses int64 `protobuf:"varint,28,opt,name=catchup_successes,json=catchupSuccesses,proto3" json:"catchup_successes,omitempty"`
 	CatchupFailures  int64 `protobuf:"varint,29,opt,name=catchup_failures,json=catchupFailures,proto3" json:"catchup_failures,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Interaction type breakdown, incremented by RecordBlockReceived,
+	// RecordSubtreeReceived and RecordTransactionReceived on the blockchain peer
+	// registry. blocks_received drives the asset service's miner-tier
+	// rate-limit exemption, so it must survive the gRPC hop.
+	BlocksReceived       int64 `protobuf:"varint,30,opt,name=blocks_received,json=blocksReceived,proto3" json:"blocks_received,omitempty"`
+	SubtreesReceived     int64 `protobuf:"varint,31,opt,name=subtrees_received,json=subtreesReceived,proto3" json:"subtrees_received,omitempty"`
+	TransactionsReceived int64 `protobuf:"varint,32,opt,name=transactions_received,json=transactionsReceived,proto3" json:"transactions_received,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *PeerRegistryInfo) Reset() {
@@ -2618,6 +2625,27 @@ func (x *PeerRegistryInfo) GetCatchupSuccesses() int64 {
 func (x *PeerRegistryInfo) GetCatchupFailures() int64 {
 	if x != nil {
 		return x.CatchupFailures
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetBlocksReceived() int64 {
+	if x != nil {
+		return x.BlocksReceived
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetSubtreesReceived() int64 {
+	if x != nil {
+		return x.SubtreesReceived
+	}
+	return 0
+}
+
+func (x *PeerRegistryInfo) GetTransactionsReceived() int64 {
+	if x != nil {
+		return x.TransactionsReceived
 	}
 	return 0
 }
@@ -3020,7 +3048,7 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"\x17IsPeerUnhealthyResponse\x12!\n" +
 	"\fis_unhealthy\x18\x01 \x01(\bR\visUnhealthy\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12)\n" +
-	"\x10reputation_score\x18\x03 \x01(\x02R\x0freputationScore\"\xe7\b\n" +
+	"\x10reputation_score\x18\x03 \x01(\x02R\x0freputationScore\"\xf2\t\n" +
 	"\x10PeerRegistryInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\rR\x06height\x12\x1d\n" +
@@ -3052,7 +3080,10 @@ const file_services_p2p_p2p_api_p2p_api_proto_rawDesc = "" +
 	"\x17last_catchup_error_time\x18\x1a \x01(\x03R\x14lastCatchupErrorTime\x12)\n" +
 	"\x10catchup_attempts\x18\x1b \x01(\x03R\x0fcatchupAttempts\x12+\n" +
 	"\x11catchup_successes\x18\x1c \x01(\x03R\x10catchupSuccesses\x12)\n" +
-	"\x10catchup_failures\x18\x1d \x01(\x03R\x0fcatchupFailures\"J\n" +
+	"\x10catchup_failures\x18\x1d \x01(\x03R\x0fcatchupFailures\x12'\n" +
+	"\x0fblocks_received\x18\x1e \x01(\x03R\x0eblocksReceived\x12+\n" +
+	"\x11subtrees_received\x18\x1f \x01(\x03R\x10subtreesReceived\x123\n" +
+	"\x15transactions_received\x18  \x01(\x03R\x14transactionsReceived\"J\n" +
 	"\x17GetPeerRegistryResponse\x12/\n" +
 	"\x05peers\x18\x01 \x03(\v2\x19.p2p_api.PeerRegistryInfoR\x05peers\"b\n" +
 	"\x1cRecordBytesDownloadedRequest\x12\x17\n" +

--- a/services/p2p/p2p_api/p2p_api.proto
+++ b/services/p2p/p2p_api/p2p_api.proto
@@ -281,6 +281,14 @@ message AddBanScoreRequest {
     int64 catchup_attempts = 27;
     int64 catchup_successes = 28;
     int64 catchup_failures = 29;
+
+    // Interaction type breakdown, incremented by RecordBlockReceived,
+    // RecordSubtreeReceived and RecordTransactionReceived on the blockchain peer
+    // registry. blocks_received drives the asset service's miner-tier
+    // rate-limit exemption, so it must survive the gRPC hop.
+    int64 blocks_received = 30;
+    int64 subtrees_received = 31;
+    int64 transactions_received = 32;
   }
 
   message GetPeerRegistryResponse {

--- a/services/p2p/server_handler_test.go
+++ b/services/p2p/server_handler_test.go
@@ -2,6 +2,8 @@ package p2p
 
 import (
 	"context"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/bsv-blockchain/teranode/services/p2p/p2p_api"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -46,6 +49,9 @@ func TestServer_PeerInfoToP2PProto_RoundTripFields(t *testing.T) {
 		CatchupAttempts:        7,
 		CatchupSuccesses:       5,
 		CatchupFailures:        2,
+		BlocksReceived:         11,
+		SubtreesReceived:       12,
+		TransactionsReceived:   13,
 	}
 
 	out := peerInfoToP2PProto(bp)
@@ -64,6 +70,91 @@ func TestServer_PeerInfoToP2PProto_RoundTripFields(t *testing.T) {
 	require.Equal(t, bp.CatchupAttempts, out.CatchupAttempts)
 	require.Equal(t, bp.CatchupSuccesses, out.CatchupSuccesses)
 	require.Equal(t, bp.CatchupFailures, out.CatchupFailures)
+	require.Equal(t, bp.BlocksReceived, out.BlocksReceived)
+	require.Equal(t, bp.SubtreesReceived, out.SubtreesReceived)
+	require.Equal(t, bp.TransactionsReceived, out.TransactionsReceived)
+}
+
+// TestServer_GetPeerRegistry_ReceivedCountersSurviveWire drives the path a
+// gRPC consumer (the asset service's miner-tier cache) takes: the blockchain
+// registry records received blocks/subtrees/txs, GetPeerRegistry builds the
+// proto, the message is marshalled and unmarshalled as gRPC would, and the
+// client-side converter maps it back. The asset service's tierMiner predicate
+// requires BlocksReceived > 0, so a zero here silently demotes every miner to
+// the ordinary per-peer rate limit.
+func TestServer_GetPeerRegistry_ReceivedCountersSurviveWire(t *testing.T) {
+	s, reg := newServerWithLocalRegistry(t)
+	pid := mustNewPeerID(t)
+	s.addConnectedPeer(pid, "miner/1.0", 10, nil, "")
+
+	reg.RecordBlockReceived(pid.String(), 5)
+	reg.RecordBlockReceived(pid.String(), 5)
+	reg.RecordSubtreeReceived(pid.String(), 5)
+	reg.RecordTransactionReceived(pid.String())
+
+	resp, err := s.GetPeerRegistry(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.Len(t, resp.Peers, 1)
+
+	wire, err := proto.Marshal(resp.Peers[0])
+	require.NoError(t, err)
+	decoded := &p2p_api.PeerRegistryInfo{}
+	require.NoError(t, proto.Unmarshal(wire, decoded))
+
+	got, err := convertFromAPIPeerInfo(decoded)
+	require.NoError(t, err)
+	require.Equal(t, pid, got.ID)
+	require.Equal(t, int64(2), got.BlocksReceived)
+	require.Equal(t, int64(1), got.SubtreesReceived)
+	require.Equal(t, int64(1), got.TransactionsReceived)
+}
+
+// TestServer_PeerRegistryInfo_CarriesEveryPeerInfoField is the guard against the
+// class of bug fixed above: a field added to the public p2p.PeerInfo contract but
+// never given a wire field, so gRPC consumers silently read a zero. Every
+// exported p2p.PeerInfo field must have a counterpart in p2p_api.PeerRegistryInfo
+// unless it is explicitly listed as intentionally in-process only.
+func TestServer_PeerRegistryInfo_CarriesEveryPeerInfoField(t *testing.T) {
+	// Fields deliberately not carried over gRPC. Adding a name here is a
+	// contract decision: document the reason.
+	notOnWire := map[string]string{
+		"CatchupBlocks":        "no writer exists yet; add a wire field when one does",
+		"LastSyncAttempt":      "sync backoff state is local to the p2p process",
+		"SyncAttemptCount":     "sync backoff state is local to the p2p process",
+		"LastReputationReset":  "sync backoff state is local to the p2p process",
+		"ReputationResetCount": "sync backoff state is local to the p2p process",
+	}
+	// Domain fields whose wire name differs beyond letter case.
+	renamed := map[string]string{
+		"AvgResponseTime": "AvgResponseTimeMs",
+	}
+
+	wireFields := map[string]bool{}
+	wt := reflect.TypeOf(p2p_api.PeerRegistryInfo{})
+	for i := 0; i < wt.NumField(); i++ {
+		wireFields[strings.ToLower(wt.Field(i).Name)] = true
+	}
+
+	dt := reflect.TypeOf(PeerInfo{})
+	for i := 0; i < dt.NumField(); i++ {
+		name := dt.Field(i).Name
+		if !dt.Field(i).IsExported() {
+			continue
+		}
+		if _, ok := notOnWire[name]; ok {
+			continue
+		}
+		if alias, ok := renamed[name]; ok {
+			name = alias
+		}
+		require.True(t, wireFields[strings.ToLower(name)],
+			"p2p.PeerInfo.%s has no p2p_api.PeerRegistryInfo field; add one (and map it in peerInfoToP2PProto/convertFromAPIPeerInfo) or list it in notOnWire", dt.Field(i).Name)
+	}
+
+	for name := range notOnWire {
+		_, ok := dt.FieldByName(name)
+		require.True(t, ok, "notOnWire lists %s, which is no longer a p2p.PeerInfo field", name)
+	}
 }
 
 func TestServer_PeerInfoToP2PProto_NilHashAndZeroTimes(t *testing.T) {


### PR DESCRIPTION
**Closes bitcoin-sv/teranode#4760.**

### Problem
`p2p_api.PeerRegistryInfo` carried none of the interaction-type counters (`blocks_received`, `subtrees_received`, `transactions_received`, `catchup_blocks`), so `peerInfoToP2PProto` and `convertFromAPIPeerInfo` silently dropped them even though `blockchain.PeerInfo` populates them and `p2p.PeerInfo` documents them as part of the public contract. The asset service's `peerTierCache.refresh` classifies `tierMiner` only when `BlocksReceived > 0`, and the gRPC client is the only `ClientI` implementation, so in a real microservice deployment no allowlisted miner was ever promoted and all were capped at the ordinary per-peer rate limit.

All cited locations confirmed still valid on `upstream/main`.

### Fix
- Add fields 30-32 (`blocks_received`, `subtrees_received`, `transactions_received`) to `PeerRegistryInfo`, mirroring the names already used in `blockchain_api.proto`, and regenerate `p2p_api.pb.go`. `catchup_blocks` is deliberately not added: nothing in the repo writes `CatchupBlocks`, so a wire field would be permanently zero.
- Populate them in `peerInfoToP2PProto` (Server.go) and map them back in `convertFromAPIPeerInfo` (Client.go).
- Update the generated proto docs table (`docs/references/protobuf_docs/p2pProto.md`), which was also missing the existing `catchup_*` rows, and correct the `GetPeerRegistry` doc in `Interface.go`, which promised "complete information" while several fields never cross the wire.

No change to the `tierMiner` predicate: the field is the right signal, it was just never transmitted.

Rolling upgrade: a new asset service against an old p2p service still reads `BlocksReceived == 0`, so miners stay at `tierPeer` until p2p is upgraded. Fails closed (stricter limit), same as today.

### Residual
Pre-existing, not introduced here: `convertFromAPIPeerInfo` maps a `0` unix timestamp to `time.Unix(0, 0)`, which is not `IsZero()`. No gRPC consumer relies on `IsZero()` today (`sync_coordinator` uses the in-process registry client). Worth a separate follow-up.

### Tests
- `TestServer_PeerInfoToP2PProto_RoundTripFields`: now asserts the three counters.
- `TestServer_GetPeerRegistry_ReceivedCountersSurviveWire` (new): registry `RecordBlockReceived`/`RecordSubtreeReceived`/`RecordTransactionReceived` -> `Server.GetPeerRegistry` -> `proto.Marshal`/`Unmarshal` -> `convertFromAPIPeerInfo`, asserting the counters survive the wire message.
- `TestServer_PeerRegistryInfo_CarriesEveryPeerInfoField` (new): reflection guard that every exported `p2p.PeerInfo` field has a `PeerRegistryInfo` counterpart unless listed in an explicit, documented not-on-wire allowlist. This turns the class of bug behind this issue into a test failure.
- `TestSimpleClientGetPeerRegistry`: gRPC client maps the three proto fields onto `p2p.PeerInfo`.
- `TestPeerTierCache_Refresh_ClassifiesByBlocksReceived` (new, asset): `refresh` promotes only `BlocksReceived > 0` with reputation at or above the threshold to `tierMiner`.

```
SETTINGS_CONTEXT=test go test -race -tags "testtxmetacache" -count=1 ./services/p2p/...   # ok
go vet -tags testtxmetacache ./services/asset/httpimpl/ ./services/p2p/                    # ok
```

`services/asset/httpimpl` tests could not be executed locally (pre-existing GoBDK cgo link failure on this machine); they type-check and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
