### PR TITLE
fix(security): backport checkpoint ancestry validation to v0.15

### DIFF
--- a/model/Block.go
+++ b/model/Block.go
@@ -411,6 +411,10 @@ func (b *Block) Valid(ctx context.Context, logger ulogger.Logger, subtreeStore S
 	)
 	defer deferFn()
 
+	if err := b.Header.HasMetPowLimit(settings.ChainCfgParams); err != nil {
+		return false, errors.NewBlockInvalidError("[BLOCK][%s] block declares a target easier than the network proof-of-work limit", b.String(), err)
+	}
+
 	// 1. Check that the block header hash is less than the target difficulty.
 	headerValid, _, err := b.Header.HasMetTargetDifficulty()
 	if err != nil {

--- a/model/BlockHeader.go
+++ b/model/BlockHeader.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/go-wire"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/util"
@@ -317,4 +318,64 @@ func (bh *BlockHeader) Bytes() []byte {
 	blockHeaderBytes = append(blockHeaderBytes, uint32Bytes...)
 
 	return blockHeaderBytes
+}
+
+// HasMetPowLimit checks the target the header DECLARES against the network's
+// proof-of-work limit. It is the necessary companion to HasMetTargetDifficulty,
+// which only asks whether the hash meets the target the header chose for itself
+// — a question a fabricated header answers trivially by choosing an easy target.
+//
+// Without this floor, nBits=0x207fffff yields a target of roughly 2^255, met by
+// about every second nonce, so a header costs two hashes. That is the free
+// proof-of-work step of GHSA-gggq-8f59-4jm9. The expected-nBits (DAA) rule is
+// the check that truly binds a block's difficulty to the chain it claims to
+// extend, but it is skipped over the checkpoint-certified prefix and is not run
+// by legacy ingestion at all, so this cheap bound is what makes a hoisted
+// proof-of-work check meaningful before any expensive or state-mutating work.
+//
+// The ceiling is the LOOSER of PowLimit and the target PowLimitBits encodes.
+// Mainnet uses a roughly 2^224 limit. STN pairs a similar PowLimit with
+// PowLimitBits of 0x207fffff (regtest instead uses a roughly 2^255 PowLimit), and
+// rejecting a block that declares the network's own minimum difficulty would be
+// wrong. Taking the looser of the two keeps the bound meaningful wherever the
+// params are self-consistent without inventing a rule where they are not.
+//
+// Absent params or an absent limit cannot be enforced, so they pass: this is a
+// bound on an attacker-chosen value, not a substitute for the caller's own
+// validation.
+func (bh *BlockHeader) HasMetPowLimit(params *chaincfg.Params) error {
+	if bh == nil || params == nil || params.PowLimit == nil {
+		return nil
+	}
+
+	target := bh.Bits.CalculateTarget()
+
+	// CalculateTarget returns 0 for malformed nBits (negative-encoded or
+	// overflowing 256 bits). A zero target is not a limit violation — no positive
+	// hash can satisfy it — so HasMetTargetDifficulty rejects it with a clearer
+	// error and this check stays out of the way.
+	if target.Sign() == 0 {
+		return nil
+	}
+
+	ceiling := params.PowLimit
+
+	if params.PowLimitBits != 0 {
+		limitBits := make([]byte, 4)
+		binary.LittleEndian.PutUint32(limitBits, params.PowLimitBits)
+
+		if nBit, err := NewNBitFromSlice(limitBits); err == nil {
+			if bitsTarget := nBit.CalculateTarget(); bitsTarget.Cmp(ceiling) > 0 {
+				ceiling = bitsTarget
+			}
+		}
+	}
+
+	if target.Cmp(ceiling) > 0 {
+		return errors.NewBlockInvalidError(
+			"block nBits %s declares target %x, which is easier than the network proof-of-work limit %x",
+			bh.Bits.String(), target, ceiling)
+	}
+
+	return nil
 }

--- a/model/BlockHeader_powlimit_test.go
+++ b/model/BlockHeader_powlimit_test.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// nBitFor builds an NBit from a compact-target string as it appears in a block
+// header (big-endian hex, e.g. "1d00ffff").
+func nBitFor(t *testing.T, s string) NBit {
+	t.Helper()
+
+	nb, err := NewNBitFromString(s)
+	require.NoError(t, err)
+
+	return *nb
+}
+
+// TestHasMetPowLimit_RejectsFreeTarget is the regression test for the free
+// proof-of-work half of GHSA-gggq-8f59-4jm9. The reported attack declared
+// nBits=0x207fffff — a target of roughly 2^255, met by about every second nonce
+// — and nothing compared that target against the network's own limit, so a
+// fabricated header cost two hashes. HasMetTargetDifficulty cannot catch this on
+// its own: it only asks whether the hash meets the target the attacker chose.
+func TestHasMetPowLimit_RejectsFreeTarget(t *testing.T) {
+	bh := &BlockHeader{Bits: nBitFor(t, "207fffff")}
+
+	err := bh.HasMetPowLimit(&chaincfg.MainNetParams)
+	require.Error(t, err, "mainnet must reject the minimum-difficulty target that made the reported attack free")
+}
+
+// TestHasMetPowLimit_AcceptsNetworkMinimum guards the other direction: the floor
+// must not reject a block that declares exactly the network's own declared
+// minimum difficulty. Mainnet's PowLimitBits is 0x1d00ffff (difficulty 1), which
+// is what the earliest real blocks on the chain carry.
+func TestHasMetPowLimit_AcceptsNetworkMinimum(t *testing.T) {
+	bh := &BlockHeader{Bits: nBitFor(t, "1d00ffff")}
+
+	require.NoError(t, bh.HasMetPowLimit(&chaincfg.MainNetParams),
+		"the network's own minimum-difficulty bits must remain valid")
+}
+
+// TestHasMetPowLimit_AcceptsHarderThanLimit — a real mainnet header at any
+// meaningful height declares a target far harder than the limit.
+func TestHasMetPowLimit_AcceptsHarderThanLimit(t *testing.T) {
+	bh := &BlockHeader{Bits: nBitFor(t, "1810b289")}
+
+	require.NoError(t, bh.HasMetPowLimit(&chaincfg.MainNetParams))
+}
+
+// TestHasMetPowLimit_HonoursLooserNetworkLimit covers the networks whose two
+// declarations of the limit disagree. STN pairs a 2^224 PowLimit with
+// PowLimitBits of 0x207fffff. Enforcing PowLimit alone would reject STN's declared
+// minimum. Regtest already has a roughly 2^255 PowLimit and is a compatibility
+// control; only STN exercises the looser-of-two rule.
+func TestHasMetPowLimit_HonoursLooserNetworkLimit(t *testing.T) {
+	for _, params := range []*chaincfg.Params{&chaincfg.StnParams, &chaincfg.RegressionNetParams} {
+		params := params
+
+		t.Run(params.Name, func(t *testing.T) {
+			bh := &BlockHeader{Bits: nBitFor(t, "207fffff")}
+
+			require.NoError(t, bh.HasMetPowLimit(params),
+				"%s declares PowLimitBits 0x207fffff, so that target must be accepted there", params.Name)
+		})
+	}
+}
+
+// TestHasMetPowLimit_MalformedBitsDeferToTargetCheck — NBit.CalculateTarget
+// returns 0 for negative-encoded or overflowing nBits. A zero target is not a
+// limit violation: no positive hash can satisfy it, so HasMetTargetDifficulty
+// rejects it with a clearer error. The floor must not claim it as its own.
+func TestHasMetPowLimit_MalformedBitsDeferToTargetCheck(t *testing.T) {
+	bh := &BlockHeader{Bits: nBitFor(t, "20800000")}
+
+	require.NoError(t, bh.HasMetPowLimit(&chaincfg.MainNetParams),
+		"malformed nBits are HasMetTargetDifficulty's rejection, not the floor's")
+}
+
+// TestHasMetPowLimit_NilSafe — the floor is called on paths where params may be
+// unset (unit tests, mis-wired settings). It must not panic, and an absent limit
+// cannot be enforced.
+func TestHasMetPowLimit_NilSafe(t *testing.T) {
+	bh := &BlockHeader{Bits: nBitFor(t, "207fffff")}
+
+	require.NoError(t, bh.HasMetPowLimit(nil))
+	require.NoError(t, bh.HasMetPowLimit(&chaincfg.Params{}))
+
+	var nilHeader *BlockHeader
+	require.NoError(t, nilHeader.HasMetPowLimit(&chaincfg.MainNetParams))
+}

--- a/model/block_valid_powlimit_test.go
+++ b/model/block_valid_powlimit_test.go
@@ -1,0 +1,36 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockValidEnforcesPowLimit(t *testing.T) {
+	for _, params := range []*chaincfg.Params{&chaincfg.MainNetParams, &chaincfg.RegressionNetParams, &chaincfg.StnParams} {
+		t.Run(params.Name, func(t *testing.T) {
+			block := &Block{Header: &BlockHeader{HashPrevBlock: &chainhash.Hash{}, HashMerkleRoot: &chainhash.Hash{}, Bits: nBitFor(t, "207fffff")}}
+			for {
+				if valid, _, _ := block.Header.HasMetTargetDifficulty(); valid {
+					break
+				}
+				block.Header.Nonce++
+			}
+			cfg := settings.NewSettings()
+			cfg.ChainCfgParams = params
+			// No coinbase or stores: a valid network target must advance to the body gate.
+			valid, err := block.Valid(context.Background(), ulogger.TestLogger{}, nil, nil, nil, nil, nil, cfg, nil)
+			require.False(t, valid)
+			if params == &chaincfg.MainNetParams {
+				require.ErrorContains(t, err, "network proof-of-work limit")
+			} else {
+				require.ErrorContains(t, err, "coinbase")
+			}
+		})
+	}
+}

--- a/model/check_duplicate_txs.go
+++ b/model/check_duplicate_txs.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+)
+
+// CheckSubtreeSlicesForDuplicateTxs is a MANDATORY consensus security floor —
+// not an optimization. It enforces the CVE-2012-2459 duplicate-transaction
+// check on any code path that holds the block's subtree slices in memory but
+// does not go through Block.Valid (which runs the full pooled/disk-backed
+// checkDuplicateTransactions). Every such path MUST call it before creating or
+// spending UTXOs.
+//
+// WHY IT IS REQUIRED (do not remove or gate it on "the block is trusted"):
+// the merkle root CANNOT detect a CVE-2012-2459 duplicate. The merkle tree's
+// duplicate-last-node-when-odd rule means a block whose trailing transactions
+// are duplicated in a specific pattern produces the SAME merkle root — and
+// therefore the same block header and the same block hash — as the honest
+// block. So CheckMerkleRoot passing does NOT imply the transaction list is
+// duplicate-free; this scan is the only thing that catches it.
+//
+// WHY IT STILL APPLIES BELOW THE CHECKPOINT: "below checkpoint" trusts the
+// chain of block HASHES (the header chain is checkpoint-anchored), NOT the
+// block BODIES, which are still downloaded from untrusted peers. A CVE-2012-2459
+// mutation produces a body that hashes to the same, trusted block hash while
+// carrying a repeated transaction — so a below-checkpoint block being "safe"
+// (its hash is on the trusted chain) does not make a peer-supplied body safe.
+// Skipping this on a below-checkpoint fast path is a cheap, peer-triggerable
+// sync-DoS / state-corruption vector, because the mutated body reuses the
+// honest block's proof-of-work (no mining required).
+//
+// It scans every node hash across all subtree slices into a plain Go map,
+// skipping the coinbase placeholder at position [0][0], and returns a
+// BlockInvalidError on the first duplicate. It is intentionally lightweight —
+// O(N) in the total transaction count with one map allocation — so it is cheap
+// enough to run unconditionally on every slice-only path. Callers on the full
+// validation path (Block.Valid) instead use the pooled/disk-backed
+// checkDuplicateTransactions; this helper is the independent floor for the
+// paths that skip it.
+func CheckSubtreeSlicesForDuplicateTxs(slices []*subtreepkg.Subtree) error {
+	// Estimate total node count for the initial map capacity to avoid rehashing.
+	totalNodes := 0
+	for _, st := range slices {
+		if st != nil {
+			totalNodes += len(st.Nodes)
+		}
+	}
+
+	seen := make(map[chainhash.Hash]struct{}, totalNodes)
+
+	for subIdx, subtree := range slices {
+		if subtree == nil {
+			continue
+		}
+		for txIdx, node := range subtree.Nodes {
+			// Skip the coinbase placeholder (all-0xFF hash) that occupies the
+			// first position of the first subtree. It is not a real transaction
+			// hash and must not be deduped against itself.
+			if subIdx == 0 && txIdx == 0 && node.Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue) {
+				continue
+			}
+
+			if _, exists := seen[node.Hash]; exists {
+				return errors.NewBlockInvalidError(
+					"[CheckSubtreeSlicesForDuplicateTxs] block contains duplicate transaction %s (CVE-2012-2459)",
+					node.Hash.String(),
+				)
+			}
+			seen[node.Hash] = struct{}{}
+		}
+	}
+
+	return nil
+}

--- a/model/check_duplicate_txs_test.go
+++ b/model/check_duplicate_txs_test.go
@@ -1,0 +1,231 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// randHash returns a deterministic non-placeholder hash seeded by n.
+func randHash(n byte) chainhash.Hash {
+	var h chainhash.Hash
+	h[0] = n
+	h[1] = 0xAB
+	return h
+}
+
+// subtreeWithHashes builds a *subtreepkg.Subtree whose Nodes contain
+// exactly the hashes provided, in order.
+func subtreeWithHashes(hashes ...chainhash.Hash) *subtreepkg.Subtree {
+	st := &subtreepkg.Subtree{}
+	for _, h := range hashes {
+		h := h
+		st.Nodes = append(st.Nodes, subtreepkg.Node{Hash: h})
+	}
+	return st
+}
+
+// TestCheckSubtreeSlicesForDuplicateTxs_Clean verifies that a set of
+// slices with no duplicate hashes passes without error.
+func TestCheckSubtreeSlicesForDuplicateTxs_Clean(t *testing.T) {
+	slices := []*subtreepkg.Subtree{
+		// First subtree: coinbase placeholder + two unique txs
+		subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, randHash(1), randHash(2)),
+		// Second subtree: two more unique txs
+		subtreeWithHashes(randHash(3), randHash(4)),
+	}
+
+	err := CheckSubtreeSlicesForDuplicateTxs(slices)
+	require.NoError(t, err, "clean slices must pass dedup check")
+}
+
+// TestCheckSubtreeSlicesForDuplicateTxs_DuplicateAcrossSubtrees verifies that
+// a hash present in two different subtrees is caught.
+func TestCheckSubtreeSlicesForDuplicateTxs_DuplicateAcrossSubtrees(t *testing.T) {
+	dup := randHash(0x42)
+
+	slices := []*subtreepkg.Subtree{
+		subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, dup, randHash(1)),
+		subtreeWithHashes(dup, randHash(2)), // dup repeated
+	}
+
+	err := CheckSubtreeSlicesForDuplicateTxs(slices)
+	require.Error(t, err, "duplicate hash must be detected")
+
+	var terr *errors.Error
+	require.ErrorAs(t, err, &terr)
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid), "error must be BlockInvalid")
+}
+
+// TestCheckSubtreeSlicesForDuplicateTxs_DuplicateWithinOneSubtree verifies that
+// two identical hashes inside the same subtree are caught.
+func TestCheckSubtreeSlicesForDuplicateTxs_DuplicateWithinOneSubtree(t *testing.T) {
+	dup := randHash(0xBE)
+
+	slices := []*subtreepkg.Subtree{
+		subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, dup, dup),
+	}
+
+	err := CheckSubtreeSlicesForDuplicateTxs(slices)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+}
+
+// TestCheckSubtreeSlicesForDuplicateTxs_CoinbasePlaceholderAllowed verifies that
+// the coinbase placeholder appearing exactly once at position [0][0] is not
+// treated as a duplicate.
+func TestCheckSubtreeSlicesForDuplicateTxs_CoinbasePlaceholderAllowed(t *testing.T) {
+	// Only one subtree: coinbase placeholder alone — trivially clean.
+	slices := []*subtreepkg.Subtree{
+		subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue),
+	}
+
+	err := CheckSubtreeSlicesForDuplicateTxs(slices)
+	require.NoError(t, err, "lone coinbase placeholder must pass")
+}
+
+// TestCheckSubtreeSlicesForDuplicateTxs_EmptySlices verifies that nil/empty
+// input returns no error.
+func TestCheckSubtreeSlicesForDuplicateTxs_EmptySlices(t *testing.T) {
+	require.NoError(t, CheckSubtreeSlicesForDuplicateTxs(nil))
+	require.NoError(t, CheckSubtreeSlicesForDuplicateTxs([]*subtreepkg.Subtree{}))
+}
+
+// TestCheckSubtreeSlicesForDuplicateTxs_NilSubtreeSkipped verifies that a nil
+// element inside the slice is skipped gracefully.
+func TestCheckSubtreeSlicesForDuplicateTxs_NilSubtreeSkipped(t *testing.T) {
+	slices := []*subtreepkg.Subtree{
+		subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, randHash(1)),
+		nil, // must be skipped, not panic
+		subtreeWithHashes(randHash(2)),
+	}
+
+	err := CheckSubtreeSlicesForDuplicateTxs(slices)
+	require.NoError(t, err)
+}
+
+// TestCVE20122459_MerklePassesDedupCatches is the linchpin test for the
+// CVE-2012-2459 defence on the unified below-checkpoint route.
+//
+// # Background — why the merkle root does NOT catch this mutation
+//
+// go-subtree's BuildMerkleTreeStoreFromBytes computes parent nodes with
+// calcMerkle, which, when the right child is the zero hash (returned by
+// getNodeHashAt for any index >= len(nodes)), hashes the left child with itself:
+//
+//	H(left, zeros) → H(left, left)
+//
+// This is the standard Bitcoin "duplicate-last-when-odd" rule.  It means that
+// an honest subtree with N=3 leaf txids  [C, A, B]  and a mutated subtree with
+// N=4 leaf txids  [C, A, B, B]  produce IDENTICAL internal merkle hashes and
+// therefore IDENTICAL subtree roots:
+//
+//	N=3: leaves [C,A,B,zeros], pairs → H(C,A), H(B,B*)  → root = H(H(C,A),H(B,B*))
+//	N=4: leaves [C,A,B,B],    pairs → H(C,A), H(B,B)   → root = H(H(C,A),H(B,B))
+//
+// (where B* = B duplicated because B is at an odd position with no right
+// neighbour, and zeros is the sentinel returned by getNodeHashAt for i>=length)
+//
+// The first subtree's node[0] is the coinbase placeholder; CheckMerkleRoot
+// replaces it with the real coinbase TXID before computing the root.  That
+// replacement is identical in both the honest and mutated cases, so the
+// root-preservation property carries through unchanged.
+//
+// # What the test proves
+//
+//  1. Build an honest single-subtree block with 3 payload nodes:
+//     [coinbase_placeholder, A, B].
+//     Record the merkle root produced by CheckMerkleRoot as the header's
+//     HashMerkleRoot.
+//
+//  2. Build a CVE-mutated subtree with 4 payload nodes:
+//     [coinbase_placeholder, A, B, B]  (B duplicated to make the count even).
+//     Place it on a block whose header carries the HONEST merkle root.
+//
+//  3. Assert CheckMerkleRoot returns NO error on the mutated block — the
+//     duplicate-last rule preserves the root, so the header hash matches.
+//     This demonstrates that CheckMerkleRoot alone cannot reject the mutation.
+//
+//  4. Assert CheckSubtreeSlicesForDuplicateTxs returns a BlockInvalidError on
+//     the same mutated subtree slices — dedup is what actually catches it.
+//
+// The value of having both assertions on the SAME mutated block is that it
+// proves the dedup check is load-bearing, not defence-in-depth.
+func TestCVE20122459_MerklePassesDedupCatches(t *testing.T) {
+	ctx := context.Background()
+
+	// Parse the coinbase transaction used throughout the model tests.
+	coinbase, err := bt.NewTxFromString(CoinbaseHex)
+	require.NoError(t, err)
+
+	txA := randHash(0x0A)
+	txB := randHash(0x0B)
+
+	// ------------------------------------------------------------------ //
+	// Step 1: build the honest block (3 payload nodes) and derive the     //
+	// header's HashMerkleRoot from CheckMerkleRoot's own computation.     //
+	// ------------------------------------------------------------------ //
+
+	honestSubtree := subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, txA, txB)
+
+	// Compute what CheckMerkleRoot will produce for the honest subtree:
+	// RootHashWithReplaceRootNode replaces node[0] with the coinbase TXID.
+	honestRoot, err := honestSubtree.RootHashWithReplaceRootNode(coinbase.TxIDChainHash(), 0, uint64(coinbase.Size())) //nolint:gosec
+	require.NoError(t, err, "honest subtree root must be computable")
+
+	// ------------------------------------------------------------------ //
+	// Step 2: build the mutated block — same header merkle root, but the  //
+	// subtree contains 4 nodes with B duplicated at the end.              //
+	// ------------------------------------------------------------------ //
+
+	// The block header references the honest (3-node) merkle root.
+	blockHeader := &BlockHeader{
+		Version:        1,
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: honestRoot,
+		Bits:           *bits,
+	}
+
+	// Fake subtree hash for the Subtrees field (must be non-nil; the exact
+	// value does not matter for CheckMerkleRoot — it only uses SubtreeSlices
+	// to compute the root, comparing the result against HashMerkleRoot).
+	dummyHash := subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, txA, txB, txB).RootHash()
+
+	mutatedBlock := &Block{
+		Header:           blockHeader,
+		CoinbaseTx:       coinbase,
+		TransactionCount: 4,
+		SizeInBytes:      256,
+		Subtrees:         []*chainhash.Hash{dummyHash},
+	}
+
+	// The mutated subtree has B appended a second time.
+	mutatedSubtree := subtreeWithHashes(subtreepkg.CoinbasePlaceholderHashValue, txA, txB, txB)
+	mutatedBlock.SubtreeSlices = []*subtreepkg.Subtree{mutatedSubtree}
+
+	// ------------------------------------------------------------------ //
+	// Step 3: CheckMerkleRoot must PASS — the duplicate-last rule makes   //
+	// the 4-node root equal to the 3-node root, so the header matches.   //
+	// ------------------------------------------------------------------ //
+
+	err = mutatedBlock.CheckMerkleRoot(ctx)
+	require.NoError(t, err,
+		"CheckMerkleRoot must not detect the CVE-2012-2459 mutation: "+
+			"the duplicate-last-when-odd rule makes the 4-node subtree root "+
+			"identical to the honest 3-node subtree root, so the header hash still matches")
+
+	// ------------------------------------------------------------------ //
+	// Step 4: CheckSubtreeSlicesForDuplicateTxs must REJECT — B appears   //
+	// twice, which is the signal that cannot be faked.                    //
+	// ------------------------------------------------------------------ //
+
+	err = CheckSubtreeSlicesForDuplicateTxs(mutatedBlock.SubtreeSlices)
+	require.Error(t, err, "dedup check must reject the mutated subtree slices")
+	require.True(t, errors.Is(err, errors.ErrBlockInvalid),
+		"error must be a BlockInvalidError, got: %v", err)
+}

