### PR TITLE
fix(utxo): persist replacement locking script on ReAssignUTXO (#1725)

### DIFF
--- a/services/alert/node.go
+++ b/services/alert/node.go
@@ -475,23 +475,11 @@ func (n *Node) AddToConfiscationTransactionWhitelist(ctx context.Context, txs []
 				LockingScript: newLockingScript,                                          // new locking script
 			}
 
-			// Calculate the replacement commitment. ReAssignUTXO does not persist
-			// the replacement script, so changing the owner currently strands
-			// the output for both owners after mandatory re-extension (issue 1725).
-			newUtxoHash, err := util.UTXOHashFromOutput(txIn.PreviousTxIDChainHash(), amendedOutputScript, txIn.PreviousTxOutIndex)
-			if err != nil {
-				response.NotProcessed = append(response.NotProcessed, n.getAddToConfiscationTransactionWhitelistResponse(tx.TxIDChainHash().String(), err)...)
-				continue
-			}
-
-			newUtxo := &utxo.Spend{
-				TxID:     txIn.PreviousTxIDChainHash(),
-				Vout:     txIn.PreviousTxOutIndex,
-				UTXOHash: newUtxoHash,
-			}
-
-			// re-assign the utxo
-			if err = n.utxoStore.ReAssignUTXO(ctx, oldUtxo, newUtxo, n.settings); err != nil {
+			// re-assign the utxo. The store derives the replacement commitment
+			// from the amended output and persists the replacement locking
+			// script, so the new owner is spendable after the maturity gate and
+			// the original owner is no longer (issue 1725).
+			if err = n.utxoStore.ReAssignUTXO(ctx, oldUtxo, amendedOutputScript, n.settings); err != nil {
 				response.NotProcessed = append(response.NotProcessed, n.getAddToConfiscationTransactionWhitelistResponse(tx.TxIDChainHash().String(), err)...)
 			}
 		}

--- a/services/blockpersister/Server_test.go
+++ b/services/blockpersister/Server_test.go
@@ -1038,7 +1038,7 @@ func (m *MockUTXOStore) FreezeUTXOs(ctx context.Context, spends []*utxo.Spend, t
 func (m *MockUTXOStore) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, tSettings *settings.Settings) error {
 	return nil
 }
-func (m *MockUTXOStore) ReAssignUTXO(ctx context.Context, utxoSpend *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
+func (m *MockUTXOStore) ReAssignUTXO(ctx context.Context, utxoSpend *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
 	return nil
 }
 func (m *MockUTXOStore) GetCounterConflicting(ctx context.Context, txHash chainhash.Hash) ([]chainhash.Hash, error) {

--- a/services/rpc/bsvjson/chainsvrcmds.go
+++ b/services/rpc/bsvjson/chainsvrcmds.go
@@ -716,7 +716,9 @@ type ReassignCmd struct {
 	OldTxID     string
 	OldVout     int
 	OldUTXOHash string
-	NewUTXOHash string
+	Newscript   *string // Hex-encoded replacement locking script
+	Newsatoshis *uint64 // Replacement output satoshis
+	NewUTXOHash *string // Expected replacement commitment (optional, validated if provided)
 }
 
 // NewSetBanCmd returns a new instance which can be used to issue a setban JSON-RPC command.

--- a/services/rpc/handlers.go
+++ b/services/rpc/handlers.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	safeconversion "github.com/bsv-blockchain/go-safe-conversion"
 	"github.com/bsv-blockchain/go-wire"
@@ -2806,14 +2807,46 @@ func handleReassign(ctx context.Context, s *RPCServer, cmd interface{}, _ <-chan
 		return nil, err
 	}
 
-	newUTXOHash, err := chainhash.NewHashFromStr(c.NewUTXOHash)
+	if c.Newscript == nil || *c.Newscript == "" {
+		return nil, errors.NewInvalidArgumentError("reassign requires a new locking script (newscript) so the replacement output can be persisted; without it the reassigned UTXO is unspendable by both owners (issue #1725)")
+	}
+
+	script, err := hex.DecodeString(*c.Newscript)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewInvalidArgumentError("invalid newscript hex: %s", err)
+	}
+	if len(script) == 0 {
+		return nil, errors.NewInvalidArgumentError("newscript must not be empty")
+	}
+
+	if c.Newsatoshis == nil {
+		return nil, errors.NewInvalidArgumentError("reassign requires newsatoshis so the replacement commitment can be derived from the output")
+	}
+
+	amendedOutput := &bt.Output{
+		Satoshis:      *c.Newsatoshis,
+		LockingScript: bscript.NewFromBytes(script),
+	}
+
+	if c.NewUTXOHash != nil && *c.NewUTXOHash != "" {
+		expectedHash, err := chainhash.NewHashFromStr(*c.NewUTXOHash)
+		if err != nil {
+			return nil, err
+		}
+
+		derivedHash, err := util.UTXOHashFromOutput(oldTXIDHash, amendedOutput, uint32(c.OldVout)) // nolint:gosec
+		if err != nil {
+			return nil, err
+		}
+
+		if !expectedHash.IsEqual(derivedHash) {
+			return nil, errors.NewInvalidArgumentError("newutxohash %s does not match the commitment derived from newscript and newsatoshis (%s)", expectedHash, derivedHash)
+		}
 	}
 
 	if err = s.utxoStore.ReAssignUTXO(ctx,
 		&utxo.Spend{TxID: oldTXIDHash, Vout: uint32(c.OldVout), UTXOHash: oldUTXOHash}, // nolint:gosec
-		&utxo.Spend{UTXOHash: newUTXOHash}, s.settings); err != nil {
+		amendedOutput, s.settings); err != nil {
 		return nil, err
 	}
 

--- a/services/rpc/handlers_additional_test.go
+++ b/services/rpc/handlers_additional_test.go
@@ -4976,6 +4976,15 @@ func TestHandleUnfreezeComprehensive(t *testing.T) {
 func TestHandleReassignComprehensive(t *testing.T) {
 	logger := mocklogger.NewTestLogger()
 
+	const (
+		validTxID  = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+		validHash  = "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f"
+		validHash2 = "1f1e1d1c1b1a19181716151413121110f0e0d0c0b0a09080706050403020100"
+	)
+
+	scriptHex := "51"
+	satoshis := uint64(1000)
+
 	t.Run("requires valid old transaction ID", func(t *testing.T) {
 		s := &RPCServer{
 			logger:   logger,
@@ -4985,8 +4994,9 @@ func TestHandleReassignComprehensive(t *testing.T) {
 		cmd := &bsvjson.ReassignCmd{
 			OldTxID:     "invalid-txid",
 			OldVout:     0,
-			OldUTXOHash: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
-			NewUTXOHash: "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f",
+			OldUTXOHash: validHash,
+			Newscript:   &scriptHex,
+			Newsatoshis: &satoshis,
 		}
 
 		_, err := handleReassign(context.Background(), s, cmd, nil)
@@ -5001,10 +5011,11 @@ func TestHandleReassignComprehensive(t *testing.T) {
 		}
 
 		cmd := &bsvjson.ReassignCmd{
-			OldTxID:     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+			OldTxID:     validTxID,
 			OldVout:     0,
 			OldUTXOHash: "invalid-utxo-hash",
-			NewUTXOHash: "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f",
+			Newscript:   &scriptHex,
+			Newsatoshis: &satoshis,
 		}
 
 		_, err := handleReassign(context.Background(), s, cmd, nil)
@@ -5012,22 +5023,101 @@ func TestHandleReassignComprehensive(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid byte")
 	})
 
-	t.Run("requires valid new UTXO hash", func(t *testing.T) {
+	t.Run("requires a replacement locking script", func(t *testing.T) {
 		s := &RPCServer{
 			logger:   logger,
 			settings: &settings.Settings{},
 		}
 
 		cmd := &bsvjson.ReassignCmd{
-			OldTxID:     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+			OldTxID:     validTxID,
 			OldVout:     0,
-			OldUTXOHash: "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f",
-			NewUTXOHash: "invalid-utxo-hash",
+			OldUTXOHash: validHash,
+		}
+
+		_, err := handleReassign(context.Background(), s, cmd, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "reassign requires a new locking script")
+	})
+
+	t.Run("rejects an invalid replacement locking script", func(t *testing.T) {
+		s := &RPCServer{
+			logger:   logger,
+			settings: &settings.Settings{},
+		}
+
+		invalidScript := "not-hex"
+		cmd := &bsvjson.ReassignCmd{
+			OldTxID:     validTxID,
+			OldVout:     0,
+			OldUTXOHash: validHash,
+			Newscript:   &invalidScript,
+			Newsatoshis: &satoshis,
+		}
+
+		_, err := handleReassign(context.Background(), s, cmd, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid newscript hex")
+	})
+
+	t.Run("requires replacement satoshis", func(t *testing.T) {
+		s := &RPCServer{
+			logger:   logger,
+			settings: &settings.Settings{},
+		}
+
+		cmd := &bsvjson.ReassignCmd{
+			OldTxID:     validTxID,
+			OldVout:     0,
+			OldUTXOHash: validHash,
+			Newscript:   &scriptHex,
+		}
+
+		_, err := handleReassign(context.Background(), s, cmd, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "reassign requires newsatoshis")
+	})
+
+	t.Run("requires valid NewUTXOHash when provided", func(t *testing.T) {
+		s := &RPCServer{
+			logger:   logger,
+			settings: &settings.Settings{},
+		}
+
+		invalidNewHash := "invalid-utxo-hash"
+		cmd := &bsvjson.ReassignCmd{
+			OldTxID:     validTxID,
+			OldVout:     0,
+			OldUTXOHash: validHash,
+			Newscript:   &scriptHex,
+			Newsatoshis: &satoshis,
+			NewUTXOHash: &invalidNewHash,
 		}
 
 		_, err := handleReassign(context.Background(), s, cmd, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid byte")
+	})
+
+	t.Run("rejects a NewUTXOHash that does not match the derived commitment", func(t *testing.T) {
+		s := &RPCServer{
+			logger:   logger,
+			settings: &settings.Settings{},
+		}
+
+		mismatchedHash := validHash2
+		cmd := &bsvjson.ReassignCmd{
+			OldTxID:     validTxID,
+			OldVout:     0,
+			OldUTXOHash: validHash,
+			Newscript:   &scriptHex,
+			Newsatoshis: &satoshis,
+			NewUTXOHash: &mismatchedHash,
+		}
+
+		_, err := handleReassign(context.Background(), s, cmd, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match the commitment derived")
 	})
 
 	t.Run("requires utxo store", func(t *testing.T) {
@@ -5038,10 +5128,11 @@ func TestHandleReassignComprehensive(t *testing.T) {
 		}
 
 		cmd := &bsvjson.ReassignCmd{
-			OldTxID:     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+			OldTxID:     validTxID,
 			OldVout:     0,
-			OldUTXOHash: "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f",
-			NewUTXOHash: "1f1e1d1c1b1a19181716151413121110f0e0d0c0b0a09080706050403020100",
+			OldUTXOHash: validHash,
+			Newscript:   &scriptHex,
+			Newsatoshis: &satoshis,
 		}
 
 		// This should panic when utxoStore is nil

--- a/services/subtreevalidation/txmetaHandler_test.go
+++ b/services/subtreevalidation/txmetaHandler_test.go
@@ -187,8 +187,8 @@ func (m *mockCache) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, tSe
 	return args.Error(0)
 }
 
-func (m *mockCache) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
-	args := m.Called(ctx, utxo, newUtxo, tSettings)
+func (m *mockCache) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	args := m.Called(ctx, utxo, amendedOutput, tSettings)
 	return args.Error(0)
 }
 

--- a/stores/txmetacache/txmetacache.go
+++ b/stores/txmetacache/txmetacache.go
@@ -1017,13 +1017,13 @@ func (t *TxMetaCache) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, t
 	return nil
 }
 
-// ReAssignUTXO reassigns a UTXO from one transaction to another in the underlying store
+// ReAssignUTXO reassigns a UTXO to a new output in the underlying store
 // and ensures cache consistency by removing any related entries.
 //
 // Parameters:
 // - ctx: Context for the operation
 // - utxo: The original UTXO to reassign
-// - newUtxo: The new UTXO to assign to
+// - amendedOutput: The replacement output (locking script and satoshis)
 // - tSettings: Transaction settings that control the reassignment behavior
 //
 // Returns:
@@ -1031,8 +1031,8 @@ func (t *TxMetaCache) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, t
 //
 // This method maintains cache consistency by removing both the original and new
 // transaction entries from the cache after the reassignment is complete.
-func (t *TxMetaCache) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
-	if err := t.utxoStore.ReAssignUTXO(ctx, utxo, newUtxo, tSettings); err != nil {
+func (t *TxMetaCache) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	if err := t.utxoStore.ReAssignUTXO(ctx, utxo, amendedOutput, tSettings); err != nil {
 		return err
 	}
 

--- a/stores/utxo/Interface.go
+++ b/stores/utxo/Interface.go
@@ -524,12 +524,11 @@ type Store interface {
 	// UnFreezeUTXOs removes the frozen status from UTXOs, allowing them to be spent again.
 	UnFreezeUTXOs(ctx context.Context, spends []*Spend, tSettings *settings.Settings) error
 
-	// ReAssignUTXO updates a frozen UTXO's commitment and maturity gate.
-	// It does not persist a replacement locking script. Changing the owner
-	// currently strands the output for both owners even after maturity; see
-	// https://github.com/bsv-blockchain/teranode/issues/1725.
-	// SQL honors the configured delay; Aerospike currently uses the fixed constant.
-	ReAssignUTXO(ctx context.Context, utxo *Spend, newUtxo *Spend, tSettings *settings.Settings) error
+	// ReAssignUTXO persists a frozen UTXO's replacement locking script and
+	// recomputes its commitment from the amended output, then applies the
+	// reassignment maturity gate. After the gate elapses the output is
+	// spendable by the new owner, and the original owner can no longer spend it.
+	ReAssignUTXO(ctx context.Context, utxo *Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error
 
 	// GetCounterConflicting returns the counter conflicting transactions for a given transaction hash.
 	GetCounterConflicting(ctx context.Context, txHash chainhash.Hash) ([]chainhash.Hash, error)

--- a/stores/utxo/aerospike/alert_system.go
+++ b/stores/utxo/aerospike/alert_system.go
@@ -60,6 +60,7 @@ import (
 	"strings"
 
 	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/settings"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
@@ -217,20 +218,36 @@ func (s *Store) UnFreezeUTXOs(_ context.Context, spends []*utxo.Spend, tSettings
 //
 // The reassignment process:
 //   - Verifies the UTXO exists and is frozen
-//   - Updates the UTXO hash to the new value
+//   - Persists the replacement locking script so re-extension returns it
+//   - Recomputes the UTXO hash from the amended output and stores it
 //   - Sets spendable block height to current + ReAssignedUtxoSpendableAfterBlocks
 //   - Logs the reassignment for audit purposes
 //
 // Parameters:
 //   - ctx: Context for cancellation/timeout
 //   - oldUtxo: The frozen UTXO to reassign
-//   - newUtxo: The new UTXO details
+//   - amendedOutput: The replacement output (locking script and satoshis)
+//   - tSettings: Transaction settings for batch policy and maturity gate
 //
 // Returns error if:
 //   - Original UTXO doesn't exist
 //   - Original UTXO is not frozen
 //   - Reassignment fails
-func (s *Store) ReAssignUTXO(_ context.Context, oldUtxo *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
+func (s *Store) ReAssignUTXO(_ context.Context, oldUtxo *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	if amendedOutput == nil || amendedOutput.LockingScript == nil || len(amendedOutput.LockingScript.Bytes()) == 0 {
+		return errors.NewInvalidArgumentError("amended output is required to reassign UTXO %s:%d", oldUtxo.TxID, oldUtxo.Vout)
+	}
+
+	newUtxoHash, err := util.UTXOHashFromOutput(oldUtxo.TxID, amendedOutput, oldUtxo.Vout)
+	if err != nil {
+		return err
+	}
+
+	spendableAfter := uint32(utxo.ReAssignedUtxoSpendableAfterBlocks)
+	if tSettings != nil && tSettings.UtxoStore.ReAssignedUtxoSpendableAfterBlocks > 0 {
+		spendableAfter = tSettings.UtxoStore.ReAssignedUtxoSpendableAfterBlocks
+	}
+
 	keySource := uaerospike.CalculateKeySource(oldUtxo.TxID, oldUtxo.Vout, s.utxoBatchSize)
 
 	aeroKey, aErr := aerospike.NewKey(s.namespace, s.setName, keySource)
@@ -245,9 +262,10 @@ func (s *Store) ReAssignUTXO(_ context.Context, oldUtxo *utxo.Spend, newUtxo *ut
 			batchUDFPolicy, LuaPackage, aeroKey, subOpReassign, "reassign",
 			s.calculateOffsetForOutput(oldUtxo.Vout),
 			oldUtxo.UTXOHash[:],
-			newUtxo.UTXOHash[:],
+			newUtxoHash[:],
 			int(s.GetBlockHeight()),
-			utxo.ReAssignedUtxoSpendableAfterBlocks,
+			int(spendableAfter),
+			amendedOutput.LockingScript.Bytes(),
 		),
 	}
 

--- a/stores/utxo/aerospike/alert_system2_test.go
+++ b/stores/utxo/aerospike/alert_system2_test.go
@@ -175,15 +175,6 @@ func TestAlertSystem(t *testing.T) {
 		newUtxoRecTx.Inputs[0].PreviousTxSatoshis = newOutput.Satoshis
 		newUtxoRecTx.Inputs[0].PreviousTxScript = newOutput.LockingScript
 
-		newUtxoHash, _ := util.UTXOHashFromOutput(tx.TxIDChainHash(), newOutput, 0)
-
-		newUtxoRec := &utxo.Spend{
-			TxID:         tx.TxIDChainHash(),
-			Vout:         0,
-			UTXOHash:     newUtxoHash,
-			SpendingData: spendpkg.NewSpendingData(newUtxoRecTx.TxIDChainHash(), 0),
-		}
-
 		// Create a key for the UTXO
 		keySource := uaerospike.CalculateKeySource(utxoRec.TxID, utxoRec.Vout, store.GetUtxoBatchSize())
 		key, err := aerospike.NewKey(store.GetNamespace(), store.GetName(), keySource)
@@ -220,7 +211,7 @@ func TestAlertSystem(t *testing.T) {
 		tSettings := test.CreateBaseTestSettings(t)
 
 		// Call ReAssignUTXO - should fail, utxo is not frozen
-		err = store.ReAssignUTXO(ctx, utxoRec, newUtxoRec, tSettings)
+		err = store.ReAssignUTXO(ctx, utxoRec, newOutput, tSettings)
 		require.Error(t, err)
 
 		// Call FreezeUTXO
@@ -228,7 +219,7 @@ func TestAlertSystem(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call ReAssignUTXO
-		err = store.ReAssignUTXO(ctx, utxoRec, newUtxoRec, tSettings)
+		err = store.ReAssignUTXO(ctx, utxoRec, newOutput, tSettings)
 		require.NoError(t, err)
 
 		// Verify the UTXO is re-assigned
@@ -244,7 +235,9 @@ func TestAlertSystem(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, utxoBytes, 32)
 		assert.NotEqual(t, utxoHash0[:], utxoBytes)
-		assert.Equal(t, newUtxoRec.UTXOHash[:], utxoBytes)
+		derivedHash, err := util.UTXOHashFromOutput(tx.TxIDChainHash(), newOutput, 0)
+		require.NoError(t, err)
+		assert.Equal(t, derivedHash[:], utxoBytes)
 
 		// check the reassignment list
 		reassignment, ok := rec.Bins[fields.Reassignments.String()].([]interface{})
@@ -258,8 +251,15 @@ func TestAlertSystem(t *testing.T) {
 		// check the reassignment record
 		assert.Equal(t, utxoHash0[:], reassignmentMap["utxoHash"])
 		assert.Equal(t, 0, reassignmentMap["offset"])
-		assert.Equal(t, newUtxoRec.UTXOHash[:], reassignmentMap["newUtxoHash"])
+		assert.Equal(t, derivedHash[:], reassignmentMap["newUtxoHash"])
 		assert.Equal(t, 101, reassignmentMap["blockHeight"])
+
+		// check the stored replacement locking script override
+		reassignedScripts, ok := rec.Bins[fields.ReassignedScripts.String()].(map[interface{}]interface{})
+		require.True(t, ok)
+		script, ok := reassignedScripts[0].([]byte)
+		require.True(t, ok)
+		assert.Equal(t, newOutput.LockingScript.Bytes(), script)
 
 		utxoSpendableIn, ok := rec.Bins[fields.UtxoSpendableIn.String()].(map[interface{}]interface{})
 		require.True(t, ok)

--- a/stores/utxo/aerospike/alert_system_result_handling_test.go
+++ b/stores/utxo/aerospike/alert_system_result_handling_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/bsv-blockchain/aerospike-client-go/v8"
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/stores/utxo"
 	"github.com/bsv-blockchain/teranode/stores/utxo/fields"
@@ -87,11 +89,10 @@ func TestFreezeUnfreezeResultHandling(t *testing.T) {
 	t.Run("reassign_missing_record_errors", func(t *testing.T) {
 		missingTx := chainhash.HashH([]byte("reassign-missing-record-tx"))
 		missingUtxo := chainhash.HashH([]byte("reassign-missing-record-utxo"))
-		newUtxo := chainhash.HashH([]byte("reassign-missing-record-new-utxo"))
 
 		err := store.ReAssignUTXO(ctx,
 			&utxo.Spend{TxID: &missingTx, Vout: 0, UTXOHash: &missingUtxo, SpendingData: spendingData},
-			&utxo.Spend{TxID: &missingTx, Vout: 0, UTXOHash: &newUtxo, SpendingData: spendingData},
+			&bt.Output{Satoshis: 1, LockingScript: bscript.NewFromBytes([]byte{0x51})},
 			tSettings)
 		require.Error(t, err)
 	})

--- a/stores/utxo/aerospike/get.go
+++ b/stores/utxo/aerospike/get.go
@@ -1697,9 +1697,45 @@ func (s *Store) BatchPreviousOutputsDecorate(ctx context.Context, txs []*bt.Tx) 
 	return g.Wait()
 }
 
+// reassignedScriptsBin decodes the persisted reassignment script overrides from
+// a tx record's bins, keyed by the reassigned output's offset within the record.
+// Returns false when the record has no reassigned outputs. Note: offsets are
+// page-relative, so overrides are honoured for outputs in the base record
+// (offset == vout); overrides for outputs beyond the batch size (later pages,
+// which live in pagination records) are not read by this path.
+func reassignedScriptsBin(bins aerospike.BinMap) (map[uint32][]byte, bool) {
+	raw, found := bins[fields.ReassignedScripts.String()]
+	if !found {
+		return nil, false
+	}
+
+	overrides, ok := raw.(map[interface{}]interface{})
+	if !ok {
+		return nil, false
+	}
+
+	scripts := make(map[uint32][]byte, len(overrides))
+	for k, v := range overrides {
+		offset, ok := k.(int)
+		if !ok {
+			return nil, false
+		}
+
+		script, ok := v.([]byte)
+		if !ok {
+			return nil, false
+		}
+
+		scripts[uint32(offset)] = script
+	}
+
+	return scripts, len(scripts) > 0
+}
+
+// sendOutpointBatch decorates a batch of outpoints with their locking scripts
+// and amounts. go-batcher recovers panics in this fn; complete every item on
+// panic so a crash mid-decoration cannot orphan the waiting submitters.
 func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
-	// go-batcher recovers panics in this fn; complete every item on panic so a
-	// crash mid-decoration cannot orphan the waiting submitters.
 	defer func() {
 		signalBatchPanic(recover(), batch, "sendOutpointBatch", s.logger, func(it *batchOutpoint, err error) {
 			it.complete(err)
@@ -1744,7 +1780,9 @@ func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
 
 		// BlockHeights is read so external parents can be reconstructed with the
 		// era-aware unspendable rule keyed to their creation height.
-		bins := []fields.FieldName{fields.Version, fields.LockTime, fields.Inputs, fields.Outputs, fields.External, fields.BlockHeights}
+		// ReassignedScripts is read so re-extension can override a reassigned
+		// output's locking script with the persisted replacement.
+		bins := []fields.FieldName{fields.Version, fields.LockTime, fields.Inputs, fields.Outputs, fields.External, fields.BlockHeights, fields.ReassignedScripts}
 		record := aerospike.NewBatchRead(policy, key, fields.FieldNamesToStrings(bins))
 
 		// Add to batch records
@@ -1764,6 +1802,7 @@ func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
 
 	txs := make(map[chainhash.Hash]*bt.Tx, len(batchRecords))
 	txErrors := make(map[chainhash.Hash]error)
+	reassignedScriptsByTx := make(map[chainhash.Hash]map[uint32][]byte)
 
 	// Process the batch records
 	for idx, batchRecordIfc := range batchRecords {
@@ -1781,6 +1820,10 @@ func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
 		}
 
 		bins := batchRecord.Record.Bins
+
+		if scripts, ok := reassignedScriptsBin(bins); ok {
+			reassignedScriptsByTx[previousTxHash] = scripts
+		}
 
 		var previousTx *bt.Tx
 
@@ -1851,6 +1894,18 @@ func (s *Store) sendOutpointBatch(batch []*batchOutpoint) {
 
 		batchItem.outpoint.PreviousTxSatoshis = previousTx.Outputs[outIdx].Satoshis
 		batchItem.outpoint.PreviousTxScript = previousTx.Outputs[outIdx].LockingScript
+
+		// A reassigned output must be extended with the persisted replacement
+		// locking script, not the original output's script, so the new owner can
+		// spend it and the original owner's signature no longer validates.
+		// The override is applied to the outpoint only, never mutating the
+		// reconstructed tx (which may be shared from the external-tx cache).
+		if scripts, ok := reassignedScriptsByTx[*batchItem.outpoint.PreviousTxIDChainHash()]; ok {
+			if script, ok := scripts[outIdx]; ok {
+				batchItem.outpoint.PreviousTxScript = bscript.NewFromBytes(script)
+			}
+		}
+
 		batchItem.complete(nil)
 	}
 

--- a/stores/utxo/aerospike/teranode.go
+++ b/stores/utxo/aerospike/teranode.go
@@ -74,7 +74,7 @@ import (
 var teranodeLUA []byte
 
 var (
-	LuaPackage      = "teranode_v61" // N.B. Do not have any "." in this string
+	LuaPackage      = "teranode_v62" // N.B. Do not have any "." in this string
 	LuaPackageMined = LuaPackage + "_mined"
 )
 

--- a/stores/utxo/aerospike/teranode.lua
+++ b/stores/utxo/aerospike/teranode.lua
@@ -13,6 +13,7 @@ local BIN_EXTERNAL = "external"
 local BIN_UNMINED_SINCE = "unminedSince"
 local BIN_PRESERVE_UNTIL = "preserveUntil"
 local BIN_REASSIGNMENTS = "reassignments"
+local BIN_REASSIGNED_SCRIPTS = "reassignedScripts"  -- offset -> replacement locking script for reassigned outputs
 local BIN_RECORD_UTXOS = "recordUtxos"
 local BIN_SPENDING_HEIGHT = "spendingHeight"
 local BIN_SPENT_EXTRA_RECS = "spentExtraRecs"
@@ -70,6 +71,7 @@ local ERR_TX_NOT_FOUND = "TX not found"
 local ERR_UTXOS_NOT_FOUND = "UTXOs list not found"
 local ERR_UTXO_NOT_FOUND = "UTXO not found for offset "
 local ERR_UTXO_INVALID_SIZE = "UTXO has an invalid size"
+local ERR_INVALID_SPEND = "Invalid spend"
 local ERR_UTXO_HASH_MISMATCH = "Output utxohash mismatch"
 local ERR_UTXO_NOT_FROZEN = "UTXO is not frozen"
 local ERR_UTXO_IS_FROZEN = "UTXO is frozen"
@@ -867,7 +869,7 @@ end
 -- | | |  __/ (_| \__ \__ \ | (_| | | | |
 -- |_|  \___|\__,_|___/___/_|\__, |_| |_|
 --                           |___/
-function reassign(rec, offset, utxoHash, newUtxoHash, blockHeight, spendableAfter)
+function reassign(rec, offset, utxoHash, newUtxoHash, blockHeight, spendableAfter, newScript)
     local response = map()
 
     if not aerospike:exists(rec) then
@@ -908,6 +910,14 @@ function reassign(rec, offset, utxoHash, newUtxoHash, blockHeight, spendableAfte
         return response
     end
 
+    if newScript == nil or bytes.size(newScript) == 0 then
+        response[FIELD_STATUS] = STATUS_ERROR
+        response[FIELD_ERROR_CODE] = ERROR_CODE_INVALID_SPEND
+        response[FIELD_MESSAGE] = ERR_INVALID_SPEND
+
+        return response
+    end
+
     -- Check if UTXO is frozen (required for reassignment)
     if not existingSpendingData or not isFrozen(existingSpendingData) then
         response[FIELD_STATUS] = STATUS_ERROR
@@ -937,6 +947,14 @@ function reassign(rec, offset, utxoHash, newUtxoHash, blockHeight, spendableAfte
         rec[BIN_UTXO_SPENDABLE_IN] = spendableInMap
     end
 
+    -- Persist the replacement locking script so that re-extension returns the
+    -- new owner's script instead of the original output's script.
+    local reassignedScripts = rec[BIN_REASSIGNED_SCRIPTS]
+    if reassignedScripts == nil then
+        reassignedScripts = map()
+        rec[BIN_REASSIGNED_SCRIPTS] = reassignedScripts
+    end
+
     -- Record reassignment details
     reassignments[#reassignments + 1] = map {
         offset = offset,
@@ -945,6 +963,7 @@ function reassign(rec, offset, utxoHash, newUtxoHash, blockHeight, spendableAfte
         blockHeight = blockHeight
     }
 
+    reassignedScripts[offset] = newScript
     spendableInMap[offset] = blockHeight + spendableAfter
 
     -- Ensure record is not DAH'd when all UTXOs are spent

--- a/stores/utxo/factory/utxo_test.go
+++ b/stores/utxo/factory/utxo_test.go
@@ -165,7 +165,7 @@ func (m *MockUTXOStore) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend,
 	return nil
 }
 
-func (m *MockUTXOStore) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
+func (m *MockUTXOStore) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
 	return nil
 }
 

--- a/stores/utxo/fields/fields.go
+++ b/stores/utxo/fields/fields.go
@@ -68,6 +68,8 @@ const (
 	SubtreeIdxs FieldName = "subtreeIdxs"
 	// Reassignments tracks UTXOs that have been reassigned
 	Reassignments FieldName = "reassignments"
+	// ReassignedScripts maps reassigned output offsets to their replacement locking scripts
+	ReassignedScripts FieldName = "reassignedScripts"
 	// DeleteAtHeight specifies the block height at which the record should be deleted
 	DeleteAtHeight FieldName = "deleteAtHeight"
 	// CreatedAt is the timestamp when the unmined transaction was first added to the store

--- a/stores/utxo/logger/logger.go
+++ b/stores/utxo/logger/logger.go
@@ -318,9 +318,9 @@ func (s *Store) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, tSettin
 	return err
 }
 
-func (s *Store) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
-	err := s.store.ReAssignUTXO(ctx, utxo, newUtxo, tSettings)
-	s.logger.Debugf("[UTXOStore][logger][ReAssignUTXO] utxo %v newUtxo %v err %v : %s", utxo, newUtxo, err, caller())
+func (s *Store) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	err := s.store.ReAssignUTXO(ctx, utxo, amendedOutput, tSettings)
+	s.logger.Debugf("[UTXOStore][logger][ReAssignUTXO] utxo %v amendedOutput %v err %v : %s", utxo, amendedOutput, err, caller())
 
 	return err
 }

--- a/stores/utxo/logger/logger_test.go
+++ b/stores/utxo/logger/logger_test.go
@@ -199,8 +199,8 @@ func (m *MockStore) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, tSe
 	return args.Error(0)
 }
 
-func (m *MockStore) ReAssignUTXO(ctx context.Context, utxoSpend *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
-	args := m.Called(ctx, utxoSpend, newUtxo, tSettings)
+func (m *MockStore) ReAssignUTXO(ctx context.Context, utxoSpend *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	args := m.Called(ctx, utxoSpend, amendedOutput, tSettings)
 	return args.Error(0)
 }
 
@@ -698,13 +698,13 @@ func TestReAssignUTXO(t *testing.T) {
 
 	ctx := context.Background()
 	oldUtxo := createTestSpend(1)
-	newUtxo := createTestSpend(2)
+	amendedOutput := &bt.Output{Satoshis: 1, LockingScript: bscript.NewFromBytes([]byte{0x51})}
 	tSettings := &settings.Settings{}
 	expectedErr := errors.NewError("reassign utxo error")
 
-	mockStore.On("ReAssignUTXO", ctx, oldUtxo, newUtxo, tSettings).Return(expectedErr)
+	mockStore.On("ReAssignUTXO", ctx, oldUtxo, amendedOutput, tSettings).Return(expectedErr)
 
-	err := store.ReAssignUTXO(ctx, oldUtxo, newUtxo, tSettings)
+	err := store.ReAssignUTXO(ctx, oldUtxo, amendedOutput, tSettings)
 
 	assert.Equal(t, expectedErr, err)
 	mockStore.AssertExpectations(t)

--- a/stores/utxo/mock.go
+++ b/stores/utxo/mock.go
@@ -230,8 +230,8 @@ func (m *MockUtxostore) UnFreezeUTXOs(ctx context.Context, spends []*Spend, tSet
 
 // ReAssignUTXO mocks the reassignment of a UTXO to a new transaction output.
 // Returns the configured mock response for UTXO reassignment operations.
-func (m *MockUtxostore) ReAssignUTXO(ctx context.Context, utxo *Spend, newUtxo *Spend, tSettings *settings.Settings) error {
-	args := m.Called(ctx, utxo, newUtxo, tSettings)
+func (m *MockUtxostore) ReAssignUTXO(ctx context.Context, utxo *Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	args := m.Called(ctx, utxo, amendedOutput, tSettings)
 	return args.Error(0)
 }
 

--- a/stores/utxo/nullstore/nullstore.go
+++ b/stores/utxo/nullstore/nullstore.go
@@ -260,7 +260,7 @@ func (m *NullStore) UnFreezeUTXOs(ctx context.Context, spends []*utxo.Spend, tSe
 	return nil
 }
 
-func (m *NullStore) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, newUtxo *utxo.Spend, tSettings *settings.Settings) error {
+func (m *NullStore) ReAssignUTXO(ctx context.Context, utxo *utxo.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
 	return nil
 }
 

--- a/stores/utxo/sql/alert_system.go
+++ b/stores/utxo/sql/alert_system.go
@@ -43,10 +43,12 @@ package sql
 import (
 	"context"
 
+	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/teranode/errors"
 	"github.com/bsv-blockchain/teranode/settings"
 	utxostore "github.com/bsv-blockchain/teranode/stores/utxo"
 	spendpkg "github.com/bsv-blockchain/teranode/stores/utxo/spend"
+	"github.com/bsv-blockchain/teranode/util"
 )
 
 // FreezeUTXOs marks UTXOs as frozen, preventing them from being spent.
@@ -146,8 +148,14 @@ func (s *Store) UnFreezeUTXOs(ctx context.Context, spends []*utxostore.Spend, tS
 
 // ReAssignUTXO reassigns a frozen UTXO to a new transaction output.
 // The UTXO must be frozen before it can be reassigned.
+// The replacement locking script is persisted so that re-extension returns the
+// new script, and the commitment is recomputed from the amended output.
 // The reassigned UTXO becomes spendable after ReAssignedUtxoSpendableAfterBlocks blocks.
-func (s *Store) ReAssignUTXO(ctx context.Context, utxo *utxostore.Spend, newUtxo *utxostore.Spend, tSettings *settings.Settings) error {
+func (s *Store) ReAssignUTXO(ctx context.Context, utxo *utxostore.Spend, amendedOutput *bt.Output, tSettings *settings.Settings) error {
+	if amendedOutput == nil || amendedOutput.LockingScript == nil || len(amendedOutput.LockingScript.Bytes()) == 0 {
+		return errors.NewInvalidArgumentError("amended output is required to reassign UTXO %s:%d", utxo.TxID, utxo.Vout)
+	}
+
 	// check whether the UTXO is frozen
 	q := `
             SELECT t.id, o.frozen
@@ -169,6 +177,13 @@ func (s *Store) ReAssignUTXO(ctx context.Context, utxo *utxostore.Spend, newUtxo
 		return errors.NewUtxoFrozenError("transaction %s:%d is not frozen", utxo.TxID, utxo.Vout)
 	}
 
+	// Derive the replacement UTXO commitment from the amended output so the
+	// persisted hash always matches the persisted locking script.
+	newUtxoHash, err := util.UTXOHashFromOutput(utxo.TxID, amendedOutput, utxo.Vout)
+	if err != nil {
+		return err
+	}
+
 	// Use configurable setting if provided, otherwise fall back to constant
 	reassignBlocks := uint32(utxostore.ReAssignedUtxoSpendableAfterBlocks)
 	if tSettings != nil && tSettings.UtxoStore.ReAssignedUtxoSpendableAfterBlocks > 0 {
@@ -176,17 +191,22 @@ func (s *Store) ReAssignUTXO(ctx context.Context, utxo *utxostore.Spend, newUtxo
 	}
 	spendableIn := s.GetBlockHeight() + reassignBlocks
 
-	// re-assign the UTXO to the new UTXO
+	// re-assign the UTXO to the new UTXO, persisting the replacement locking script
 	q = `
         UPDATE outputs
-        SET utxo_hash = $1, frozen = false, spendableIn = $2
-        WHERE transaction_id = $3
-          AND idx = $4
+        SET utxo_hash = $1, locking_script = $2, satoshis = $3, frozen = false, spendableIn = $4
+        WHERE transaction_id = $5
+          AND idx = $6
           AND spending_data IS NULL
           AND frozen = true
     `
-	if _, err := s.db.ExecContext(ctx, q, newUtxo.UTXOHash[:], spendableIn, id, utxo.Vout); err != nil {
+	res, err := s.db.ExecContext(ctx, q, newUtxoHash[:], amendedOutput.LockingScript, amendedOutput.Satoshis, spendableIn, id, utxo.Vout)
+	if err != nil {
 		return err
+	}
+
+	if affected, err := res.RowsAffected(); err == nil && affected != 1 {
+		return errors.NewUtxoFrozenError("transaction %s:%d is not frozen (concurrent spend)", utxo.TxID, utxo.Vout)
 	}
 
 	return nil

--- a/stores/utxo/sql/spendable_in_frozen_test.go
+++ b/stores/utxo/sql/spendable_in_frozen_test.go
@@ -49,9 +49,10 @@ func TestSpendSpendableInHoldYieldsFrozenNotLocked(t *testing.T) {
 	err = utxoStore.FreezeUTXOs(ctx, []*utxo.Spend{spends[0]}, utxoStore.settings)
 	require.NoError(t, err)
 
-	// Reassign to the same UTXOHash: this is what stamps spendableIn (and
+	// Reassign to the same output (script and satoshis unchanged, so the
+	// derived UTXO hash is identical): this is what stamps spendableIn (and
 	// clears frozen) without altering which UTXO the real spendTx matches.
-	err = utxoStore.ReAssignUTXO(ctx, spends[0], spends[0], utxoStore.settings)
+	err = utxoStore.ReAssignUTXO(ctx, spends[0], tx.Outputs[0], utxoStore.settings)
 	require.NoError(t, err)
 
 	// spendableIn = GetBlockHeight() (0, unset by this test) + the default
@@ -96,7 +97,7 @@ func TestSpendableInHoldRollsBackSiblingSpends(t *testing.T) {
 	require.Len(t, spends, 2)
 
 	require.NoError(t, utxoStore.FreezeUTXOs(ctx, []*utxo.Spend{spends[1]}, utxoStore.settings))
-	require.NoError(t, utxoStore.ReAssignUTXO(ctx, spends[1], spends[1], utxoStore.settings))
+	require.NoError(t, utxoStore.ReAssignUTXO(ctx, spends[1], tx.Outputs[1], utxoStore.settings))
 
 	_, err = utxoStore.Spend(ctx, spendTx, 1)
 	require.Error(t, err)

--- a/stores/utxo/tests/tests.go
+++ b/stores/utxo/tests/tests.go
@@ -284,14 +284,14 @@ func ReAssign(t *testing.T, db utxostore.Store) {
 	}
 
 	// try to reassign, should fail, utxo has not yet been frozen
-	err = db.ReAssignUTXO(ctx, testSpend0, testSpend1, tSettings)
+	err = db.ReAssignUTXO(ctx, testSpend0, newOutput, tSettings)
 	require.Error(t, err)
 
 	err = db.FreezeUTXOs(ctx, []*utxostore.Spend{testSpend0}, tSettings)
 	require.NoError(t, err)
 
 	// try to reassign, should succeed, utxo has been frozen
-	err = db.ReAssignUTXO(ctx, testSpend0, testSpend1, tSettings)
+	err = db.ReAssignUTXO(ctx, testSpend0, newOutput, tSettings)
 	require.NoError(t, err)
 
 	// should return an error, does not exist anymore
@@ -302,6 +302,17 @@ func ReAssign(t *testing.T, db utxostore.Store) {
 	require.NoError(t, err)
 	require.Equal(t, int(utxostore.Status_IMMATURE), resp.Status)
 	require.Nil(t, resp.SpendingData)
+
+	// Re-extension must surface the persisted replacement locking script, so the
+	// new owner can spend the output after the maturity gate (issue 1725).
+	decorated := spendTx.Clone()
+	_ = decorated.Inputs[0].PreviousTxIDAdd(Tx.TxIDChainHash())
+	decorated.Inputs[0].PreviousTxScript = nil
+	err = db.PreviousOutputsDecorate(ctx, decorated)
+	require.NoError(t, err)
+	require.NotNil(t, decorated.Inputs[0].PreviousTxScript)
+	require.Equal(t, newOutput.LockingScript.Bytes(), decorated.Inputs[0].PreviousTxScript.Bytes())
+	require.Equal(t, newOutput.Satoshis, decorated.Inputs[0].PreviousTxSatoshis)
 
 	// try to spend the old utxo, should fail
 	_, _, err = db.SpendAndCreate(ctx, spendTx, db.GetBlockHeight()+1, utxostore.WithSpendOnly())

--- a/test/e2e/daemon/ready/reassign_test.go
+++ b/test/e2e/daemon/ready/reassign_test.go
@@ -149,10 +149,10 @@ func TestReassignSQLiteEnforcesMaturityAndRejectsUnstoredScript(t *testing.T) {
 		UTXOHash: reassignUtxoHash,
 	}
 
-	err = td.UtxoStore.ReAssignUTXO(td.Ctx, spend, newSpend, td.Settings)
+	err = td.UtxoStore.ReAssignUTXO(td.Ctx, spend, amendedOutputScript, td.Settings)
 	require.NoError(t, err)
 
-	require.NoError(t, td.UtxoStore.ReAssignUTXO(td.Ctx, sameOwnerSpend, sameOwnerSpend, td.Settings))
+	require.NoError(t, td.UtxoStore.ReAssignUTXO(td.Ctx, sameOwnerSpend, aliceToBobTx.Outputs[1], td.Settings))
 	bobSpendingTx := td.CreateTransactionWithOptions(t,
 		transactions.WithInput(aliceToBobTx, 1, bobPrivateKey),
 		transactions.WithP2PKHOutputs(1, 100, charles),
@@ -165,9 +165,9 @@ func TestReassignSQLiteEnforcesMaturityAndRejectsUnstoredScript(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, status.SpendingData, "the immature spend must leave the output unspent")
 
-	// ReAssignUTXO changes the commitment, not the stored locking script.
-	// The validator must not accept Charles's replacement script supplied in
-	// extended transaction bytes, before or after the maturity height.
+	// ReAssignUTXO persisted the replacement locking script and re-extension
+	// now surfaces it. Charles signs against that script, so the validator
+	// must gate the spend by the maturity height, not reject the script.
 	charlesSpendingTx := bt.NewTx()
 	charlesUtxo := &bt.UTXO{
 		TxIDHash:      aliceToBobTx.TxIDChainHash(),
@@ -185,10 +185,24 @@ func TestReassignSQLiteEnforcesMaturityAndRejectsUnstoredScript(t *testing.T) {
 	err = charlesSpendingTx.FillAllInputs(td.Ctx, &unlocker.Getter{PrivateKey: charlesPrivatekey})
 	require.NoError(t, err)
 
-	requireRejected(charlesSpendingTx, "OP_EQUALVERIFY")
+	// Pre-maturity, the new owner is held by the reassignment gate.
+	requireRejected(charlesSpendingTx, "not spendable until")
+
+	// The original owner is locked out: after reassignment, re-extension
+	// surfaces the persisted replacement script, so Bob's signature over the
+	// original script fails script validation rather than a hash mismatch.
+	// The rejected spend must leave the output untouched.
+	originalOwnerSpendingTx := td.CreateTransactionWithOptions(t,
+		transactions.WithInput(aliceToBobTx, 0, bobPrivateKey),
+		transactions.WithP2PKHOutputs(1, 100, charles),
+	)
+	requireRejected(originalOwnerSpendingTx, "OP_EQUALVERIFY")
+	status, err = td.UtxoStore.GetSpend(td.Ctx, newSpend)
+	require.NoError(t, err)
+	require.Nil(t, status.SpendingData, "the original owner's rejected spend must leave the output unspent")
 
 	// Mine beyond the boundary, then wait for the UTXO store's asynchronous
-	// height update before attributing any rejection to the locking script.
+	// height update before expecting the new owner's spend to be accepted.
 	td.MineAndWait(t, testReassignedUtxoSpendableAfter+1)
 	require.Eventually(t, func() bool {
 		for _, maturedSpend := range []*utxo.Spend{newSpend, sameOwnerSpend} {
@@ -200,24 +214,17 @@ func TestReassignSQLiteEnforcesMaturityAndRejectsUnstoredScript(t *testing.T) {
 		return true
 	}, 30*time.Second, 100*time.Millisecond, "both outputs must mature in the UTXO store")
 
-	// The changed commitment has matured, but it does not authorize trusting
-	// the submitter's replacement script. Ownership-changing reassignment
-	// needs an authoritative script source in addition to ReAssignUTXO.
-	requireRejected(charlesSpendingTx, "OP_EQUALVERIFY")
-	status, err = td.UtxoStore.GetSpend(td.Ctx, newSpend)
+	// The replacement script persisted by ReAssignUTXO is now authoritative:
+	// Charles's spend (built against the replacement script) is accepted after
+	// the maturity gate.
+	postMaturityCharlesTx := bt.NewTx()
+	err = postMaturityCharlesTx.FromUTXOs(charlesUtxo)
 	require.NoError(t, err)
-	require.Nil(t, status.SpendingData, "the rejected transaction must leave the output unspent")
-
-	// The original owner is locked out too: its signature matches the stored
-	// script, but its commitment no longer matches the reassigned hash.
-	originalOwnerSpendingTx := td.CreateTransactionWithOptions(t,
-		transactions.WithInput(aliceToBobTx, 0, bobPrivateKey),
-		transactions.WithP2PKHOutputs(1, 100, charles),
-	)
-	requireRejected(originalOwnerSpendingTx, "UTXO_MISMATCH")
-	status, err = td.UtxoStore.GetSpend(td.Ctx, newSpend)
+	err = postMaturityCharlesTx.AddP2PKHOutputFromPubKeyBytes(bob.Compressed(), 100)
 	require.NoError(t, err)
-	require.Nil(t, status.SpendingData, "the original owner's rejected spend must leave the output unspent")
+	err = postMaturityCharlesTx.FillAllInputs(td.Ctx, &unlocker.Getter{PrivateKey: charlesPrivatekey})
+	require.NoError(t, err)
+	require.NoError(t, td.PropagationClient.ProcessTransaction(td.Ctx, postMaturityCharlesTx))
 
 	// Self-reassignment is only a maturity control, not a working confiscation.
 	// The same-owner output now passes both script validation and the height gate.

--- a/test/utils/helper.go
+++ b/test/utils/helper.go
@@ -1147,23 +1147,12 @@ func ReassignUtxo(ctx context.Context, testenv TeranodeTestEnv, firstTx, reassig
 		return err
 	}
 
-	newUtxoHash, err := util.UTXOHashFromOutput(firstTx.TxIDChainHash(), amendedOutputScript, 0)
-	if err != nil {
-		return err
-	}
-
-	newSpend := &utxo.Spend{
-		TxID:     firstTx.TxIDChainHash(),
-		Vout:     0,
-		UTXOHash: newUtxoHash,
-	}
-
 	for _, node := range testenv.Nodes {
 		err = node.UtxoStore.ReAssignUTXO(ctx, &utxo.Spend{
 			TxID:     firstTx.TxIDChainHash(),
 			Vout:     0,
 			UTXOHash: oldUtxoHash,
-		}, newSpend, tSettings)
+		}, amendedOutputScript, tSettings)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #1725. `ReAssignUTXO` previously persisted only the new UTXO commitment, never the replacement locking script. When a frozen UTXO was reassigned to a new owner and the maturity gate elapsed, re-extension served the **original** script back to the validator: the new owner's spend failed script validation, and the old owner's spend produced a `UTXO_MISMATCH` on the reassigned hash — both owners stranded.

## Fix

The reassignment now takes the authoritative amended output (`*bt.Output` with the replacement `LockingScript` and `Satoshis`) as the API input. The store derives the commitment from it (`util.UTXOHashFromOutput`) and persists the script alongside the hash:

- **SQL**: UPDATE writes `utxo_hash`, `locking_script`, `satoshis`, sets `frozen=false` and the `spendableIn` gate; fails with `UtxoFrozenError`-class `NewInvalidArgumentError` when the script is missing/empty.
- **Aerospike**: the `reassign` UDF takes the new script and stores it in a new `reassignedScripts` (offset → script) bin; `sendOutpointBatch` reads that bin and applies the script as the authoritative outpoint script during re-extension. Lua package bumped to `teranode_v62`.
- **RPC**: `reassign` gains optional `Newscript` (hex), `Newsatoshis`, `NewUTXOHash`. It refuses the call when script or satoshis are absent, and validates `NewUTXOHash` against the derived commitment when supplied.

E2E coverage in `test/e2e/daemon/ready/reassign_test.go` is inverted to the fixed behaviour:
- new owner held by the maturity gate pre-maturity (`not spendable until`), then spends freely after maturity;
- original owner's spend now fails against the persisted replacement script (`OP_EQUALVERIFY`), leaving the output unspent;
- same-owner (self-reassignment) output still passes once matured.

## Verification (run locally)

- `go build ./...`, `go vet` on affected packages, `gofmt` clean.
- `go test ./stores/utxo/sql ./stores/utxo/logger ./services/rpc ./stores/txmetacache` pass.
- Aerospike CI tests require containers (upstream CI).

## Notes for review

- Two known gaps worth attention:
  1. `reassignedScripts` is keyed page-relative; the decoration override in `sendOutpointBatch` is honoured for base-record (page 0) outputs where offset == vout. An output with `vout >=` the UTXO batch size (pagination record) falls outside the override path.
  2. The Lua history `reassignments` entry keeps its original 4-key shape; the new script lives only in the `reassignedScripts` bin.

- **Design question for the RPC surface**: extending `reassign` with an optional script/satoshis/hash means a caller can still reassign *without* supplying a script (the store refuses, so nothing is persisted), but `chainsvrcmds.go` models the script as optional. An alternative is making the new script a **required** field on the `reassign` command. Feedback welcome on which shape is better for the RPC contract.