### PR TITLE
test: fix CI fixtures after transaction re-extension (release/v0.15)

### DIFF
--- a/docs/topics/services/alert.md
+++ b/docs/topics/services/alert.md
@@ -138,6 +138,16 @@ The Alert Service initializes the necessary components and services to start pro
 
 ### 2.4. UTXO Reassignment
 
+**Current limitation:** `ReAssignUTXO` updates the UTXO commitment, clears the freeze,
+and sets a maturity height, but does not persist the replacement locking script.
+Mandatory transaction re-extension therefore still retrieves the original script
+from the UTXO store. A spend signed only for the replacement owner is rejected even
+after maturity; supplying the replacement script in extended transaction bytes
+cannot authorize it. Supporting a different owner requires an authoritative source
+for the replacement script and corresponding validation support. Reassignment to
+the stored owner still enforces the maturity delay and permits a valid spend after
+that delay. The reassignment smoke test covers both behaviors.
+
 ![alert_reassign_utxo.svg](img/plantuml/alert/alert_reassign_utxo.svg)
 
 1. The P2P Alert library initiates the process by calling `AddToConfiscationTransactionWhitelist` with a list of transactions.

--- a/services/propagation/Server_test.go
+++ b/services/propagation/Server_test.go
@@ -924,21 +924,29 @@ func testProcessTransactionInternal(t *testing.T, utxoStoreURL string) {
 			numGoroutines = 10
 		}
 
-		// add the transaction in parallel
+		// Each submission owns its decoded transaction, as real ingress does.
+		// Validation re-extends inputs in place; sharing pointers across requests
+		// races even though the transactions have identical txids.
+		tx2Bytes, tx3Bytes := txs[2].ExtendedBytes(), txs[3].ExtendedBytes()
 		for i := 0; i < numGoroutines; i++ {
+			tx2, err := bt.NewTxFromBytes(tx2Bytes)
+			require.NoError(t, err)
+			tx3, err := bt.NewTxFromBytes(tx3Bytes)
+			require.NoError(t, err)
+
 			g.Go(func() error {
-				if err := ps.processTransactionInternal(t.Context(), txs[2]); err != nil {
+				if err := ps.processTransactionInternal(t.Context(), tx2); err != nil {
 					return err
 				}
 
-				return ps.processTransactionInternal(t.Context(), txs[3])
+				return ps.processTransactionInternal(t.Context(), tx3)
 			})
 		}
 
 		require.NoError(t, g.Wait(), "processTransactionInternal should not return an error for valid transaction")
 
 		// make sure we only added the transaction once to block assembly
-		assert.Len(t, blockAssemblyClient.Mock.Calls, 2, "processTransactionInternal should only call block assembly once for the same transaction")
+		require.Len(t, blockAssemblyClient.Mock.Calls, 2, "processTransactionInternal should only call block assembly once for the same transaction")
 	})
 }
 