--- a/model/checkpoint.go
+++ b/model/checkpoint.go
@@ -25,6 +25,7 @@ func BelowCheckpoint(checkpoints []chaincfg.Checkpoint, height uint32) bool {
 }
 
 // SkipExpectedDifficulty permits historical DAA rules only while building the checkpoint prefix.
+// Callers must independently prove checkpoint ancestry; height alone grants no trust.
 // Once synced, a new low-height fork must satisfy the expected difficulty.
 func SkipExpectedDifficulty(checkpoints []chaincfg.Checkpoint, blockHeight, bestHeight uint32) bool {
 	if !BelowCheckpoint(checkpoints, blockHeight) {

--- a/model/checkpoint.go
+++ b/model/checkpoint.go
@@ -1,0 +1,35 @@
+package model
+
+import "github.com/bsv-blockchain/go-chaincfg"
+
+// HighestCheckpointHeight returns the highest non-negative checkpoint height.
+func HighestCheckpointHeight(checkpoints []chaincfg.Checkpoint) uint32 {
+	var highest uint32
+	for _, cp := range checkpoints {
+		if cp.Height < 0 {
+			continue
+		}
+		if h := uint32(cp.Height); h > highest {
+			highest = h
+		}
+	}
+
+	return highest
+}
+
+// BelowCheckpoint excludes genesis and networks without checkpoints.
+func BelowCheckpoint(checkpoints []chaincfg.Checkpoint, height uint32) bool {
+	highest := HighestCheckpointHeight(checkpoints)
+
+	return highest > 0 && height > 0 && height <= highest
+}
+
+// SkipExpectedDifficulty permits historical DAA rules only while building the checkpoint prefix.
+// Once synced, a new low-height fork must satisfy the expected difficulty.
+func SkipExpectedDifficulty(checkpoints []chaincfg.Checkpoint, blockHeight, bestHeight uint32) bool {
+	if !BelowCheckpoint(checkpoints, blockHeight) {
+		return false
+	}
+
+	return bestHeight < HighestCheckpointHeight(checkpoints)
+}

--- a/model/checkpoint_difficulty_test.go
+++ b/model/checkpoint_difficulty_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+const mainnetHighestCheckpoint = uint32(945_000)
+
+// TestSkipExpectedDifficulty_DeniesOnSyncedNode is the regression test for the
+// free-proof-of-work step of GHSA-gggq-8f59-4jm9 as it survives on a synced node.
+//
+// The expected-nBits (DAA) rule is the only check that binds a block's declared
+// difficulty to the chain it claims to extend. It was skipped for EVERY height in
+// 1..945000 on a pure height test, so a fully synced node would accept a fork at
+// 944,999 declaring the network minimum difficulty — seconds of GPU work instead
+// of the real target at that height. The block's own PoW floor cannot substitute:
+// it only bounds how easy a target may be, not whether it is the right one.
+//
+// A node that already holds the whole certified prefix has no legitimate reason
+// to accept a NEW block inside it, so it must demand the real difficulty rule.
+func TestSkipExpectedDifficulty_DeniesOnSyncedNode(t *testing.T) {
+	cps := chaincfg.MainNetParams.Checkpoints
+
+	require.False(t, SkipExpectedDifficulty(cps, 944_999, 964_784),
+		"a synced node must apply the real expected-nBits rule to a new below-checkpoint block")
+	require.False(t, SkipExpectedDifficulty(cps, 944_999, mainnetHighestCheckpoint),
+		"a node exactly at the highest checkpoint has the whole prefix and must not skip")
+}
+
+// TestSkipExpectedDifficulty_AllowsDuringInitialSync is the other half of the
+// contract, and the reason this predicate is not simply "always check".
+//
+// Re-deriving the expected difficulty over the historical prefix would require
+// reproducing every retarget rule the chain has ever used exactly; that is what
+// the pinned checkpoint hashes stand in for. A node still building the prefix
+// must keep the skip, or initial block download fails on blocks that are in fact
+// canonical.
+func TestSkipExpectedDifficulty_AllowsDuringInitialSync(t *testing.T) {
+	cps := chaincfg.MainNetParams.Checkpoints
+
+	require.True(t, SkipExpectedDifficulty(cps, 1, 0),
+		"a fresh node must keep the skip")
+	require.True(t, SkipExpectedDifficulty(cps, 500_000, 499_999),
+		"mid-sync must keep the skip")
+	require.True(t, SkipExpectedDifficulty(cps, mainnetHighestCheckpoint, mainnetHighestCheckpoint-1),
+		"the last block of the prefix must keep the skip")
+}
+
+// TestSkipExpectedDifficulty_DeniesAboveCheckpoint — above the prefix there is
+// no checkpoint to stand in for the difficulty schedule, so the rule always runs.
+func TestSkipExpectedDifficulty_DeniesAboveCheckpoint(t *testing.T) {
+	cps := chaincfg.MainNetParams.Checkpoints
+
+	require.False(t, SkipExpectedDifficulty(cps, mainnetHighestCheckpoint+1, 100))
+	require.False(t, SkipExpectedDifficulty(cps, 1_000_000, 100))
+}
+
+// TestSkipExpectedDifficulty_DeniesGenesis mirrors BelowCheckpoint's mandatory
+// height > 0 guard: a peer must not obtain the skip by declaring height 0.
+func TestSkipExpectedDifficulty_DeniesGenesis(t *testing.T) {
+	require.False(t, SkipExpectedDifficulty(chaincfg.MainNetParams.Checkpoints, 0, 0))
+}
+
+// TestSkipExpectedDifficulty_DeniesWithoutCheckpoints — regtest defines none, so
+// there is nothing certifying any difficulty schedule and the rule always runs.
+func TestSkipExpectedDifficulty_DeniesWithoutCheckpoints(t *testing.T) {
+	require.False(t, SkipExpectedDifficulty(chaincfg.RegressionNetParams.Checkpoints, 1, 0))
+	require.False(t, SkipExpectedDifficulty(nil, 1, 0))
+}

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -63,6 +63,9 @@ type ValidateBlockOptions struct {
 	// When provided, ValidateBlock will use these headers instead of fetching them.
 	CachedHeaders []*model.BlockHeader
 
+	// checkpointProven is set only for a block in a verified catchup header prefix.
+	checkpointProven bool
+
 	// IsCatchupMode indicates the block is being validated during catchup.
 	// This enables optimizations like reduced logging and header reuse.
 	IsCatchupMode bool
@@ -1427,19 +1430,12 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 				u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
 			}
 
-			return errors.NewBlockInvalidError("[ValidateBlock][%s] block does not meet target difficulty: %s", block.Header.Hash().String(), err)
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] %s", block.Header.Hash().String(), reason, err)
 		}
 
-		// Skip the expected-nBits (DAA) check for blocks at or below the highest checkpoint:
-		// the difficulty schedule over that prefix is already certified by the pinned
-		// checkpoint hashes, and re-deriving it would require reproducing every historical
-		// retarget rule exactly. block.Height is settled against the parent before this
-		// function runs (Server.deriveBlockHeight on the peer route; catchup and the operator
-		// revalidation endpoint carry authoritative heights), and BelowCheckpoint applies the
-		// mandatory height > 0 guard, so a peer cannot obtain the skip by declaring height 0
-		// or a fabricated sub-checkpoint height. The checkpoint hash-match itself was
-		// asserted above.
-		skipDifficultyCheck := u.skipExpectedDifficulty(ctx, block)
+		// Only checkpoint-proven ancestry certifies historical difficulty rules.
+		// Parent-derived height alone does not authenticate a peer's fork.
+		skipDifficultyCheck := u.skipExpectedDifficulty(ctx, block, opts.checkpointProven)
 
 		if skipDifficultyCheck {
 			ctxLogger.Debugf("[ValidateBlock][%s] skipping expected-nBits validation for block at height %d (at or below highest checkpoint height %d)",
@@ -1943,12 +1939,12 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 	}
 
 	if headerValid, _, err := blockData.block.Header.HasMetTargetDifficulty(); !headerValid {
-		return errors.NewBlockInvalidError("[reValidateBlock][%s] block does not meet target difficulty: %s", blockData.block.Header.Hash().String(), err)
+		return errors.NewBlockInvalidError("[reValidateBlock][%s] block does not meet target difficulty: %s", blockData.block.Header.Hash().String(), err.Error(), err)
 	}
 
 	// Skip the expected-nBits (DAA) check for blocks at or below the highest checkpoint:
 	// the difficulty schedule over that prefix is certified by the pinned checkpoint hashes.
-	skipDifficultyCheck := u.skipExpectedDifficulty(ctx, blockData.block)
+	skipDifficultyCheck := u.skipExpectedDifficulty(ctx, blockData.block, false)
 
 	if skipDifficultyCheck {
 		u.logger.Debugf("[reValidateBlock][%s] skipping expected-nBits validation for block at height %d (at or below highest checkpoint height %d)",
@@ -2491,8 +2487,8 @@ func (u *BlockValidation) StopCaches() {
 	u.subtreeExistsCache.Stop()
 }
 
-// skipExpectedDifficulty fails closed if the best-chain height cannot be established.
-func (u *BlockValidation) skipExpectedDifficulty(ctx context.Context, block *model.Block) bool {
+// skipExpectedDifficulty requires checkpoint ancestry and fails closed on missing chain state.
+func (u *BlockValidation) skipExpectedDifficulty(ctx context.Context, block *model.Block, checkpointProven bool) bool {
 	checkpoints := u.settings.ChainCfgParams.Checkpoints
 
 	if !model.BelowCheckpoint(checkpoints, block.Height) {
@@ -2507,5 +2503,32 @@ func (u *BlockValidation) skipExpectedDifficulty(ctx context.Context, block *mod
 
 	// Invalidation removes descendants from the best chain, so reconsidering
 	// historical blocks is covered by the syncing arm as the prefix is rebuilt.
-	return model.SkipExpectedDifficulty(checkpoints, block.Height, bestMeta.Height)
+	if !model.SkipExpectedDifficulty(checkpoints, block.Height, bestMeta.Height) {
+		return false
+	}
+	if checkpointProven {
+		return true
+	}
+
+	// Historical reconsideration may rebuild an invalidated prefix. Prove its
+	// ancestry from a stored pinned checkpoint, including invalidated headers;
+	// merely finding the candidate in storage would also trust stored forks.
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Height < 0 || uint32(checkpoint.Height) < block.Height || checkpoint.Hash == nil {
+			continue
+		}
+		if uint32(checkpoint.Height) == block.Height && checkpoint.Hash.IsEqual(block.Hash()) {
+			return true
+		}
+		_, checkpointMeta, err := u.blockchainClient.GetBlockHeader(ctx, checkpoint.Hash)
+		if err != nil || checkpointMeta == nil || checkpointMeta.Height != uint32(checkpoint.Height) {
+			continue
+		}
+		headers, metas, err := u.blockchainClient.GetBlockHeadersFromOldest(ctx, checkpoint.Hash, block.Hash(), 1)
+		if err == nil && len(headers) == 1 && len(metas) == 1 && headers[0] != nil && metas[0] != nil &&
+			metas[0].Height == block.Height && headers[0].Hash().IsEqual(block.Hash()) {
+			return true
+		}
+	}
+	return false
 }

--- a/services/blockvalidation/BlockValidation.go
+++ b/services/blockvalidation/BlockValidation.go
@@ -35,6 +35,7 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
 	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
 	"github.com/bsv-blockchain/teranode/services/validator"
 	"github.com/bsv-blockchain/teranode/settings"
@@ -1329,6 +1330,14 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			return errors.NewBlockInvalidError("[ValidateBlock][%s] bad coinbase length", block.Header.Hash().String())
 		}
 
+		if err = catchup.ValidateHeaderAgainstCheckpoints(block.Header, block.Height, u.settings.ChainCfgParams.Checkpoints); err != nil {
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, err.Error())
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] block conflicts with hardcoded checkpoint", block.Hash().String(), err)
+		}
+
 		// Use cached headers if available (during catchup), otherwise fetch from blockchain
 		var blockHeaders []*model.BlockHeader
 		if opts.CachedHeaders != nil && len(opts.CachedHeaders) > 0 {
@@ -1399,6 +1408,61 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			}
 		}
 
+		// Reject invalid headers before subtree validation can mutate transaction state.
+		if limitErr := block.Header.HasMetPowLimit(u.settings.ChainCfgParams); limitErr != nil {
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, "block declares a target easier than the network proof-of-work limit")
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] block declares a target easier than the network proof-of-work limit", block.Header.Hash().String(), limitErr)
+		}
+
+		headerValid, _, err := block.Header.HasMetTargetDifficulty()
+		if !headerValid {
+			reason := "block does not meet target difficulty"
+			if err != nil {
+				reason = fmt.Sprintf("block does not meet target difficulty: %s", err.Error())
+			}
+			if !opts.IsRevalidation {
+				u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
+			}
+
+			return errors.NewBlockInvalidError("[ValidateBlock][%s] block does not meet target difficulty: %s", block.Header.Hash().String(), err)
+		}
+
+		// Skip the expected-nBits (DAA) check for blocks at or below the highest checkpoint:
+		// the difficulty schedule over that prefix is already certified by the pinned
+		// checkpoint hashes, and re-deriving it would require reproducing every historical
+		// retarget rule exactly. block.Height is settled against the parent before this
+		// function runs (Server.deriveBlockHeight on the peer route; catchup and the operator
+		// revalidation endpoint carry authoritative heights), and BelowCheckpoint applies the
+		// mandatory height > 0 guard, so a peer cannot obtain the skip by declaring height 0
+		// or a fabricated sub-checkpoint height. The checkpoint hash-match itself was
+		// asserted above.
+		skipDifficultyCheck := u.skipExpectedDifficulty(ctx, block)
+
+		if skipDifficultyCheck {
+			ctxLogger.Debugf("[ValidateBlock][%s] skipping expected-nBits validation for block at height %d (at or below highest checkpoint height %d)",
+				block.Header.Hash().String(), block.Height, blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints))
+		} else {
+			// Check that the nBits (difficulty target) is correct for this block
+			expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, block.Header.HashPrevBlock, int64(block.Header.Timestamp))
+			if err != nil {
+				return errors.NewServiceError("[ValidateBlock][%s] failed to get expected work required", block.Header.Hash().String(), err)
+			}
+
+			// Compare the block's nBits with the expected nBits
+			if expectedNBits != nil && block.Header.Bits != *expectedNBits {
+				reason := fmt.Sprintf("incorrect difficulty bits: got %v, expected %v", block.Header.Bits, *expectedNBits)
+				if !opts.IsRevalidation {
+					u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
+				}
+
+				return errors.NewBlockInvalidError("[ValidateBlock][%s] block has incorrect difficulty bits: got %v, expected %v",
+					block.Header.Hash().String(), block.Header.Bits, expectedNBits)
+			}
+		}
+
 		// validate all the subtrees in the block
 		ctxLogger.Infof("[ValidateBlock][%s] validating %d subtrees", block.Hash().String(), len(block.Subtrees))
 
@@ -1434,47 +1498,6 @@ func (u *BlockValidation) ValidateBlockWithOptions(ctx context.Context, block *m
 			useOptimisticMining = false
 			if !opts.IsCatchupMode {
 				ctxLogger.Infof("[ValidateBlock][%s] useOptimisticMining override: %v", block.Header.Hash().String(), useOptimisticMining)
-			}
-		}
-
-		// Skip difficulty validation for blocks at or below the highest checkpoint
-		// These blocks are already verified by checkpoints, so we don't need to validate difficulty
-		highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
-		skipDifficultyCheck := block.Height <= highestCheckpointHeight
-
-		if skipDifficultyCheck {
-			ctxLogger.Debugf("[ValidateBlock][%s] skipping difficulty validation for block at height %d (at or below checkpoint height %d)",
-				block.Header.Hash().String(), block.Height, highestCheckpointHeight)
-		} else {
-			// First check that the nBits (difficulty target) is correct for this block
-			expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, block.Header.HashPrevBlock, int64(block.Header.Timestamp))
-			if err != nil {
-				return errors.NewServiceError("[ValidateBlock][%s] failed to get expected work required", block.Header.Hash().String(), err)
-			}
-
-			// Compare the block's nBits with the expected nBits
-			if expectedNBits != nil && block.Header.Bits != *expectedNBits {
-				reason := fmt.Sprintf("incorrect difficulty bits: got %v, expected %v", block.Header.Bits, *expectedNBits)
-				if !opts.IsRevalidation {
-					u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
-				}
-
-				return errors.NewBlockInvalidError("[ValidateBlock][%s] block has incorrect difficulty bits: got %v, expected %v",
-					block.Header.Hash().String(), block.Header.Bits, expectedNBits)
-			}
-
-			// Then check that the block hash meets the difficulty target
-			headerValid, _, err := block.Header.HasMetTargetDifficulty()
-			if !headerValid {
-				reason := "block does not meet target difficulty"
-				if err != nil {
-					reason = fmt.Sprintf("block does not meet target difficulty: %s", err.Error())
-				}
-				if !opts.IsRevalidation {
-					u.storeInvalidBlock(ctx, block, opts.PeerID, reason)
-				}
-
-				return errors.NewBlockInvalidError("[ValidateBlock][%s] block does not meet target difficulty: %s", block.Header.Hash().String(), err)
 			}
 		}
 
@@ -1899,16 +1922,39 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 	)
 	defer deferFn()
 
