### PR TITLE
fix: authenticate catchup bodies and complete legacy shutdown

### DIFF
--- a/services/blockvalidation/Server_test.go
+++ b/services/blockvalidation/Server_test.go
@@ -585,8 +585,8 @@ func TestServer_catchup(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// Set the best block to the last stored block (block 49)
-		mockBlockchainStore.BestBlock = blocks[49]
+		// StoreBlock already selected block 49 under its lock. Do not write
+		// BestBlock directly while the subscription goroutine reads it.
 
 		// Build headers response - should include common ancestor (block 49) and new blocks (50-99)
 		// Headers should be in order from oldest to newest

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -844,6 +844,10 @@ func (u *Server) fetchAndValidateBlocks(ctx context.Context, catchupCtx *Catchup
 	}
 	defer u.restoreFSMState(ctx, catchupCtx)
 
+	// Carry ownership through tracing and detached subtree-data downloads.
+	artifacts := &catchupArtifacts{Store: u.subtreeStore, files: make(map[catchupArtifactKey]*catchupArtifact)}
+	ctx = context.WithValue(ctx, catchupArtifactsKey{}, artifacts)
+
 	// Create error group for concurrent operations
 	errorGroup, gCtx := errgroup.WithContext(ctx)
 
@@ -879,6 +883,7 @@ func (u *Server) fetchAndValidateBlocks(ctx context.Context, catchupCtx *Catchup
 	// Wait for both operations to complete
 	err := errorGroup.Wait()
 	if err != nil {
+		artifacts.cleanup(u.logger)
 		catchupCtx.catchupError = err
 	}
 
@@ -1197,6 +1202,8 @@ func (u *Server) tryQuickValidation(ctx context.Context, block *model.Block, cat
 				}
 			}
 		}
+		// Force normal validation to reload metadata after a partial quick attempt.
+		block.SubtreeSlices = nil
 		// Quick validation failed, try normal validation
 		return true, nil
 	}

--- a/services/blockvalidation/catchup.go
+++ b/services/blockvalidation/catchup.go
@@ -883,7 +883,11 @@ func (u *Server) fetchAndValidateBlocks(ctx context.Context, catchupCtx *Catchup
 	// Wait for both operations to complete
 	err := errorGroup.Wait()
 	if err != nil {
-		artifacts.cleanup(u.logger)
+		// Discard rejected bodies, but retain partial downloads after transient
+		// failures (such as peer rate limits) so the next attempt can progress.
+		if errors.Is(err, errors.ErrBlockInvalid) || errors.Is(err, errors.ErrTxInvalid) {
+			artifacts.cleanup(u.logger)
+		}
 		catchupCtx.catchupError = err
 	}
 

--- a/services/blockvalidation/catchup_artifacts.go
+++ b/services/blockvalidation/catchup_artifacts.go
@@ -1,0 +1,94 @@
+package blockvalidation
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/stores/blob"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/ulogger"
+)
+
+type catchupArtifactsKey struct{}
+
+type catchupArtifactKey struct {
+	hash chainhash.Hash
+	kind fileformat.FileType
+}
+
+type catchupArtifact struct {
+	mu      sync.Mutex
+	created bool
+}
+
+// catchupArtifacts owns only pending files created by one catchup attempt.
+// Validation continues to use the shared store and can promote accepted subtrees.
+// Cleanup must run after all fetchers and async validation writers have joined.
+type catchupArtifacts struct {
+	blob.Store
+	mu    sync.Mutex
+	files map[catchupArtifactKey]*catchupArtifact
+}
+
+func (u *Server) catchupSubtreeStore(ctx context.Context) blob.Store {
+	if store, ok := ctx.Value(catchupArtifactsKey{}).(*catchupArtifacts); ok {
+		return store
+	}
+	return u.subtreeStore
+}
+
+func (s *catchupArtifacts) Set(ctx context.Context, key []byte, kind fileformat.FileType, value []byte, opts ...options.FileOption) error {
+	hash, err := chainhash.NewHash(key)
+	if err != nil {
+		return err
+	}
+	file := catchupArtifactKey{hash: *hash, kind: kind}
+	s.mu.Lock()
+	entry := s.files[file]
+	if entry == nil {
+		entry = &catchupArtifact{}
+		s.files[file] = entry
+	}
+	s.mu.Unlock()
+	// Multiple prefetched blocks can share a subtree. Serialize only writes to
+	// that file, leaving independent subtree downloads and writes concurrent.
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	opts = append(opts, options.WithAllowOverwrite(false))
+	if err := s.Store.Set(ctx, key, kind, value, opts...); err != nil {
+		if errors.Is(err, errors.ErrBlobAlreadyExists) {
+			return nil // preserve existing data, and never claim ownership of it
+		}
+		return err
+	}
+	entry.created = true
+	return nil
+}
+
+func (s *catchupArtifacts) cleanup(logger ulogger.Logger) {
+	// The fetch errgroup's context is canceled on failure (and after Wait).
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	for file, entry := range s.files {
+		if !entry.created {
+			continue
+		}
+		// A previous block in this attempt, or another validator, may already
+		// have accepted this subtree. Keep its shared transaction data intact.
+		validated, err := s.Store.Exists(ctx, file.hash[:], fileformat.FileTypeSubtree)
+		if err != nil {
+			logger.Warnf("[catchup] cannot check artifact %s before cleanup: %v", file.hash.String(), err)
+			continue
+		}
+		if validated {
+			continue
+		}
+		if err := s.Store.Del(ctx, file.hash[:], file.kind); err != nil && !errors.Is(err, errors.ErrNotFound) {
+			logger.Warnf("[catchup] failed to remove pending %s for %s: %v", file.kind, file.hash.String(), err)
+		}
+	}
+}

--- a/services/blockvalidation/catchup_artifacts_test.go
+++ b/services/blockvalidation/catchup_artifacts_test.go
@@ -22,6 +22,15 @@ import (
 )
 
 func TestCatchupArtifacts_InvalidBodyCanBeRetried(t *testing.T) {
+	testCatchupArtifactsRetry(t, true)
+}
+
+func TestCatchupArtifacts_TemporaryFailurePreservesProgress(t *testing.T) {
+	testCatchupArtifactsRetry(t, false)
+}
+
+func testCatchupArtifactsRetry(t *testing.T, invalidBody bool) {
+	t.Helper()
 	ctx := context.Background()
 	bv, block, _, blobs := newQuickBodyFixture(t, "async")
 	payloads := make(map[string][]byte)
@@ -42,7 +51,10 @@ func TestCatchupArtifacts_InvalidBodyCanBeRetried(t *testing.T) {
 			require.NoError(t, blobs.Del(ctx, hash[:], fileformat.FileTypeSubtreeData))
 		}
 	}
-	block.TransactionCount = 7 // same genuine header, dishonest serialized body count
+	bv.settings.BlockValidation.SubtreeFetchConcurrency = 1
+	if invalidBody {
+		block.TransactionCount = 7 // same genuine header, dishonest serialized body count
+	}
 	badBody, err := block.Bytes()
 	require.NoError(t, err)
 	block.TransactionCount = 6
@@ -61,6 +73,10 @@ func TestCatchupArtifacts_InvalidBodyCanBeRetried(t *testing.T) {
 		}
 		if data, ok := payloads[r.URL.Path]; ok {
 			fetched.Add(1)
+			if !invalidBody && !goodPeer.Load() && r.URL.Path == "/subtree_data/"+block.Subtrees[1].String() {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
 			_, _ = w.Write(data)
 			return
 		}
@@ -76,18 +92,28 @@ func TestCatchupArtifacts_InvalidBodyCanBeRetried(t *testing.T) {
 			blockHeaders: []*model.BlockHeader{block.Header}, commonAncestorMeta: &model.BlockHeaderMeta{Height: 0},
 			useQuickValidation: true, highestCheckpointHeight: 1})
 	}
-	require.ErrorIs(t, attempt(), errors.ErrBlockInvalid)
+	err = attempt()
+	require.Error(t, err)
+	require.Equal(t, invalidBody, errors.Is(err, errors.ErrBlockInvalid), "%v", err)
 	require.EqualValues(t, 4, fetched.Load())
 	for i, hash := range block.Subtrees {
 		for _, kind := range []fileformat.FileType{fileformat.FileTypeSubtreeToCheck, fileformat.FileTypeSubtreeData} {
 			exists, err := blobs.Exists(ctx, hash[:], kind)
 			require.NoError(t, err)
-			require.Equal(t, i == 2, exists, "only preexisting files survive failed catchup")
+			expected := i == 2
+			if !invalidBody {
+				expected = i != 1 || kind == fileformat.FileTypeSubtreeToCheck
+			}
+			require.Equal(t, expected, exists, "invalid bodies discard their files; transient failures retain progress")
 		}
 	}
 	goodPeer.Store(true)
 	require.NoError(t, attempt())
-	require.EqualValues(t, 8, fetched.Load(), "the next peer must refetch files discarded with the invalid body")
+	if invalidBody {
+		require.EqualValues(t, 8, fetched.Load(), "the next peer must refetch files discarded with the invalid body")
+	} else {
+		require.EqualValues(t, 5, fetched.Load(), "only the missing transaction data should be fetched on retry")
+	}
 	stored, err := bv.blockchainClient.GetBlock(ctx, block.Hash())
 	require.NoError(t, err)
 	require.EqualValues(t, 6, stored.TransactionCount)