--- a/services/validator/utxo_commitment_ambiguity_test.go
+++ b/services/validator/utxo_commitment_ambiguity_test.go
@@ -181,6 +181,10 @@ func TestValidate_RejectsGenuineUnspendableOutput(t *testing.T) {
 	for _, f := range ambiguityFixtures {
 		t.Run(f.name, func(t *testing.T) {
 			v, parent, ctx := newAmbiguityValidator(t, "ambiguity_honest_"+f.name, f)
+			// The zero-value fixture cannot pay a fee. Disable the fee requirement
+			// explicitly so CI policy settings cannot mask the script failure.
+			v.settings.Policy.MinMiningTxFee = 0
+			v.txValidator = NewTxValidator(v.logger, v.settings)
 
 			honest := spendOf(t, parent, f.realScript, f.realSats, 0)
 

--- a/test/e2e/daemon/ready/reassign_test.go
+++ b/test/e2e/daemon/ready/reassign_test.go
@@ -71,7 +71,7 @@ func TestShouldAllowReassign(t *testing.T) {
 
 	aliceToBobTx := td.CreateTransactionWithOptions(t,
 		transactions.WithInput(parentTx, 0, alicePrivateKey),
-		transactions.WithP2PKHOutputs(1, 10000, bob),
+		transactions.WithP2PKHOutputs(2, 10000, bob),
 	)
 
 	// Send Alice to Bob transaction
@@ -100,7 +100,13 @@ func TestShouldAllowReassign(t *testing.T) {
 		UTXOHash: aliceBobUtxoHash,
 	}
 
-	err = td.UtxoStore.FreezeUTXOs(td.Ctx, []*utxo.Spend{spend}, td.Settings)
+	// Keep a second output assigned to its stored owner to test the maturity
+	// gate independently of changing the locking script.
+	sameOwnerHash, err := util.UTXOHashFromOutput(aliceToBobTx.TxIDChainHash(), aliceToBobTx.Outputs[1], 1)
+	require.NoError(t, err)
+	sameOwnerSpend := &utxo.Spend{TxID: aliceToBobTx.TxIDChainHash(), Vout: 1, UTXOHash: sameOwnerHash}
+
+	err = td.UtxoStore.FreezeUTXOs(td.Ctx, []*utxo.Spend{spend, sameOwnerSpend}, td.Settings)
 	require.NoError(t, err)
 
 	amendedOutputScript := &bt.Output{
@@ -121,7 +127,20 @@ func TestShouldAllowReassign(t *testing.T) {
 	err = td.UtxoStore.ReAssignUTXO(td.Ctx, spend, newSpend, td.Settings)
 	require.NoError(t, err)
 
-	// Try to spend the reassigned UTXO before reassignment height - should fail
+	require.NoError(t, td.UtxoStore.ReAssignUTXO(td.Ctx, sameOwnerSpend, sameOwnerSpend, td.Settings))
+	bobSpendingTx := td.CreateTransactionWithOptions(t,
+		transactions.WithInput(aliceToBobTx, 1, bobPrivateKey),
+		transactions.WithP2PKHOutputs(1, 100, charles),
+	)
+	status, err := td.UtxoStore.GetSpend(td.Ctx, sameOwnerSpend)
+	require.NoError(t, err)
+	require.Equal(t, int(utxo.Status_IMMATURE), status.Status)
+	require.Error(t, td.PropagationClient.ProcessTransaction(td.Ctx, bobSpendingTx),
+		"a valid signature must not bypass the reassignment maturity gate")
+
+	// ReAssignUTXO changes the commitment, not the stored locking script.
+	// The validator must not accept Charles's replacement script supplied in
+	// extended transaction bytes, before or after the maturity height.
 	charlesSpendingTx := bt.NewTx()
 	charlesUtxo := &bt.UTXO{
 		TxIDHash:      aliceToBobTx.TxIDChainHash(),
@@ -140,12 +159,23 @@ func TestShouldAllowReassign(t *testing.T) {
 	require.NoError(t, err)
 
 	err = td.PropagationClient.ProcessTransaction(td.Ctx, charlesSpendingTx)
-	require.Error(t, err, "Transaction should be rejected since UTXO is not spendable until reassignment height")
+	require.Error(t, err, "an unstored replacement script must not be accepted")
 
 	// Generate blocks to reach reassignment height
 	td.MineAndWait(t, testReassignedUtxoSpendableAfter)
 
-	// Now try spending the reassigned UTXO - should succeed
-	err = td.PropagationClient.ProcessTransaction(td.Ctx, charlesSpendingTx)
+	// The changed commitment has matured, but it does not authorize trusting
+	// the submitter's replacement script. Ownership-changing reassignment
+	// needs an authoritative script source in addition to ReAssignUTXO.
+	status, err = td.UtxoStore.GetSpend(td.Ctx, newSpend)
 	require.NoError(t, err)
+	require.Equal(t, int(utxo.Status_OK), status.Status)
+	require.Error(t, td.PropagationClient.ProcessTransaction(td.Ctx, charlesSpendingTx),
+		"maturity must not make an unstored replacement script authoritative")
+	status, err = td.UtxoStore.GetSpend(td.Ctx, newSpend)
+	require.NoError(t, err)
+	require.Nil(t, status.SpendingData, "the rejected transaction must leave the output unspent")
+
+	// The same-owner output now passes both script validation and the height gate.
+	require.NoError(t, td.PropagationClient.ProcessTransaction(td.Ctx, bobSpendingTx))
 }


### PR DESCRIPTION
Backport of https://github.com/bsv-blockchain/teranode/pull/1721 to `release/v0.15`. The test and documentation changes are identical to main, with no branch-specific adjustments.

Mandatory transaction re-extension exposed three test assumptions: concurrent propagation submissions shared a mutable transaction, the zero-value script fixture depended on the configured minimum fee, and the reassignment smoke test trusted a replacement script that was never stored.

This change gives each concurrent submission its own decoded transaction while retaining the duplicate-submission assertion, explicitly disables the minimum fee only for the unspendable-script control, and checks reassignment maturity with a spend signed for the stored owner. The smoke test also verifies that an unstored replacement script remains rejected after maturity and leaves the output unspent.

**Reassignment limitation:** `ReAssignUTXO` changes the commitment and maturity state but does not persist the replacement locking script. Re-extension therefore retrieves the original script. Supporting a different owner requires an authoritative replacement-script source and corresponding validation support. This limitation is documented in the alert-service guide; production code is unchanged.

Validation on this branch:
- Full propagation and validator packages with `SETTINGS_CONTEXT=test`, the race detector, and `testtxmetacache`, including real Aerospike/PostgreSQL containers.
- Targeted propagation concurrency tests and reassignment smoke test, each repeated three times with the race detector.
- `go vet` and `staticcheck` for the three affected packages.
- Repository pre-commit checks, including Go lint and Markdown lint.

The zero-value fixture's `insufficient-fee` failure was reproduced with a nonzero minimum fee before verifying the fix.

A broader local run also hit an HTTP startup failure on main and a batch-test failure on release. Both full propagation packages and three isolated runs of the release batch test passed on rerun. These tests are unchanged by this patch.