-	// Skip difficulty validation for blocks at or below the highest checkpoint
-	// These blocks are already verified by checkpoints, so we don't need to validate difficulty
-	highestCheckpointHeight := blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints)
-	skipDifficultyCheck := blockData.block.Height <= highestCheckpointHeight
+	// Checkpoint enforcement, mirroring ValidateBlockWithOptions: this path is reachable
+	// before that guard runs (the GetBlockHeaders-failure branch enqueues here) and carries
+	// the same difficulty skip, so assert the checkpoint hash-match here too. block.Height is
+	// already settled against the parent by the time a block reaches this worker (every
+	// ReValidateBlock call site sits inside ValidateBlockWithOptions, downstream of
+	// Server.deriveBlockHeight). No storeInvalidBlock: this is a revalidation path.
+	if err := catchup.ValidateHeaderAgainstCheckpoints(blockData.block.Header, blockData.block.Height, u.settings.ChainCfgParams.Checkpoints); err != nil {
+		return errors.NewBlockInvalidError("[reValidateBlock][%s] block conflicts with hardcoded checkpoint", blockData.block.Hash().String(), err)
+	}
+
+	// The header hash must meet the target its own nBits declares, below checkpoint or not
+	// — see the matching block in ValidateBlockWithOptions for why this half of the old
+	// skip is never safe to take. Enforced before the subtree work below.
+	// Same floor as ValidateBlockWithOptions, and for the same reason: this path
+	// runs validateBlockSubtrees (UTXO-mutating) below, so the declared target must
+	// be bounded here rather than left to block.Valid afterwards.
+	if limitErr := blockData.block.Header.HasMetPowLimit(u.settings.ChainCfgParams); limitErr != nil {
+		return errors.NewBlockInvalidError("[reValidateBlock][%s] block declares a target easier than the network proof-of-work limit", blockData.block.Header.Hash().String(), limitErr)
+	}
+
+	if headerValid, _, err := blockData.block.Header.HasMetTargetDifficulty(); !headerValid {
+		return errors.NewBlockInvalidError("[reValidateBlock][%s] block does not meet target difficulty: %s", blockData.block.Header.Hash().String(), err)
+	}
+
+	// Skip the expected-nBits (DAA) check for blocks at or below the highest checkpoint:
+	// the difficulty schedule over that prefix is certified by the pinned checkpoint hashes.
+	skipDifficultyCheck := u.skipExpectedDifficulty(ctx, blockData.block)
 
 	if skipDifficultyCheck {
-		u.logger.Debugf("[reValidateBlock][%s] skipping difficulty validation for block at height %d (at or below checkpoint height %d)",
-			blockData.block.Header.Hash().String(), blockData.block.Height, highestCheckpointHeight)
+		u.logger.Debugf("[reValidateBlock][%s] skipping expected-nBits validation for block at height %d (at or below highest checkpoint height %d)",
+			blockData.block.Header.Hash().String(), blockData.block.Height, blockchain.HighestCheckpointHeight(u.settings.ChainCfgParams.Checkpoints))
 	} else {
-		// First check that the nBits (difficulty target) is correct for this block
+		// Check that the nBits (difficulty target) is correct for this block
 		expectedNBits, err := u.blockchainClient.GetNextWorkRequired(ctx, blockData.block.Header.HashPrevBlock, int64(blockData.block.Header.Timestamp))
 		if err != nil {
 			return errors.NewServiceError("[reValidateBlock][%s] failed to get expected work required", blockData.block.Header.Hash().String(), err)
@@ -1918,12 +1964,6 @@ func (u *BlockValidation) reValidateBlock(blockData revalidateBlockData) error {
 		if expectedNBits != nil && blockData.block.Header.Bits != *expectedNBits {
 			return errors.NewBlockInvalidError("[reValidateBlock][%s] block has incorrect difficulty bits: got %v, expected %v",
 				blockData.block.Header.Hash().String(), blockData.block.Header.Bits, expectedNBits)
-		}
-
-		// Then check that the block hash meets the difficulty target
-		headerValid, _, err := blockData.block.Header.HasMetTargetDifficulty()
-		if !headerValid {
-			return errors.NewBlockInvalidError("[reValidateBlock][%s] block does not meet target difficulty: %s", blockData.block.Header.Hash().String(), err)
 		}
 	}
 
@@ -2449,4 +2489,23 @@ func (u *BlockValidation) StopCaches() {
 	u.lastValidatedBlocks.Stop()
 	u.blockExistsCache.Stop()
 	u.subtreeExistsCache.Stop()
+}
+
+// skipExpectedDifficulty fails closed if the best-chain height cannot be established.
+func (u *BlockValidation) skipExpectedDifficulty(ctx context.Context, block *model.Block) bool {
+	checkpoints := u.settings.ChainCfgParams.Checkpoints
+
+	if !model.BelowCheckpoint(checkpoints, block.Height) {
+		return false
+	}
+
+	_, bestMeta, err := u.blockchainClient.GetBestBlockHeader(ctx)
+	if err != nil || bestMeta == nil {
+		u.logger.Warnf("[skipExpectedDifficulty][%s] could not read best block header, applying the expected-nBits rule: %v", block.Hash().String(), err)
+		return false
+	}
+
+	// Invalidation removes descendants from the best chain, so reconsidering
+	// historical blocks is covered by the syncing arm as the prefix is rebuilt.
+	return model.SkipExpectedDifficulty(checkpoints, block.Height, bestMeta.Height)
 }

--- a/services/blockvalidation/BlockValidation_difficulty_test.go
+++ b/services/blockvalidation/BlockValidation_difficulty_test.go
@@ -253,9 +253,7 @@ func TestValidateBlock_DoesNotMeetTargetDifficulty(t *testing.T) {
 	notificationChan := make(chan *blockchain_api.Notification, 1)
 	mockBlockchain.On("Subscribe", mock.Anything, mock.Anything).Return(notificationChan, nil).Maybe()
 
-	// Mock GetNextWorkRequired to return the expected difficulty
-	mockBlockchain.On("GetNextWorkRequired", mock.Anything, prevBlockHeader.Hash(), mock.Anything).
-		Return(expectedNBits, nil).Once()
+	// A header that fails its own target must be rejected before querying expected work.
 
 	// Mock AddBlock to store invalid block when difficulty target is not met
 	mockBlockchain.On("AddBlock", mock.Anything, block, "", mock.Anything).Return(nil).Once()

--- a/services/blockvalidation/BlockValidation_test.go
+++ b/services/blockvalidation/BlockValidation_test.go
@@ -410,7 +410,7 @@ func TestBlockValidationValidateBlockSmall(t *testing.T) {
 
 	tSettings := test.CreateBaseTestSettings(t)
 
-	tSettings.ChainCfgParams = &chaincfg.MainNetParams
+	tSettings.ChainCfgParams = test.MainNetParamsForSyntheticPoW()
 
 	blockHeader := &model.BlockHeader{
 		Version:        1,
@@ -1258,7 +1258,7 @@ func TestBlockValidationRequestMissingTransaction(t *testing.T) {
 	}
 
 	// Create block header
-	nBits, _ := model.NewNBitFromString("2000ffff")
+	nBits, _ := model.NewNBitFromString("207fffff")
 	hashPrevBlock := chaincfg.RegressionNetParams.GenesisBlock.BlockHash()
 
 	// Calculate merkle root using coinbase and subtree
@@ -1815,7 +1815,7 @@ func createValidBlock(t *testing.T, tSettings *settings.Settings, txMetaStore ut
 	replicatedSubtree.ReplaceRootNode(coinbaseTx.TxIDChainHash(), 0, uint64(coinbaseTx.Size())) //nolint:gosec
 	calculatedMerkleRootHash := replicatedSubtree.RootHash()
 
-	nBits, _ := model.NewNBitFromString("2000ffff")
+	nBits, _ := model.NewNBitFromString("207fffff")
 	blockHeader := &model.BlockHeader{
 		Version:        1,
 		HashPrevBlock:  tSettings.ChainCfgParams.GenesisHash,

--- a/services/blockvalidation/Server.go
+++ b/services/blockvalidation/Server.go
@@ -1496,6 +1496,28 @@ func (u *Server) processBlockFound(ctx context.Context, hash *chainhash.Hash, pe
 		return nil
 	}
 
+	// Settle the peer-supplied height against the on-chain parent before anything reads
+	// block.Height (block-assembly gating below, and downstream
+	// the checkpoint guard, difficulty skip and coinbase subsidy in ValidateBlockWithOptions).
+	// See deriveBlockHeight.
+	_, parentMeta, err := u.blockchainClient.GetBlockHeader(ctx, block.Header.HashPrevBlock)
+	if err != nil {
+		return errors.NewServiceError("[processBlockFound][%s] failed to get parent header %s", hash.String(), block.Header.HashPrevBlock.String(), err)
+	}
+
+	// No implementation returns a nil meta with a nil error, but the settled height is
+	// security-relevant, so fail closed rather than derive it from a nil dereference.
+	if parentMeta == nil {
+		return errors.NewServiceError("[processBlockFound][%s] nil metadata for parent header %s", hash.String(), block.Header.HashPrevBlock.String())
+	}
+
+	settledHeight, err := deriveBlockHeight(block.Height, parentMeta.Height)
+	if err != nil {
+		return errors.NewBlockInvalidError("[processBlockFound][%s] rejecting block with peer-inconsistent height", hash.String(), err)
+	}
+
+	block.Height = settledHeight
+
 	// Wait for block assembly to be ready before processing the block
 	if err = blockassemblyutil.WaitForBlockAssemblyReady(ctx, u.logger, u.blockAssemblyClient, block.Height, u.settings.BlockValidation.MaxBlocksBehindBlockAssembly); err != nil {
 		// block-assembly is still behind, so we cannot process this block
@@ -1903,4 +1925,17 @@ func (u *Server) processBlockWithPriority(ctx context.Context, blockFound proces
 	}
 
 	return err
+}
+
+// deriveBlockHeight verifies a supplied height against the stored parent.
+func deriveBlockHeight(claimed, parentHeight uint32) (uint32, error) {
+	derived := parentHeight + 1
+	if derived == 0 {
+		return 0, errors.NewBlockInvalidError("parent height %d overflows the block height", parentHeight)
+	}
+	if claimed != 0 && claimed != derived {
+		return 0, errors.NewBlockInvalidError("claimed height %d does not match parent height %d + 1", claimed, parentHeight)
+	}
+
+	return derived, nil
 }

--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -32,6 +32,7 @@ import (
 	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/go-subtree"
 	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/bsv-blockchain/go-wire"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/adaptivefetch"
@@ -402,49 +403,41 @@ func TestBlockHeadersN(t *testing.T) {
 func Test_Server_processBlockFound(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
 	tSettings := test.CreateBaseTestSettings(t)
-	// regtest SubsidyReductionInterval is 150
-	// so use mainnet params
-	tSettings.ChainCfgParams = &chaincfg.MainNetParams
-
-	blockHex := "010000000edfb8ccf30a17b7deae9c1f1a3dbbaeb1741ff5906192b921cbe7ece5ab380081caee50ec9ca9b5686bb6f71693a1c4284a269ab5f90d8662343a18e1a7200f52a83b66ffff00202601000001fdb1010001000000010000000000000000000000000000000000000000000000000000000000000000ffffffff17033501002f6d322d75732fc1eaad86485d9cc712818b47ffffffff03ac505763000000001976a914c362d5af234dd4e1f2a1bfbcab90036d38b0aa9f88acaa505763000000001976a9143c22b6d9ba7b50b6d6e615c69d11ecb2ba3db14588acaa505763000000001976a9141e7ee30c5c564b78533a44aae23bec1be188281d88ac00000000fd3501"
-	blockBytes, err := hex.DecodeString(blockHex)
+	storeURL := &url.URL{Scheme: "sqlitememory"}
+	blockchainStore, err := blockchain_store.NewStore(ulogger.TestLogger{}, storeURL, tSettings)
 	require.NoError(t, err)
-
-	block, err := model.NewBlockFromBytes(blockBytes)
+	utxoStore, err := sql.New(ctx, ulogger.TestLogger{}, tSettings, storeURL)
 	require.NoError(t, err)
-
-	blockchainStore := blockchain_store.NewMockStore()
-	blockchainStore.BlockExists[*block.Header.HashPrevBlock] = true
-
-	logger := ulogger.NewErrorTestLogger(t)
-
-	utxoStoreURL, err := url.Parse("sqlitememory:///test")
-	if err != nil {
-		panic(err)
-	}
-
-	utxoStore, err := sql.New(ctx, logger, tSettings, utxoStoreURL)
-	if err != nil {
-		panic(err)
-	}
-
-	txStore := memory.New()
-
+	t.Cleanup(func() { require.NoError(t, utxoStore.Close(context.Background())) })
 	blockchainClient, err := blockchain.NewLocalClient(ulogger.TestLogger{}, tSettings, blockchainStore, nil, utxoStore)
 	require.NoError(t, err)
-
-	kafkaConsumerClient := &kafka.KafkaConsumerGroup{}
-
-	subtreeStore := memory.New()
-	tSettings.GlobalBlockHeightRetention = uint32(1)
-
-	s := New(ulogger.TestLogger{}, tSettings, nil, txStore, utxoStore, nil, blockchainClient, kafkaConsumerClient, nil, nil)
-	s.blockValidation = NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, blockchainClient, subtreeStore, txStore, utxoStore, nil, nil)
-
-	err = s.processBlockFound(context.Background(), block.Hash(), "", "legacy", block)
+	// A real parent in SQL is required now that supplied heights are verified.
+	header := tSettings.ChainCfgParams.GenesisBlock.Header
+	header.PrevBlock = *tSettings.ChainCfgParams.GenesisHash
+	header.Timestamp = header.Timestamp.Add(10 * time.Minute)
+	coinbase := wire.NewMsgTx(1)
+	coinbase.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Index: 0xffffffff}, SignatureScript: []byte{1, 1}, Sequence: 0xffffffff})
+	coinbase.AddTxOut(&wire.TxOut{Value: 50 * 100_000_000, PkScript: []byte{0x51}})
+	header.MerkleRoot = coinbase.TxHash()
+	block, err := model.NewBlockFromMsgBlock(&wire.MsgBlock{Header: header, Transactions: []*wire.MsgTx{coinbase}}, nil)
 	require.NoError(t, err)
+	for {
+		met, _, _ := block.Header.HasMetTargetDifficulty()
+		if met {
+			break
+		}
+		block.Header.Nonce++
+	}
+	txStore, subtreeStore := memory.New(), memory.New()
+	s := New(ulogger.TestLogger{}, tSettings, nil, txStore, utxoStore, nil, blockchainClient, nil, nil, nil)
+	s.blockValidation = NewBlockValidation(ctx, ulogger.TestLogger{}, tSettings, blockchainClient, subtreeStore, txStore, utxoStore, nil, nil)
+	t.Cleanup(s.blockValidation.StopCaches)
+	require.NoError(t, s.processBlockFound(ctx, block.Hash(), "", "legacy", block))
+	require.Equal(t, uint32(1), block.Height)
+	exists, err := blockchainClient.GetBlockExists(ctx, block.Hash())
+	require.NoError(t, err)
+	require.True(t, exists)
 }
 
 func TestServer_processBlockFoundChannel(t *testing.T) {

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -628,9 +628,19 @@ func (u *Server) buildHeaderCache(catchupCtx *CatchupContext) error {
 
 	// Verify first header connects to common ancestor
 	if len(catchupCtx.blockHeaders) > 0 {
+		if catchupCtx.commonAncestorHash == nil || catchupCtx.blockHeaders[0] == nil {
+			return errors.NewBlockInvalidError("[catchup] missing common ancestor or first header")
+		}
 		firstHeaderParent := catchupCtx.blockHeaders[0].HashPrevBlock
 		if !firstHeaderParent.IsEqual(catchupCtx.commonAncestorHash) {
-			u.logger.Warnf("[catchup][%s] first header parent %s doesn't match common ancestor %s", catchupCtx.blockUpTo.Hash().String(), firstHeaderParent.String(), catchupCtx.commonAncestorHash.String())
+			return errors.NewBlockInvalidError("[catchup][%s] first header parent %s doesn't match common ancestor %s", catchupCtx.blockUpTo.Hash().String(), firstHeaderParent.String(), catchupCtx.commonAncestorHash.String())
+		}
+	}
+
+	// Check every link before positional heights can authorize validation skips.
+	for i := 1; i < len(catchupCtx.blockHeaders); i++ {
+		if catchupCtx.blockHeaders[i] == nil || !catchupCtx.blockHeaders[i].HashPrevBlock.IsEqual(catchupCtx.blockHeaders[i-1].Hash()) {
+			return errors.NewBlockInvalidError("[catchup] disconnected header at index %d", i)
 		}
 	}
 
@@ -659,11 +669,7 @@ func (u *Server) buildHeaderCache(catchupCtx *CatchupContext) error {
 //   - error: If checkpoint verification fails
 func (u *Server) verifyCheckpointsInHeaderChain(catchupCtx *CatchupContext) error {
 	catchupCtx.useQuickValidation = false
-
-	// Quick validation disabled, no need to verify checkpoints
-	if !u.settings.BlockValidation.CatchupAllowQuickValidation {
-		return nil
-	}
+	catchupCtx.highestCheckpointHeight = 0
 
 	// Get checkpoints from catchup context
 	if len(catchupCtx.checkpoints) == 0 {
@@ -691,7 +697,7 @@ func (u *Server) verifyCheckpointsInHeaderChain(catchupCtx *CatchupContext) erro
 
 	if checkpointsChecked > 0 {
 		u.logger.Infof("[catchup][%s] Successfully verified %d checkpoint(s) in header chain", catchupCtx.blockUpTo.Hash().String(), checkpointsChecked)
-		catchupCtx.useQuickValidation = true // enabled: BlockAssembly sync check added in tryQuickValidation
+		catchupCtx.useQuickValidation = u.settings.BlockValidation.CatchupAllowQuickValidation
 	}
 
 	return nil
@@ -707,9 +713,20 @@ func (u *Server) verifyCheckpointsInHeaderChain(catchupCtx *CatchupContext) erro
 //   - int: Number of checkpoints successfully verified
 //   - error: If checkpoint verification fails (hash mismatch)
 func (u *Server) verifyCheckpointsAgainstHeaders(catchupCtx *CatchupContext) (int, error) {
-	// Get the highest checkpoint height for reference
-	highestCheckpointHeight := blockchain.HighestCheckpointHeight(catchupCtx.checkpoints)
-	catchupCtx.highestCheckpointHeight = highestCheckpointHeight
+	catchupCtx.highestCheckpointHeight = 0
+	if catchupCtx.commonAncestorMeta == nil || catchupCtx.commonAncestorHash == nil {
+		return 0, errors.NewBlockInvalidError("[catchup] missing common ancestor")
+	}
+	if uint64(catchupCtx.commonAncestorMeta.Height)+uint64(len(catchupCtx.blockHeaders)) > uint64(^uint32(0)) {
+		return 0, errors.NewBlockInvalidError("[catchup] header heights overflow uint32")
+	}
+	previousHash := catchupCtx.commonAncestorHash
+	for i, header := range catchupCtx.blockHeaders {
+		if header == nil || !header.HashPrevBlock.IsEqual(previousHash) {
+			return 0, errors.NewBlockInvalidError("[catchup] header at index %d does not connect to common ancestor", i)
+		}
+		previousHash = header.Hash()
+	}
 
 	firstBlockHeight := catchupCtx.commonAncestorMeta.Height + 1
 	lastBlockHeight := catchupCtx.commonAncestorMeta.Height + uint32(len(catchupCtx.blockHeaders))
@@ -717,6 +734,7 @@ func (u *Server) verifyCheckpointsAgainstHeaders(catchupCtx *CatchupContext) (in
 	u.logger.Debugf("[catchup][%s] Verifying checkpoints in height range %d-%d (common ancestor at %d)", catchupCtx.blockUpTo.Hash().String(), firstBlockHeight, lastBlockHeight, catchupCtx.commonAncestorMeta.Height)
 
 	checkpointsChecked := 0
+	var verifiedHeight uint32
 	for _, checkpoint := range catchupCtx.checkpoints {
 		checkpointHeight := uint32(checkpoint.Height)
 
@@ -742,9 +760,13 @@ func (u *Server) verifyCheckpointsAgainstHeaders(catchupCtx *CatchupContext) (in
 
 			u.logger.Infof("[catchup][%s] Verified checkpoint at height %d with hash %s", catchupCtx.blockUpTo.Hash().String(), checkpointHeight, checkpoint.Hash.String())
 			checkpointsChecked++
+			if checkpointHeight > verifiedHeight {
+				verifiedHeight = checkpointHeight
+			}
 		}
 	}
 
+	catchupCtx.highestCheckpointHeight = verifiedHeight
 	return checkpointsChecked, nil
 }
 
@@ -765,6 +787,10 @@ func (u *Server) verifyChainContinuity(ctx context.Context, catchupCtx *CatchupC
 	}
 
 	firstBlock := catchupCtx.blockHeaders[0]
+
+	if catchupCtx.commonAncestorHash == nil || !firstBlock.HashPrevBlock.IsEqual(catchupCtx.commonAncestorHash) {
+		return errors.NewBlockInvalidError("[catchup] first header does not connect to common ancestor")
+	}
 
 	// Verify parent exists (should be common ancestor)
 	parentExists, err := u.blockValidation.GetBlockExists(ctx, firstBlock.HashPrevBlock)
@@ -1060,6 +1086,7 @@ func (u *Server) validateBlocksOnChannel(validateBlocksChan chan blockForValidat
 				// Create validation options with cached headers
 				opts := &ValidateBlockOptions{
 					CachedHeaders:           cachedHeaders,
+					checkpointProven:        catchupCtx.blockCheckpointProven(block),
 					IsCatchupMode:           true,
 					DisableOptimisticMining: true,
 					PeerID:                  peerID,
@@ -1114,7 +1141,7 @@ func (u *Server) validateBlocksOnChannel(validateBlocksChan chan blockForValidat
 func (u *Server) tryQuickValidation(ctx context.Context, block *model.Block, catchupCtx *CatchupContext, peerID, baseURL string, writeJobsChan chan<- *SubtreeWriteJob) (bool, error) {
 	// Determine if this specific block can use quick validation
 	// A block can use quick validation if it's at or below the highest verified checkpoint height
-	canUseQuickValidation := catchupCtx.useQuickValidation && block.Height <= catchupCtx.highestCheckpointHeight
+	canUseQuickValidation := catchupCtx.useQuickValidation && catchupCtx.blockCheckpointProven(block)
 
 	// If block is not eligible for quick validation, use normal validation
 	if !canUseQuickValidation {
@@ -1143,9 +1170,13 @@ func (u *Server) tryQuickValidation(ctx context.Context, block *model.Block, cat
 			prometheusCatchupErrors.WithLabelValues(peerID, "validation_failure").Inc()
 		}
 
-		// Block is incomplete (e.g. seeded peer without full block data) — abort catchup for this peer
-		// Keep subtree files — they contain valid data that the next peer's validation can reuse
-		// Failure reporting is handled by the caller (Server.go / peer_selection.go)
+		// A body-authentication failure must abort without retrying the body through
+		// a state-mutating path or deleting another block's shared subtree files.
+		if errors.Is(err, errors.ErrBlockInvalid) {
+			return false, err
+		}
+		// Block is incomplete (e.g. seeded peer without full block data) — abort catchup for this peer.
+		// Keep subtree files that the next peer's validation can reuse.
 		if errors.Is(err, errors.ErrBlockIncomplete) {
 			u.logger.Warnf("[catchup:tryQuickValidation][%s] block %s from peer %s is incomplete (no coinbase), aborting catchup",
 				catchupCtx.blockUpTo.Hash().String(), block.Hash().String(), peerID)
@@ -1312,4 +1343,14 @@ func newHashFromStr(hexStr string) *chainhash.Hash {
 	}
 
 	return hash
+}
+
+// blockCheckpointProven binds the verified height range to the actual fetched header.
+func (c *CatchupContext) blockCheckpointProven(block *model.Block) bool {
+	if c.commonAncestorMeta == nil || block.Height == 0 ||
+		block.Height <= c.commonAncestorMeta.Height || block.Height > c.highestCheckpointHeight {
+		return false
+	}
+	index := uint64(block.Height - c.commonAncestorMeta.Height - 1)
+	return index < uint64(len(c.blockHeaders)) && c.blockHeaders[index].Hash().IsEqual(block.Hash())
 }

--- a/services/blockvalidation/catchup_consolidated_test.go
+++ b/services/blockvalidation/catchup_consolidated_test.go
@@ -555,7 +555,7 @@ func TestCatchup_ContextStateConsistency(t *testing.T) {
 			currentHeight:      1000,
 			blockHeaders:       testHeaders[1:],
 			headersFetchResult: &catchup.Result{
-				Headers: testHeaders[1:], // Headers to be filtered
+				Headers: testHeaders, // Include the common ancestor at index zero
 			},
 		}
 

--- a/services/blockvalidation/catchup_quickvalidation_test.go
+++ b/services/blockvalidation/catchup_quickvalidation_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-chaincfg"
 	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/pkg/fileformat"
 	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ func TestTryQuickValidation(t *testing.T) {
 
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
 		block.Height = 100
+		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
 
 		catchupCtx := &CatchupContext{
 			useQuickValidation:      false,
@@ -72,12 +74,15 @@ func TestTryQuickValidation(t *testing.T) {
 
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
 		block.Height = 100
+		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
 		block.Subtrees = []*chainhash.Hash{subtreeHash1, subtreeHash2}
 
 		catchupCtx := &CatchupContext{
 			useQuickValidation:      true,
 			highestCheckpointHeight: 200,
 			blockUpTo:               block,
+			commonAncestorMeta:      &model.BlockHeaderMeta{Height: block.Height - 1},
+			blockHeaders:            []*model.BlockHeader{block.Header},
 		}
 
 		// Create a buffered channel for async writes
@@ -113,11 +118,14 @@ func TestTryQuickValidation(t *testing.T) {
 
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
 		block.Height = 100
+		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
 
 		catchupCtx := &CatchupContext{
 			useQuickValidation:      true,
 			highestCheckpointHeight: 200,
 			blockUpTo:               block,
+			commonAncestorMeta:      &model.BlockHeaderMeta{Height: block.Height - 1},
+			blockHeaders:            []*model.BlockHeader{block.Header},
 		}
 
 		// Create a buffered channel for async writes
@@ -141,12 +149,15 @@ func TestTryQuickValidation(t *testing.T) {
 
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
 		block.Height = 100
+		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
 		block.Subtrees = []*chainhash.Hash{subtreeHash}
 
 		catchupCtx := &CatchupContext{
 			useQuickValidation:      true,
 			highestCheckpointHeight: 200,
 			blockUpTo:               block,
+			commonAncestorMeta:      &model.BlockHeaderMeta{Height: block.Height - 1},
+			blockHeaders:            []*model.BlockHeader{block.Header},
 		}
 
 		// Create a buffered channel for async writes

--- a/services/blockvalidation/catchup_test.go
+++ b/services/blockvalidation/catchup_test.go
@@ -3453,6 +3453,7 @@ func TestCheckpointValidationHeightCalculation(t *testing.T) {
 			Header: blocks[14].Header,
 			Height: 14,
 		},
+		commonAncestorHash: blocks[7].Hash(),
 		commonAncestorMeta: &model.BlockHeaderMeta{
 			Height: 7, // This is the key: common ancestor at height 7
 		},

--- a/services/blockvalidation/checkpoint_callsite_test.go
+++ b/services/blockvalidation/checkpoint_callsite_test.go
@@ -1,0 +1,132 @@
+package blockvalidation
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// Stop immediately after the header gates. A removed gate must produce this
+// distinct error rather than being hidden by a later generic invalid-block error.
+type checkpointSubtreeBoundary struct{ subtreevalidation.Interface }
+
+func (*checkpointSubtreeBoundary) CheckBlockSubtrees(context.Context, *model.Block, string, string) error {
+	return errors.NewProcessingError("checkpoint subtree boundary reached")
+}
+
+func TestCheckpointValidationCallSites(t *testing.T) {
+	for _, worker := range []bool{false, true} {
+		entry := "ValidateBlockWithOptions"
+		if worker {
+			entry = "reValidateBlock"
+		}
+		t.Run(entry, func(t *testing.T) {
+			for _, gate := range []string{"pow limit", "expected difficulty", "unmet target", "checkpoint mismatch", "matching checkpoint"} {
+				t.Run(gate, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					settings := test.CreateBaseTestSettings(t)
+					if gate == "pow limit" {
+						params := chaincfg.MainNetParams
+						settings.ChainCfgParams = &params
+					}
+					storeURL, err := url.Parse("sqlitememory:///")
+					require.NoError(t, err)
+					store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, settings)
+					require.NoError(t, err)
+					client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, settings, store, nil, nil)
+					require.NoError(t, err)
+
+					// Reach a synthetic checkpoint through real SQL chain state. A new fork
+					// at height one must no longer inherit the historical difficulty skip.
+					prev := settings.ChainCfgParams.GenesisHash
+					for height := uint32(1); height <= 2; height++ {
+						header := settings.ChainCfgParams.GenesisBlock.Header
+						header.PrevBlock = *prev
+						header.Nonce += height
+						coinbase := wire.NewMsgTx(1)
+						coinbase.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Index: 0xffffffff}, SignatureScript: []byte{1, byte(height)}, Sequence: 0xffffffff})
+						coinbase.AddTxOut(&wire.TxOut{Value: 50 * 100_000_000, PkScript: []byte{0x51}})
+						header.MerkleRoot = coinbase.TxHash()
+						block, err := model.NewBlockFromMsgBlock(&wire.MsgBlock{Header: header, Transactions: []*wire.MsgTx{coinbase}}, nil)
+						require.NoError(t, err)
+						require.NoError(t, client.AddBlock(ctx, block, "test"))
+						prev = block.Hash()
+					}
+					settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 2, Hash: prev}}
+					_, best, err := client.GetBestBlockHeader(ctx)
+					require.NoError(t, err)
+					require.Equal(t, uint32(2), best.Height)
+
+					header := settings.ChainCfgParams.GenesisBlock.Header
+					header.PrevBlock = *settings.ChainCfgParams.GenesisHash
+					header.Bits = 0x207fffff
+					if gate == "expected difficulty" {
+						header.Bits = 0x2070ffff
+					}
+					// Keep a distinct candidate and meet its declared target. Only the gate
+					// under test may reject it, not HasMetTargetDifficulty.
+					header.Timestamp = header.Timestamp.Add(10 * time.Minute)
+					candidate, err := model.NewBlockFromMsgBlock(&wire.MsgBlock{Header: header, Transactions: settings.ChainCfgParams.GenesisBlock.Transactions}, nil)
+					require.NoError(t, err)
+					candidate.Height = 1
+					candidate.ID = 0
+					for {
+						if met, _, _ := candidate.Header.HasMetTargetDifficulty(); met {
+							break
+						}
+						candidate.Header.Nonce++
+					}
+					if gate == "unmet target" {
+						candidate.Header.Bits = model.NBit{}
+					}
+					if gate == "checkpoint mismatch" {
+						settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1, Hash: &chainhash.Hash{9}}}
+					}
+					if gate == "matching checkpoint" {
+						settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1, Hash: candidate.Hash()}}
+					}
+					candidate.Subtrees = []*chainhash.Hash{{1}}
+					candidate.SubtreeSlices = nil
+					require.True(t, candidate.Height > 0 && candidate.Height <= blockchain.HighestCheckpointHeight(settings.ChainCfgParams.Checkpoints))
+
+					u := NewBlockValidation(ctx, ulogger.TestLogger{}, settings, client, memory.New(), memory.New(), nil, nil, &checkpointSubtreeBoundary{})
+					t.Cleanup(func() { cancel(); u.StopCaches() })
+					if worker {
+						err = u.reValidateBlock(revalidateBlockData{block: candidate})
+					} else {
+						err = u.ValidateBlockWithOptions(ctx, candidate, "", &ValidateBlockOptions{DisableOptimisticMining: true})
+					}
+					switch gate {
+					case "pow limit":
+						require.ErrorContains(t, err, "block declares a target easier than the network proof-of-work limit")
+					case "expected difficulty":
+						require.ErrorContains(t, err, "block has incorrect difficulty bits")
+					case "unmet target":
+						require.ErrorContains(t, err, "block does not meet target difficulty")
+					case "checkpoint mismatch":
+						require.ErrorContains(t, err, "block conflicts with hardcoded checkpoint")
+					case "matching checkpoint":
+						require.ErrorContains(t, err, "checkpoint subtree boundary reached")
+						return
+					}
+					require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+				})
+			}
+		})
+	}
+}

--- a/services/blockvalidation/checkpoint_callsite_test.go
+++ b/services/blockvalidation/checkpoint_callsite_test.go
@@ -35,7 +35,7 @@ func TestCheckpointValidationCallSites(t *testing.T) {
 			entry = "reValidateBlock"
 		}
 		t.Run(entry, func(t *testing.T) {
-			for _, gate := range []string{"pow limit", "expected difficulty", "unmet target", "checkpoint mismatch", "matching checkpoint"} {
+			for _, gate := range []string{"pow limit", "expected difficulty", "expected difficulty during IBD", "pinned checkpoint during IBD", "unmet target", "checkpoint mismatch", "matching checkpoint"} {
 				t.Run(gate, func(t *testing.T) {
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
@@ -75,7 +75,7 @@ func TestCheckpointValidationCallSites(t *testing.T) {
 					header := settings.ChainCfgParams.GenesisBlock.Header
 					header.PrevBlock = *settings.ChainCfgParams.GenesisHash
 					header.Bits = 0x207fffff
-					if gate == "expected difficulty" {
+					if gate == "expected difficulty" || gate == "expected difficulty during IBD" || gate == "pinned checkpoint during IBD" {
 						header.Bits = 0x2070ffff
 					}
 					// Keep a distinct candidate and meet its declared target. Only the gate
@@ -100,6 +100,12 @@ func TestCheckpointValidationCallSites(t *testing.T) {
 					if gate == "matching checkpoint" {
 						settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1, Hash: candidate.Hash()}}
 					}
+					if gate == "expected difficulty during IBD" {
+						settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 100, Hash: &chainhash.Hash{9}}}
+					}
+					if gate == "pinned checkpoint during IBD" {
+						settings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1, Hash: candidate.Hash()}, {Height: 100, Hash: &chainhash.Hash{9}}}
+					}
 					candidate.Subtrees = []*chainhash.Hash{{1}}
 					candidate.SubtreeSlices = nil
 					require.True(t, candidate.Height > 0 && candidate.Height <= blockchain.HighestCheckpointHeight(settings.ChainCfgParams.Checkpoints))
@@ -114,13 +120,15 @@ func TestCheckpointValidationCallSites(t *testing.T) {
 					switch gate {
 					case "pow limit":
 						require.ErrorContains(t, err, "block declares a target easier than the network proof-of-work limit")
-					case "expected difficulty":
+					case "expected difficulty", "expected difficulty during IBD":
 						require.ErrorContains(t, err, "block has incorrect difficulty bits")
 					case "unmet target":
 						require.ErrorContains(t, err, "block does not meet target difficulty")
+						require.NotContains(t, err.Error(), "%!")
+						require.ErrorContains(t, err, "block header does not meet target")
 					case "checkpoint mismatch":
 						require.ErrorContains(t, err, "block conflicts with hardcoded checkpoint")
-					case "matching checkpoint":
+					case "matching checkpoint", "pinned checkpoint during IBD":
 						require.ErrorContains(t, err, "checkpoint subtree boundary reached")
 						return
 					}

--- a/services/blockvalidation/checkpoint_difficulty_reconsider_test.go
+++ b/services/blockvalidation/checkpoint_difficulty_reconsider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-wire"
 	"github.com/bsv-blockchain/teranode/model"
 	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
 	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
 	"github.com/bsv-blockchain/teranode/ulogger"
 	"github.com/bsv-blockchain/teranode/util/test"
@@ -50,13 +51,40 @@ func TestSkipExpectedDifficulty_RebuildsInvalidatedPrefix(t *testing.T) {
 	_, best, err := client.GetBestBlockHeader(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), best.Height)
-	require.False(t, u.skipExpectedDifficulty(ctx, blocks[0]), "a completed prefix needs no stored-block exception")
+	require.False(t, u.skipExpectedDifficulty(ctx, blocks[0], false), "a completed prefix needs no stored-block exception")
 
 	_, err = client.InvalidateBlock(ctx, blocks[0].Hash())
 	require.NoError(t, err)
 	_, best, err = client.GetBestBlockHeader(ctx)
 	require.NoError(t, err)
 	require.Zero(t, best.Height, "invalidation must remove the whole descendant prefix")
-	require.True(t, u.skipExpectedDifficulty(ctx, blocks[0]), "rebuilding historical blocks must retain the syncing skip")
-	require.True(t, u.skipExpectedDifficulty(ctx, blocks[1]))
+	require.True(t, u.skipExpectedDifficulty(ctx, blocks[0], false), "rebuilding historical blocks must retain the syncing skip")
+	require.True(t, u.skipExpectedDifficulty(ctx, blocks[1], false))
+}
+
+func TestSkipExpectedDifficultyRejectsStoredFork(t *testing.T) {
+	ctx := context.Background()
+	cfg := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.(interface{ Close() error }).Close()) })
+	client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, cfg, store, nil, nil)
+	require.NoError(t, err)
+	blocks := testhelpers.CreateTestBlocksWithPrev(t, 2, cfg.ChainCfgParams.GenesisHash)
+	for i, block := range blocks {
+		block.Height = uint32(i + 1)
+		require.NoError(t, client.AddBlock(ctx, block, "test"))
+	}
+	cfg.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 2, Hash: blocks[1].Hash()}}
+	_, err = client.InvalidateBlock(ctx, blocks[0].Hash())
+	require.NoError(t, err)
+	fork := testhelpers.CreateTestBlocksWithPrev(t, 1, cfg.ChainCfgParams.GenesisHash)[0]
+	fork.Height = 1
+	fork.Header.Nonce++
+	require.NoError(t, client.AddBlock(ctx, fork, "test"))
+	u := &BlockValidation{settings: cfg, blockchainClient: client, logger: ulogger.TestLogger{}}
+	require.False(t, u.skipExpectedDifficulty(ctx, fork, false), "being stored below checkpoint does not prove ancestry")
+	require.True(t, u.skipExpectedDifficulty(ctx, blocks[0], false), "the invalidated checkpoint ancestor remains proven")
 }

--- a/services/blockvalidation/checkpoint_difficulty_reconsider_test.go
+++ b/services/blockvalidation/checkpoint_difficulty_reconsider_test.go
@@ -1,0 +1,62 @@
+package blockvalidation
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipExpectedDifficulty_RebuildsInvalidatedPrefix(t *testing.T) {
+	ctx := context.Background()
+	tSettings := test.CreateBaseTestSettings(t)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, tSettings, store, nil, nil)
+	require.NoError(t, err)
+
+	// Two synthetic historical blocks suffice to exercise the actual invalidation
+	// cascade and best-height lookup, independently of the historical DAA rules.
+	prev := tSettings.ChainCfgParams.GenesisHash
+	blocks := make([]*model.Block, 0, 2)
+	for height := uint32(1); height <= 2; height++ {
+		genesis := tSettings.ChainCfgParams.GenesisBlock
+		header := genesis.Header
+		header.PrevBlock = *prev
+		header.Nonce += height
+		coinbase := wire.NewMsgTx(1)
+		coinbase.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Index: 0xffffffff}, SignatureScript: []byte{1, byte(height)}, Sequence: 0xffffffff})
+		coinbase.AddTxOut(&wire.TxOut{Value: 50 * 100_000_000, PkScript: []byte{0x51}})
+		header.MerkleRoot = coinbase.TxHash()
+		block, err := model.NewBlockFromMsgBlock(&wire.MsgBlock{Header: header, Transactions: []*wire.MsgTx{coinbase}}, nil)
+		require.NoError(t, err)
+		require.NoError(t, client.AddBlock(ctx, block, "test"))
+		block.Height = height
+		blocks = append(blocks, block)
+		prev = block.Hash()
+	}
+	tSettings.ChainCfgParams.Checkpoints = []chaincfg.Checkpoint{{Height: 2, Hash: blocks[1].Hash()}}
+	u := &BlockValidation{settings: tSettings, blockchainClient: client, logger: ulogger.TestLogger{}}
+	_, best, err := client.GetBestBlockHeader(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), best.Height)
+	require.False(t, u.skipExpectedDifficulty(ctx, blocks[0]), "a completed prefix needs no stored-block exception")
+
+	_, err = client.InvalidateBlock(ctx, blocks[0].Hash())
+	require.NoError(t, err)
+	_, best, err = client.GetBestBlockHeader(ctx)
+	require.NoError(t, err)
+	require.Zero(t, best.Height, "invalidation must remove the whole descendant prefix")
+	require.True(t, u.skipExpectedDifficulty(ctx, blocks[0]), "rebuilding historical blocks must retain the syncing skip")
+	require.True(t, u.skipExpectedDifficulty(ctx, blocks[1]))
+}

--- a/services/blockvalidation/checkpoint_height_test.go
+++ b/services/blockvalidation/checkpoint_height_test.go
@@ -1,0 +1,100 @@
+package blockvalidation
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessBlockFound_CheckpointHeight(t *testing.T) {
+	for _, claimed := range []uint32{0, 1, 11111} {
+		t.Run(fmt.Sprint(claimed), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			settings := test.CreateBaseTestSettings(t)
+			storeURL, err := url.Parse("sqlitememory:///")
+			require.NoError(t, err)
+			store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, settings)
+			require.NoError(t, err)
+			client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, settings, store, nil, nil)
+			require.NoError(t, err)
+			header := settings.ChainCfgParams.GenesisBlock.Header
+			header.PrevBlock = *settings.ChainCfgParams.GenesisHash
+			header.Timestamp = header.Timestamp.Add(10 * time.Minute)
+			block, err := model.NewBlockFromMsgBlock(&wire.MsgBlock{Header: header, Transactions: settings.ChainCfgParams.GenesisBlock.Transactions}, nil)
+			require.NoError(t, err)
+			for {
+				met, _, _ := block.Header.HasMetTargetDifficulty()
+				if met {
+					break
+				}
+				block.Header.Nonce++
+			}
+			block.Height = claimed
+			block.Subtrees = []*chainhash.Hash{{1}}
+			block.SubtreeSlices = nil
+			server := New(ulogger.TestLogger{}, settings, nil, memory.New(), nil, nil, client, nil, nil, nil)
+			server.blockValidation = NewBlockValidation(ctx, ulogger.TestLogger{}, settings, client, memory.New(), memory.New(), nil, nil, &checkpointSubtreeBoundary{})
+			t.Cleanup(server.blockValidation.StopCaches)
+			err = server.processBlockFound(ctx, block.Hash(), "", "legacy", block)
+			if claimed == 11111 {
+				require.ErrorContains(t, err, "peer-inconsistent height")
+				require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+			} else {
+				require.ErrorContains(t, err, "checkpoint subtree boundary reached")
+				require.Equal(t, uint32(1), block.Height)
+			}
+			exists, err := client.GetBlockExists(ctx, block.Hash())
+			require.NoError(t, err)
+			require.False(t, exists, "a supplied height must not poison the stored header")
+		})
+	}
+}
+
+func TestDeriveBlockHeight(t *testing.T) {
+	const cp = 100 // a checkpoint height, for the poisoning case
+
+	tests := []struct {
+		name       string
+		claimed    uint32
+		parent     uint32
+		want       uint32
+		wantReject bool
+	}{
+		{name: "parent height overflow rejected", parent: ^uint32(0), wantReject: true},
+		{name: "honest height passes", claimed: 501, parent: 500, want: 501},
+		{name: "genesis child derived", claimed: 1, parent: 0, want: 1},
+		{name: "wire height zeroed is derived", claimed: 0, parent: cp - 1, want: cp},
+		{name: "honest height at a checkpoint", claimed: cp, parent: cp - 1, want: cp},
+		// The poisoning attempt: relabel the honest tip (real height 501) as checkpoint height 100.
+		{name: "spoofed checkpoint height rejected", claimed: cp, parent: 500, wantReject: true},
+		{name: "wire height one past rejected", claimed: cp + 1, parent: cp - 1, wantReject: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deriveBlockHeight(tc.claimed, tc.parent)
+			if tc.wantReject {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/services/blockvalidation/checkpoint_review_test.go
+++ b/services/blockvalidation/checkpoint_review_test.go
@@ -1,0 +1,166 @@
+package blockvalidation
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuickValidationAuthenticatesBodyBeforeMutation(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		for _, mutation := range []string{"duplicate", "late duplicate", "merkle", "coinbase only"} {
+			t.Run(fmt.Sprintf("%s/%s", mode, mutation), func(t *testing.T) {
+				ctx := context.Background()
+				cfg := test.CreateBaseTestSettings(t)
+				cfg.BlockValidation.SubtreeBatchSize = 1
+				cfg.BlockValidation.SubtreeBatchPrefetchDepth = 0
+				if mode == "pipeline" {
+					cfg.BlockValidation.SubtreeBatchPrefetchDepth = 2
+				}
+				storeURL, err := url.Parse("sqlitememory:///")
+				require.NoError(t, err)
+				store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, cfg)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, store.(interface{ Close() error }).Close()) })
+				client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, cfg, store, nil, nil)
+				require.NoError(t, err)
+				blobs := memory.New()
+				u := &BlockValidation{logger: ulogger.TestLogger{}, settings: cfg, blockchainClient: client, subtreeStore: blobs}
+				block := testhelpers.CreateTestBlocksWithPrev(t, 1, cfg.ChainCfgParams.GenesisHash)[0]
+				block.Height = 1
+				subtree, err := subtreepkg.NewTreeByLeafCount(4)
+				require.NoError(t, err)
+				require.NoError(t, subtree.AddCoinbaseNode())
+				for _, hash := range []chainhash.Hash{{1}, {2}} {
+					require.NoError(t, subtree.AddNode(hash, 0, 1))
+				}
+				if mutation == "late duplicate" {
+					require.NoError(t, subtree.AddNode(chainhash.Hash{3}, 0, 1))
+				}
+				root, err := subtree.RootHashWithReplaceRootNode(block.CoinbaseTx.TxIDChainHash(), 0, uint64(block.CoinbaseTx.Size()))
+				require.NoError(t, err)
+				block.Header.HashMerkleRoot = root
+				if mutation == "duplicate" {
+					require.NoError(t, subtree.AddNode(chainhash.Hash{2}, 0, 1))
+				}
+				block.Subtrees = []*chainhash.Hash{subtree.RootHash()}
+				block.SubtreeSlices = []*subtreepkg.Subtree{subtree}
+				if mutation == "late duplicate" {
+					last, err := subtreepkg.NewTreeByLeafCount(4)
+					require.NoError(t, err)
+					for _, hash := range []chainhash.Hash{{4}, {5}, {6}} {
+						require.NoError(t, last.AddNode(hash, 0, 1))
+					}
+					lastRoot := last.RootHash()
+					combined := chainhash.DoubleHashH(append(root.CloneBytes(), lastRoot[:]...))
+					block.Header.HashMerkleRoot = &combined
+					require.NoError(t, last.AddNode(chainhash.Hash{6}, 0, 1))
+					block.Subtrees = append(block.Subtrees, last.RootHash())
+					block.SubtreeSlices = append(block.SubtreeSlices, last)
+					data, err := last.Serialize()
+					require.NoError(t, err)
+					require.NoError(t, blobs.Set(ctx, last.RootHash()[:], fileformat.FileTypeSubtreeToCheck, data))
+				}
+				require.NoError(t, block.CheckMerkleRoot(ctx), "the duplicate body must retain the honest header commitment")
+				serialized, err := subtree.Serialize()
+				require.NoError(t, err)
+				require.NoError(t, blobs.Set(ctx, block.Subtrees[0][:], fileformat.FileTypeSubtreeToCheck, serialized))
+				if mutation == "merkle" {
+					block.Header.HashMerkleRoot = &chainhash.Hash{99}
+				}
+				if mutation == "coinbase only" {
+					block.Subtrees = nil
+					block.SubtreeSlices = nil
+				}
+				block.SubtreeSlices = nil
+				jobs := make(chan *SubtreeWriteJob, 10)
+				if mode == "async" {
+					err = u.quickValidateBlockAsync(ctx, block, "peer", "", jobs)
+				} else {
+					err = u.quickValidateBlock(ctx, block, "peer", "")
+				}
+				if mutation == "duplicate" || mutation == "late duplicate" {
+					require.ErrorContains(t, err, "duplicate transaction")
+				} else {
+					require.ErrorContains(t, err, "body does not match header merkle root")
+				}
+				require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+				require.Zero(t, block.ID, "no ID may be assigned before the body is authenticated")
+				require.Empty(t, jobs, "no async writes may be queued")
+				exists, err := client.GetBlockExists(ctx, block.Hash())
+				require.NoError(t, err)
+				require.False(t, exists)
+				for _, hash := range block.Subtrees {
+					exists, err := blobs.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
+					require.NoError(t, err)
+					require.False(t, exists)
+				}
+			})
+		}
+	}
+}
+
+func TestCatchupCheckpointProofAnchorsAndBounds(t *testing.T) {
+	cfg := test.CreateBaseTestSettings(t)
+	cfg.BlockValidation.CatchupAllowQuickValidation = true
+	server := &Server{logger: ulogger.TestLogger{}, settings: cfg}
+	blocks := testhelpers.CreateTestBlocks(t, 4)
+	headers := make([]*model.BlockHeader, len(blocks))
+	for i, block := range blocks {
+		block.Height = uint32(i + 1)
+		headers[i] = block.Header
+	}
+	c := &CatchupContext{
+		blockUpTo:          blocks[3],
+		commonAncestorHash: headers[0].HashPrevBlock,
+		commonAncestorMeta: &model.BlockHeaderMeta{Height: 0},
+		blockHeaders:       headers,
+		checkpoints: []chaincfg.Checkpoint{
+			{Height: 2, Hash: blocks[1].Hash()},
+			{Height: 100, Hash: &chainhash.Hash{99}},
+		},
+	}
+	require.NoError(t, server.verifyCheckpointsInHeaderChain(c))
+	require.Equal(t, uint32(2), c.highestCheckpointHeight, "unseen checkpoints cannot prove later blocks")
+	require.True(t, c.blockCheckpointProven(blocks[0]))
+	require.True(t, c.blockCheckpointProven(blocks[1]))
+	require.False(t, c.blockCheckpointProven(blocks[2]))
+	cfg.BlockValidation.CatchupAllowQuickValidation = false
+	require.NoError(t, server.verifyCheckpointsInHeaderChain(c))
+	require.False(t, c.useQuickValidation)
+	require.True(t, c.blockCheckpointProven(blocks[0]), "full validation still has authenticated ancestry")
+	cfg.BlockValidation.CatchupAllowQuickValidation = true
+	c.checkpoints = append(c.checkpoints, chaincfg.Checkpoint{Height: 3, Hash: &chainhash.Hash{77}})
+	require.ErrorContains(t, server.verifyCheckpointsInHeaderChain(c), "CHECKPOINT VERIFICATION FAILED")
+	require.Zero(t, c.highestCheckpointHeight, "a failed verification must publish no proof")
+	c.checkpoints = c.checkpoints[:len(c.checkpoints)-1]
+	require.NoError(t, server.verifyCheckpointsInHeaderChain(c))
+	fork := testhelpers.CreateTestBlocks(t, 1)[0]
+	fork.Height = 1
+	fork.Header.Nonce++
+	require.False(t, c.blockCheckpointProven(fork))
+	c.commonAncestorHash = &chainhash.Hash{42}
+	require.ErrorContains(t, server.verifyCheckpointsInHeaderChain(c), "does not connect to common ancestor")
+	require.False(t, c.useQuickValidation)
+	require.ErrorContains(t, server.buildHeaderCache(c), "doesn't match common ancestor")
+	require.ErrorContains(t, server.verifyChainContinuity(context.Background(), c), "does not connect to common ancestor")
+	c.commonAncestorHash = headers[0].HashPrevBlock
+	headers[2].HashPrevBlock = &chainhash.Hash{42}
+	require.ErrorContains(t, server.verifyCheckpointsInHeaderChain(c), "does not connect to common ancestor")
+	require.ErrorContains(t, server.buildHeaderCache(c), "disconnected header")
+}

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -198,6 +198,10 @@ func (u *BlockValidation) quickValidateBlock(ctx context.Context, block *model.B
 		return errors.NewBlockIncompleteError("[quickValidateBlock][%s] coinbase tx is nil or has no inputs, peer may not have full block data", block.Hash().String())
 	}
 