--- a/services/blockvalidation/catchup_artifacts_test.go
+++ b/services/blockvalidation/catchup_artifacts_test.go
@@ -1,0 +1,127 @@
+package blockvalidation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/adaptivefetch"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/catchup"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	"github.com/bsv-blockchain/teranode/stores/blob/options"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatchupArtifacts_InvalidBodyCanBeRetried(t *testing.T) {
+	ctx := context.Background()
+	bv, block, _, blobs := newQuickBodyFixture(t, "async")
+	payloads := make(map[string][]byte)
+	for i, hash := range block.Subtrees {
+		nodes, err := blobs.Get(ctx, hash[:], fileformat.FileTypeSubtreeToCheck)
+		require.NoError(t, err)
+		st, err := subtreepkg.NewSubtreeFromBytes(nodes)
+		require.NoError(t, err)
+		var hashes []byte
+		for _, node := range st.Nodes {
+			hashes = append(hashes, node.Hash[:]...)
+		}
+		payloads["/subtree/"+hash.String()] = hashes
+		payloads["/subtree_data/"+hash.String()], err = blobs.Get(ctx, hash[:], fileformat.FileTypeSubtreeData)
+		require.NoError(t, err)
+		if i < 2 {
+			require.NoError(t, blobs.Del(ctx, hash[:], fileformat.FileTypeSubtreeToCheck))
+			require.NoError(t, blobs.Del(ctx, hash[:], fileformat.FileTypeSubtreeData))
+		}
+	}
+	block.TransactionCount = 7 // same genuine header, dishonest serialized body count
+	badBody, err := block.Bytes()
+	require.NoError(t, err)
+	block.TransactionCount = 6
+	goodBody, err := block.Bytes()
+	require.NoError(t, err)
+	var goodPeer atomic.Bool
+	var fetched atomic.Int32
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/blocks/"+block.Hash().String() {
+			if goodPeer.Load() {
+				_, _ = w.Write(goodBody)
+			} else {
+				_, _ = w.Write(badBody)
+			}
+			return
+		}
+		if data, ok := payloads[r.URL.Path]; ok {
+			fetched.Add(1)
+			_, _ = w.Write(data)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer peer.Close()
+	af, err := adaptivefetch.New(adaptivefetch.DefaultConfig(), "artifact-test", prometheus.NewRegistry())
+	require.NoError(t, err)
+	s := &Server{logger: ulogger.TestLogger{}, settings: bv.settings, blockchainClient: bv.blockchainClient,
+		blockValidation: bv, subtreeStore: blobs, adaptiveFetch: af, headerChainCache: catchup.NewHeaderChainCache(ulogger.TestLogger{})}
+	attempt := func() error {
+		return s.fetchAndValidateBlocks(ctx, &CatchupContext{blockUpTo: block, baseURL: peer.URL,
+			blockHeaders: []*model.BlockHeader{block.Header}, commonAncestorMeta: &model.BlockHeaderMeta{Height: 0},
+			useQuickValidation: true, highestCheckpointHeight: 1})
+	}
+	require.ErrorIs(t, attempt(), errors.ErrBlockInvalid)
+	require.EqualValues(t, 4, fetched.Load())
+	for i, hash := range block.Subtrees {
+		for _, kind := range []fileformat.FileType{fileformat.FileTypeSubtreeToCheck, fileformat.FileTypeSubtreeData} {
+			exists, err := blobs.Exists(ctx, hash[:], kind)
+			require.NoError(t, err)
+			require.Equal(t, i == 2, exists, "only preexisting files survive failed catchup")
+		}
+	}
+	goodPeer.Store(true)
+	require.NoError(t, attempt())
+	require.EqualValues(t, 8, fetched.Load(), "the next peer must refetch files discarded with the invalid body")
+	stored, err := bv.blockchainClient.GetBlock(ctx, block.Hash())
+	require.NoError(t, err)
+	require.EqualValues(t, 6, stored.TransactionCount)
+}
+
+func TestCatchupArtifacts_PreservesSharedFiles(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	blobs := memory.New()
+	artifacts := &catchupArtifacts{Store: blobs, files: make(map[catchupArtifactKey]*catchupArtifact)}
+	for i := byte(0); i < 3; i++ {
+		hash := chainhash.Hash{i}
+		if i == 0 {
+			require.NoError(t, blobs.Set(ctx, hash[:], fileformat.FileTypeSubtreeData, []byte("original")))
+		}
+		require.NoError(t, artifacts.Set(ctx, hash[:], fileformat.FileTypeSubtreeData, []byte("new"), options.WithAllowOverwrite(true)))
+		if i == 1 {
+			// Validation accepted a shared subtree before another block failed.
+			require.NoError(t, blobs.Set(ctx, hash[:], fileformat.FileTypeSubtree, []byte("validated")))
+		}
+	}
+	cancel()
+	artifacts.cleanup(ulogger.TestLogger{})
+	for i := byte(0); i < 3; i++ {
+		hash := chainhash.Hash{i}
+		data, err := blobs.Get(context.Background(), hash[:], fileformat.FileTypeSubtreeData)
+		if i == 2 {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		if i == 0 {
+			require.Equal(t, "original", string(data))
+		} else {
+			require.Equal(t, "new", string(data))
+		}
+	}
+}

--- a/services/blockvalidation/catchup_quickvalidation_test.go
+++ b/services/blockvalidation/catchup_quickvalidation_test.go
@@ -56,7 +56,7 @@ func TestTryQuickValidation(t *testing.T) {
 		assert.True(t, shouldTryNormal, "should return true to use normal validation when block is above checkpoint height")
 	})
 
-	t.Run("should handle subtree deletion when quick validation fails", func(t *testing.T) {
+	t.Run("should reject malformed body without deleting shared subtrees", func(t *testing.T) {
 		suite := NewCatchupTestSuite(t)
 		defer suite.Cleanup()
 
@@ -88,21 +88,14 @@ func TestTryQuickValidation(t *testing.T) {
 		// Create a buffered channel for async writes
 		writeJobsChan := make(chan *SubtreeWriteJob, 10)
 
-		// The quick validation will fail because we didn't set up all the necessary mocks
-		// This should trigger the subtree cleanup logic
 		shouldTryNormal, err := suite.Server.tryQuickValidation(ctx, block, catchupCtx, "", "http://test", writeJobsChan)
-
-		assert.NoError(t, err, "should not return error even when quick validation fails")
-		assert.True(t, shouldTryNormal, "should return true to fallback to normal validation")
-
-		// Verify subtrees were deleted
-		_, err = suite.Server.subtreeStore.Get(ctx, subtreeHash1[:], fileformat.FileTypeSubtree)
-		assert.Error(t, err, "subtree1 should have been deleted")
-		assert.True(t, errors.Is(err, errors.ErrNotFound))
-
-		_, err = suite.Server.subtreeStore.Get(ctx, subtreeHash2[:], fileformat.FileTypeSubtree)
-		assert.Error(t, err, "subtree2 should have been deleted")
-		assert.True(t, errors.Is(err, errors.ErrNotFound))
+		require.True(t, errors.Is(err, errors.ErrBlockInvalid), "%v", err)
+		require.False(t, shouldTryNormal)
+		for _, hash := range block.Subtrees {
+			exists, err := suite.Server.subtreeStore.Exists(ctx, hash[:], fileformat.FileTypeSubtree)
+			require.NoError(t, err)
+			require.True(t, exists, "body rejection must preserve shared subtree files")
+		}
 	})
 
 	t.Run("should return false when quick validation succeeds", func(t *testing.T) {

--- a/services/blockvalidation/catchup_quickvalidation_test.go
+++ b/services/blockvalidation/catchup_quickvalidation_test.go
@@ -119,6 +119,7 @@ func TestTryQuickValidation(t *testing.T) {
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
 		block.Height = 100
 		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
+		block.TransactionCount = 1
 
 		catchupCtx := &CatchupContext{
 			useQuickValidation:      true,

--- a/services/blockvalidation/get_blocks.go
+++ b/services/blockvalidation/get_blocks.go
@@ -444,12 +444,13 @@ func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, s
 	)
 	defer deferFn()
 
+	store := u.catchupSubtreeStore(ctx)
 	dah := block.Height + u.settings.GetSubtreeValidationBlockHeightRetention()
 
 	// Check if we already have the subtree, under either FileTypeSubtreeToCheck
 	// (peer-fetched, pending validation) or FileTypeSubtree (already validated).
 	// See findLocalSubtreeFile for why both must be consulted.
-	localFileType, localExists, err := findLocalSubtreeFile(ctx, u.subtreeStore, *subtreeHash)
+	localFileType, localExists, err := findLocalSubtreeFile(ctx, store, *subtreeHash)
 	if err != nil {
 		return nil, errors.NewStorageError("[catchup:fetchAndStoreSubtree] error checking subtree existence for %s", subtreeHash.String(), err)
 	}
@@ -458,7 +459,7 @@ func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, s
 		u.logger.Debugf("[catchup:fetchAndStoreSubtree] Subtree already exists for %s, loading from store", subtreeHash.String())
 
 		// Load existing subtree from store under whichever file type was found
-		subtreeBytes, err := u.subtreeStore.Get(ctx, subtreeHash[:], localFileType)
+		subtreeBytes, err := store.Get(ctx, subtreeHash[:], localFileType)
 		if err != nil {
 			return nil, errors.NewStorageError("[catchup:fetchAndStoreSubtree] Failed to get existing subtree for %s", subtreeHash.String(), err)
 		}
@@ -517,7 +518,7 @@ func (u *Server) fetchAndStoreSubtree(ctx context.Context, block *model.Block, s
 	}
 
 	// Store subtree (for subtreeToCheck) in subtreeStore
-	if err = u.subtreeStore.Set(ctx,
+	if err = store.Set(ctx,
 		subtreeHash[:],
 		fileformat.FileTypeSubtreeToCheck,
 		subtreeBytes,
@@ -541,10 +542,11 @@ func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Bloc
 	)
 	defer deferFn()
 
+	store := u.catchupSubtreeStore(ctx)
 	dah := block.Height + u.settings.GetSubtreeValidationBlockHeightRetention()
 
 	// Check if we already have the subtreeData
-	subtreeDataExists, err := u.subtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtreeData)
+	subtreeDataExists, err := store.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtreeData)
 	if err != nil {
 		return errors.NewProcessingError("[catchup:fetchAndStoreSubtreeData] Error checking subtreeData existence for %s: %v", subtreeHash.String(), err)
 	}
@@ -606,7 +608,7 @@ func (u *Server) fetchAndStoreSubtreeData(ctx context.Context, block *model.Bloc
 	}
 
 	// Store subtreeData (raw data) in subtreeStore
-	if err = u.subtreeStore.Set(ctx,
+	if err = store.Set(ctx,
 		subtreeHash[:],
 		fileformat.FileTypeSubtreeData,
 		subtreeDataBytes,

--- a/services/blockvalidation/quick_body_preflight_test.go
+++ b/services/blockvalidation/quick_body_preflight_test.go
@@ -1,0 +1,245 @@
+package blockvalidation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/teranode/errors"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/bsv-blockchain/teranode/pkg/fileformat"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/blockvalidation/testhelpers"
+	"github.com/bsv-blockchain/teranode/stores/blob"
+	"github.com/bsv-blockchain/teranode/stores/blob/memory"
+	bloboptions "github.com/bsv-blockchain/teranode/stores/blob/options"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/stores/utxo"
+	"github.com/bsv-blockchain/teranode/stores/utxo/meta"
+	"github.com/bsv-blockchain/teranode/stores/utxo/sql"
+	"github.com/bsv-blockchain/teranode/test/utils/transactions"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+type preflightReadStore struct {
+	blob.Store
+	nodeReads   atomic.Int32
+	gateHash    *chainhash.Hash
+	gateEntered chan struct{}
+	gateRelease chan struct{}
+	gateOnce    sync.Once
+}
+
+func (s *preflightReadStore) GetIoReader(ctx context.Context, key []byte, kind fileformat.FileType, opts ...bloboptions.FileOption) (io.ReadCloser, error) {
+	if kind == fileformat.FileTypeSubtreeData && s.gateHash != nil && bytes.Equal(key, s.gateHash[:]) {
+		s.gateOnce.Do(func() { close(s.gateEntered) })
+		<-s.gateRelease
+	}
+	reader, err := s.Store.GetIoReader(ctx, key, kind, opts...)
+	if err == nil && (kind == fileformat.FileTypeSubtree || kind == fileformat.FileTypeSubtreeToCheck) {
+		s.nodeReads.Add(1)
+	}
+	return reader, err
+}
+
+type preflightMutationStore struct {
+	utxo.Store
+	created chan struct{}
+	once    sync.Once
+}
+
+func (s *preflightMutationStore) Create(ctx context.Context, tx *bt.Tx, height uint32, opts ...utxo.CreateOption) (*meta.Data, error) {
+	data, err := s.Store.Create(ctx, tx, height, opts...)
+	if err == nil {
+		s.once.Do(func() { close(s.created) })
+	}
+	return data, err
+}
+
+func newQuickBodyFixture(t *testing.T, mode string) (*BlockValidation, *model.Block, []*bt.Tx, *preflightReadStore) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := test.CreateBaseTestSettings(t)
+	cfg.BlockValidation.SubtreeBatchSize = 1
+	cfg.BlockValidation.SubtreeBatchPrefetchDepth = 0
+	if mode == "pipeline" {
+		cfg.BlockValidation.SubtreeBatchPrefetchDepth = 2
+	}
+	storeURL, err := url.Parse("sqlitememory:///")
+	require.NoError(t, err)
+	chain, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, chain.(interface{ Close() error }).Close()) })
+	client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, cfg, chain, nil, nil)
+	require.NoError(t, err)
+	utxos, err := sql.New(ctx, ulogger.TestLogger{}, cfg, storeURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, utxos.Close(context.Background())) })
+	require.NoError(t, utxos.SetBlockHeight(200))
+	blobs := &preflightReadStore{Store: memory.New()}
+	u := NewBlockValidation(ctx, ulogger.TestLogger{}, cfg, client, blobs, memory.New(), utxos, nil, nil)
+	t.Cleanup(func() { cancel(); u.StopCaches() })
+	txs := transactions.CreateTestTransactionChainWithCount(t, 8)[1:]
+	require.Len(t, txs, 6)
+	_, err = utxos.Create(ctx, txs[0], 1)
+	require.NoError(t, err)
+	block := testhelpers.CreateTestBlocksWithPrev(t, 1, cfg.ChainCfgParams.GenesisHash)[0]
+	block.Height = 1
+	block.TransactionCount = 6
+	block.Subtrees = nil
+	block.SubtreeSlices = nil
+	for i := 0; i < 3; i++ {
+		st, err := subtreepkg.NewTreeByLeafCount(2)
+		require.NoError(t, err)
+		if i == 0 {
+			require.NoError(t, st.AddCoinbaseNode())
+		} else {
+			require.NoError(t, st.AddNode(*txs[i*2].TxIDChainHash(), 0, uint64(txs[i*2].Size())))
+		}
+		require.NoError(t, st.AddNode(*txs[i*2+1].TxIDChainHash(), 0, uint64(txs[i*2+1].Size())))
+		data := subtreepkg.NewSubtreeData(st)
+		if i > 0 {
+			require.NoError(t, data.AddTx(txs[i*2], 0))
+		}
+		require.NoError(t, data.AddTx(txs[i*2+1], 1))
+		raw, err := st.Serialize()
+		require.NoError(t, err)
+		require.NoError(t, blobs.Set(ctx, st.RootHash()[:], fileformat.FileTypeSubtreeToCheck, raw))
+		raw, err = data.Serialize()
+		require.NoError(t, err)
+		require.NoError(t, blobs.Set(ctx, st.RootHash()[:], fileformat.FileTypeSubtreeData, raw))
+		block.Subtrees = append(block.Subtrees, st.RootHash())
+		block.SubtreeSlices = append(block.SubtreeSlices, st)
+	}
+	roots := make([]*chainhash.Hash, len(block.Subtrees))
+	copy(roots, block.Subtrees)
+	roots[0], err = block.SubtreeSlices[0].RootHashWithReplaceRootNode(block.CoinbaseTx.TxIDChainHash(), 0, 0)
+	require.NoError(t, err)
+	combined, err := subtreepkg.NewTreeByLeafCount(4)
+	require.NoError(t, err)
+	for _, root := range roots {
+		require.NoError(t, combined.AddNode(*root, 0, 0))
+	}
+	block.Header.HashMerkleRoot = combined.RootHash()
+	require.NoError(t, block.CheckMerkleRoot(ctx))
+	block.SubtreeSlices = nil
+	return u, block, txs, blobs
+}
+
+func runQuickBody(u *BlockValidation, block *model.Block, mode string, jobs chan *SubtreeWriteJob) error {
+	if mode == "async" {
+		return u.quickValidateBlockAsync(context.Background(), block, "test", "", jobs)
+	}
+	return u.quickValidateBlock(context.Background(), block, "test", "")
+}
+
+func TestQuickBodyPreflightRejectsMalformedData(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		for _, mutation := range []string{"early hash mismatch", "late hash mismatch", "late missing", "late truncated"} {
+			t.Run(mode+"/"+mutation, func(t *testing.T) {
+				u, block, txs, blobs := newQuickBodyFixture(t, mode)
+				index := 2
+				if mutation == "early hash mismatch" {
+					index = 0
+				}
+				payload := txs[1].Bytes()
+				if mutation == "early hash mismatch" {
+					payload = txs[2].Bytes()
+				}
+				if mutation == "late missing" {
+					payload = nil
+				}
+				if mutation == "late truncated" {
+					payload = txs[4].Bytes()[:12]
+				}
+				require.NoError(t, blobs.Set(context.Background(), block.Subtrees[index][:], fileformat.FileTypeSubtreeData, payload, bloboptions.WithAllowOverwrite(true)))
+				jobs := make(chan *SubtreeWriteJob, 10)
+				// Hold the final data read so earlier pipeline stages have time
+				// to mutate state if the whole-body preflight is removed.
+				watched := &preflightMutationStore{Store: u.utxoStore, created: make(chan struct{})}
+				u.utxoStore = watched
+				blobs.gateHash = block.Subtrees[index]
+				blobs.gateEntered = make(chan struct{})
+				blobs.gateRelease = make(chan struct{})
+				finished := make(chan error, 1)
+				go func() { finished <- runQuickBody(u, block, mode, jobs) }()
+				select {
+				case <-blobs.gateEntered:
+				case <-time.After(5 * time.Second):
+					close(blobs.gateRelease)
+					t.Fatal("transaction data read was not reached")
+				}
+				mutated := false
+				select {
+				case <-watched.created:
+					mutated = true
+				case <-time.After(100 * time.Millisecond):
+				}
+				close(blobs.gateRelease)
+				err := <-finished
+				require.False(t, mutated, "no UTXOs may be created while later transaction data is unauthenticated")
+				require.Error(t, err)
+				require.Zero(t, block.ID, "malformed later data must be rejected before the first batch mutates state")
+				require.Empty(t, jobs)
+				for _, tx := range txs[1:] {
+					_, err := u.utxoStore.Get(context.Background(), tx.TxIDChainHash())
+					require.True(t, errors.Is(err, errors.ErrTxNotFound), "no child transaction may be created: %v", err)
+				}
+				spend, err := u.utxoStore.GetSpend(context.Background(), &utxo.Spend{TxID: txs[0].TxIDChainHash(), Vout: txs[1].Inputs[0].PreviousTxOutIndex})
+				require.NoError(t, err)
+				require.Equal(t, int(utxo.Status_OK), spend.Status)
+				for _, hash := range block.Subtrees {
+					exists, err := blobs.Exists(context.Background(), hash[:], fileformat.FileTypeSubtree)
+					require.NoError(t, err)
+					require.False(t, exists)
+				}
+			})
+		}
+	}
+}
+
+func TestQuickBodyPreflightTransactionCount(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		for _, coinbaseOnly := range []bool{false, true} {
+			for _, count := range []uint64{0, 5, 7} {
+				t.Run(fmt.Sprintf("%s/coinbase=%v/count=%d", mode, coinbaseOnly, count), func(t *testing.T) {
+					u, block, _, _ := newQuickBodyFixture(t, mode)
+					if coinbaseOnly {
+						block.Subtrees = nil
+						block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
+					}
+					block.TransactionCount = count
+					jobs := make(chan *SubtreeWriteJob, 10)
+					require.ErrorContains(t, runQuickBody(u, block, mode, jobs), "transaction count")
+					require.Zero(t, block.ID)
+					require.Empty(t, jobs)
+				})
+			}
+		}
+	}
+}
+
+func TestQuickBodyPreflightReusesNodes(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		t.Run(mode, func(t *testing.T) {
+			u, block, _, blobs := newQuickBodyFixture(t, mode)
+			jobs := make(chan *SubtreeWriteJob, 10)
+			require.NoError(t, runQuickBody(u, block, mode, jobs))
+			require.EqualValues(t, len(block.Subtrees), blobs.nodeReads.Load(), "each subtree's nodes should only be deserialized once")
+			stored, err := u.blockchainClient.GetBlock(context.Background(), block.Hash())
+			require.NoError(t, err)
+			require.EqualValues(t, 6, stored.TransactionCount)
+		})
+	}
+}