+	if err := u.authenticateQuickBlockBody(ctx, block); err != nil {
+		return err
+	}
+
 	var (
 		err error
 		id  uint64
@@ -285,6 +289,10 @@ func (u *BlockValidation) quickValidateBlockAsync(ctx context.Context, block *mo
 	// Reject blocks without a valid coinbase (e.g. from seeded peers that don't have full block data)
 	if block.CoinbaseTx == nil || len(block.CoinbaseTx.Inputs) == 0 {
 		return errors.NewBlockIncompleteError("[quickValidateBlockAsync][%s] coinbase tx is nil or has no inputs, peer may not have full block data", block.Hash().String())
+	}
+
+	if err := u.authenticateQuickBlockBody(ctx, block); err != nil {
+		return err
 	}
 
 	var (
@@ -1531,5 +1539,22 @@ func (u *BlockValidation) extendBatch(
 		}
 	}
 
+	return nil
+}
+
+// authenticateQuickBlockBody checks the complete body before any batch can assign
+// a block ID, mutate UTXOs, or promote subtree files. The preflight reads only node
+// hashes; transaction data is still streamed in batches by the existing pipeline.
+func (u *BlockValidation) authenticateQuickBlockBody(ctx context.Context, block *model.Block) error {
+	body := &model.Block{Header: block.Header, CoinbaseTx: block.CoinbaseTx, Subtrees: block.Subtrees}
+	if err := body.GetAndValidateSubtrees(ctx, u.logger, u.subtreeStore, u.settings.BlockValidation.SubtreeBatchSize); err != nil {
+		return err
+	}
+	if err := model.CheckSubtreeSlicesForDuplicateTxs(body.SubtreeSlices); err != nil {
+		return err
+	}
+	if err := body.CheckMerkleRoot(ctx); err != nil {
+		return errors.NewBlockInvalidError("[quickValidateBlock][%s] body does not match header merkle root", block.Hash().String(), err)
+	}
 	return nil
 }

--- a/services/blockvalidation/quick_validate_test.go
+++ b/services/blockvalidation/quick_validate_test.go
@@ -30,6 +30,7 @@ func TestQuickValidateBlock(t *testing.T) {
 		suite.MockBlockchain.On("SetBlockSubtreesSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
+		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
 
 		err := suite.Server.blockValidation.quickValidateBlock(suite.Ctx, block, "test", "")
 		assert.NoError(t, err, "Should successfully quick validate an empty block")

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -707,5 +707,10 @@ func (s *Server) Stop(_ context.Context) error {
 		return nil
 	}
 
-	return s.server.Stop()
+	if err := s.server.Stop(); err != nil {
+		return err
+	}
+	// The peer server stop only signals shutdown. Join the sync manager before
+	// the service manager returns and the daemon closes its UTXO store.
+	return s.server.syncManager.Stop()
 }

--- a/services/legacy/netsync/HandleBlockDirect_test.go
+++ b/services/legacy/netsync/HandleBlockDirect_test.go
@@ -131,6 +131,6 @@ func Test_HandleBlockDirect(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = sm.HandleBlockDirect(context.Background(), &peer.Peer{}, *block.Hash(), nil)
+	err = sm.HandleBlockDirect(context.Background(), &peer.Peer{}, *block.Hash(), nil, blockRequestOrigin{})
 	require.NoError(t, err)
 }

--- a/services/legacy/netsync/body_commitment_test.go
+++ b/services/legacy/netsync/body_commitment_test.go
@@ -1,0 +1,201 @@
+package netsync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	bt "github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation"
+	legacychain "github.com/bsv-blockchain/teranode/services/legacy/blockchain"
+	"github.com/bsv-blockchain/teranode/services/legacy/bsvutil"
+	"github.com/bsv-blockchain/teranode/services/subtreevalidation"
+	"github.com/bsv-blockchain/teranode/services/validator"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	utxosql "github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/stretchr/testify/require"
+)
+
+type bodyCommitmentBlockValidation struct {
+	blockvalidation.Interface
+	called bool
+}
+
+func (v *bodyCommitmentBlockValidation) ProcessBlock(context.Context, *model.Block, uint32, string, string, uint32) error {
+	v.called = true
+	return errors.NewProcessingError("body commitment downstream sentinel")
+}
+
+type bodySubtreeBoundary struct {
+	subtreevalidation.Interface
+	called bool
+}
+
+func (v *bodySubtreeBoundary) CheckSubtreeFromBlock(context.Context, chainhash.Hash, string, uint32, *chainhash.Hash, *chainhash.Hash) error {
+	v.called = true
+	return errors.NewProcessingError("full script validation boundary")
+}
+
+type bodySubtreeStore struct {
+	*memory.Memory
+	writes atomic.Int32
+}
+
+func (s *bodySubtreeStore) Set(ctx context.Context, key []byte, kind fileformat.FileType, value []byte, opts ...options.FileOption) error {
+	s.writes.Add(1)
+	return s.Memory.Set(ctx, key, kind, value, opts...)
+}
+
+// Exercise delivery from a real checkpoint header request. Invalid bodies must
+// neither spend/create UTXOs nor write even a subtree marker. The valid controls
+// also check that the per-peer proof, rather than the global map, selects the route.
+func TestHandleBlockMsg_BodyCommitment(t *testing.T) {
+	for _, proven := range []bool{false, true} {
+		for _, mutation := range []string{"none", "transaction", "coinbase", "coinbase only", "valid coinbase only", "duplicate", "incomplete final subtree"} {
+			t.Run(fmt.Sprintf("proven=%v/%s", proven, mutation), func(t *testing.T) {
+				initPrometheusMetrics()
+				sm, p, state := newHeaderProvenanceManager(t)
+				sm.settings.BlockAssembly.MaximumMerkleItemsPerSubtree = 4
+				storeURL, err := url.Parse("sqlitememory:///")
+				require.NoError(t, err)
+				store, err := utxosql.New(sm.ctx, ulogger.TestLogger{}, sm.settings, storeURL)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, store.Close(sm.ctx)) })
+				sm.utxoStore = store
+				blobs := &bodySubtreeStore{Memory: memory.New()}
+				sm.subtreeStore = blobs
+				fullValidation := &bodySubtreeBoundary{}
+				sm.subtreeValidation = fullValidation
+				downstream := &bodyCommitmentBlockValidation{}
+				sm.blockValidation = downstream
+				sm.validationClient = &bodySpendValidator{store: store}
+
+				makeTx := func(parent chainhash.Hash, value int64) *wire.MsgTx {
+					tx := wire.NewMsgTx(1)
+					tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: parent}, Sequence: 0xffffffff, SignatureScript: []byte{0x00}})
+					tx.AddTxOut(&wire.TxOut{Value: value, PkScript: []byte{0x51}})
+					return tx
+				}
+				parentWire := makeTx(chainhash.Hash{}, 1000)
+				parentWire.TxIn[0].PreviousOutPoint.Index = 0xffffffff
+				parentWire.TxIn[0].SignatureScript = []byte{1, 1}
+				parent := &bt.Tx{}
+				require.NoError(t, WireTxToGoBtTx(bsvutil.NewTx(parentWire), parent))
+				_, err = store.Create(sm.ctx, parent, 0)
+				require.NoError(t, err)
+				before, err := store.Get(sm.ctx, parent.TxIDChainHash(), fields.Utxos)
+				require.NoError(t, err)
+
+				block := makeDuplicateTxidBlock(1).MsgBlock()
+				block.Transactions = block.Transactions[:1]
+				count := 3
+				if mutation == "coinbase only" || mutation == "valid coinbase only" {
+					count = 1
+				}
+				if mutation == "incomplete final subtree" {
+					count = 7
+				}
+				prev := parentWire.TxHash()
+				for i := 1; i < count; i++ {
+					tx := makeTx(prev, 1000-int64(i))
+					block.Transactions = append(block.Transactions, tx)
+					prev = tx.TxHash()
+				}
+				block.Header.PrevBlock = *sm.chainParams.GenesisHash
+				block.Header.Bits = 0x207fffff
+				setBodyMerkleRoot(block)
+				require.True(t, solveBlock(&block.Header, sm.chainParams.PowLimit))
+				hash := block.Header.BlockHash()
+				sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 1, Hash: &hash}
+				sm.headerList.PushBack(&headerNode{height: 0, hash: sm.chainParams.GenesisHash})
+				headers := wire.NewMsgHeaders()
+				require.NoError(t, headers.AddBlockHeader(&block.Header))
+				sm.handleHeadersMsg(&headersMsg{headers: headers, peer: p})
+				require.True(t, sm.blockOrigin(state, hash).headerProven)
+				// Simulate an ordinary inventory request for the unproven case, and put
+				// the opposite provenance in the shorter-lived global deduplication map.
+				state.requestedBlocks.Set(hash, blockRequestOrigin{headerProven: proven})
+				sm.requestedBlocks.Set(hash, blockRequestOrigin{headerProven: !proven})
+
+				switch mutation {
+				case "duplicate":
+					block.Transactions = append(block.Transactions, block.Transactions[len(block.Transactions)-1])
+				case "transaction":
+					block.Transactions[len(block.Transactions)-1].TxOut[0].Value--
+				case "coinbase", "coinbase only":
+					block.Transactions[0].TxOut[0].Value--
+				}
+				if mutation == "duplicate" {
+					roots := legacychain.BuildMerkleTreeStore(bsvutil.NewBlock(block).Transactions())
+					require.Equal(t, block.Header.MerkleRoot, *roots[len(roots)-1], "duplicate padding must preserve the proven header's commitment")
+				}
+				err = sm.handleBlockMsg(&blockQueueMsg{block: block, blockHash: hash, peer: p})
+				_, requested := state.requestedBlocks.Get(hash)
+				require.False(t, requested)
+				if mutation == "none" || mutation == "incomplete final subtree" || mutation == "valid coinbase only" {
+					if mutation != "valid coinbase only" {
+						require.Positive(t, blobs.writes.Load(), "valid bodies must exercise the tracked write boundary")
+					}
+					if proven || mutation == "valid coinbase only" {
+						require.ErrorContains(t, err, "body commitment downstream sentinel")
+						require.True(t, downstream.called)
+						require.False(t, fullValidation.called)
+					} else {
+						require.ErrorContains(t, err, "full script validation boundary")
+						require.True(t, fullValidation.called)
+						require.False(t, downstream.called)
+					}
+					return
+				}
+				if mutation == "duplicate" {
+					require.ErrorContains(t, err, "duplicate transaction")
+				} else {
+					require.ErrorContains(t, err, "merkle root does not match")
+				}
+				require.True(t, errors.Is(err, errors.ErrBlockInvalid), "%v", err)
+				require.False(t, downstream.called)
+				require.False(t, fullValidation.called)
+				require.Zero(t, blobs.writes.Load())
+				after, err := store.Get(sm.ctx, parent.TxIDChainHash(), fields.Utxos)
+				require.NoError(t, err)
+				require.Equal(t, before.SpendingDatas, after.SpendingDatas)
+				for _, tx := range block.Transactions {
+					hash := tx.TxHash()
+					_, err := store.Get(sm.ctx, &hash)
+					require.True(t, errors.Is(err, errors.ErrTxNotFound), "received transaction must not be created: %v", err)
+				}
+			})
+		}
+	}
+}
+
+// Use real SQL spends to exercise the release's legacy prevalidation writes.
+type bodySpendValidator struct {
+	validator.Interface
+	store *utxosql.Store
+}
+
+func (v *bodySpendValidator) Validate(ctx context.Context, tx *bt.Tx, height uint32, _ ...validator.Option) (*meta.Data, error) {
+	_, err := v.store.Spend(ctx, tx, height)
+	return &meta.Data{}, err
+}
+
+func (s *bodySubtreeStore) SetFromReader(ctx context.Context, key []byte, kind fileformat.FileType, reader io.ReadCloser, opts ...options.FileOption) error {
+	s.writes.Add(1)
+	return s.Memory.SetFromReader(ctx, key, kind, reader, opts...)
+}
+
+func (v *bodySpendValidator) EnsureMTPLoaded(context.Context, uint32) error { return nil }

--- a/services/legacy/netsync/checkpoint_fixtures_test.go
+++ b/services/legacy/netsync/checkpoint_fixtures_test.go
@@ -1,0 +1,58 @@
+package netsync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/model"
+	legacychain "github.com/bsv-blockchain/teranode/services/legacy/blockchain"
+	"github.com/bsv-blockchain/teranode/services/legacy/bsvutil"
+	"github.com/stretchr/testify/require"
+)
+
+func makeDuplicateTxidBlock(height int32) *bsvutil.Block {
+	makeCoinbase := func(h int32) *wire.MsgTx {
+		cb := wire.NewMsgTx(1)
+		cb.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+			SignatureScript:  []byte{byte(h & 0xff), 0x01}, //nolint:gosec // test coinbase script
+			Sequence:         0xffffffff,
+		})
+		cb.AddTxOut(&wire.TxOut{Value: 5000, PkScript: []byte{0x76, 0xa9, 0x14}})
+		return cb
+	}
+
+	// A single regular tx, added to the block twice → identical txid twice.
+	external := chainhash.Hash{0xde, 0xad, 0x42}
+	tx := wire.NewMsgTx(1)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: external, Index: 0},
+		SignatureScript:  []byte{0x00, 0x42},
+		Sequence:         0xffffffff,
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x76, 0xa9, 0x14, 0x42}})
+
+	msgBlock := &wire.MsgBlock{
+		Header:       wire.BlockHeader{Version: 1, Timestamp: time.Now(), Bits: 0x1d00ffff},
+		Transactions: []*wire.MsgTx{makeCoinbase(height), tx, tx}, // tx duplicated
+	}
+
+	block := bsvutil.NewBlock(msgBlock)
+	block.SetHeight(height)
+
+	return block
+}
+func bodyCommitment(t *testing.T, block *bsvutil.Block) *model.Block {
+	t.Helper()
+	commitment, err := model.NewBlockFromMsgBlock(block.MsgBlock(), nil)
+	require.NoError(t, err)
+	commitment.Subtrees = nil
+	commitment.SubtreeSlices = nil
+	return commitment
+}
+func setBodyMerkleRoot(block *wire.MsgBlock) {
+	roots := legacychain.BuildMerkleTreeStore(bsvutil.NewBlock(block).Transactions())
+	block.Header.MerkleRoot = *roots[len(roots)-1]
+}

--- a/services/legacy/netsync/checkpoint_provenance_test.go
+++ b/services/legacy/netsync/checkpoint_provenance_test.go
@@ -1,0 +1,113 @@
+package netsync
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// peerAdvertised is the provenance handleInvMsg records: we are fetching the
+// block only because a peer said it exists.
+var peerAdvertised = blockRequestOrigin{}
+
+// headerProven is the provenance fetchHeaderBlocks records: the hash came from a
+// header run verified to terminate at a pinned checkpoint hash.
+var headerProven = blockRequestOrigin{headerProven: true}
+
+// provenanceSyncManager builds the minimal SyncManager needed to exercise
+// quickValidationAllowed. The gate consults nothing but the chain params and the
+// provenance it is handed — no blockchain client, UTXO store, settings or request
+// map — which is the point: it cannot be fooled by, or made to depend on, the
+// state of anything else.
+func provenanceSyncManager(t *testing.T) *SyncManager {
+	t.Helper()
+
+	return &SyncManager{chainParams: &chaincfg.MainNetParams}
+}
+
+// TestQuickValidationAllowed_DeniesPeerAdvertisedBlock is the regression test
+// for GHSA-gggq-8f59-4jm9. The reported attack is exactly this shape: a peer
+// advertises an unknown block by inv, we request it (which is the only
+// unsolicited-block check on the path), and it claims a height below the highest
+// hardcoded checkpoint. Before the fix the gate was a pure height test, so the
+// block was granted checkpoint trust: script validation was skipped and its
+// transactions spent real UTXOs.
+//
+// A peer-advertised request carries no proof of anything. The gate must deny it.
+func TestQuickValidationAllowed_DeniesPeerAdvertisedBlock(t *testing.T) {
+	sm := provenanceSyncManager(t)
+
+	require.False(t, sm.quickValidationAllowed(peerAdvertised, 944_999),
+		"a peer-advertised below-checkpoint block must never be granted checkpoint trust")
+}
+
+// TestQuickValidationAllowed_AllowsHeaderProvenBlock is the other half of the
+// contract: initial block download must keep the fast path, or mainnet sync
+// regresses to full script validation over the whole certified prefix.
+//
+// fetchHeaderBlocks only ever requests hashes from a header run that
+// handleHeadersMsg verified links back to a block we already trust and forward
+// to a pinned checkpoint hash. That run IS the proof of checkpoint ancestry.
+func TestQuickValidationAllowed_AllowsHeaderProvenBlock(t *testing.T) {
+	sm := provenanceSyncManager(t)
+
+	require.True(t, sm.quickValidationAllowed(headerProven, 944_999),
+		"a block requested from a checkpoint-terminated header run must keep the fast path")
+}
+
+// TestQuickValidationAllowed_DeniesEveryHeightInCertifiedPrefix — the pure
+// height test was true for EVERY height in 1..945000, which is what made the
+// prefix forgeable. Sample across it to pin that provenance, not height, decides.
+func TestQuickValidationAllowed_DeniesEveryHeightInCertifiedPrefix(t *testing.T) {
+	sm := provenanceSyncManager(t)
+
+	for _, h := range []uint32{1, 11_111, 500_000, 944_998, 944_999, 945_000} {
+		require.False(t, sm.quickValidationAllowed(peerAdvertised, h),
+			"height %d is inside the certified prefix but carries no ancestry proof", h)
+		require.True(t, sm.quickValidationAllowed(headerProven, h),
+			"height %d is inside the certified prefix and is header-proven", h)
+	}
+}
+
+// TestQuickValidationAllowed_DeniesAboveCheckpoint — above the highest
+// checkpoint there is no certified prefix to appeal to, so provenance is
+// irrelevant and the answer is always no.
+func TestQuickValidationAllowed_DeniesAboveCheckpoint(t *testing.T) {
+	sm := provenanceSyncManager(t)
+
+	require.False(t, sm.quickValidationAllowed(headerProven, 945_001),
+		"height above the highest checkpoint must never fast-path, however it was requested")
+	require.False(t, sm.quickValidationAllowed(headerProven, 0),
+		"genesis must never fast-path")
+}
+
+// TestQuickValidationAllowed_FailsClosedWithoutChainParams — with no chain params
+// there are no checkpoints to appeal to, so the gate must deny rather than panic.
+// The cost of a false negative is slower but fully correct validation; the cost of
+// a false positive is an unauthenticated peer writing forged spends.
+func TestQuickValidationAllowed_FailsClosedWithoutChainParams(t *testing.T) {
+	noParams := &SyncManager{}
+	require.False(t, noParams.quickValidationAllowed(headerProven, 944_999),
+		"no chain params means nothing is certified")
+}
+
+// TestQuickValidationAllowed_DeniesOnNetworkWithoutCheckpoints — regtest defines
+// no checkpoints, so nothing is certified and the fast path cannot apply.
+func TestQuickValidationAllowed_DeniesOnNetworkWithoutCheckpoints(t *testing.T) {
+	sm := &SyncManager{chainParams: &chaincfg.RegressionNetParams}
+
+	require.False(t, sm.quickValidationAllowed(headerProven, 1),
+		"a network with no checkpoints has no certified prefix")
+}
+
+// TestBlockRequestOrigin_ZeroValueIsUntrusted pins the safety property that
+// makes the request map safe to extend: the zero value must mean "no
+// provenance". Any new call site that records a request without thinking about
+// provenance therefore gets the safe answer by default.
+func TestBlockRequestOrigin_ZeroValueIsUntrusted(t *testing.T) {
+	var origin blockRequestOrigin
+
+	require.False(t, origin.headerProven,
+		"the zero value of blockRequestOrigin must be untrusted, so new call sites fail closed")
+}

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -36,7 +36,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, blockHash chainhash.Hash, msgBlock *wire.MsgBlock) (err error) {
+func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, blockHash chainhash.Hash, msgBlock *wire.MsgBlock, origin blockRequestOrigin) (err error) {
 	sm.logger.Debugf("[HandleBlockDirect][%s] starting handling block", blockHash.String())
 
 	// Make sure we have the correct height for this block before continuing
@@ -123,6 +123,29 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 		deferFn(err)
 	}()
 