--- a/services/blockvalidation/quick_body_preflight_test.go
+++ b/services/blockvalidation/quick_body_preflight_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -189,7 +190,7 @@ func TestQuickBodyPreflightRejectsMalformedData(t *testing.T) {
 				close(blobs.gateRelease)
 				err := <-finished
 				require.False(t, mutated, "no UTXOs may be created while later transaction data is unauthenticated")
-				require.Error(t, err)
+				require.True(t, errors.Is(err, errors.ErrBlockInvalid), "%v", err)
 				require.Zero(t, block.ID, "malformed later data must be rejected before the first batch mutates state")
 				require.Empty(t, jobs)
 				for _, tx := range txs[1:] {
@@ -240,6 +241,214 @@ func TestQuickBodyPreflightReusesNodes(t *testing.T) {
 			stored, err := u.blockchainClient.GetBlock(context.Background(), block.Hash())
 			require.NoError(t, err)
 			require.EqualValues(t, 6, stored.TransactionCount)
+		})
+	}
+}
+
+func TestQuickBodyPreflightRequiresCoinbasePlaceholder(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		t.Run(mode, func(t *testing.T) {
+			u, block, txs, blobs := newQuickBodyFixture(t, mode)
+			// A different coinbase in the first slot must not be silently replaced
+			// when checking the header's merkle root or parsing transaction data.
+			otherCoinbase := block.CoinbaseTx.Clone()
+			otherCoinbase.Outputs[0].Satoshis++
+			st, err := subtreepkg.NewTreeByLeafCount(2)
+			require.NoError(t, err)
+			require.NoError(t, st.AddNode(*otherCoinbase.TxIDChainHash(), 0, uint64(otherCoinbase.Size())))
+			require.NoError(t, st.AddNode(*txs[1].TxIDChainHash(), 0, uint64(txs[1].Size())))
+			block.Subtrees[0] = st.RootHash()
+			raw, err := st.Serialize()
+			require.NoError(t, err)
+			require.NoError(t, blobs.Set(context.Background(), st.RootHash()[:], fileformat.FileTypeSubtreeToCheck, raw))
+			raw = append(otherCoinbase.Bytes(), txs[1].Bytes()...)
+			require.NoError(t, blobs.Set(context.Background(), st.RootHash()[:], fileformat.FileTypeSubtreeData, raw))
+			jobs := make(chan *SubtreeWriteJob, 10)
+			require.ErrorContains(t, runQuickBody(u, block, mode, jobs), "coinbase placeholder")
+			require.Zero(t, block.ID)
+			require.Empty(t, jobs)
+			for _, tx := range txs[1:] {
+				_, err := u.utxoStore.Get(context.Background(), tx.TxIDChainHash())
+				require.True(t, errors.Is(err, errors.ErrTxNotFound), "%v", err)
+			}
+		})
+	}
+}
+
+func TestQuickBodyPreflightMmapOwnership(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		t.Run(mode, func(t *testing.T) {
+			u, block, _, blobs := newQuickBodyFixture(t, mode)
+			u.mmapDir = t.TempDir()
+			cleanup, err := u.authenticateQuickBlockBody(context.Background(), block)
+			require.NoError(t, err)
+			defer cleanup()
+			for _, st := range block.SubtreeSlices {
+				require.True(t, st.IsMmapBacked())
+			}
+			batch, err := u.prefetchSubtreeBatch(context.Background(), block, 0, len(block.Subtrees))
+			require.NoError(t, err)
+			batch.Close()
+			// A failed intermediate batch must not unmap the block's borrowed nodes.
+			require.NoError(t, block.CheckMerkleRoot(context.Background()))
+			require.EqualValues(t, len(block.Subtrees), blobs.nodeReads.Load())
+			cleanup()
+			for _, st := range block.SubtreeSlices {
+				require.Nil(t, st, "fallback must not see an unmapped subtree")
+			}
+			files, err := os.ReadDir(u.mmapDir)
+			require.NoError(t, err)
+			require.Empty(t, files)
+			jobs := make(chan *SubtreeWriteJob, 10)
+			require.NoError(t, runQuickBody(u, block, mode, jobs), "a fresh attempt must reload after cleanup")
+		})
+	}
+}
+
+func TestQuickBodyPreflightRecomputesStoredRoot(t *testing.T) {
+	for _, mmap := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mmap=%v", mmap), func(t *testing.T) {
+			u, block, txs, blobs := newQuickBodyFixture(t, "sequential")
+			if mmap {
+				u.mmapDir = t.TempDir()
+			}
+			hash := block.Subtrees[2]
+			raw, err := blobs.Get(context.Background(), hash[:], fileformat.FileTypeSubtreeToCheck)
+			require.NoError(t, err)
+			// Keep the serialized root and store key, replace a node and its data.
+			copy(raw[56:88], txs[0].TxIDChainHash()[:])
+			require.NoError(t, blobs.Set(context.Background(), hash[:], fileformat.FileTypeSubtreeToCheck, raw, bloboptions.WithAllowOverwrite(true)))
+			data := append(txs[0].Bytes(), txs[5].Bytes()...)
+			require.NoError(t, blobs.Set(context.Background(), hash[:], fileformat.FileTypeSubtreeData, data, bloboptions.WithAllowOverwrite(true)))
+			cleanup, err := u.authenticateQuickBlockBody(context.Background(), block)
+			defer cleanup()
+			require.ErrorContains(t, err, "nodes do not match its root")
+			require.True(t, errors.Is(err, errors.ErrBlockInvalid))
+			require.Zero(t, block.ID)
+		})
+	}
+}
+
+func TestQuickBodyPreflightMissingFileIsNotInvalid(t *testing.T) {
+	u, block, _, blobs := newQuickBodyFixture(t, "sequential")
+	require.NoError(t, blobs.Del(context.Background(), block.Subtrees[2][:], fileformat.FileTypeSubtreeData))
+	cleanup, err := u.authenticateQuickBlockBody(context.Background(), block)
+	defer cleanup()
+	require.Error(t, err)
+	require.False(t, errors.Is(err, errors.ErrBlockInvalid), "a missing file is not a verdict on the body")
+	require.Zero(t, block.ID)
+}
+
+type failingPreflightCreateStore struct{ utxo.Store }
+
+func (s *failingPreflightCreateStore) Create(context.Context, *bt.Tx, uint32, ...utxo.CreateOption) (*meta.Data, error) {
+	return nil, errors.NewStorageError("injected UTXO write failure")
+}
+
+func TestQuickBodyPreflightMmapProcessingFailure(t *testing.T) {
+	for _, mode := range []string{"sequential", "pipeline", "async"} {
+		t.Run(mode, func(t *testing.T) {
+			u, block, _, _ := newQuickBodyFixture(t, mode)
+			u.mmapDir = t.TempDir()
+			utxos := u.utxoStore
+			u.utxoStore = &failingPreflightCreateStore{Store: utxos}
+			jobs := make(chan *SubtreeWriteJob, 10)
+			require.Error(t, runQuickBody(u, block, mode, jobs))
+			for _, st := range block.SubtreeSlices {
+				if st != nil {
+					require.False(t, st.IsMmapBacked(), "failed processing must not leave an unmapped reference")
+				}
+			}
+			files, err := os.ReadDir(u.mmapDir)
+			require.NoError(t, err)
+			require.Empty(t, files)
+			u.utxoStore = utxos
+			require.NoError(t, runQuickBody(u, block, mode, make(chan *SubtreeWriteJob, 10)))
+		})
+	}
+}
+
+type parallelPreflightStore struct {
+	blob.Store
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *parallelPreflightStore) GetIoReader(ctx context.Context, key []byte, kind fileformat.FileType, opts ...bloboptions.FileOption) (io.ReadCloser, error) {
+	if kind == fileformat.FileTypeSubtreeData {
+		select {
+		case s.entered <- struct{}{}:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return s.Store.GetIoReader(ctx, key, kind, opts...)
+}
+
+func TestQuickBodyPreflightBoundedParallelReads(t *testing.T) {
+	u, block, _, blobs := newQuickBodyFixture(t, "sequential")
+	u.settings.Block.GetAndValidateSubtreesConcurrency = 2
+	u.settings.BlockValidation.SubtreeBatchSize = 100
+	reads := &parallelPreflightStore{Store: blobs, entered: make(chan struct{}, 3), release: make(chan struct{})}
+	u.subtreeStore = reads
+	finished := make(chan error, 1)
+	go func() {
+		cleanup, err := u.authenticateQuickBlockBody(context.Background(), block)
+		cleanup()
+		finished <- err
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-reads.entered:
+		case <-time.After(5 * time.Second):
+			close(reads.release)
+			t.Fatal("preflight did not read two subtrees concurrently")
+		}
+	}
+	select {
+	case <-reads.entered:
+		t.Error("preflight exceeded the configured read concurrency")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(reads.release)
+	require.NoError(t, <-finished)
+}
+
+type reopenFailureStore struct {
+	blob.Store
+	reads atomic.Int32
+}
+
+func (s *reopenFailureStore) GetIoReader(ctx context.Context, key []byte, kind fileformat.FileType, opts ...bloboptions.FileOption) (io.ReadCloser, error) {
+	if kind == fileformat.FileTypeSubtreeToCheck && s.reads.Add(1) > 1 {
+		return nil, errors.NewStorageError("injected reopen failure")
+	}
+	return s.Store.GetIoReader(ctx, key, kind, opts...)
+}
+
+func TestQuickBodyPreflightMmapFallback(t *testing.T) {
+	for _, reopenFails := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reopenFails=%v", reopenFails), func(t *testing.T) {
+			u, block, _, blobs := newQuickBodyFixture(t, "sequential")
+			u.mmapDir = t.TempDir() + "/missing/directory"
+			if reopenFails {
+				u.subtreeStore = &reopenFailureStore{Store: blobs}
+			}
+			result := u.readSubtree(context.Background(), block, 0, block.Subtrees[0])
+			if reopenFails {
+				require.Error(t, result.err)
+				require.True(t, errors.Is(result.err, errors.ErrStorageError))
+				return
+			}
+			require.NoError(t, result.err, "fallback must reopen at byte zero")
+			defer result.subtree.Close()
+			require.False(t, result.subtree.IsMmapBacked())
+			require.Equal(t, *block.Subtrees[0], *result.subtree.RootHash())
 		})
 	}
 }

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -394,7 +394,9 @@ func (u *BlockValidation) processBlockSubtrees(ctx context.Context, block *model
 // This is the fallback when SubtreeBatchPrefetchDepth is 0.
 func (u *BlockValidation) processBlockSubtreesSequential(ctx context.Context, block *model.Block) (uint64, error) {
 	numSubtrees := len(block.Subtrees)
-	block.SubtreeSlices = make([]*subtreepkg.Subtree, numSubtrees)
+	if len(block.SubtreeSlices) != numSubtrees {
+		block.SubtreeSlices = make([]*subtreepkg.Subtree, numSubtrees)
+	}
 	var existingBlockID uint64
 
 	// Get block ID first (check for retry using first tx after reading first batch)
@@ -475,7 +477,9 @@ func (u *BlockValidation) processBlockSubtreesSequential(ctx context.Context, bl
 //   - On retry, Create() returns ErrTxExists, and SetMinedMulti() updates the correct BlockID
 func (u *BlockValidation) processBlockSubtreesPipeline(ctx context.Context, block *model.Block, prefetchDepth int) (uint64, error) {
 	numSubtrees := len(block.Subtrees)
-	block.SubtreeSlices = make([]*subtreepkg.Subtree, numSubtrees)
+	if len(block.SubtreeSlices) != numSubtrees {
+		block.SubtreeSlices = make([]*subtreepkg.Subtree, numSubtrees)
+	}
 	var existingBlockID uint64
 	blockIDSet := false
 
@@ -617,7 +621,9 @@ func (u *BlockValidation) processBlockSubtreesPipeline(ctx context.Context, bloc
 //   - error: If processing fails or context is cancelled
 func (u *BlockValidation) processBlockSubtreesPipelineAsync(ctx context.Context, block *model.Block, prefetchDepth int, writeJobsChan chan<- *SubtreeWriteJob) (uint64, error) {
 	numSubtrees := len(block.Subtrees)
-	block.SubtreeSlices = make([]*subtreepkg.Subtree, numSubtrees)
+	if len(block.SubtreeSlices) != numSubtrees {
+		block.SubtreeSlices = make([]*subtreepkg.Subtree, numSubtrees)
+	}
 	var existingBlockID uint64
 	blockIDSet := false
 
@@ -768,35 +774,41 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 	if !localExists {
 		return subtreeResult{err: errors.NewNotFoundError("[getBlockTransactions][%s] subtree %s not found locally", block.Hash().String(), subtreeHash.String())}
 	}
-	subtreeReader, err := u.subtreeStore.GetIoReader(ctx, subtreeHash[:], localFileType)
-	if err != nil {
-		return subtreeResult{err: errors.NewNotFoundError("[getBlockTransactions][%s] failed to get subtree %s", block.Hash().String(), subtreeHash.String(), err)}
+	// Reuse nodes authenticated by the quick preflight. Each batch reads its
+	// slice before the processing stage replaces it with the completed subtree.
+	var subtree *subtreepkg.Subtree
+	if len(block.SubtreeSlices) == len(block.Subtrees) {
+		subtree = block.SubtreeSlices[subtreeIdx]
 	}
-	defer subtreeReader.Close()
-
-	// Use pooled buffered reader to reduce GC pressure
 	bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
-	bufferedReader.Reset(subtreeReader)
 	defer func() {
 		bufferedReader.Reset(nil)
 		bufioReaderPool.Put(bufferedReader)
 	}()
-
-	// subtree only contains the tx hashes (nodes) of the subtree
-	var subtree *subtreepkg.Subtree
-	if u.mmapDir != "" {
-		subtree, err = subtreepkg.NewSubtreeFromReaderMmap(bufferedReader, u.mmapDir)
+	if subtree == nil {
+		subtreeReader, err := u.subtreeStore.GetIoReader(ctx, subtreeHash[:], localFileType)
 		if err != nil {
-			// Fallback to heap on mmap failure — reset reader and retry
-			u.logger.Warnf("[getBlockTransactions][%s] mmap deserialization failed for subtree %s, falling back to heap: %v", block.Hash().String(), subtreeHash.String(), err)
-			bufferedReader.Reset(subtreeReader)
+			return subtreeResult{err: errors.NewNotFoundError("[getBlockTransactions][%s] failed to get subtree %s", block.Hash().String(), subtreeHash.String(), err)}
+		}
+		defer subtreeReader.Close()
+
+		bufferedReader.Reset(subtreeReader)
+		// subtree only contains the tx hashes (nodes) of the subtree
+		if u.mmapDir != "" {
+			subtree, err = subtreepkg.NewSubtreeFromReaderMmap(bufferedReader, u.mmapDir)
+			if err != nil {
+				// Fallback to heap on mmap failure — reset reader and retry
+				u.logger.Warnf("[getBlockTransactions][%s] mmap deserialization failed for subtree %s, falling back to heap: %v", block.Hash().String(), subtreeHash.String(), err)
+				bufferedReader.Reset(subtreeReader)
+				subtree, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
+			}
+		} else {
 			subtree, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
 		}
-	} else {
-		subtree, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
-	}
-	if err != nil {
-		return subtreeResult{err: errors.NewProcessingError("[getBlockTransactions][%s] failed to deserialize subtree %s", block.Hash().String(), subtreeHash.String(), err)}
+		if err != nil {
+			return subtreeResult{err: errors.NewProcessingError("[getBlockTransactions][%s] failed to deserialize subtree %s", block.Hash().String(), subtreeHash.String(), err)}
+		}
+
 	}
 
 	// get the subtree data from disk
@@ -1542,9 +1554,10 @@ func (u *BlockValidation) extendBatch(
 	return nil
 }
 
-// authenticateQuickBlockBody checks the complete body before any batch can assign
-// a block ID, mutate UTXOs, or promote subtree files. The preflight reads only node
-// hashes; transaction data is still streamed in batches by the existing pipeline.
+// authenticateQuickBlockBody checks every subtree and transaction body before any
+// batch can assign a block ID, mutate UTXOs, or promote subtree files. Retain the
+// authenticated nodes for processing, but release decoded transactions one subtree
+// at a time to avoid retaining a second complete block's transaction data.
 func (u *BlockValidation) authenticateQuickBlockBody(ctx context.Context, block *model.Block) error {
 	body := &model.Block{Header: block.Header, CoinbaseTx: block.CoinbaseTx, Subtrees: block.Subtrees}
 	if err := body.GetAndValidateSubtrees(ctx, u.logger, u.subtreeStore, u.settings.BlockValidation.SubtreeBatchSize); err != nil {
@@ -1556,5 +1569,24 @@ func (u *BlockValidation) authenticateQuickBlockBody(ctx context.Context, block 
 	if err := body.CheckMerkleRoot(ctx); err != nil {
 		return errors.NewBlockInvalidError("[quickValidateBlock][%s] body does not match header merkle root", block.Hash().String(), err)
 	}
+	authenticatedCount := body.TransactionCount
+	if len(body.Subtrees) == 0 {
+		authenticatedCount = 1 // the separately serialized coinbase is the whole body
+	}
+	if block.TransactionCount != authenticatedCount {
+		return errors.NewBlockInvalidError("[quickValidateBlock][%s] transaction count %d does not match authenticated body count %d", block.Hash().String(), block.TransactionCount, authenticatedCount)
+	}
+	// Parsing transaction bytes checks each hash against the authenticated nodes
+	// and rejects missing or malformed data even in batches processed much later.
+	for i, hash := range body.Subtrees {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if result := u.readSubtree(ctx, body, i, hash); result.err != nil {
+			return result.err
+		}
+	}
+	block.SubtreeSlices = body.SubtreeSlices
+
 	return nil
 }

--- a/services/blockvalidation/quick_validate.go
+++ b/services/blockvalidation/quick_validate.go
@@ -3,6 +3,7 @@ package blockvalidation
 import (
 	"bufio"
 	"context"
+	"runtime"
 	"sync"
 	"time"
 
@@ -150,6 +151,10 @@ func (u *BlockValidation) buildSubtreeAndQueueWrite(ctx context.Context, block *
 		}
 	}
 
+	// RootHash initializes a lazy cache. Populate it before sharing the subtree
+	// with the async serializer and the block merkle check.
+	fullSubtree.RootHash()
+
 	// Set on block for merkle validation (synchronous)
 	block.SubtreeSlices[subtreeIdx] = fullSubtree
 
@@ -198,14 +203,13 @@ func (u *BlockValidation) quickValidateBlock(ctx context.Context, block *model.B
 		return errors.NewBlockIncompleteError("[quickValidateBlock][%s] coinbase tx is nil or has no inputs, peer may not have full block data", block.Hash().String())
 	}
 
-	if err := u.authenticateQuickBlockBody(ctx, block); err != nil {
+	cleanup, err := u.authenticateQuickBlockBody(ctx, block)
+	defer cleanup()
+	if err != nil {
 		return err
 	}
 
-	var (
-		err error
-		id  uint64
-	)
+	var id uint64
 
 	if len(block.Subtrees) > 0 {
 		// Process all subtrees in streaming fashion - creates UTXOs, spends, writes files
@@ -291,14 +295,13 @@ func (u *BlockValidation) quickValidateBlockAsync(ctx context.Context, block *mo
 		return errors.NewBlockIncompleteError("[quickValidateBlockAsync][%s] coinbase tx is nil or has no inputs, peer may not have full block data", block.Hash().String())
 	}
 
-	if err := u.authenticateQuickBlockBody(ctx, block); err != nil {
+	cleanup, err := u.authenticateQuickBlockBody(ctx, block)
+	defer cleanup()
+	if err != nil {
 		return err
 	}
 
-	var (
-		err error
-		id  uint64
-	)
+	var id uint64
 
 	if len(block.Subtrees) > 0 {
 		// Process subtrees with async file writes
@@ -360,6 +363,7 @@ type subtreeResult struct {
 	subtreeHash       chainhash.Hash
 	subtreeIdx        int
 	fullSubtreeExists bool // True if full .subtree file already exists (checked during prefetch)
+	borrowed          bool // nodes owned by the whole-block preflight
 	err               error
 }
 
@@ -763,7 +767,7 @@ func (u *BlockValidation) validateSubtrees(ctx context.Context, block *model.Blo
 }
 
 // readSubtree reads a single subtree from disk and validates its transactions.
-func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, subtreeIdx int, subtreeHash *chainhash.Hash) subtreeResult {
+func (u *BlockValidation) readSubtreeNodes(ctx context.Context, block *model.Block, subtreeIdx int, subtreeHash *chainhash.Hash) (result subtreeResult) {
 	// On retry the subtree may already be promoted to FileTypeSubtree (the
 	// "already validated" marker) and FileTypeSubtreeToCheck cleaned up, so
 	// consult both file types — see findLocalSubtreeFile.
@@ -780,6 +784,12 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 	if len(block.SubtreeSlices) == len(block.Subtrees) {
 		subtree = block.SubtreeSlices[subtreeIdx]
 	}
+	borrowed := subtree != nil
+	defer func() {
+		if result.err != nil && !borrowed && subtree != nil {
+			_ = subtree.Close()
+		}
+	}()
 	bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
 	defer func() {
 		bufferedReader.Reset(nil)
@@ -790,7 +800,7 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 		if err != nil {
 			return subtreeResult{err: errors.NewNotFoundError("[getBlockTransactions][%s] failed to get subtree %s", block.Hash().String(), subtreeHash.String(), err)}
 		}
-		defer subtreeReader.Close()
+		defer func() { _ = subtreeReader.Close() }()
 
 		bufferedReader.Reset(subtreeReader)
 		// subtree only contains the tx hashes (nodes) of the subtree
@@ -799,6 +809,12 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 			if err != nil {
 				// Fallback to heap on mmap failure — reset reader and retry
 				u.logger.Warnf("[getBlockTransactions][%s] mmap deserialization failed for subtree %s, falling back to heap: %v", block.Hash().String(), subtreeHash.String(), err)
+				_ = subtreeReader.Close()
+				reopened, openErr := u.subtreeStore.GetIoReader(ctx, subtreeHash[:], localFileType)
+				if openErr != nil {
+					return subtreeResult{err: errors.NewStorageError("failed to reopen subtree after mmap failure", openErr)}
+				}
+				subtreeReader = reopened
 				bufferedReader.Reset(subtreeReader)
 				subtree, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
 			}
@@ -806,11 +822,45 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 			subtree, err = subtreepkg.NewSubtreeFromReader(bufferedReader)
 		}
 		if err != nil {
-			return subtreeResult{err: errors.NewProcessingError("[getBlockTransactions][%s] failed to deserialize subtree %s", block.Hash().String(), subtreeHash.String(), err)}
+			return subtreeResult{err: errors.NewBlockInvalidError("[getBlockTransactions][%s] failed to deserialize subtree %s", block.Hash().String(), subtreeHash.String(), err)}
 		}
 
 	}
 
+	// Check if full .subtree file already exists (for retry scenarios). If the
+	// reader above already pulled from FileTypeSubtree we know it's present
+	// without another store round-trip.
+	fullSubtreeExists := localFileType == fileformat.FileTypeSubtree
+	if !fullSubtreeExists {
+		fullSubtreeExists, _ = u.subtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtree)
+	}
+
+	return subtreeResult{
+		subtree:           subtree,
+		subtreeHash:       *subtreeHash,
+		subtreeIdx:        subtreeIdx,
+		fullSubtreeExists: fullSubtreeExists,
+		borrowed:          borrowed,
+	}
+}
+
+func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, subtreeIdx int, subtreeHash *chainhash.Hash) (result subtreeResult) {
+	result = u.readSubtreeNodes(ctx, block, subtreeIdx, subtreeHash)
+	if result.err != nil {
+		return result
+	}
+	subtree := result.subtree
+	borrowed := result.borrowed
+	defer func() {
+		if result.err != nil && !borrowed {
+			_ = subtree.Close()
+		}
+	}()
+	bufferedReader := bufioReaderPool.Get().(*bufio.Reader)
+	defer func() {
+		bufferedReader.Reset(nil)
+		bufioReaderPool.Put(bufferedReader)
+	}()
 	// get the subtree data from disk
 	subtreeDataReader, err := u.subtreeStore.GetIoReader(ctx, subtreeHash[:], fileformat.FileTypeSubtreeData)
 	if err != nil {
@@ -824,7 +874,7 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 	// the subtree data reader will make sure the data matches the transaction ids from the subtree
 	subtreeData, err := subtreepkg.NewSubtreeDataFromReader(subtree, bufferedReader)
 	if err != nil {
-		return subtreeResult{err: errors.NewProcessingError("[getBlockTransactions][%s] failed to deserialize subtree data %s: %v", block.Hash().String(), subtreeHash.String(), err)}
+		return subtreeResult{err: errors.NewBlockInvalidError("[getBlockTransactions][%s] failed to deserialize subtree data %s: %v", block.Hash().String(), subtreeHash.String(), err)}
 	}
 
 	// Validate transactions in this subtree
@@ -832,31 +882,18 @@ func (u *BlockValidation) readSubtree(ctx context.Context, block *model.Block, s
 		if subtreeIdx == 0 && idx == 0 {
 			// First tx in first subtree must be coinbase
 			if tx != nil && !tx.IsCoinbase() {
-				return subtreeResult{err: errors.NewProcessingError("[getBlockTransactions][%s] invalid coinbase tx at index %d in subtree %s", block.Hash().String(), idx, subtreeHash.String())}
+				return subtreeResult{err: errors.NewBlockInvalidError("[getBlockTransactions][%s] invalid coinbase tx at index %d in subtree %s", block.Hash().String(), idx, subtreeHash.String())}
 			}
 			subtreeData.Txs[idx] = nil // set to nil to indicate coinbase
 		} else {
 			if tx == nil {
-				return subtreeResult{err: errors.NewProcessingError("[getBlockTransactions][%s] missing tx at index %d in subtree %s", block.Hash().String(), idx, subtreeHash.String())}
+				return subtreeResult{err: errors.NewBlockInvalidError("[getBlockTransactions][%s] missing tx at index %d in subtree %s", block.Hash().String(), idx, subtreeHash.String())}
 			}
 		}
 	}
 
-	// Check if full .subtree file already exists (for retry scenarios). If the
-	// reader above already pulled from FileTypeSubtree we know it's present
-	// without another store round-trip.
-	fullSubtreeExists := localFileType == fileformat.FileTypeSubtree
-	if !fullSubtreeExists {
-		fullSubtreeExists, _ = u.subtreeStore.Exists(ctx, subtreeHash[:], fileformat.FileTypeSubtree)
-	}
-
-	return subtreeResult{
-		subtree:           subtree,
-		subtreeData:       subtreeData,
-		subtreeHash:       *subtreeHash,
-		subtreeIdx:        subtreeIdx,
-		fullSubtreeExists: fullSubtreeExists,
-	}
+	result.subtreeData = subtreeData
+	return result
 }
 
 // writeSubtreeFilesFromTxs writes the full subtree file to disk.
@@ -988,7 +1025,8 @@ func (u *BlockValidation) unlockSubtreeTransactions(ctx context.Context, subtree
 // to avoid recomputing data and enable parallel operations.
 type SubtreeProcessingBatch struct {
 	// subtrees contains the raw subtree structures (tx hashes/nodes)
-	subtrees []*subtreepkg.Subtree
+	subtrees         []*subtreepkg.Subtree
+	borrowedSubtrees []bool
 
 	// subtreeData contains the full transaction data for each subtree
 	subtreeData []*subtreepkg.Data
@@ -1015,9 +1053,9 @@ type SubtreeProcessingBatch struct {
 
 // Close releases mmap-backed subtree resources in this batch.
 func (b *SubtreeProcessingBatch) Close() {
-	for _, st := range b.subtrees {
-		if st != nil {
-			st.Close()
+	for i, st := range b.subtrees {
+		if st != nil && (i >= len(b.borrowedSubtrees) || !b.borrowedSubtrees[i]) {
+			_ = st.Close()
 		}
 	}
 }
@@ -1121,13 +1159,14 @@ func (u *BlockValidation) processSubtreeBatch(
 	batchSize := batchEnd - batchStart
 
 	batch := &SubtreeProcessingBatch{
-		subtrees:      make([]*subtreepkg.Subtree, batchSize),
-		subtreeData:   make([]*subtreepkg.Data, batchSize),
-		subtreeHashes: make([]chainhash.Hash, batchSize),
-		txRanges:      make([][2]int, batchSize),
-		batchTxs:      make([]*bt.Tx, 0),
-		batchStart:    batchStart,
-		batchEnd:      batchEnd,
+		subtrees:         make([]*subtreepkg.Subtree, batchSize),
+		borrowedSubtrees: make([]bool, batchSize),
+		subtreeData:      make([]*subtreepkg.Data, batchSize),
+		subtreeHashes:    make([]chainhash.Hash, batchSize),
+		txRanges:         make([][2]int, batchSize),
+		batchTxs:         make([]*bt.Tx, 0),
+		batchStart:       batchStart,
+		batchEnd:         batchEnd,
 	}
 
 	// Phase 1: Read subtrees in parallel
@@ -1138,6 +1177,7 @@ func (u *BlockValidation) processSubtreeBatch(
 
 	readerCtx, cancelReaders := context.WithCancel(ctx)
 	g, gCtx := errgroup.WithContext(readerCtx)
+	defer func() { cancelReaders(); _ = g.Wait() }()
 	util.SafeSetLimit(g, 128)
 
 	for i := 0; i < batchSize; i++ {
@@ -1178,6 +1218,7 @@ func (u *BlockValidation) processSubtreeBatch(
 		}
 
 		batch.subtrees[i] = result.subtree
+		batch.borrowedSubtrees[i] = result.borrowed
 		batch.subtreeData[i] = result.subtreeData
 		batch.subtreeHashes[i] = result.subtreeHash
 
@@ -1430,6 +1471,7 @@ func (u *BlockValidation) prefetchSubtreeBatch(
 
 	batch := &SubtreeProcessingBatch{
 		subtrees:          make([]*subtreepkg.Subtree, batchSize),
+		borrowedSubtrees:  make([]bool, batchSize),
 		subtreeData:       make([]*subtreepkg.Data, batchSize),
 		subtreeHashes:     make([]chainhash.Hash, batchSize),
 		txRanges:          make([][2]int, batchSize),
@@ -1447,6 +1489,7 @@ func (u *BlockValidation) prefetchSubtreeBatch(
 
 	readerCtx, cancelReaders := context.WithCancel(ctx)
 	g, gCtx := errgroup.WithContext(readerCtx)
+	defer func() { cancelReaders(); _ = g.Wait() }()
 	util.SafeSetLimit(g, 128)
 
 	for i := 0; i < batchSize; i++ {
@@ -1485,6 +1528,7 @@ func (u *BlockValidation) prefetchSubtreeBatch(
 		}
 
 		batch.subtrees[i] = result.subtree
+		batch.borrowedSubtrees[i] = result.borrowed
 		batch.subtreeData[i] = result.subtreeData
 		batch.subtreeHashes[i] = result.subtreeHash
 		batch.fullSubtreeExists[i] = result.fullSubtreeExists
@@ -1554,39 +1598,102 @@ func (u *BlockValidation) extendBatch(
 	return nil
 }
 
-// authenticateQuickBlockBody checks every subtree and transaction body before any
-// batch can assign a block ID, mutate UTXOs, or promote subtree files. Retain the
-// authenticated nodes for processing, but release decoded transactions one subtree
-// at a time to avoid retaining a second complete block's transaction data.
-func (u *BlockValidation) authenticateQuickBlockBody(ctx context.Context, block *model.Block) error {
-	body := &model.Block{Header: block.Header, CoinbaseTx: block.CoinbaseTx, Subtrees: block.Subtrees}
-	if err := body.GetAndValidateSubtrees(ctx, u.logger, u.subtreeStore, u.settings.BlockValidation.SubtreeBatchSize); err != nil {
-		return err
+// authenticateQuickBlockBody authenticates every node and transaction before
+// mutation. The returned cleanup owns the loaded nodes until all processing has
+// joined; batches borrow them and cannot unmap them on an intermediate error.
+func (u *BlockValidation) authenticateQuickBlockBody(ctx context.Context, block *model.Block) (func(), error) {
+	body := &model.Block{Header: block.Header, CoinbaseTx: block.CoinbaseTx, Subtrees: block.Subtrees,
+		SubtreeSlices: make([]*subtreepkg.Subtree, len(block.Subtrees))}
+	cleanup := func() {
+		for i, st := range body.SubtreeSlices {
+			if st != nil {
+				_ = st.Close()
+				if i < len(block.SubtreeSlices) && block.SubtreeSlices[i] == st {
+					block.SubtreeSlices[i] = nil
+				}
+			}
+		}
+	}
+	// Bound both mapped-node reads and decoded transaction data. Each worker
+	// releases decoded transactions before accepting another subtree.
+	concurrency := u.settings.Block.GetAndValidateSubtreesConcurrency
+	if concurrency <= 0 {
+		concurrency = max(4, runtime.NumCPU()/2)
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	util.SafeSetLimit(g, concurrency)
+	sizes := make([]uint64, len(body.Subtrees))
+	for i, hash := range body.Subtrees {
+		g.Go(func() error {
+			// Use a separate read view: its slices are empty, so this read owns
+			// the mmap allocation. Publishing results does not race other readers.
+			view := &model.Block{Header: body.Header, CoinbaseTx: body.CoinbaseTx, Subtrees: body.Subtrees}
+			result := u.readSubtreeNodes(gCtx, view, i, hash)
+			if result.err != nil {
+				return result.err
+			}
+			st := result.subtree
+			body.SubtreeSlices[i] = st
+			if len(st.Nodes) == 0 || (i == 0 && !st.Nodes[0].Hash.Equal(subtreepkg.CoinbasePlaceholderHashValue)) {
+				return errors.NewBlockInvalidError("[quickValidateBlock][%s] first subtree must start with the coinbase placeholder and subtrees must not be empty", block.Hash().String())
+			}
+			// Deserialization reads a cached root from the file. Recompute it
+			// from nodes instead of trusting that cache or the blob-store key.
+			root, err := st.RootHashWithReplaceRootNode(&st.Nodes[0].Hash, st.Nodes[0].Fee, st.Nodes[0].SizeInBytes)
+			if err != nil || root == nil || !root.IsEqual(hash) || !st.RootHash().IsEqual(hash) {
+				return errors.NewBlockInvalidError("[quickValidateBlock][%s] subtree %s nodes do not match its root", block.Hash().String(), hash.String(), err)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return cleanup, err
 	}
 	if err := model.CheckSubtreeSlicesForDuplicateTxs(body.SubtreeSlices); err != nil {
-		return err
+		return cleanup, err
 	}
 	if err := body.CheckMerkleRoot(ctx); err != nil {
-		return errors.NewBlockInvalidError("[quickValidateBlock][%s] body does not match header merkle root", block.Hash().String(), err)
+		return cleanup, errors.NewBlockInvalidError("[quickValidateBlock][%s] body does not match header merkle root", block.Hash().String(), err)
 	}
-	authenticatedCount := body.TransactionCount
+	var authenticatedCount uint64
+	for i, st := range body.SubtreeSlices {
+		if i > 0 && i < len(body.SubtreeSlices)-1 && st.Length() != body.SubtreeSlices[0].Length() {
+			return cleanup, errors.NewBlockInvalidError("[quickValidateBlock][%s] subtree %d has inconsistent length", block.Hash().String(), i)
+		}
+		authenticatedCount += uint64(st.Length())
+	}
 	if len(body.Subtrees) == 0 {
-		authenticatedCount = 1 // the separately serialized coinbase is the whole body
+		authenticatedCount = 1
 	}
 	if block.TransactionCount != authenticatedCount {
-		return errors.NewBlockInvalidError("[quickValidateBlock][%s] transaction count %d does not match authenticated body count %d", block.Hash().String(), block.TransactionCount, authenticatedCount)
+		return cleanup, errors.NewBlockInvalidError("[quickValidateBlock][%s] transaction count %d does not match authenticated body count %d", block.Hash().String(), block.TransactionCount, authenticatedCount)
 	}
-	// Parsing transaction bytes checks each hash against the authenticated nodes
-	// and rejects missing or malformed data even in batches processed much later.
+	// With node structure and header commitments established, parse all bodies
+	// in parallel before permitting the first UTXO operation.
+	dataGroup, dataCtx := errgroup.WithContext(ctx)
+	util.SafeSetLimit(dataGroup, concurrency)
 	for i, hash := range body.Subtrees {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if result := u.readSubtree(ctx, body, i, hash); result.err != nil {
-			return result.err
-		}
+		dataGroup.Go(func() error {
+			result := u.readSubtree(dataCtx, body, i, hash)
+			if result.err != nil {
+				return result.err
+			}
+			for _, tx := range result.subtreeData.Txs {
+				if tx != nil {
+					sizes[i] += uint64(tx.Size())
+				}
+			}
+			return nil
+		})
 	}
-	block.SubtreeSlices = body.SubtreeSlices
-
-	return nil
+	if err := dataGroup.Wait(); err != nil {
+		return cleanup, err
+	}
+	var transactionBytes uint64
+	for _, size := range sizes {
+		transactionBytes += size
+	}
+	block.SubtreeSlices = append([]*subtreepkg.Subtree(nil), body.SubtreeSlices...)
+	block.SizeInBytes = 80 + util.VarintSize(authenticatedCount) + uint64(block.CoinbaseTx.Size()) + transactionBytes
+	return cleanup, nil
 }

--- a/services/blockvalidation/quick_validate_test.go
+++ b/services/blockvalidation/quick_validate_test.go
@@ -31,6 +31,7 @@ func TestQuickValidateBlock(t *testing.T) {
 
 		block := testhelpers.CreateTestBlocks(t, 1)[0]
 		block.Header.HashMerkleRoot = block.CoinbaseTx.TxIDChainHash()
+		block.TransactionCount = 1
 
 		err := suite.Server.blockValidation.quickValidateBlock(suite.Ctx, block, "test", "")
 		assert.NoError(t, err, "Should successfully quick validate an empty block")

--- a/services/legacy/Server.go
+++ b/services/legacy/Server.go
@@ -707,10 +707,5 @@ func (s *Server) Stop(_ context.Context) error {
 		return nil
 	}
 
-	if err := s.server.Stop(); err != nil {
-		return err
-	}
-	// The peer server stop only signals shutdown. Join the sync manager before
-	// the service manager returns and the daemon closes its UTXO store.
-	return s.server.syncManager.Stop()
+	return s.server.stopAndWait()
 }

--- a/services/legacy/netsync/header_provenance_flow_test.go
+++ b/services/legacy/netsync/header_provenance_flow_test.go
@@ -239,9 +239,41 @@ func TestHeaderProvenance_ConcurrentReset(t *testing.T) {
 			go func() { defer wg.Done(); <-start; sm.fetchHeaderBlocks() }()
 			close(start)
 			wg.Wait()
+			// Reset disables headers-first mode under headerMu. If it wins
+			// the lock first, the late header is ignored; otherwise it clears
+			// the proof published by the header handler.
 			require.Zero(t, sm.verifiedCheckpointHeight)
 			require.Nil(t, sm.startHeader)
 			require.Equal(t, 1, sm.headerList.Len())
+		})
+	}
+}
+
+func TestHeaderProvenance_ResetOrdering(t *testing.T) {
+	for _, resetFirst := range []bool{false, true} {
+		t.Run(fmt.Sprintf("resetFirst=%v", resetFirst), func(t *testing.T) {
+			sm, p, _ := newHeaderProvenanceManager(t)
+			anchor := hashFrom(0x52)
+			header := wire.NewBlockHeader(1, &anchor, &chainhash.Hash{}, 0x207fffff, 1)
+			hash := header.BlockHash()
+			sm.nextCheckpoint = &chaincfg.Checkpoint{Height: 101, Hash: &hash}
+			sm.headerList.PushBack(&headerNode{height: 100, hash: &anchor})
+			headers := wire.NewMsgHeaders()
+			require.NoError(t, headers.AddBlockHeader(header))
+			if resetFirst {
+				sm.resetHeaderState(&anchor, 100)
+			}
+			sm.handleHeadersMsg(&headersMsg{headers: headers, peer: p})
+			if !resetFirst {
+				require.Equal(t, int32(101), sm.verifiedCheckpointHeight)
+				sm.resetHeaderState(&anchor, 100)
+			}
+			sm.fetchHeaderBlocks()
+			require.False(t, sm.headersFirstMode.Load())
+			require.Zero(t, sm.verifiedCheckpointHeight)
+			require.Nil(t, sm.startHeader)
+			require.Equal(t, 1, sm.headerList.Len())
+			require.Equal(t, anchor, *sm.headerList.Front().Value.(*headerNode).hash)
 		})
 	}
 }

--- a/services/legacy/netsync/manager.go
+++ b/services/legacy/netsync/manager.go
@@ -2355,6 +2355,8 @@ out:
 	}
 
 	blockWorker.Wait()
+	// Queued blocks are abandoned on shutdown; peer waits also observe shutdown.
+	sm.blockBacklog.Store(0)
 	close(sm.handlerDone)
 	sm.logger.Infof("Block handler done")
 }
@@ -2364,11 +2366,11 @@ func (sm *SyncManager) NewPeer(peer *peerpkg.Peer, done chan struct{}) {
 	// Ignore if we are shutting down.
 	if atomic.LoadInt32(&sm.shutdown) != 0 {
 		if done != nil {
-			done <- struct{}{}
+			sendDuringShutdown(done, struct{}{}, sm.quit)
 		}
 		return
 	}
-	sm.msgChan <- &newPeerMsg{peer: peer, reply: done}
+	sendDuringShutdown[interface{}](sm.msgChan, &newPeerMsg{peer: peer, reply: done}, sm.quit)
 }
 
 // QueueTx adds the passed transaction message and peer to the block handling
@@ -2378,12 +2380,12 @@ func (sm *SyncManager) QueueTx(tx *bsvutil.Tx, peer *peerpkg.Peer, done chan str
 	// Don't accept more transactions if we're shutting down.
 	if atomic.LoadInt32(&sm.shutdown) != 0 {
 		if done != nil {
-			done <- struct{}{}
+			sendDuringShutdown(done, struct{}{}, sm.quit)
 		}
 		return
 	}
 
-	sm.msgChan <- &txMsg{tx: tx, peer: peer, reply: done}
+	sendDuringShutdown[interface{}](sm.msgChan, &txMsg{tx: tx, peer: peer, reply: done}, sm.quit)
 }
 
 // QueueBlock adds the passed block message and peer to the block handling
@@ -2392,33 +2394,29 @@ func (sm *SyncManager) QueueTx(tx *bsvutil.Tx, peer *peerpkg.Peer, done chan str
 func (sm *SyncManager) QueueBlock(block *bsvutil.Block, peer *peerpkg.Peer, done chan error) {
 	// Don't accept more blocks if we're shutting down.
 	if atomic.LoadInt32(&sm.shutdown) != 0 {
-		done <- nil
+		sendDuringShutdown[error](done, nil, sm.quit)
 		return
 	}
 
-	sm.msgChan <- &blockMsg{block: block, peer: peer, reply: done}
+	sendDuringShutdown[interface{}](sm.msgChan, &blockMsg{block: block, peer: peer, reply: done}, sm.quit)
 }
 
-// sendDuringShutdown delivers v on ch, recovering from the "send on closed
-// channel" panic that races teardown. Inv delivery runs on peer read-loop
-// goroutines (OnInv -> QueueInv), but the channels they target are torn down by
-// a different goroutine during shutdown: the kafka async producer closes
-// legacyKafkaInvCh in its Stop(), and the block handler stops draining msgChan.
-// The shutdown flag check in QueueInv narrows but cannot close that window — a
-// flag check and a channel send are not atomic against a concurrent close — so
-// a late inv would otherwise crash the whole process. Dropping an inv during
-// shutdown is safe: inv is an advisory announcement, re-sent by the peer (or a
-// later session) on the next connection. Returns false if the channel was closed.
-func sendDuringShutdown[T any](ch chan T, v T) (sent bool) {
+// sendDuringShutdown lets blocked producers exit when consumers stop draining.
+// The Kafka producer can also close its input during teardown, so tolerate a
+// late send to that channel. Returns false when delivery is abandoned.
+func sendDuringShutdown[T any](ch chan T, v T, quit <-chan struct{}) (sent bool) {
 	defer func() {
 		if recover() != nil {
 			sent = false
 		}
 	}()
 
-	ch <- v
-
-	return true
+	select {
+	case ch <- v:
+		return true
+	case <-quit:
+		return false
+	}
 }
 
 // QueueInv adds the passed inv message and peer to the block handling queue.
@@ -2452,7 +2450,7 @@ func (sm *SyncManager) QueueInv(inv *wire.MsgInv, peer *peerpkg.Peer) {
 
 		if len(invBlockMsg.InvList) > 0 {
 			netsyncInvMsg := invMsg{inv: invBlockMsg, peer: peer}
-			sendDuringShutdown[interface{}](sm.msgChan, &netsyncInvMsg)
+			sendDuringShutdown[interface{}](sm.msgChan, &netsyncInvMsg, sm.quit)
 		}
 
 		if len(invTxMsg.InvList) > 0 {
@@ -2468,11 +2466,11 @@ func (sm *SyncManager) QueueInv(inv *wire.MsgInv, peer *peerpkg.Peer) {
 			sm.logger.Debugf("writing INV message to Kafka from peer %s, length: %d", peer.String(), len(value))
 			sendDuringShutdown(sm.legacyKafkaInvCh, &kafka.Message{
 				Value: value,
-			})
+			}, sm.quit)
 		}
 	} else {
 		netsyncInvMsg := invMsg{inv: inv, peer: peer}
-		sendDuringShutdown[interface{}](sm.msgChan, &netsyncInvMsg)
+		sendDuringShutdown[interface{}](sm.msgChan, &netsyncInvMsg, sm.quit)
 	}
 }
 
@@ -2485,7 +2483,7 @@ func (sm *SyncManager) QueueHeaders(headers *wire.MsgHeaders, peer *peerpkg.Peer
 		return
 	}
 
-	sm.msgChan <- &headersMsg{headers: headers, peer: peer}
+	sendDuringShutdown[interface{}](sm.msgChan, &headersMsg{headers: headers, peer: peer}, sm.quit)
 }
 
 // DonePeer informs the blockmanager that a peer has disconnected.
@@ -2493,13 +2491,13 @@ func (sm *SyncManager) DonePeer(peer *peerpkg.Peer, done chan struct{}) {
 	// Ignore if we are shutting down.
 	if atomic.LoadInt32(&sm.shutdown) != 0 {
 		if done != nil {
-			done <- struct{}{}
+			sendDuringShutdown(done, struct{}{}, sm.quit)
 		}
 		return
 	}
 
 	sm.logger.Infof("Done peer %s", peer)
-	sm.msgChan <- &donePeerMsg{peer: peer, reply: done}
+	sendDuringShutdown[interface{}](sm.msgChan, &donePeerMsg{peer: peer, reply: done}, sm.quit)
 }
 
 // beginHandler admits work before shutdown and lets Stop wait for it. Holding
@@ -2551,9 +2549,13 @@ func (sm *SyncManager) Stop() error {
 // SyncPeerID returns the ID of the current sync peer, or 0 if there is none.
 func (sm *SyncManager) SyncPeerID() int32 {
 	reply := make(chan int32)
-	sm.msgChan <- getSyncPeerMsg{reply: reply}
-
-	return <-reply
+	sendDuringShutdown[interface{}](sm.msgChan, getSyncPeerMsg{reply: reply}, sm.quit)
+	select {
+	case id := <-reply:
+		return id
+	case <-sm.quit:
+		return 0
+	}
 }
 
 // IsCurrent returns whether the sync manager believes it is synced with
@@ -2568,7 +2570,7 @@ func (sm *SyncManager) IsCurrent() bool {
 // message sender should avoid pausing the sync manager for long durations.
 func (sm *SyncManager) Pause() chan<- struct{} {
 	c := make(chan struct{})
-	sm.msgChan <- pauseMsg{c}
+	sendDuringShutdown[interface{}](sm.msgChan, pauseMsg{c}, sm.quit)
 
 	return c
 }

--- a/services/legacy/netsync/manager_shutdown_test.go
+++ b/services/legacy/netsync/manager_shutdown_test.go
@@ -136,3 +136,48 @@ func TestStop_WhilePaused(t *testing.T) {
 		t.Fatal("Stop waited for the paused caller to resume")
 	}
 }
+
+func TestShutdown_ReleasesBlockedQueueCalls(t *testing.T) {
+	for _, operation := range []string{"inventory", "headers", "block", "transaction", "new peer", "done peer", "sync peer", "pause"} {
+		t.Run(operation, func(t *testing.T) {
+			sm, p, _ := newHeaderProvenanceManager(t)
+			sm.quit = make(chan struct{})
+			sm.msgChan = make(chan interface{}) // no consumer can accept the send
+			sm.orphanTxs = expiringmap.New[chainhash.Hash, *orphanTxAndParents](time.Hour)
+			sm.requestedTxns = expiringmap.New[chainhash.Hash, struct{}](time.Hour)
+			returned := make(chan struct{})
+			go func() {
+				switch operation {
+				case "inventory":
+					sm.QueueInv(wire.NewMsgInv(), p)
+				case "headers":
+					sm.QueueHeaders(wire.NewMsgHeaders(), p)
+				case "block":
+					sm.QueueBlock(nil, p, make(chan error, 1))
+				case "transaction":
+					sm.QueueTx(nil, p, nil)
+				case "new peer":
+					sm.NewPeer(p, nil)
+				case "done peer":
+					sm.DonePeer(p, nil)
+				case "sync peer":
+					sm.SyncPeerID()
+				case "pause":
+					close(sm.Pause())
+				}
+				close(returned)
+			}()
+			select {
+			case <-returned:
+				t.Fatal("queue call returned without a consumer or shutdown")
+			case <-time.After(50 * time.Millisecond):
+			}
+			require.NoError(t, sm.Stop())
+			select {
+			case <-returned:
+			case <-time.After(5 * time.Second):
+				t.Fatal("queue call remained blocked after shutdown")
+			}
+		})
+	}
+}

--- a/services/legacy/netsync/manager_test.go
+++ b/services/legacy/netsync/manager_test.go
@@ -418,7 +418,7 @@ func setupQueueInvTests() (chan interface{}, chan *kafka.Message, *SyncManager, 
 func TestSendDuringShutdown(t *testing.T) {
 	t.Run("open channel delivers", func(t *testing.T) {
 		ch := make(chan int, 1)
-		require.True(t, sendDuringShutdown(ch, 7))
+		require.True(t, sendDuringShutdown(ch, 7, nil))
 		require.Equal(t, 7, <-ch)
 	})
 
@@ -426,7 +426,7 @@ func TestSendDuringShutdown(t *testing.T) {
 		ch := make(chan int)
 		close(ch)
 		require.NotPanics(t, func() {
-			require.False(t, sendDuringShutdown(ch, 1))
+			require.False(t, sendDuringShutdown(ch, 1, nil))
 		})
 	})
 }

--- a/services/legacy/peer_server.go
+++ b/services/legacy/peer_server.go
@@ -312,6 +312,7 @@ type server struct {
 	relayInv             chan relayMsg
 	broadcast            chan broadcastMsg
 	peerHeightsUpdate    chan updatePeerHeightsMsg
+	lifecycleMu          sync.Mutex // serializes worker registration with Stop
 	wg                   sync.WaitGroup
 	quit                 chan struct{}
 	nat                  NAT
@@ -918,16 +919,21 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err == nil {
 		// Use a channel to get the response from the query
-		respChan := make(chan bool)
+		respChan := make(chan bool, 1)
 
 		// Create a proper query message to check if the peer is banned
-		sp.server.query <- &isPeerBannedMsg{
-			addr:  host,
-			reply: respChan,
+		select {
+		case sp.server.query <- &isPeerBannedMsg{addr: host, reply: respChan}:
+		case <-sp.server.quit:
+			return
 		}
 
-		// Wait for the response
-		isBanned := <-respChan
+		var isBanned bool
+		select {
+		case isBanned = <-respChan:
+		case <-sp.server.quit:
+			return
+		}
 		if isBanned {
 			sp.server.logger.Warnf("Ignoring block %s from banned legacy peer %s",
 				msg.BlockHash().String(), sp.Addr())
@@ -963,7 +969,12 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 		// the bitcoin block has been fully processed.
 		sp.server.syncManager.QueueBlock(block, sp.Peer, sp.blockProcessed)
 
-		err = <-sp.blockProcessed
+		// Shutdown can discard queued blocks and their replies.
+		select {
+		case err = <-sp.blockProcessed:
+		case <-sp.server.quit:
+			return
+		}
 		if err != nil {
 			sp.server.logger.Errorf("block processing failed: %v", err)
 
@@ -2529,7 +2540,10 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 // done along with other performing other desirable cleanup.
 func (s *server) peerDoneHandler(sp *serverPeer) {
 	sp.WaitForDisconnect()
-	s.donePeers <- sp
+	select {
+	case s.donePeers <- sp:
+	case <-s.quit:
+	}
 
 	// Only tell sync manager we are gone if we ever told it we existed.
 	if sp.VersionKnown() {
@@ -2885,31 +2899,32 @@ cleanup:
 
 // Start begins accepting connections from peers.
 func (s *server) Start() {
-	// Already started?
-	if atomic.AddInt32(&s.started, 1) != 1 {
+	s.lifecycleMu.Lock()
+	if atomic.LoadInt32(&s.shutdown) != 0 || !atomic.CompareAndSwapInt32(&s.started, 0, 1) {
+		s.lifecycleMu.Unlock()
 		return
 	}
-
-	s.wg.Add(1)
-	go s.rebroadcastHandler()
-
-	s.wg.Add(1)
-	s.peerHandler()
-
+	// Register all workers before Stop can begin waiting for them.
+	s.wg.Add(2)
 	if s.nat != nil {
 		s.wg.Add(1)
+	}
+	s.lifecycleMu.Unlock()
+
+	go s.rebroadcastHandler()
+	if s.nat != nil {
 		go s.upnpUpdateThread()
 	}
-
-	// Start listening for ban events
 	go s.listenForBanEvents(s.ctx)
-
+	s.peerHandler()
 	s.WaitForShutdown()
 }
 
 // Stop gracefully shuts down the server by stopping and disconnecting all
 // peers and the main listener.
 func (s *server) Stop() error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 	// Make sure this only happens once.
 	if atomic.AddInt32(&s.shutdown, 1) != 1 {
 		s.logger.Infof("Server is already in the process of shutting down")
@@ -2921,6 +2936,19 @@ func (s *server) Stop() error {
 	// Signal the remaining goroutines to quit.
 	close(s.quit)
 
+	return nil
+}
+
+// stopAndWait preserves peerHandler's disconnect-before-sync-manager ordering.
+// The final Stop also joins a manager initialized without starting the server.
+func (s *server) stopAndWait() error {
+	if err := s.Stop(); err != nil {
+		return err
+	}
+	s.WaitForShutdown()
+	if s.syncManager != nil {
+		return s.syncManager.Stop()
+	}
 	return nil
 }
 
@@ -3388,8 +3416,7 @@ func newServer(ctx context.Context, logger ulogger.Logger, tSettings *settings.S
 		// wait for the ctx to be done
 		<-ctx.Done()
 		// stop the servers
-		_ = s.Stop()
-		_ = s.syncManager.Stop()
+		_ = s.stopAndWait()
 	}()
 
 	return &s, nil

--- a/services/legacy/peer_shutdown_test.go
+++ b/services/legacy/peer_shutdown_test.go
@@ -1,0 +1,98 @@
+package legacy
+
+import (
+	"context"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-wire"
+	"github.com/bsv-blockchain/teranode/services/blockchain"
+	"github.com/bsv-blockchain/teranode/services/legacy/netsync"
+	"github.com/bsv-blockchain/teranode/services/legacy/peer"
+	"github.com/bsv-blockchain/teranode/settings"
+	blockchainstore "github.com/bsv-blockchain/teranode/stores/blockchain"
+	"github.com/bsv-blockchain/teranode/ulogger"
+	"github.com/bsv-blockchain/teranode/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerStop_JoinsPeerShutdown(t *testing.T) {
+	inner := &server{logger: ulogger.TestLogger{}, quit: make(chan struct{})}
+	inner.wg.Add(1) // peerHandler is still disconnecting peers
+	service := &Server{server: inner}
+	returned := make(chan error, 2)
+	go func() { returned <- service.Stop(context.Background()) }()
+	<-inner.quit
+	go func() { returned <- service.Stop(context.Background()) }()
+	select {
+	case <-returned:
+		t.Error("service Stop returned before the peer handler completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	inner.wg.Done()
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-returned:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("service Stop did not join peer shutdown")
+		}
+	}
+	inner.Start()
+	require.Zero(t, atomic.LoadInt32(&inner.started), "a stopped server must not register new workers")
+}
+
+func TestOnBlock_ShutdownCancelsWait(t *testing.T) {
+	for _, waitingFor := range []string{"ban query send", "ban query reply", "block reply"} {
+		t.Run(waitingFor, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			cfg := test.CreateBaseTestSettings(t)
+			cfg.Kafka = settings.KafkaSettings{}
+			storeURL, err := url.Parse("sqlitememory:///")
+			require.NoError(t, err)
+			store, err := blockchainstore.NewStore(ulogger.TestLogger{}, storeURL, cfg)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, store.(interface{ Close() error }).Close()) }()
+			client, err := blockchain.NewLocalClient(ulogger.TestLogger{}, cfg, store, nil, nil)
+			require.NoError(t, err)
+			sm, err := netsync.New(ctx, ulogger.TestLogger{}, cfg, client, nil, nil, nil, nil, nil, nil,
+				&netsync.Config{ChainParams: cfg.ChainCfgParams, DisableCheckpoints: true})
+			require.NoError(t, err)
+			defer func() { cancel(); require.NoError(t, sm.Stop()) }()
+			s := &server{ctx: ctx, logger: ulogger.TestLogger{}, settings: cfg, blockchainClient: client,
+				syncManager: sm, quit: make(chan struct{}), query: make(chan interface{})}
+			sp := newServerPeer(s, false)
+			sp.Peer, err = peer.NewOutboundPeer(ulogger.TestLogger{}, cfg, &peer.Config{}, "127.0.0.1:8333")
+			require.NoError(t, err)
+			finished := make(chan struct{})
+			go func() {
+				sp.OnBlock(sp.Peer, &wire.MsgBlock{}, nil)
+				close(finished)
+			}()
+			if waitingFor != "ban query send" {
+				select {
+				case query := <-s.query:
+					if waitingFor == "block reply" {
+						query.(*isPeerBannedMsg).reply <- false
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("OnBlock did not submit its ban query")
+				}
+			}
+			select {
+			case <-finished:
+				t.Fatal("OnBlock returned before its reply or shutdown")
+			case <-time.After(50 * time.Millisecond):
+			}
+			require.NoError(t, s.stopAndWait())
+			select {
+			case <-finished:
+			case <-time.After(5 * time.Second):
+				t.Fatal("OnBlock remained blocked after shutdown")
+			}
+		})
+	}
+}

--- a/test/e2e/daemon/ready/catchup_test.go
+++ b/test/e2e/daemon/ready/catchup_test.go
@@ -241,6 +241,9 @@ func newNode(t *testing.T, nodeNumber int, enableBlockPersister bool, enablePrun
 				s.P2P.StaticPeers = []string{}
 				s.ChainCfgParams.CoinbaseMaturity = 1
 				s.GlobalBlockHeightRetention = 1
+				// This test exercises recovery after pruning. Allow the small block
+				// burst without rate-limit retries consuming the sync deadline.
+				s.Asset.HTTPHeavyRateLimit = 100
 				s.P2P.SyncCoordinatorPeriodicEvaluationInterval = 1 * time.Second
 				s.Pruner.BlockTrigger = settings.PrunerBlockTriggerOnBlockPersisted
 			},


### PR DESCRIPTION
Quick validation could mutate UTXOs before discovering malformed transaction data in a later subtree. It now authenticates the complete checkpoint-proven body before assigning a block ID or starting mutation, and completes legacy peer-server shutdown.

- Recompute subtree roots directly from nodes, verify the cached roots and requested hashes, coinbase placeholder, duplicates, block merkle root and declared transaction count, then parse every transaction body. Merkle validation is the authoritative subtree-length check.
- Honor subtree-read concurrency and mmap configuration. Batches borrow authenticated nodes until all readers finish. Root recomputation avoids cloning mmap-backed nodes. Transaction data is decoded again during processing to keep retained memory bounded.
- Track files created by each catchup attempt. Invalid bodies discard that attempt's pending files after workers join, preserving shared files and promoted subtree data. Transient failures retain download progress.
- Distinguish corrupt cached files from bad downloads made in the current attempt, including `.subtreeToCheck` files retained from earlier attempts. Cached corruption aborts as a local service/storage failure without peer penalties or normal-validation fallback; only the identified corrupt files are evicted after workers join, allowing a later attempt to refetch them. Preflight failures on newly downloaded malformed files retain the invalid-body verdict.
- Bound cleanup using subtree-fetch concurrency (default eight), a five-second per-file timeout and a one-minute overall deadline. Aggregate failures into one warning and retain files whose deletion did not complete.
- Register and join legacy workers before shutdown can wait for them. Ban-event query sends and reply waits now honor shutdown/context cancellation, and buffered replies prevent late responses from blocking the peer handler. The Start reordering also activates UPnP maintenance and the ban-event listener during normal runtime; on the release branch they previously launched only after the synchronous peer handler exited.
- Preserve the catchup-after-pruning smoke fixture's small HTTP burst allowance; production rate limits remain unchanged. Documentation now distinguishes invalid-body aborts, cached-file recovery, incomplete blocks and normal-validation fallback.

Validation for review follow-up `797157b1c`:

- TDD: new shutdown, corrupt-cache/retry and concurrent-cleanup regressions failed on the original implementation before the fixes.
- Focused legacy/blockvalidation regressions passed twice with `-race -tags testtxmetacache`, covering malformed bodies, cached roots, mmap ownership/fallback, retry and shared-file preservation, cleanup timeouts, late replies and listener shutdown.
- Normal legacy package suites passed. The full normal blockvalidation package passed in the repository-wide run (393.458s). An earlier Kafka test's 500 ms processing assertion failed locally and also reproduced on the unmodified PR head under the same configuration.
- Affected-package vet, scoped diff lint, `staticcheck ./...`, formatting and all commit hooks passed.
- A direct 65,536-leaf Merkle comparison produced identical roots and reduced allocation from 7,366,822 to 2,110,379 B/op. This is a local primitive benchmark, not a full mainnet or multi-GB sync benchmark.
- Repository-wide validation is not all green: full vet reports four lock-copy warnings in unchanged `test/utils` code; full lint reports 50 preallocation warnings in unchanged code; gosec reports 746 findings, none on added/modified lines; govulncheck reports 48 reachable Go/dependency vulnerabilities. Dependencies are unchanged.
- Full normal/race repository runs reached failures outside this diff, and remaining broad integration work was stopped: SQL UTXO pruning assertions in the normal run and a `DiskTxMapUint64.writerLoop`/`Stats` race in the race run. The full affected-service race suite also hit that same model race while all legacy suites passed. Both the model regression and the blockvalidation duplicate-transaction regression reproduce the race on the unmodified PR head through a Go source overlay. The focused new regressions remain green; full-suite verification is not green.
- Frontend checks were attempted but lack installed Playwright/Prettier/Vite dependencies and a `typecheck` script; no frontend files changed. GitHub CI for the pushed head is still running.