+	// Reject invalid proof of work before waits or transaction processing.
+	var headerBytes bytes.Buffer
+	if err = block.MsgBlock().Header.Serialize(&headerBytes); err != nil {
+		return errors.NewProcessingError("failed to serialize header", err)
+	}
+
+	// create the Teranode compatible block header
+	header, err := model.NewBlockHeaderFromBytes(headerBytes.Bytes())
+	if err != nil {
+		return errors.NewProcessingError("failed to create block header from bytes", err)
+	}
+
+	if err = header.HasMetPowLimit(sm.chainParams); err != nil {
+		return errors.NewBlockInvalidError("block declares a target easier than the network proof-of-work limit", err)
+	}
+	if valid, _, powErr := header.HasMetTargetDifficulty(); !valid {
+		return errors.NewBlockInvalidError("invalid block header: %s", header.Hash().String(), powErr)
+	}
+
+	if len(block.Transactions()) == 0 {
+		return errors.NewBlockInvalidError("block contains no transactions")
+	}
+
 	// Wait for block assembly to be ready
 	if err = blockassemblyutil.WaitForBlockAssemblyReady(ctx, sm.logger, sm.blockAssembly, blockHeight, sm.settings.BlockValidation.MaxBlocksBehindBlockAssembly); err != nil {
 		// block-assembly is still behind, so we cannot process this block
@@ -136,18 +159,6 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 		if err = sm.waitForPreviousBlockMined(ctx, &block.MsgBlock().Header.PrevBlock, blockHeight); err != nil {
 			return err
 		}
-	}
-
-	// 3. Create a block message with (block hash, coinbase tx and slice if 1 subtree)
-	var headerBytes bytes.Buffer
-	if err = block.MsgBlock().Header.Serialize(&headerBytes); err != nil {
-		return errors.NewProcessingError("failed to serialize header", err)
-	}
-
-	// create the Teranode compatible block header
-	header, err := model.NewBlockHeaderFromBytes(headerBytes.Bytes())
-	if err != nil {
-		return errors.NewProcessingError("failed to create block header from bytes", err)
 	}
 
 	var coinbase bytes.Buffer
@@ -168,7 +179,8 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 
 	// validate all subtrees and store all subtree data
 	// this also should spend and create all utxos
-	subtrees, blockID, err := sm.prepareSubtrees(ctx, block)
+	commitment := &model.Block{Header: header, CoinbaseTx: coinbaseTx}
+	subtrees, blockID, err := sm.prepareSubtrees(ctx, block, origin, commitment)
 	if err != nil {
 		return err
 	}
@@ -184,12 +196,6 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 	teranodeBlock, err := model.NewBlock(header, coinbaseTx, subtrees, uint64(len(block.Transactions())), blockSizeUint64, blockHeight, blockID)
 	if err != nil {
 		return errors.NewProcessingError("failed to create model.NewBlock", err)
-	}
-
-	// pre-check that there is enough proof of work on the block, before we do any other processing
-	headerValid, _, err := teranodeBlock.Header.HasMetTargetDifficulty()
-	if !headerValid {
-		return errors.NewBlockInvalidError("invalid block header: %s", teranodeBlock.Header.Hash().String(), err)
 	}
 
 	// call the process block wrapper, which will add tracing and logging
@@ -292,7 +298,7 @@ type TxMapWrapper struct {
 	ChildLevelInBlock  uint32
 }
 
-func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block) (subtrees []*chainhash.Hash, blockID uint32, err error) {
+func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block, origin blockRequestOrigin, commitment *model.Block) (subtrees []*chainhash.Hash, blockID uint32, err error) {
 	ctx, _, deferFn := tracing.Tracer("netsync").Start(ctx, "prepareSubtrees",
 		tracing.WithLogMessage(
 			sm.logger,
@@ -315,6 +321,9 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 
 	txCount := len(block.Transactions())
 	if txCount <= 1 {
+		if err = commitment.CheckMerkleRoot(ctx); err != nil {
+			return nil, 0, errors.NewBlockInvalidError("block body does not match header", err)
+		}
 		return subtrees, blockID, nil
 	}
 
@@ -374,17 +383,28 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 		return nil, 0, err
 	}
 
+	// Authenticate the body before assigning IDs or writing UTXOs/subtree markers.
+	// Merkle padding can hide duplicate transactions, so both checks are required.
+	if err = model.CheckSubtreeSlicesForDuplicateTxs(subtreeSlices); err != nil {
+		return nil, 0, err
+	}
+	for _, slice := range subtreeSlices {
+		subtrees = append(subtrees, slice.RootHash())
+	}
+	commitment.Subtrees = subtrees
+	commitment.SubtreeSlices = subtreeSlices
+	if err = commitment.CheckMerkleRoot(ctx); err != nil {
+		return nil, 0, errors.NewBlockInvalidError("block body does not match header", err)
+	}
+	commitment.SubtreeSlices = nil
+
 	blockHeight32, convErr := safeconversion.Int32ToUint32(block.Height())
 	if convErr != nil {
 		return nil, 0, errors.NewProcessingError("[prepareSubtrees] failed to convert block height", convErr)
 	}
 
-	// Quick validation is safe whenever the block sits at/below the highest hard-coded
-	// checkpoint for the active network. POW (verified upstream by HasMetTargetDifficulty)
-	// plus checkpoint-anchored chain linkage make the block canonical regardless of which
-	// FSM state drove the catch-up. The checkpoint list is owned by go-chaincfg — see PR
-	// #844 for the matching FSM-RUN gate that relies on the same invariant.
-	quickValidationMode := sm.quickValidationAllowed(blockHeight32)
+	// Only checkpoint-proven requests may bypass full script validation.
+	quickValidationMode := sm.quickValidationAllowed(origin, blockHeight32)
 
 	if quickValidationMode {
 		// Fetch block ID upfront so UTXOs carry mined info from creation. This ID is
@@ -434,32 +454,20 @@ func (sm *SyncManager) prepareSubtrees(ctx context.Context, block *bsvutil.Block
 		}
 	}
 
-	for i := 0; i < numSubtrees; i++ {
-		subtrees = append(subtrees, subtreeSlices[i].RootHash())
-	}
-
 	return subtrees, blockID, nil
 }
 
-// quickValidationAllowed reports whether the given block height is covered by a
-// hard-coded checkpoint for the active network. Checkpoint-anchored chain linkage
-// combined with the upstream PoW check makes the block canonical, so we can skip
-// subtree re-validation and the per-UTXO setTxMined cross-check.
-//
-// Returns false when the network defines no checkpoints (regtest) or when the
-// block height is above the highest checkpoint — those blocks must follow the
-// regular validation path.
-func (sm *SyncManager) quickValidationAllowed(blockHeight uint32) bool {
+// quickValidationAllowed requires a positive checkpoint-covered height and a proven header request.
+func (sm *SyncManager) quickValidationAllowed(origin blockRequestOrigin, blockHeight uint32) bool {
 	if sm.chainParams == nil {
 		return false
 	}
 
-	highest := blockchain.HighestCheckpointHeight(sm.chainParams.Checkpoints)
-	if highest == 0 {
+	if !origin.headerProven {
 		return false
 	}
 
-	return blockHeight <= highest
+	return model.BelowCheckpoint(sm.chainParams.Checkpoints, blockHeight)
 }
 
 func (sm *SyncManager) checkSubtreeFromBlock(ctx context.Context, block *bsvutil.Block, subtree *subtreepkg.Subtree) error {
@@ -1154,11 +1162,8 @@ func (sm *SyncManager) PreValidateTransactions(ctx context.Context, txMap *txmap
 					validator.WithInBlock(true),
 					validator.WithSkipTxMetaPublishing(true),
 					validator.WithCreateConflicting(true),
-					// PreValidateTransactions is only reached via the quickValidationMode
-					// path (see prepareSubtrees → ValidateTransactionsLegacyMode), which
-					// runs only when the block height is at or below the highest
-					// hard-coded checkpoint. PoW + checkpoint linkage establish the chain
-					// as canonical, so re-running BDK scripts is pure overhead.
+					// prepareSubtrees permits this skip only for a checkpoint-proven
+					// request whose transaction body matches the header commitment.
 					validator.WithSkipScriptValidation(true),
 					validator.WithCandidateBlockTime(candidateBlockTime),
 					validator.WithCandidateParentMedianTime(candidateParentMedianTime),
@@ -1669,7 +1674,9 @@ func (sm *SyncManager) createTxMap(ctx context.Context, block *bsvutil.Block, tx
 			// bt.Tx and the TxMapWrapper it lands in.
 			hashCopy := *wireTx.Hash()
 			tx.SetTxHash(&hashCopy)
-			txMap.Set(hashCopy, &TxMapWrapper{Tx: tx})
+			if _, inserted := txMap.SetIfNotExists(hashCopy, &TxMapWrapper{Tx: tx}); !inserted {
+				return errors.NewBlockInvalidError("block contains duplicate transaction %s", hashCopy.String())
+			}
 		}
 	}
 

--- a/services/legacy/netsync/handle_block.go
+++ b/services/legacy/netsync/handle_block.go
@@ -139,7 +139,7 @@ func (sm *SyncManager) HandleBlockDirect(ctx context.Context, peer *peer.Peer, b
 		return errors.NewBlockInvalidError("block declares a target easier than the network proof-of-work limit", err)
 	}
 	if valid, _, powErr := header.HasMetTargetDifficulty(); !valid {
-		return errors.NewBlockInvalidError("invalid block header: %s", header.Hash().String(), powErr)
+		return errors.NewBlockInvalidError("invalid block header: %s: %v", header.Hash().String(), powErr.Error(), powErr)
 	}
 
 	if len(block.Transactions()) == 0 {

--- a/services/legacy/netsync/handle_block_memory_test.go
+++ b/services/legacy/netsync/handle_block_memory_test.go
@@ -383,7 +383,7 @@ func TestHandleBlockDirect_TestnetLargeBlock(t *testing.T) {
 	t.Logf("[%s] Starting HandleBlockDirect...", time.Since(benchStartTime))
 	startTime := time.Now()
 
-	err = sm.HandleBlockDirect(ctx, &peer.Peer{}, *blockHash, block.MsgBlock())
+	err = sm.HandleBlockDirect(ctx, &peer.Peer{}, *blockHash, block.MsgBlock(), blockRequestOrigin{})
 	elapsed := time.Since(startTime)
 
 	// === Stop CPU profiling ===

--- a/services/legacy/netsync/handle_block_test.go
+++ b/services/legacy/netsync/handle_block_test.go
@@ -103,7 +103,7 @@ func TestSyncManager_HandleBlockDirect(t *testing.T) {
 	err = msgBlock.Deserialize(bytes.NewReader(blockBytes))
 	require.NoError(t, err)
 
-	err = sm.HandleBlockDirect(t.Context(), &peer.Peer{}, *blockHash, msgBlock)
+	err = sm.HandleBlockDirect(t.Context(), &peer.Peer{}, *blockHash, msgBlock, blockRequestOrigin{})
 	require.NoError(t, err)
 }
 
@@ -572,7 +572,7 @@ func TestSyncManager_prepareSubtrees(t *testing.T) {
 	}
 
 	// For single transaction blocks, prepareSubtrees returns empty
-	subtrees, blockID, err := sm.prepareSubtrees(context.Background(), block)
+	subtrees, blockID, err := sm.prepareSubtrees(context.Background(), block, blockRequestOrigin{}, bodyCommitment(t, block))
 	assert.NoError(t, err)
 	assert.NotNil(t, subtrees)
 	assert.Equal(t, uint32(0), blockID) // single-tx block exits early, IsFSMCurrentState=false → blockID stays 0
@@ -1510,10 +1510,10 @@ func TestSyncManager_quickValidationAllowed(t *testing.T) {
 			want:        false,
 		},
 		{
-			name:        "mainnet height 0 is covered",
+			name:        "mainnet height 0 is excluded",
 			chainParams: &chaincfg.MainNetParams,
 			height:      0,
-			want:        true,
+			want:        false,
 		},
 		{
 			name:        "mainnet height equal to highest checkpoint is covered",
@@ -1532,7 +1532,7 @@ func TestSyncManager_quickValidationAllowed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sm := &SyncManager{chainParams: tt.chainParams}
-			require.Equal(t, tt.want, sm.quickValidationAllowed(tt.height))
+			require.Equal(t, tt.want, sm.quickValidationAllowed(headerProven, tt.height))
 		})
 	}
 }

--- a/services/legacy/netsync/header_provenance_flow_test.go
+++ b/services/legacy/netsync/header_provenance_flow_test.go
@@ -118,6 +118,8 @@ func TestHandleBlockDirect_RejectsPoWBeforeAssemblyWait(t *testing.T) {
 			require.ErrorContains(t, err, "block declares a target easier than the network proof-of-work limit")
 		} else {
 			require.ErrorContains(t, err, "invalid block header")
+			require.ErrorContains(t, err, "block header does not meet target")
+			require.NotContains(t, err.Error(), "%!")
 		}
 	}
 }

--- a/services/legacy/netsync/header_provenance_flow_test.go
+++ b/services/legacy/netsync/header_provenance_flow_test.go
@@ -1,0 +1,245 @@
+package netsync
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/services/blockassembly"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/legacy/peer"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/expiringmap"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// Use the real SQL blockchain client so provenance tests exercise inventory
+// lookups and block delivery without mocked chain state.
+func newHeaderProvenanceManager(t *testing.T) (*SyncManager, *peer.Peer, *peerSyncState) {
+	t.Helper()
+	tSettings := test.CreateBaseTestSettings(t)
+	params := tSettings.ChainCfgParams
+	params.Checkpoints = []chaincfg.Checkpoint{{Height: 33_333, Hash: &chainhash.Hash{0x7f}}}
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, tSettings)
+	require.NoError(t, err)
+	client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, tSettings, store, nil, nil)
+	require.NoError(t, err)
+	p := peer.NewInboundPeer(ulogger.TestLogger{}, tSettings, &peer.Config{})
+	state := &peerSyncState{requestedBlocks: expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Hour)}
+	t.Cleanup(state.requestedBlocks.Stop)
+	sm := &SyncManager{
+		ctx: context.Background(), logger: ulogger.TestLogger{}, settings: tSettings,
+		chainParams: params, blockchainClient: client,
+		peerStates:      txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
+		requestedBlocks: expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Minute),
+		headerList:      list.New(), blockSizeTracker: newBlockSizeTracker(10),
+	}
+	t.Cleanup(sm.requestedBlocks.Stop)
+	sm.peerStates.Set(p, state)
+	sm.storeSyncPeer(p, &syncPeerState{})
+	sm.headersFirstMode.Store(true)
+	return sm, p, state
+}
+
+func TestHeaderProvenance_CheckpointAdvanceDoesNotVerifyTail(t *testing.T) {
+	sm, p, state := newHeaderProvenanceManager(t)
+	anchor := hashFrom(0x41)
+	checkpointHeader := wire.NewBlockHeader(1, &anchor, &chainhash.Hash{}, 0x207fffff, 0)
+	checkpointHash := checkpointHeader.BlockHash()
+	sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 11_111, Hash: &checkpointHash}
+	sm.headerList.PushBack(&headerNode{height: 11_110, hash: &anchor})
+	headers := wire.NewMsgHeaders()
+	require.NoError(t, headers.AddBlockHeader(checkpointHeader))
+	sm.handleHeadersMsg(&headersMsg{headers: headers, peer: p})
+	require.True(t, sm.blockOrigin(state, checkpointHash).headerProven,
+		"matching the pinned hash must preserve the IBD fast path")
+
+	// Block delivery advances the pending checkpoint independently of header
+	// verification. No header in the next interval has matched a pinned hash.
+	sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 33_333, Hash: &chainhash.Hash{0x7f}}
+	tailHeader := wire.NewBlockHeader(1, &checkpointHash, &chainhash.Hash{}, 0x207fffff, 1)
+	tailHash := tailHeader.BlockHash()
+	tail := wire.NewMsgHeaders()
+	require.NoError(t, tail.AddBlockHeader(tailHeader))
+	sm.handleHeadersMsg(&headersMsg{headers: tail, peer: p})
+	sm.fetchHeaderBlocks() // also triggered by a delayed block from the previous run
+	origin, requested := state.requestedBlocks.Get(tailHash)
+	require.True(t, requested, "exercise the production request-provenance write")
+	require.False(t, origin.headerProven, "advancing the pending checkpoint must not bless the unverified tail")
+	require.False(t, sm.quickValidationAllowed(origin, 11_112))
+}
+
+func TestHeaderProvenance_UnmatchedCheckpointDeniesRequests(t *testing.T) {
+	sm, p, state := newHeaderProvenanceManager(t)
+	anchor := hashFrom(0x42)
+	header := wire.NewBlockHeader(1, &anchor, &chainhash.Hash{}, 0x207fffff, 0)
+	hash := header.BlockHash()
+	sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 11_111, Hash: &chainhash.Hash{0x7f}}
+	sm.headerList.PushBack(&headerNode{height: 11_110, hash: &anchor})
+	headers := wire.NewMsgHeaders()
+	require.NoError(t, headers.AddBlockHeader(header))
+	sm.handleHeadersMsg(&headersMsg{headers: headers, peer: p})
+	// A failed checkpoint comparison currently leaves the node in the list.
+	// Even if another block delivery requests it, it must never acquire trust.
+	sm.fetchHeaderBlocks()
+	require.False(t, sm.blockOrigin(state, hash).headerProven)
+}
+
+func TestHandleBlockDirect_RejectsPoWBeforeAssemblyWait(t *testing.T) {
+	sm, p, _ := newHeaderProvenanceManager(t)
+	sm.chainParams = &chaincfg.MainNetParams
+	// Any call to this mock is unexpected: both PoW rejections must precede it.
+	sm.blockAssembly = blockassembly.NewMock()
+	for _, bits := range []uint32{0x207fffff, 0} {
+		block := makeDuplicateTxidBlock(1).MsgBlock()
+		block.Header.PrevBlock = *sm.settings.ChainCfgParams.GenesisHash
+		block.Header.Bits = bits
+		if bits != 0 {
+			require.True(t, solveBlock(&block.Header, chaincfg.RegressionNetParams.PowLimit))
+		}
+		initPrometheusMetrics()
+		err := sm.HandleBlockDirect(sm.ctx, p, block.Header.BlockHash(), block, blockRequestOrigin{})
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid), "%v", err)
+		if bits != 0 {
+			require.ErrorContains(t, err, "block declares a target easier than the network proof-of-work limit")
+		} else {
+			require.ErrorContains(t, err, "invalid block header")
+		}
+	}
+}
+
+func TestHeaderProvenance_CheckpointBlockDelivery(t *testing.T) {
+	for _, final := range []bool{false, true} {
+		name := "next checkpoint"
+		if final {
+			name = "final checkpoint"
+		}
+		t.Run(name, func(t *testing.T) {
+			sm, p, state := newHeaderProvenanceManager(t)
+			block := makeDuplicateTxidBlock(1).MsgBlock()
+			block.Header.PrevBlock = *sm.chainParams.GenesisHash
+			block.Header.Timestamp = time.Unix(1231006505, 0)
+			// An already-stored block exercises successful delivery bookkeeping
+			// without coupling the checkpoint transition test to UTXO validation.
+			stored, err := model.NewBlockFromMsgBlock(block, nil)
+			require.NoError(t, err)
+			require.NoError(t, sm.blockchainClient.AddBlock(sm.ctx, stored, "test"))
+			hash := block.Header.BlockHash()
+			sm.chainParams.Checkpoints = []chaincfg.Checkpoint{{Height: 1, Hash: &hash}}
+			if !final {
+				sm.chainParams.Checkpoints = append(sm.chainParams.Checkpoints, chaincfg.Checkpoint{Height: 3, Hash: &chainhash.Hash{0x7f}})
+			}
+			sm.nextCheckpoint = &sm.chainParams.Checkpoints[0]
+			sm.verifiedCheckpointHeight = 1
+			sm.headerList.PushBack(&headerNode{height: 1, hash: &hash})
+			sm.startHeader = sm.headerList.PushBack(&headerNode{height: 2, hash: &chainhash.Hash{0x44}})
+			sm.rejectedTxns = txmap.NewSyncedMap[chainhash.Hash, struct{}]()
+			state.requestedBlocks.Set(hash, blockRequestOrigin{headerProven: true})
+			sm.requestedBlocks.Set(hash, blockRequestOrigin{headerProven: true})
+
+			require.NoError(t, sm.handleBlockMsg(&blockQueueMsg{block: block, blockHash: hash, blockHeight: 1, peer: p}))
+			if final {
+				require.Nil(t, sm.nextCheckpoint)
+				require.Zero(t, sm.verifiedCheckpointHeight)
+				require.Zero(t, sm.headerList.Len())
+				require.Nil(t, sm.startHeader)
+				require.False(t, sm.headersFirstMode.Load())
+			} else {
+				require.Equal(t, int32(3), sm.nextCheckpoint.Height)
+				require.Equal(t, int32(1), sm.verifiedCheckpointHeight)
+				require.False(t, sm.headerNodeProven(sm.startHeader.Value.(*headerNode)))
+			}
+		})
+	}
+}
+
+// Drive the actual asynchronous header handler against a shared anchor. A
+// sibling of an interior header must never inherit the matched run's proof.
+func TestHeaderProvenance_ConcurrentHeaders(t *testing.T) {
+	for attempt := 0; attempt < 100; attempt++ {
+		t.Run(fmt.Sprint(attempt), func(t *testing.T) {
+			sm, p, state := newHeaderProvenanceManager(t)
+			anchor := hashFrom(0x51)
+			sm.headerList.PushBack(&headerNode{height: 100, hash: &anchor})
+			headers := wire.NewMsgHeaders()
+			prev := anchor
+			var sibling *wire.BlockHeader
+			for i := 0; i < 64; i++ {
+				header := wire.NewBlockHeader(1, &prev, &chainhash.Hash{}, 0x207fffff, uint32(i))
+				require.NoError(t, headers.AddBlockHeader(header))
+				if i == 32 {
+					sibling = wire.NewBlockHeader(1, &prev, &chainhash.Hash{1}, 0x207fffff, 99)
+				}
+				prev = header.BlockHash()
+			}
+			sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 164, Hash: &prev}
+			forgedHash := sibling.BlockHash()
+			forged := wire.NewMsgHeaders()
+			require.NoError(t, forged.AddBlockHeader(sibling))
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for _, msg := range []*wire.MsgHeaders{headers, forged} {
+				wg.Add(1)
+				go func(msg *wire.MsgHeaders) {
+					defer wg.Done()
+					<-start
+					sm.handleHeadersMsg(&headersMsg{headers: msg, peer: p})
+				}(msg)
+			}
+			close(start)
+			wg.Wait()
+			// Drain the genuine run so a bad sibling cannot hide beyond the first
+			// request batch. Preserve the request records for the final assertion.
+			for sm.startHeader != nil {
+				// The global and peer request maps are only dedupe/admission state here.
+				// Remove genuine requests to make room for the remaining header entries.
+				for _, header := range headers.Headers {
+					state.requestedBlocks.Delete(header.BlockHash())
+				}
+				sm.fetchHeaderBlocks()
+			}
+			require.False(t, sm.blockOrigin(state, forgedHash).headerProven)
+			require.Equal(t, int32(164), sm.verifiedCheckpointHeight)
+		})
+	}
+}
+
+func TestHeaderProvenance_ConcurrentReset(t *testing.T) {
+	for attempt := 0; attempt < 50; attempt++ {
+		t.Run(fmt.Sprint(attempt), func(t *testing.T) {
+			sm, p, _ := newHeaderProvenanceManager(t)
+			anchor := hashFrom(0x52)
+			header := wire.NewBlockHeader(1, &anchor, &chainhash.Hash{}, 0x207fffff, 1)
+			hash := header.BlockHash()
+			sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 101, Hash: &hash}
+			sm.headerList.PushBack(&headerNode{height: 100, hash: &anchor})
+			headers := wire.NewMsgHeaders()
+			require.NoError(t, headers.AddBlockHeader(header))
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(3)
+			go func() { defer wg.Done(); <-start; sm.handleHeadersMsg(&headersMsg{headers: headers, peer: p}) }()
+			go func() { defer wg.Done(); <-start; sm.resetHeaderState(&anchor, 100) }()
+			go func() { defer wg.Done(); <-start; sm.fetchHeaderBlocks() }()
+			close(start)
+			wg.Wait()
+			require.Zero(t, sm.verifiedCheckpointHeight)
+			require.Nil(t, sm.startHeader)
+			require.Equal(t, 1, sm.headerList.Len())
+		})
+	}
+}

--- a/services/legacy/netsync/header_provenance_test.go
+++ b/services/legacy/netsync/header_provenance_test.go
@@ -1,0 +1,119 @@
+package netsync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-chaincfg"
+	"github.com/bsv-blockchain/teranode/util/expiringmap"
+	"github.com/stretchr/testify/require"
+)
+
+// hashFrom builds a distinct, stable hash from a single byte.
+func hashFrom(b byte) chainhash.Hash {
+	var h chainhash.Hash
+	h[0] = b
+
+	return h
+}
+
+// Only headers at or below an actually matched checkpoint have provenance,
+// even after checkpoint block delivery advances the pending download target.
+func TestHeaderNodeProven_DeniesAboveVerifiedCheckpoint(t *testing.T) {
+	sm := &SyncManager{
+		nextCheckpoint:           &chaincfg.Checkpoint{Height: 33_333},
+		verifiedCheckpointHeight: 11_111,
+	}
+
+	require.True(t, sm.headerNodeProven(&headerNode{height: 11_111}),
+		"the checkpoint height itself is committed by the hash match")
+	require.True(t, sm.headerNodeProven(&headerNode{height: 11_110}),
+		"heights below the matched checkpoint are committed by linkage to it")
+	require.False(t, sm.headerNodeProven(&headerNode{height: 11_112}),
+		"a header above the matched checkpoint is committed by nothing and must not be proven")
+	require.False(t, sm.headerNodeProven(&headerNode{height: 900_000}),
+		"a far-above header must not be proven either")
+}
+
+// TestHeaderNodeProven_FailsClosedWithoutCheckpoint — no next checkpoint means
+// there is no pinned hash to appeal to, so nothing can be proven.
+func TestHeaderNodeProven_FailsClosedWithoutCheckpoint(t *testing.T) {
+	sm := &SyncManager{}
+
+	require.False(t, sm.headerNodeProven(&headerNode{height: 1}))
+	require.False(t, sm.headerNodeProven(nil))
+}
+
+// TestBlockOrigin_SurvivesGlobalMapExpiry is the regression test for the TTL bug
+// found in review.
+//
+// New() builds sm.requestedBlocks with a 60-SECOND expiry, while the per-peer map
+// gets 60 MINUTES ("needed for legacy sync/checkpoints"). expiringmap.Get does not
+// refresh and reports a miss past expiry, so reading provenance from the global
+// map made every block slower than a minute — the common case on mainnet, with
+// multi-GB blocks behind a 20-deep FIFO — silently lose its header proof and drop
+// to full script validation.
+//
+// Provenance must come from the same record the unsolicited-block check consults,
+// so it lives exactly as long as admission does.
+func TestBlockOrigin_SurvivesGlobalMapExpiry(t *testing.T) {
+	hash := hashFrom(0x77)
+
+	globalMap := expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Millisecond)
+	t.Cleanup(globalMap.Stop)
+
+	perPeerMap := expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Hour)
+	t.Cleanup(perPeerMap.Stop)
+
+	sm := &SyncManager{requestedBlocks: globalMap}
+	state := &peerSyncState{requestedBlocks: perPeerMap}
+
+	// fetchHeaderBlocks records the proof in both maps.
+	globalMap.Set(hash, blockRequestOrigin{headerProven: true})
+	perPeerMap.Set(hash, blockRequestOrigin{headerProven: true})
+
+	// Let the short-lived global entry lapse, as it does for any block that takes
+	// more than a minute to reach the FIFO consumer.
+	require.Eventually(t, func() bool {
+		_, ok := globalMap.Get(hash)
+		return !ok
+	}, time.Second, 5*time.Millisecond, "the global entry must lapse for this test to mean anything")
+
+	require.True(t, sm.blockOrigin(state, hash).headerProven,
+		"provenance must survive the global map's short TTL")
+}
+
+// TestBlockOrigin_FailsClosed — an unknown hash, or no peer state, yields the
+// untrusted zero value rather than a panic.
+func TestBlockOrigin_FailsClosed(t *testing.T) {
+	perPeerMap := expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Hour)
+	t.Cleanup(perPeerMap.Stop)
+
+	sm := &SyncManager{}
+
+	require.False(t, sm.blockOrigin(&peerSyncState{requestedBlocks: perPeerMap}, hashFrom(0x78)).headerProven,
+		"a hash that was never requested has no provenance")
+	require.False(t, sm.blockOrigin(nil, hashFrom(0x79)).headerProven,
+		"no peer state means no provenance")
+	require.False(t, sm.blockOrigin(&peerSyncState{}, hashFrom(0x7a)).headerProven,
+		"no request map means no provenance")
+}
+
+func TestHeaderNodeProven_FailsClosedBeforeMatch(t *testing.T) {
+	sm := &SyncManager{nextCheckpoint: &chaincfg.Checkpoint{Height: 11_111}}
+	require.False(t, sm.headerNodeProven(&headerNode{height: 1}))
+	require.False(t, sm.headerNodeProven(&headerNode{height: 0}))
+	require.False(t, sm.headerNodeProven(nil))
+}
+
+func TestHeaderProvenance_ResetDiscardsProof(t *testing.T) {
+	sm, _, _ := newHeaderProvenanceManager(t)
+	hash := hashFrom(0x43)
+	sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 33_333, Hash: &hash}
+	sm.verifiedCheckpointHeight = 11_111
+	sm.resetHeaderState(&hash, 100)
+	require.Zero(t, sm.verifiedCheckpointHeight)
+	require.Nil(t, sm.startHeader)
+	require.False(t, sm.headerNodeProven(&headerNode{height: 100}))
+}

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -154,13 +154,29 @@ type headerNode struct {
 	hash   *chainhash.Hash
 }
 
+// blockRequestOrigin records HOW a block came to be requested. It is the proof
+// that backs every below-checkpoint fast path: the hardcoded checkpoints certify
+// one chain, not a height range, so "this block sits below the highest
+// checkpoint" says nothing about whether it belongs to that chain.
+//
+// The zero value is deliberately untrusted, so a request recorded by a call site
+// that has not thought about provenance fails closed.
+type blockRequestOrigin struct {
+	// headerProven is true when the request came from fetchHeaderBlocks, i.e. from
+	// a header run handleHeadersMsg verified links back to a block we already
+	// trust AND forward to a pinned checkpoint hash. That run is the ancestry
+	// proof. Blocks requested because a peer advertised them (handleInvMsg) carry
+	// no such proof and are never header-proven.
+	headerProven bool
+}
+
 // peerSyncState stores additional information that the SyncManager tracks
 // about a peer.
 type peerSyncState struct {
 	syncCandidate   bool
 	requestQueue    *txmap.SyncedSlice[wire.InvVect]
 	requestedTxns   *expiringmap.ExpiringMap[chainhash.Hash, struct{}]
-	requestedBlocks *expiringmap.ExpiringMap[chainhash.Hash, struct{}]
+	requestedBlocks *expiringmap.ExpiringMap[chainhash.Hash, blockRequestOrigin]
 }
 
 // syncPeerState stores additional info about the sync peer.
@@ -401,7 +417,7 @@ type SyncManager struct {
 	// (except syncPeer/syncPeerState which are protected by syncPeerMu).
 	rejectedTxns    *txmap.SyncedMap[chainhash.Hash, struct{}]
 	requestedTxns   *expiringmap.ExpiringMap[chainhash.Hash, struct{}]
-	requestedBlocks *expiringmap.ExpiringMap[chainhash.Hash, struct{}]
+	requestedBlocks *expiringmap.ExpiringMap[chainhash.Hash, blockRequestOrigin]
 	syncPeerMu      sync.RWMutex // protects syncPeer and syncPeerState
 	syncPeer        *peerpkg.Peer
 	syncPeerState   *syncPeerState
@@ -417,10 +433,15 @@ type SyncManager struct {
 
 	// The following fields are used for headers-first mode.
 	headersFirstMode atomic.Bool // accessed from multiple goroutines, must be atomic
-	headerList       *list.List
-	startHeader      *list.Element
-	nextCheckpoint   *chaincfg.Checkpoint
-	blockSizeTracker *blockSizeTracker // tracks block sizes for dynamic in-flight adjustment
+
+	// headerMu protects the header list, cursor, pending checkpoint and verified
+	// boundary as one state. Never hold it during full block validation.
+	headerMu                 sync.Mutex
+	headerList               *list.List
+	startHeader              *list.Element
+	nextCheckpoint           *chaincfg.Checkpoint
+	verifiedCheckpointHeight int32             // highest checkpoint hash matched by handleHeadersMsg
+	blockSizeTracker         *blockSizeTracker // tracks block sizes for dynamic in-flight adjustment
 
 	// An optional fee estimator.
 	// feeEstimator *mempool.FeeEstimator
@@ -478,9 +499,17 @@ func (sm *SyncManager) storeSyncPeer(peer *peerpkg.Peer, state *syncPeerState) {
 // resetHeaderState sets the headers-first mode state to values appropriate for
 // syncing from a new peer.
 func (sm *SyncManager) resetHeaderState(newestHash *chainhash.Hash, newestHeight int32) {
+	sm.headerMu.Lock()
+	defer sm.headerMu.Unlock()
+	sm.resetHeaderStateLocked(newestHash, newestHeight)
+}
+
+// resetHeaderStateLocked requires headerMu.
+func (sm *SyncManager) resetHeaderStateLocked(newestHash *chainhash.Hash, newestHeight int32) {
 	sm.headersFirstMode.Store(false)
 	sm.headerList.Init()
 	sm.startHeader = nil
+	sm.verifiedCheckpointHeight = 0
 
 	// When there is a next checkpoint, add an entry for the latest known
 	// block into the header pool.  This allows the next downloaded header
@@ -677,6 +706,8 @@ func (sm *SyncManager) startSync() {
 	// and fully validate them.  Finally, regression test mode does
 	// not support the headers-first approach so do normal block
 	// downloads when in regression test mode.
+	sm.headerMu.Lock()
+	defer sm.headerMu.Unlock()
 	if sm.nextCheckpoint != nil &&
 		bestBlockHeightInt32 < sm.nextCheckpoint.Height &&
 		sm.chainParams != &chaincfg.RegressionNetParams {
@@ -820,8 +851,8 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
 	sm.peerStates.Set(peer, &peerSyncState{
 		syncCandidate:   isSyncCandidate,
 		requestQueue:    txmap.NewSyncedSlice[wire.InvVect](maxRequestedBlocks),
-		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second), // allow the node 10 seconds to respond to the tx request
-		requestedBlocks: expiringmap.New[chainhash.Hash, struct{}](60 * time.Minute), // allow the node 1 hour to respond to the requested blocks, needed for legacy sync/checkpoints
+		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second),           // allow the node 10 seconds to respond to the tx request
+		requestedBlocks: expiringmap.New[chainhash.Hash, blockRequestOrigin](60 * time.Minute), // allow the node 1 hour to respond to the requested blocks, needed for legacy sync/checkpoints
 	})
 
 	// Start syncing by choosing the best candidate if needed.
@@ -982,11 +1013,14 @@ func (sm *SyncManager) updateSyncPeer(_ *peerSyncState) {
 
 	// Only disconnect if we have a valid sync peer
 	if sp != nil {
+		sm.headerMu.Lock()
 		// Log current sync state before disconnecting
 		if sm.headersFirstMode.Load() {
 			sm.logger.Debugf("Current header sync state - headerList length: %d, startHeader exists: %v",
 				sm.headerList.Len(), sm.startHeader != nil)
 		}
+
+		sm.headerMu.Unlock()
 
 		sp.SetSyncPeer(false)
 		sp.DisconnectWithInfo("updateSyncPeer - disconnect old sync peer")
@@ -1319,7 +1353,8 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	// properly.
 	isCheckpointBlock := false
 
-	if sm.headersFirstMode.Load() {
+	sm.headerMu.Lock()
+	if sm.headersFirstMode.Load() && sm.nextCheckpoint != nil {
 		sm.logger.Debugf("[handleBlockMsg][%s] headers-first mode, checking block", bmsg.blockHash)
 
 		firstNodeEl := sm.headerList.Front()
@@ -1335,6 +1370,14 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 			}
 		}
 	}
+
+	sm.headerMu.Unlock()
+
+	// Read the request provenance BEFORE the delete below removes it, and pass it
+	// explicitly to HandleBlockDirect. It is the proof that backs the
+	// below-checkpoint fast paths (see blockRequestOrigin), so it has to outlive
+	// the request bookkeeping.
+	blockOrigin := sm.blockOrigin(state, bmsg.blockHash)
 
 	// Remove block from request maps. Either chain will know about it, and
 	// so we shouldn't have any more instances of trying to fetch it, or we
@@ -1360,7 +1403,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	// if not in Legacy Sync mode, we need to potentially download the block,
 	// promote block to the block validation via kafka (p2p -> blockvalidation message),
 	// without calling HandleBlockDirect. Such that it doesn't interfere with the operation of block validation.
-	if err = sm.HandleBlockDirect(sm.ctx, bmsg.peer, bmsg.blockHash, bmsg.block); err != nil {
+	if err = sm.HandleBlockDirect(sm.ctx, bmsg.peer, bmsg.blockHash, bmsg.block, blockOrigin); err != nil {
 		if errors.Is(err, errors.ErrBlockNotFound) {
 			// We don't have the parent of this block. During legacy sync /
 			// catching blocks this is typically the peer announcing its tip
@@ -1485,13 +1528,19 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 		}
 	}
 
+	sm.headerMu.Lock()
+	defer sm.headerMu.Unlock()
+	// A peer reset may have changed header state while the block was validated.
+	isCheckpointBlock = isCheckpointBlock && sm.headersFirstMode.Load() &&
+		sm.nextCheckpoint != nil && bmsg.blockHash.IsEqual(sm.nextCheckpoint.Hash)
+
 	// This is headers-first mode, so if the block is not a checkpoint
 	// request more blocks using the header list to maintain the pipeline
 	// at the dynamic max limit (adjusts based on block size).
 	if !isCheckpointBlock {
 		dynamicMax := sm.blockSizeTracker.calculateMaxInFlightBlocks()
 		if sm.startHeader != nil && state.requestedBlocks.Len() < dynamicMax {
-			sm.fetchHeaderBlocks()
+			sm.fetchHeaderBlocksLocked()
 		} else if !sm.current() && state.requestedBlocks.Len() == 0 {
 			sm.logger.Debugf("Not current, and no headers to sync to, fetching more headers")
 
@@ -1542,6 +1591,8 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	// from the block after this one up to the end of the chain (zero hash).
 	sm.headersFirstMode.Store(false)
 	sm.headerList.Init()
+	sm.startHeader = nil
+	sm.verifiedCheckpointHeight = 0
 	sm.logger.Infof("Reached the final checkpoint -- switching to normal mode")
 
 	locator := blockchain.BlockLocator([]*chainhash.Hash{&bmsg.blockHash})
@@ -1552,9 +1603,62 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockQueueMsg) error {
 	return nil
 }
 
+// headerNodeProven reports whether this list entry is committed by a checkpoint
+// hash actually matched by handleHeadersMsg. Linkage alone is not proof.
+//
+// nextCheckpoint is the pending download target: it advances on checkpoint BLOCK
+// delivery, before the next header run is verified. Only verifiedCheckpointHeight
+// bounds the proven prefix, including while an unverified tail is being appended.
+// Resetting header state discards this proof along with the list it certifies.
+func (sm *SyncManager) headerNodeProven(node *headerNode) bool {
+	sm.headerMu.Lock()
+	defer sm.headerMu.Unlock()
+	return sm.headerNodeProvenLocked(node)
+}
+
+// headerNodeProvenLocked requires headerMu.
+func (sm *SyncManager) headerNodeProvenLocked(node *headerNode) bool {
+	if node == nil || sm.nextCheckpoint == nil {
+		return false
+	}
+
+	return node.height > 0 && node.height <= sm.verifiedCheckpointHeight
+}
+
+// blockOrigin returns the request provenance for a delivered block.
+//
+// It reads the PER-PEER record, not sm.requestedBlocks: New() builds the global
+// map with a 60-second expiry (it exists for handleInvMsg dedupe) while the
+// per-peer map gets 60 minutes precisely because legacy sync and checkpoints need
+// it, and expiringmap.Get neither refreshes nor tolerates expiry. Reading the
+// global map made any block slower than a minute — the common case on mainnet,
+// with multi-GB blocks queued behind up to dynamicMaxInFlight earlier requests —
+// silently lose its header proof and fall back to full validation.
+//
+// This is also the record the unsolicited-block check consults, so provenance and
+// admission consult the same per-peer map. An inv re-request can replace a proof
+// with the untrusted zero value, which safely restores full validation. An absent
+// entry, map or peer state also yields the untrusted zero value.
+func (sm *SyncManager) blockOrigin(state *peerSyncState, blockHash chainhash.Hash) blockRequestOrigin {
+	if state == nil || state.requestedBlocks == nil {
+		return blockRequestOrigin{}
+	}
+
+	origin, _ := state.requestedBlocks.Get(blockHash)
+
+	return origin
+}
+
 // fetchHeaderBlocks creates and sends a request to the syncPeer for the next
 // list of blocks to be downloaded based on the current list of headers.
 func (sm *SyncManager) fetchHeaderBlocks() {
+	sm.headerMu.Lock()
+	defer sm.headerMu.Unlock()
+	sm.fetchHeaderBlocksLocked()
+}
+
+// fetchHeaderBlocksLocked requires headerMu.
+func (sm *SyncManager) fetchHeaderBlocksLocked() {
 	// Nothing to do if there is no sync peer.
 	sp := sm.loadSyncPeer()
 	if sp == nil {
@@ -1619,9 +1723,10 @@ func (sm *SyncManager) fetchHeaderBlocks() {
 				break
 			}
 
-			sm.requestedBlocks.Set(*node.hash, struct{}{})
-			peerState, _ := sm.peerStates.Get(sp)
-			peerState.requestedBlocks.Set(*node.hash, struct{}{})
+			// Reuse the checked peer state even if the peer disconnects during the request.
+			origin := blockRequestOrigin{headerProven: sm.headerNodeProvenLocked(node)}
+			sm.requestedBlocks.Set(*node.hash, origin)
+			peerState.requestedBlocks.Set(*node.hash, origin)
 
 			numRequested++
 		}
@@ -1642,6 +1747,9 @@ func (sm *SyncManager) fetchHeaderBlocks() {
 // handleHeadersMsg handles block header messages from all peers.  Headers are
 // requested when performing a headers-first sync.
 func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
+	sm.headerMu.Lock()
+	defer sm.headerMu.Unlock()
+
 	sm.logger.Debugf("[handleHeadersMsg] received headers message with %d headers from %s", len(hmsg.headers.Headers), hmsg.peer)
 	peer := hmsg.peer
 
@@ -1669,7 +1777,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 	msg := hmsg.headers
 	numHeaders := len(msg.Headers)
 
-	if !sm.headersFirstMode.Load() {
+	if !sm.headersFirstMode.Load() || sm.nextCheckpoint == nil {
 		reason := fmt.Sprintf("Got %d unrequested headers from %s", numHeaders, peer.String())
 		peer.DisconnectWithWarning(reason)
 
@@ -1698,7 +1806,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 			return
 		}
 
-		sm.resetHeaderState(bestBlockHeader.Hash(), bestBlockHeightInt32)
+		sm.resetHeaderStateLocked(bestBlockHeader.Hash(), bestBlockHeightInt32)
 
 		prevNodeEl = sm.headerList.Back()
 		if prevNodeEl == nil {
@@ -1746,6 +1854,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		// Verify the header at the next checkpoint height matches.
 		if node.height == sm.nextCheckpoint.Height {
 			if node.hash.IsEqual(sm.nextCheckpoint.Hash) {
+				sm.verifiedCheckpointHeight = node.height
 				receivedCheckpoint = true
 
 				sm.logger.Infof("Verified downloaded block "+
@@ -1774,7 +1883,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		// fetching the blocks.
 		sm.headerList.Remove(sm.headerList.Front())
 		sm.logger.Infof("Received %v block headers: Fetching blocks", sm.headerList.Len())
-		sm.fetchHeaderBlocks()
+		sm.fetchHeaderBlocksLocked()
 
 		return
 	}
@@ -1955,8 +2064,12 @@ outside:
 					break outside
 				}
 
-				sm.requestedBlocks.Set(iv.Hash, struct{}{})
-				state.requestedBlocks.Set(iv.Hash, struct{}{})
+				// Peer-advertised: we are requesting this only because a peer said it
+				// exists. That is no proof of checkpoint ancestry, so the origin stays
+				// at its untrusted zero value and quickValidationAllowed will deny the
+				// below-checkpoint fast path for it.
+				sm.requestedBlocks.Set(iv.Hash, blockRequestOrigin{})
+				state.requestedBlocks.Set(iv.Hash, blockRequestOrigin{})
 
 				numRequested++
 			}
@@ -2412,9 +2525,9 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 		// txMemPool:     config.TxMemPool,
 		orphanTxs:       expiringmap.New[chainhash.Hash, *orphanTxAndParents](tSettings.Legacy.OrphanEvictionDuration).WithMaxSize(tSettings.Legacy.MaxOrphanTxs),
 		chainParams:     config.ChainParams,
-		rejectedTxns:    txmap.NewSyncedMap[chainhash.Hash, struct{}](maxRejectedTxns), // limit map size to maxRejectedTxns
-		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second),   // give peers 10 seconds to respond
-		requestedBlocks: expiringmap.New[chainhash.Hash, struct{}](60 * time.Second),   // give peers 60 seconds to respond
+		rejectedTxns:    txmap.NewSyncedMap[chainhash.Hash, struct{}](maxRejectedTxns),         // limit map size to maxRejectedTxns
+		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second),           // give peers 10 seconds to respond
+		requestedBlocks: expiringmap.New[chainhash.Hash, blockRequestOrigin](60 * time.Second), // give peers 60 seconds to respond
 		peerStates:      txmap.NewSyncedMap[*peerpkg.Peer, *peerSyncState](),
 		// progressLogger:  newBlockProgressLogger("Processed", log),
 		msgChan:          make(chan interface{}, maxMsgQueueSize),

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -396,6 +396,9 @@ type SyncManager struct {
 	peerNotifier PeerNotifier
 	started      int32
 	shutdown     int32
+	stopOnce     sync.Once
+	handlerMu    sync.Mutex // serializes handler admission and Start with shutdown
+	handlers     sync.WaitGroup
 	orphanTxs    *expiringmap.ExpiringMap[chainhash.Hash, *orphanTxAndParents]
 	chainParams  *chaincfg.Params
 	msgChan      chan interface{}
@@ -1054,6 +1057,11 @@ func (sm *SyncManager) updateSyncPeer(_ *peerSyncState) {
 
 // handleTxMsg handles transaction messages from all peers.
 func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
+	if !sm.beginHandler() {
+		return
+	}
+	defer sm.handlers.Done()
+
 	ctx, _, _ := tracing.Tracer("SyncManager").Start(sm.ctx, "handleTxMsg",
 		tracing.WithHistogram(prometheusLegacyNetsyncHandleTxMsg),
 		tracing.WithDebugLogMessage(sm.logger, "handling transaction message for %s from %s", tmsg.tx.Hash(), tmsg.peer),
@@ -1747,6 +1755,11 @@ func (sm *SyncManager) fetchHeaderBlocksLocked() {
 // handleHeadersMsg handles block header messages from all peers.  Headers are
 // requested when performing a headers-first sync.
 func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
+	if !sm.beginHandler() {
+		return
+	}
+	defer sm.handlers.Done()
+
 	sm.headerMu.Lock()
 	defer sm.headerMu.Unlock()
 
@@ -1939,6 +1952,11 @@ func (sm *SyncManager) haveInventory(invVect *wire.InvVect) (bool, error) {
 // handleInvMsg handles inv messages from all peers.
 // We examine the inventory advertised by the remote peer and act accordingly.
 func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
+	if !sm.beginHandler() {
+		return
+	}
+	defer sm.handlers.Done()
+
 	sm.logger.Debugf("[handleInvMsg] received inv message with %d inv vectors from %s", len(imsg.inv.InvList), imsg.peer)
 	peer := imsg.peer
 
@@ -2195,8 +2213,11 @@ func (sm *SyncManager) blockHandler() {
 	// create a block queue to handle block messages in a separate goroutine, in order
 	blockQueue := make(chan *blockQueueMsg, maxBlockQueue)
 
-	// start the block queue handler
+	// Join the sequential worker before signalling that the block handler is done.
+	var blockWorker sync.WaitGroup
+	blockWorker.Add(1)
 	go func() {
+		defer blockWorker.Done()
 		for {
 			select {
 			case <-sm.quit:
@@ -2209,7 +2230,10 @@ func (sm *SyncManager) blockHandler() {
 				sm.blockBacklog.Add(-1)
 
 				if msg.reply != nil {
-					msg.reply <- err
+					select {
+					case msg.reply <- err:
+					case <-sm.quit:
+					}
 				}
 			}
 		}
@@ -2244,7 +2268,10 @@ out:
 			case *newPeerMsg:
 				sm.handleNewPeerMsg(msg.peer)
 				if msg.reply != nil {
-					msg.reply <- struct{}{}
+					select {
+					case msg.reply <- struct{}{}:
+					case <-sm.quit:
+					}
 				}
 
 			case *txMsg:
@@ -2252,7 +2279,10 @@ out:
 					// process tx messages in parallel
 					sm.handleTxMsg(msg)
 					if msg.reply != nil {
-						msg.reply <- struct{}{}
+						select {
+						case msg.reply <- struct{}{}:
+						case <-sm.quit:
+						}
 					}
 				}(msg)
 
@@ -2261,12 +2291,17 @@ out:
 
 				sm.blockBacklog.Add(1)
 
-				blockQueue <- &blockQueueMsg{
+				select {
+				case blockQueue <- &blockQueueMsg{
 					block:       msg.block.MsgBlock(),
 					blockHash:   *msg.block.Hash(),
 					blockHeight: msg.block.Height(),
 					peer:        msg.peer,
 					reply:       msg.reply,
+				}:
+				case <-sm.quit:
+					sm.blockBacklog.Add(-1)
+					break out
 				}
 
 			case *invMsg:
@@ -2278,7 +2313,10 @@ out:
 			case *donePeerMsg:
 				sm.handleDonePeerMsg(msg.peer)
 				if msg.reply != nil {
-					msg.reply <- struct{}{}
+					select {
+					case msg.reply <- struct{}{}:
+					case <-sm.quit:
+					}
 				}
 
 			case getSyncPeerMsg:
@@ -2287,15 +2325,25 @@ out:
 				if sp := sm.loadSyncPeer(); sp != nil {
 					peerID = sp.ID()
 				}
-				msg.reply <- peerID
+				select {
+				case msg.reply <- peerID:
+				case <-sm.quit:
+				}
 
 			case isCurrentMsg:
 				sm.logger.Warnf("isCurrentMsg is deprecated, use current() instead")
-				msg.reply <- sm.current()
+				select {
+				case msg.reply <- sm.current():
+				case <-sm.quit:
+				}
 
 			case pauseMsg:
 				// Wait until the sender unpauses the manager.
-				<-msg.unpause
+				select {
+				case <-msg.unpause:
+				case <-sm.quit:
+					break out
+				}
 
 			default:
 				sm.logger.Warnf("Invalid message type in block handler: %T", msg)
@@ -2306,6 +2354,7 @@ out:
 		}
 	}
 
+	blockWorker.Wait()
 	close(sm.handlerDone)
 	sm.logger.Infof("Block handler done")
 }
@@ -2453,35 +2502,49 @@ func (sm *SyncManager) DonePeer(peer *peerpkg.Peer, done chan struct{}) {
 	sm.msgChan <- &donePeerMsg{peer: peer, reply: done}
 }
 
+// beginHandler admits work before shutdown and lets Stop wait for it. Holding
+// handlerMu across Add prevents a late Kafka callback from racing Wait.
+func (sm *SyncManager) beginHandler() bool {
+	sm.handlerMu.Lock()
+	defer sm.handlerMu.Unlock()
+	if atomic.LoadInt32(&sm.shutdown) != 0 {
+		return false
+	}
+	sm.handlers.Add(1)
+	return true
+}
+
 // Start begins the core block handler which processes block and inv messages.
 func (sm *SyncManager) Start() {
-	// Already started?
-	if atomic.AddInt32(&sm.started, 1) != 1 {
+	sm.handlerMu.Lock()
+	defer sm.handlerMu.Unlock()
+	if atomic.LoadInt32(&sm.shutdown) != 0 || !atomic.CompareAndSwapInt32(&sm.started, 0, 1) {
 		return
 	}
-
 	sm.logger.Infof("Starting sync manager")
-
 	go sm.blockHandler()
 }
 
-// Stop gracefully shuts down the sync manager by stopping all asynchronous
-// handlers and waiting for them to finish.
+// Stop prevents new message processing and waits for active handlers to
+// finish. Every caller waits for completion.
 func (sm *SyncManager) Stop() error {
-	if atomic.AddInt32(&sm.shutdown, 1) != 1 {
-		sm.logger.Warnf("Sync manager is already in the process of " +
-			"shutting down")
-		return nil
-	}
+	sm.stopOnce.Do(func() {
+		sm.handlerMu.Lock()
+		atomic.StoreInt32(&sm.shutdown, 1)
+		close(sm.quit)
+		started := atomic.LoadInt32(&sm.started) != 0
+		sm.handlerMu.Unlock()
 
-	sm.logger.Infof("Sync manager shutting down")
-	close(sm.quit)
-	<-sm.handlerDone
+		sm.logger.Infof("Sync manager shutting down")
+		if started {
+			<-sm.handlerDone
+		}
+		sm.handlers.Wait()
 
-	sm.orphanTxs.Stop()
-	sm.requestedTxns.Stop()
-	sm.requestedBlocks.Stop()
-
+		sm.orphanTxs.Stop()
+		sm.requestedTxns.Stop()
+		sm.requestedBlocks.Stop()
+	})
 	return nil
 }
 
@@ -2564,6 +2627,11 @@ func New(ctx context.Context, logger ulogger.Logger, tSettings *settings.Setting
 	// set an eviction function for orphan transactions
 	// this will be called when an orphan transaction is evicted from the map
 	sm.orphanTxs.WithEvictionFunction(func(txHash chainhash.Hash, orphanTx *orphanTxAndParents) bool {
+		if !sm.beginHandler() {
+			return true
+		}
+		defer sm.handlers.Done()
+
 		// try to process one last time
 		// passing in block height 0, which will default to utxo store block height in validator
 		if _, err := sm.validationClient.Validate(sm.ctx, orphanTx.tx, 0); err != nil {

--- a/services/legacy/netsync/manager_shutdown_test.go
+++ b/services/legacy/netsync/manager_shutdown_test.go
@@ -1,0 +1,138 @@
+package netsync
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	txmap "github.com/bsv-blockchain/go-tx-map"
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/expiringmap"
+	"github.com/stretchr/testify/require"
+)
+
+// Hold an inventory lookup immediately before it enters the real SQL batcher.
+type heldInventoryStore struct {
+	utxo.Store
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+func (s *heldInventoryStore) Get(ctx context.Context, hash *chainhash.Hash, selected ...fields.FieldName) (*meta.Data, error) {
+	s.calls.Add(1)
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+	return s.Store.Get(ctx, hash, selected...)
+}
+
+func TestStop_WaitsForInventoryBeforeClosingStore(t *testing.T) {
+	sm, p, state := newHeaderProvenanceManager(t)
+	sm.quit = make(chan struct{})
+	sm.handlerDone = make(chan struct{})
+	sm.msgChan = make(chan interface{}, 1)
+	sm.orphanTxs = expiringmap.New[chainhash.Hash, *orphanTxAndParents](time.Hour)
+	sm.requestedTxns = expiringmap.New[chainhash.Hash, struct{}](time.Hour)
+	sm.rejectedTxns = txmap.NewSyncedMap[chainhash.Hash, struct{}]()
+	sm.headersFirstMode.Store(false)
+	state.requestQueue = txmap.NewSyncedSlice[wire.InvVect](1)
+	state.requestedTxns = expiringmap.New[chainhash.Hash, struct{}](time.Hour)
+	t.Cleanup(state.requestedTxns.Stop)
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	store, err := sql.New(context.Background(), ulogger.TestLogger{}, sm.settings, storeURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close(context.Background())) })
+	held := &heldInventoryStore{Store: store, entered: make(chan struct{}), release: make(chan struct{})}
+	sm.utxoStore = held
+	sm.Start()
+
+	inv := wire.NewMsgInv()
+	require.NoError(t, inv.AddInvVect(wire.NewInvVect(wire.InvTypeTx, &chainhash.Hash{1})))
+	handled := make(chan struct{})
+	go func() {
+		sm.handleInvMsg(&invMsg{inv: inv, peer: p})
+		close(handled)
+	}()
+	select {
+	case <-held.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("inventory lookup did not start")
+	}
+
+	remaining := 2
+	stopped := make(chan error, 2)
+	go func() { stopped <- sm.Stop() }()
+	<-sm.quit
+	// The service and its context watcher can call Stop concurrently. Both must join.
+	go func() { stopped <- sm.Stop() }()
+	select {
+	case err := <-stopped:
+		remaining--
+		t.Errorf("Stop returned before the inventory lookup completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(held.release)
+	<-handled
+	for i := 0; i < remaining; i++ {
+		select {
+		case err := <-stopped:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Stop did not finish after inventory completed")
+		}
+	}
+	// A delayed Kafka callback must not submit another lookup after shutdown.
+	sm.handleInvMsg(&invMsg{inv: inv, peer: p})
+	require.EqualValues(t, 1, held.calls.Load())
+}
+
+func TestStop_BeforeStart(t *testing.T) {
+	sm, _, _ := newHeaderProvenanceManager(t)
+	sm.quit = make(chan struct{})
+	sm.handlerDone = make(chan struct{})
+	sm.orphanTxs = expiringmap.New[chainhash.Hash, *orphanTxAndParents](time.Hour)
+	sm.requestedTxns = expiringmap.New[chainhash.Hash, struct{}](time.Hour)
+	stopped := make(chan error, 1)
+	go func() { stopped <- sm.Stop() }()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop waited for a block handler that was never started")
+	}
+	sm.Start()
+	require.Zero(t, atomic.LoadInt32(&sm.started), "Start must not revive a stopped manager")
+	require.NoError(t, sm.Stop())
+}
+
+func TestStop_WhilePaused(t *testing.T) {
+	sm, _, _ := newHeaderProvenanceManager(t)
+	sm.quit = make(chan struct{})
+	sm.handlerDone = make(chan struct{})
+	sm.msgChan = make(chan interface{})
+	sm.orphanTxs = expiringmap.New[chainhash.Hash, *orphanTxAndParents](time.Hour)
+	sm.requestedTxns = expiringmap.New[chainhash.Hash, struct{}](time.Hour)
+	sm.Start()
+	// The unbuffered queue makes Pause wait until blockHandler receives it.
+	unpause := sm.Pause()
+	defer close(unpause)
+	stopped := make(chan error, 1)
+	go func() { stopped <- sm.Stop() }()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop waited for the paused caller to resume")
+	}
+}

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -963,22 +963,22 @@ func TestHandleBlockMsg_OrphanDuringCatchup(t *testing.T) {
 
 	state := &peerSyncState{
 		requestedTxns:   expiringmap.New[chainhash.Hash, struct{}](10 * time.Second),
-		requestedBlocks: expiringmap.New[chainhash.Hash, struct{}](time.Minute),
+		requestedBlocks: expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Minute),
 	}
 	defer state.requestedTxns.Stop()
 	defer state.requestedBlocks.Stop()
-	state.requestedBlocks.Set(blockHash, struct{}{})
+	state.requestedBlocks.Set(blockHash, blockRequestOrigin{})
 
 	sm := &SyncManager{
 		ctx:              context.Background(),
 		logger:           ulogger.TestLogger{},
 		blockchainClient: blockchainClient,
 		peerStates:       txmap.NewSyncedMap[*peer.Peer, *peerSyncState](),
-		requestedBlocks:  expiringmap.New[chainhash.Hash, struct{}](time.Minute),
+		requestedBlocks:  expiringmap.New[chainhash.Hash, blockRequestOrigin](time.Minute),
 	}
 	defer sm.requestedBlocks.Stop()
 	sm.peerStates.Set(p, state)
-	sm.requestedBlocks.Set(blockHash, struct{}{})
+	sm.requestedBlocks.Set(blockHash, blockRequestOrigin{})
 
 	err := sm.handleBlockMsg(&blockQueueMsg{
 		block:       msgBlock,

--- a/settings.conf
+++ b/settings.conf
@@ -656,6 +656,8 @@ legacy_config_ConnectPeers   =
 legacy_config_DataDir          = ${DATADIR}/legacy
 legacy_config_DataDir.operator = ${DATADIR}/${clientName}/legacy
 
+# Disabling checkpoints also disables the proven-header validation fast path.
+# Legacy initial block download then uses full validation and can be slower.
 legacy_config_DisableCheckpoints = false
 
 # this forces IPv4 only, set to empty for IPv4 & IPv6 support

--- a/util/test/helpers.go
+++ b/util/test/helpers.go
@@ -35,3 +35,12 @@ func CreateBaseTestSettings(t TestingT) *settings.Settings {
 
 	return tSettings
 }
+
+// MainNetParamsForSyntheticPoW preserves mainnet rules while allowing easy test headers.
+// Real proof-of-work limit tests must use the unmodified network parameters.
+func MainNetParamsForSyntheticPoW() *chaincfg.Params {
+	params := chaincfg.MainNetParams
+	params.PowLimit = chaincfg.RegressionNetParams.PowLimit
+	params.PowLimitBits = 0x207fffff
+	return &params
+}


### PR DESCRIPTION
Backport checkpoint-ancestry hardening to `release/v0.15`. Peer-advertised blocks cannot gain checkpoint trust from height alone, and malformed bodies are rejected before quick-validation state changes.

The change tracks verified legacy header provenance, derives peer heights from their parents, enforces checkpoint hashes and proof of work, and authenticates legacy block bodies before transaction or subtree writes. Review follow-ups also enforce the network PoW floor in shared `Block.Valid` (covering the ValidateBlock RPC), authenticate the complete quick-catchup body before processing any subtree batch, and reject catchup headers disconnected from the selected common ancestor.

Expected-difficulty exceptions require an explicitly verified catchup header, an exact pinned checkpoint, or stored ancestry to a pinned checkpoint. Stored ancestry preserves historical reconsideration after invalidation without trusting arbitrary stored forks. Quick validation stops at the highest checkpoint actually verified in the fetched chain. Proof-of-work errors retain both their diagnostic text and wrapped cause.

Rebased onto `5904ceb70`, which includes the propagation concurrency, validator fee, and reassignment smoke-test fixture fixes from https://github.com/bsv-blockchain/teranode/pull/1722. No dependency, schema, or protobuf changes.

Legacy shutdown now waits for active inventory, transaction, header, and block handlers before the daemon closes its stores. Concurrent stop callers wait for completion, late inventory callbacks cannot submit SQL batcher work, and pending queue/reply/pause waits can exit during shutdown. This addresses the `send on closed channel` crashes in `TestBIP68_DisableFlag` and `TestSimpleTransaction_SVNodeFirst`.

Validation:

- CI on `9e1273617`: all three smoke shards, legacy-sync, repository unit tests, and lint passed. [Smoke workflow](https://github.com/bsv-blockchain/teranode/actions/runs/34622357510). The previously failing shard passed on its first attempt; legacy-sync completed 22 tests with 3 existing skips.
- The local full legacy-sync run encountered six SV Node port-binding failures during overlapping local test activity; all six passed on rerun once the ports were free.
- Full race suites passed for model, blockvalidation (including catchup), all legacy packages, and util/test.
- Both crashing smoke cases passed three consecutive runs with the race detector. Shutdown regressions cover an in-flight real SQL inventory lookup, concurrent stop calls, late inventory, stop before start, and shutdown while paused. The inventory regression fails on the previous commit.
- The previously failing propagation tests passed against Aerospike and PostgreSQL under the race detector; the validator regression and reassignment smoke test also passed under the race detector.
- Focused regressions cover early and later-batch duplicates through sequential, pipelined, and async quick validation; mismatched bodies; checkpoint ancestry and proof boundaries; historical reconsideration; and error diagnostics. Removing both quick body-authentication calls with a temporary Go overlay makes all six duplicate regressions fail.
- Full build, affected-package vet/staticcheck, release-relative lint (including Go security lint), and commit hooks passed.
- The affected-package vulnerability scan reports the same 20 reachable advisory IDs on the unchanged release baseline and this branch, with no additions. Dependency/toolchain triage remains tracked in https://github.com/bsv-blockchain/teranode/issues/1719.

Quick body authentication adds a complete read of subtree node hashes and an O(N) duplicate scan before the existing transaction pipeline. No full mainnet initial-sync or multi-GB performance run was performed.

